### PR TITLE
AG: focused job edit modal with pricing recalc, cascade, audit log

### DIFF
--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -270,6 +270,81 @@ async function runBookingSchemaGuard(): Promise<void> {
         UNIQUE (user_id, page, column_key)
       )
     ` },
+
+    // ── AG: Job Edit modal — schema additions (2026-04-27) ───────────────────
+    // Manual-rate flag on jobs: set true when a user overrides the
+    // pricing-engine-calculated base_fee in the edit modal. Cleared when
+    // scope/freq/add-ons change AND base_fee is omitted from the patch.
+    { label: "jobs.manual_rate_override",
+      stmt: `ALTER TABLE jobs ADD COLUMN IF NOT EXISTS manual_rate_override BOOLEAN NOT NULL DEFAULT false` },
+
+    // Add-ons traceability — link the per-job add-on row to the
+    // tenant's pricing_addon row for recalc lookups.
+    { label: "job_add_ons.pricing_addon_id",
+      stmt: `ALTER TABLE job_add_ons ADD COLUMN IF NOT EXISTS pricing_addon_id INTEGER` },
+
+    // Recurring schedule — fields that AG can cascade. Backfill is
+    // intentionally not done; existing schedules stay null until edited.
+    { label: "recurring_schedules.scheduled_time",
+      stmt: `ALTER TABLE recurring_schedules ADD COLUMN IF NOT EXISTS scheduled_time TIME` },
+    { label: "recurring_schedules.instructions",
+      stmt: `ALTER TABLE recurring_schedules ADD COLUMN IF NOT EXISTS instructions TEXT` },
+    { label: "recurring_schedules.manual_rate_override",
+      stmt: `ALTER TABLE recurring_schedules ADD COLUMN IF NOT EXISTS manual_rate_override BOOLEAN NOT NULL DEFAULT false` },
+    { label: "recurring_schedules.custom_frequency_weeks",
+      stmt: `ALTER TABLE recurring_schedules ADD COLUMN IF NOT EXISTS custom_frequency_weeks INTEGER` },
+
+    // Recurring add-ons junction — parent template for what spawns onto
+    // each child job.
+    { label: "CREATE recurring_schedule_add_ons", stmt: `
+      CREATE TABLE IF NOT EXISTS recurring_schedule_add_ons (
+        id                     SERIAL PRIMARY KEY,
+        recurring_schedule_id  INTEGER NOT NULL REFERENCES recurring_schedules(id) ON DELETE CASCADE,
+        pricing_addon_id       INTEGER NOT NULL,
+        qty                    NUMERIC(6,2) NOT NULL DEFAULT 1,
+        created_at             TIMESTAMP NOT NULL DEFAULT NOW()
+      )
+    ` },
+    { label: "idx_rs_addons_schedule",
+      stmt: `CREATE INDEX IF NOT EXISTS idx_rs_addons_schedule ON recurring_schedule_add_ons(recurring_schedule_id)` },
+
+    // Recurring techs junction — multi-tech default for spawned jobs.
+    { label: "CREATE recurring_schedule_technicians", stmt: `
+      CREATE TABLE IF NOT EXISTS recurring_schedule_technicians (
+        id                     SERIAL PRIMARY KEY,
+        recurring_schedule_id  INTEGER NOT NULL REFERENCES recurring_schedules(id) ON DELETE CASCADE,
+        user_id                INTEGER NOT NULL REFERENCES users(id),
+        is_primary             BOOLEAN NOT NULL DEFAULT false,
+        created_at             TIMESTAMP NOT NULL DEFAULT NOW(),
+        UNIQUE (recurring_schedule_id, user_id)
+      )
+    ` },
+    { label: "idx_rs_techs_schedule",
+      stmt: `CREATE INDEX IF NOT EXISTS idx_rs_techs_schedule ON recurring_schedule_technicians(recurring_schedule_id)` },
+
+    // Job audit log — per-field diffs for the edit modal.
+    { label: "CREATE job_audit_log", stmt: `
+      CREATE TABLE IF NOT EXISTS job_audit_log (
+        id             SERIAL PRIMARY KEY,
+        job_id         INTEGER NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
+        company_id     INTEGER NOT NULL,
+        user_id        INTEGER NOT NULL REFERENCES users(id),
+        user_name      TEXT NOT NULL,
+        user_email     TEXT NOT NULL,
+        field_name     TEXT NOT NULL,
+        old_value      JSONB,
+        new_value      JSONB,
+        cascade_scope  TEXT,
+        schedule_id    INTEGER,
+        edited_at      TIMESTAMP NOT NULL DEFAULT NOW()
+      )
+    ` },
+    { label: "idx_job_audit_log_job_id",
+      stmt: `CREATE INDEX IF NOT EXISTS idx_job_audit_log_job_id ON job_audit_log(job_id)` },
+    { label: "idx_job_audit_log_user_id",
+      stmt: `CREATE INDEX IF NOT EXISTS idx_job_audit_log_user_id ON job_audit_log(user_id)` },
+    { label: "idx_job_audit_log_edited_at",
+      stmt: `CREATE INDEX IF NOT EXISTS idx_job_audit_log_edited_at ON job_audit_log(edited_at DESC)` },
   ];
 
   for (const { label, stmt } of guards) {

--- a/artifacts/api-server/src/routes/jobs.ts
+++ b/artifacts/api-server/src/routes/jobs.ts
@@ -681,6 +681,399 @@ router.put("/:id", requireAuth, async (req, res) => {
   }
 });
 
+// [AG] PATCH /api/jobs/:id — focused job edit modal endpoint.
+//
+// Distinct from PUT (above) which is bare-bones and used by drag-and-drop /
+// quick reschedule flows. This handler:
+//   - Diffs each editable field and writes per-field rows into job_audit_log
+//   - Honors a cascade flag ('this_job' | 'this_and_future') for recurring jobs
+//   - Blocks edits to date/time/team when a tech is currently clocked in
+//   - Persists multi-tech assignments via job_technicians (replaces existing)
+//   - Persists add-ons via job_add_ons (replaces existing) with pricing_addon_id
+//   - Trusts the client-computed base_fee; client owns manual_rate_override flag
+//
+// 409 Conflict when status in (complete, cancelled) OR locked_at is non-null.
+router.patch("/:id", requireAuth, async (req, res) => {
+  try {
+    const jobId = parseInt(req.params.id);
+    const companyId = req.auth!.companyId!;
+    const userId = req.auth!.userId!;
+    if (!Number.isFinite(jobId)) return res.status(400).json({ error: "Invalid job id" });
+
+    const {
+      service_type,
+      frequency,
+      scheduled_date,
+      scheduled_time,
+      allowed_hours,
+      base_fee,
+      manual_rate_override,
+      add_ons,
+      team_user_ids,
+      instructions,
+      cascade_scope,
+    } = req.body ?? {};
+
+    if (cascade_scope !== "this_job" && cascade_scope !== "this_and_future") {
+      return res.status(400).json({ error: "cascade_scope must be 'this_job' or 'this_and_future'" });
+    }
+
+    // ── Pull current job + actor identity ──────────────────────────────────
+    const jobRows = await db.execute(sql`
+      SELECT id, company_id, recurring_schedule_id, status, locked_at,
+             service_type, frequency, scheduled_date, scheduled_time,
+             allowed_hours, base_fee, manual_rate_override, notes,
+             assigned_user_id
+      FROM jobs WHERE id = ${jobId} AND company_id = ${companyId} LIMIT 1
+    `);
+    if (!jobRows.rows.length) return res.status(404).json({ error: "Job not found" });
+    const before = jobRows.rows[0] as Record<string, unknown>;
+
+    if (before.status === "complete" || before.status === "cancelled" || before.locked_at != null) {
+      return res.status(409).json({
+        error: "Job is locked",
+        message: "Completed, cancelled, or locked jobs cannot be edited.",
+      });
+    }
+
+    if (cascade_scope === "this_and_future" && before.recurring_schedule_id == null) {
+      return res.status(400).json({
+        error: "Cannot cascade",
+        message: "This job is not part of a recurring schedule. Use cascade_scope='this_job'.",
+      });
+    }
+
+    // ── In-progress guard: open timeclock blocks date/time/team edits ──────
+    const tcRows = await db.execute(sql`
+      SELECT user_id FROM timeclock
+      WHERE job_id = ${jobId} AND clock_out_at IS NULL
+      LIMIT 1
+    `);
+    const isClockedIn = tcRows.rows.length > 0;
+    if (isClockedIn) {
+      const blockedFields: string[] = [];
+      if (scheduled_date !== undefined && scheduled_date !== before.scheduled_date) blockedFields.push("scheduled_date");
+      if (scheduled_time !== undefined && scheduled_time !== before.scheduled_time) blockedFields.push("scheduled_time");
+      if (team_user_ids !== undefined) blockedFields.push("team_user_ids");
+      if (blockedFields.length) {
+        return res.status(409).json({
+          error: "Tech clocked in",
+          message: "A technician is currently clocked in. Stop the timer before changing date, time, or team.",
+          blocked_fields: blockedFields,
+        });
+      }
+    }
+
+    // ── Lookup actor (user_name + email at time of edit, for audit snapshot) ─
+    const userRows = await db.execute(sql`
+      SELECT first_name, last_name, email FROM users WHERE id = ${userId} LIMIT 1
+    `);
+    const actor = (userRows.rows[0] as Record<string, unknown>) ?? {};
+    const actorName = `${actor.first_name ?? ""} ${actor.last_name ?? ""}`.trim() || "Unknown";
+    const actorEmail = String(actor.email ?? "");
+
+    // ── Build per-field change set (only fields actually present in body) ──
+    type FieldName =
+      | "service_type" | "frequency" | "scheduled_date" | "scheduled_time"
+      | "allowed_hours" | "base_fee" | "manual_rate_override" | "instructions"
+      | "add_ons" | "team_user_ids";
+    const changes: Array<{ field: FieldName; old: unknown; next: unknown }> = [];
+    const pushChange = (field: FieldName, next: unknown, prev: unknown) => {
+      const norm = (v: unknown) => v === null || v === undefined ? null : v;
+      if (JSON.stringify(norm(next)) !== JSON.stringify(norm(prev))) {
+        changes.push({ field, old: prev ?? null, next: next ?? null });
+      }
+    };
+
+    if (service_type !== undefined) pushChange("service_type", service_type, before.service_type);
+    if (frequency !== undefined) pushChange("frequency", frequency, before.frequency);
+    if (scheduled_date !== undefined) pushChange("scheduled_date", scheduled_date, before.scheduled_date);
+    if (scheduled_time !== undefined) pushChange("scheduled_time", scheduled_time, before.scheduled_time);
+    if (allowed_hours !== undefined) pushChange("allowed_hours", String(allowed_hours), String(before.allowed_hours ?? ""));
+    if (base_fee !== undefined) pushChange("base_fee", String(base_fee), String(before.base_fee ?? ""));
+    if (manual_rate_override !== undefined) pushChange("manual_rate_override", !!manual_rate_override, !!before.manual_rate_override);
+    if (instructions !== undefined) pushChange("instructions", instructions, before.notes);
+
+    // For add_ons + team_user_ids we always emit an audit row when payload is present,
+    // since per-row diff is verbose; the JSON payload carries the full new value.
+    let addOnsProvided = false;
+    let teamProvided = false;
+    if (Array.isArray(add_ons)) {
+      addOnsProvided = true;
+      pushChange("add_ons", add_ons, "[unknown — see job_add_ons history]");
+    }
+    if (Array.isArray(team_user_ids)) {
+      if (team_user_ids.length === 0) {
+        return res.status(400).json({ error: "team_user_ids must include at least one user" });
+      }
+      teamProvided = true;
+      pushChange("team_user_ids", team_user_ids, "[unknown — see job_technicians history]");
+    }
+
+    if (changes.length === 0) {
+      return res.status(200).json({ ok: true, changed: false, message: "No changes detected" });
+    }
+
+    // ── manual_rate_override semantics ─────────────────────────────────────
+    // Honor explicit flag from client. If client omitted it but sent a base_fee,
+    // assume manual override. If client changed scope/freq/addons/hours but sent
+    // no base_fee, clear the override flag (caller has accepted recalc-driven price).
+    let nextManualOverride: boolean | undefined = undefined;
+    if (manual_rate_override !== undefined) {
+      nextManualOverride = !!manual_rate_override;
+    } else if (base_fee !== undefined) {
+      nextManualOverride = true;
+    } else if (
+      service_type !== undefined || frequency !== undefined ||
+      addOnsProvided || allowed_hours !== undefined
+    ) {
+      nextManualOverride = false;
+    }
+
+    // ── Apply changes in a transaction ─────────────────────────────────────
+    await db.transaction(async (tx) => {
+      // Update the jobs row itself.
+      const setParts: any = {};
+      if (service_type !== undefined) setParts.service_type = service_type;
+      if (frequency !== undefined) setParts.frequency = frequency;
+      if (scheduled_date !== undefined) setParts.scheduled_date = scheduled_date;
+      if (scheduled_time !== undefined) setParts.scheduled_time = scheduled_time;
+      if (allowed_hours !== undefined) setParts.allowed_hours = String(allowed_hours);
+      if (base_fee !== undefined) setParts.base_fee = String(base_fee);
+      if (nextManualOverride !== undefined) setParts.manual_rate_override = nextManualOverride;
+      if (instructions !== undefined) setParts.notes = instructions;
+
+      if (Object.keys(setParts).length > 0) {
+        await tx.update(jobsTable).set(setParts).where(and(
+          eq(jobsTable.id, jobId),
+          eq(jobsTable.company_id, companyId),
+        ));
+      }
+
+      // Replace job_technicians if team_user_ids provided. First user = primary.
+      if (teamProvided && Array.isArray(team_user_ids)) {
+        await tx.execute(sql`DELETE FROM job_technicians WHERE job_id = ${jobId}`);
+        for (let i = 0; i < team_user_ids.length; i++) {
+          const uid = team_user_ids[i];
+          const isPrimary = i === 0;
+          await tx.execute(sql`
+            INSERT INTO job_technicians (job_id, user_id, company_id, is_primary)
+            VALUES (${jobId}, ${uid}, ${companyId}, ${isPrimary})
+            ON CONFLICT (job_id, user_id) DO UPDATE SET is_primary = EXCLUDED.is_primary
+          `);
+        }
+        // Mirror the primary onto jobs.assigned_user_id so the dispatch grid
+        // (which reads assigned_user_id, not job_technicians) shows the new
+        // tech immediately. Fixes the Jaira-Estrada split-brain we saw.
+        await tx.update(jobsTable).set({ assigned_user_id: team_user_ids[0] }).where(and(
+          eq(jobsTable.id, jobId),
+          eq(jobsTable.company_id, companyId),
+        ));
+      }
+
+      // Replace job_add_ons if add_ons provided.
+      if (addOnsProvided && Array.isArray(add_ons)) {
+        await tx.execute(sql`DELETE FROM job_add_ons WHERE job_id = ${jobId}`);
+        for (const a of add_ons as Array<{ pricing_addon_id?: number; add_on_id?: number; qty?: number; unit_price?: number; subtotal?: number }>) {
+          const pricingId = Number(a.pricing_addon_id ?? 0) || null;
+          const addOnId = Number(a.add_on_id ?? 0);
+          const qty = Number(a.qty ?? 1) || 1;
+          const unitPrice = a.unit_price != null ? String(a.unit_price) : "0";
+          const subtotal = a.subtotal != null ? String(a.subtotal) : "0";
+          if (!addOnId) continue;
+          await tx.execute(sql`
+            INSERT INTO job_add_ons (job_id, add_on_id, quantity, unit_price, subtotal, pricing_addon_id)
+            VALUES (${jobId}, ${addOnId}, ${qty}, ${unitPrice}, ${subtotal}, ${pricingId})
+            ON CONFLICT (job_id, add_on_id) DO UPDATE
+              SET quantity = EXCLUDED.quantity,
+                  unit_price = EXCLUDED.unit_price,
+                  subtotal = EXCLUDED.subtotal,
+                  pricing_addon_id = EXCLUDED.pricing_addon_id
+          `);
+        }
+      }
+
+      // ── Cascade: this_and_future ─────────────────────────────────────────
+      let futureCount = 0;
+      let futureClockedSkipped = 0;
+      if (cascade_scope === "this_and_future" && before.recurring_schedule_id != null) {
+        const scheduleId = Number(before.recurring_schedule_id);
+
+        // Update the parent recurring_schedules row with the cascadable fields.
+        const rsSet: string[] = [];
+        const rsVals: any[] = [];
+        const push = (col: string, val: any) => { rsSet.push(col); rsVals.push(val); };
+        if (service_type !== undefined) push("service_type", service_type);
+        if (scheduled_time !== undefined) push("scheduled_time", scheduled_time);
+        if (allowed_hours !== undefined) push("duration_minutes", Math.round(parseFloat(String(allowed_hours)) * 60));
+        if (base_fee !== undefined) push("base_fee", String(base_fee));
+        if (instructions !== undefined) push("instructions", instructions);
+        if (nextManualOverride !== undefined) push("manual_rate_override", nextManualOverride);
+        // Map jobs.frequency to recurring_schedules.frequency. 'every_3_weeks'
+        // and 'on_demand' have no direct enum value; we fall back to 'custom'
+        // and write the cadence into custom_frequency_weeks.
+        if (frequency !== undefined) {
+          const map: Record<string, { f: string; weeks: number | null }> = {
+            weekly: { f: "weekly", weeks: 1 },
+            biweekly: { f: "biweekly", weeks: 2 },
+            every_3_weeks: { f: "custom", weeks: 3 },
+            monthly: { f: "monthly", weeks: 4 },
+            on_demand: { f: "custom", weeks: null },
+          };
+          const m = map[String(frequency)] ?? { f: "custom", weeks: null };
+          push("frequency", m.f);
+          push("custom_frequency_weeks", m.weeks);
+        }
+
+        if (rsSet.length > 0) {
+          // Build a parameterised UPDATE … SET col = $n
+          const setClauses = rsSet.map((c, i) => sql`${sql.identifier(c)} = ${rsVals[i]}`);
+          const setSql = sql.join(setClauses, sql`, `);
+          await tx.execute(sql`UPDATE recurring_schedules SET ${setSql} WHERE id = ${scheduleId} AND company_id = ${companyId}`);
+        }
+
+        // UPDATE all future scheduled jobs (excluding any in-progress).
+        const futureJobsSet: string[] = [];
+        const futureJobsVals: any[] = [];
+        const pushFj = (col: string, val: any) => { futureJobsSet.push(col); futureJobsVals.push(val); };
+        if (service_type !== undefined) pushFj("service_type", service_type);
+        if (frequency !== undefined) pushFj("frequency", frequency);
+        if (scheduled_time !== undefined) pushFj("scheduled_time", scheduled_time);
+        if (allowed_hours !== undefined) pushFj("allowed_hours", String(allowed_hours));
+        if (base_fee !== undefined) pushFj("base_fee", String(base_fee));
+        if (instructions !== undefined) pushFj("notes", instructions);
+        if (nextManualOverride !== undefined) pushFj("manual_rate_override", nextManualOverride);
+
+        if (futureJobsSet.length > 0) {
+          // Find candidate future job ids first, exclude any currently clocked-in.
+          const candidates = await tx.execute(sql`
+            SELECT j.id FROM jobs j
+            WHERE j.recurring_schedule_id = ${scheduleId}
+              AND j.company_id = ${companyId}
+              AND j.scheduled_date > CURRENT_DATE
+              AND j.status = 'scheduled'
+          `);
+          const candIds = (candidates.rows as Array<{ id: number }>).map(r => Number(r.id));
+          const clockedRows = candIds.length === 0 ? { rows: [] as any[] } : await tx.execute(sql`
+            SELECT DISTINCT job_id FROM timeclock
+            WHERE clock_out_at IS NULL AND job_id = ANY(${candIds}::int[])
+          `);
+          const clockedSet = new Set((clockedRows.rows as Array<{ job_id: number }>).map(r => Number(r.job_id)));
+          const applyIds = candIds.filter(id => !clockedSet.has(id));
+          futureClockedSkipped = candIds.length - applyIds.length;
+
+          if (applyIds.length > 0) {
+            const setClauses = futureJobsSet.map((c, i) => sql`${sql.identifier(c)} = ${futureJobsVals[i]}`);
+            const setSql = sql.join(setClauses, sql`, `);
+            const updRes = await tx.execute(sql`
+              UPDATE jobs SET ${setSql}
+              WHERE id = ANY(${applyIds}::int[])
+            `);
+            futureCount = (updRes as any).rowCount ?? applyIds.length;
+          }
+        }
+
+        // Replace recurring_schedule_add_ons + recurring_schedule_technicians.
+        if (addOnsProvided && Array.isArray(add_ons)) {
+          await tx.execute(sql`DELETE FROM recurring_schedule_add_ons WHERE recurring_schedule_id = ${scheduleId}`);
+          for (const a of add_ons as Array<{ pricing_addon_id?: number; qty?: number }>) {
+            const pricingId = Number(a.pricing_addon_id ?? 0);
+            const qty = Number(a.qty ?? 1) || 1;
+            if (!pricingId) continue;
+            await tx.execute(sql`
+              INSERT INTO recurring_schedule_add_ons (recurring_schedule_id, pricing_addon_id, qty)
+              VALUES (${scheduleId}, ${pricingId}, ${qty})
+            `);
+          }
+        }
+        if (teamProvided && Array.isArray(team_user_ids)) {
+          await tx.execute(sql`DELETE FROM recurring_schedule_technicians WHERE recurring_schedule_id = ${scheduleId}`);
+          for (let i = 0; i < team_user_ids.length; i++) {
+            const uid = team_user_ids[i];
+            const isPrimary = i === 0;
+            await tx.execute(sql`
+              INSERT INTO recurring_schedule_technicians (recurring_schedule_id, user_id, is_primary)
+              VALUES (${scheduleId}, ${uid}, ${isPrimary})
+              ON CONFLICT (recurring_schedule_id, user_id) DO UPDATE SET is_primary = EXCLUDED.is_primary
+            `);
+          }
+          // Mirror primary onto recurring_schedules.assigned_employee_id so the
+          // existing recurring engine (which still reads the single column) sees
+          // the new owner.
+          await tx.execute(sql`
+            UPDATE recurring_schedules SET assigned_employee_id = ${team_user_ids[0]}
+            WHERE id = ${scheduleId} AND company_id = ${companyId}
+          `);
+        }
+
+        // Single summary audit row for the cascade. new_value carries the full
+        // payload; field_name='cascade_summary'.
+        const summary = {
+          changed_fields: changes.map(c => c.field),
+          values: Object.fromEntries(changes.map(c => [c.field, c.next])),
+          future_jobs_updated: futureCount,
+          future_jobs_skipped_in_progress: futureClockedSkipped,
+        };
+        await tx.execute(sql`
+          INSERT INTO job_audit_log
+            (job_id, company_id, user_id, user_name, user_email,
+             field_name, old_value, new_value, cascade_scope, schedule_id)
+          VALUES
+            (${jobId}, ${companyId}, ${userId}, ${actorName}, ${actorEmail},
+             'cascade_summary',
+             ${null}::jsonb,
+             ${JSON.stringify(summary)}::jsonb,
+             'this_and_future', ${scheduleId})
+        `);
+      }
+
+      // Per-field audit rows (always written, regardless of cascade).
+      for (const c of changes) {
+        await tx.execute(sql`
+          INSERT INTO job_audit_log
+            (job_id, company_id, user_id, user_name, user_email,
+             field_name, old_value, new_value, cascade_scope, schedule_id)
+          VALUES
+            (${jobId}, ${companyId}, ${userId}, ${actorName}, ${actorEmail},
+             ${c.field},
+             ${JSON.stringify(c.old)}::jsonb,
+             ${JSON.stringify(c.next)}::jsonb,
+             ${cascade_scope},
+             ${cascade_scope === "this_and_future" ? Number(before.recurring_schedule_id) : null})
+        `);
+      }
+
+      // Stash counters for the response (read after commit via closure).
+      (req as any)._agFutureCount = futureCount;
+      (req as any)._agFutureSkipped = futureClockedSkipped;
+    });
+
+    // ── Build response ────────────────────────────────────────────────────
+    const updatedRows = await db.execute(sql`
+      SELECT id, status, service_type, frequency, scheduled_date, scheduled_time,
+             allowed_hours, base_fee, manual_rate_override, notes, assigned_user_id,
+             recurring_schedule_id
+      FROM jobs WHERE id = ${jobId} AND company_id = ${companyId} LIMIT 1
+    `);
+    const updated = updatedRows.rows[0];
+
+    return res.json({
+      ok: true,
+      changed: true,
+      job: updated,
+      diff: changes.map(c => ({ field: c.field, old: c.old, new: c.next })),
+      cascade: {
+        scope: cascade_scope,
+        future_jobs_updated: (req as any)._agFutureCount ?? 0,
+        future_jobs_skipped_in_progress: (req as any)._agFutureSkipped ?? 0,
+      },
+    });
+  } catch (err) {
+    console.error("PATCH /jobs/:id error:", err);
+    return res.status(500).json({ error: "Internal Server Error", message: "Failed to edit job" });
+  }
+});
+
 router.delete("/:id", requireAuth, async (req, res) => {
   try {
     const jobId = parseInt(req.params.id);

--- a/artifacts/qleno/src/components/edit-job-modal.tsx
+++ b/artifacts/qleno/src/components/edit-job-modal.tsx
@@ -1,0 +1,649 @@
+// [AG] Focused job edit modal — accessed from JobPanel drawer's action footer.
+// Sections: Service · Schedule · Team · Add-ons · Pricing · Instructions
+// Cascade prompt shown when job has recurring_schedule_id.
+//
+// Pricing approach: tenant's pricing_scopes is a dropdown (decision 1c).
+// Modal calls POST /api/pricing/calculate as inputs change. base_fee is the
+// only persisted pricing value; manual_rate_override flips when user types
+// a custom rate.
+import { useEffect, useMemo, useRef, useState } from "react";
+import { X, AlertTriangle, Loader2 } from "lucide-react";
+import { useAuthStore } from "@/store/auth";
+import { useToast } from "@/hooks/use-toast";
+
+const FF = "'Plus Jakarta Sans', sans-serif";
+
+// Mirrors the DispatchJob shape from jobs.tsx — only the fields the modal
+// reads. Kept loose-typed so we don't have to cross-import.
+export interface EditableJob {
+  id: number;
+  client_id: number;
+  client_name: string;
+  recurring_schedule_id?: number | null;
+  service_type: string;
+  frequency: string;
+  scheduled_date: string;
+  scheduled_time: string | null;
+  duration_minutes: number;
+  amount: number;
+  base_fee?: number | string | null;
+  notes: string | null;
+  status: string;
+  locked_at?: string | null;
+  assigned_user_id: number | null;
+}
+
+export interface TeamCandidate {
+  id: number;
+  name: string;
+  role?: string;
+  is_primary?: boolean;
+}
+
+interface PricingScope {
+  id: number;
+  name: string;
+  scope_group: string;
+  pricing_method: string;
+  hourly_rate: string | number;
+}
+
+interface PricingAddon {
+  id: number;
+  name: string;
+  price: string | number;
+  price_type: string;
+  time_add_minutes?: number;
+}
+
+interface CalcResponse {
+  base_price: number;
+  addons_total: number;
+  bundle_discount: number;
+  bundle_breakdown?: { name: string; discount: number }[];
+  addon_breakdown?: { id: number; name: string; amount: number; price_type: string }[];
+  total_hours: number;
+  hourly_rate: number;
+  subtotal: number;
+  final_total: number;
+}
+
+const FREQUENCIES: Array<{ value: string; label: string }> = [
+  { value: "on_demand", label: "One-time" },
+  { value: "weekly", label: "Weekly" },
+  { value: "biweekly", label: "Biweekly" },
+  { value: "every_3_weeks", label: "Every 3 weeks" },
+  { value: "monthly", label: "Every 4 weeks / Monthly" },
+];
+
+const SECTION: React.CSSProperties = {
+  margin: "14px 20px 0",
+  backgroundColor: "#FFFFFF",
+  borderRadius: 12,
+  border: "1px solid #E5E2DC",
+  padding: "14px 16px",
+};
+const LABEL: React.CSSProperties = {
+  fontSize: 10, fontWeight: 700, color: "#9E9B94",
+  textTransform: "uppercase", letterSpacing: "0.07em",
+  display: "block", marginBottom: 10,
+};
+const INPUT: React.CSSProperties = {
+  width: "100%", height: 40, padding: "0 12px",
+  border: "1px solid #E5E2DC", borderRadius: 8,
+  fontSize: 14, outline: "none", boxSizing: "border-box",
+  fontFamily: FF, backgroundColor: "#F7F6F3", color: "#1A1917",
+};
+
+export default function EditJobModal({
+  job, employees, mobile, onClose, onSaved,
+}: {
+  job: EditableJob;
+  employees: TeamCandidate[];
+  mobile: boolean;
+  onClose: () => void;
+  onSaved: (info: { future_jobs_updated: number; future_jobs_skipped_in_progress: number }) => void;
+}) {
+  const token = useAuthStore(s => s.token)!;
+  const { toast } = useToast();
+  const API = import.meta.env.BASE_URL.replace(/\/$/, "");
+  const isRecurring = job.recurring_schedule_id != null;
+
+  // ── Initial values (snapshot from the loaded job) ──────────────────────
+  const initialBaseFee = useMemo(
+    () => Number(job.base_fee ?? job.amount ?? 0),
+    [job.base_fee, job.amount],
+  );
+  const initialAllowedHours = useMemo(
+    () => Math.max(0.25, Math.round((job.duration_minutes / 60) * 100) / 100),
+    [job.duration_minutes],
+  );
+
+  // ── Form state ─────────────────────────────────────────────────────────
+  const [scopeId, setScopeId] = useState<number | null>(null);
+  const [scopes, setScopes] = useState<PricingScope[]>([]);
+  const [scopesLoading, setScopesLoading] = useState(true);
+
+  const [frequency, setFrequency] = useState(job.frequency || "on_demand");
+  const [scheduledDate, setScheduledDate] = useState(job.scheduled_date);
+  const [scheduledTime, setScheduledTime] = useState(job.scheduled_time || "09:00");
+  const [allowedHours, setAllowedHours] = useState<number>(initialAllowedHours);
+  const [instructions, setInstructions] = useState(job.notes || "");
+
+  const [selectedTechIds, setSelectedTechIds] = useState<number[]>(
+    job.assigned_user_id != null ? [job.assigned_user_id] : []
+  );
+
+  const [availableAddons, setAvailableAddons] = useState<PricingAddon[]>([]);
+  const [addonsLoading, setAddonsLoading] = useState(false);
+  const [selectedAddons, setSelectedAddons] = useState<Map<number, number>>(new Map());
+
+  const [baseFee, setBaseFee] = useState<number>(initialBaseFee);
+  const [manualRate, setManualRate] = useState(false);
+  const [manualOpen, setManualOpen] = useState(false);
+  const [manualValue, setManualValue] = useState<string>(String(initialBaseFee));
+
+  const [calcResult, setCalcResult] = useState<CalcResponse | null>(null);
+  const [calcBusy, setCalcBusy] = useState(false);
+  const [calcError, setCalcError] = useState<string>("");
+
+  // Cascade prompt state
+  const [cascadePromptOpen, setCascadePromptOpen] = useState(false);
+  const [cascadeChoice, setCascadeChoice] = useState<"this_job" | "this_and_future">("this_job");
+
+  const [saving, setSaving] = useState(false);
+
+  // ── Load scopes once ────────────────────────────────────────────────────
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const r = await fetch(`${API}/api/pricing/scopes`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        const d = await r.json();
+        const list: PricingScope[] = Array.isArray(d) ? d : (d.data ?? []);
+        if (cancelled) return;
+        setScopes(list);
+        // Best-effort match on name to current job.service_type label
+        const guess = list.find(s =>
+          s.name.toLowerCase().replace(/[^a-z0-9]+/g, "_").includes(job.service_type)
+          || job.service_type.includes(s.name.toLowerCase().replace(/[^a-z0-9]+/g, "_"))
+        );
+        if (guess) setScopeId(guess.id);
+        else if (list[0]) setScopeId(list[0].id);
+      } catch {
+        if (!cancelled) toast({ title: "Could not load pricing scopes", variant: "destructive" });
+      } finally {
+        if (!cancelled) setScopesLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [API, token, job.service_type, toast]);
+
+  // ── Load addons whenever scope changes ─────────────────────────────────
+  useEffect(() => {
+    if (scopeId == null) return;
+    let cancelled = false;
+    setAddonsLoading(true);
+    (async () => {
+      try {
+        const r = await fetch(`${API}/api/pricing/scopes/${scopeId}/addons`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        const d = await r.json();
+        const rows: PricingAddon[] = Array.isArray(d) ? d : (d.data ?? d.rows ?? []);
+        if (!cancelled) setAvailableAddons(rows);
+      } catch {
+        if (!cancelled) setAvailableAddons([]);
+      } finally {
+        if (!cancelled) setAddonsLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [API, token, scopeId]);
+
+  // ── Recalc on input changes (debounced) ─────────────────────────────────
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    if (manualRate) return; // honor manual override; no recalc
+    if (scopeId == null) return;
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(async () => {
+      setCalcBusy(true);
+      setCalcError("");
+      try {
+        const r = await fetch(`${API}/api/pricing/calculate`, {
+          method: "POST",
+          headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+          body: JSON.stringify({
+            scope_id: scopeId,
+            hours: allowedHours,
+            frequency,
+            addon_ids: Array.from(selectedAddons.keys()),
+            addon_quantities: Object.fromEntries(
+              Array.from(selectedAddons.entries()).map(([k, v]) => [String(k), v])
+            ),
+          }),
+        });
+        const d = await r.json();
+        if (!r.ok) throw new Error(d.error || "Calc failed");
+        setCalcResult(d);
+        setBaseFee(Number(d.final_total ?? d.subtotal ?? 0));
+      } catch (err: any) {
+        setCalcError(err.message || "Could not calculate price");
+      } finally {
+        setCalcBusy(false);
+      }
+    }, 250);
+    return () => { if (debounceRef.current) clearTimeout(debounceRef.current); };
+  }, [API, token, scopeId, allowedHours, frequency, selectedAddons, manualRate]);
+
+  // ── Validation / dirty check ────────────────────────────────────────────
+  const dirty = useMemo(() => {
+    if (frequency !== job.frequency) return true;
+    if (scheduledDate !== job.scheduled_date) return true;
+    if ((job.scheduled_time || "09:00") !== scheduledTime) return true;
+    if (Math.abs(allowedHours - initialAllowedHours) > 0.001) return true;
+    if (Math.abs(baseFee - initialBaseFee) > 0.01) return true;
+    if ((job.notes || "") !== instructions) return true;
+    if (manualRate) return true;
+    if (selectedAddons.size > 0) return true;
+    if (job.assigned_user_id != null && (selectedTechIds[0] !== job.assigned_user_id || selectedTechIds.length !== 1)) return true;
+    if (job.assigned_user_id == null && selectedTechIds.length > 0) return true;
+    return false;
+  }, [frequency, scheduledDate, scheduledTime, allowedHours, baseFee, instructions, manualRate, selectedAddons, selectedTechIds, job, initialAllowedHours, initialBaseFee]);
+
+  const canSave = dirty
+    && !saving
+    && allowedHours > 0
+    && selectedTechIds.length > 0
+    && /^\d{2}:\d{2}$/.test(scheduledTime);
+
+  // ── Cascade prompt or direct submit ─────────────────────────────────────
+  function onSaveClick() {
+    if (!canSave) return;
+    if (isRecurring) {
+      setCascadeChoice("this_job");
+      setCascadePromptOpen(true);
+      return;
+    }
+    submit("this_job");
+  }
+
+  async function submit(cascade: "this_job" | "this_and_future") {
+    setSaving(true);
+    try {
+      // Build add-ons payload. We persist into job_add_ons via add_on_id (legacy
+      // FK), but also pass pricing_addon_id for traceability per AG.
+      // For now the simplest approach: write add_on_id = pricing_addon_id (DB
+      // permits this since pricing_addons rows have similar shape). A future
+      // pass can map distinct addon catalogs.
+      const addOnsPayload = Array.from(selectedAddons.entries()).map(([pricingAddonId, qty]) => {
+        const detail = calcResult?.addon_breakdown?.find(x => x.id === pricingAddonId);
+        return {
+          add_on_id: pricingAddonId,
+          pricing_addon_id: pricingAddonId,
+          qty,
+          unit_price: detail ? Math.round((detail.amount / qty) * 100) / 100 : 0,
+          subtotal: detail ? detail.amount : 0,
+        };
+      });
+
+      const payload = {
+        // Note: service_type omitted — we don't have a clean enum mapping from
+        // the pricing_scopes.id back to jobs.service_type enum yet (decision 1c
+        // says no persist of scope_id). Frequency and other fields cascade.
+        frequency,
+        scheduled_date: scheduledDate,
+        scheduled_time: scheduledTime,
+        allowed_hours: allowedHours,
+        base_fee: baseFee,
+        manual_rate_override: manualRate,
+        add_ons: addOnsPayload,
+        team_user_ids: selectedTechIds,
+        instructions,
+        cascade_scope: cascade,
+      };
+
+      const r = await fetch(`${API}/api/jobs/${job.id}`, {
+        method: "PATCH",
+        headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const d = await r.json();
+      if (!r.ok) {
+        if (r.status === 409) {
+          toast({ title: "Cannot edit", description: d.message || "Job is locked or a tech is clocked in.", variant: "destructive" });
+        } else {
+          toast({ title: "Save failed", description: d.message || d.error || "Try again", variant: "destructive" });
+        }
+        return;
+      }
+      onSaved({
+        future_jobs_updated: d.cascade?.future_jobs_updated ?? 0,
+        future_jobs_skipped_in_progress: d.cascade?.future_jobs_skipped_in_progress ?? 0,
+      });
+    } catch {
+      toast({ title: "Network error", description: "Could not save changes", variant: "destructive" });
+    } finally {
+      setSaving(false);
+      setCascadePromptOpen(false);
+    }
+  }
+
+  // ── Render ─────────────────────────────────────────────────────────────
+  const overlay: React.CSSProperties = {
+    position: "fixed", inset: 0, backgroundColor: "rgba(0,0,0,0.5)", zIndex: 399,
+  };
+  const shell: React.CSSProperties = mobile
+    ? {
+        position: "fixed", bottom: 0, left: 0, right: 0, zIndex: 400,
+        backgroundColor: "#F7F6F3", borderRadius: "16px 16px 0 0",
+        maxHeight: "92vh", display: "flex", flexDirection: "column", fontFamily: FF,
+      }
+    : {
+        position: "fixed", top: "50%", left: "50%", transform: "translate(-50%, -50%)",
+        zIndex: 400, backgroundColor: "#F7F6F3", borderRadius: 16,
+        width: "100%", maxWidth: 680, maxHeight: "92vh",
+        display: "flex", flexDirection: "column",
+        boxShadow: "0 24px 64px rgba(0,0,0,0.25)", fontFamily: FF,
+      };
+
+  return (
+    <>
+      <div style={overlay} onClick={() => !saving && onClose()} />
+      <div style={shell}>
+        {/* Header */}
+        <div style={{
+          display: "flex", alignItems: "center", justifyContent: "space-between",
+          padding: "18px 20px 16px", backgroundColor: "#FFFFFF",
+          borderRadius: "16px 16px 0 0", borderBottom: "1px solid #E5E2DC", flexShrink: 0,
+        }}>
+          <div>
+            <span style={{ fontSize: 16, fontWeight: 700, color: "#1A1917" }}>Edit Job</span>
+            <div style={{ fontSize: 12, color: "#6B6860", marginTop: 2 }}>{job.client_name}</div>
+          </div>
+          <button onClick={onClose} disabled={saving}
+            style={{ background: "none", border: "none", cursor: saving ? "wait" : "pointer", padding: 6, display: "flex", alignItems: "center" }}>
+            <X size={18} color="#6B6860" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div style={{ overflowY: "auto", flex: 1, padding: "0 0 8px" }}>
+          {/* Section 1 — Service */}
+          <div style={SECTION}>
+            <span style={LABEL}>Service</span>
+            <div style={{ display: "grid", gridTemplateColumns: mobile ? "1fr" : "1fr 1fr", gap: 10 }}>
+              <div>
+                <span style={{ fontSize: 12, color: "#6B6860", display: "block", marginBottom: 4 }}>Scope</span>
+                <select value={scopeId ?? ""} onChange={e => setScopeId(parseInt(e.target.value))}
+                  style={INPUT} disabled={scopesLoading}>
+                  {scopesLoading ? <option>Loading…</option> : null}
+                  {scopes.map(s => (
+                    <option key={s.id} value={s.id}>{s.name} {s.scope_group ? `· ${s.scope_group}` : ""}</option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <span style={{ fontSize: 12, color: "#6B6860", display: "block", marginBottom: 4 }}>Frequency</span>
+                <select value={frequency} onChange={e => setFrequency(e.target.value)} style={INPUT}>
+                  {FREQUENCIES.map(f => <option key={f.value} value={f.value}>{f.label}</option>)}
+                </select>
+              </div>
+            </div>
+            <div style={{ marginTop: 10 }}>
+              <span style={{ fontSize: 12, color: "#6B6860", display: "block", marginBottom: 4 }}>Allowed hours</span>
+              <input type="number" min={0.25} step={0.25} value={allowedHours}
+                onChange={e => setAllowedHours(parseFloat(e.target.value) || 0)}
+                style={INPUT} />
+            </div>
+          </div>
+
+          {/* Section 2 — Schedule */}
+          <div style={SECTION}>
+            <span style={LABEL}>Schedule</span>
+            <div style={{ display: "grid", gridTemplateColumns: mobile ? "1fr" : "1fr 1fr", gap: 10 }}>
+              <div>
+                <span style={{ fontSize: 12, color: "#6B6860", display: "block", marginBottom: 4 }}>Date</span>
+                <input type="date" value={scheduledDate}
+                  onChange={e => setScheduledDate(e.target.value)} style={INPUT} />
+              </div>
+              <div>
+                <span style={{ fontSize: 12, color: "#6B6860", display: "block", marginBottom: 4 }}>Start time</span>
+                <input type="time" value={scheduledTime} step={900}
+                  onChange={e => setScheduledTime(e.target.value)} style={INPUT} />
+              </div>
+            </div>
+          </div>
+
+          {/* Section 3 — Team */}
+          <div style={SECTION}>
+            <span style={LABEL}>Team {selectedTechIds.length > 1 ? `(${selectedTechIds.length})` : ""}</span>
+            <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+              {employees.length === 0 && (
+                <span style={{ fontSize: 12, color: "#9E9B94" }}>No technicians available</span>
+              )}
+              {employees.map(e => {
+                const idx = selectedTechIds.indexOf(e.id);
+                const selected = idx >= 0;
+                const isPrimary = idx === 0 && selectedTechIds.length > 0;
+                return (
+                  <div key={e.id} style={{
+                    display: "flex", alignItems: "center", justifyContent: "space-between",
+                    padding: "10px 12px", borderRadius: 8,
+                    border: `1.5px solid ${selected ? "var(--brand, #00C9A0)" : "#E5E2DC"}`,
+                    backgroundColor: selected ? "rgba(0,201,160,0.07)" : "#F7F6F3",
+                    cursor: "pointer", fontFamily: FF,
+                  }}
+                  onClick={() => {
+                    setSelectedTechIds(prev => {
+                      const cur = prev.indexOf(e.id);
+                      if (cur >= 0) return prev.filter(id => id !== e.id);
+                      return [...prev, e.id];
+                    });
+                  }}>
+                    <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                      <input type="checkbox" checked={selected} readOnly />
+                      <span style={{ fontSize: 13, fontWeight: 600, color: "#1A1917" }}>{e.name}</span>
+                      {isPrimary && (
+                        <span style={{ fontSize: 10, fontWeight: 700, color: "#15803D", backgroundColor: "#DCFCE7", padding: "2px 6px", borderRadius: 4 }}>Primary</span>
+                      )}
+                    </div>
+                    {selected && !isPrimary && (
+                      <button onClick={ev => {
+                        ev.stopPropagation();
+                        setSelectedTechIds(prev => [e.id, ...prev.filter(id => id !== e.id)]);
+                      }} style={{
+                        fontSize: 11, color: "#1D4ED8", background: "none", border: "none",
+                        cursor: "pointer", fontFamily: FF, fontWeight: 600,
+                      }}>Set as primary</button>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* Section 4 — Add-ons */}
+          <div style={SECTION}>
+            <span style={LABEL}>Add-ons</span>
+            {addonsLoading ? (
+              <div style={{ fontSize: 12, color: "#9E9B94", display: "flex", alignItems: "center", gap: 6 }}>
+                <Loader2 size={12} className="spin" /> Loading add-ons…
+              </div>
+            ) : availableAddons.length === 0 ? (
+              <span style={{ fontSize: 12, color: "#9E9B94" }}>No add-ons configured for this scope.</span>
+            ) : (
+              <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+                {availableAddons.map(a => {
+                  const checked = selectedAddons.has(a.id);
+                  return (
+                    <label key={a.id} style={{
+                      display: "flex", alignItems: "center", gap: 8,
+                      padding: "8px 10px", borderRadius: 8,
+                      border: `1px solid ${checked ? "var(--brand, #00C9A0)" : "#E5E2DC"}`,
+                      backgroundColor: checked ? "rgba(0,201,160,0.05)" : "#F7F6F3",
+                      cursor: "pointer", fontFamily: FF,
+                    }}>
+                      <input type="checkbox" checked={checked}
+                        onChange={() => {
+                          setSelectedAddons(prev => {
+                            const next = new Map(prev);
+                            if (next.has(a.id)) next.delete(a.id);
+                            else next.set(a.id, 1);
+                            return next;
+                          });
+                        }} />
+                      <span style={{ flex: 1, fontSize: 13, color: "#1A1917" }}>{a.name}</span>
+                      <span style={{ fontSize: 12, color: "#6B6860" }}>
+                        {a.price_type === "percent" ? `${a.price}%` : `$${Number(a.price).toFixed(0)}`}
+                      </span>
+                    </label>
+                  );
+                })}
+              </div>
+            )}
+            {calcResult?.bundle_breakdown && calcResult.bundle_breakdown.length > 0 && (
+              <div style={{ marginTop: 8, padding: "6px 10px", backgroundColor: "#F0FDF4", borderRadius: 6, border: "1px solid #BBF7D0" }}>
+                {calcResult.bundle_breakdown.map(b => (
+                  <div key={b.name} style={{ fontSize: 11, color: "#166534", fontWeight: 600 }}>
+                    Bundle: {b.name} − ${b.discount.toFixed(0)}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Section 5 — Pricing */}
+          <div style={SECTION}>
+            <span style={LABEL}>Pricing</span>
+            {calcError && (
+              <div style={{ fontSize: 12, color: "#991B1B", marginBottom: 8 }}>{calcError}</div>
+            )}
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline" }}>
+              <span style={{ fontSize: 14, color: "#6B6860" }}>Current</span>
+              <span style={{ fontSize: 14, fontWeight: 600, color: "#1A1917" }}>${initialBaseFee.toFixed(2)}</span>
+            </div>
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", marginTop: 4 }}>
+              <span style={{ fontSize: 14, color: "#6B6860" }}>New</span>
+              <span style={{ fontSize: 18, fontWeight: 700, color: "#1A1917" }}>
+                {calcBusy ? "…" : `$${baseFee.toFixed(2)}`}
+                {!calcBusy && Math.abs(baseFee - initialBaseFee) > 0.01 && (
+                  <span style={{ fontSize: 12, fontWeight: 600, marginLeft: 8, color: baseFee > initialBaseFee ? "#15803D" : "#991B1B" }}>
+                    {baseFee > initialBaseFee ? "+" : ""}{(baseFee - initialBaseFee).toFixed(2)}
+                  </span>
+                )}
+              </span>
+            </div>
+            {manualRate && (
+              <div style={{ marginTop: 8, padding: "6px 10px", backgroundColor: "#FEF3C7", border: "1px solid #FCD34D", borderRadius: 6, fontSize: 12, color: "#92400E", display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+                <span style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                  <AlertTriangle size={12} /> Manual rate active
+                </span>
+                <button onClick={() => { setManualRate(false); setManualOpen(false); }}
+                  style={{ fontSize: 11, color: "#92400E", background: "none", border: "none", cursor: "pointer", fontWeight: 700 }}>
+                  Reset to calculated
+                </button>
+              </div>
+            )}
+            {!manualOpen && !manualRate && (
+              <button onClick={() => { setManualOpen(true); setManualValue(baseFee.toFixed(2)); }}
+                style={{ marginTop: 8, fontSize: 12, color: "#1D4ED8", background: "none", border: "none", cursor: "pointer", fontFamily: FF, fontWeight: 600, padding: 0 }}>
+                Override rate
+              </button>
+            )}
+            {manualOpen && !manualRate && (
+              <div style={{ marginTop: 8, display: "flex", gap: 6, alignItems: "center" }}>
+                <span style={{ fontSize: 13, color: "#6B6860" }}>$</span>
+                <input type="number" min={0} step={0.01} value={manualValue}
+                  onChange={e => setManualValue(e.target.value)}
+                  style={{ ...INPUT, width: 140 }} />
+                <button onClick={() => {
+                  const v = parseFloat(manualValue);
+                  if (!isNaN(v) && v >= 0) {
+                    setBaseFee(v); setManualRate(true); setManualOpen(false);
+                  }
+                }} style={{ fontSize: 12, fontWeight: 700, color: "#fff", background: "var(--brand, #00C9A0)", border: "none", borderRadius: 6, padding: "8px 12px", cursor: "pointer", fontFamily: FF }}>
+                  Apply
+                </button>
+                <button onClick={() => setManualOpen(false)} style={{ fontSize: 12, color: "#6B7280", background: "none", border: "none", cursor: "pointer", fontFamily: FF }}>Cancel</button>
+              </div>
+            )}
+          </div>
+
+          {/* Section 6 — Instructions */}
+          <div style={SECTION}>
+            <span style={LABEL}>Instructions</span>
+            <textarea value={instructions} onChange={e => setInstructions(e.target.value)}
+              placeholder="Notes for technicians on this job…"
+              rows={4}
+              style={{ ...INPUT, height: "auto", padding: "10px 12px", lineHeight: 1.5, resize: "vertical" }} />
+          </div>
+
+          <div style={{ height: 16 }} />
+        </div>
+
+        {/* Footer */}
+        <div style={{ padding: "12px 20px", borderTop: "1px solid #E5E2DC", backgroundColor: "#FFFFFF", flexShrink: 0, display: "flex", gap: 8 }}>
+          <button onClick={onClose} disabled={saving}
+            style={{ flex: 1, padding: "12px", border: "1px solid #E5E2DC", borderRadius: 10, background: "#FFFFFF", color: "#6B7280", fontSize: 14, fontWeight: 600, cursor: saving ? "wait" : "pointer", fontFamily: FF }}>
+            Cancel
+          </button>
+          <button onClick={onSaveClick} disabled={!canSave}
+            style={{ flex: 2, padding: "12px", border: "none", borderRadius: 10, background: canSave ? "var(--brand, #00C9A0)" : "#E5E2DC", color: canSave ? "#FFFFFF" : "#9E9B94", fontSize: 14, fontWeight: 700, cursor: canSave ? "pointer" : "not-allowed", fontFamily: FF }}>
+            {saving ? "Saving…" : "Save changes"}
+          </button>
+        </div>
+      </div>
+
+      {/* Cascade prompt */}
+      {cascadePromptOpen && (
+        <>
+          <div style={{ position: "fixed", inset: 0, backgroundColor: "rgba(0,0,0,0.5)", zIndex: 410 }} />
+          <div style={{
+            position: "fixed", top: "50%", left: "50%", transform: "translate(-50%, -50%)",
+            zIndex: 411, backgroundColor: "#FFFFFF", borderRadius: 14, padding: 24,
+            width: "100%", maxWidth: 420, fontFamily: FF, boxShadow: "0 16px 48px rgba(0,0,0,0.3)",
+          }}>
+            <div style={{ fontSize: 16, fontWeight: 700, color: "#1A1917", marginBottom: 6 }}>Recurring job</div>
+            <div style={{ fontSize: 13, color: "#6B6860", marginBottom: 16, lineHeight: 1.5 }}>
+              This job is part of a recurring schedule. Apply changes to:
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 8, marginBottom: 18 }}>
+              {[
+                { v: "this_job" as const, label: "This job only", sub: "Other future jobs in this schedule won't change." },
+                { v: "this_and_future" as const, label: "This and all future occurrences", sub: "Updates the schedule template + all future scheduled jobs." },
+              ].map(opt => {
+                const sel = cascadeChoice === opt.v;
+                return (
+                  <button key={opt.v} type="button" onClick={() => setCascadeChoice(opt.v)}
+                    style={{
+                      textAlign: "left", padding: "12px 14px", borderRadius: 10,
+                      border: `1.5px solid ${sel ? "var(--brand, #00C9A0)" : "#E5E2DC"}`,
+                      backgroundColor: sel ? "rgba(0,201,160,0.07)" : "#F7F6F3",
+                      cursor: "pointer", fontFamily: FF,
+                    }}>
+                    <div style={{ fontSize: 13, fontWeight: 600, color: "#1A1917" }}>{opt.label}</div>
+                    <div style={{ fontSize: 11, color: "#6B6860", marginTop: 2 }}>{opt.sub}</div>
+                  </button>
+                );
+              })}
+            </div>
+            <div style={{ display: "flex", gap: 8 }}>
+              <button onClick={() => setCascadePromptOpen(false)} disabled={saving}
+                style={{ flex: 1, padding: "10px", borderRadius: 8, border: "1px solid #E5E2DC", background: "#FFFFFF", color: "#6B7280", fontSize: 13, fontWeight: 600, cursor: "pointer", fontFamily: FF }}>
+                Cancel
+              </button>
+              <button onClick={() => submit(cascadeChoice)} disabled={saving}
+                style={{ flex: 2, padding: "10px", borderRadius: 8, border: "none", background: "var(--brand, #00C9A0)", color: "#FFFFFF", fontSize: 13, fontWeight: 700, cursor: saving ? "wait" : "pointer", fontFamily: FF }}>
+                {saving ? "Applying…" : "Apply changes"}
+              </button>
+            </div>
+          </div>
+        </>
+      )}
+    </>
+  );
+}

--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -4,6 +4,7 @@ import { getAuthHeaders, useAuthStore } from "@/lib/auth";
 import { useBranch } from "@/contexts/branch-context";
 import { useToast } from "@/hooks/use-toast";
 import { JobWizard } from "@/components/job-wizard";
+import EditJobModal from "@/components/edit-job-modal";
 import {
   DndContext, DragOverlay, PointerSensor, useSensor, useSensors,
   useDraggable, useDroppable, type DragEndEvent, type DragStartEvent,
@@ -357,6 +358,8 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
   const [smsMessage, setSmsMessage] = useState("");
   const [smsBusy, setSmsBusy] = useState(false);
   const [smsTwilioOk, setSmsTwilioOk] = useState<boolean | null>(null);
+  // [AG] Edit modal state — triggered by the Edit button in the drawer footer.
+  const [editOpen, setEditOpen] = useState(false);
 
   // Commission override state
   const [commTechs, setCommTechs] = useState<JobTechCommission[]>(job.technicians ?? []);
@@ -907,6 +910,14 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
               <DollarSign size={13} /> Charge Client
             </button>
           )}
+          {/* [AG] Edit button — opens the focused edit modal. Disabled with the
+              same isLocked rule as Reschedule (complete / cancelled / locked_at). */}
+          <button
+            disabled={isLocked}
+            onClick={() => { if (!isLocked) setEditOpen(true); }}
+            style={{ padding: "10px 12px", border: `1px solid ${isLocked ? "#E5E2DC" : "#A7F3D0"}`, borderRadius: 8, backgroundColor: isLocked ? "#F8F7F4" : "#ECFDF5", color: isLocked ? "#9E9B94" : "#065F46", fontSize: 13, fontWeight: 600, cursor: isLocked ? "not-allowed" : "pointer", fontFamily: FF, opacity: isLocked ? 0.6 : 1 }}>
+            Edit
+          </button>
           <button
             disabled={isLocked}
             onClick={() => {
@@ -1290,6 +1301,42 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
             </div>
           </div>
         </div>
+      )}
+
+      {/* [AG] Edit Job modal */}
+      {editOpen && (
+        <EditJobModal
+          job={{
+            id: job.id,
+            client_id: job.client_id,
+            client_name: job.client_name,
+            recurring_schedule_id: (job as any).recurring_schedule_id ?? null,
+            service_type: job.service_type,
+            frequency: job.frequency,
+            scheduled_date: job.scheduled_date,
+            scheduled_time: job.scheduled_time,
+            duration_minutes: job.duration_minutes,
+            amount: job.amount,
+            base_fee: (job as any).base_fee ?? job.amount,
+            notes: job.notes,
+            status: job.status,
+            locked_at: job.locked_at,
+            assigned_user_id: job.assigned_user_id,
+          }}
+          employees={employees.map(e => ({ id: e.id, name: e.name, role: e.role }))}
+          mobile={mobile}
+          onClose={() => setEditOpen(false)}
+          onSaved={(info) => {
+            setEditOpen(false);
+            const skipped = info.future_jobs_skipped_in_progress;
+            const updated = info.future_jobs_updated;
+            const desc = updated > 0
+              ? `${updated} future job${updated === 1 ? "" : "s"} updated${skipped > 0 ? `. ${skipped} job${skipped === 1 ? " is" : "s are"} in progress and was not modified.` : "."}`
+              : "Changes saved.";
+            toast({ title: "Job updated", description: desc });
+            onUpdate();
+          }}
+        />
       )}
     </>
   );

--- a/lib/db/src/schema/index.ts
+++ b/lib/db/src/schema/index.ts
@@ -69,3 +69,8 @@ export * from "./rate_locks";
 export * from "./offer_settings";
 export * from "./notifications";
 export * from "./user_views";
+// [AG] Job edit modal — audit trail + multi-tech junctions
+export * from "./job_audit_log";
+export * from "./job_technicians";
+export * from "./recurring_schedule_add_ons";
+export * from "./recurring_schedule_technicians";

--- a/lib/db/src/schema/job_add_ons.ts
+++ b/lib/db/src/schema/job_add_ons.ts
@@ -8,6 +8,9 @@ export const jobAddOnsTable = pgTable("job_add_ons", {
   quantity: integer("quantity").notNull().default(1),
   unit_price: numeric("unit_price", { precision: 10, scale: 2 }).notNull(),
   subtotal: numeric("subtotal", { precision: 10, scale: 2 }).notNull(),
+  // [AG] Traceability link to pricing_addons.id for recalc lookups. Nullable
+  // for backward compat with rows seeded before AG.
+  pricing_addon_id: integer("pricing_addon_id"),
 }, (t) => [primaryKey({ columns: [t.job_id, t.add_on_id] })]);
 
 export type JobAddOn = typeof jobAddOnsTable.$inferSelect;

--- a/lib/db/src/schema/job_audit_log.ts
+++ b/lib/db/src/schema/job_audit_log.ts
@@ -1,0 +1,20 @@
+import { pgTable, serial, integer, text, jsonb, timestamp } from "drizzle-orm/pg-core";
+import { jobsTable } from "./jobs";
+import { usersTable } from "./users";
+
+export const jobAuditLogTable = pgTable("job_audit_log", {
+  id: serial("id").primaryKey(),
+  job_id: integer("job_id").references(() => jobsTable.id, { onDelete: "cascade" }).notNull(),
+  company_id: integer("company_id").notNull(),
+  user_id: integer("user_id").references(() => usersTable.id).notNull(),
+  user_name: text("user_name").notNull(),
+  user_email: text("user_email").notNull(),
+  field_name: text("field_name").notNull(),
+  old_value: jsonb("old_value"),
+  new_value: jsonb("new_value"),
+  cascade_scope: text("cascade_scope"),
+  schedule_id: integer("schedule_id"),
+  edited_at: timestamp("edited_at").notNull().defaultNow(),
+});
+
+export type JobAuditLog = typeof jobAuditLogTable.$inferSelect;

--- a/lib/db/src/schema/job_technicians.ts
+++ b/lib/db/src/schema/job_technicians.ts
@@ -1,0 +1,16 @@
+import { pgTable, serial, integer, boolean, numeric, timestamp, unique } from "drizzle-orm/pg-core";
+import { jobsTable } from "./jobs";
+import { usersTable } from "./users";
+
+export const jobTechniciansTable = pgTable("job_technicians", {
+  id: serial("id").primaryKey(),
+  job_id: integer("job_id").references(() => jobsTable.id, { onDelete: "cascade" }).notNull(),
+  user_id: integer("user_id").references(() => usersTable.id, { onDelete: "cascade" }).notNull(),
+  company_id: integer("company_id").notNull(),
+  is_primary: boolean("is_primary").notNull().default(false),
+  pay_override: numeric("pay_override", { precision: 10, scale: 2 }),
+  final_pay: numeric("final_pay", { precision: 10, scale: 2 }),
+  created_at: timestamp("created_at").notNull().defaultNow(),
+}, (t) => [unique().on(t.job_id, t.user_id)]);
+
+export type JobTechnician = typeof jobTechniciansTable.$inferSelect;

--- a/lib/db/src/schema/jobs.ts
+++ b/lib/db/src/schema/jobs.ts
@@ -90,6 +90,10 @@ export const jobsTable = pgTable("jobs", {
   // ── Office notes (pushed from quote call notes) ─────────────────────────────
   office_notes: text("office_notes"),
   flagged: boolean("flagged").notNull().default(false),
+  // [AG] Set true when a user manually overrides the calculated base_fee in
+  // the edit modal. Cleared when scope/freq/add-ons change AND base_fee is
+  // omitted from the patch (recalc pulls a fresh value from pricing engine).
+  manual_rate_override: boolean("manual_rate_override").notNull().default(false),
 });
 
 export const insertJobSchema = createInsertSchema(jobsTable).omit({ id: true, created_at: true });

--- a/lib/db/src/schema/recurring_schedule_add_ons.ts
+++ b/lib/db/src/schema/recurring_schedule_add_ons.ts
@@ -1,0 +1,14 @@
+import { pgTable, serial, integer, numeric, timestamp } from "drizzle-orm/pg-core";
+import { recurringSchedulesTable } from "./recurring_schedules";
+
+export const recurringScheduleAddOnsTable = pgTable("recurring_schedule_add_ons", {
+  id: serial("id").primaryKey(),
+  recurring_schedule_id: integer("recurring_schedule_id")
+    .references(() => recurringSchedulesTable.id, { onDelete: "cascade" })
+    .notNull(),
+  pricing_addon_id: integer("pricing_addon_id").notNull(),
+  qty: numeric("qty", { precision: 6, scale: 2 }).notNull().default("1"),
+  created_at: timestamp("created_at").notNull().defaultNow(),
+});
+
+export type RecurringScheduleAddOn = typeof recurringScheduleAddOnsTable.$inferSelect;

--- a/lib/db/src/schema/recurring_schedule_technicians.ts
+++ b/lib/db/src/schema/recurring_schedule_technicians.ts
@@ -1,0 +1,15 @@
+import { pgTable, serial, integer, boolean, timestamp, unique } from "drizzle-orm/pg-core";
+import { recurringSchedulesTable } from "./recurring_schedules";
+import { usersTable } from "./users";
+
+export const recurringScheduleTechniciansTable = pgTable("recurring_schedule_technicians", {
+  id: serial("id").primaryKey(),
+  recurring_schedule_id: integer("recurring_schedule_id")
+    .references(() => recurringSchedulesTable.id, { onDelete: "cascade" })
+    .notNull(),
+  user_id: integer("user_id").references(() => usersTable.id).notNull(),
+  is_primary: boolean("is_primary").notNull().default(false),
+  created_at: timestamp("created_at").notNull().defaultNow(),
+}, (t) => [unique().on(t.recurring_schedule_id, t.user_id)]);
+
+export type RecurringScheduleTechnician = typeof recurringScheduleTechniciansTable.$inferSelect;

--- a/lib/db/src/schema/recurring_schedules.ts
+++ b/lib/db/src/schema/recurring_schedules.ts
@@ -1,4 +1,4 @@
-import { pgTable, serial, integer, text, boolean, date, timestamp, pgEnum } from "drizzle-orm/pg-core";
+import { pgTable, serial, integer, text, boolean, date, time, timestamp, pgEnum } from "drizzle-orm/pg-core";
 import { companiesTable } from "./companies";
 import { clientsTable } from "./clients";
 import { usersTable } from "./users";
@@ -27,6 +27,14 @@ export const recurringSchedulesTable = pgTable("recurring_schedules", {
   is_active: boolean("is_active").notNull().default(true),
   last_generated_date: date("last_generated_date"),
   created_at: timestamp("created_at").notNull().defaultNow(),
+  // [AG] Cascade-from-edit fields. Stay null on existing schedules until
+  // the user picks "this and all future" in the edit modal.
+  scheduled_time: time("scheduled_time"),
+  instructions: text("instructions"),
+  manual_rate_override: boolean("manual_rate_override").notNull().default(false),
+  // Used when jobs.frequency='every_3_weeks' (no matching enum value on
+  // recurring_schedules.frequency, which only has weekly/biweekly/monthly/custom).
+  custom_frequency_weeks: integer("custom_frequency_weeks"),
 });
 
 export type RecurringSchedule = typeof recurringSchedulesTable.$inferSelect;


### PR DESCRIPTION
## Summary

Implements the AG spec — a focused job edit modal accessed from the JobPanel drawer. Backend is a new `PATCH /api/jobs/:id` with cascade-to-recurring, in-progress guard, and per-field audit logging.

Decisions applied (all 5 from the audit + cascade order-of-ops):
- **1c** — pricing_scope dropdown, no persist
- **2b** — extend `recurring_schedules` schema before cascading
- **3** — separate scope and frequency dropdowns
- **4** — `pricing_addon_id` added to `job_add_ons` (nullable)
- **5** — new PATCH endpoint, leave existing PUT alone

## Schema changes (idempotent migration)

Added to `phes-data-migration.ts` `runBookingSchemaGuard`:
- `jobs.manual_rate_override BOOLEAN`
- `job_add_ons.pricing_addon_id INTEGER`
- `recurring_schedules.{scheduled_time, instructions, manual_rate_override, custom_frequency_weeks}`
- `recurring_schedule_add_ons` (new junction)
- `recurring_schedule_technicians` (new junction)
- `job_audit_log` (per-field diff + cascade summary rows)

4 new Drizzle schema files; 3 existing updated; index.ts barrel export.

## PATCH /api/jobs/:id

- 409 on locked / complete / cancelled / locked_at non-null
- 409 on open `timeclock` for date/time/team field changes
- Transaction order: jobs UPDATE → job_technicians replace → job_add_ons replace → (cascade only) recurring_schedules UPDATE → future jobs UPDATE (excludes any in-progress) → RS junction tables replace → audit log rows
- Per-field audit log row + single `cascade_summary` row when cascading
- Mirrors primary tech onto `jobs.assigned_user_id` (fixes the Jaira Estrada split-brain we saw earlier today — chip-on-Alma but commission-on-Juan)
- Frequency mapping when cascading to `recurring_schedules.frequency`: `every_3_weeks` → `custom` + `custom_frequency_weeks=3`

## Frontend

`artifacts/qleno/src/components/edit-job-modal.tsx` (new):
- 6 sections — Service / Schedule / Team / Add-ons / Pricing / Instructions
- Tenant `pricing_scopes` dropdown + frequency dropdown (independent)
- Multi-tech picker with Set-as-primary affordance
- Add-ons checkbox list driven by `/api/pricing/scopes/:id/addons`
- Auto-recalc via `/api/pricing/calculate` (debounced 250ms)
- Manual rate override with Reset-to-calculated affordance
- Cascade prompt shown only when job has `recurring_schedule_id`
- Save disabled until at least one field changes; `allowed_hours > 0`; team ≥ 1

`jobs.tsx`:
- Edit button in drawer footer next to Reschedule, same `isLocked` disable rule
- On save, toast surfaces cascade summary including any in-progress future jobs that were skipped

## Test plan

- [ ] Migration runs clean on PHES startup (idempotent — safe re-run)
- [ ] Open Jaira Estrada (recurring, Apr 27): click Edit → modal opens with current values
- [ ] Change allowed hours from 7 → 8: pricing diff line shows new total
- [ ] Add Oven add-on: total goes up, line item shown, bundle banner if applicable
- [ ] Click Save → cascade prompt appears (recurring) → "This job only" → drawer refreshes with new total
- [ ] `SELECT * FROM job_audit_log WHERE job_id = <id>` shows N rows (one per changed field, cascade_scope='this_job')
- [ ] Edit a one-time job: no cascade prompt, submits directly
- [ ] Edit a completed job: Edit button disabled
- [ ] Edit Daniel Walter recurring + "This and all future" → `recurring_schedules` row updates + future scheduled jobs update; past completed untouched; in-progress future jobs (if any) skipped with toast warning
- [ ] Pricing dropdown lists tenant's `pricing_scopes`; recalc fires on scope/freq/addon/hours change
- [ ] Manual rate override → diff line replaced with "Manual rate active" + Reset-to-calculated link

## Audit findings worth flagging (not fixed in this PR)

- **`job_technicians` table existed in DB but had no Drizzle schema.** Existing code uses raw SQL. Drizzle file added in this PR for consistency; existing call sites unchanged.
- **`add_ons` (legacy) and `pricing_addons` are two parallel addon tables.** Modal writes to `job_add_ons` using `pricing_addon_id` for both columns (`add_on_id` and `pricing_addon_id`); a future pass should consolidate or formalize the mapping.
- **`service_type` mapping unspec'd.** Per decision 1c we don't persist `scope_id` on jobs, so `service_type` enum on the job stays whatever it was; the modal does not rewrite it. If users want the dispatch-board "scope" label to follow their pricing-scope choice, we'll need to add a `service_type` mapping per pricing-scope.

## Typecheck

Workspace-wide `pnpm typecheck` reports the existing module-resolution class (drizzle-orm types not installed). No new errors on AG-touched files beyond that class. Three implicit-any warnings in junction-table callbacks are downstream of the same root cause and resolve once `node_modules` is installed.

https://claude.ai/code/session_01CguZ1HXwLYhd8ZuRtZQZsN

---
_Generated by [Claude Code](https://claude.ai/code/session_01CguZ1HXwLYhd8ZuRtZQZsN)_