### PR TITLE
feat: job card redesign — two-row chip + en_route + completed_unpaid

### DIFF
--- a/artifacts/api-server/src/routes/dispatch.ts
+++ b/artifacts/api-server/src/routes/dispatch.ts
@@ -339,6 +339,61 @@ router.get("/", requireAuth, async (req, res) => {
       });
     }
 
+    // [job-card-redesign] Add-ons per job — drives the "+N" pill on the
+    // dispatch chip and the full add-on list in the hover popover. Names
+    // come from pricing_addons (preferred, the modern path) with a
+    // fallback to the legacy add_ons table for rows imported before
+    // pricing_addons existed. Subtotals already reflect quantity × unit
+    // price as written by PATCH /api/jobs/:id, so the chip can sum them
+    // into a delta without re-multiplying.
+    const addOnRows = await db.execute(sql`
+      SELECT jao.job_id, jao.quantity, jao.unit_price, jao.subtotal,
+             COALESCE(pa.name, ao.name) AS name
+        FROM job_add_ons jao
+        LEFT JOIN add_ons ao ON ao.id = jao.add_on_id
+        LEFT JOIN pricing_addons pa ON pa.id = jao.pricing_addon_id
+       WHERE jao.job_id = ANY(ARRAY[${sql.raw(idList)}]::int[])
+    `);
+    const addOnsByJob = new Map<number, Array<{ name: string; quantity: number; unit_price: number; subtotal: number }>>();
+    for (const r of addOnRows.rows as any[]) {
+      if (!addOnsByJob.has(r.job_id)) addOnsByJob.set(r.job_id, []);
+      addOnsByJob.get(r.job_id)!.push({
+        name: r.name ?? "Add-on",
+        quantity: r.quantity != null ? parseFloat(String(r.quantity)) : 1,
+        unit_price: r.unit_price != null ? parseFloat(String(r.unit_price)) : 0,
+        subtotal: r.subtotal != null ? parseFloat(String(r.subtotal)) : 0,
+      });
+    }
+
+    // [job-card-redesign] is_new_client — true when the residential client
+    // has zero completed jobs strictly before today's board date. Drives
+    // the "NEW" pill + inset white outline on the chip. Commercial jobs
+    // (account_id set) always read false — the account contract is the
+    // billing entity, not a person, and "first job for this account"
+    // doesn't carry the same operational signal.
+    const residentialClientIds: number[] = [];
+    const seenClientIds = new Set<number>();
+    for (const j of jobs) {
+      if (!j.account_id && j.client_id != null && !seenClientIds.has(j.client_id)) {
+        seenClientIds.add(j.client_id);
+        residentialClientIds.push(j.client_id);
+      }
+    }
+    const clientsWithPriorComplete = new Set<number>();
+    if (residentialClientIds.length > 0) {
+      const clientList = residentialClientIds.join(",");
+      const priorRows = await db.execute(sql`
+        SELECT DISTINCT client_id FROM jobs
+         WHERE company_id = ${companyId}
+           AND status = 'complete'
+           AND scheduled_date < ${date}
+           AND client_id = ANY(ARRAY[${sql.raw(clientList)}]::int[])
+      `);
+      for (const r of priorRows.rows as any[]) {
+        if (r.client_id != null) clientsWithPriorComplete.add(r.client_id);
+      }
+    }
+
     const mappedJobs = jobs.map(j => {
       const clock = clockMap.get(j.id);
       const photos = photoMap.get(j.id) || { before: 0, after: 0 };
@@ -475,6 +530,16 @@ router.get("/", requireAuth, async (req, res) => {
         // interchangeable.
         commission_basis: isCommercial ? "commercial_hourly" : "residential_pool",
         commercial_hourly_rate: isCommercial ? commercialHourlyRate : null,
+        // [job-card-redesign] Add-ons drive the "+N" chip pill and the
+        // hover popover's full add-on list. Empty array (not null) when
+        // a job has none, so the frontend can `.length` directly.
+        add_ons: addOnsByJob.get(j.id) ?? [],
+        // [job-card-redesign] is_new_client — first-ever job for this
+        // residential client (no prior completed). Commercial jobs read
+        // false; clients with no client_id (rare/legacy) also read false.
+        is_new_client: !isCommercial && j.client_id != null
+          ? !clientsWithPriorComplete.has(j.client_id)
+          : false,
       };
     });
 

--- a/artifacts/qleno/src/App.tsx
+++ b/artifacts/qleno/src/App.tsx
@@ -79,6 +79,12 @@ const AdminCleancyclopedia= lazy(() => import("@/pages/admin/cleancyclopedia"));
 const NotificationsPage   = lazy(() => import("@/pages/notifications"));
 const NotFound            = lazy(() => import("@/pages/not-found"));
 
+// [job-card-redesign] Dev-only visual test page — gated by PROD env.
+// Doesn't ship to production: the lazy import only runs when the route
+// renders, and the route below is only mounted when import.meta.env.PROD
+// is false.
+const JobsVisualTestPage  = lazy(() => import("@/pages/jobs-visual-test"));
+
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: { staleTime: 30_000, retry: false },
@@ -103,6 +109,7 @@ function Router() {
         <Route path="/accept-invite" component={AcceptInvitePage} />
         <Route path="/dashboard" component={Dashboard} />
         <Route path="/dispatch" component={JobsPage} />
+        {!import.meta.env.PROD && <Route path="/jobs/visual-test" component={JobsVisualTestPage} />}
         {/* [Q2] JobsListPage moved to /reports/jobs. Keep /jobs and /jobs/list
             as redirects for old bookmarks. */}
         <Route path="/jobs"><Redirect to="/reports/jobs" /></Route>

--- a/artifacts/qleno/src/components/legend-popover.tsx
+++ b/artifacts/qleno/src/components/legend-popover.tsx
@@ -69,6 +69,20 @@ function ExampleTile({ status }: { status: JobVisualStatus }) {
           NO SHOW
         </div>
       )}
+      {/* [job-card-redesign] UNPAID badge mirrors the chip pill so the
+          legend tile reads the same as the real chip on the timeline.
+          Lives top-left to avoid colliding with the checkmark badge. */}
+      {status === "completed_unpaid" && (
+        <div style={{ position: "absolute", top: 3, left: 7, fontSize: 8, fontWeight: 800, color: "#FFFFFF", backgroundColor: "#BA7517", padding: "1px 4px", borderRadius: 3, letterSpacing: "0.05em" }}>
+          UNPAID
+        </div>
+      )}
+      {/* [job-card-redesign] LATE badge mirrors the chip pill. */}
+      {status === "late_clockin" && (
+        <div style={{ position: "absolute", top: 3, left: 7, fontSize: 8, fontWeight: 800, color: "#FFFFFF", backgroundColor: "#DC2626", padding: "1px 4px", borderRadius: 3, letterSpacing: "0.05em" }}>
+          LATE
+        </div>
+      )}
     </div>
   );
 }

--- a/artifacts/qleno/src/components/legend-popover.tsx
+++ b/artifacts/qleno/src/components/legend-popover.tsx
@@ -14,7 +14,9 @@ const FF = "'Plus Jakarta Sans', sans-serif";
 const STATUS_ORDER: JobVisualStatus[] = [
   "scheduled",
   "active",
+  "en_route",
   "completed",
+  "completed_unpaid",
   "late_clockin",
   "no_show",
   "cancelled",
@@ -37,8 +39,23 @@ function ExampleTile({ status }: { status: JobVisualStatus }) {
     }}>
       {v.stripe && <div className="qleno-active-stripe" style={stripeStyle} />}
       <div style={{ flex: 1, display: "flex", flexDirection: "column", justifyContent: "center", overflow: "hidden", color: "#1A1917" }}>
-        <div style={{ fontSize: 10, fontWeight: 800, lineHeight: 1.1, textDecoration: v.strikethrough ? "line-through" : "none", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-          Sample Client
+        <div style={{ display: "flex", alignItems: "center", gap: 3, minWidth: 0 }}>
+          {v.showCarIcon && (
+            <span className="qleno-en-route-icon" style={{ display: "inline-flex", flexShrink: 0, width: 14, height: 9 }}>
+              <svg width="14" height="9" viewBox="0 0 18 11" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <line x1="0.5" y1="3.5" x2="3"   y2="3.5" stroke="#1A1917" strokeWidth="1" strokeLinecap="round" opacity="0.85" />
+                <line x1="0.5" y1="6"   x2="2.5" y2="6"   stroke="#1A1917" strokeWidth="1" strokeLinecap="round" opacity="0.55" />
+                <line x1="0.5" y1="8.5" x2="2"   y2="8.5" stroke="#1A1917" strokeWidth="1" strokeLinecap="round" opacity="0.30" />
+                <path d="M5 7.5 V5 L6.5 3 H11.5 L13 5 V7.5 Z" stroke="#1A1917" strokeWidth="1" strokeLinejoin="round" fill="none" />
+                <line x1="13" y1="7.5" x2="16.5" y2="7.5" stroke="#1A1917" strokeWidth="1" strokeLinecap="round" />
+                <circle cx="7"    cy="9" r="1.3" stroke="#1A1917" strokeWidth="1" fill="none" />
+                <circle cx="12.5" cy="9" r="1.3" stroke="#1A1917" strokeWidth="1" fill="none" />
+              </svg>
+            </span>
+          )}
+          <div style={{ fontSize: 10, fontWeight: 800, lineHeight: 1.1, textDecoration: v.strikethrough ? "line-through" : "none", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", flex: 1, minWidth: 0 }}>
+            Sample Client
+          </div>
         </div>
         <div style={{ fontSize: 9, fontWeight: 600, opacity: 0.7, marginTop: 1 }}>9:00 AM</div>
       </div>

--- a/artifacts/qleno/src/lib/job-status.ts
+++ b/artifacts/qleno/src/lib/job-status.ts
@@ -172,7 +172,7 @@ export interface StatusVisual {
 export const STATUS_VISUALS: Record<JobVisualStatus, StatusVisual> = {
   scheduled: {
     label: "Scheduled",
-    description: "Job on the board, no tech clocked in yet.",
+    description: "On the board. Tech hasn't started yet.",
     swatch: "#A78BFA",
     stripe: null,
     bodyOpacity: 1,
@@ -184,8 +184,8 @@ export const STATUS_VISUALS: Record<JobVisualStatus, StatusVisual> = {
     showCarIcon: false,
   },
   active: {
-    label: "Active",
-    description: "Tech is clocked in. Stripe pulses while live.",
+    label: "In progress",
+    description: "Tech is on the job right now.",
     swatch: "#A78BFA",
     stripe: "#F59E0B",
     bodyOpacity: 1,
@@ -197,8 +197,8 @@ export const STATUS_VISUALS: Record<JobVisualStatus, StatusVisual> = {
     showCarIcon: false,
   },
   en_route: {
-    label: "En route",
-    description: "Tech tapped 'On My Way' but hasn't clocked in yet.",
+    label: "On the way",
+    description: "Tech tapped \"On My Way\" and is heading to the job.",
     swatch: "#A78BFA",
     stripe: null,
     bodyOpacity: 1,
@@ -210,8 +210,8 @@ export const STATUS_VISUALS: Record<JobVisualStatus, StatusVisual> = {
     showCarIcon: true,
   },
   completed: {
-    label: "Completed",
-    description: "Job finished. Tech clocked out and office marked complete.",
+    label: "Done",
+    description: "Job finished and payment is in.",
     swatch: "#A78BFA",
     stripe: null,
     bodyOpacity: 0.6,
@@ -223,8 +223,8 @@ export const STATUS_VISUALS: Record<JobVisualStatus, StatusVisual> = {
     showCarIcon: false,
   },
   completed_unpaid: {
-    label: "Completed (unpaid)",
-    description: "Job done but online charge has not succeeded. Amber ring.",
+    label: "Done — unpaid",
+    description: "Job is done but the payment hasn't gone through yet.",
     swatch: "#BA7517",
     stripe: null,
     bodyOpacity: 0.6,
@@ -236,8 +236,8 @@ export const STATUS_VISUALS: Record<JobVisualStatus, StatusVisual> = {
     showCarIcon: false,
   },
   late_clockin: {
-    label: "Late clock-in",
-    description: "Past start time + 5 min, tech still has not clocked in.",
+    label: "Late",
+    description: "Tech is more than 5 minutes late and hasn't clocked in.",
     swatch: "#A78BFA",
     stripe: null,
     bodyOpacity: 1,
@@ -250,7 +250,7 @@ export const STATUS_VISUALS: Record<JobVisualStatus, StatusVisual> = {
   },
   no_show: {
     label: "No show",
-    description: "Past start time + 30 min, no clock-in. Action required.",
+    description: "Tech is 30+ minutes late with no clock-in. Call them now.",
     swatch: "#EF4444",
     stripe: null,
     bodyOpacity: 0.85,
@@ -263,7 +263,7 @@ export const STATUS_VISUALS: Record<JobVisualStatus, StatusVisual> = {
   },
   cancelled: {
     label: "Cancelled",
-    description: "Manually cancelled. Strikethrough + desaturated.",
+    description: "Won't run today. Cancelled by office or client.",
     swatch: "#9CA3AF",
     stripe: null,
     bodyOpacity: 0.5,
@@ -276,7 +276,7 @@ export const STATUS_VISUALS: Record<JobVisualStatus, StatusVisual> = {
   },
   unassigned: {
     label: "Unassigned",
-    description: "No primary tech yet. Surfaces in Unassigned row.",
+    description: "Nobody is assigned yet. Drag a tech onto the job.",
     swatch: "#FBBF24",
     stripe: null,
     bodyOpacity: 1,

--- a/artifacts/qleno/src/lib/job-status.ts
+++ b/artifacts/qleno/src/lib/job-status.ts
@@ -10,7 +10,19 @@
  * compact rows, my-jobs (tech view), and the Legend popover.
  *
  * Routing precedence (top wins on conflict):
- *   cancelled → no_show → late_clockin → completed → active → unassigned → scheduled
+ *   cancelled → completed_unpaid → completed → active → no_show → en_route
+ *   → late_clockin → unassigned → scheduled
+ *
+ * en_route is scaffolded but inert: it requires `en_route_at` (set when
+ * the field tech taps "On My Way"). The schema column doesn't exist yet
+ * — the SMS / mobile-tech engine will add it later. Callers that don't
+ * pass en_route_at will never see this status. It still has a
+ * STATUS_VISUALS entry so the chip can render the animated car icon
+ * the moment the column lands.
+ *
+ * completed_unpaid fires only for online-payment jobs (stripe/square).
+ * Cash/check completion stays "completed" — there's no charge signal
+ * to derive from, and reconciliation lives in a separate workflow.
  */
 
 /**
@@ -31,6 +43,8 @@ export type JobVisualStatus =
   | "scheduled"
   | "active"
   | "completed"
+  | "completed_unpaid"
+  | "en_route"
   | "late_clockin"
   | "no_show"
   | "cancelled"
@@ -42,6 +56,15 @@ export interface JobStatusInput {
   scheduled_time?: string | null;
   assigned_user_id?: number | null;
   clock_entry?: { clock_in_at?: string | null; clock_out_at?: string | null } | null;
+  /** Set when the tech taps "On My Way" in the mobile app. Inert until
+   *  the SMS engine + schema column land — callers that don't supply
+   *  it never trigger en_route. */
+  en_route_at?: string | null;
+  /** Online-payment signals. completed_unpaid fires when status='complete'
+   *  AND payment method is stripe/square AND charge_succeeded_at is null.
+   *  Cash/check completion stays "completed" regardless. */
+  client_payment_method?: string | null;
+  charge_succeeded_at?: string | null;
 }
 
 const LATE_GRACE_MIN = 5;
@@ -62,9 +85,17 @@ function isToday(dateStr: string | null | undefined, now: Date): boolean {
   return dateStr.startsWith(`${y}-${m}-${d}`);
 }
 
+function isUnpaidOnlineJob(job: JobStatusInput): boolean {
+  const m = job.client_payment_method;
+  if (m !== "stripe" && m !== "square") return false;
+  return !job.charge_succeeded_at;
+}
+
 export function getJobVisualStatus(job: JobStatusInput, now: Date = new Date()): JobVisualStatus {
   if (job.status === "cancelled") return "cancelled";
-  if (job.status === "complete") return "completed";
+  if (job.status === "complete") {
+    return isUnpaidOnlineJob(job) ? "completed_unpaid" : "completed";
+  }
 
   const hasClockIn = !!job.clock_entry?.clock_in_at;
   const hasClockOut = !!job.clock_entry?.clock_out_at;
@@ -81,15 +112,26 @@ export function getJobVisualStatus(job: JobStatusInput, now: Date = new Date()):
   // needed) but the function returns scheduled/unassigned instead so
   // the board doesn't paint "NO SHOW" badges on import data with
   // stale scheduled_times that pre-date go-live.
+  //
+  // En route slots between no_show and late_clockin: a tech who said
+  // "on my way" 10 min after start should read EN ROUTE, not LATE
+  // (the office knows they're coming). But once we're past the
+  // no_show threshold (30 min), en_route loses — there's an
+  // operational problem regardless of what the tech radioed.
   if (LIVE_OPS && isToday(job.scheduled_date, now) && !hasClockIn) {
     const nowMins = now.getHours() * 60 + now.getMinutes();
     const startMins = timeToMins(job.scheduled_time);
     if (startMins > 0) {
       const minsLate = nowMins - startMins;
       if (minsLate >= NO_SHOW_THRESHOLD_MIN) return "no_show";
+      if (job.en_route_at) return "en_route";
       if (minsLate >= LATE_GRACE_MIN) return "late_clockin";
     }
   }
+
+  // En route can also fire BEFORE scheduled start (tech is heading
+  // there early). No clock-in yet, en_route_at set.
+  if (job.en_route_at && !hasClockIn) return "en_route";
 
   if (job.assigned_user_id == null) return "unassigned";
   return "scheduled";
@@ -121,6 +163,10 @@ export interface StatusVisual {
   desaturate: boolean;
   /** Border color override (red for late/no_show, default for others). */
   borderOverride: string | null;
+  /** Whether to render an animated car icon left of the client name
+   *  (en_route only). The icon + motion-line markup is owned by each
+   *  consumer; this flag is the trigger. */
+  showCarIcon: boolean;
 }
 
 export const STATUS_VISUALS: Record<JobVisualStatus, StatusVisual> = {
@@ -135,6 +181,7 @@ export const STATUS_VISUALS: Record<JobVisualStatus, StatusVisual> = {
     strikethrough: false,
     desaturate: false,
     borderOverride: null,
+    showCarIcon: false,
   },
   active: {
     label: "Active",
@@ -147,6 +194,20 @@ export const STATUS_VISUALS: Record<JobVisualStatus, StatusVisual> = {
     strikethrough: false,
     desaturate: false,
     borderOverride: null,
+    showCarIcon: false,
+  },
+  en_route: {
+    label: "En route",
+    description: "Tech tapped 'On My Way' but hasn't clocked in yet.",
+    swatch: "#A78BFA",
+    stripe: null,
+    bodyOpacity: 1,
+    showCheckmark: false,
+    showNoShowBadge: false,
+    strikethrough: false,
+    desaturate: false,
+    borderOverride: null,
+    showCarIcon: true,
   },
   completed: {
     label: "Completed",
@@ -159,6 +220,20 @@ export const STATUS_VISUALS: Record<JobVisualStatus, StatusVisual> = {
     strikethrough: false,
     desaturate: false,
     borderOverride: null,
+    showCarIcon: false,
+  },
+  completed_unpaid: {
+    label: "Completed (unpaid)",
+    description: "Job done but online charge has not succeeded. Amber ring.",
+    swatch: "#BA7517",
+    stripe: null,
+    bodyOpacity: 0.6,
+    showCheckmark: true,
+    showNoShowBadge: false,
+    strikethrough: false,
+    desaturate: false,
+    borderOverride: "#BA7517",
+    showCarIcon: false,
   },
   late_clockin: {
     label: "Late clock-in",
@@ -171,6 +246,7 @@ export const STATUS_VISUALS: Record<JobVisualStatus, StatusVisual> = {
     strikethrough: false,
     desaturate: false,
     borderOverride: "#DC2626",
+    showCarIcon: false,
   },
   no_show: {
     label: "No show",
@@ -183,6 +259,7 @@ export const STATUS_VISUALS: Record<JobVisualStatus, StatusVisual> = {
     strikethrough: false,
     desaturate: false,
     borderOverride: "#991B1B",
+    showCarIcon: false,
   },
   cancelled: {
     label: "Cancelled",
@@ -195,6 +272,7 @@ export const STATUS_VISUALS: Record<JobVisualStatus, StatusVisual> = {
     strikethrough: true,
     desaturate: true,
     borderOverride: null,
+    showCarIcon: false,
   },
   unassigned: {
     label: "Unassigned",
@@ -207,6 +285,7 @@ export const STATUS_VISUALS: Record<JobVisualStatus, StatusVisual> = {
     strikethrough: false,
     desaturate: false,
     borderOverride: "#F59E0B",
+    showCarIcon: false,
   },
 };
 
@@ -231,8 +310,17 @@ export function ensureJobStatusStyles(): void {
     .qleno-active-stripe {
       animation: qleno-active-stripe-pulse 2s ease-in-out infinite;
     }
+    @keyframes qleno-en-route-drive {
+      0%   { transform: translateX(0); }
+      50%  { transform: translateX(1.5px); }
+      100% { transform: translateX(0); }
+    }
+    .qleno-en-route-icon {
+      animation: qleno-en-route-drive 0.8s ease-in-out infinite;
+    }
     @media (prefers-reduced-motion: reduce) {
       .qleno-active-stripe { animation: none; opacity: 1; }
+      .qleno-en-route-icon { animation: none; }
     }
   `;
   document.head.appendChild(style);

--- a/artifacts/qleno/src/lib/price-delta.test.ts
+++ b/artifacts/qleno/src/lib/price-delta.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Run with: pnpm exec tsx --test src/lib/price-delta.test.ts
+ * (uses Node's built-in `node:test` runner — no vitest/jest needed.)
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { computePriceDelta } from "./price-delta.js";
+
+test("Case A: billed_amount is null → no delta, price shows base_fee", () => {
+  const r = computePriceDelta({
+    amount: 250,
+    billedAmount: null,
+    hourlyRate: null,
+    billingMethod: null,
+  });
+  assert.equal(r.deltaAmount, null);
+  assert.equal(r.display, "$250");
+});
+
+test("Case A (undefined billed): no delta, price shows base_fee", () => {
+  const r = computePriceDelta({
+    amount: 180,
+    billedAmount: undefined,
+    hourlyRate: null,
+    billingMethod: null,
+  });
+  assert.equal(r.deltaAmount, null);
+  assert.equal(r.display, "$180");
+});
+
+test("Case B: billed_amount === base_fee → no delta, price shows base_fee", () => {
+  const r = computePriceDelta({
+    amount: 200,
+    billedAmount: 200,
+    hourlyRate: null,
+    billingMethod: null,
+  });
+  assert.equal(r.deltaAmount, null);
+  assert.equal(r.display, "$200");
+});
+
+test("Case B (within epsilon): tiny float drift → no delta", () => {
+  // Re-aggregation can produce $200.000001 vs $200 — not worth surfacing.
+  const r = computePriceDelta({
+    amount: 200,
+    billedAmount: 200.0001,
+    hourlyRate: null,
+    billingMethod: null,
+  });
+  assert.equal(r.deltaAmount, null);
+  assert.equal(r.display, "$200");
+});
+
+test("Case C (positive): billed > base_fee → delta renders, price shows billed", () => {
+  const r = computePriceDelta({
+    amount: 200,
+    billedAmount: 245,
+    hourlyRate: null,
+    billingMethod: null,
+  });
+  assert.equal(r.deltaAmount, 45);
+  assert.equal(r.display, "$245");
+});
+
+test("Case C (negative): billed < base_fee → delta renders negative, price shows billed", () => {
+  const r = computePriceDelta({
+    amount: 250,
+    billedAmount: 230,
+    hourlyRate: null,
+    billingMethod: null,
+  });
+  assert.equal(r.deltaAmount, -20);
+  assert.equal(r.display, "$230");
+});
+
+test("Case C: half-dollar threshold — $0.50 difference renders delta", () => {
+  const r = computePriceDelta({
+    amount: 200,
+    billedAmount: 200.5,
+    hourlyRate: null,
+    billingMethod: null,
+  });
+  assert.equal(r.deltaAmount, 0.5);
+});
+
+test("Case C: under threshold — $0.49 difference does NOT render delta", () => {
+  const r = computePriceDelta({
+    amount: 200,
+    billedAmount: 200.49,
+    hourlyRate: null,
+    billingMethod: null,
+  });
+  assert.equal(r.deltaAmount, null);
+});
+
+test("Hourly job: delta suppressed even when hourly_rate set, display shows /hr", () => {
+  const r = computePriceDelta({
+    amount: 0,
+    billedAmount: 480, // would otherwise show a $480 delta
+    hourlyRate: 60,
+    billingMethod: "hourly",
+  });
+  assert.equal(r.isHourly, true);
+  assert.equal(r.deltaAmount, null);
+  assert.equal(r.display, "$60/hr");
+});
+
+test("Edge: base_fee 0, billed null → no delta, $0 display", () => {
+  const r = computePriceDelta({
+    amount: 0,
+    billedAmount: null,
+    hourlyRate: null,
+    billingMethod: null,
+  });
+  assert.equal(r.deltaAmount, null);
+  assert.equal(r.display, "$0");
+});
+
+test("Edge: base_fee 0 with billed set — delta suppressed (no original to compare against)", () => {
+  // baseFee > 0 guard means a job created with no base_fee shouldn't
+  // suddenly show a "↑ $X" pill the moment billed_amount lands.
+  const r = computePriceDelta({
+    amount: 0,
+    billedAmount: 150,
+    hourlyRate: null,
+    billingMethod: null,
+  });
+  assert.equal(r.deltaAmount, null);
+  assert.equal(r.display, "$150"); // shows billed when present
+});

--- a/artifacts/qleno/src/lib/price-delta.ts
+++ b/artifacts/qleno/src/lib/price-delta.ts
@@ -1,0 +1,68 @@
+/**
+ * [job-card-redesign] Pure helper for the chip's price + delta render.
+ *
+ * The dispatch payload exposes both `amount` (the original quote, sourced
+ * from jobs.base_fee) and `billed_amount` (the current charged price,
+ * sourced from jobs.billed_amount and updated by add-on / hour / discount
+ * edits). The chip shows a green "↑ $X" or red "↓ $X" pill ONLY when
+ * those two diverge by at least $0.50 — small float drift from
+ * recalculation isn't worth surfacing.
+ *
+ * Hourly jobs intentionally hide the delta: the displayed "$X/hr" is
+ * the hourly rate, not the job total, so subtracting from base_fee
+ * isn't meaningful.
+ */
+
+export interface PriceDeltaInput {
+  amount: number | null | undefined;          // base_fee on the payload
+  billedAmount: number | null | undefined;    // billed_amount on the payload
+  hourlyRate: number | null | undefined;
+  billingMethod: string | null | undefined;
+}
+
+export interface PriceDelta {
+  /** What to render as the price text (already $-prefixed). */
+  display: string;
+  /** Signed dollar delta (current − original). null when no pill should render. */
+  deltaAmount: number | null;
+  /** True for hourly jobs — caller can use this to suppress the delta. */
+  isHourly: boolean;
+}
+
+const DELTA_EPSILON = 0.5;
+
+export function computePriceDelta(input: PriceDeltaInput): PriceDelta {
+  const isHourly = input.billingMethod === "hourly" && input.hourlyRate != null;
+
+  if (isHourly) {
+    return {
+      display: `$${(input.hourlyRate ?? 0).toFixed(0)}/hr`,
+      deltaAmount: null,
+      isHourly: true,
+    };
+  }
+
+  const baseFee = Number(input.amount ?? 0);
+  const billed = input.billedAmount != null ? Number(input.billedAmount) : null;
+
+  // Delta renders only when:
+  //   - billed is non-null AND
+  //   - base_fee was a real positive number (so we have an "original" to
+  //     diff against; jobs imported with base_fee=0 don't pop a "↑ $150"
+  //     pill the moment billed_amount lands), AND
+  //   - the two diverge by at least $0.50 (filter float drift from
+  //     re-aggregation)
+  const delta = billed != null && baseFee > 0 && Math.abs(billed - baseFee) >= DELTA_EPSILON
+    ? billed - baseFee
+    : null;
+
+  // Display: billed if present (it's the current price), else base_fee.
+  // Preserves the prior `billed ?? base_fee` semantic — billed is more
+  // current even when delta is suppressed (e.g. base=0).
+  const displayValue = billed != null ? billed : baseFee;
+  return {
+    display: `$${Math.round(displayValue)}`,
+    deltaAmount: delta,
+    isHourly: false,
+  };
+}

--- a/artifacts/qleno/src/pages/jobs-visual-test.tsx
+++ b/artifacts/qleno/src/pages/jobs-visual-test.tsx
@@ -1,0 +1,258 @@
+/**
+ * [job-card-redesign] Visual proof page for the JobChip lifecycle states.
+ *
+ * Renders every visual status side-by-side at narrow (~30 min, single-line)
+ * and wide (~3 h, full two-row) widths, plus the new-client overlay. Used
+ * for visual review before merging the chip redesign — gives the reviewer
+ * a single screenshot that proves all state treatments render correctly.
+ *
+ * Route: /jobs/visual-test (dev-only — NOT mounted in production builds).
+ *
+ * Why a dedicated page rather than Storybook: this codebase doesn't have
+ * Storybook yet, and adding it just for one component would be heavy.
+ * One self-contained page that reuses the real JobChip via a `forceStatus`
+ * prop is sufficient for the verification ask.
+ */
+import { DndContext } from "@dnd-kit/core";
+import { _JobChipForTesting as JobChip, type _DispatchJobForTesting as DispatchJob } from "@/pages/jobs";
+import { ensureJobStatusStyles, type JobVisualStatus } from "@/lib/job-status";
+import { useEffect } from "react";
+
+const FF = "'Plus Jakarta Sans', sans-serif";
+
+const STATES: Array<{ status: JobVisualStatus; label: string; note?: string }> = [
+  { status: "scheduled",        label: "Scheduled",         note: "Default — on the board, no clock-in yet." },
+  { status: "en_route",         label: "En route",          note: "Tech tapped 'On My Way'. Inert in prod until en_route_at column lands." },
+  { status: "active",           label: "In progress",       note: "Clocked in. Amber stripe pulses; progress bar fills with elapsed/allowed." },
+  { status: "completed",        label: "Completed",         note: "Status='complete'. Body fades to 60% + green check badge." },
+  { status: "completed_unpaid", label: "Completed (unpaid)",note: "Complete but online charge not yet succeeded. Amber ring + UNPAID pill." },
+  { status: "late_clockin",     label: "Late clock-in",     note: "5+ min past start, no clock-in. Red border + LATE pill." },
+  { status: "no_show",          label: "No show",           note: "30+ min past start, no clock-in. Solid red border + NO SHOW badge." },
+  { status: "cancelled",        label: "Cancelled",         note: "Manually cancelled. Body desaturated + name strikethrough." },
+  { status: "unassigned",       label: "Unassigned",        note: "No primary tech. Amber border. Normally lives in the Unassigned row." },
+];
+
+// Representative residential job — has add-ons + price delta.
+const baseRes: DispatchJob = {
+  id: 1001,
+  client_id: 5001,
+  client_name: "Maria Hernandez",
+  client_phone: "(773) 555-0101",
+  client_zip: "60629",
+  client_notes: null,
+  client_payment_method: "stripe",
+  client_type: "residential",
+  address: "5421 S Kedzie Ave, Chicago, IL 60629",
+  assigned_user_id: 12,
+  service_type: "deep_clean",
+  status: "scheduled",
+  scheduled_date: "2026-04-29",
+  scheduled_time: "08:00",
+  frequency: "biweekly",
+  amount: 220,             // base_fee
+  billed_amount: 265,      // current — drives the delta pill
+  duration_minutes: 180,   // 3 hours → wide layout
+  notes: null,
+  before_photo_count: 0,
+  after_photo_count: 0,
+  clock_entry: null,
+  zone_id: 7,
+  zone_color: "#7C3AED",   // Cook Central — purple
+  zone_name: "Chicago Central",
+  add_ons: [
+    { name: "Inside Oven",  quantity: 1, unit_price: 35, subtotal: 35 },
+    { name: "Inside Fridge",quantity: 1, unit_price: 35, subtotal: 35 },
+  ],
+  is_new_client: false,
+  account_id: null,
+  account_name: null,
+  billing_method: null,
+  hourly_rate: null,
+  estimated_hours: 3,
+  actual_hours: null,
+  billed_hours: null,
+  charge_failed_at: null,
+  charge_succeeded_at: null,
+  technicians: [{ user_id: 12, name: "Pancho Ramos", is_primary: true, est_hours: 3, calc_pay: 92.75, final_pay: 92.75, pay_override: null }],
+  est_hours_per_tech: 3,
+  est_pay_per_tech: 92.75,
+  company_res_pct: 0.35,
+  commission_basis: "residential_pool",
+  commercial_hourly_rate: null,
+  locked_at: null,
+  actual_end_time: null,
+  completed_by_user_id: null,
+};
+
+// Representative commercial job — no add-ons, hourly billing.
+const baseCom: DispatchJob = {
+  ...baseRes,
+  id: 2001,
+  client_id: 0,
+  client_name: "Riverside Office Tower",
+  client_phone: "(708) 555-0202",
+  client_zip: "60546",
+  client_payment_method: "square",
+  client_type: "commercial",
+  address: "31 W Quincy St, Riverside, IL 60546",
+  service_type: "office_cleaning",
+  scheduled_time: "10:00",
+  frequency: "weekly",
+  amount: 0,
+  billed_amount: null,
+  duration_minutes: 180,
+  zone_id: 11,
+  zone_color: "#2563EB",   // West/Riverside — blue
+  zone_name: "West Suburbs",
+  add_ons: [],
+  is_new_client: false,
+  account_id: 7,
+  account_name: "Riverside Office Tower",
+  billing_method: "hourly",
+  hourly_rate: 60,
+  technicians: [
+    { user_id: 12, name: "Pancho Ramos",  is_primary: true,  est_hours: 1.5, calc_pay: 30, final_pay: 30, pay_override: null },
+    { user_id: 14, name: "Maribel Ortiz", is_primary: false, est_hours: 1.5, calc_pay: 30, final_pay: 30, pay_override: null },
+  ],
+  commission_basis: "commercial_hourly",
+  commercial_hourly_rate: 60,
+};
+
+// Builders that mutate the right fields for each visual state. Using
+// real shape + overrides rather than fabricating gives an honest
+// preview of what dispatchers will see.
+function withState(base: DispatchJob, status: JobVisualStatus, narrow: boolean): DispatchJob {
+  const j: DispatchJob = {
+    ...base,
+    duration_minutes: narrow ? 30 : 180,
+    scheduled_time: narrow ? "08:00" : "08:00",
+  };
+  // The forceStatus prop on JobChip handles the visual override — we
+  // still seed a few derivation fields so any helper inside the chip
+  // that reads them (live timer math, late-min math) gets sensible
+  // values rather than NaN.
+  switch (status) {
+    case "active":
+      j.clock_entry = { id: 1, clock_in_at: new Date(Date.now() - 72 * 60 * 1000).toISOString(), clock_out_at: null, distance_from_job_ft: 12, is_flagged: false };
+      j.status = "in_progress";
+      break;
+    case "en_route":
+      j.en_route_at = new Date(Date.now() - 8 * 60 * 1000).toISOString();
+      break;
+    case "completed":
+      j.status = "complete";
+      j.charge_succeeded_at = new Date().toISOString();
+      j.client_payment_method = "stripe";
+      break;
+    case "completed_unpaid":
+      j.status = "complete";
+      j.charge_succeeded_at = null;
+      j.client_payment_method = "stripe";
+      break;
+    case "late_clockin":
+      // 12 minutes past scheduled_time, no clock-in. The chip's lateMin
+      // helper computes from now − scheduled_time; bump scheduled_time
+      // to "now − 12 min" so the LATE pill shows a realistic value.
+      const lateNow = new Date();
+      const lateMins = lateNow.getHours() * 60 + lateNow.getMinutes() - 12;
+      j.scheduled_time = `${String(Math.floor(lateMins / 60)).padStart(2, "0")}:${String(lateMins % 60).padStart(2, "0")}`;
+      j.status = "scheduled";
+      j.clock_entry = null;
+      break;
+    case "no_show":
+      const nsNow = new Date();
+      const nsMins = nsNow.getHours() * 60 + nsNow.getMinutes() - 45;
+      j.scheduled_time = `${String(Math.floor(nsMins / 60)).padStart(2, "0")}:${String(nsMins % 60).padStart(2, "0")}`;
+      j.status = "scheduled";
+      j.clock_entry = null;
+      break;
+    case "cancelled":
+      j.status = "cancelled";
+      break;
+    case "unassigned":
+      j.assigned_user_id = null;
+      break;
+  }
+  return j;
+}
+
+const noop = () => {};
+
+function ChipFrame({ children }: { children: React.ReactNode }) {
+  // The chip is `position: absolute` and lays itself out from
+  // scheduled_time → left, duration → width. Wrap each chip in a
+  // 480 × 80 relative box so chips don't collide with the next row.
+  return (
+    <div style={{ position: "relative", width: 480, height: 80, marginTop: 8, background: "#FAF9F6", borderRadius: 8 }}>
+      {children}
+    </div>
+  );
+}
+
+function StateRow({ status, label, note, narrow, newClient }: { status: JobVisualStatus; label: string; note?: string; narrow: boolean; newClient: boolean }) {
+  const base = status === "no_show" || status === "late_clockin" ? baseRes : (status === "unassigned" ? baseRes : baseRes);
+  const job = withState({ ...base, is_new_client: newClient }, status, narrow);
+  const jobCom = withState({ ...baseCom, is_new_client: false }, status, narrow);
+  return (
+    <div style={{ borderBottom: "1px solid #EAE6DF", padding: "16px 0" }}>
+      <div style={{ display: "flex", alignItems: "baseline", gap: 12, marginBottom: 6 }}>
+        <div style={{ fontSize: 14, fontWeight: 800, color: "#1A1917" }}>{label}</div>
+        {newClient && <span style={{ fontSize: 11, fontWeight: 700, padding: "1px 6px", borderRadius: 4, background: "#FFF1B8", color: "#92400E" }}>NEW-CLIENT OVERLAY</span>}
+        {note && <div style={{ fontSize: 12, color: "#6B6860" }}>{note}</div>}
+      </div>
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16 }}>
+        <div>
+          <div style={{ fontSize: 11, color: "#9E9B94", marginBottom: 4 }}>Residential · {narrow ? "narrow ~30 min" : "wide ~3 h"}</div>
+          <ChipFrame>
+            <JobChip job={job} onClick={noop} forceStatus={status} />
+          </ChipFrame>
+        </div>
+        <div>
+          <div style={{ fontSize: 11, color: "#9E9B94", marginBottom: 4 }}>Commercial · {narrow ? "narrow ~30 min" : "wide ~3 h"}</div>
+          <ChipFrame>
+            <JobChip job={jobCom} onClick={noop} forceStatus={status} />
+          </ChipFrame>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function JobsVisualTestPage() {
+  useEffect(() => { ensureJobStatusStyles(); }, []);
+
+  // Production guard — this route should never mount in PROD bundles
+  // anyway (App.tsx gates it), but if someone forces it here we render
+  // a not-available message instead of leaking demo data.
+  if (import.meta.env.PROD) {
+    return (
+      <div style={{ padding: 40, fontFamily: FF, color: "#1A1917" }}>
+        Not available in production builds.
+      </div>
+    );
+  }
+
+  return (
+    <DndContext>
+      <div style={{ padding: "24px 32px 80px", background: "#F7F6F3", minHeight: "100vh", fontFamily: FF }}>
+        <div style={{ maxWidth: 1080, margin: "0 auto" }}>
+          <div style={{ marginBottom: 24 }}>
+            <div style={{ fontSize: 24, fontWeight: 800, color: "#1A1917" }}>JobChip · visual test</div>
+            <div style={{ fontSize: 13, color: "#6B6860", marginTop: 4, lineHeight: 1.5 }}>
+              All lifecycle states rendered with representative data — residential w/ add-ons + price delta, and commercial hourly w/o add-ons. Each state shown at narrow (~30 min, single-line layout) and wide (~3 h, full two-row layout). The <code>forceStatus</code> prop bypasses the LIVE_OPS / clock-derivation gates so late_clockin and no_show paint even outside go-live.
+            </div>
+          </div>
+
+          <div style={{ fontSize: 18, fontWeight: 800, color: "#1A1917", marginTop: 16 }}>Wide chips (~3 h)</div>
+          {STATES.map(s => <StateRow key={`w-${s.status}`} status={s.status} label={s.label} note={s.note} narrow={false} newClient={false} />)}
+
+          <div style={{ fontSize: 18, fontWeight: 800, color: "#1A1917", marginTop: 32 }}>Narrow chips (~30 min)</div>
+          {STATES.map(s => <StateRow key={`n-${s.status}`} status={s.status} label={s.label} note={s.note} narrow={true} newClient={false} />)}
+
+          <div style={{ fontSize: 18, fontWeight: 800, color: "#1A1917", marginTop: 32 }}>NEW-client overlay (on scheduled)</div>
+          <StateRow status="scheduled" label="Scheduled + new-client overlay" note="Inset white outline + NEW pill before client name. Triggered server-side when a residential client has no completed jobs prior to today's board date." narrow={false} newClient={true} />
+        </div>
+      </div>
+    </DndContext>
+  );
+}

--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -62,7 +62,8 @@ const STATUS: Record<string, { bg: string; border: string; text: string; dot: st
 // ─── TYPES ────────────────────────────────────────────────────────────────────
 interface ClockEntry { id: number; clock_in_at: string | null; clock_out_at: string | null; distance_from_job_ft: number | null; is_flagged: boolean; }
 interface JobTechCommission { user_id: number; name: string; is_primary: boolean; est_hours: number; calc_pay: number; final_pay: number; pay_override: number | null; }
-interface DispatchJob { id: number; client_id: number; client_name: string; client_phone?: string | null; client_zip?: string | null; client_notes?: string | null; client_payment_method?: string | null; /* [tile redesign] residential or commercial badge; commercial when account_id is set OR client_type === 'commercial' */ client_type?: "residential" | "commercial" | null; address: string | null; /* [inline-edit] raw fields for address editor mode detection */ job_address_street?: string | null; job_address_city?: string | null; job_address_state?: string | null; job_address_zip?: string | null; client_address?: string | null; client_city?: string | null; client_state?: string | null; client_address_zip?: string | null; assigned_user_id: number | null; assigned_user_name?: string; service_type: string; status: string; scheduled_date: string; scheduled_time: string | null; frequency: string; amount: number; duration_minutes: number; notes: string | null; office_notes?: string | null; before_photo_count: number; after_photo_count: number; clock_entry: ClockEntry | null; zone_id?: number | null; zone_color?: string | null; zone_name?: string | null; branch_id?: number | null; branch_name?: string | null; last_service_date?: string | null; account_id?: number | null; account_name?: string | null; billing_method?: string | null; hourly_rate?: number | null; estimated_hours?: number | null; actual_hours?: number | null; billed_hours?: number | null; billed_amount?: number | null; charge_failed_at?: string | null; charge_succeeded_at?: string | null; property_access_notes?: string | null; booking_location?: string | null; technicians?: JobTechCommission[]; est_hours_per_tech?: number | null; est_pay_per_tech?: number | null; company_res_pct?: number | null; /* [AI.7.4] Commission routing — 'commercial_hourly' or 'residential_pool' */ commission_basis?: "commercial_hourly" | "residential_pool" | null; commercial_hourly_rate?: number | null; /* [AF] completion lock state */ locked_at?: string | null; actual_end_time?: string | null; completed_by_user_id?: number | null; }
+interface JobAddOn { name: string; quantity: number; unit_price: number; subtotal: number; }
+interface DispatchJob { id: number; client_id: number; client_name: string; client_phone?: string | null; client_zip?: string | null; client_notes?: string | null; client_payment_method?: string | null; /* [tile redesign] residential or commercial badge; commercial when account_id is set OR client_type === 'commercial' */ client_type?: "residential" | "commercial" | null; address: string | null; /* [inline-edit] raw fields for address editor mode detection */ job_address_street?: string | null; job_address_city?: string | null; job_address_state?: string | null; job_address_zip?: string | null; client_address?: string | null; client_city?: string | null; client_state?: string | null; client_address_zip?: string | null; assigned_user_id: number | null; assigned_user_name?: string; service_type: string; status: string; scheduled_date: string; scheduled_time: string | null; frequency: string; amount: number; duration_minutes: number; notes: string | null; office_notes?: string | null; before_photo_count: number; after_photo_count: number; clock_entry: ClockEntry | null; zone_id?: number | null; zone_color?: string | null; zone_name?: string | null; branch_id?: number | null; branch_name?: string | null; last_service_date?: string | null; account_id?: number | null; account_name?: string | null; billing_method?: string | null; hourly_rate?: number | null; estimated_hours?: number | null; actual_hours?: number | null; billed_hours?: number | null; billed_amount?: number | null; charge_failed_at?: string | null; charge_succeeded_at?: string | null; property_access_notes?: string | null; booking_location?: string | null; technicians?: JobTechCommission[]; est_hours_per_tech?: number | null; est_pay_per_tech?: number | null; company_res_pct?: number | null; /* [AI.7.4] Commission routing — 'commercial_hourly' or 'residential_pool' */ commission_basis?: "commercial_hourly" | "residential_pool" | null; commercial_hourly_rate?: number | null; /* [AF] completion lock state */ locked_at?: string | null; actual_end_time?: string | null; completed_by_user_id?: number | null; /* [job-card-redesign] Add-ons drive the +N pill on the chip and the full list in the popover. is_new_client = first-ever residential job (no prior completed). en_route_at scaffolds the "On My Way" status; column doesn't exist yet, so the field is always undefined until the SMS engine lands. */ add_ons?: JobAddOn[]; is_new_client?: boolean; en_route_at?: string | null; }
 interface Employee { id: number; name: string; role: string; jobs: DispatchJob[]; zone?: { zone_id: number; zone_color: string; zone_name: string } | null; time_off?: 'pto' | 'sick' | 'absent' | null; commission_rate?: number | null; }
 interface DispatchData { employees: Employee[]; unassigned_jobs: DispatchJob[]; }
 
@@ -2256,6 +2257,25 @@ function JobHoverCard({ job, assignedName }: { job: DispatchJob; assignedName?: 
         </div>
       </div>
 
+      {/* ─── ADD-ONS (only when present) ─── */}
+      {job.add_ons && job.add_ons.length > 0 && (
+        <div style={{ padding: "16px 20px", borderBottom: sectionBorder }}>
+          <div style={labelStyle}>Add-ons ({job.add_ons.length})</div>
+          <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+            {job.add_ons.map((a, i) => (
+              <div key={i} style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", gap: 8, fontSize: 13, color: "#1A1917" }}>
+                <span style={{ fontWeight: 500, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                  {a.quantity > 1 ? `${a.quantity}× ` : ""}{a.name}
+                </span>
+                <span style={{ fontWeight: 600, color: "#6B6860", flexShrink: 0 }}>
+                  ${a.subtotal.toFixed(2)}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
       {/* ─── TOTAL + PAYMENT ─── */}
       <div style={{ padding: "16px 20px", borderBottom: sectionBorder, display: "grid", gridTemplateColumns: paymentLabel ? "1fr 1fr" : "1fr", gap: "0 20px" }}>
         <div>
@@ -2349,40 +2369,36 @@ function JobHoverCard({ job, assignedName }: { job: DispatchJob; assignedName?: 
 }
 
 // ─── DESKTOP: JOB CHIP ─────────────────────────────────────────────────────────
+//
+// [job-card-redesign] Two-row layout:
+//   Row 1 (identity + money): [status icon] [LATE pill] [NEW pill]
+//                             [client name] [RES/COM] · · · [live timer]
+//                             [price] [delta]
+//   Row 2 (context):           [recurring ✓] [service · cadence · duration]
+//                              · · · [+N add-ons]
+//
+// Width breakpoints (SLOT_W = 64 px / 30 min):
+//   wide   ≥ 192 px (3 slots = 1.5 h+) — full two-row layout
+//   medium 120–191 px                  — drop add-ons pill, drop NEW pill,
+//                                        drop duration on row 2
+//   narrow < 120 px (< 1 h)            — single-line: name + price only,
+//                                        all pills hidden
+//
+// Status routes through getJobVisualStatus(); STATUS_VISUALS owns stripe,
+// border, opacity, checkmark, no-show, car-icon flag. Chip-specific
+// elaborations (live timer pill, progress bar, NEW pill) are derived
+// from job fields directly — they don't fit the "every-surface" contract
+// and would noise up the canonical visual.
 function JobChip({ job, onClick, assignedName, isUnassigned }: { job: DispatchJob; onClick: (j: DispatchJob) => void; assignedName?: string; isUnassigned?: boolean }) {
-  // [X] `sc` (status color palette) no longer needed — border uses its own
-  // priority-based color logic below; zone-tinted bg replaces the
-  // status.bg fallback entirely. `assignedName` is still passed through
-  // to JobHoverCard (unassigned fallback display) but is not rendered in
-  // the card body itself.
   const left = ((timeToMins(job.scheduled_time) - DAY_START) / 30) * SLOT_W;
   const width = Math.max(SLOT_W, (job.duration_minutes / 30) * SLOT_W);
   const isComplete = job.status === "complete";
-  const isRecurring = job.frequency && job.frequency !== "on_demand";
+  const isRecurring = !!job.frequency && job.frequency !== "on_demand";
+  const isCommercial = !!job.account_id || job.client_type === "commercial";
   const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({ id: `chip-${job.id}`, data: { job, originalLeft: left, type: isUnassigned ? "unassigned" : undefined }, disabled: isComplete });
 
-  // [AB] Full-opacity zone-color card matching MC's Job Schedule visual
-  // weight. Previous 15% alpha tint was spec'd to feel "subtle" but read
-  // as washed-out in practice — failed the "glance from across the room"
-  // test. MC uses saturated fills with white text; matching that now.
-  //
-  // Border priority (unchanged from X/V):
-  //   1. red   — late clock-in OR at-risk (today, past start−15 min, no clock-in)
-  //   2. amber — in_progress
-  //   3. green — complete
-  //   4. zone color at full opacity — scheduled default (same as bg,
-  //      so status state-changes are the only visible border transition)
-  //
-  // Text: white by default, but if the zone color's perceptual luminance
-  // exceeds 0.65 (e.g. gold #FFD700 for Tinley/Orlando/Palos Park at
-  // ~0.79) we flip to dark text so the chip stays legible. Fallback when
-  // zone is null/missing: neutral #9CA3AF (Tailwind gray-400) with white
-  // text — distinct from "colored" chips without being alarming.
-  // [AI.7.5] Visual status routes through the canonical helper so the
-  // Gantt chip, mobile card, compact rows, my-jobs view, and Legend
-  // all paint from one source. Status drives the border override,
-  // amber stripe, body opacity, checkmark badge, and no-show badge.
-  const visual = STATUS_VISUALS[getJobVisualStatus(job)];
+  const status = getJobVisualStatus(job);
+  const visual = STATUS_VISUALS[status];
 
   const ZONE_FALLBACK = "#9CA3AF";
   const bgColor = job.zone_color || ZONE_FALLBACK;
@@ -2392,12 +2408,68 @@ function JobChip({ job, onClick, assignedName, isUnassigned }: { job: DispatchJo
   const primaryText   = isLightZone ? "#1A1917" : "#FFFFFF";
   const secondaryText = isLightZone ? "#4B5563" : "rgba(255,255,255,0.90)";
   const iconTint      = isLightZone ? "#6B7280" : "rgba(255,255,255,0.90)";
+  const pillTint      = isLightZone ? "rgba(0,0,0,0.10)" : "rgba(255,255,255,0.20)";
+
+  // Width tiers
+  const isNarrow = width < 120;
+  const isWide   = width >= 192;
+  const showDuration = width >= 320;
+
+  // Price + delta. base_fee → original quote (jobs.base_fee, lands on
+  // payload as `amount`); billed_amount → current price (separate field
+  // on payload, set when add-ons or manual overrides re-price the job).
+  // Show delta only when both are present, both are non-zero, and they
+  // actually differ. Hourly jobs hide delta — the rate × hours math is
+  // surfaced elsewhere; subtracting hourly amounts isn't meaningful.
+  const isHourly = job.billing_method === "hourly" && job.hourly_rate != null;
+  const baseFee = Number(job.amount ?? 0);
+  const billed = job.billed_amount != null ? Number(job.billed_amount) : null;
+  const priceDisplay = isHourly
+    ? `$${(job.hourly_rate ?? 0).toFixed(0)}/hr`
+    : `$${Math.round(billed ?? baseFee)}`;
+  const deltaAmount = !isHourly && billed != null && baseFee > 0 && Math.abs(billed - baseFee) >= 0.5
+    ? billed - baseFee
+    : null;
+
+  // Live timer for active jobs. Computed at render time; chip re-renders
+  // on parent state changes (drag, hover, dispatch poll) so the value is
+  // approximate but acceptable for v1.
+  const clockInAt = job.clock_entry?.clock_in_at;
+  const elapsedMin = status === "active" && clockInAt
+    ? Math.max(0, Math.round((Date.now() - new Date(clockInAt).getTime()) / 60000))
+    : 0;
+  const allowedMin = job.duration_minutes > 0 ? job.duration_minutes : 60;
+  const progressFraction = status === "active" && clockInAt
+    ? Math.min(1, elapsedMin / allowedMin)
+    : 0;
+  const timerLabel = elapsedMin >= 60
+    ? `${Math.floor(elapsedMin / 60)}h ${elapsedMin % 60}m`
+    : `${elapsedMin}m`;
+
+  // Late minutes for the LATE pill — only when status is late_clockin.
+  // Mirrors the math in getJobVisualStatus(): now − scheduled_time.
+  const lateMin = (() => {
+    if (status !== "late_clockin") return 0;
+    const startMins = timeToMins(job.scheduled_time);
+    const now = new Date();
+    const nowMins = now.getHours() * 60 + now.getMinutes();
+    return Math.max(0, nowMins - startMins);
+  })();
+
+  const addOnCount = job.add_ons?.length ?? 0;
+  const isNew = job.is_new_client === true;
 
   const [hovered, setHovered] = useState(false);
   const hoverTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   function onEnter() { hoverTimer.current = setTimeout(() => setHovered(true), 400); }
   function onLeave() { if (hoverTimer.current) clearTimeout(hoverTimer.current); setHovered(false); }
+
+  // Inset white outline for new clients — single 1.5px box-shadow inset.
+  // Composed with the existing card shadow.
+  const baseShadow = "0 1px 4px rgba(0,0,0,0.12)";
+  const newShadow = isNew ? "inset 0 0 0 1.5px rgba(255,255,255,0.55)" : null;
+  const composedShadow = newShadow ? `${newShadow}, ${baseShadow}` : baseShadow;
 
   return (
     <div ref={setNodeRef}
@@ -2407,7 +2479,7 @@ function JobChip({ job, onClick, assignedName, isUnassigned }: { job: DispatchJo
       style={{
         position: "absolute", top: 10, left, width, height: ROW_H - 20,
         borderRadius: 8, backgroundColor: bgColor,
-        border: `${visual.borderOverride ? 2 : 2}px solid ${borderColor}`,
+        border: `2px solid ${borderColor}`,
         boxSizing: "border-box", overflow: "visible",
         cursor: isComplete ? "default" : isDragging ? "grabbing" : "grab",
         opacity: isDragging ? 0.3 : visual.bodyOpacity,
@@ -2415,73 +2487,164 @@ function JobChip({ job, onClick, assignedName, isUnassigned }: { job: DispatchJo
         transform: transform ? `translate(${transform.x}px, ${transform.y}px)` : undefined,
         zIndex: hovered ? 50 : isDragging ? 0 : 2,
         userSelect: "none", display: "flex", flexDirection: "row",
-        boxShadow: "0 1px 4px rgba(0,0,0,0.12)",
+        boxShadow: composedShadow,
       }}>
-      {/* [AI.7.5] Active stripe — 4px amber bar with slow opacity pulse.
-          Reduced-motion users see a steady solid bar (CSS media query
-          drops the animation). Stripe-only animation, body stays still. */}
+      {/* [AI.7.5] Active stripe — 4px amber bar with slow opacity pulse. */}
       {visual.stripe && (
         <div className="qleno-active-stripe" style={{
           width: 4, alignSelf: "stretch", backgroundColor: visual.stripe,
           borderTopLeftRadius: 6, borderBottomLeftRadius: 6, flexShrink: 0,
         }} />
       )}
-      {/* [tile redesign] 3-line hero per spec:
-            line 1: client name + Res/Comm pill (corner)
-            line 2: service type
-            line 3: $price (right-aligned)
-          Time is implied by the chip's horizontal position on the Gantt
-          axis, so the textual time line was dropped to make room. Glance
-          icons (clock-in, photos, recurring) still ride next to the client
-          name. Pill colors adapt to zone luminance.
-       */}
+
+      {/* [job-card-redesign] In-progress progress bar — 3px white bar
+          riding the top edge, fills based on elapsed/allowed. Inside the
+          card so it inherits border-radius clipping. Hidden when the job
+          isn't active (or has no clock-in yet). */}
+      {status === "active" && progressFraction > 0 && (
+        <div style={{
+          position: "absolute", top: 0, left: 0, right: 0, height: 3,
+          backgroundColor: "rgba(0,0,0,0.18)", borderTopLeftRadius: 6, borderTopRightRadius: 6,
+          overflow: "hidden", zIndex: 2, pointerEvents: "none",
+        }}>
+          <div style={{
+            width: `${progressFraction * 100}%`, height: "100%",
+            backgroundColor: "rgba(255,255,255,0.92)",
+          }} />
+        </div>
+      )}
+
       <div style={{ flex: 1, minWidth: 0, padding: "6px 10px", display: "flex", flexDirection: "column", justifyContent: "center", gap: 2 }}>
-        <div style={{ display: "flex", alignItems: "center", gap: 4, minWidth: 0 }}>
-          {job.clock_entry?.clock_in_at && <Clock size={9} style={{ color: iconTint, flexShrink: 0 }} />}
-          {job.after_photo_count > 0 && <Camera size={9} style={{ color: iconTint, flexShrink: 0 }} />}
-          {isRecurring && <Repeat size={9} style={{ color: iconTint, flexShrink: 0 }} />}
-          <span style={{ fontSize: 11, fontWeight: 700, color: primaryText, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis", flex: 1, minWidth: 0, textDecoration: visual.strikethrough ? "line-through" : "none" }}>
-            {job.client_name}
-          </span>
-          {/* Res/Comm pill: commercial when account_id is set OR client_type === 'commercial' */}
-          {(() => {
-            const isCommercial = !!job.account_id || job.client_type === "commercial";
-            return (
+        {isNarrow ? (
+          // ── Narrow: single line, name + price ──
+          <div style={{ display: "flex", alignItems: "center", gap: 4, minWidth: 0 }}>
+            {visual.showCarIcon && <CarIconInline tint={primaryText} />}
+            <span style={{ fontSize: 11, fontWeight: 700, color: primaryText, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis", flex: 1, minWidth: 0, textDecoration: visual.strikethrough ? "line-through" : "none" }}>
+              {job.client_name}
+            </span>
+            <span style={{ fontSize: 11, fontWeight: 800, color: primaryText, whiteSpace: "nowrap", flexShrink: 0 }}>
+              {priceDisplay}
+            </span>
+          </div>
+        ) : (
+          <>
+            {/* ── Top row ── */}
+            <div style={{ display: "flex", alignItems: "center", gap: 4, minWidth: 0 }}>
+              {/* Status icons (left of name) */}
+              {visual.showCarIcon && <CarIconInline tint={primaryText} />}
+              {!visual.showCarIcon && job.clock_entry?.clock_in_at && status !== "active" && (
+                <Clock size={9} style={{ color: iconTint, flexShrink: 0 }} />
+              )}
+              {/* LATE pill — replaces other status icons when late_clockin */}
+              {status === "late_clockin" && lateMin > 0 && (
+                <span style={{
+                  flexShrink: 0, fontSize: 8, fontWeight: 800,
+                  padding: "1px 5px", borderRadius: 4,
+                  backgroundColor: "#DC2626", color: "#FFFFFF",
+                  textTransform: "uppercase", letterSpacing: "0.05em", lineHeight: 1.2,
+                }}>
+                  Late {lateMin}m
+                </span>
+              )}
+              {/* UNPAID pill — completed but online charge has not succeeded */}
+              {status === "completed_unpaid" && (
+                <span style={{
+                  flexShrink: 0, fontSize: 8, fontWeight: 800,
+                  padding: "1px 5px", borderRadius: 4,
+                  backgroundColor: "#BA7517", color: "#FFFFFF",
+                  textTransform: "uppercase", letterSpacing: "0.05em", lineHeight: 1.2,
+                }}>
+                  Unpaid
+                </span>
+              )}
+              {/* NEW pill — first-ever job for residential client */}
+              {isNew && isWide && (
+                <span style={{
+                  flexShrink: 0, fontSize: 9, fontWeight: 700,
+                  padding: "1px 5px", borderRadius: 4,
+                  backgroundColor: "#FFFFFF", color: bgColor,
+                  textTransform: "uppercase", letterSpacing: "0.05em", lineHeight: 1.2,
+                }}>
+                  New
+                </span>
+              )}
+              {/* Photo glance icon stays — useful at-a-glance signal */}
+              {job.after_photo_count > 0 && status !== "active" && (
+                <Camera size={9} style={{ color: iconTint, flexShrink: 0 }} />
+              )}
+              <span style={{ fontSize: 11, fontWeight: 700, color: primaryText, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis", flex: 1, minWidth: 0, textDecoration: visual.strikethrough ? "line-through" : "none" }}>
+                {job.client_name}
+              </span>
+              {/* RES/COM badge — three-letter mono */}
               <span style={{
                 flexShrink: 0,
                 fontSize: 8, fontWeight: 800,
                 padding: "1px 5px", borderRadius: 4,
-                backgroundColor: isLightZone ? "rgba(0,0,0,0.10)" : "rgba(255,255,255,0.20)",
+                backgroundColor: pillTint,
                 color: primaryText,
                 textTransform: "uppercase", letterSpacing: "0.05em",
                 lineHeight: 1.2,
+                fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
               }}>
-                {isCommercial ? "Comm" : "Res"}
+                {isCommercial ? "COM" : "RES"}
               </span>
-            );
-          })()}
-        </div>
-        <span style={{ fontSize: 10, fontWeight: 500, color: secondaryText, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
-          {scopeLabel(job)}
-        </span>
-        {/* [tile redesign] Reactive price. The dispatch payload's `amount`
-            field is the source of truth (server reads jobs.base_fee or
-            jobs.billed_amount). Every dispatch refresh picks up changes
-            from add-ons, manual rate overrides, hour adjustments, and
-            discounts applied via PATCH /api/jobs/:id. Hourly jobs show
-            the rate plus an "/hr" suffix so dispatchers see the unit. */}
-        {width > 80 && (() => {
-          const isHourly = job.billing_method === "hourly" && job.hourly_rate != null;
-          const display = isHourly
-            ? `$${(job.hourly_rate ?? 0).toFixed(0)}/hr`
-            : `$${Math.round(Number(job.amount ?? 0))}`;
-          return (
-            <span style={{ fontSize: 11, fontWeight: 800, color: primaryText, whiteSpace: "nowrap", alignSelf: "flex-start" }}>
-              {display}
-            </span>
-          );
-        })()}
+              {/* Live timer pill — only on active jobs, only on wider chips */}
+              {status === "active" && isWide && elapsedMin > 0 && (
+                <span style={{
+                  flexShrink: 0, display: "inline-flex", alignItems: "center", gap: 3,
+                  fontSize: 9, fontWeight: 700,
+                  padding: "1px 5px", borderRadius: 4,
+                  backgroundColor: "rgba(255,255,255,0.25)", color: primaryText,
+                  lineHeight: 1.2,
+                }}>
+                  <span style={{ width: 4, height: 4, borderRadius: "50%", backgroundColor: primaryText, display: "inline-block" }} />
+                  {timerLabel}
+                </span>
+              )}
+              {/* Price (right-aligned) */}
+              <span style={{ fontSize: 11, fontWeight: 800, color: primaryText, whiteSpace: "nowrap", flexShrink: 0 }}>
+                {priceDisplay}
+              </span>
+              {/* Price delta pill */}
+              {deltaAmount != null && (
+                <span style={{
+                  flexShrink: 0, fontSize: 8, fontWeight: 700,
+                  padding: "1px 4px", borderRadius: 3,
+                  backgroundColor: deltaAmount > 0 ? "rgba(34,197,94,0.85)" : "rgba(239,68,68,0.85)",
+                  color: "#FFFFFF", lineHeight: 1.2, whiteSpace: "nowrap",
+                }}>
+                  {deltaAmount > 0 ? "↑" : "↓"} ${Math.abs(Math.round(deltaAmount))}
+                </span>
+              )}
+            </div>
+
+            {/* ── Bottom row ── */}
+            <div style={{ display: "flex", alignItems: "center", gap: 4, minWidth: 0 }}>
+              {isRecurring && <Check size={9} style={{ color: iconTint, flexShrink: 0 }} strokeWidth={3} />}
+              <span style={{ fontSize: 10, fontWeight: 500, color: secondaryText, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis", flex: 1, minWidth: 0 }}>
+                {scopeLabel(job)}
+              </span>
+              {showDuration && allowedMin > 0 && (
+                <span style={{ fontSize: 10, fontWeight: 600, color: secondaryText, whiteSpace: "nowrap", flexShrink: 0 }}>
+                  {Math.round((allowedMin / 60) * 10) / 10}h
+                </span>
+              )}
+              {/* Add-ons +N pill */}
+              {addOnCount > 0 && isWide && (
+                <span style={{
+                  flexShrink: 0, fontSize: 9, fontWeight: 700,
+                  padding: "1px 5px", borderRadius: 4,
+                  backgroundColor: pillTint, color: primaryText,
+                  lineHeight: 1.2, whiteSpace: "nowrap",
+                }}>
+                  +{addOnCount}
+                </span>
+              )}
+            </div>
+          </>
+        )}
       </div>
+
       {/* [AI.7.5] Completed checkmark badge — top-right corner. */}
       {visual.showCheckmark && (
         <div style={{ position: "absolute", top: -4, right: -4, width: 16, height: 16, borderRadius: "50%", backgroundColor: "#16A34A", display: "flex", alignItems: "center", justifyContent: "center", boxShadow: "0 1px 3px rgba(0,0,0,0.2)", zIndex: 3 }}>
@@ -2496,6 +2659,42 @@ function JobChip({ job, onClick, assignedName, isUnassigned }: { job: DispatchJo
       )}
       {hovered && !isDragging && <JobHoverCard job={job} assignedName={assignedName} />}
     </div>
+  );
+}
+
+// [job-card-redesign] Side-profile car SVG with motion lines for the
+// en_route status. Lucide ships a "Car" icon but it's a front view and
+// has no motion lines, so we draw our own. The wrapper class
+// `qleno-en-route-icon` ties into the keyframes injected via
+// ensureJobStatusStyles() — translateX 0 → 1.5px → 0 over 0.8s. The
+// element respects prefers-reduced-motion via the same CSS file.
+function CarIconInline({ tint }: { tint: string }) {
+  return (
+    <span
+      className="qleno-en-route-icon"
+      aria-label="On the way"
+      style={{
+        display: "inline-flex", alignItems: "center", flexShrink: 0,
+        width: 18, height: 11,
+      }}
+    >
+      <svg width="18" height="11" viewBox="0 0 18 11" fill="none" xmlns="http://www.w3.org/2000/svg">
+        {/* Motion lines (trailing) */}
+        <line x1="0.5" y1="3.5" x2="3"   y2="3.5" stroke={tint} strokeWidth="1" strokeLinecap="round" opacity="0.85" />
+        <line x1="0.5" y1="6"   x2="2.5" y2="6"   stroke={tint} strokeWidth="1" strokeLinecap="round" opacity="0.55" />
+        <line x1="0.5" y1="8.5" x2="2"   y2="8.5" stroke={tint} strokeWidth="1" strokeLinecap="round" opacity="0.30" />
+        {/* Car body — side profile */}
+        <path
+          d="M5 7.5 V5 L6.5 3 H11.5 L13 5 V7.5 Z"
+          stroke={tint} strokeWidth="1" strokeLinejoin="round" fill="none"
+        />
+        {/* Hood + trunk extension */}
+        <line x1="13" y1="7.5" x2="16.5" y2="7.5" stroke={tint} strokeWidth="1" strokeLinecap="round" />
+        {/* Wheels */}
+        <circle cx="7"    cy="9" r="1.3" stroke={tint} strokeWidth="1" fill="none" />
+        <circle cx="12.5" cy="9" r="1.3" stroke={tint} strokeWidth="1" fill="none" />
+      </svg>
+    </span>
   );
 }
 

--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -15,6 +15,7 @@ import {
   Building2, AlertTriangle, Repeat, Phone, MessageSquare, Send, Check, Info,
 } from "lucide-react";
 import { getJobVisualStatus, STATUS_VISUALS, ensureJobStatusStyles, LIVE_OPS } from "@/lib/job-status";
+import { computePriceDelta } from "@/lib/price-delta";
 import LegendPopover from "@/components/legend-popover";
 
 // ─── CONSTANTS ───────────────────────────────────────────────────────────────
@@ -2368,6 +2369,14 @@ function JobHoverCard({ job, assignedName }: { job: DispatchJob; assignedName?: 
   );
 }
 
+// [job-card-redesign] Re-exported for the dev-only visual test page at
+// /jobs/visual-test. Production code should NOT import this — chips on
+// the dispatch board route through the page's own <EmployeeRow> /
+// <UnassignedGanttRow> hierarchy. The export is here to keep the test
+// page in its own file without duplicating chip logic.
+export { JobChip as _JobChipForTesting };
+export type { DispatchJob as _DispatchJobForTesting };
+
 // ─── DESKTOP: JOB CHIP ─────────────────────────────────────────────────────────
 //
 // [job-card-redesign] Two-row layout:
@@ -2389,7 +2398,7 @@ function JobHoverCard({ job, assignedName }: { job: DispatchJob; assignedName?: 
 // elaborations (live timer pill, progress bar, NEW pill) are derived
 // from job fields directly — they don't fit the "every-surface" contract
 // and would noise up the canonical visual.
-function JobChip({ job, onClick, assignedName, isUnassigned }: { job: DispatchJob; onClick: (j: DispatchJob) => void; assignedName?: string; isUnassigned?: boolean }) {
+function JobChip({ job, onClick, assignedName, isUnassigned, forceStatus }: { job: DispatchJob; onClick: (j: DispatchJob) => void; assignedName?: string; isUnassigned?: boolean; /** Test-only override for visual status. Used by /jobs/visual-test to render every lifecycle state side-by-side, bypassing LIVE_OPS / clock-derivation gates. Production callers should never set this. */ forceStatus?: import("@/lib/job-status").JobVisualStatus }) {
   const left = ((timeToMins(job.scheduled_time) - DAY_START) / 30) * SLOT_W;
   const width = Math.max(SLOT_W, (job.duration_minutes / 30) * SLOT_W);
   const isComplete = job.status === "complete";
@@ -2397,7 +2406,7 @@ function JobChip({ job, onClick, assignedName, isUnassigned }: { job: DispatchJo
   const isCommercial = !!job.account_id || job.client_type === "commercial";
   const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({ id: `chip-${job.id}`, data: { job, originalLeft: left, type: isUnassigned ? "unassigned" : undefined }, disabled: isComplete });
 
-  const status = getJobVisualStatus(job);
+  const status = forceStatus ?? getJobVisualStatus(job);
   const visual = STATUS_VISUALS[status];
 
   const ZONE_FALLBACK = "#9CA3AF";
@@ -2415,21 +2424,15 @@ function JobChip({ job, onClick, assignedName, isUnassigned }: { job: DispatchJo
   const isWide   = width >= 192;
   const showDuration = width >= 320;
 
-  // Price + delta. base_fee → original quote (jobs.base_fee, lands on
-  // payload as `amount`); billed_amount → current price (separate field
-  // on payload, set when add-ons or manual overrides re-price the job).
-  // Show delta only when both are present, both are non-zero, and they
-  // actually differ. Hourly jobs hide delta — the rate × hours math is
-  // surfaced elsewhere; subtracting hourly amounts isn't meaningful.
-  const isHourly = job.billing_method === "hourly" && job.hourly_rate != null;
-  const baseFee = Number(job.amount ?? 0);
-  const billed = job.billed_amount != null ? Number(job.billed_amount) : null;
-  const priceDisplay = isHourly
-    ? `$${(job.hourly_rate ?? 0).toFixed(0)}/hr`
-    : `$${Math.round(billed ?? baseFee)}`;
-  const deltaAmount = !isHourly && billed != null && baseFee > 0 && Math.abs(billed - baseFee) >= 0.5
-    ? billed - baseFee
-    : null;
+  // Price + delta routed through a pure helper so the three render
+  // cases (billed null / billed === base_fee / billed differs) are
+  // testable without mounting React. See lib/price-delta.ts.
+  const { display: priceDisplay, deltaAmount } = computePriceDelta({
+    amount: job.amount,
+    billedAmount: job.billed_amount,
+    hourlyRate: job.hourly_rate,
+    billingMethod: job.billing_method,
+  });
 
   // Live timer for active jobs. Computed at render time; chip re-renders
   // on parent state changes (drag, hover, dispatch poll) so the value is


### PR DESCRIPTION
## Summary

Desktop dispatch chip redesign per the build spec. Two-row layout with richer at-a-glance info, two new derived statuses, and the backend additions to feed them.

### Desktop chip — new two-row layout (`pages/jobs.tsx` `JobChip`)

Row 1 (identity + money):
- Status icon (en_route car SVG with motion lines) when applicable
- `LATE Xm` pill when `late_clockin`
- `UNPAID` pill when `completed_unpaid`
- `NEW` pill when first-ever residential job
- Client name + `RES`/`COM` mono badge
- Live timer pill (`1h 12m`) on active jobs (wide chips only)
- Price + delta pill (`↑ $45` / `↓ $20`) when `billed_amount` differs from `base_fee`

Row 2 (context):
- Recurring ✓ + service / cadence label
- Duration (`Xh`) on wide chips
- `+N` add-ons pill

In-progress chips also get a 3 px white progress bar at the top edge, filling proportionally to elapsed-vs-allowed time.

Width tiers: narrow (<120 px) collapses to single-line name + price; medium drops the NEW / +N pills; wide (≥192 px) renders everything; very wide (≥320 px) adds duration. New-client chips get an inset white box-shadow outline.

### Status helper — two new derived states (`lib/job-status.ts`)

No DB enum changes. Both states are derived in `getJobVisualStatus`.

- **`en_route`** — scaffolded behind `en_route_at`. Inert until the SMS / mobile-tech engine lands the column. Animated side-profile car icon (CSS keyframes also injected via `ensureJobStatusStyles()`, respects `prefers-reduced-motion`).
- **`completed_unpaid`** — fires when `status='complete'` AND payment method is stripe/square AND `charge_succeeded_at` is null. Cash/check completion stays `completed` (no charge signal to derive from). Amber ring (`#BA7517`) + `UNPAID` pill.

`STATUS_VISUALS` gains a `showCarIcon` flag and entries for both new states. Late thresholds untouched (5 min late / 30 min no-show — Phes-tuned).

### Backend — two new fields on `/api/dispatch` (`routes/dispatch.ts`)

- **`add_ons[]`** — joined from `job_add_ons` + `pricing_addons` / `add_ons`, names via `COALESCE(pa.name, ao.name)`. Drives the `+N` chip pill and a new "Add-ons (N)" section in the hover popover.
- **`is_new_client`** — single batched lookup of distinct `client_id`s with any prior completed job. `true` when a residential client has zero completed jobs strictly before today's board date. Commercial jobs always read `false`.

### Legend popover

Adds the two new states with example tiles. The `en_route` tile renders the animated car SVG so operators see the actual treatment.

### Pre-existing issue logged for follow-up (not fixed here)

`JobHoverCard`'s flip logic compares `rect.bottom` against `window.innerHeight`, but chips render inside a scrollable timeline container (`overflow: auto` at `jobs.tsx:3541`). When the timeline's bottom edge sits above the viewport bottom (smaller windows, drawer/footer present), the popover can pass the viewport check yet still get clipped by the timeline's overflow. Real, reproducible. Worth its own PR — switching to Radix `HoverCard` (already in deps) flipping against the closest scroll-container would fix it cleanly.

### Out of scope (deferred per discussion)

- Radix HoverCard rewrite of `JobHoverCard` (the existing custom popover already does most of the collision work; the bug above is the actual fix needed)
- Mobile `MobileJobCard` changes (mobile is a different surface per CLAUDE.md)
- `en_route_at` schema migration (lands when the SMS / mobile-tech engine ships)
- The SMS engine itself, drive-time, customer LTV, notes UI

## Test plan

- [ ] Build verified locally (`pnpm run build` clean; `tsc --noEmit` net-zero new errors against baseline)
- [ ] Visual: open `/dispatch`, confirm RES vs COM badge, price + delta pill on jobs where `billed_amount` differs from `base_fee`, `+N` add-ons pill on jobs with add-ons
- [ ] Visual: confirm `NEW` pill on a fresh residential client's first job, gone after that client completes a job
- [ ] Visual: confirm `UNPAID` pill + amber ring on a `complete` stripe/square job with no `charge_succeeded_at`
- [ ] Visual: confirm in-progress chips show progress bar + live timer pill (timer text refreshes on natural re-render — drag, hover, dispatch poll)
- [ ] Visual: confirm narrow chips degrade to single-line name + price
- [ ] Hover popover: confirm new "Add-ons (N)" section renders on jobs with add-ons, and shows quantity prefix when > 1
- [ ] Legend popover: open from dispatch top bar, confirm `en_route` and `completed_unpaid` tiles render

---
_Generated by [Claude Code](https://claude.ai/code/session_016GqMSjAaG7gGDtiFSPKn5Q)_