### PR TITLE
chore: verify backups on + document disaster recovery

### DIFF
--- a/artifacts/api-server/src/index.ts
+++ b/artifacts/api-server/src/index.ts
@@ -103,6 +103,14 @@ function startFollowUpCron() {
 // Start listening immediately so health checks pass, then seed in the background
 app.listen(port, "0.0.0.0", () => {
   console.log("Server running on port", process.env.PORT || 3000);
+  // [DR runbook 2026-04-30] Static reminder visible on every cold
+  // start. Surfaces backup-state in Railway logs without requiring
+  // a RAILWAY_API_TOKEN credential we'd then have to manage. The
+  // intent is to keep "verify backups quarterly" in the operator's
+  // eyeline, not to give live timestamp data — Railway Hobby's
+  // backup state changes maybe twice a year.
+  // Procedure + RPO/RTO targets: docs/disaster-recovery.md
+  console.log("[backup-check] static reminder: Railway Hobby plan provides daily backups, 7-day retention. Verify quarterly via dashboard. Procedure: docs/disaster-recovery.md");
   const recurringEngineEnabled = process.env.RECURRING_ENGINE_ENABLED !== "false";
   // [2026-04-22 J3] Startup invocation of runRecurringJobGeneration() removed —
   // Railway restart cascades caused 5x concurrent engine runs on the

--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -1,0 +1,119 @@
+# Disaster Recovery — Qleno production
+
+Owner: Sal Martinez (operator). Reviewed: 2026-04-30.
+
+## Purpose
+
+This document describes how to recover Qleno's production data when something goes catastrophically wrong — a bad migration, a bad cascade, accidental row deletion, infrastructure failure. It's not a step-by-step automation; it's the runbook an operator opens when the system is on fire.
+
+Read it once before you need it.
+
+## Where the data lives
+
+- **Primary database**: Railway Postgres, project `selfless-manifestation`, service `Postgres`. The Railway-managed instance is the only authoritative copy of production data.
+- **Backups**: managed by Railway. The Hobby plan that Phes runs on includes **daily snapshots with 7-day retention**, taken automatically. There is no manual backup step today.
+- **Source of truth pre-cutover**: MaidCentral (the legacy cleaning-business platform Phes is migrating off). Until the cutover completes, MaidCentral data is recoverable independently — for any pre-2026-04 record, MC is a second copy of truth.
+
+## Recovery objectives
+
+These are the targets the system can meet today on Railway Hobby. They are not contractual SLAs.
+
+| Metric | Target | Notes |
+|---|---|---|
+| **RPO** (Recovery Point Objective — how much data can be lost) | ≤ 24 hours | Daily snapshots; worst case is losing one full operating day. |
+| **RTO** (Recovery Time Objective — how long to restore service) | ≤ 30 minutes | Railway snapshot restore is operator-driven via the dashboard; takes a few minutes plus DNS settle. |
+
+**Phes can tolerate these limits.** A $750k/yr operation with ~1,300 clients can run for 30 minutes from MC backup or paper records, and can recover a day of data manually from a combination of MC, bookkeeper exports, and operator memory of in-progress work.
+
+If the business outgrows these limits — e.g. multi-tenant SaaS with stricter SLAs, or post-cutover when MC is no longer a fallback — revisit. Options at that point: continuous WAL archiving (Railway Pro), point-in-time recovery, off-platform replicas.
+
+## Quarterly check (do this every January, April, July, October)
+
+1. Open Railway dashboard → project `selfless-manifestation` → service `Postgres`.
+2. Click **Backups** in the left nav.
+3. Confirm:
+   - Daily backups are enabled.
+   - Retention is 7 days (or whatever the current Hobby plan offers — verify it hasn't been silently downgraded).
+   - The most recent backup is from within the last 24 hours.
+4. If anything is off, fix it before doing anything else. A backup-less production is a single bad PR away from disaster.
+
+The api-server logs a static reminder on every cold start (`[backup-check] static reminder: …`) so this check is in the operator's eyeline. The reminder is intentionally static — implementing a live Railway API check requires an `RAILWAY_API_TOKEN` credential that adds operational surface area without solving a problem that matters more than twice a year.
+
+## Scenario: I deployed a PR that corrupted production data
+
+Symptoms: rows have wrong values, jobs got deleted that shouldn't have, a cascade did the wrong thing across hundreds of rows, etc.
+
+**Stop deploying.** Revert the offending PR on `main` first so the next Railway redeploy doesn't recompound the damage. Then:
+
+1. **Triage how bad it is.** Run `SELECT count(*) FROM jobs WHERE updated_at > NOW() - INTERVAL '4 hours'` and similar for affected tables. If the blast radius is small (< ~100 rows) and you can identify them precisely, hand-fix via SQL UPDATE/INSERT statements without a restore. Document what you ran in a postmortem.
+
+2. **If the blast radius is large**, restore from snapshot:
+   - Railway dashboard → Postgres service → Backups tab → pick the most recent snapshot **before** the bad deploy.
+   - Click **Restore**. Railway prompts to confirm; the restore replaces the current database in place. **This loses any data written between the snapshot and now.**
+   - Wait ~5 minutes for restore + healthcheck.
+   - Verify with `SELECT count(*) FROM jobs`, `SELECT count(*) FROM clients`, etc. against pre-incident expectations.
+
+3. **If you don't want to overwrite prod** (e.g. you need to extract specific rows from yesterday without losing today's writes), see "Spin up a recovery DB" below.
+
+## Scenario: I want to extract specific rows from a backup without overwriting prod
+
+This is the case when prod has good data from the last 24 hours that you want to keep, but you also need to recover a specific table/row that got corrupted earlier and is now overwritten in prod.
+
+Railway doesn't natively support "restore to a side instance" on Hobby. The procedure:
+
+1. Railway dashboard → Postgres service → Backups → pick the snapshot you want.
+2. Download the snapshot (Railway provides a `.sql` or `.dump` export — formats vary; check the dashboard).
+3. Locally, spin up a throwaway Postgres in Docker:
+   ```bash
+   docker run --rm -d --name qleno-recovery -p 5433:5432 \
+     -e POSTGRES_PASSWORD=recover -e POSTGRES_DB=qleno_recovery \
+     postgres:16
+   ```
+4. Restore the snapshot into the throwaway:
+   ```bash
+   pg_restore -h localhost -p 5433 -U postgres -d qleno_recovery <snapshot-file>
+   # or for plain SQL:
+   psql -h localhost -p 5433 -U postgres qleno_recovery -f <snapshot.sql>
+   ```
+5. Connect a client to the throwaway and SELECT the rows you need. Export to CSV / SQL inserts as needed.
+6. Apply the extracted data to production via targeted INSERT/UPDATE statements. **Manual SQL only — do not script bulk migrations against prod from a recovery DB without a senior review.**
+7. `docker rm -f qleno-recovery` when done.
+
+Expected total time: 30-60 minutes including snapshot download. The bottleneck is usually the snapshot download size (Phes prod is currently <500 MB; this will grow).
+
+## Scenario: Railway is fully down
+
+Symptoms: `app.qleno.com` doesn't respond, Railway status page shows incident.
+
+1. Tell operations: "we're down, fall back to MaidCentral or paper for jobs scheduled today, do not take new bookings until we're back."
+2. Watch Railway's status page. There is no Qleno-side action that brings us back faster — we are downstream of their infra.
+3. When Railway recovers, the api-server cold-starts and the data is intact (Railway maintains the disk; it's just compute that was down). Verify with the quarterly-check procedure above.
+4. If the outage is >2 hours, evaluate whether to spin up an emergency replica on a different platform. This is a multi-day project, not an outage-day option — file as a BCP improvement task if it happens.
+
+## Scenario: I deleted the wrong row(s) by hand
+
+You ran a manual SQL UPDATE/DELETE in the Railway shell or a database client and zapped the wrong thing.
+
+1. **Don't run anything else.** Including queries against the same table — concurrent transactions can complicate recovery.
+2. If the deletion happened in the last few minutes and Postgres still has the row in WAL, contact Railway support. They can sometimes recover from WAL on Hobby; sometimes they can't. Don't count on this.
+3. Otherwise, restore the affected rows from yesterday's snapshot via the "Spin up a recovery DB" procedure above.
+4. Postmortem: document what got deleted, what got recovered, and what (if anything) is permanently gone. File a postmortem in `/docs/incidents/` (create directory if needed).
+
+## What's NOT covered here
+
+- **Stripe / Square refunds**: payment data lives at the payment processor. Recovering a database row that says "this job was paid" doesn't undo a real card charge. Refund flows are separate.
+- **Twilio / Resend message logs**: comms providers retain their own logs; we don't restore them.
+- **QuickBooks**: QB is write-only from Qleno's perspective. Qleno never pulls from QB. Restoring Qleno doesn't affect QB. If QB is also corrupted, that's a separate Intuit-side recovery.
+- **Email / DNS / domain registrar**: out of scope for database disaster recovery.
+
+## Postmortem expectations
+
+Every restore-from-snapshot incident gets a postmortem in `/docs/incidents/YYYY-MM-DD-<short-name>.md`. Template:
+
+- What happened (timeline)
+- What we lost (rows, hours of data, customer impact)
+- What we recovered (and how)
+- What we'd do differently (engineering + operations)
+- Action items with owners
+
+Even if the impact was small. The point isn't blame; the point is that the next person who hits this scenario can read the runbook + last incident and skip the diagnosis phase.


### PR DESCRIPTION
## What

Operational hardening — Sal needs to know production data is recoverable if a bad cascade or migration corrupts the DB. Two additive changes, no code-path changes, no schema, no env vars.

### `docs/disaster-recovery.md` (new)

Runbook covering:
- Quarterly backup-verification check (Jan/Apr/Jul/Oct cadence)
- Recovery objectives table (RPO ≤24h, RTO ~30min) + the "Phes can tolerate these limits" rationale based on MC fallback + paper records
- Scenario walkthroughs:
  - PR corrupted production data → revert + restore-in-place
  - Need to extract specific rows from a backup without overwriting prod → throwaway recovery DB via `docker run postgres`
  - Railway-side outage → comms playbook + status-page watch
  - Manual SQL deletion → WAL-recovery long-shot + snapshot fallback
- What's NOT covered (Stripe refunds, Twilio/Resend logs, QB, DNS)
- Postmortem template + expectations

### `artifacts/api-server/src/index.ts` (8-line addition)

Static `[backup-check] static reminder: …` log line on every cold start. Surfaces "verify backups quarterly" in Railway logs without a `RAILWAY_API_TOKEN` credential we'd then have to manage.

Per Sal's Q1.1 = **(a)**: live API check on every cold start is gold-plating for a ~2x/yr operational concern; the doc-only path delivers all the recovery value with zero new credential surface area.

## Self-verify

Code-only verification per the standing cadence:

- `tsc` net-zero new errors (single-line `console.log` addition)
- Doc renders correctly (markdown lint clean by inspection)
- Boot reminder string is grep-able for future operator eyes:
  ```
  $ grep "\[backup-check\]" artifacts/api-server/src/index.ts
  ```

## Sal's action items post-deploy

1. **Run the quarterly check once now** — open Railway dashboard → Postgres service → Backups, confirm daily backups are on with 7-day retention, confirm latest snapshot is <24h old. Document the verified state in your operator notes.
2. **Bookmark `/docs/disaster-recovery.md`.** When something goes wrong it should be the first place you look.
3. **Optional**: file a calendar reminder for next quarterly check (~Jul 30, 2026).

## Diff

```
docs/disaster-recovery.md         | 119 +++++++++++++ (new)
artifacts/api-server/src/index.ts |   8 ++ 
2 files changed, 127 insertions(+)
```

Net 127 lines, mostly docs. Well under the 400-line ceiling.

## Cadence

Opening Ready with auto-merge SQUASH attempt. Auto-merge will likely fall back to manual merge per the recurring "no CI = clean status" issue on this repo until you flip the repo-level toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016GqMSjAaG7gGDtiFSPKn5Q)_