### PR TITLE
fix: PR #25 array binding bug in recurring_schedules INSERT

### DIFF
--- a/artifacts/api-server/src/routes/jobs.ts
+++ b/artifacts/api-server/src/routes/jobs.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import { db } from "@workspace/db";
-import { jobsTable, clientsTable, usersTable, jobPhotosTable, timeclockTable, invoicesTable, scorecardsTable, serviceZonesTable, serviceZoneEmployeesTable, companiesTable, accountsTable, accountRateCardsTable, accountPropertiesTable, paymentsTable } from "@workspace/db/schema";
+import { jobsTable, clientsTable, usersTable, jobPhotosTable, timeclockTable, invoicesTable, scorecardsTable, serviceZonesTable, serviceZoneEmployeesTable, companiesTable, accountsTable, accountRateCardsTable, accountPropertiesTable, paymentsTable, recurringSchedulesTable } from "@workspace/db/schema";
 import { eq, and, gte, lte, count, desc, sql, notExists, inArray, isNotNull } from "drizzle-orm";
 import { requireAuth } from "../lib/auth.js";
 import { logAudit } from "../lib/audit.js";
@@ -1240,36 +1240,43 @@ router.patch("/:id", requireAuth, async (req, res) => {
           ? parking_fee_days
           : null;
 
-        const inserted = await tx.execute(sql`
-          INSERT INTO recurring_schedules
-            (company_id, customer_id, frequency, day_of_week, days_of_week,
-             custom_frequency_weeks, start_date, end_date, scheduled_time,
-             assigned_employee_id, service_type, duration_minutes, base_fee,
-             commercial_hourly_rate, notes, instructions, is_active,
-             parking_fee_enabled, parking_fee_amount, parking_fee_days)
-          VALUES
-            (${companyId}, ${Number(before.client_id)},
-             ${fmap.f}::recurring_frequency,
-             ${scheduleDow}::recurring_day,
-             ${scheduleDays}::int[],
-             ${fmap.weeks},
-             ${effectiveDate}::date,
-             NULL,
-             ${effectiveTime},
-             ${primaryUid},
-             ${effectiveServiceType},
-             ${durationMin},
-             ${effectiveBaseFee},
-             ${effectiveHourlyRate},
-             ${effectiveNotes},
-             ${effectiveNotes},
-             true,
-             ${effParkingEnabled},
-             ${effParkingAmount},
-             ${effParkingDays}::int[])
-          RETURNING id
-        `);
-        createdScheduleId = Number((inserted.rows[0] as any).id);
+        // [recurring-on-save 2026-04-30 / fix #25] Switched from raw
+        // `sql` template to Drizzle ORM .insert().values().returning()
+        // because the previous tag interpolated `${scheduleDays}` (a
+        // JS array) by spreading each element as a separate scalar
+        // bind — yielding `($5, $6, $7, $8, $9)::int[]` which is
+        // invalid SQL and shifted every subsequent param off by N-1.
+        // The ORM path uses the schema's column codecs (notably
+        // integer().array() for days_of_week / parking_fee_days and
+        // the pgEnum types for frequency / day_of_week) and binds
+        // each value as exactly one parameter. Same pattern as
+        // POST /api/recurring (routes/recurring.ts:54-66).
+        const [insertedRow] = await tx
+          .insert(recurringSchedulesTable)
+          .values({
+            company_id: companyId,
+            customer_id: Number(before.client_id),
+            frequency: fmap.f as any,
+            day_of_week: scheduleDow as any,
+            days_of_week: scheduleDays,
+            custom_frequency_weeks: fmap.weeks,
+            start_date: effectiveDate,
+            end_date: null,
+            scheduled_time: effectiveTime as any,
+            assigned_employee_id: primaryUid,
+            service_type: effectiveServiceType,
+            duration_minutes: durationMin,
+            base_fee: effectiveBaseFee,
+            commercial_hourly_rate: effectiveHourlyRate,
+            notes: effectiveNotes,
+            instructions: effectiveNotes,
+            is_active: true,
+            parking_fee_enabled: effParkingEnabled,
+            parking_fee_amount: effParkingAmount,
+            parking_fee_days: effParkingDays,
+          })
+          .returning({ id: recurringSchedulesTable.id });
+        createdScheduleId = Number(insertedRow.id);
         setParts.recurring_schedule_id = createdScheduleId;
       }
 


### PR DESCRIPTION
## Bug

PR #25 ([already merged](https://github.com/salmartinez-design/qleno/pull/25)) shipped the `create_recurring` cascade scope, but the actual `recurring_schedules` INSERT threw at runtime in production. Sal hit the error banner on the Jaira Apr 27 repro:

```
Failed query: INSERT INTO recurring_schedules (…) VALUES (
  $1, $2, $3::recurring_frequency, $4::recurring_day,
  ($5, $6, $7, $8, $9)::int[], $10, $11::date, NULL, $12, $13,
  $14, $15, $16, $17, $18, $19, true, $20, $21, $22::int[]
) RETURNING id
params: 1, 21, weekdays, 1, 2, 3, 4, 5, 2026-04-27, 08:00, …
```

## Root cause

Drizzle's `sql` template tag interpolates a JS array via `${arr}` by **spreading each element as a separate scalar bind** — the same behavior used to expand id lists in `IN` clauses. So `${scheduleDays}::int[]` with `scheduleDays = [1,2,3,4,5]` rendered as `($5, $6, $7, $8, $9)::int[]`, which is invalid SQL and shifted every subsequent parameter off by N-1. Trailing values (`notes`, `instructions`, `parking_fee_amount`) wound up bound as empty strings.

`parking_fee_days` had the same latent bug — it didn't surface in the production log only because the `days_of_week` failure aborted the statement first.

## Fix

Switch the raw `sql` INSERT to Drizzle ORM:

```ts
const [insertedRow] = await tx
  .insert(recurringSchedulesTable)
  .values({ company_id, customer_id, frequency, day_of_week, days_of_week, … })
  .returning({ id: recurringSchedulesTable.id });
```

Matches `POST /api/recurring` (`routes/recurring.ts:54-66`). The schema's column codecs handle:
- `days_of_week` / `parking_fee_days` as `int[]` in a single parameter bind (column declared `integer(...).array()`)
- `frequency` / `day_of_week` `pgEnum` casts (no manual `::recurring_frequency` / `::recurring_day` needed)
- `start_date` / `scheduled_time` type coercion

20 columns → 20 fields, 1:1 mapping, no manual SQL casts.

Added `recurringSchedulesTable` to the existing `@workspace/db/schema` import. Already exported from the package via `lib/db/src/schema/index.ts`.

## Net delta

- 1 file changed: `artifacts/api-server/src/routes/jobs.ts` (+38 / -31)
- Same payload, same response shape, same cascade scopes
- Same modal flow (no frontend change required)
- Same fan-out logic (`generateJobsFromSchedule` post-commit, best-effort, error surfaces via `cascade.create_recurring.error`)
- `tsc` net-zero new errors (54 pre / 54 post in `routes/jobs.ts`, all pre-existing patterns)
- Frontend build clean

## Out of scope

- Modal-side changes — payload didn't change, no edit needed
- `generateJobsFromSchedule` semantics — unchanged
- `parking_fee_*` / `recurring_schedule_addons_days` consolidation — still deferred from PR #24
- New validation — none added

## Verification plan

Same Jaira repro Sal ran on PR #25:

1. Open `jobs.id=4145` (or 4147 — whichever is kept) in the Edit Job modal.
2. Frequency: **Weekdays (M-F)**, allowed hours 6, 8:00 AM, Parking Fee checked.
3. Click Save. Expect silent success (no red banner).
4. DevTools Network: response carries `cascade.created_schedule_id` (new id) + `cascade.create_recurring = { jobs_generated, jobs_skipped }`. With today on or before Tue Apr 28, `jobs_generated` should be ~4 for this week (Tue/Wed/Thu/Fri) + ~40 forward weekday occurrences over the 60-day horizon (some count depending on cron lag and end-of-window).
5. DB sanity:
   ```sql
   SELECT id, frequency, day_of_week, days_of_week, start_date,
          parking_fee_enabled, parking_fee_amount, parking_fee_days,
          assigned_employee_id, base_fee
     FROM recurring_schedules WHERE customer_id = 21 AND company_id = 1;

   SELECT id, scheduled_date, scheduled_time, frequency, recurring_schedule_id, status
     FROM jobs WHERE client_id = 21 AND company_id = 1
       AND scheduled_date BETWEEN CURRENT_DATE - 7 AND CURRENT_DATE + 14
     ORDER BY scheduled_date, id;
   ```
   Expect 1 schedule (`days_of_week = {1,2,3,4,5}`, `parking_fee_days = {1,2,3,4,5}` if "match schedule" was used), Monday job linked, fresh Tue–Fri jobs with `recurring_schedule_id = <new id>`.
6. Inspect a generated Tue/Wed/Thu/Fri job's `job_add_ons` row — Parking Fee stamped per the engine's existing logic.
7. After verification: manual cleanup of whichever Apr 27 row (4145 or 4147) wasn't promoted.

## Cadence

Draft now. Ready when you've reviewed the diff. Merge → Railway deploy → you re-run the Jaira repro → explicit "verified, start next" before anything else moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016GqMSjAaG7gGDtiFSPKn5Q)_