### PR TITLE
fix: commercial commission routing + admin dedupe endpoints + Settings→Commission

### DIFF
--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -793,9 +793,9 @@ async function runJobsDedupeAndConstraint(): Promise<void> {
     RETURNING id
   `);
   const removed = (deleted.rows ?? []).length;
-  if (removed > 0) {
-    console.log(`[jobs-dedupe] Removed ${removed} duplicate job row(s) (kept latest per client/date/time, NULL-time included).`);
-  }
+  // [iter 2 logging] Always log — distinguishes "ran, found nothing"
+  // from "didn't run at all" when staring at Railway logs.
+  console.log(`[jobs-dedupe] Migration ran. Removed ${removed} duplicate job row(s).`);
 
   // Step 2: replace the old index with the COALESCE-keyed version.
   // Drop-then-create is safe because the dedupe in step 1 just ran;

--- a/artifacts/api-server/src/routes/admin.ts
+++ b/artifacts/api-server/src/routes/admin.ts
@@ -398,6 +398,131 @@ router.post("/smoke-tests/run", ...isSuperAdmin, async (_req, res) => {
   }
 });
 
+/* ── JOBS DEDUPE — DIAGNOSTIC + FORCE-RUN ──────────────────────────
+ * GET  /api/admin/jobs-duplicates       → returns current duplicates
+ *                                          without modifying anything
+ *                                          (pre-flight check Sal can
+ *                                          hit before deciding to
+ *                                          dedupe)
+ * POST /api/admin/jobs-dedupe-run       → executes the same dedupe +
+ *                                          unique-index logic that
+ *                                          phes-data-migration runs
+ *                                          on cold-start, but
+ *                                          on-demand. Returns a JSON
+ *                                          report (rows removed, ids,
+ *                                          index status) so Sal can
+ *                                          verify the migration
+ *                                          actually did its job.
+ *
+ * Both endpoints only return rows that look like real duplicates:
+ * same (company_id, client_id, scheduled_date, scheduled_time)
+ * tuple — including NULL-time matches via COALESCE — and not
+ * cancelled. The dedupe matches the migration's deletion logic
+ * exactly so the report previews what's about to happen.
+ */
+router.get("/jobs-duplicates", ...isSuperAdmin, async (_req, res) => {
+  try {
+    const dupes = await db.execute(sql`
+      WITH partitioned AS (
+        SELECT id, company_id, client_id, scheduled_date,
+               scheduled_time, status, billed_amount,
+               assigned_user_id, created_at,
+               ROW_NUMBER() OVER (
+                 PARTITION BY company_id, client_id, scheduled_date,
+                              COALESCE(scheduled_time::text, '00:00:00')
+                 ORDER BY created_at DESC NULLS LAST, id DESC
+               ) AS rn,
+               COUNT(*) OVER (
+                 PARTITION BY company_id, client_id, scheduled_date,
+                              COALESCE(scheduled_time::text, '00:00:00')
+               ) AS slot_size
+        FROM jobs
+        WHERE status NOT IN ('cancelled')
+      )
+      SELECT id, company_id, client_id, scheduled_date,
+             scheduled_time, status, billed_amount,
+             assigned_user_id, created_at,
+             rn, slot_size
+      FROM partitioned
+      WHERE slot_size > 1
+      ORDER BY scheduled_date DESC, client_id, rn ASC
+      LIMIT 500
+    `);
+    const rows = dupes.rows as any[];
+    return res.json({
+      total_rows_in_collisions: rows.length,
+      distinct_slots: new Set(rows.map(r => `${r.company_id}|${r.client_id}|${r.scheduled_date}|${r.scheduled_time ?? "null"}`)).size,
+      rows,
+    });
+  } catch (err: any) {
+    console.error("[admin] jobs-duplicates error:", err);
+    return res.status(500).json({ error: "Internal Server Error", message: err.message });
+  }
+});
+
+router.post("/jobs-dedupe-run", ...isSuperAdmin, async (_req, res) => {
+  try {
+    // Snapshot which rows would be deleted, then delete them and
+    // (re)create the partial unique index. Returns the deleted ids
+    // so Sal can verify after the call.
+    const preview = await db.execute(sql`
+      WITH dupes AS (
+        SELECT id, scheduled_date, scheduled_time, client_id,
+               ROW_NUMBER() OVER (
+                 PARTITION BY company_id, client_id, scheduled_date,
+                              COALESCE(scheduled_time::text, '00:00:00')
+                 ORDER BY created_at DESC NULLS LAST, id DESC
+               ) AS rn
+        FROM jobs
+        WHERE status NOT IN ('cancelled')
+      )
+      SELECT id, scheduled_date, scheduled_time, client_id
+      FROM dupes
+      WHERE rn > 1
+      ORDER BY scheduled_date DESC, client_id, id
+    `);
+    const previewRows = preview.rows as any[];
+
+    const deleted = await db.execute(sql`
+      WITH dupes AS (
+        SELECT id,
+               ROW_NUMBER() OVER (
+                 PARTITION BY company_id, client_id, scheduled_date,
+                              COALESCE(scheduled_time::text, '00:00:00')
+                 ORDER BY created_at DESC NULLS LAST, id DESC
+               ) AS rn
+        FROM jobs
+        WHERE status NOT IN ('cancelled')
+      )
+      DELETE FROM jobs
+      WHERE id IN (SELECT id FROM dupes WHERE rn > 1)
+      RETURNING id
+    `);
+
+    await db.execute(sql`DROP INDEX IF EXISTS uq_jobs_no_double_book`);
+    await db.execute(sql`
+      CREATE UNIQUE INDEX IF NOT EXISTS uq_jobs_no_double_book
+        ON jobs (
+          company_id,
+          client_id,
+          scheduled_date,
+          (COALESCE(scheduled_time::text, '00:00:00'))
+        )
+        WHERE status NOT IN ('cancelled')
+    `);
+
+    return res.json({
+      deleted_count: (deleted.rows ?? []).length,
+      deleted_ids: (deleted.rows as any[]).map(r => r.id),
+      preview_rows: previewRows,
+      index: "uq_jobs_no_double_book recreated",
+    });
+  } catch (err: any) {
+    console.error("[admin] jobs-dedupe-run error:", err);
+    return res.status(500).json({ error: "Internal Server Error", message: err.message });
+  }
+});
+
 /* ── AUDIT LOG HEALTH CHECK ──────────────────────────────────────── */
 router.post("/audit-test", ...isSuperAdmin, async (req, res) => {
   try {

--- a/artifacts/api-server/src/routes/dispatch.ts
+++ b/artifacts/api-server/src/routes/dispatch.ts
@@ -416,7 +416,15 @@ router.get("/", requireAuth, async (req, res) => {
       const durationMinutes = j.allowed_hours
         ? Math.max(30, Math.round((parseFloat(j.allowed_hours) / numTechsForDur) * 60))
         : 120;
-      const isCommercial = !!j.account_id;
+      // [commission-fix 2026-04-29] Commercial routing falls back to
+      // residential 35% pool when account_id is null. But Jaira-style
+      // jobs (commercial client booked through the residential flow,
+      // OR imported without account linkage) carry client_type =
+      // 'commercial' on the clients row even though jobs.account_id
+      // stays null. Routing on account_id alone gave $112 instead of
+      // $120 on Jaira's 6-hour commercial visit (320 × 0.35 vs
+      // 20 × 6). Now both signals trigger the commercial path.
+      const isCommercial = !!j.account_id || (j as any).client_type === "commercial";
       // [AI.7.6] Canonical address render: "<street>, <city>, <state> <zip>".
       // formatAddress() inlined here on the server side; the same shape
       // ships to the frontend so there's only one rule. State + zip are

--- a/artifacts/qleno/src/App.tsx
+++ b/artifacts/qleno/src/App.tsx
@@ -84,6 +84,8 @@ const NotFound            = lazy(() => import("@/pages/not-found"));
 // renders, and the route below is only mounted when import.meta.env.PROD
 // is false.
 const JobsVisualTestPage  = lazy(() => import("@/pages/jobs-visual-test"));
+// [commission-settings 2026-04-29] Settings → Commission page.
+const CommissionSettingsPage = lazy(() => import("@/pages/settings-commission"));
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -110,6 +112,7 @@ function Router() {
         <Route path="/dashboard" component={Dashboard} />
         <Route path="/dispatch" component={JobsPage} />
         {!import.meta.env.PROD && <Route path="/jobs/visual-test" component={JobsVisualTestPage} />}
+        <Route path="/settings/commission" component={CommissionSettingsPage} />
         {/* [Q2] JobsListPage moved to /reports/jobs. Keep /jobs and /jobs/list
             as redirects for old bookmarks. */}
         <Route path="/jobs"><Redirect to="/reports/jobs" /></Route>

--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -1494,7 +1494,25 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
                     {assignedEmp?.name || job.assigned_user_name || "Unassigned"} · Est. {(job.est_hours_per_tech ?? job.estimated_hours ?? 0).toFixed(1)} hrs
                   </span>
                   <span style={{ fontSize: 12, fontWeight: 700, color: "#16A34A" }}>
-                    ${(job.est_pay_per_tech ?? ((job.billed_amount ?? job.amount ?? 0) * (job.company_res_pct ?? 0.35))).toFixed(2)} est.
+                    {/* [commission-fix 2026-04-29] When est_pay_per_tech
+                        falls back, it must respect commission_basis.
+                        Commercial → hourly_rate × est_hours; residential
+                        → 35% pool. The old code applied 35% to every
+                        job regardless of basis, which paid commercial
+                        techs $112 instead of $120 on Jaira's 6-hour
+                        $320 visit. */}
+                    ${(() => {
+                      if (job.est_pay_per_tech != null) return job.est_pay_per_tech.toFixed(2);
+                      const isCommercialFallback = job.commission_basis === "commercial_hourly"
+                        || (!job.commission_basis && (job.account_id != null || job.client_type === "commercial"));
+                      if (isCommercialFallback) {
+                        const rate = job.commercial_hourly_rate ?? 20;
+                        const hrs = job.est_hours_per_tech ?? job.estimated_hours ?? 0;
+                        return (rate * hrs).toFixed(2);
+                      }
+                      const total = job.billed_amount ?? job.amount ?? 0;
+                      return (total * (job.company_res_pct ?? 0.35)).toFixed(2);
+                    })()} est.
                   </span>
                 </div>
               )}
@@ -1503,7 +1521,7 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
                   Routing comes from server's commission_basis flag —
                   fallback to account_id signal for older payloads. */}
               <div style={{ marginTop: 4, fontSize: 11, color: "#9E9B94" }}>
-                {(job.commission_basis === "commercial_hourly" || (!job.commission_basis && job.account_id != null))
+                {(job.commission_basis === "commercial_hourly" || (!job.commission_basis && (job.account_id != null || job.client_type === "commercial")))
                   ? `Hourly rate: $${(job.commercial_hourly_rate ?? 20).toFixed(0)}/hr × ${(job.est_hours_per_tech != null && (job.technicians?.length ?? 1) > 1
                       ? (job.est_hours_per_tech * (job.technicians?.length ?? 1))
                       : (job.est_hours_per_tech ?? 0)).toFixed(1)} hrs`

--- a/artifacts/qleno/src/pages/settings-commission.tsx
+++ b/artifacts/qleno/src/pages/settings-commission.tsx
@@ -1,0 +1,247 @@
+/**
+ * [commission-settings 2026-04-29] Settings → Commission page.
+ *
+ * Phes operations needed a discoverable page for commission rate
+ * configuration (residential pool % and commercial hourly $/hr) plus
+ * per-tech overrides. The underlying fields already existed on the
+ * companies table (`res_tech_pay_pct`, `commercial_hourly_rate`,
+ * `commercial_comp_mode`) and the per-tech override on
+ * `users.commission_rate_override`. This page wires them into a
+ * focused UI without ambiguity about where to find them.
+ *
+ * Backed by existing endpoints:
+ *   GET  /api/companies/me                 → reads current rates
+ *   PUT  /api/companies/me                 → updates company-level rates
+ *   GET  /api/employees                    → list of techs + their overrides
+ *   PATCH /api/employees/:id               → update commission_rate_override
+ *
+ * Type model: residential is %-based, commercial is $/hr. The
+ * "configurable type" the original ask mentioned (e.g., make
+ * residential hourly too) needs schema work — flagged in the page
+ * footer so Sal knows it's a follow-up rather than missing here.
+ */
+import { useEffect, useState } from "react";
+import { DashboardLayout } from "@/components/layout/dashboard-layout";
+import { getAuthHeaders } from "@/lib/auth";
+import { useToast } from "@/hooks/use-toast";
+
+const FF = "'Plus Jakarta Sans', sans-serif";
+
+type Employee = {
+  id: number;
+  first_name: string;
+  last_name: string;
+  role: string;
+  is_active: boolean;
+  commission_rate_override: number | null;
+};
+
+export default function CommissionSettingsPage() {
+  const BASE = import.meta.env.BASE_URL.replace(/\/$/, "");
+  const { toast } = useToast();
+  const [loading, setLoading] = useState(true);
+  const [resPct, setResPct] = useState<string>("35");        // 0–100 in UI; stored as fraction 0–1
+  const [commercialHourly, setCommercialHourly] = useState<string>("20");
+  const [commercialMode, setCommercialMode] = useState<"allowed_hours" | "worked_hours">("allowed_hours");
+  const [employees, setEmployees] = useState<Employee[]>([]);
+  const [savingCompany, setSavingCompany] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const [cRes, eRes] = await Promise.all([
+          fetch(`${BASE}/api/companies/me`, { headers: getAuthHeaders() }).then(r => r.ok ? r.json() : null),
+          fetch(`${BASE}/api/employees`, { headers: getAuthHeaders() }).then(r => r.ok ? r.json() : null),
+        ]);
+        if (cancelled) return;
+        const c = cRes?.data ?? cRes;
+        if (c?.res_tech_pay_pct != null) {
+          setResPct(String(Math.round(parseFloat(c.res_tech_pay_pct) * 100)));
+        }
+        if (c?.commercial_hourly_rate != null) {
+          setCommercialHourly(String(c.commercial_hourly_rate));
+        }
+        if (c?.commercial_comp_mode != null) setCommercialMode(c.commercial_comp_mode);
+        const list: Employee[] = Array.isArray(eRes?.data) ? eRes.data : Array.isArray(eRes) ? eRes : [];
+        setEmployees(list.filter(u => u.is_active));
+      } catch (err: any) {
+        toast({ title: "Load failed", description: err?.message ?? "Could not load commission settings.", variant: "destructive" });
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [BASE, toast]);
+
+  async function saveCompany() {
+    setSavingCompany(true);
+    try {
+      const r = await fetch(`${BASE}/api/companies/me`, {
+        method: "PUT",
+        headers: { ...getAuthHeaders(), "Content-Type": "application/json" },
+        body: JSON.stringify({
+          res_tech_pay_pct: parseFloat(resPct) / 100,
+          commercial_hourly_rate: parseFloat(commercialHourly),
+          commercial_comp_mode: commercialMode,
+        }),
+      });
+      if (!r.ok) {
+        const d = await r.json().catch(() => ({}));
+        toast({ title: "Save failed", description: d.message || d.error || `HTTP ${r.status}`, variant: "destructive" });
+        return;
+      }
+      toast({ title: "Saved", description: "Company commission rates updated." });
+    } catch (err: any) {
+      toast({ title: "Network error", description: err?.message ?? "Could not save.", variant: "destructive" });
+    } finally {
+      setSavingCompany(false);
+    }
+  }
+
+  async function saveEmployeeOverride(id: number, value: string) {
+    const parsed = value.trim() === "" ? null : parseFloat(value);
+    if (parsed != null && (Number.isNaN(parsed) || parsed < 0)) {
+      toast({ title: "Invalid", description: "Override must be a non-negative number or blank.", variant: "destructive" });
+      return;
+    }
+    try {
+      const r = await fetch(`${BASE}/api/employees/${id}`, {
+        method: "PATCH",
+        headers: { ...getAuthHeaders(), "Content-Type": "application/json" },
+        body: JSON.stringify({ commission_rate_override: parsed }),
+      });
+      if (!r.ok) {
+        const d = await r.json().catch(() => ({}));
+        toast({ title: "Save failed", description: d.message || d.error || `HTTP ${r.status}`, variant: "destructive" });
+        return;
+      }
+      setEmployees(prev => prev.map(e => e.id === id ? { ...e, commission_rate_override: parsed } : e));
+      toast({ title: "Saved", description: "Override updated." });
+    } catch (err: any) {
+      toast({ title: "Network error", description: err?.message ?? "Could not save.", variant: "destructive" });
+    }
+  }
+
+  const sectionCard: React.CSSProperties = {
+    background: "#FFFFFF", border: "1px solid #E5E2DC", borderRadius: 12,
+    padding: "20px 22px", marginBottom: 16,
+  };
+  const labelStyle: React.CSSProperties = {
+    fontSize: 12, fontWeight: 700, color: "#6B6860",
+    textTransform: "uppercase", letterSpacing: "0.05em", marginBottom: 6, display: "block",
+  };
+  const inputStyle: React.CSSProperties = {
+    padding: "8px 10px", border: "1px solid #E5E2DC", borderRadius: 6,
+    fontSize: 14, fontFamily: FF, color: "#1A1917", width: 120,
+  };
+
+  return (
+    <DashboardLayout>
+      <div style={{ padding: "24px 32px 80px", background: "#F7F6F3", minHeight: "100%", fontFamily: FF }}>
+        <div style={{ maxWidth: 760, margin: "0 auto" }}>
+          <h1 style={{ fontSize: 22, fontWeight: 800, color: "#1A1917", marginBottom: 4 }}>Commission settings</h1>
+          <p style={{ fontSize: 13, color: "#6B6860", marginBottom: 20, lineHeight: 1.5 }}>
+            How techs get paid per job. Residential jobs use a % of job total; commercial jobs use an hourly rate. Per-tech overrides below replace the default for individual techs.
+          </p>
+
+          {loading ? (
+            <div style={{ ...sectionCard, color: "#9E9B94", textAlign: "center" }}>Loading…</div>
+          ) : (
+            <>
+              <div style={sectionCard}>
+                <h2 style={{ fontSize: 15, fontWeight: 800, color: "#1A1917", marginBottom: 10 }}>Residential — pool rate</h2>
+                <p style={{ fontSize: 12, color: "#6B6860", marginBottom: 12, lineHeight: 1.5 }}>
+                  Job total × pool rate ÷ techs on job. Default 35%.
+                </p>
+                <label style={labelStyle}>Commission % of job total</label>
+                <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                  <input type="number" min={0} max={100} step={1} value={resPct}
+                    onChange={e => setResPct(e.target.value)} style={inputStyle} placeholder="35" />
+                  <span style={{ fontSize: 13, color: "#6B7280" }}>%</span>
+                </div>
+              </div>
+
+              <div style={sectionCard}>
+                <h2 style={{ fontSize: 15, fontWeight: 800, color: "#1A1917", marginBottom: 10 }}>Commercial — hourly rate</h2>
+                <p style={{ fontSize: 12, color: "#6B6860", marginBottom: 12, lineHeight: 1.5 }}>
+                  Hourly rate × hours per tech. Default $20/hr. The hours signal below picks scheduled (allowed) hours vs actual clock time.
+                </p>
+                <label style={labelStyle}>Hourly rate</label>
+                <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 16 }}>
+                  <span style={{ fontSize: 14, fontWeight: 600, color: "#1A1917" }}>$</span>
+                  <input type="number" min={0} step={0.25} value={commercialHourly}
+                    onChange={e => setCommercialHourly(e.target.value)} style={inputStyle} placeholder="20.00" />
+                  <span style={{ fontSize: 13, color: "#6B7280" }}>/hr</span>
+                </div>
+                <label style={labelStyle}>Hours used for pay calculation</label>
+                <div style={{ display: "flex", gap: 8 }}>
+                  {([
+                    { v: "allowed_hours", label: "Allowed hours", sub: "Scheduled / estimated" },
+                    { v: "worked_hours",  label: "Worked hours",  sub: "Actual clock time" },
+                  ] as const).map(opt => (
+                    <button key={opt.v} type="button" onClick={() => setCommercialMode(opt.v)}
+                      style={{
+                        flex: 1, padding: "10px 12px", borderRadius: 8, cursor: "pointer", textAlign: "left",
+                        border: `1.5px solid ${commercialMode === opt.v ? "var(--brand, #00C9A0)" : "#E5E2DC"}`,
+                        background: commercialMode === opt.v ? "rgba(0,201,160,0.08)" : "#FFFFFF",
+                        fontFamily: FF,
+                      }}>
+                      <div style={{ fontSize: 13, fontWeight: 700, color: "#1A1917" }}>{opt.label}</div>
+                      <div style={{ fontSize: 11, color: "#9E9B94", marginTop: 2 }}>{opt.sub}</div>
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              <button onClick={saveCompany} disabled={savingCompany}
+                style={{ padding: "10px 22px", background: "var(--brand, #00C9A0)", color: "#FFFFFF", border: "none", borderRadius: 8, fontWeight: 700, fontSize: 13, fontFamily: FF, cursor: savingCompany ? "wait" : "pointer", marginBottom: 28 }}>
+                {savingCompany ? "Saving…" : "Save company defaults"}
+              </button>
+
+              <div style={sectionCard}>
+                <h2 style={{ fontSize: 15, fontWeight: 800, color: "#1A1917", marginBottom: 6 }}>Per-tech overrides</h2>
+                <p style={{ fontSize: 12, color: "#6B6860", marginBottom: 14, lineHeight: 1.5 }}>
+                  Optional. Leave blank to use the company default. Numeric value is a flat rate that replaces the default — e.g. "22" for a senior tech who earns $22/hr on commercial work, or "40" for a tech on a 40% pool rate residentially. The value is stored as-is on the user record; the dispatch route reads <code>users.commission_rate_override</code>.
+                </p>
+                <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                  {employees.length === 0 ? (
+                    <div style={{ fontSize: 13, color: "#9E9B94" }}>No active employees.</div>
+                  ) : employees.map(emp => (
+                    <PerTechRow key={emp.id} emp={emp} onSave={(v) => saveEmployeeOverride(emp.id, v)} />
+                  ))}
+                </div>
+              </div>
+
+              <div style={{ fontSize: 11, color: "#9E9B94", lineHeight: 1.6 }}>
+                Note: residential is currently fixed at %-based and commercial at hourly. Configurable type per service category (e.g. residential hourly, commercial %) is a follow-up — needs schema work to split type from rate.
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+}
+
+function PerTechRow({ emp, onSave }: { emp: Employee; onSave: (v: string) => void }) {
+  const [val, setVal] = useState<string>(emp.commission_rate_override != null ? String(emp.commission_rate_override) : "");
+  const [dirty, setDirty] = useState(false);
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "8px 10px", border: "1px solid #F0EEE9", borderRadius: 8 }}>
+      <div style={{ flex: 1, fontSize: 13, color: "#1A1917" }}>
+        {emp.first_name} {emp.last_name}
+        <span style={{ color: "#9E9B94", marginLeft: 6, fontSize: 11 }}>· {emp.role}</span>
+      </div>
+      <input type="number" min={0} step={0.25} value={val}
+        onChange={e => { setVal(e.target.value); setDirty(true); }}
+        placeholder="—"
+        style={{ padding: "6px 8px", border: "1px solid #E5E2DC", borderRadius: 6, fontSize: 13, fontFamily: FF, width: 90, textAlign: "right" }} />
+      <button onClick={() => { onSave(val); setDirty(false); }}
+        disabled={!dirty}
+        style={{ padding: "6px 12px", borderRadius: 6, border: "none", background: dirty ? "var(--brand, #00C9A0)" : "#E5E2DC", color: dirty ? "#FFFFFF" : "#9E9B94", fontSize: 12, fontWeight: 700, fontFamily: FF, cursor: dirty ? "pointer" : "not-allowed" }}>
+        Save
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Honest start: I cannot verify on production from this sandbox.

I tried during earlier PRs — `https://app.qleno.com/dispatch` and the Railway URL both return `HTTP 403 x-deny-reason: host_not_allowed`. I cannot screenshot, cannot run SQL on the prod DB, cannot watch the deploy land. I should have flagged that harder before claiming #10 and #12 "shipped". Going forward, "done from my side" means **code in main, build clean, migration idempotent** — never *verified live*. You verify the prod side.

This PR contains the four code fixes plus two endpoints you can hit directly from your terminal to verify Bug 1 yourself.

---

## Bug 3 — Commercial commission rendering at residential rate

**Root cause:** `routes/dispatch.ts:419` had `isCommercial = !!j.account_id`. Jaira's commercial job has `client_type='commercial'` on the clients row but `jobs.account_id` is null (booked through the residential flow or imported without account linkage), so the dispatch payload tagged her job residential. `commission_basis` then said `residential_pool` and `est_pay_per_tech` calculated as `$320 × 0.35 = $112` exactly.

**Fix:**

```ts
// routes/dispatch.ts
const isCommercial = !!j.account_id || (j as any).client_type === "commercial";
```

Plus the JobPanel fallback (`pages/jobs.tsx:1497`) now respects `commission_basis` instead of always applying 35% when `est_pay_per_tech` is missing.

After deploy + hard-refresh: Alma should show **$120 (6h × $20)** on Jaira's job.

---

## Bug 1 — Jaira chip duplicate (diagnostic + force-run endpoints)

Two iterations of dedupe shipped (#10, #12) but you're still seeing the duplicate. I can't query the prod DB, so I'm handing you the tools to verify and force-fix yourself.

### SQL you can run

The query you wrote (column names adjusted to actual schema — there's no `scheduled_start_time` / `scheduled_end_time`; we use `scheduled_time` + `allowed_hours`):

```sql
SELECT id, client_id, scheduled_date, scheduled_time, allowed_hours,
       assigned_user_id, billed_amount, base_fee, status,
       account_id, recurring_schedule_id, created_at
FROM jobs
WHERE scheduled_date = '2026-04-27'
  AND client_id IN (
    SELECT id FROM clients
    WHERE first_name ILIKE '%Jaira%' OR last_name ILIKE '%Estrada%'
  )
ORDER BY created_at;
```

### Force-fix endpoints (super-admin only)

After this PR deploys, hit:

```bash
# 1. See current duplicates without modifying anything
curl -H "Authorization: Bearer $TOKEN" \
  https://app.qleno.com/api/admin/jobs-duplicates

# 2. Force-run the dedupe + recreate the unique index, get a JSON report
curl -X POST -H "Authorization: Bearer $TOKEN" \
  https://app.qleno.com/api/admin/jobs-dedupe-run
```

The dedupe logic is the same one in `phes-data-migration.ts` — partition by `(company_id, client_id, scheduled_date, COALESCE(scheduled_time::text, '00:00:00'))`, keep `created_at DESC, id DESC`, delete the rest, drop + recreate the partial unique index.

### Migration logs now distinguish "ran, found nothing" from "didn't run"

`phes-data-migration.ts` previously only logged when `removed > 0`. Now it always logs `[jobs-dedupe] Migration ran. Removed N duplicate job row(s).` so you can grep Railway logs for that line to confirm boot-time dedupe actually fires.

---

## Bug 4 — Settings → Commission page

New page at **`/settings/commission`** (`pages/settings-commission.tsx`):

- **Residential — pool rate**: editable %. Wired to `companies.res_tech_pay_pct`.
- **Commercial — hourly rate**: editable $/hr + hours-mode toggle (Allowed vs Worked). Wired to `companies.commercial_hourly_rate` + `companies.commercial_comp_mode`.
- **Per-tech overrides**: list of active employees with editable `commission_rate_override` field. Saved per-employee via existing `PATCH /api/employees/:id`.

These fields already existed in the older `/company` Payroll Settings panel; this is a focused, discoverable page.

**Configurable commission type** (residential hourly, commercial %) is **not** in this PR. The companies table has rate columns but no type column to split type from rate. I flagged this in the page footer rather than backfilling schema work into a hotfix. Follow-up if you want it.

---

## Bug 2 — Time field editor

`InlineTimeEdit` is at `jobs.tsx:759` (defined) and `jobs.tsx:1336` (rendered) on main. Shipped in **PR #12 (`0bd8ffb`)**. If you're not seeing the pencil button after Railway picks up #12:

1. Hard refresh (Cmd+Shift+R / Ctrl+Shift+R) — the JS bundle hash changes per build, but the cached HTML can serve stale assets briefly.
2. Check the Network tab for `jobs-*.js` — the latest bundle from #12 includes `InlineTimeEdit`.
3. If it's still missing after a hard refresh, the deploy didn't fully roll out — `gh api repos/salmartinez-design/qleno/deployments` will show what Railway has.

Not adding more code for this until you confirm the deploy issue, since the component is in main.

---

## Files

- `artifacts/api-server/src/routes/dispatch.ts` — `isCommercial` widened to include `client_type='commercial'`
- `artifacts/api-server/src/routes/admin.ts` — `GET /jobs-duplicates`, `POST /jobs-dedupe-run`
- `artifacts/api-server/src/phes-data-migration.ts` — always log dedupe outcome
- `artifacts/qleno/src/pages/jobs.tsx` — JobPanel commission fallback respects `commission_basis`
- `artifacts/qleno/src/pages/settings-commission.tsx` — new page
- `artifacts/qleno/src/App.tsx` — route wiring

---

## Acceptance — what you verify on production

1. Open `/dispatch`, click Jaira's chip → JobPanel commission shows **$120**, not $112.
2. Hit `GET /api/admin/jobs-duplicates`. If rows return, hit `POST /api/admin/jobs-dedupe-run`, then re-check.
3. Open `/settings/commission` — sees residential %, commercial $/hr, per-tech overrides. Change commercial to $25, save, confirm dispatch board re-loads with $25/hr × 6h = $150 on Jaira's row.
4. After Railway picks up #12 + this PR, hard-refresh `/dispatch`, click any chip → JobPanel time row has a pencil button.

If any of those fail on production, send the screenshot + the JSON response from the admin endpoints and I'll dig in further.

---
_Generated by [Claude Code](https://claude.ai/code/session_016GqMSjAaG7gGDtiFSPKn5Q)_