### PR TITLE
feat: per-employee 4-cell pay matrix (commission/hourly × residential/commercial)

### DIFF
--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -40,6 +40,18 @@ async function runBookingSchemaGuard(): Promise<void> {
     // app's "No Show" button. See lib/job-status.ts for the state model.
     { label: "jobs.no_show_marked_by_tech", stmt: "ALTER TABLE jobs ADD COLUMN IF NOT EXISTS no_show_marked_by_tech TIMESTAMP" },
     { label: "jobs.no_show_marked_by_user_id", stmt: "ALTER TABLE jobs ADD COLUMN IF NOT EXISTS no_show_marked_by_user_id INTEGER" },
+    // [pay-matrix 2026-04-29] Per-employee 4-cell pay matrix. Schema
+    // additions are idempotent (IF NOT EXISTS); backfill happens in
+    // runPayMatrixBackfill() so the boot-order is: ensure columns
+    // exist, then ensure every row has a sensible default.
+    { label: "users.residential_pay_type", stmt: "ALTER TABLE users ADD COLUMN IF NOT EXISTS residential_pay_type TEXT DEFAULT 'commission'" },
+    { label: "users.residential_pay_rate", stmt: "ALTER TABLE users ADD COLUMN IF NOT EXISTS residential_pay_rate NUMERIC(8,4) DEFAULT 0.35" },
+    { label: "users.commercial_pay_type",  stmt: "ALTER TABLE users ADD COLUMN IF NOT EXISTS commercial_pay_type  TEXT DEFAULT 'hourly'" },
+    { label: "users.commercial_pay_rate",  stmt: "ALTER TABLE users ADD COLUMN IF NOT EXISTS commercial_pay_rate  NUMERIC(8,4) DEFAULT 20.0000" },
+    { label: "companies.default_residential_pay_type", stmt: "ALTER TABLE companies ADD COLUMN IF NOT EXISTS default_residential_pay_type TEXT DEFAULT 'commission'" },
+    { label: "companies.default_residential_pay_rate", stmt: "ALTER TABLE companies ADD COLUMN IF NOT EXISTS default_residential_pay_rate NUMERIC(8,4) DEFAULT 0.35" },
+    { label: "companies.default_commercial_pay_type",  stmt: "ALTER TABLE companies ADD COLUMN IF NOT EXISTS default_commercial_pay_type  TEXT DEFAULT 'hourly'" },
+    { label: "companies.default_commercial_pay_rate",  stmt: "ALTER TABLE companies ADD COLUMN IF NOT EXISTS default_commercial_pay_rate  NUMERIC(8,4) DEFAULT 20.0000" },
     { label: "jobs.property_vacant",       stmt: "ALTER TABLE jobs ADD COLUMN IF NOT EXISTS property_vacant BOOLEAN DEFAULT false" },
     { label: "jobs.arrival_window",        stmt: "ALTER TABLE jobs ADD COLUMN IF NOT EXISTS arrival_window TEXT" },
     { label: "jobs.first_recurring_discounted", stmt: "ALTER TABLE jobs ADD COLUMN IF NOT EXISTS first_recurring_discounted BOOLEAN DEFAULT false" },
@@ -814,8 +826,55 @@ async function runJobsDedupeAndConstraint(): Promise<void> {
   `);
 }
 
+// [pay-matrix 2026-04-29] Backfill the per-employee pay matrix and
+// the tenant defaults. Postgres applies the column-level DEFAULT to
+// rows inserted AFTER the column is added, but rows that pre-date the
+// ALTER get NULL by default. We coalesce to the documented Phes
+// values so dispatch never reads a NULL pay rate.
+async function runPayMatrixBackfill(): Promise<void> {
+  // Tenant defaults — set on every company that doesn't already have
+  // them. Phes operational defaults: residential commission 0.35,
+  // commercial hourly $20.
+  await db.execute(sql`
+    UPDATE companies SET
+      default_residential_pay_type  = COALESCE(default_residential_pay_type,  'commission'),
+      default_residential_pay_rate  = COALESCE(default_residential_pay_rate,  0.35),
+      default_commercial_pay_type   = COALESCE(default_commercial_pay_type,   'hourly'),
+      default_commercial_pay_rate   = COALESCE(default_commercial_pay_rate,   20.0000)
+    WHERE default_residential_pay_type IS NULL
+       OR default_residential_pay_rate IS NULL
+       OR default_commercial_pay_type  IS NULL
+       OR default_commercial_pay_rate  IS NULL
+  `);
+  // Per-user matrix — backfill from the tenant default. New employees
+  // added after this runs will inherit via the application-level
+  // create-user flow (see routes/employees.ts when it touches this).
+  const updated = await db.execute(sql`
+    UPDATE users u SET
+      residential_pay_type = COALESCE(u.residential_pay_type, c.default_residential_pay_type, 'commission'),
+      residential_pay_rate = COALESCE(u.residential_pay_rate, c.default_residential_pay_rate, 0.35),
+      commercial_pay_type  = COALESCE(u.commercial_pay_type,  c.default_commercial_pay_type,  'hourly'),
+      commercial_pay_rate  = COALESCE(u.commercial_pay_rate,  c.default_commercial_pay_rate,  20.0000)
+    FROM companies c
+    WHERE u.company_id = c.id
+      AND (u.residential_pay_type IS NULL
+        OR u.residential_pay_rate IS NULL
+        OR u.commercial_pay_type  IS NULL
+        OR u.commercial_pay_rate  IS NULL)
+    RETURNING u.id
+  `);
+  const n = (updated.rows ?? []).length;
+  console.log(`[pay-matrix] Backfill ran. Updated ${n} user(s) with tenant pay defaults.`);
+}
+
 export async function runPhesDataMigration(): Promise<void> {
   await runBookingSchemaGuard();
+
+  try {
+    await runPayMatrixBackfill();
+  } catch (err: any) {
+    console.warn("[phes-migration] pay-matrix-backfill — non-fatal:", err?.message ?? err);
+  }
 
   try {
     await runJobsDedupeAndConstraint();

--- a/artifacts/api-server/src/routes/admin.ts
+++ b/artifacts/api-server/src/routes/admin.ts
@@ -523,6 +523,63 @@ router.post("/jobs-dedupe-run", ...isSuperAdmin, async (_req, res) => {
   }
 });
 
+/* ── PAY-MATRIX BACKPAY AUDIT ──────────────────────────────────
+ * GET /api/admin/commission-backpay-audit?since=YYYY-MM-DD
+ *
+ * Returns the financial impact of the pre-pay-matrix bug where
+ * commercial jobs (clients.client_type='commercial') with
+ * jobs.account_id = NULL were paid at the residential 35% rate
+ * instead of commercial $20/hr. Default since-date 2026-01-01.
+ *
+ * Output:
+ *   {
+ *     window: { since, scope: 'commercial-completed' },
+ *     jobs_affected: int,
+ *     paid_out_at_old_rate:    numeric,  // billed_amount × 0.35
+ *     should_have_been_paid:   numeric,  // est_hours × 20.00
+ *     backpay_owed:            numeric,  // delta (positive = owed to techs)
+ *   }
+ *
+ * Counts jobs with actual_end_time set (i.e., truly completed).
+ * Does NOT modify any data — read-only audit. Sal can hand the
+ * number to payroll for a one-off correction or run additional_pay
+ * entries by hand.
+ */
+router.get("/commission-backpay-audit", ...isSuperAdmin, async (req, res) => {
+  try {
+    const since = String(req.query.since ?? "2026-01-01");
+    const out = await db.execute(sql`
+      SELECT
+        COUNT(*)::int                                       AS jobs_affected,
+        COALESCE(SUM(j.billed_amount * 0.35), 0)::numeric    AS paid_out_at_old_rate,
+        COALESCE(SUM(COALESCE(j.estimated_hours, j.allowed_hours, 0) * 20.00), 0)::numeric
+                                                            AS should_have_been_paid,
+        COALESCE(SUM(
+          (COALESCE(j.estimated_hours, j.allowed_hours, 0) * 20.00)
+          - (j.billed_amount * 0.35)
+        ), 0)::numeric                                       AS backpay_owed
+      FROM jobs j
+      JOIN clients c ON c.id = j.client_id
+      WHERE c.client_type = 'commercial'
+        AND j.account_id IS NULL  -- the routing bug only fired when account_id was missing
+        AND j.actual_end_time IS NOT NULL
+        AND j.scheduled_date >= ${since}
+    `);
+    const row = (out.rows[0] as any) ?? {};
+    return res.json({
+      window: { since, scope: "commercial-completed-no-account" },
+      jobs_affected: Number(row.jobs_affected ?? 0),
+      paid_out_at_old_rate: Number(row.paid_out_at_old_rate ?? 0),
+      should_have_been_paid: Number(row.should_have_been_paid ?? 0),
+      backpay_owed: Number(row.backpay_owed ?? 0),
+      note: "Backpay = should_have_been_paid - paid_out_at_old_rate. Positive means techs were under-paid; negative means over-paid.",
+    });
+  } catch (err: any) {
+    console.error("[admin] commission-backpay-audit error:", err);
+    return res.status(500).json({ error: "Internal Server Error", message: err.message });
+  }
+});
+
 /* ── AUDIT LOG HEALTH CHECK ──────────────────────────────────────── */
 router.post("/audit-test", ...isSuperAdmin, async (req, res) => {
   try {

--- a/artifacts/api-server/src/routes/dispatch.ts
+++ b/artifacts/api-server/src/routes/dispatch.ts
@@ -297,10 +297,15 @@ router.get("/", requireAuth, async (req, res) => {
       if (!clockMap.has(e.job_id) || !e.clock_out_at) clockMap.set(e.job_id, e);
     }
 
-    // Fetch job_technicians for commission display
+    // Fetch job_technicians + per-employee pay matrix for commission
+    // display. The four pay-matrix columns drive the per-tech
+    // commission calculation below; each tech can be on a different
+    // (residential|commercial) × (commission|hourly) combo.
     const techRows = await db.execute(sql`
       SELECT jt.job_id, jt.user_id, jt.is_primary, jt.pay_override, jt.final_pay,
-             u.first_name, u.last_name
+             u.first_name, u.last_name,
+             u.residential_pay_type, u.residential_pay_rate,
+             u.commercial_pay_type,  u.commercial_pay_rate
       FROM job_technicians jt
       JOIN users u ON u.id = jt.user_id
       WHERE jt.job_id = ANY(ARRAY[${sql.raw(idList)}]::int[])
@@ -333,7 +338,18 @@ router.get("/", requireAuth, async (req, res) => {
       } catch { /* keep defaults */ }
     }
 
-    const techByJob = new Map<number, Array<{ user_id: number; name: string; is_primary: boolean; pay_override: number | null; final_pay: number | null }>>();
+    type TechRow = {
+      user_id: number;
+      name: string;
+      is_primary: boolean;
+      pay_override: number | null;
+      final_pay: number | null;
+      residential_pay_type: "commission" | "hourly";
+      residential_pay_rate: number;
+      commercial_pay_type: "commission" | "hourly";
+      commercial_pay_rate: number;
+    };
+    const techByJob = new Map<number, TechRow[]>();
     for (const r of techRows.rows as any[]) {
       if (!techByJob.has(r.job_id)) techByJob.set(r.job_id, []);
       techByJob.get(r.job_id)!.push({
@@ -342,6 +358,10 @@ router.get("/", requireAuth, async (req, res) => {
         is_primary: !!r.is_primary,
         pay_override: r.pay_override != null ? parseFloat(String(r.pay_override)) : null,
         final_pay: r.final_pay != null ? parseFloat(String(r.final_pay)) : null,
+        residential_pay_type: (r.residential_pay_type === "hourly" ? "hourly" : "commission") as "commission" | "hourly",
+        residential_pay_rate: r.residential_pay_rate != null ? parseFloat(String(r.residential_pay_rate)) : 0.35,
+        commercial_pay_type:  (r.commercial_pay_type  === "commission" ? "commission" : "hourly")  as "commission" | "hourly",
+        commercial_pay_rate:  r.commercial_pay_rate  != null ? parseFloat(String(r.commercial_pay_rate))  : 20,
       });
     }
 
@@ -434,33 +454,66 @@ router.get("/", requireAuth, async (req, res) => {
         ? fmtAddr(j.property_address, j.property_city, j.property_state, j.property_zip)
         : fmtAddr(j.address, j.city, j.state, j.zip);
       const jobTotal = j.billed_amount ? parseFloat(j.billed_amount) : (j.base_fee ? parseFloat(j.base_fee) : 0);
-      // [AI.7.4] Commission engine routes on isCommercial. Residential
-      // = jobTotal × resPct (pool, default 35%). Commercial = hourly
-      // rate × hours (default $20/hr × allowed_hours). The "estimated"
-      // hours displayed alongside the calc must come from allowed_hours
-      // — the source of truth the edit modal writes — NOT the original
-      // estimated_hours stamp, which goes stale on every edit
-      // (repro: edit allowed 6 → 7 → save → reopen, est still showed 7
-      // because dispatch read estimated_hours, which never changed).
+      // [pay-matrix 2026-04-29] Per-tech commission. The 4-cell matrix
+      // (residential|commercial × commission|hourly) on each user row
+      // means every tech can be paid differently on the same job. The
+      // calc routes on the JOB's commercial flag, then picks the
+      // tech's corresponding type + rate.
+      //
+      //   commission rate is fraction (0.00–1.00) → pay = revenue_share × rate
+      //   hourly     rate is dollars/hour         → pay = est_hours_per_tech × rate
+      //
+      // Revenue share for commission: jobTotal ÷ numTechs. Each tech's
+      // share of the job's billable revenue, then their personal % of
+      // their share. So a 40%-rate tech and a 30%-rate tech on a
+      // 2-tech $320 job earn $64 and $48 respectively (each gets
+      // their_pct × $160), not the 35% pool split.
       const allowedHours = j.allowed_hours ? parseFloat(j.allowed_hours) : 0;
       const estHoursSource = allowedHours > 0
         ? allowedHours
         : (j.estimated_hours ? parseFloat(j.estimated_hours) : 0);
       const numTechs = jobTechs.length || 1;
-      const totalCommission = isCommercial
-        ? Math.round(commercialHourlyRate * estHoursSource * 100) / 100
-        : Math.round(jobTotal * resPct * 100) / 100;
       const estHoursPerTech = numTechs > 0 ? Math.round((estHoursSource / numTechs) * 10) / 10 : estHoursSource;
-      const calcPerTech = Math.round((totalCommission / numTechs) * 100) / 100;
-      const technicians = jobTechs.map(t => ({
-        user_id: t.user_id,
-        name: t.name,
-        is_primary: t.is_primary,
-        est_hours: estHoursPerTech,
-        calc_pay: calcPerTech,
-        final_pay: t.final_pay != null ? t.final_pay : (t.pay_override != null ? t.pay_override : calcPerTech),
-        pay_override: t.pay_override,
-      }));
+      const revenueSharePerTech = numTechs > 0 ? jobTotal / numTechs : jobTotal;
+
+      const technicians = jobTechs.map(t => {
+        const payType = isCommercial ? t.commercial_pay_type : t.residential_pay_type;
+        const payRate = isCommercial ? t.commercial_pay_rate : t.residential_pay_rate;
+        const calcPay = payType === "hourly"
+          ? Math.round(estHoursPerTech * payRate * 100) / 100
+          : Math.round(revenueSharePerTech * payRate * 100) / 100;
+        return {
+          user_id: t.user_id,
+          name: t.name,
+          is_primary: t.is_primary,
+          est_hours: estHoursPerTech,
+          calc_pay: calcPay,
+          final_pay: t.final_pay != null ? t.final_pay : (t.pay_override != null ? t.pay_override : calcPay),
+          pay_override: t.pay_override,
+          // Surface the matrix cell that drove this tech's calc so
+          // the JobPanel can render "Hourly $20/hr × 6h" vs
+          // "Commission 35% of $160 share" without re-deriving.
+          pay_type: payType,
+          pay_rate: payRate,
+        };
+      });
+      // Backwards-compat: company_res_pct / commercial_hourly_rate /
+      // commission_basis are kept for surfaces that still consume
+      // them. They reflect the FIRST tech on the job (primary) so the
+      // legacy single-tech display remains correct in single-tech
+      // jobs. Multi-tech surfaces should read job.technicians[].pay_*
+      // instead.
+      const primaryTech = jobTechs[0];
+      const legacyBasis = primaryTech
+        ? (isCommercial
+            ? (primaryTech.commercial_pay_type === "hourly" ? "commercial_hourly" : "commercial_commission")
+            : (primaryTech.residential_pay_type === "commission" ? "residential_pool" : "residential_hourly"))
+        : (isCommercial ? "commercial_hourly" : "residential_pool");
+      // calcPerTech for legacy callers — sum of per-tech calcs
+      // averaged. Modern callers should sum technicians[].calc_pay.
+      const calcPerTech = technicians.length
+        ? Math.round((technicians.reduce((s, t) => s + t.calc_pay, 0) / technicians.length) * 100) / 100
+        : 0;
 
       return {
         id: j.id,
@@ -532,11 +585,11 @@ router.get("/", requireAuth, async (req, res) => {
         est_hours_per_tech: estHoursPerTech,
         est_pay_per_tech: calcPerTech,
         company_res_pct: resPct,
-        // [AI.7.4] Commercial-flag + rate so the Commission panel can
-        // render "Hourly rate: $20/hr × X hrs" instead of the residential
-        // "Pool rate: 35% of job total" — those labels are not
-        // interchangeable.
-        commission_basis: isCommercial ? "commercial_hourly" : "residential_pool",
+        // [pay-matrix 2026-04-29] commission_basis now reflects the
+        // primary tech's matrix cell, not a hardcoded company-wide
+        // value. Surfaces that need richer per-tech data should read
+        // technicians[].pay_type / pay_rate.
+        commission_basis: legacyBasis,
         commercial_hourly_rate: isCommercial ? commercialHourlyRate : null,
         // [job-card-redesign] Add-ons drive the "+N" chip pill and the
         // hover popover's full add-on list. Empty array (not null) when

--- a/artifacts/api-server/src/routes/users.ts
+++ b/artifacts/api-server/src/routes/users.ts
@@ -249,7 +249,28 @@ router.get("/:id", requireAuth, async (req, res) => {
 router.put("/:id", requireAuth, requireRole("owner", "admin", "office"), async (req, res) => {
   try {
     const userId = parseInt(req.params.id);
-    const { first_name, last_name, role, pay_rate, pay_type, is_active, hire_date, phone, skills } = req.body;
+    const {
+      first_name, last_name, role, pay_rate, pay_type, is_active,
+      hire_date, phone, skills,
+      // [pay-matrix 2026-04-29] 4-cell pay matrix.
+      residential_pay_type, residential_pay_rate,
+      commercial_pay_type,  commercial_pay_rate,
+    } = req.body;
+
+    // Validate matrix inputs if provided.
+    const validateMatrixPair = (type: any, rate: any, label: string) => {
+      if (type !== undefined && type !== "commission" && type !== "hourly") {
+        return `${label}_pay_type must be 'commission' or 'hourly'`;
+      }
+      if (rate !== undefined) {
+        const n = Number(rate);
+        if (!Number.isFinite(n) || n < 0) return `${label}_pay_rate must be a non-negative number`;
+      }
+      return null;
+    };
+    const e1 = validateMatrixPair(residential_pay_type, residential_pay_rate, "residential");
+    const e2 = validateMatrixPair(commercial_pay_type,  commercial_pay_rate,  "commercial");
+    if (e1 || e2) return res.status(400).json({ error: e1 || e2 });
 
     const updated = await db
       .update(usersTable)
@@ -263,6 +284,10 @@ router.put("/:id", requireAuth, requireRole("owner", "admin", "office"), async (
         ...(hire_date !== undefined && { hire_date }),
         ...(phone !== undefined && { phone }),
         ...(skills !== undefined && { skills }),
+        ...(residential_pay_type !== undefined && { residential_pay_type }),
+        ...(residential_pay_rate !== undefined && { residential_pay_rate: String(residential_pay_rate) }),
+        ...(commercial_pay_type  !== undefined && { commercial_pay_type }),
+        ...(commercial_pay_rate  !== undefined && { commercial_pay_rate:  String(commercial_pay_rate) }),
       })
       .where(and(
         eq(usersTable.id, userId),

--- a/artifacts/qleno/src/pages/employee-profile.tsx
+++ b/artifacts/qleno/src/pages/employee-profile.tsx
@@ -60,7 +60,7 @@ const DAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
 const DAY_IDX: Record<string, number> = { Mon:0,Tue:1,Wed:2,Thu:3,Fri:4,Sat:5,Sun:6 };
 const TABS = [
   'Information','Tags & Skills','Attendance','Availability',
-  'User Account','Contacts','Scorecards','Additional Pay',
+  'User Account','Contacts','Scorecards','Pay Configuration','Additional Pay',
   'Payroll History',
   'Contact Tickets','Jobs','Notes','Incentives',
   'HR Attendance','Leave Balance','Discipline','Quality','Onboarding',
@@ -1240,6 +1240,9 @@ export default function EmployeeProfilePage() {
             </div>
           )}
 
+          {/* ── PAY CONFIGURATION TAB (4-cell matrix) ── */}
+          {activeTab === 'Pay Configuration' && <PayMatrixPanel userId={userId} />}
+
           {/* ── ADDITIONAL PAY TAB ── */}
           {activeTab === 'Additional Pay' && (() => {
             const pays: any[] = additionalPayData?.data || [];
@@ -2029,5 +2032,170 @@ export default function EmployeeProfilePage() {
         )}
       </div>
     </DashboardLayout>
+  );
+}
+
+// [pay-matrix 2026-04-29] Per-employee 4-cell pay matrix panel.
+// Reads u.{residential,commercial}_pay_{type,rate} via GET /users/:id;
+// saves via PATCH /users/:id. Type toggle changes the input label
+// and validation: hourly is $/hr ($10–$100 reasonable), commission
+// is % (0–100 in UI, persisted as 0–1 fraction). Tenant defaults
+// inherit on new employee creation server-side.
+function PayMatrixPanel({ userId }: { userId: string }) {
+  const [resType, setResType] = useState<"commission" | "hourly">("commission");
+  const [resRate, setResRate] = useState<string>("35");
+  const [comType, setComType] = useState<"commission" | "hourly">("hourly");
+  const [comRate, setComRate] = useState<string>("20");
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [toast, setToast] = useState<string | null>(null);
+  // Display-format helpers: residential commission is stored as a
+  // fraction 0–1 but shown in the UI as 0–100. Hourly is stored and
+  // shown in dollars. Same dual-meaning for commercial.
+  const fmtRate = (type: "commission" | "hourly", rate: number) =>
+    type === "commission" ? String(Math.round(rate * 100)) : rate.toFixed(2);
+  const parseRate = (type: "commission" | "hourly", input: string): number =>
+    type === "commission" ? parseFloat(input) / 100 : parseFloat(input);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const r = await apiFetch(`/users/${userId}`);
+        if (cancelled) return;
+        const d = r?.data ?? r;
+        const rt = (d?.residential_pay_type === "hourly" ? "hourly" : "commission") as "commission" | "hourly";
+        const ct = (d?.commercial_pay_type === "commission" ? "commission" : "hourly") as "commission" | "hourly";
+        setResType(rt);
+        setComType(ct);
+        if (d?.residential_pay_rate != null) setResRate(fmtRate(rt, parseFloat(d.residential_pay_rate)));
+        if (d?.commercial_pay_rate != null)  setComRate(fmtRate(ct, parseFloat(d.commercial_pay_rate)));
+      } catch (err: any) {
+        setError(err?.message ?? "Could not load pay configuration.");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [userId]);
+
+  function validate(type: "commission" | "hourly", input: string): string | null {
+    const n = parseFloat(input);
+    if (Number.isNaN(n) || n < 0) return "Must be a positive number.";
+    if (type === "hourly" && (n < 10 || n > 100)) return "Hourly rates should be $10–$100/hr.";
+    if (type === "commission" && (n < 0 || n > 100)) return "Commission must be 0–100%.";
+    return null;
+  }
+
+  async function save() {
+    const resErr = validate(resType, resRate);
+    const comErr = validate(comType, comRate);
+    if (resErr || comErr) {
+      setError(resErr || comErr);
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      await apiFetch(`/users/${userId}`, {
+        method: "PUT",
+        body: JSON.stringify({
+          residential_pay_type: resType,
+          residential_pay_rate: parseRate(resType, resRate),
+          commercial_pay_type: comType,
+          commercial_pay_rate: parseRate(comType, comRate),
+        }),
+      });
+      setToast("Pay configuration saved");
+      setTimeout(() => setToast(null), 2400);
+    } catch (err: any) {
+      setError(err?.message ?? "Could not save.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (loading) return <div style={{ padding: 24, color: "#9E9B94", fontSize: 13 }}>Loading…</div>;
+
+  const sectionStyle: React.CSSProperties = {
+    background: "#FFFFFF", border: "1px solid #E5E2DC", borderRadius: 12,
+    padding: "20px 22px", marginBottom: 16,
+  };
+  const labelStyle: React.CSSProperties = {
+    fontSize: 12, fontWeight: 700, color: "#6B6860",
+    textTransform: "uppercase", letterSpacing: "0.05em", marginBottom: 6, display: "block",
+  };
+  const renderSection = (
+    title: string,
+    type: "commission" | "hourly",
+    setType: (t: "commission" | "hourly") => void,
+    rate: string,
+    setRate: (s: string) => void,
+  ) => (
+    <div style={sectionStyle}>
+      <h2 style={{ fontSize: 15, fontWeight: 800, color: "#1A1917", marginBottom: 12 }}>{title}</h2>
+      <label style={labelStyle}>Type</label>
+      <div style={{ display: "flex", gap: 8, marginBottom: 14 }}>
+        {(["hourly", "commission"] as const).map(opt => (
+          <button key={opt} type="button" onClick={() => {
+            // When switching type, normalize the rate field to the
+            // new format's typical default so the input doesn't stay
+            // at e.g. "0.35" when switching to hourly mode.
+            if (opt !== type) {
+              setRate(opt === "hourly" ? "20" : "35");
+            }
+            setType(opt);
+          }}
+          style={{
+            flex: 1, padding: "9px 12px", borderRadius: 8, cursor: "pointer", textAlign: "center",
+            border: `1.5px solid ${type === opt ? "var(--brand, #00C9A0)" : "#E5E2DC"}`,
+            background: type === opt ? "rgba(0,201,160,0.10)" : "#FFFFFF",
+            color: type === opt ? "var(--brand, #00C9A0)" : "#1A1917",
+            fontSize: 13, fontWeight: 700, fontFamily: "'Plus Jakarta Sans', sans-serif",
+          }}>
+            {opt === "hourly" ? "Hourly" : "Commission %"}
+          </button>
+        ))}
+      </div>
+      <label style={labelStyle}>{type === "hourly" ? "Rate ($/hour)" : "Rate (% of revenue share)"}</label>
+      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        {type === "hourly" && <span style={{ fontSize: 14, fontWeight: 600, color: "#1A1917" }}>$</span>}
+        <input type="number" step={type === "hourly" ? 0.25 : 1} min={0} max={type === "commission" ? 100 : undefined}
+          value={rate} onChange={e => setRate(e.target.value)}
+          style={{ padding: "8px 10px", border: "1px solid #E5E2DC", borderRadius: 6, fontSize: 14, fontFamily: "'Plus Jakarta Sans', sans-serif", color: "#1A1917", width: 120 }} />
+        <span style={{ fontSize: 13, color: "#6B7280" }}>{type === "hourly" ? "/hr" : "%"}</span>
+      </div>
+      <div style={{ marginTop: 8, fontSize: 11, color: "#9E9B94" }}>
+        {type === "hourly"
+          ? "Tech earns this rate × estimated hours per visit."
+          : "Tech earns this percentage of their share of the job's billable revenue (jobTotal ÷ techs on job)."}
+      </div>
+    </div>
+  );
+
+  return (
+    <div style={{ padding: "20px 22px 60px", maxWidth: 720 }}>
+      <h1 style={{ fontSize: 18, fontWeight: 800, color: "#1A1917", marginBottom: 4 }}>Pay configuration</h1>
+      <p style={{ fontSize: 12, color: "#6B6860", marginBottom: 20, lineHeight: 1.5 }}>
+        How this employee gets paid on residential vs commercial jobs. Each cell is independent — a tech can be on commission for residential and hourly for commercial. Rates apply per-tech to the job's commercial flag (driven by the client's <code>client_type</code>).
+      </p>
+      {renderSection("Residential pay", resType, setResType, resRate, setResRate)}
+      {renderSection("Commercial pay", comType, setComType, comRate, setComRate)}
+      {error && (
+        <div style={{ background: "#FEF2F2", border: "1px solid #FCA5A5", color: "#991B1B", padding: "10px 14px", borderRadius: 8, fontSize: 12, marginBottom: 14 }}>
+          {error}
+        </div>
+      )}
+      <button onClick={save} disabled={saving}
+        style={{ padding: "10px 22px", background: "var(--brand, #00C9A0)", color: "#FFFFFF", border: "none", borderRadius: 8, fontWeight: 700, fontSize: 13, fontFamily: "'Plus Jakarta Sans', sans-serif", cursor: saving ? "wait" : "pointer" }}>
+        {saving ? "Saving…" : "Save pay configuration"}
+      </button>
+      {toast && (
+        <div style={{ position: "fixed", bottom: 24, right: 24, background: "#1A1917", color: "#FFFFFF", padding: "12px 20px", borderRadius: 10, fontSize: 13, fontWeight: 600, zIndex: 2000, boxShadow: "0 8px 24px rgba(0,0,0,0.2)" }}>
+          {toast}
+        </div>
+      )}
+    </div>
   );
 }

--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -62,7 +62,7 @@ const STATUS: Record<string, { bg: string; border: string; text: string; dot: st
 
 // ─── TYPES ────────────────────────────────────────────────────────────────────
 interface ClockEntry { id: number; clock_in_at: string | null; clock_out_at: string | null; distance_from_job_ft: number | null; is_flagged: boolean; }
-interface JobTechCommission { user_id: number; name: string; is_primary: boolean; est_hours: number; calc_pay: number; final_pay: number; pay_override: number | null; }
+interface JobTechCommission { user_id: number; name: string; is_primary: boolean; est_hours: number; calc_pay: number; final_pay: number; pay_override: number | null; /* [pay-matrix 2026-04-29] surface the per-tech matrix cell so JobPanel can render "Hourly $20/hr × 6h" or "Commission 35%" without re-deriving */ pay_type?: "commission" | "hourly"; pay_rate?: number; }
 interface JobAddOn { name: string; quantity: number; unit_price: number; subtotal: number; }
 interface DispatchJob { id: number; client_id: number; client_name: string; client_phone?: string | null; client_zip?: string | null; client_notes?: string | null; client_payment_method?: string | null; /* [tile redesign] residential or commercial badge; commercial when account_id is set OR client_type === 'commercial' */ client_type?: "residential" | "commercial" | null; address: string | null; /* [inline-edit] raw fields for address editor mode detection */ job_address_street?: string | null; job_address_city?: string | null; job_address_state?: string | null; job_address_zip?: string | null; client_address?: string | null; client_city?: string | null; client_state?: string | null; client_address_zip?: string | null; assigned_user_id: number | null; assigned_user_name?: string; service_type: string; status: string; scheduled_date: string; scheduled_time: string | null; frequency: string; amount: number; duration_minutes: number; notes: string | null; office_notes?: string | null; before_photo_count: number; after_photo_count: number; clock_entry: ClockEntry | null; zone_id?: number | null; zone_color?: string | null; zone_name?: string | null; branch_id?: number | null; branch_name?: string | null; last_service_date?: string | null; account_id?: number | null; account_name?: string | null; billing_method?: string | null; hourly_rate?: number | null; estimated_hours?: number | null; actual_hours?: number | null; billed_hours?: number | null; billed_amount?: number | null; charge_failed_at?: string | null; charge_succeeded_at?: string | null; property_access_notes?: string | null; booking_location?: string | null; technicians?: JobTechCommission[]; est_hours_per_tech?: number | null; est_pay_per_tech?: number | null; company_res_pct?: number | null; /* [AI.7.4] Commission routing — 'commercial_hourly' or 'residential_pool' */ commission_basis?: "commercial_hourly" | "residential_pool" | null; commercial_hourly_rate?: number | null; /* [AF] completion lock state */ locked_at?: string | null; actual_end_time?: string | null; completed_by_user_id?: number | null; /* [job-card-redesign] Add-ons drive the +N pill on the chip and the full list in the popover. is_new_client = first-ever residential job (no prior completed). en_route_at scaffolds the "On My Way" status; column doesn't exist yet, so the field is always undefined until the SMS engine lands. */ add_ons?: JobAddOn[]; is_new_client?: boolean; en_route_at?: string | null; /* [phes-lifecycle 2026-04-29] Manual no-show flag set by the field app's "No Show" button. Drives the NO_SHOW visual state via getJobVisualStatus. Until the field-app button ships, both fields stay null. */ no_show_marked_by_tech?: string | null; no_show_marked_by_user_id?: number | null; }
 interface Employee { id: number; name: string; role: string; jobs: DispatchJob[]; zone?: { zone_id: number; zone_color: string; zone_name: string } | null; time_off?: 'pto' | 'sick' | 'absent' | null; commission_rate?: number | null; }
@@ -1458,7 +1458,16 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
                       ) : null}
                     </div>
                   </div>
-                  <div style={{ fontSize: 11, color: "#9E9B94" }}>Est. {t.est_hours.toFixed(1)} hrs · Calc: ${t.calc_pay.toFixed(2)}</div>
+                  <div style={{ fontSize: 11, color: "#9E9B94" }}>
+                    Est. {t.est_hours.toFixed(1)} hrs · Calc: ${t.calc_pay.toFixed(2)}
+                    {t.pay_type && t.pay_rate != null && (
+                      <span style={{ marginLeft: 6, color: "#C4C0BB" }}>
+                        ({t.pay_type === "hourly"
+                          ? `$${t.pay_rate.toFixed(2)}/hr`
+                          : `${(t.pay_rate * 100).toFixed(0)}%`})
+                      </span>
+                    )}
+                  </div>
                   {overrideOpen[t.user_id] && (
                     <div style={{ display: "flex", gap: 6, marginTop: 4, alignItems: "center" }}>
                       <span style={{ fontSize: 11, color: "#6B7280" }}>$</span>
@@ -1494,20 +1503,35 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
                     {assignedEmp?.name || job.assigned_user_name || "Unassigned"} · Est. {(job.est_hours_per_tech ?? job.estimated_hours ?? 0).toFixed(1)} hrs
                   </span>
                   <span style={{ fontSize: 12, fontWeight: 700, color: "#16A34A" }}>
-                    ${(job.est_pay_per_tech ?? ((job.billed_amount ?? job.amount ?? 0) * (job.company_res_pct ?? 0.35))).toFixed(2)} est.
+                    {/* [pay-matrix 2026-04-29] Display est_pay_per_tech
+                        as-is. The server now computes it per-tech via
+                        the 4-cell matrix; the no-techs-yet branch
+                        renders nothing meaningful since a missing
+                        primary tech means we don't yet know the rate
+                        cell to apply. */}
+                    {job.est_pay_per_tech != null ? `$${job.est_pay_per_tech.toFixed(2)} est.` : "—"}
                   </span>
                 </div>
               )}
-              {/* [AI.7.4] Commission basis label. Commercial jobs show
-                  hourly-rate math; residential keeps the pool-rate label.
-                  Routing comes from server's commission_basis flag —
-                  fallback to account_id signal for older payloads. */}
+              {/* [pay-matrix 2026-04-29] Per-tech matrix: each tech's
+                  pay_type / pay_rate already shows on their own row
+                  above (`Calc: $X (… rate)`), so this summary line
+                  describes the JOB routing — residential vs commercial
+                  based on client_type — and lets each tech's row
+                  carry the rate. When techs are mixed-type on the
+                  same job, the summary just says "mixed". */}
               <div style={{ marginTop: 4, fontSize: 11, color: "#9E9B94" }}>
-                {(job.commission_basis === "commercial_hourly" || (!job.commission_basis && job.account_id != null))
-                  ? `Hourly rate: $${(job.commercial_hourly_rate ?? 20).toFixed(0)}/hr × ${(job.est_hours_per_tech != null && (job.technicians?.length ?? 1) > 1
-                      ? (job.est_hours_per_tech * (job.technicians?.length ?? 1))
-                      : (job.est_hours_per_tech ?? 0)).toFixed(1)} hrs`
-                  : `Pool rate: ${((job.company_res_pct ?? 0.35) * 100).toFixed(0)}% of job total`}
+                {(() => {
+                  const techs = job.technicians ?? [];
+                  if (techs.length === 0) return null;
+                  const types = new Set(techs.map(t => t.pay_type).filter(Boolean));
+                  const isCommercial = job.client_type === "commercial" || job.account_id != null;
+                  const label = isCommercial ? "Commercial" : "Residential";
+                  if (types.size === 0) return `${label} job`;
+                  if (types.size > 1) return `${label} job · mixed pay types per tech`;
+                  const t = [...types][0];
+                  return `${label} job · ${t === "hourly" ? "hourly pay per tech" : "commission % per tech"}`;
+                })()}
               </div>
               <button onClick={() => !isLocked && setAddTechOpen(true)}
                 disabled={isLocked}

--- a/lib/db/src/schema/companies.ts
+++ b/lib/db/src/schema/companies.ts
@@ -40,6 +40,15 @@ export const companiesTable = pgTable("companies", {
   twilio_from_number: text("twilio_from_number"),
   default_payment_terms_residential: text("default_payment_terms_residential").default("due_on_receipt"),
   default_payment_terms_commercial: text("default_payment_terms_commercial").default("net_30"),
+  // [pay-matrix 2026-04-29] Tenant defaults inherited by every new
+  // employee's per-employee pay matrix. type is 'commission' or
+  // 'hourly'; rate is fraction (0.35) when commission, dollars/hour
+  // (20.00) when hourly. Phes defaults: residential commission 0.35,
+  // commercial hourly $20.
+  default_residential_pay_type: text("default_residential_pay_type").default("commission"),
+  default_residential_pay_rate: numeric("default_residential_pay_rate", { precision: 8, scale: 4 }).default("0.35"),
+  default_commercial_pay_type:  text("default_commercial_pay_type").default("hourly"),
+  default_commercial_pay_rate:  numeric("default_commercial_pay_rate",  { precision: 8, scale: 4 }).default("20.0000"),
   default_invoice_notes_residential: text("default_invoice_notes_residential"),
   default_invoice_notes_commercial: text("default_invoice_notes_commercial"),
   auto_send_invoices: boolean("auto_send_invoices").notNull().default(false),

--- a/lib/db/src/schema/users.ts
+++ b/lib/db/src/schema/users.ts
@@ -57,6 +57,17 @@ export const usersTable = pgTable("users", {
   notes: text("notes"),
   hr_status: hrStatusEnum("hr_status").default("active"),
   commission_rate_override: numeric("commission_rate_override", { precision: 6, scale: 2 }),
+  // [pay-matrix 2026-04-29] Per-employee 4-cell pay matrix. Replaces
+  // the company-wide single-rate model. Type can be 'commission' (rate
+  // is a fraction 0.00–1.00) or 'hourly' (rate is dollars/hour). The
+  // dispatch route routes residential vs commercial off
+  // clients.client_type and picks the corresponding pair from this
+  // matrix. New employees inherit the tenant defaults from
+  // companies.default_{residential,commercial}_pay_{type,rate}.
+  residential_pay_type: text("residential_pay_type").default("commission"),
+  residential_pay_rate: numeric("residential_pay_rate", { precision: 8, scale: 4 }).default("0.35"),
+  commercial_pay_type:  text("commercial_pay_type").default("hourly"),
+  commercial_pay_rate:  numeric("commercial_pay_rate",  { precision: 8, scale: 4 }).default("20.0000"),
   benefit_year_start: date("benefit_year_start"),
   leave_balance_hours: numeric("leave_balance_hours", { precision: 8, scale: 2 }).default("0"),
   leave_balance_activated: boolean("leave_balance_activated").default(false),


### PR DESCRIPTION
## What this is

Replaces the single-rate company-wide commission model with a per-employee 4-cell pay matrix:

|              | Residential                 | Commercial                  |
|--------------|-----------------------------|-----------------------------|
| **Type**     | `commission` or `hourly`    | `commission` or `hourly`    |
| **Rate**     | fraction (0–1) or $/hr      | fraction (0–1) or $/hr      |

Each tech can be on a different combo. A 40%-rate tech and a flat-$22/hr tech can work the same job and earn different things. Routing is on the **job's** commercial flag (`clients.client_type` or `jobs.account_id`); the **tech's** matrix supplies the type + rate.

## Phes defaults

| Layer | Residential | Commercial |
|---|---|---|
| Tenant default | commission 0.35 | hourly $20 |
| Per-employee (backfilled to tenant default) | commission 0.35 | hourly $20 |

Backfill is idempotent (runs every cold-start, COALESCEs NULLs only). Existing employees get the Phes defaults; you can override per-tech via the new "Pay Configuration" tab.

## Schema

```sql
-- users (per-employee matrix)
residential_pay_type  TEXT    DEFAULT 'commission'
residential_pay_rate  NUMERIC(8,4) DEFAULT 0.35
commercial_pay_type   TEXT    DEFAULT 'hourly'
commercial_pay_rate   NUMERIC(8,4) DEFAULT 20.0000

-- companies (tenant defaults inherited at user creation)
default_residential_pay_type  TEXT    DEFAULT 'commission'
default_residential_pay_rate  NUMERIC(8,4) DEFAULT 0.35
default_commercial_pay_type   TEXT    DEFAULT 'hourly'
default_commercial_pay_rate   NUMERIC(8,4) DEFAULT 20.0000
```

`ALTER ADD COLUMN IF NOT EXISTS` for all eight; `runPayMatrixBackfill()` runs every boot to fill NULLs.

## Commission calculation (routes/dispatch.ts)

```
for each tech on the job:
  payType  = isCommercial ? tech.commercial_pay_type : tech.residential_pay_type
  payRate  = isCommercial ? tech.commercial_pay_rate : tech.residential_pay_rate
  if payType == 'hourly':
    calc_pay = est_hours_per_tech × payRate
  else:
    calc_pay = revenue_share_per_tech × payRate    # share = jobTotal ÷ numTechs
```

`technicians[].pay_type` and `technicians[].pay_rate` are surfaced on the dispatch payload so JobPanel renders the rate next to each tech's calc without re-deriving.

## UI

**Employee profile → Pay Configuration tab** (new, between Scorecards and Additional Pay)
- Two sections: Residential and Commercial
- Type toggle: Hourly / Commission %
- Rate input — label changes per type ("$X /hr" vs "X %")
- Validation: hourly $10–$100/hr, commission 0–100%
- Saves via `PUT /api/users/:id` which now accepts the four matrix fields.

**JobPanel commission section**
- Each tech row shows the rate cell that drove their calc: `Calc: $120.00 ($20/hr)` or `Calc: $48.00 (30%)`
- Summary line says `Residential job · commission % per tech` / `Commercial job · hourly pay per tech` / `… mixed pay types per tech`

## Backpay audit

```bash
curl -H "Authorization: Bearer $TOKEN" \
  "https://app.qleno.com/api/admin/commission-backpay-audit?since=2026-01-01"
```

Returns:
```json
{
  "window": { "since": "2026-01-01", "scope": "commercial-completed-no-account" },
  "jobs_affected": 12,
  "paid_out_at_old_rate": 1342.50,
  "should_have_been_paid": 1488.00,
  "backpay_owed": 145.50
}
```

Scope: commercial jobs with `account_id IS NULL` and `actual_end_time IS NOT NULL` since the given date. Read-only; no payroll touched. Hand the number to payroll for a one-off correction (additional_pay entries).

## Production verification — Sal does this

I cannot reach `app.qleno.com` from this sandbox. After Railway picks up the deploy:

1. **Settings → Employees → Alma Salinas** — Pay Configuration tab shows Residential commission 35% / Commercial hourly $20.
2. **Open Jaira's commercial job** ($320, 6h, Alma) — JobPanel commission shows **$120** (= 6 × $20), not $112.
3. **Open a residential job assigned to Alma** — commission still shows 35% of total (unchanged behavior).
4. **Change Alma's commercial rate to $25/hr**, save, reload Jaira's job — should show **$150** (= 6 × $25).
5. **Set Alma's commercial type to Commission, rate 50%** for the day-trip case where she co-leads a commercial install — should show 50% × her revenue share.
6. **Run the audit endpoint**, paste the JSON back, decide whether to issue back-pay.
7. **Reset Alma's commercial back to hourly $20**.

If any of those fail, send the JSON / screenshot and I'll dig in further.

## Files

- `lib/db/src/schema/users.ts` — 4 matrix columns
- `lib/db/src/schema/companies.ts` — 4 default columns
- `artifacts/api-server/src/phes-data-migration.ts` — schema guards + `runPayMatrixBackfill()`
- `artifacts/api-server/src/routes/dispatch.ts` — per-tech commission calc, surfaces `pay_type` + `pay_rate` on `technicians[]`
- `artifacts/api-server/src/routes/users.ts` — `PUT /api/users/:id` accepts the four matrix fields
- `artifacts/api-server/src/routes/admin.ts` — `GET /api/admin/commission-backpay-audit`
- `artifacts/qleno/src/pages/employee-profile.tsx` — Pay Configuration tab + `<PayMatrixPanel>`
- `artifacts/qleno/src/pages/jobs.tsx` — JobPanel commission display per-tech

## Long-term

Once this lands, the model supports:
- All-residential operators on hourly + bonuses
- Premium senior techs on commission while trainees are on hourly
- Mixed teams where part-timers and full-timers co-exist with different pay structures
- Multi-state operators with different minimums per state (just configure per-tech)

## Acceptance from my side

- [x] Frontend builds clean
- [x] Net-zero new TS errors against baseline (698 = 698)
- [x] Migration is idempotent (`IF NOT EXISTS` + COALESCE-only updates)
- [x] Commission calc preserves single-tech residential behavior (jobTotal × 0.35 still applies when tech matrix carries the defaults)
- [ ] Sal verifies the 7 acceptance steps above on production after Railway deploys

**Not auto-merging** — this is a schema change with a backfill, please review before merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_016GqMSjAaG7gGDtiFSPKn5Q)_