### PR TITLE
feat: simplify lifecycle states for Phes (20-min threshold + manual no-show)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,34 +149,63 @@
   delegate to one of these three sources of truth — never inline
   `× 0.35` or `× 20` again.
 - **Job visual status — single source of truth**: every card surface
-  (dispatch Gantt chip, mobile MobileJobCard, mobile UPCOMING compact
-  rows, desktop list cards, my-jobs tech view) routes through
-  `getJobVisualStatus(job, now)` in `lib/job-status.ts`. Returns one
-  of seven canonical states; consumers compose the matching
+  (dispatch Gantt chip, list view, drag overlay, mobile MobileJobCard,
+  mobile UPCOMING compact rows, my-jobs tech view) routes through
+  `getJobVisualStatus(job, now)` in `lib/job-status.ts`. Returns one of
+  nine canonical states; consumers compose the matching
   `STATUS_VISUALS[state]` (stripe color, body opacity, badge,
-  strikethrough, desaturate, border override) onto their card. New
-  surfaces MUST NOT re-derive status from `job.status` directly.
-  | State          | Trigger                                                                        | Treatment                                                          |
-  |----------------|--------------------------------------------------------------------------------|--------------------------------------------------------------------|
-  | scheduled      | status='scheduled', no clock-in yet                                            | Default tech color, full opacity                                   |
-  | active         | clocked-in (clock_in_at && !clock_out_at) or status='in_progress'              | Tech color + 4px amber (#F59E0B) left stripe + slow opacity pulse  |
-  | completed      | status='complete'                                                              | Tech color at 60% opacity + green checkmark badge                  |
-  | late_clockin   | today + scheduled_time + 5 min, no clock-in                                    | Existing red 2px border                                            |
-  | no_show        | today + scheduled_time + 30 min, no clock-in                                   | Solid red border + "NO SHOW" badge, 85% opacity                    |
-  | cancelled      | status='cancelled'                                                             | Tech color desaturated to grayscale + strikethrough on title       |
-  | unassigned     | assigned_user_id is null                                                       | Amber border, full opacity                                         |
+  strikethrough, desaturate, border override, car-icon flag) onto their
+  card. New surfaces MUST NOT re-derive status from `job.status`
+  directly.
+  | State            | Trigger                                                                                  | Treatment                                                                  |
+  |------------------|------------------------------------------------------------------------------------------|----------------------------------------------------------------------------|
+  | scheduled        | default — no later state matches and now < scheduled_start_time OR no live signal        | Default tech color, full opacity                                           |
+  | en_route         | en_route_at IS NOT NULL, no clock-in (inert until field-app column lands)                | Default tech color + animated side-profile car icon left of name           |
+  | active           | clock_in_at && !clock_out_at, OR status='in_progress'                                    | Tech color + 4px amber (#F59E0B) left stripe + 2px orange ring (#EF9F27)   |
+  | late_clockin     | today + now ≥ scheduled_start_time + 20 min, no clock-in, no manual no-show              | Existing red 2px border + LATE pill with dynamic minute count              |
+  | no_show          | no_show_marked_by_tech IS NOT NULL (manual flag set by field-app "No Show" button)       | Solid dark-red border + "NO SHOW" badge, 85% opacity                       |
+  | completed        | status='complete', not online-payment-unpaid                                             | Tech color at 60% opacity + green checkmark badge                          |
+  | completed_unpaid | status='complete', payment is stripe/square, charge_succeeded_at IS NULL                 | 60% opacity + amber ring (#BA7517) + UNPAID pill + green checkmark         |
+  | cancelled        | status='cancelled'                                                                       | Tech color desaturated to grayscale + strikethrough on title               |
+  | unassigned       | assigned_user_id is null                                                                 | Amber border, full opacity                                                 |
   Active stripe animation uses CSS keyframes (`qleno-active-stripe-pulse`,
-  2 s ease-in-out, 1.0 → 0.6 → 1.0). `prefers-reduced-motion` drops
-  the animation to a steady solid stripe. Inject once per session via
-  `ensureJobStatusStyles()` from any component that mounts a card.
-  The Legend popover (`components/legend-popover.tsx`) shows all seven
-  states with example tiles + descriptions; mounted from the dispatch
-  top bar's Legend button (desktop popover, mobile bottom sheet). Late
-  / no_show are derived from time, NOT stored — DO NOT add new enum
-  values to `job_status`. The DB enum stays
-  `scheduled | in_progress | complete | cancelled` because operational
-  state lives in the clock entry + scheduled time, not the status
-  column.
+  2 s ease-in-out, 1.0 → 0.6 → 1.0). En-route car uses
+  `qleno-en-route-drive` (translateX 0 → 1.5px, 0.8 s ease-in-out).
+  `prefers-reduced-motion` drops both to steady. Inject once per
+  session via `ensureJobStatusStyles()` from any component that mounts
+  a card. The Legend popover (`components/legend-popover.tsx`) shows
+  all nine states with example tiles + descriptions; mounted from the
+  dispatch top bar's Legend button (desktop popover, mobile bottom
+  sheet).
+  Late + en_route are derived from time + columns, NOT stored. no_show
+  IS stored (manual flag) — the field app's "No Show" button writes
+  `no_show_marked_by_tech` (and `_by_user_id`) when the tech has waited
+  long enough on-site for the customer. The DB job_status enum stays
+  `scheduled | in_progress | complete | cancelled` — DO NOT add new
+  enum values; operational state lives in the clock entry + scheduled
+  time + the manual flag, not the status column.
+
+  *(phes-lifecycle 2026-04-29)* Phes-specific simplifications:
+  - Single 20-minute threshold for `late_clockin` (was 5/30 split).
+    `LATE_THRESHOLD_MINUTES = 20` and `NO_SHOW_WAIT_MINUTES = 20`
+    hardcoded in `lib/job-status.ts`. Multi-tenant later →
+    `tenant_settings.late_threshold_minutes` /
+    `.no_show_wait_minutes`.
+  - `no_show` is a MANUAL flag (`no_show_marked_by_tech`), not
+    time-derived. Set by the field-app "No Show" button only. Until
+    the button ships the column stays null and no_show never fires
+    in production.
+  - **Hard scheduled-start gate**: nothing negative (late_clockin /
+    en_route-as-late) fires before `scheduled_start_time`. A future
+    job is always SCHEDULED. The William Rosenbloom regression
+    (chip painted late before start time elapsed) is closed by the
+    explicit `nowMins >= startMins + LATE_THRESHOLD_MINUTES` check
+    in `getJobVisualStatus` and the matching guard on the page-level
+    `lateClockIns` / `atRisk` counters.
+  - Semantic: LATE = tech accountability ("where's the tech?"). 
+    NO_SHOW = customer accountability ("where's the customer?").
+    Both share the 20-minute wait threshold but represent different
+    things — they're not interchangeable.
 - **Address display — single canonical format**: every surface that
   renders an address MUST route through
   `formatAddress(street, city, state, zip)` in `lib/format-address.ts`.

--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -36,6 +36,10 @@ async function runBookingSchemaGuard(): Promise<void> {
     { label: "jobs.upsell_declined",       stmt: "ALTER TABLE jobs ADD COLUMN IF NOT EXISTS upsell_declined BOOLEAN DEFAULT false" },
     { label: "jobs.upsell_deferred",       stmt: "ALTER TABLE jobs ADD COLUMN IF NOT EXISTS upsell_deferred BOOLEAN DEFAULT false" },
     { label: "jobs.upsell_cadence_selected", stmt: "ALTER TABLE jobs ADD COLUMN IF NOT EXISTS upsell_cadence_selected TEXT" },
+    // [phes-lifecycle 2026-04-29] Manual no-show flag set by the field
+    // app's "No Show" button. See lib/job-status.ts for the state model.
+    { label: "jobs.no_show_marked_by_tech", stmt: "ALTER TABLE jobs ADD COLUMN IF NOT EXISTS no_show_marked_by_tech TIMESTAMP" },
+    { label: "jobs.no_show_marked_by_user_id", stmt: "ALTER TABLE jobs ADD COLUMN IF NOT EXISTS no_show_marked_by_user_id INTEGER" },
     { label: "jobs.property_vacant",       stmt: "ALTER TABLE jobs ADD COLUMN IF NOT EXISTS property_vacant BOOLEAN DEFAULT false" },
     { label: "jobs.arrival_window",        stmt: "ALTER TABLE jobs ADD COLUMN IF NOT EXISTS arrival_window TEXT" },
     { label: "jobs.first_recurring_discounted", stmt: "ALTER TABLE jobs ADD COLUMN IF NOT EXISTS first_recurring_discounted BOOLEAN DEFAULT false" },

--- a/artifacts/api-server/src/routes/dispatch.ts
+++ b/artifacts/api-server/src/routes/dispatch.ts
@@ -176,6 +176,12 @@ router.get("/", requireAuth, async (req, res) => {
         locked_at: jobsTable.locked_at,
         actual_end_time: jobsTable.actual_end_time,
         completed_by_user_id: jobsTable.completed_by_user_id,
+        // [phes-lifecycle 2026-04-29] Manual no-show flag — drives the
+        // NO_SHOW visual state. Set by the field app's "No Show" button
+        // after the tech waits NO_SHOW_WAIT_MINUTES on-site for the
+        // customer.
+        no_show_marked_by_tech: jobsTable.no_show_marked_by_tech,
+        no_show_marked_by_user_id: jobsTable.no_show_marked_by_user_id,
       })
       .from(jobsTable)
       .leftJoin(clientsTable, eq(jobsTable.client_id, clientsTable.id))
@@ -513,6 +519,8 @@ router.get("/", requireAuth, async (req, res) => {
         locked_at: j.locked_at ?? null,
         actual_end_time: j.actual_end_time ?? null,
         completed_by_user_id: j.completed_by_user_id ?? null,
+        no_show_marked_by_tech: (j as any).no_show_marked_by_tech ?? null,
+        no_show_marked_by_user_id: (j as any).no_show_marked_by_user_id ?? null,
         clock_entry: clock ? {
           id: clock.id,
           clock_in_at: clock.clock_in_at,

--- a/artifacts/qleno/src/lib/job-status.ts
+++ b/artifacts/qleno/src/lib/job-status.ts
@@ -10,8 +10,8 @@
  * compact rows, my-jobs (tech view), and the Legend popover.
  *
  * Routing precedence (top wins on conflict):
- *   cancelled → completed_unpaid → completed → active → no_show → en_route
- *   → late_clockin → unassigned → scheduled
+ *   cancelled → completed_unpaid → completed → active → no_show
+ *   → en_route → late_clockin → unassigned → scheduled
  *
  * en_route is scaffolded but inert: it requires `en_route_at` (set when
  * the field tech taps "On My Way"). The schema column doesn't exist yet
@@ -23,6 +23,22 @@
  * completed_unpaid fires only for online-payment jobs (stripe/square).
  * Cash/check completion stays "completed" — there's no charge signal
  * to derive from, and reconciliation lives in a separate workflow.
+ *
+ * [phes-lifecycle 2026-04-29] Phes-specific simplification:
+ *   - Single 20-minute threshold for late_clockin (was 5/30 split).
+ *   - no_show is now a MANUAL flag (no_show_marked_by_tech IS NOT NULL),
+ *     not time-derived. The field app's "No Show" button writes the
+ *     timestamp after the tech has waited the configured period
+ *     on-site. Until that button ships, no_show never fires in
+ *     production.
+ *   - Hard gate: nothing negative (late_clockin / en_route /
+ *     unassigned-as-late) fires before scheduled_start_time. A future
+ *     job is always SCHEDULED. Closes the William Rosenbloom bug
+ *     where the chip painted late before the start time elapsed.
+ *
+ * The thresholds below are hardcoded for Phes. When multi-tenant
+ * settings ship they become per-tenant: tenant_settings.late_threshold_
+ * minutes / tenant_settings.no_show_wait_minutes.
  */
 
 /**
@@ -73,10 +89,23 @@ export interface JobStatusInput {
    *  Cash/check completion stays "completed" regardless. */
   client_payment_method?: string | null;
   charge_succeeded_at?: string | null;
+  /** [phes-lifecycle 2026-04-29] Manual no-show flag. Set when the
+   *  tech taps "No Show" in the field app after waiting the configured
+   *  period on-site. Distinct from late_clockin: late = "where's the
+   *  tech?" (tech accountability), no_show = "where's the customer?"
+   *  (customer accountability). The button doesn't exist yet — until
+   *  it ships this field stays null and no_show never fires. */
+  no_show_marked_by_tech?: string | null;
 }
 
-const LATE_GRACE_MIN = 5;
-const NO_SHOW_THRESHOLD_MIN = 30;
+// [phes-lifecycle 2026-04-29] Phes-specific thresholds. Multi-tenant
+// later → tenant_settings.late_threshold_minutes / .no_show_wait_minutes.
+const LATE_THRESHOLD_MINUTES = 20;
+// Kept for documentation parity with the no-show button's wait period;
+// the derived `no_show` state itself doesn't read this constant
+// because it's now a manual flag. The field app reads this when it
+// decides whether to enable the No Show button on the tech's screen.
+export const NO_SHOW_WAIT_MINUTES = 20;
 
 function timeToMins(t: string | null | undefined): number {
   if (!t) return 0;
@@ -113,33 +142,34 @@ export function getJobVisualStatus(job: JobStatusInput, now: Date = new Date()):
   if (hasClockIn && !hasClockOut && job.status !== "complete") return "active";
   if (job.status === "in_progress") return "active";
 
-  // [AI.7.5.hotfix3] Late / no-show derive from time + clock-entry
-  // absence. Suppressed entirely when LIVE_OPS=false — engine still
-  // computes the math (LATE_GRACE_MIN / NO_SHOW_THRESHOLD_MIN
-  // constants live above; flipping LIVE_OPS=true is the only switch
-  // needed) but the function returns scheduled/unassigned instead so
-  // the board doesn't paint "NO SHOW" badges on import data with
-  // stale scheduled_times that pre-date go-live.
-  //
-  // En route slots between no_show and late_clockin: a tech who said
-  // "on my way" 10 min after start should read EN ROUTE, not LATE
-  // (the office knows they're coming). But once we're past the
-  // no_show threshold (30 min), en_route loses — there's an
-  // operational problem regardless of what the tech radioed.
-  if (LIVE_OPS && isToday(job.scheduled_date, now) && !hasClockIn) {
-    const nowMins = now.getHours() * 60 + now.getMinutes();
-    const startMins = timeToMins(job.scheduled_time);
-    if (startMins > 0) {
-      const minsLate = nowMins - startMins;
-      if (minsLate >= NO_SHOW_THRESHOLD_MIN) return "no_show";
-      if (job.en_route_at) return "en_route";
-      if (minsLate >= LATE_GRACE_MIN) return "late_clockin";
-    }
-  }
+  // [phes-lifecycle 2026-04-29] no_show is a manual flag now — fires
+  // ONLY when the field app's "No Show" button has been tapped. Wins
+  // over en_route / late_clockin because once the tech has marked
+  // no-show, the situation isn't "where's the tech" or "tech is
+  // arriving" anymore.
+  if (job.no_show_marked_by_tech) return "no_show";
 
-  // En route can also fire BEFORE scheduled start (tech is heading
-  // there early). No clock-in yet, en_route_at set.
+  // [phes-lifecycle 2026-04-29] Hard gate: nothing negative fires
+  // before scheduled_start_time. A future job is always SCHEDULED
+  // (or unassigned, if no tech). Pre-start jobs can never read as
+  // late or unassigned-as-risk. This is the William Rosenbloom fix.
+  const isJobToday = isToday(job.scheduled_date, now);
+  const nowMins = now.getHours() * 60 + now.getMinutes();
+  const startMins = timeToMins(job.scheduled_time);
+  const hasStarted = isJobToday && startMins > 0 && nowMins >= startMins;
+
+  // En route: tech tapped "On My Way" but hasn't clocked in yet. Can
+  // fire before or after scheduled_start_time — a tech heading there
+  // early is still en_route.
   if (job.en_route_at && !hasClockIn) return "en_route";
+
+  // Late: 20+ min past scheduled start, no clock-in, no manual no-show
+  // flag. LIVE_OPS gate is symbolic now (operations went live in #9)
+  // but kept for an emergency off-switch.
+  if (LIVE_OPS && hasStarted && !hasClockIn) {
+    const minsLate = nowMins - startMins;
+    if (minsLate >= LATE_THRESHOLD_MINUTES) return "late_clockin";
+  }
 
   if (job.assigned_user_id == null) return "unassigned";
   return "scheduled";
@@ -252,7 +282,7 @@ export const STATUS_VISUALS: Record<JobVisualStatus, StatusVisual> = {
   },
   late_clockin: {
     label: "Late",
-    description: "Tech is more than 5 minutes late and hasn't clocked in.",
+    description: "Tech is more than 20 minutes past start time and hasn't clocked in.",
     swatch: "#A78BFA",
     stripe: null,
     bodyOpacity: 1,
@@ -265,7 +295,7 @@ export const STATUS_VISUALS: Record<JobVisualStatus, StatusVisual> = {
   },
   no_show: {
     label: "No show",
-    description: "Tech is 30+ minutes late with no clock-in. Call them now.",
+    description: "Tech tapped \"No Show\" — customer wasn't there after 20+ min wait.",
     swatch: "#EF4444",
     stripe: null,
     bodyOpacity: 0.85,

--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -64,7 +64,7 @@ const STATUS: Record<string, { bg: string; border: string; text: string; dot: st
 interface ClockEntry { id: number; clock_in_at: string | null; clock_out_at: string | null; distance_from_job_ft: number | null; is_flagged: boolean; }
 interface JobTechCommission { user_id: number; name: string; is_primary: boolean; est_hours: number; calc_pay: number; final_pay: number; pay_override: number | null; }
 interface JobAddOn { name: string; quantity: number; unit_price: number; subtotal: number; }
-interface DispatchJob { id: number; client_id: number; client_name: string; client_phone?: string | null; client_zip?: string | null; client_notes?: string | null; client_payment_method?: string | null; /* [tile redesign] residential or commercial badge; commercial when account_id is set OR client_type === 'commercial' */ client_type?: "residential" | "commercial" | null; address: string | null; /* [inline-edit] raw fields for address editor mode detection */ job_address_street?: string | null; job_address_city?: string | null; job_address_state?: string | null; job_address_zip?: string | null; client_address?: string | null; client_city?: string | null; client_state?: string | null; client_address_zip?: string | null; assigned_user_id: number | null; assigned_user_name?: string; service_type: string; status: string; scheduled_date: string; scheduled_time: string | null; frequency: string; amount: number; duration_minutes: number; notes: string | null; office_notes?: string | null; before_photo_count: number; after_photo_count: number; clock_entry: ClockEntry | null; zone_id?: number | null; zone_color?: string | null; zone_name?: string | null; branch_id?: number | null; branch_name?: string | null; last_service_date?: string | null; account_id?: number | null; account_name?: string | null; billing_method?: string | null; hourly_rate?: number | null; estimated_hours?: number | null; actual_hours?: number | null; billed_hours?: number | null; billed_amount?: number | null; charge_failed_at?: string | null; charge_succeeded_at?: string | null; property_access_notes?: string | null; booking_location?: string | null; technicians?: JobTechCommission[]; est_hours_per_tech?: number | null; est_pay_per_tech?: number | null; company_res_pct?: number | null; /* [AI.7.4] Commission routing — 'commercial_hourly' or 'residential_pool' */ commission_basis?: "commercial_hourly" | "residential_pool" | null; commercial_hourly_rate?: number | null; /* [AF] completion lock state */ locked_at?: string | null; actual_end_time?: string | null; completed_by_user_id?: number | null; /* [job-card-redesign] Add-ons drive the +N pill on the chip and the full list in the popover. is_new_client = first-ever residential job (no prior completed). en_route_at scaffolds the "On My Way" status; column doesn't exist yet, so the field is always undefined until the SMS engine lands. */ add_ons?: JobAddOn[]; is_new_client?: boolean; en_route_at?: string | null; }
+interface DispatchJob { id: number; client_id: number; client_name: string; client_phone?: string | null; client_zip?: string | null; client_notes?: string | null; client_payment_method?: string | null; /* [tile redesign] residential or commercial badge; commercial when account_id is set OR client_type === 'commercial' */ client_type?: "residential" | "commercial" | null; address: string | null; /* [inline-edit] raw fields for address editor mode detection */ job_address_street?: string | null; job_address_city?: string | null; job_address_state?: string | null; job_address_zip?: string | null; client_address?: string | null; client_city?: string | null; client_state?: string | null; client_address_zip?: string | null; assigned_user_id: number | null; assigned_user_name?: string; service_type: string; status: string; scheduled_date: string; scheduled_time: string | null; frequency: string; amount: number; duration_minutes: number; notes: string | null; office_notes?: string | null; before_photo_count: number; after_photo_count: number; clock_entry: ClockEntry | null; zone_id?: number | null; zone_color?: string | null; zone_name?: string | null; branch_id?: number | null; branch_name?: string | null; last_service_date?: string | null; account_id?: number | null; account_name?: string | null; billing_method?: string | null; hourly_rate?: number | null; estimated_hours?: number | null; actual_hours?: number | null; billed_hours?: number | null; billed_amount?: number | null; charge_failed_at?: string | null; charge_succeeded_at?: string | null; property_access_notes?: string | null; booking_location?: string | null; technicians?: JobTechCommission[]; est_hours_per_tech?: number | null; est_pay_per_tech?: number | null; company_res_pct?: number | null; /* [AI.7.4] Commission routing — 'commercial_hourly' or 'residential_pool' */ commission_basis?: "commercial_hourly" | "residential_pool" | null; commercial_hourly_rate?: number | null; /* [AF] completion lock state */ locked_at?: string | null; actual_end_time?: string | null; completed_by_user_id?: number | null; /* [job-card-redesign] Add-ons drive the +N pill on the chip and the full list in the popover. is_new_client = first-ever residential job (no prior completed). en_route_at scaffolds the "On My Way" status; column doesn't exist yet, so the field is always undefined until the SMS engine lands. */ add_ons?: JobAddOn[]; is_new_client?: boolean; en_route_at?: string | null; /* [phes-lifecycle 2026-04-29] Manual no-show flag set by the field app's "No Show" button. Drives the NO_SHOW visual state via getJobVisualStatus. Until the field-app button ships, both fields stay null. */ no_show_marked_by_tech?: string | null; no_show_marked_by_user_id?: number | null; }
 interface Employee { id: number; name: string; role: string; jobs: DispatchJob[]; zone?: { zone_id: number; zone_color: string; zone_name: string } | null; time_off?: 'pto' | 'sick' | 'absent' | null; commission_rate?: number | null; }
 interface DispatchData { employees: Employee[]; unassigned_jobs: DispatchJob[]; }
 
@@ -2794,13 +2794,16 @@ function JobChipBody({
               <Clock size={9} style={{ color: tokens.icon, flexShrink: 0 }} />
             )}
             {status === "late_clockin" && lateMin > 0 && (
+              // [phes-lifecycle 2026-04-29] "LATE 24m" — caps via literal,
+              // not textTransform, so the trailing minute "m" stays
+              // lowercase per the spec.
               <span style={{
                 flexShrink: 0, fontSize: 8, fontWeight: 800,
                 padding: "1px 5px", borderRadius: 4,
                 backgroundColor: "#DC2626", color: "#FFFFFF",
-                textTransform: "uppercase", letterSpacing: "0.05em", lineHeight: 1.2,
+                letterSpacing: "0.05em", lineHeight: 1.2,
               }}>
-                Late {lateMin}m
+                LATE {lateMin}m
               </span>
             )}
             {status === "completed_unpaid" && (
@@ -3334,18 +3337,21 @@ export default function JobsPage() {
     // counts when expanded.
     const NOW_MS = Date.now();
     const NOW_MINS = (() => { const n = new Date(); return n.getHours() * 60 + n.getMinutes(); })();
-    // [AI.7.3] LIVE_OPS gates time-based clock-in alerts. Pre-launch the
-    // historical seed data has no clock-ins, so every past job today
-    // qualified as "late" — flooding the strip and drowning out real
-    // data-quality issues (unassigned, missing zone). Flip LIVE_OPS=true
-    // once operations are running.
+    // [phes-lifecycle 2026-04-29] Late = 20+ min past start, no clock-in,
+    // no manual no-show flag. Mirrors getJobVisualStatus's late_clockin
+    // derivation so the Needs Attention counter and the chip ring agree.
+    // The William Rosenbloom bug (counter said late before scheduled
+    // start) is closed by the strict `NOW_MINS >= start + 20` check.
+    const LATE_THRESHOLD_MIN_UI = 20;
     const lateClockIns = LIVE_OPS && isToday && data ? data.employees.flatMap(e =>
-      e.jobs.filter(j =>
-        j.status !== "cancelled" && j.status !== "complete" &&
-        !j.clock_entry?.clock_in_at &&
-        NOW_MINS >= timeToMins(j.scheduled_time) - 15 &&
-        timeToMins(j.scheduled_time) > 0
-      ).map(j => ({ job: j, tech_name: e.name }))
+      e.jobs.filter(j => {
+        if (j.status === "cancelled" || j.status === "complete") return false;
+        if (j.clock_entry?.clock_in_at) return false;
+        if (j.no_show_marked_by_tech) return false;
+        const startMins = timeToMins(j.scheduled_time);
+        if (startMins <= 0) return false;
+        return NOW_MINS >= startMins + LATE_THRESHOLD_MIN_UI;
+      }).map(j => ({ job: j, tech_name: e.name }))
     ) : [];
     const unassignedToday = data?.unassigned_jobs ?? [];
     const missingAddress = isToday && data ? data.employees.flatMap(e =>
@@ -3916,17 +3922,28 @@ export default function JobsPage() {
             const now = new Date();
             const nowMins = now.getHours() * 60 + now.getMinutes();
             const isLiveDay = dateKey(selectedDate) === dateKey(now);
+            // [phes-lifecycle 2026-04-29] Same 20-min threshold as the
+            // chip ring + Needs Attention strip. "At risk" is the
+            // warning window — between scheduled start and the LATE
+            // threshold. Both counters skip manual no-shows.
+            const LATE_MIN_HEADER = 20;
             const lateClockIns = isLiveDay ? allJobs.filter(j => {
               if (j.status === "cancelled" || j.status === "complete") return false;
+              if (j.clock_entry?.clock_in_at) return false;
+              if (j.no_show_marked_by_tech) return false;
               const startMins = timeToMins(j.scheduled_time);
-              if (nowMins <= startMins) return false;
-              return !j.clock_entry?.clock_in_at;
+              if (startMins <= 0) return false;
+              return nowMins >= startMins + LATE_MIN_HEADER;
             }).length : 0;
             const atRisk = isLiveDay ? allJobs.filter(j => {
               if (j.status === "cancelled" || j.status === "complete") return false;
+              if (j.clock_entry?.clock_in_at) return false;
+              if (j.no_show_marked_by_tech) return false;
               const startMins = timeToMins(j.scheduled_time);
-              if (nowMins < startMins - 15 || nowMins > startMins + 15) return false;
-              return !j.clock_entry?.clock_in_at;
+              if (startMins <= 0) return false;
+              // Between scheduled start and the LATE threshold — the
+              // warning window before the chip flips to red.
+              return nowMins >= startMins && nowMins < startMins + LATE_MIN_HEADER;
             }).length : 0;
 
             return (
@@ -3949,7 +3966,7 @@ export default function JobsPage() {
                   <div style={{ padding: "6px 20px", borderBottom: "1px solid #E5E2DC", backgroundColor: "#FFFFFF", fontSize: 12, color: "#6B6860", fontFamily: FF }}>
                     {lateClockIns > 0 && <span>{lateClockIns} late clock-in{lateClockIns > 1 ? "s" : ""}</span>}
                     {lateClockIns > 0 && atRisk > 0 && <span style={{ margin: "0 8px" }}>&middot;</span>}
-                    {atRisk > 0 && <span>{atRisk} job{atRisk > 1 ? "s" : ""} at risk (no clock-in within 15 min of start)</span>}
+                    {atRisk > 0 && <span>{atRisk} job{atRisk > 1 ? "s" : ""} at risk (past start, &lt;20 min)</span>}
                   </div>
                 )}
               </>

--- a/lib/db/src/schema/jobs.ts
+++ b/lib/db/src/schema/jobs.ts
@@ -60,6 +60,14 @@ export const jobsTable = pgTable("jobs", {
   actual_end_time: timestamp("actual_end_time"),
   locked_at: timestamp("locked_at"),
   completed_by_user_id: integer("completed_by_user_id"),
+  // [phes-lifecycle 2026-04-29] Manual no-show flag. Set by the field
+  // app's "No Show" button after the tech has waited NO_SHOW_WAIT_MINUTES
+  // on-site for the customer. Distinct from late_clockin (tech
+  // accountability) — this represents customer accountability. Until
+  // the field app ships, both fields stay null and no_show never
+  // fires in production.
+  no_show_marked_by_tech: timestamp("no_show_marked_by_tech"),
+  no_show_marked_by_user_id: integer("no_show_marked_by_user_id"),
   job_lat: numeric("job_lat", { precision: 10, scale: 7 }),
   job_lng: numeric("job_lng", { precision: 10, scale: 7 }),
   geocode_failed: boolean("geocode_failed").notNull().default(false),


### PR DESCRIPTION
Phes operational threshold is **20 minutes** for both LATE (tech accountability — "where's the tech?") and NO_SHOW (customer accountability — "where's the customer?"). They share the threshold but represent different things.

## Lifecycle changes

| State | Trigger before | Trigger after |
|---|---|---|
| `late_clockin` | now ≥ scheduled_start + **5 min**, no clock-in (LIVE_OPS gated) | now ≥ scheduled_start + **20 min**, no clock-in, `no_show_marked_by_tech IS NULL` (LIVE_OPS gated) |
| `no_show` | now ≥ scheduled_start + 30 min, no clock-in (time-derived) | **`no_show_marked_by_tech IS NOT NULL`** (manual flag from field-app button) |
| All other states | unchanged | unchanged |

`TECH_MISSING` dropped — a single 20-min threshold, no second tier.

## Hard scheduled-start gate

Closes the William Rosenbloom regression where the chip painted late before scheduled_start elapsed. The new code in `getJobVisualStatus`:

```ts
const hasStarted = isJobToday && startMins > 0 && nowMins >= startMins;
// ...
if (LIVE_OPS && hasStarted && !hasClockIn) {
  const minsLate = nowMins - startMins;
  if (minsLate >= LATE_THRESHOLD_MINUTES) return "late_clockin";
}
```

Plus matching gates in the page-level `lateClockIns` / `atRisk` counters so the Needs Attention strip and the chip ring agree.

## Schema additions

```sql
ALTER TABLE jobs ADD COLUMN IF NOT EXISTS no_show_marked_by_tech TIMESTAMP;
ALTER TABLE jobs ADD COLUMN IF NOT EXISTS no_show_marked_by_user_id INTEGER;
```

Idempotent in `phes-data-migration.ts`. Both stay `NULL` until the field app's "No Show" button ships, so `no_show` never fires in production today. Surfaced on `/api/dispatch` and the frontend `DispatchJob` type so it flows through to `getJobVisualStatus` automatically once data arrives.

## Constants

```ts
const LATE_THRESHOLD_MINUTES = 20;
export const NO_SHOW_WAIT_MINUTES = 20;
```

Hardcoded for Phes. Multi-tenant later → `tenant_settings.late_threshold_minutes` / `.no_show_wait_minutes`.

## Pill copy

`LATE` pill: caps via literal, not `textTransform`, so the trailing minute "m" stays lowercase per spec → renders as **"LATE 24m"**, not "LATE 24M".

`NO SHOW` badge unchanged (already correct).

## CLAUDE.md

Updated the canonical state-model table to nine states (was seven — `en_route` and `completed_unpaid` landed in earlier PRs but the doc lagged). New section documents the Phes thresholds + manual-flag semantics + scheduled-start gate. Notes the LATE-vs-NO_SHOW accountability distinction.

## Files

- `artifacts/qleno/src/lib/job-status.ts` — single threshold; manual `no_show`; explicit `hasStarted` gate.
- `artifacts/qleno/src/pages/jobs.tsx` — `LATE 24m` literal-caps; counters use 20-min threshold + skip manual no-shows.
- `lib/db/src/schema/jobs.ts` — `no_show_marked_by_tech` + `_by_user_id` columns.
- `artifacts/api-server/src/phes-data-migration.ts` — idempotent `ALTER ADD COLUMN IF NOT EXISTS`.
- `artifacts/api-server/src/routes/dispatch.ts` — surface new fields on payload.
- `CLAUDE.md` — state-model invariant updated.

## Acceptance

- [x] Frontend builds clean (`pnpm run build`)
- [x] Unit tests pass (`price-delta.test.ts` 11/11)
- [x] Backend net-zero new TS errors
- [x] Migration is idempotent (`IF NOT EXISTS`)
- [ ] Sal verifies on production after Railway deploys

---
_Generated by [Claude Code](https://claude.ai/code/session_016GqMSjAaG7gGDtiFSPKn5Q)_