### PR TITLE
feat: service_types + recurring_schedule_addons_days schema + Phes seed (PR #1 of commercial workflow)

### DIFF
--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -171,6 +171,52 @@ async function runBookingSchemaGuard(): Promise<void> {
         UNIQUE (company_id, slug)
       )
     ` },
+    // ── service_types table ──────────────────────────────────────────────────
+    // [commercial-workflow 2026-04-29] Hierarchical service types
+    // (parent_slug = residential | commercial). Replaces hardcoded
+    // SERVICE_TYPES / COMMERCIAL_SERVICE_TYPES arrays in the wizard.
+    // Slugs match the existing serviceTypeEnum so historical jobs
+    // continue to type-check. UNIQUE (company_id, slug) lets the
+    // seed below ON CONFLICT DO NOTHING.
+    { label: "CREATE service_types", stmt: `
+      CREATE TABLE IF NOT EXISTS service_types (
+        id                    SERIAL PRIMARY KEY,
+        company_id            INTEGER NOT NULL,
+        parent_slug           TEXT NOT NULL CHECK (parent_slug IN ('residential', 'commercial')),
+        slug                  TEXT NOT NULL,
+        name                  TEXT NOT NULL,
+        description           TEXT,
+        is_active             BOOLEAN NOT NULL DEFAULT true,
+        display_order         INTEGER NOT NULL DEFAULT 100,
+        default_allowed_hours NUMERIC(5,2),
+        created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        UNIQUE (company_id, slug)
+      )
+    ` },
+    // ── recurring_schedule_addons_days table ─────────────────────────────────
+    // [commercial-workflow 2026-04-29] Per-add-on, per-weekday
+    // scoping for recurring schedule add-ons. CASCADE delete with
+    // the parent recurring_schedule_add_ons row. Day convention:
+    // 0=Sun..6=Sat (matches recurring_schedules.parking_fee_days).
+    { label: "CREATE recurring_schedule_addons_days", stmt: `
+      CREATE TABLE IF NOT EXISTS recurring_schedule_addons_days (
+        id                          SERIAL PRIMARY KEY,
+        recurring_schedule_addon_id INTEGER NOT NULL
+                                    REFERENCES recurring_schedule_add_ons(id) ON DELETE CASCADE,
+        day_of_week                 SMALLINT NOT NULL CHECK (day_of_week BETWEEN 0 AND 6),
+        created_at                  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        UNIQUE (recurring_schedule_addon_id, day_of_week)
+      )
+    ` },
+    // ── quotes.client_type ───────────────────────────────────────────────────
+    // [commercial-workflow 2026-04-29] Per-quote type override.
+    // Quote flow's Type toggle (Residential/Commercial) defaults to
+    // the client's primary client_type but can be overridden — the
+    // bridge for first-time crossovers (residential client gets a
+    // commercial quote, etc). Per Sal's decision: client primary
+    // type stays sticky on conversion; the booked job carries the
+    // quote's type, but clients.client_type is unchanged.
+    { label: "quotes.client_type", stmt: "ALTER TABLE quotes ADD COLUMN IF NOT EXISTS client_type TEXT CHECK (client_type IS NULL OR client_type IN ('residential', 'commercial'))" },
     // ── follow_up_steps table ────────────────────────────────────────────────
     { label: "CREATE follow_up_steps", stmt: `
       CREATE TABLE IF NOT EXISTS follow_up_steps (
@@ -933,6 +979,45 @@ async function runAcquisitionSourcesSeed(): Promise<void> {
   console.log(`[acquisition-sources-seed] Ensured ${sources.length} Phes default sources.`);
 }
 
+// [commercial-workflow 2026-04-29] Seed Phes-default service types
+// (5 residential + 7 commercial = 12 rows). Each slug matches an
+// existing serviceTypeEnum value so historical jobs stay valid;
+// `name` is the display label per Sal's spec. default_allowed_hours
+// stays NULL on first seed — operators set per-tenant defaults via
+// the management UI in PR #2 (Sal will fill in 2.5 for Standard
+// Clean, 4.0 for Deep Clean, etc., once that surface ships).
+//
+// Idempotent: ON CONFLICT (company_id, slug) DO NOTHING. Safe to
+// re-run on every cold-start. Existing rows are not overwritten,
+// so any operator edits to display name / order / default hours
+// stick across deploys.
+async function runServiceTypesSeed(): Promise<void> {
+  const services = [
+    // Residential (parent_slug='residential')
+    { parent: "residential", slug: "standard_clean",     name: "Standard Clean",     order: 10 },
+    { parent: "residential", slug: "deep_clean",         name: "Deep Clean",         order: 20 },
+    { parent: "residential", slug: "move_in",            name: "Move In",            order: 30 },
+    { parent: "residential", slug: "move_out",           name: "Move Out",           order: 40 },
+    { parent: "residential", slug: "post_construction",  name: "Post-Construction",  order: 50 },
+    // Commercial (parent_slug='commercial')
+    { parent: "commercial",  slug: "office_cleaning",    name: "Office Cleaning",    order: 110 },
+    { parent: "commercial",  slug: "common_areas",       name: "Common Areas",       order: 120 },
+    { parent: "commercial",  slug: "ppm_common_areas",   name: "PPM Common Areas",   order: 130 },
+    { parent: "commercial",  slug: "retail_store",       name: "Retail Store",       order: 140 },
+    { parent: "commercial",  slug: "medical_office",     name: "Medical Office",     order: 150 },
+    { parent: "commercial",  slug: "ppm_turnover",       name: "PPM Turnover",       order: 160 },
+    { parent: "commercial",  slug: "post_event",         name: "Post Event",         order: 170 },
+  ];
+  for (const s of services) {
+    await db.execute(sql`
+      INSERT INTO service_types (company_id, parent_slug, slug, name, is_active, display_order)
+      VALUES (${PHES}, ${s.parent}, ${s.slug}, ${s.name}, true, ${s.order})
+      ON CONFLICT (company_id, slug) DO NOTHING
+    `);
+  }
+  console.log(`[service-types-seed] Ensured ${services.length} Phes default service types (5 residential + 7 commercial).`);
+}
+
 export async function runPhesDataMigration(): Promise<void> {
   await runBookingSchemaGuard();
 
@@ -958,6 +1043,12 @@ export async function runPhesDataMigration(): Promise<void> {
     await runAcquisitionSourcesSeed();
   } catch (err: any) {
     console.warn("[phes-migration] acquisition-sources-seed — non-fatal:", err?.message ?? err);
+  }
+
+  try {
+    await runServiceTypesSeed();
+  } catch (err: any) {
+    console.warn("[phes-migration] service-types-seed — non-fatal:", err?.message ?? err);
   }
 
   try {

--- a/lib/db/src/schema/index.ts
+++ b/lib/db/src/schema/index.ts
@@ -80,3 +80,7 @@ export * from "./client_audit_log";
 export * from "./commercial_service_types";
 // [scheduling-engine 2026-04-29] Tenant-managed acquisition sources
 export * from "./acquisition_sources";
+// [commercial-workflow 2026-04-29] Hierarchical service types +
+// per-day add-on scoping
+export * from "./service_types";
+export * from "./recurring_schedule_addons_days";

--- a/lib/db/src/schema/recurring_schedule_addons_days.ts
+++ b/lib/db/src/schema/recurring_schedule_addons_days.ts
@@ -1,0 +1,44 @@
+/**
+ * [commercial-workflow 2026-04-29] Per-add-on, per-weekday scoping
+ * for recurring schedule add-ons.
+ *
+ * Until now, `recurring_schedule_add_ons` was just (schedule_id,
+ * pricing_addon_id, qty) — every scheduled occurrence of the parent
+ * recurring_schedule got every add-on. Parking-fee was bespoke: it
+ * lived as parking_fee_days int[] directly on recurring_schedules
+ * (with values 0=Sun..6=Sat).
+ *
+ * This table generalizes that pattern. For any add-on linked to a
+ * recurring schedule, operators can scope which weekdays the add-on
+ * applies to. The recurring engine, when generating each child job,
+ * looks up day rows for the add-on and stamps job_add_ons only for
+ * occurrences whose weekday matches.
+ *
+ * Convention: 0=Sunday..6=Saturday — exactly matches
+ * recurring_schedules.parking_fee_days, so the engine doesn't have
+ * to translate between systems.
+ *
+ * Backwards compat: existing recurring_schedule_add_ons rows that
+ * pre-date this table have ZERO day rows here. Engine semantics:
+ *   - day rows present → apply only on listed weekdays
+ *   - day rows absent  → apply to every scheduled occurrence
+ * That preserves current behavior for legacy rows while letting
+ * new ones scope. The UI will default new add-ons to "no days
+ * selected" with a save-time warning + "All days" quick action,
+ * so operators can't accidentally land in the legacy "no rows"
+ * state without seeing a prompt (Sal's decision #5).
+ */
+import { pgTable, serial, integer, smallint, timestamp } from "drizzle-orm/pg-core";
+import { recurringScheduleAddOnsTable } from "./recurring_schedule_add_ons";
+
+export const recurringScheduleAddonsDaysTable = pgTable("recurring_schedule_addons_days", {
+  id: serial("id").primaryKey(),
+  recurring_schedule_addon_id: integer("recurring_schedule_addon_id")
+    .references(() => recurringScheduleAddOnsTable.id, { onDelete: "cascade" })
+    .notNull(),
+  day_of_week: smallint("day_of_week").notNull(),    // 0=Sun..6=Sat (CHECK 0..6 enforced in migration)
+  created_at: timestamp("created_at").notNull().defaultNow(),
+});
+
+export type RecurringScheduleAddonsDay = typeof recurringScheduleAddonsDaysTable.$inferSelect;
+export type InsertRecurringScheduleAddonsDay = typeof recurringScheduleAddonsDaysTable.$inferInsert;

--- a/lib/db/src/schema/service_types.ts
+++ b/lib/db/src/schema/service_types.ts
@@ -1,0 +1,46 @@
+/**
+ * [commercial-workflow 2026-04-29] Hierarchical service types.
+ *
+ * Replaces three separate sources of truth: hardcoded SERVICE_TYPES /
+ * COMMERCIAL_SERVICE_TYPES arrays in job-wizard.tsx, and the
+ * commercial-only commercial_service_types table. All UI surfaces
+ * read from this table, filtered by parent_slug ('residential' or
+ * 'commercial') and the consumer's client_type / is_hybrid_client
+ * signal.
+ *
+ * `slug` matches a value in jobs.service_type (the Postgres enum),
+ * so historical jobs continue to FK / type-check correctly. The
+ * Postgres enum stays append-only — we cannot remove legacy values
+ * (e.g. 'recurring') without a multi-step rewrite, so the migration
+ * strategy is: stop *displaying* legacy slugs by leaving them out of
+ * service_types (or marking is_active=false), while historical jobs
+ * keep their stored value.
+ *
+ * `default_allowed_hours` lets the picker pre-fill the stepper for
+ * residential service types (e.g. Standard Clean = 2.5h). NULL on
+ * commercial — those are explicitly negotiated per-account, no
+ * default.
+ *
+ * `commercial_service_types` will be soft-deprecated in a follow-up
+ * PR. During the transition both tables coexist; new UI consumers
+ * read from `service_types`, the legacy edit-job-modal commercial
+ * path keeps reading from `commercial_service_types` until #9 in
+ * the implementation order lands.
+ */
+import { pgTable, serial, integer, text, boolean, numeric, timestamp } from "drizzle-orm/pg-core";
+
+export const serviceTypesTable = pgTable("service_types", {
+  id: serial("id").primaryKey(),
+  company_id: integer("company_id").notNull(),
+  parent_slug: text("parent_slug").notNull(),         // 'residential' | 'commercial' (CHECK constraint enforced in migration)
+  slug: text("slug").notNull(),                       // matches jobs.service_type enum value
+  name: text("name").notNull(),                       // display label
+  description: text("description"),
+  is_active: boolean("is_active").notNull().default(true),
+  display_order: integer("display_order").notNull().default(100),
+  default_allowed_hours: numeric("default_allowed_hours", { precision: 5, scale: 2 }),
+  created_at: timestamp("created_at").notNull().defaultNow(),
+});
+
+export type ServiceType = typeof serviceTypesTable.$inferSelect;
+export type InsertServiceType = typeof serviceTypesTable.$inferInsert;


### PR DESCRIPTION
**PR #1 of the commercial workflow architecture pass.** Pure data layer. No API routes, no UI, no behavior change.

Sequential cadence per Sal — PR #2 won't go up until this is reviewed and merged. Avoids the stacking situation from PR #16.

## Three additive schema changes

### 1. `service_types` (new table) — hierarchical service types

Replaces the hardcoded `SERVICE_TYPES` / `COMMERCIAL_SERVICE_TYPES` arrays in `job-wizard.tsx` and centralizes the source of truth that `EditJobModal` already partially uses from `commercial_service_types`.

```sql
CREATE TABLE IF NOT EXISTS service_types (
  id                    SERIAL PRIMARY KEY,
  company_id            INTEGER NOT NULL,
  parent_slug           TEXT NOT NULL CHECK (parent_slug IN ('residential', 'commercial')),
  slug                  TEXT NOT NULL,
  name                  TEXT NOT NULL,
  description           TEXT,
  is_active             BOOLEAN NOT NULL DEFAULT true,
  display_order         INTEGER NOT NULL DEFAULT 100,
  default_allowed_hours NUMERIC(5,2),
  created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
  UNIQUE (company_id, slug)
);
```

- **Slugs match `serviceTypeEnum`** values (`standard_clean`, `office_cleaning`, etc.) so historical jobs continue to FK / type-check correctly.
- `default_allowed_hours` pre-fills the stepper for residential types in PR #4. Left NULL on first seed; Sal sets per-tenant via the management UI in PR #2.
- `commercial_service_types` stays in place for now — PR #9 will consolidate (copy → drop).

### 2. `recurring_schedule_addons_days` (new table) — per-add-on per-weekday scoping

Generalizes the parking-fee-days bespoke pattern to any add-on.

```sql
CREATE TABLE IF NOT EXISTS recurring_schedule_addons_days (
  id                          SERIAL PRIMARY KEY,
  recurring_schedule_addon_id INTEGER NOT NULL
                              REFERENCES recurring_schedule_add_ons(id) ON DELETE CASCADE,
  day_of_week                 SMALLINT NOT NULL CHECK (day_of_week BETWEEN 0 AND 6),
  created_at                  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
  UNIQUE (recurring_schedule_addon_id, day_of_week)
);
```

- **0 = Sunday … 6 = Saturday** — exactly matches `recurring_schedules.parking_fee_days`. Engine doesn't translate.
- **Backwards compat**: existing `recurring_schedule_add_ons` rows keep zero day rows here. Engine semantics (added in PR #4):
  - day rows present → apply only on listed weekdays
  - day rows absent  → apply to every scheduled occurrence (legacy behavior preserved)
- UI in PR #4 will default new add-ons to "no days selected" with a save-time warning + "All days" quick action, so operators can't silently land in the legacy state without prompting.

### 3. `quotes.client_type` (new column) — per-quote type override

```sql
ALTER TABLE quotes ADD COLUMN IF NOT EXISTS client_type TEXT
  CHECK (client_type IS NULL OR client_type IN ('residential', 'commercial'));
```

- Nullable. Existing rows stay NULL until backfilled in PR #5 (quote flow type toggle).
- Per Sal's decision F.6.1: client primary type is **sticky** on conversion. The booked job carries the quote's `client_type`, but `clients.client_type` is unchanged.

## Phes seed — 12 rows, idempotent

`runServiceTypesSeed()` runs at boot via `phes-data-migration.ts`. `ON CONFLICT (company_id, slug) DO NOTHING` means re-runs are no-ops; operator edits to `name` / `display_order` / `default_allowed_hours` stick across deploys.

| Parent | Slug | Name | Display order |
|---|---|---|---|
| residential | `standard_clean` | Standard Clean | 10 |
| residential | `deep_clean` | Deep Clean | 20 |
| residential | `move_in` | Move In | 30 |
| residential | `move_out` | Move Out | 40 |
| residential | `post_construction` | Post-Construction | 50 |
| commercial | `office_cleaning` | Office Cleaning | 110 |
| commercial | `common_areas` | Common Areas | 120 |
| commercial | `ppm_common_areas` | PPM Common Areas | 130 |
| commercial | `retail_store` | Retail Store | 140 |
| commercial | `medical_office` | Medical Office | 150 |
| commercial | `ppm_turnover` | PPM Turnover | 160 |
| commercial | `post_event` | Post Event | 170 |

## Files

- `lib/db/src/schema/service_types.ts` — new
- `lib/db/src/schema/recurring_schedule_addons_days.ts` — new
- `lib/db/src/schema/index.ts` — export the two new tables
- `artifacts/api-server/src/phes-data-migration.ts` — `CREATE TABLE` for both, `ALTER TABLE quotes ADD COLUMN`, `runServiceTypesSeed()` + boot wiring

## Acceptance from my side

- [x] Frontend builds clean (`pnpm run build`)
- [x] Net-zero new TS errors against baseline (the +2 line-shift delta is identical pre-existing TS6305 lib/db-not-built warnings)
- [x] Migration is idempotent (`IF NOT EXISTS` + `ON CONFLICT DO NOTHING`)
- [x] No data migration of `jobs.service_type = 'recurring'` here — only 1 row total per the production count, gets cleaned up in PR #6 alongside the F.2 customer-profile.tsx inference fix

## Verification (Sal does this after Railway deploys)

1. **Cold-start log line**: `[service-types-seed] Ensured 12 Phes default service types (5 residential + 7 commercial).` should appear in Railway logs.
2. **DB query** in the Railway dashboard SQL editor:
   ```sql
   SELECT parent_slug, slug, name, display_order
   FROM service_types
   WHERE company_id = 1
   ORDER BY display_order;
   ```
   Should return all 12 rows.
3. **Quotes column check**:
   ```sql
   SELECT column_name, data_type FROM information_schema.columns
   WHERE table_name = 'quotes' AND column_name = 'client_type';
   ```
   Should return one row.

If any of those fail, send me the log line / query output and I'll triage before opening PR #2.

## What's next (NOT in this PR)

- **PR #2** — `/api/service-types` route (GET parent+active, POST/PATCH for tenant-managed) + `is_hybrid_client` derivation on `/api/clients/:id/full-profile`
- **PR #3** — JobWizard + CustomerProfile Schedule Job rewrite (two-level picker, frequency filter, stepper, hybrid-aware)
- **PR #4** — Per-day add-on scoping (engine + UI day picker)
- **PR #5** — Quote flow type toggle + `quotes.client_type` backfill + conversion path
- **PR #6** — `service_type = 'recurring'` migration + customer-profile.tsx inference fix (F.2)
- **PR #7** — EditJobModal alignment + `commercial_service_types` consolidation

**Not auto-merging — schema PR.** Your call on timing.

---
_Generated by [Claude Code](https://claude.ai/code/session_016GqMSjAaG7gGDtiFSPKn5Q)_