### PR TITLE
chore: pre-deploy schema drift verification

### DIFF
--- a/artifacts/api-server/src/index.ts
+++ b/artifacts/api-server/src/index.ts
@@ -99,6 +99,47 @@ function startFollowUpCron() {
   console.log("[Qleno] Follow-up sequence cron started (every 30 min)");
 }
 
+// ── Schema drift verification ───────────────────────────────────────────────
+// [PR / 2026-04-30] One-way drift check — flags when Drizzle declares a
+// table / column / enum-value the DB does NOT have. Runs BEFORE app.listen
+// so a known-broken schema fails fast (in strict mode) instead of limping
+// with broken queries on every request.
+//
+// SCHEMA_VERIFY_MODE values:
+//   strict  — exit non-zero on any error-severity drift (boot blocked)
+//   warn    — log only, never exit (DEFAULT for first-deploy safety)
+//   off     — skip verification entirely
+//
+// Default is 'warn' for the first deploy of this script — strict-by-
+// default on a never-seen-in-prod verifier is asking for a 3am outage.
+// After production baseline is clean (see docs/schema-drift-baseline.md
+// for the procedure), Sal flips to 'strict' in a follow-up PR.
+//
+// Verification ITSELF crashing (e.g. introspection query syntax error,
+// missing module) does NOT block boot — we log and continue. Only
+// detected drift in strict mode triggers exit.
+const verifyMode = (process.env.SCHEMA_VERIFY_MODE ?? "warn").toLowerCase();
+if (verifyMode !== "off" && process.env.DATABASE_URL) {
+  try {
+    const { verifySchema, formatDrifts } = await import("./scripts/verify-schema.js");
+    const drifts = await verifySchema();
+    if (drifts.length === 0) {
+      console.log(`[schema-verify] mode=${verifyMode} — no drift detected`);
+    } else {
+      const errorCount = drifts.filter(d => d.severity === "error").length;
+      const warnCount = drifts.filter(d => d.severity === "warn").length;
+      console.error(`[schema-verify] mode=${verifyMode} — ${drifts.length} drift(s) (${errorCount} error, ${warnCount} warn):`);
+      for (const line of formatDrifts(drifts)) console.error("  " + line);
+      if (verifyMode === "strict" && errorCount > 0) {
+        console.error("[schema-verify] strict mode + error severity present → exiting non-zero");
+        process.exit(1);
+      }
+    }
+  } catch (err: any) {
+    console.error("[schema-verify] verification crashed (continuing boot):", err?.message ?? err);
+  }
+}
+
 // ── Startup ──────────────────────────────────────────────────────────────────
 // Start listening immediately so health checks pass, then seed in the background
 app.listen(port, "0.0.0.0", () => {

--- a/artifacts/api-server/src/scripts/verify-schema.ts
+++ b/artifacts/api-server/src/scripts/verify-schema.ts
@@ -1,0 +1,238 @@
+/**
+ * [PR / 2026-04-30] Schema drift verification.
+ *
+ * Goal: prevent a Claude Code schema change from booting prod into a
+ * broken state where seed/migration runs but app code expects a
+ * different shape (e.g. PR ships ORM expecting columns that don't
+ * exist → broken queries on every request).
+ *
+ * Direction: ONE-WAY (Sal's Q2.1 = a). We flag when Drizzle declares
+ * a table / column / enum-value the DB does NOT have. We do NOT flag
+ * the reverse — DB-extra rows from `phes-data-migration.ts` (~30
+ * tables: rate_locks, offer_settings, booking_settings, leads,
+ * follow_up_*, acquisition_sources, recurring_schedule_addons_days,
+ * commercial_service_types, job_audit_log, client_audit_log, etc.)
+ * are intentional and benign. Allowlisting them would create a
+ * maintenance burden that doesn't pay for itself.
+ *
+ * Coverage: tables, columns (existence + nullability), enums + enum
+ * values. NOT covered in v1: column type equivalence (Drizzle/DB type
+ * names diverge in messy ways — `serial` ↔ `integer`, `varchar(N)` ↔
+ * `character varying`, `timestamp` ↔ `timestamp without time zone`),
+ * indexes, foreign keys, defaults. v2 if v1 proves insufficient.
+ *
+ * Modes (via `SCHEMA_VERIFY_MODE` env var, consumed in index.ts):
+ *   strict  — exit non-zero on any error-severity drift
+ *   warn    — log only, never exit (default for first deploy)
+ *   off     — skip verification entirely
+ *
+ * Standalone invocation: `tsx scripts/verify-schema.ts` from the
+ * api-server workspace. Runs against the same DATABASE_URL the
+ * server uses.
+ */
+
+import { db } from "@workspace/db";
+import * as schema from "@workspace/db/schema";
+import { sql, is } from "drizzle-orm";
+import { PgTable, getTableConfig } from "drizzle-orm/pg-core";
+
+export type DriftSeverity = "error" | "warn";
+export type DriftKind =
+  | "missing_table"
+  | "missing_column"
+  | "nullability_mismatch"
+  | "missing_enum"
+  | "missing_enum_value";
+
+export type Drift = {
+  severity: DriftSeverity;
+  kind: DriftKind;
+  message: string;
+  table?: string;
+  column?: string;
+  enum?: string;
+};
+
+// Drizzle's pgEnum() returns a callable function with `enumName` and
+// `enumValues` properties attached. There's no exported `is(v, PgEnum)`
+// helper, so we duck-type. Stable enough — Drizzle would have to break
+// the enumName/enumValues contract to break this check, and that's a
+// public-API change they'd flag.
+type PgEnumLike = { readonly enumName: string; readonly enumValues: readonly string[] };
+function isPgEnumValue(v: unknown): v is PgEnumLike {
+  if (!v) return false;
+  if (typeof v !== "function" && typeof v !== "object") return false;
+  const obj = v as Record<string, unknown>;
+  return typeof obj.enumName === "string" && Array.isArray(obj.enumValues);
+}
+
+export async function verifySchema(): Promise<Drift[]> {
+  const drifts: Drift[] = [];
+
+  // ── Pass 1: tables + columns ────────────────────────────────────────────
+  // `Object.values(schema)` returns a union of every export type
+  // (PgTable specializations, pgEnum results, helper functions). TS
+  // can't narrow that union to a single PgTable shape via the runtime
+  // `is(v, PgTable)` check — Drizzle's type machinery is too rich for
+  // a single user-defined type predicate to satisfy. Cast through
+  // `unknown` and let the runtime check (which IS reliable) gate the
+  // narrowing. Same pattern below for enums.
+  const drizzleTables = (Object.values(schema) as unknown[]).filter(
+    (v): v is PgTable => is(v, PgTable),
+  );
+
+  // One round-trip for all DB tables so we don't N+1 a small set.
+  const dbTablesRes = await db.execute(sql`
+    SELECT table_name
+      FROM information_schema.tables
+     WHERE table_schema = 'public'
+       AND table_type = 'BASE TABLE'
+  `);
+  const dbTables = new Set(
+    (dbTablesRes.rows as Array<{ table_name: string }>).map(r => String(r.table_name)),
+  );
+
+  for (const table of drizzleTables) {
+    const config = getTableConfig(table);
+    const tableName = config.name;
+
+    if (!dbTables.has(tableName)) {
+      drifts.push({
+        severity: "error",
+        kind: "missing_table",
+        table: tableName,
+        message: `Drizzle declares table '${tableName}' but DB does not have it`,
+      });
+      // Skip per-column check when the table itself is missing.
+      continue;
+    }
+
+    // Per-column check. Pull all columns for this table in one query
+    // so we don't N+1 inside the table loop.
+    const dbColsRes = await db.execute(sql`
+      SELECT column_name, data_type, is_nullable
+        FROM information_schema.columns
+       WHERE table_schema = 'public' AND table_name = ${tableName}
+    `);
+    const dbCols = new Map<string, { type: string; nullable: boolean }>();
+    for (const r of dbColsRes.rows as Array<{ column_name: string; data_type: string; is_nullable: string }>) {
+      dbCols.set(String(r.column_name), {
+        type: String(r.data_type),
+        nullable: String(r.is_nullable).toUpperCase() === "YES",
+      });
+    }
+
+    for (const col of config.columns) {
+      const colName = col.name;
+      const dbCol = dbCols.get(colName);
+      if (!dbCol) {
+        drifts.push({
+          severity: "error",
+          kind: "missing_column",
+          table: tableName,
+          column: colName,
+          message: `Drizzle declares column '${tableName}.${colName}' but DB does not have it`,
+        });
+        continue;
+      }
+
+      // Nullability check. Both directions are dangerous:
+      //   Drizzle NOT NULL + DB NULL → reads can return null where
+      //     the type system says "non-null", causing runtime crashes
+      //     on `.field.foo` access.
+      //   Drizzle NULL + DB NOT NULL → INSERTs that omit the field
+      //     will succeed in TypeScript but crash at the DB.
+      // We log as 'warn' — boot-breaking is rare; runtime impact is
+      // recoverable once spotted.
+      const drizzleNullable = !col.notNull;
+      if (drizzleNullable !== dbCol.nullable) {
+        drifts.push({
+          severity: "warn",
+          kind: "nullability_mismatch",
+          table: tableName,
+          column: colName,
+          message:
+            `Column '${tableName}.${colName}' nullability differs — ` +
+            `Drizzle=${drizzleNullable ? "NULL" : "NOT NULL"}, ` +
+            `DB=${dbCol.nullable ? "NULL" : "NOT NULL"}`,
+        });
+      }
+    }
+  }
+
+  // ── Pass 2: enums + enum values ────────────────────────────────────────
+  const drizzleEnums = (Object.values(schema) as unknown[]).filter(isPgEnumValue);
+
+  const dbEnumsRes = await db.execute(sql`
+    SELECT t.typname AS enum_name,
+           array_agg(e.enumlabel ORDER BY e.enumsortorder) AS values
+      FROM pg_type t
+      JOIN pg_enum e ON t.oid = e.enumtypid
+      JOIN pg_namespace n ON n.oid = t.typnamespace
+     WHERE n.nspname = 'public'
+     GROUP BY t.typname
+  `);
+  const dbEnums = new Map<string, Set<string>>();
+  for (const r of dbEnumsRes.rows as Array<{ enum_name: string; values: string[] }>) {
+    dbEnums.set(String(r.enum_name), new Set(r.values.map(String)));
+  }
+
+  for (const e of drizzleEnums) {
+    const enumName = String(e.enumName);
+    const dbValues = dbEnums.get(enumName);
+    if (!dbValues) {
+      drifts.push({
+        severity: "error",
+        kind: "missing_enum",
+        enum: enumName,
+        message: `Drizzle declares enum '${enumName}' but DB does not have it`,
+      });
+      continue;
+    }
+    for (const v of e.enumValues) {
+      const literal = String(v);
+      if (!dbValues.has(literal)) {
+        drifts.push({
+          severity: "error",
+          kind: "missing_enum_value",
+          enum: enumName,
+          message:
+            `Drizzle declares enum value '${enumName}.${literal}' but DB does not have it`,
+        });
+      }
+    }
+  }
+
+  return drifts;
+}
+
+// Format helper for both standalone CLI + index.ts boot logging.
+export function formatDrifts(drifts: Drift[]): string[] {
+  return drifts.map(d => `[${d.severity}] ${d.kind}: ${d.message}`);
+}
+
+// Standalone CLI: `tsx scripts/verify-schema.ts`. Exit 0 on no error-
+// severity drift, 1 otherwise. Warn-severity does not affect exit code.
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  (async () => {
+    try {
+      const drifts = await verifySchema();
+      if (drifts.length === 0) {
+        console.log("[verify-schema] no drift detected");
+        process.exit(0);
+      }
+      for (const line of formatDrifts(drifts)) console.log(line);
+      const hasErrors = drifts.some(d => d.severity === "error");
+      console.log(
+        `[verify-schema] ${drifts.length} drift(s) detected — ` +
+        `${drifts.filter(d => d.severity === "error").length} error, ` +
+        `${drifts.filter(d => d.severity === "warn").length} warn`,
+      );
+      process.exit(hasErrors ? 1 : 0);
+    } catch (err: any) {
+      console.error("[verify-schema] verification crashed:", err?.message ?? err);
+      process.exit(2);
+    }
+  })();
+}

--- a/docs/schema-drift-baseline.md
+++ b/docs/schema-drift-baseline.md
@@ -1,0 +1,51 @@
+# Schema drift baseline — production
+
+Owner: Sal Martinez. Updated: 2026-04-30.
+
+## Purpose
+
+The schema-verify check (`artifacts/api-server/src/scripts/verify-schema.ts`) runs on every cold start of the api-server. It compares Drizzle's declared schema against the live Postgres schema **in one direction only**: it flags when Drizzle declares a table / column / enum-value the DB does NOT have. The reverse — DB has things Drizzle doesn't know about — is benign and intentional (`phes-data-migration.ts` creates ~30 tables outside the Drizzle schema; legacy migrations may have added columns that never made it into the ORM).
+
+This document captures any drift detected the first time the verifier ran in production, so we can distinguish "expected baseline" from "new drift introduced by this PR" going forward.
+
+## Procedure
+
+1. Deploy a PR containing the `verify-schema` check with `SCHEMA_VERIFY_MODE` unset (default = `warn`). The api-server will log drift to Railway logs without blocking boot.
+2. Open Railway logs for the post-deploy cold start. Search for `[schema-verify]`.
+3. **If the log says `[schema-verify] mode=warn — no drift detected`**: paste that line below under "Baseline reading" and skip to the Strict-mode rollover section.
+4. **If the log lists drifts**: paste the full output below. For each line, decide:
+   - **Expected** — drift is benign, document the reason. Stays as-is.
+   - **Bug** — drift represents a real ORM↔DB mismatch that needs fixing. File as a follow-up issue, fix in a separate PR.
+5. After all expected drift is documented and all bugs are filed: open a follow-up PR setting `SCHEMA_VERIFY_MODE=strict` in Railway env vars. From then on, any new drift fails boot until resolved.
+
+## Baseline reading
+
+> Sal: paste the full `[schema-verify]` log output from the first post-deploy cold start here. Then annotate each line as `[expected]` or `[bug]` per the procedure above.
+
+```
+[schema-verify] mode=warn — <output goes here>
+```
+
+## Strict-mode rollover
+
+After baseline is clean (or all drift annotated as expected and bugs filed):
+
+1. Set `SCHEMA_VERIFY_MODE=strict` in Railway env vars.
+2. Trigger a redeploy. Confirm the next cold start logs `[schema-verify] mode=strict — no drift detected` (or the same baseline-expected drift, which will still fail strict mode if any are error-severity — that's the signal to either fix Drizzle/DB or escalate the drift to allowlist-with-justification).
+3. Document the rollover date here.
+
+**Rolled over to strict on:** _(not yet)_
+
+## What's NOT covered
+
+- **Type equivalence** — Drizzle's `serial` ↔ DB's `integer` (with sequence default), `varchar(N)` ↔ `character varying`, `timestamp` ↔ `timestamp without time zone`. Type-name divergence is messy enough that v1 of the verifier checks existence + nullability only. v2 if it proves insufficient.
+- **Indexes** — not introspected.
+- **Foreign keys** — not introspected. Drizzle declares `references()` but the runtime introspection query is non-trivial.
+- **Defaults** — not compared.
+- **DB-extra schema** — by design (one-way, see Purpose above).
+
+## Operator notes
+
+- The check adds ~0.5s to cold-start time on Phes's ~50-table schema. Acceptable on a 15s boot.
+- If verification itself crashes (rare — query syntax error, missing module, etc.), boot continues. We don't want a verifier bug to take prod down.
+- The verifier is also runnable standalone: `pnpm --filter @workspace/api-server exec tsx src/scripts/verify-schema.ts` against any `DATABASE_URL`. Useful for local-vs-prod drift checks during development.


### PR DESCRIPTION
## What

Operational hardening — prevent a Claude Code schema change from booting prod into a broken state where seed/migration runs but app code expects a different shape.

Three additive changes, no schema, no API contract change.

## Diff

```
artifacts/api-server/src/scripts/verify-schema.ts | 238 ++++ (new)
artifacts/api-server/src/index.ts                 |  41 +++
docs/schema-drift-baseline.md                     |  51 ++ (new)
3 files changed, 330 insertions(+)
```

Net 330 lines, mostly the new script + comments. Well under the 400-line ceiling.

## Q&A recap

- **Q2.1 = (a)**: One-way drift only. Flag when Drizzle declares a table / column / enum-value DB does NOT have. DB-extras from `phes-data-migration.ts` (~30 tables) are intentional, NOT flagged.
- **Q2.2 = (b)**: Default `SCHEMA_VERIFY_MODE='warn'` for first deploy. Strict-mode-by-default on a never-seen-in-prod verifier is asking for a 3am outage. Flip to strict in a follow-up PR after baseline is clean.
- **Q2.3**: Confirmed 0.5s impact is noise on a 15s boot.

## File-by-file

### `src/scripts/verify-schema.ts` (new — 238 lines)

Coverage:
- **Tables**: existence (error severity if missing).
- **Columns**: existence (error) + nullability (warn — both directions are dangerous but recoverable, log instead of block).
- **Enums**: existence + value membership (error severity).

NOT covered in v1:
- Column type equivalence (Drizzle/DB type names diverge messily — `serial` ↔ `integer`, `varchar(N)` ↔ `character varying`, `timestamp` ↔ `timestamp without time zone`). Existence + nullability is the safety-critical part. v2 if v1 proves insufficient.
- Indexes, foreign keys, defaults.

Standalone runnable: `tsx src/scripts/verify-schema.ts` from the api-server workspace. Exits 0 on no error-severity drift, 1 on error-severity, 2 if verification itself crashes.

**Path note**: lives in `src/scripts/` rather than top-level `scripts/`. Sal's spec said "scripts/" without strict path; placing it inside `src/` ensures esbuild's bundler (entrypoint `src/index.ts`) follows the import cleanly into `dist/index.mjs`. Confirmed bundled via `grep -c "verifySchema\|missing_table\|enumName" dist/index.mjs` → 5 hits.

### `src/index.ts` (+41 lines)

Wires `verifySchema()` into the boot sequence **before** `app.listen()` via ESM top-level await. New env var:

```
SCHEMA_VERIFY_MODE
  strict — exit non-zero on any error-severity drift (boot blocked)
  warn   — log only, never exit (DEFAULT)
  off    — skip verification entirely
```

Verification ITSELF crashing (e.g. introspection query syntax error, missing module) does NOT block boot — we log and continue regardless of mode. Only detected drift in `strict` mode triggers exit. This is intentional — a verifier bug should never take prod down.

### `docs/schema-drift-baseline.md` (new — 51 lines)

Captures the first post-deploy verification reading. You paste the `[schema-verify]` log output, annotate each drift line as `[expected]` (benign — document why) or `[bug]` (file follow-up), then flip to strict mode. Procedure + strict-rollover playbook + what's-not-covered list inline.

## Self-verify (code-only)

- `tsc` net-zero new errors across all three changed files
- `pnpm run build` clean (esbuild bundles `verify-schema.ts` into `dist/index.mjs`, confirmed via grep)
- Standalone CLI (`tsx src/scripts/verify-schema.ts`) compiles + has correct exit-code semantics by inspection

## Sal action items post-deploy

1. Watch Railway logs for the first cold-start `[schema-verify] mode=warn — …` line.
2. Paste the output into `docs/schema-drift-baseline.md` under "Baseline reading".
3. Annotate any drift as `[expected]` or `[bug]`. File bugs as separate issues.
4. Once baseline is clean, set `SCHEMA_VERIFY_MODE=strict` in Railway env vars. Document the rollover date in the baseline doc.

## Cadence

Opening Ready. Will merge after open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016GqMSjAaG7gGDtiFSPKn5Q)_