### PR TITLE
chore: admin dedupe endpoints + always-log on dedupe migration

### DIFF
--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -793,9 +793,9 @@ async function runJobsDedupeAndConstraint(): Promise<void> {
     RETURNING id
   `);
   const removed = (deleted.rows ?? []).length;
-  if (removed > 0) {
-    console.log(`[jobs-dedupe] Removed ${removed} duplicate job row(s) (kept latest per client/date/time, NULL-time included).`);
-  }
+  // [iter 2 logging] Always log — distinguishes "ran, found nothing"
+  // from "didn't run at all" when staring at Railway logs.
+  console.log(`[jobs-dedupe] Migration ran. Removed ${removed} duplicate job row(s).`);
 
   // Step 2: replace the old index with the COALESCE-keyed version.
   // Drop-then-create is safe because the dedupe in step 1 just ran;

--- a/artifacts/api-server/src/routes/admin.ts
+++ b/artifacts/api-server/src/routes/admin.ts
@@ -398,6 +398,131 @@ router.post("/smoke-tests/run", ...isSuperAdmin, async (_req, res) => {
   }
 });
 
+/* ── JOBS DEDUPE — DIAGNOSTIC + FORCE-RUN ──────────────────────────
+ * GET  /api/admin/jobs-duplicates       → returns current duplicates
+ *                                          without modifying anything
+ *                                          (pre-flight check Sal can
+ *                                          hit before deciding to
+ *                                          dedupe)
+ * POST /api/admin/jobs-dedupe-run       → executes the same dedupe +
+ *                                          unique-index logic that
+ *                                          phes-data-migration runs
+ *                                          on cold-start, but
+ *                                          on-demand. Returns a JSON
+ *                                          report (rows removed, ids,
+ *                                          index status) so Sal can
+ *                                          verify the migration
+ *                                          actually did its job.
+ *
+ * Both endpoints only return rows that look like real duplicates:
+ * same (company_id, client_id, scheduled_date, scheduled_time)
+ * tuple — including NULL-time matches via COALESCE — and not
+ * cancelled. The dedupe matches the migration's deletion logic
+ * exactly so the report previews what's about to happen.
+ */
+router.get("/jobs-duplicates", ...isSuperAdmin, async (_req, res) => {
+  try {
+    const dupes = await db.execute(sql`
+      WITH partitioned AS (
+        SELECT id, company_id, client_id, scheduled_date,
+               scheduled_time, status, billed_amount,
+               assigned_user_id, created_at,
+               ROW_NUMBER() OVER (
+                 PARTITION BY company_id, client_id, scheduled_date,
+                              COALESCE(scheduled_time::text, '00:00:00')
+                 ORDER BY created_at DESC NULLS LAST, id DESC
+               ) AS rn,
+               COUNT(*) OVER (
+                 PARTITION BY company_id, client_id, scheduled_date,
+                              COALESCE(scheduled_time::text, '00:00:00')
+               ) AS slot_size
+        FROM jobs
+        WHERE status NOT IN ('cancelled')
+      )
+      SELECT id, company_id, client_id, scheduled_date,
+             scheduled_time, status, billed_amount,
+             assigned_user_id, created_at,
+             rn, slot_size
+      FROM partitioned
+      WHERE slot_size > 1
+      ORDER BY scheduled_date DESC, client_id, rn ASC
+      LIMIT 500
+    `);
+    const rows = dupes.rows as any[];
+    return res.json({
+      total_rows_in_collisions: rows.length,
+      distinct_slots: new Set(rows.map(r => `${r.company_id}|${r.client_id}|${r.scheduled_date}|${r.scheduled_time ?? "null"}`)).size,
+      rows,
+    });
+  } catch (err: any) {
+    console.error("[admin] jobs-duplicates error:", err);
+    return res.status(500).json({ error: "Internal Server Error", message: err.message });
+  }
+});
+
+router.post("/jobs-dedupe-run", ...isSuperAdmin, async (_req, res) => {
+  try {
+    // Snapshot which rows would be deleted, then delete them and
+    // (re)create the partial unique index. Returns the deleted ids
+    // so Sal can verify after the call.
+    const preview = await db.execute(sql`
+      WITH dupes AS (
+        SELECT id, scheduled_date, scheduled_time, client_id,
+               ROW_NUMBER() OVER (
+                 PARTITION BY company_id, client_id, scheduled_date,
+                              COALESCE(scheduled_time::text, '00:00:00')
+                 ORDER BY created_at DESC NULLS LAST, id DESC
+               ) AS rn
+        FROM jobs
+        WHERE status NOT IN ('cancelled')
+      )
+      SELECT id, scheduled_date, scheduled_time, client_id
+      FROM dupes
+      WHERE rn > 1
+      ORDER BY scheduled_date DESC, client_id, id
+    `);
+    const previewRows = preview.rows as any[];
+
+    const deleted = await db.execute(sql`
+      WITH dupes AS (
+        SELECT id,
+               ROW_NUMBER() OVER (
+                 PARTITION BY company_id, client_id, scheduled_date,
+                              COALESCE(scheduled_time::text, '00:00:00')
+                 ORDER BY created_at DESC NULLS LAST, id DESC
+               ) AS rn
+        FROM jobs
+        WHERE status NOT IN ('cancelled')
+      )
+      DELETE FROM jobs
+      WHERE id IN (SELECT id FROM dupes WHERE rn > 1)
+      RETURNING id
+    `);
+
+    await db.execute(sql`DROP INDEX IF EXISTS uq_jobs_no_double_book`);
+    await db.execute(sql`
+      CREATE UNIQUE INDEX IF NOT EXISTS uq_jobs_no_double_book
+        ON jobs (
+          company_id,
+          client_id,
+          scheduled_date,
+          (COALESCE(scheduled_time::text, '00:00:00'))
+        )
+        WHERE status NOT IN ('cancelled')
+    `);
+
+    return res.json({
+      deleted_count: (deleted.rows ?? []).length,
+      deleted_ids: (deleted.rows as any[]).map(r => r.id),
+      preview_rows: previewRows,
+      index: "uq_jobs_no_double_book recreated",
+    });
+  } catch (err: any) {
+    console.error("[admin] jobs-dedupe-run error:", err);
+    return res.status(500).json({ error: "Internal Server Error", message: err.message });
+  }
+});
+
 /* ── AUDIT LOG HEALTH CHECK ──────────────────────────────────────── */
 router.post("/audit-test", ...isSuperAdmin, async (req, res) => {
   try {


### PR DESCRIPTION
Salvaged from #13 before that PR is closed. The commission portion of #13 is superseded by #14's pay matrix; these dedupe diagnostics are still useful for operational cleanup of duplicate jobs (the Jaira-on-Monday-April-27 case).

## Endpoints

| Method | Path | Purpose |
|---|---|---|
| GET | `/api/admin/jobs-duplicates` | Pre-flight — returns current `(client, date, time)` collisions without modifying anything |
| POST | `/api/admin/jobs-dedupe-run` | Force the dedupe + recreate `uq_jobs_no_double_book`, returns deleted ids in JSON |

Both super-admin gated. Mirror the same dedupe partition the boot-time migration uses (`COALESCE(scheduled_time::text, '00:00:00')`) so NULL-time duplicates collide and get cleaned.

## Migration log change

`phes-data-migration.ts` `runJobsDedupeAndConstraint()` now always logs the result, even when 0 rows were removed:

```
[jobs-dedupe] Migration ran. Removed 0 duplicate job row(s).
```

So Railway logs distinguish "ran, found nothing" from "didn't run at all" — the question Sal couldn't answer when the Jaira duplicate persisted across deploys.

## Files

- `artifacts/api-server/src/routes/admin.ts` — two new routes
- `artifacts/api-server/src/phes-data-migration.ts` — always-log line

## Test plan (after deploy)

```bash
# Show current duplicates
curl -H "Authorization: Bearer $TOKEN" \
  https://app.qleno.com/api/admin/jobs-duplicates

# Force-run dedupe + index recreation, get JSON report
curl -X POST -H "Authorization: Bearer $TOKEN" \
  https://app.qleno.com/api/admin/jobs-dedupe-run
```

## Refs

- #13 (closing without merge — commission portion superseded by #14)
- #14 (pay matrix — the canonical fix for the commercial commission bug #13 was trying to band-aid)

---
_Generated by [Claude Code](https://claude.ai/code/session_016GqMSjAaG7gGDtiFSPKn5Q)_