### PR TITLE
fix: Places loader runtime-key fallback in EditProfileDrawer + HomesTab

### DIFF
--- a/artifacts/qleno/src/pages/customer-profile.tsx
+++ b/artifacts/qleno/src/pages/customer-profile.tsx
@@ -495,7 +495,16 @@ function EditProfileDrawer({ client, onClose, onSave, onToast }: { client: any; 
   const addressInputRef = useRef<HTMLInputElement | null>(null);
   const [mapsReady, setMapsReady] = useState(false);
   useEffect(() => {
-    const key = (import.meta as any).env?.VITE_GOOGLE_MAPS_API_KEY ?? "";
+    // [places-key-fallback 2026-04-29] Try the runtime config endpoint
+    // first (server reads process.env.GOOGLE_MAPS_API_KEY from
+    // Railway's runtime env), fall back to the build-time
+    // VITE_GOOGLE_MAPS_API_KEY only if the server isn't reachable.
+    // Without this fallback the Places loader silently bails when
+    // the frontend build was made without the env var present —
+    // which is what was happening on production after PR #16
+    // deployed (build-time injection was empty, runtime env had
+    // the key, but only InlineAddressEdit on the dispatch page was
+    // wired to the runtime endpoint).
     if ((window as any).google?.maps?.places) { setMapsReady(true); return; }
     const scriptId = "gmap-places-script";
     if (document.getElementById(scriptId)) {
@@ -503,13 +512,39 @@ function EditProfileDrawer({ client, onClose, onSave, onToast }: { client: any; 
       existing.addEventListener("load", () => setMapsReady(true));
       return;
     }
-    if (!key) return;
-    const s = document.createElement("script");
-    s.id = scriptId;
-    s.src = `https://maps.googleapis.com/maps/api/js?key=${key}&libraries=places`;
-    s.async = true; s.defer = true;
-    s.onload = () => setMapsReady(true);
-    document.head.appendChild(s);
+    let cancelled = false;
+    (async () => {
+      let key = "";
+      try {
+        const r = await fetch(`${API}/api/config/google-maps-key`, {
+          headers: { ...getAuthHeaders() },
+        });
+        if (r.ok) {
+          const body = await r.json().catch(() => ({}));
+          key = String(body?.key ?? "");
+        }
+      } catch { /* fall through to build-time */ }
+      if (!key) {
+        key = (import.meta as any).env?.VITE_GOOGLE_MAPS_API_KEY ?? "";
+      }
+      if (cancelled) return;
+      if (!key) return;
+      // Re-check after the await — another instance may have injected
+      // the script while we were fetching the key.
+      if (document.getElementById(scriptId)) {
+        const existing = document.getElementById(scriptId) as HTMLScriptElement;
+        existing.addEventListener("load", () => setMapsReady(true));
+        if ((window as any).google?.maps?.places) setMapsReady(true);
+        return;
+      }
+      const s = document.createElement("script");
+      s.id = scriptId;
+      s.src = `https://maps.googleapis.com/maps/api/js?key=${key}&libraries=places`;
+      s.async = true; s.defer = true;
+      s.onload = () => setMapsReady(true);
+      document.head.appendChild(s);
+    })();
+    return () => { cancelled = true; };
   }, []);
   useEffect(() => {
     if (!mapsReady || !addressInputRef.current) return;
@@ -978,7 +1013,16 @@ function HomesTab({ clientId, homes, refetch, zoneColor, zoneName }: { clientId:
   const addressInputRef = useRef<HTMLInputElement | null>(null);
   const [mapsReady, setMapsReady] = useState(false);
   useEffect(() => {
-    const key = (import.meta as any).env?.VITE_GOOGLE_MAPS_API_KEY ?? "";
+    // [places-key-fallback 2026-04-29] Try the runtime config endpoint
+    // first (server reads process.env.GOOGLE_MAPS_API_KEY from
+    // Railway's runtime env), fall back to the build-time
+    // VITE_GOOGLE_MAPS_API_KEY only if the server isn't reachable.
+    // Without this fallback the Places loader silently bails when
+    // the frontend build was made without the env var present —
+    // which is what was happening on production after PR #16
+    // deployed (build-time injection was empty, runtime env had
+    // the key, but only InlineAddressEdit on the dispatch page was
+    // wired to the runtime endpoint).
     if ((window as any).google?.maps?.places) { setMapsReady(true); return; }
     const scriptId = "gmap-places-script";
     if (document.getElementById(scriptId)) {
@@ -986,13 +1030,39 @@ function HomesTab({ clientId, homes, refetch, zoneColor, zoneName }: { clientId:
       existing.addEventListener("load", () => setMapsReady(true));
       return;
     }
-    if (!key) return;
-    const s = document.createElement("script");
-    s.id = scriptId;
-    s.src = `https://maps.googleapis.com/maps/api/js?key=${key}&libraries=places`;
-    s.async = true; s.defer = true;
-    s.onload = () => setMapsReady(true);
-    document.head.appendChild(s);
+    let cancelled = false;
+    (async () => {
+      let key = "";
+      try {
+        const r = await fetch(`${API}/api/config/google-maps-key`, {
+          headers: { ...getAuthHeaders() },
+        });
+        if (r.ok) {
+          const body = await r.json().catch(() => ({}));
+          key = String(body?.key ?? "");
+        }
+      } catch { /* fall through to build-time */ }
+      if (!key) {
+        key = (import.meta as any).env?.VITE_GOOGLE_MAPS_API_KEY ?? "";
+      }
+      if (cancelled) return;
+      if (!key) return;
+      // Re-check after the await — another instance may have injected
+      // the script while we were fetching the key.
+      if (document.getElementById(scriptId)) {
+        const existing = document.getElementById(scriptId) as HTMLScriptElement;
+        existing.addEventListener("load", () => setMapsReady(true));
+        if ((window as any).google?.maps?.places) setMapsReady(true);
+        return;
+      }
+      const s = document.createElement("script");
+      s.id = scriptId;
+      s.src = `https://maps.googleapis.com/maps/api/js?key=${key}&libraries=places`;
+      s.async = true; s.defer = true;
+      s.onload = () => setMapsReady(true);
+      document.head.appendChild(s);
+    })();
+    return () => { cancelled = true; };
   }, []);
   useEffect(() => {
     if (!showForm || !mapsReady || !addressInputRef.current) return;


### PR DESCRIPTION
After PR #16 deployed, Sal typed `1700 west 18th st` into the Edit Client Profile drawer's Service Address and Google didn't suggest anything. **The Places loader silently bailed** because `import.meta.env.VITE_GOOGLE_MAPS_API_KEY` was empty in the production frontend bundle.

## Why the build-time injection was empty

`vite.config.ts:34` injects the var at **build time**:

```ts
'import.meta.env.VITE_GOOGLE_MAPS_API_KEY': JSON.stringify(process.env.GOOGLE_MAPS_API_KEY ?? ''),
```

That only works when `GOOGLE_MAPS_API_KEY` is present in Railway's **build** environment at the moment the frontend bundle compiles. Railway runtime env vars (where the key actually lives) aren't visible to Vite at build time. So the bundle ships with an empty string for the key, the loader hits `if (!key) return;`, and Places never loads.

## Why dispatch's InlineAddressEdit works

The pre-existing `InlineAddressEdit` on the dispatch board has a runtime fallback:

```ts
let key = "";
try {
  const r = await fetch(`${API}/api/config/google-maps-key`, { headers: { ... } });
  if (r.ok) key = String((await r.json())?.key ?? "");
} catch { /* fall through */ }
if (!key) key = (import.meta as any).env?.VITE_GOOGLE_MAPS_API_KEY ?? "";
```

`/api/config/google-maps-key` reads `process.env.GOOGLE_MAPS_API_KEY` from Railway's **runtime** env. So dispatch's address autocomplete works regardless of build-time injection state.

## Fix

PR #16 added two new Places loaders (EditProfileDrawer + HomesTab) and I forgot to mirror the runtime-fetch path. Both now do, with the same structure as InlineAddressEdit:

1. Fetch `/api/config/google-maps-key` first.
2. Fall back to build-time `VITE_GOOGLE_MAPS_API_KEY` only if the server isn't reachable.
3. Re-check `document.getElementById(scriptId)` after the await — another instance may have injected the script while we were fetching the key.
4. Cleanup flag for component-unmount during the in-flight fetch.

## Files

- `artifacts/qleno/src/pages/customer-profile.tsx` — both `EditProfileDrawer` and `HomesTab` Places loaders updated. (Same loader pattern, both use the same `gmap-places-script` element id, so they coexist correctly.)

## What's not changed

- `routes/config.ts` — endpoint already exists, returns `{ key }` from `process.env.GOOGLE_MAPS_API_KEY`.
- Dispatch `InlineAddressEdit` — already correct, untouched.
- `vite.config.ts` — left as a fallback. If you ever want to expose the key without the runtime endpoint (e.g. an unauthenticated public booking form), the build-time injection is still there.

## After merge

After Railway picks up the deploy and you hard-refresh `app.qleno.com/customers/21`:

1. Click Edit, click in Street Address, start typing — Google should now suggest addresses.
2. Same on the HomesTab "Add Service Address" form.

If Places STILL doesn't fire after this lands, the issue is downstream: either `GOOGLE_MAPS_API_KEY` isn't in Railway's runtime env at all, or Google's billing isn't enabled on the project. Both are operational, not code.

---
_Generated by [Claude Code](https://claude.ai/code/session_016GqMSjAaG7gGDtiFSPKn5Q)_