### PR TITLE
fix: column name corrections in clients full-profile and smoke-test queries

### DIFF
--- a/artifacts/api-server/src/lib/smoke-test.ts
+++ b/artifacts/api-server/src/lib/smoke-test.ts
@@ -163,8 +163,12 @@ export async function runSmokeTests(manual = false): Promise<SmokeTestResult> {
     {
       name: "Recurring schedules exist",
       test: async () => {
+        // [hotfix 2026-04-29] Column is `is_active boolean`, not
+        // `status text`. Pre-existing wrong column reference; smoke
+        // test failed silently against an admin-only endpoint until
+        // the audit during the clients full-profile hang surfaced it.
         const r = await pool.query(
-          `SELECT count(*) FROM recurring_schedules WHERE company_id = $1 AND status = 'active'`,
+          `SELECT count(*) FROM recurring_schedules WHERE company_id = $1 AND is_active = true`,
           [PHES_ID]
         );
         const cnt = parseInt(r.rows[0].count);

--- a/artifacts/api-server/src/routes/clients.ts
+++ b/artifacts/api-server/src/routes/clients.ts
@@ -296,11 +296,15 @@ router.get("/:id/full-profile", requireAuth, async (req, res) => {
       last_cleaning_ms >= sixty_days_ago_ms || upcoming_jobs.length > 0 ? "active" : "inactive";
 
     // RECURRING if the client has any active recurring_schedules row.
+    // [hotfix 2026-04-29] Column is `is_active`, not `active`. The bad
+    // name caused Postgres 42703 missing-column on every full-profile
+    // load, which the frontend surfaced as an indefinite "Loading client
+    // profile…" spinner.
     const recurringRows = await db.execute(sql`
       SELECT 1 FROM recurring_schedules
        WHERE customer_id = ${clientId}
          AND company_id = ${companyId}
-         AND COALESCE(active, true) = true
+         AND COALESCE(is_active, true) = true
        LIMIT 1
     `);
     const client_recurrence: "recurring" | "one_time" = recurringRows.rows.length > 0 ? "recurring" : "one_time";


### PR DESCRIPTION
Two queries referenced columns that don't exist on `recurring_schedules`. Postgres returned `42703 missing-column` on every `GET /api/clients/:id/full-profile`, which the frontend surfaced as an indefinite "Loading client profile…" spinner — Sal couldn't open any client profile after PR #16 deployed.

## The two corrections

### `routes/clients.ts:303` — the production hang

```diff
-  AND COALESCE(active, true) = true
+  AND COALESCE(is_active, true) = true
```

Schema column is `is_active boolean DEFAULT true` (`lib/db/src/schema/recurring_schedules.ts:32`). The wrong name shipped with PR #16's `client_recurrence` derivation. Confirmed via Railway logs: `42703 errorMissingColumn`, hint `"Perhaps you meant to reference the column recurring_schedules.is_active"`.

### `lib/smoke-test.ts:167` — pre-existing, surfaced during the audit

```diff
-  WHERE company_id = $1 AND status = 'active'
+  WHERE company_id = $1 AND is_active = true
```

Wrong on two counts (`status` doesn't exist; `is_active` is boolean, not a text status). Pre-existing, not from PR #16 — but same column-family bug, found during the audit triggered by the production hang. Affects only the admin-only `POST /api/admin/smoke-tests/run` path; not user-facing.

## Audit findings (no other bugs)

Full audit done before this PR:

- **All 58 references** to `recurring_schedules` checked against the schema. The two above are the only column-name mismatches; every other reference uses `is_active` or doesn't touch an active column.
- `acquisition_sources`: schema, migration (`CREATE TABLE IF NOT EXISTS` + `INSERT … ON CONFLICT DO NOTHING`), and routes all match. No ordering dependency.
- Pay matrix (`users.{residential,commercial}_pay_*`, `companies.default_*`): all `ALTER ADD COLUMN IF NOT EXISTS`, backfill only `COALESCE`s NULLs, ordering correct.
- New `dispatch.ts` SELECTs (`client_company_name`, `client_first_name`, `client_last_name`): all reference columns that exist on `clients`.
- Tech-consistency SQL in `clients.ts`: clean.
- `recurring.ts` POST sync-generation: clean, has its own try/catch so even if it threw it wouldn't block schedule creation.
- Frontend `{job.display_name ?? job.client_name}` fallback: pure JS, never throws.

## Files

- `artifacts/api-server/src/routes/clients.ts` — one-word fix
- `artifacts/api-server/src/lib/smoke-test.ts` — one-line fix

No schema changes, no migration. Pure column-name correction.

## After merge

You'll re-verify with the 17-step checklist on `app.qleno.com/customers/21`. I'll watch this PR for review events.

**Not auto-merging** — your call on timing.

---
_Generated by [Claude Code](https://claude.ai/code/session_016GqMSjAaG7gGDtiFSPKn5Q)_