### PR TITLE
feat: cascade dry-run mode for destructive operation preview

### DIFF
--- a/artifacts/api-server/src/routes/config.ts
+++ b/artifacts/api-server/src/routes/config.ts
@@ -28,4 +28,27 @@ router.get("/google-maps-key", requireAuth, (_req, res) => {
   return res.json({ key: process.env.GOOGLE_MAPS_API_KEY ?? "" });
 });
 
+/**
+ * GET /api/config/feature-flags
+ *
+ * Runtime feature flags for the frontend. Values come from Railway env
+ * vars so we can flip a flag without rebuilding the bundle. Auth-gated
+ * (same reasoning as google-maps-key — flags are operator-facing,
+ * exposing them to authenticated users adds no real attack surface).
+ *
+ * Add new flags here as they're introduced. Keep the response shape
+ * flat — frontend code reads `flags.<name>` with a default.
+ *
+ *   cascade_preview  — gates the EditJobModal "Preview changes" button
+ *                      that runs PATCH /api/jobs/:id with dry_run=true
+ *                      and shows the would-change counters before the
+ *                      operator commits to a real save. Default off
+ *                      (Sal flips it on when ready).
+ */
+router.get("/feature-flags", requireAuth, (_req, res) => {
+  return res.json({
+    cascade_preview: process.env.CASCADE_PREVIEW_ENABLED === "true",
+  });
+});
+
 export default router;

--- a/artifacts/api-server/src/routes/jobs.ts
+++ b/artifacts/api-server/src/routes/jobs.ts
@@ -786,6 +786,27 @@ router.patch("/:id", requireAuth, async (req, res) => {
       parking_fee_days,
     } = req.body ?? {};
 
+    // [PR / 2026-04-30] Cascade dry-run mode. Counters-only for v1
+    // (Sal Q3.1 = a). When dry_run=true, the route runs the entire
+    // cascade transaction as normal — accumulating in-tx counters
+    // (future_jobs_updated/deleted/inserted/skipped, schedule_created
+    // bool) — then ROLLS BACK at the end of the tx via a sentinel
+    // throw. The outer handler catches the sentinel and returns the
+    // counters. Production state stays untouched.
+    //
+    // The post-commit fan-out (generateJobsFromSchedule for the
+    // create_recurring path) is SKIPPED entirely under dry_run — it
+    // runs outside the tx and would persist real INSERTs that
+    // rollback can't reverse. For v1 we omit fan-out simulation; the
+    // operator can re-run without dry_run to see the real fan-out
+    // count. v2 if v1 proves insufficient.
+    //
+    // Backend dry-run is always live (any JWT can hit
+    // PATCH ?dry_run=true). Frontend "Preview changes" button is
+    // gated behind CASCADE_PREVIEW_ENABLED via /api/config/feature-
+    // flags (Sal Q3.4).
+    const dry_run = req.body?.dry_run === true;
+
     // [AI] Validate day-pattern exclusivity. Only daily/weekdays/custom_days
     // populate days_of_week; weekly/biweekly/every_3_weeks/monthly use
     // day_of_week (the schedule column) and days_of_week stays null. The
@@ -1133,6 +1154,16 @@ router.patch("/:id", requireAuth, async (req, res) => {
     // generateJobsFromSchedule which has its own dedupe + best-effort
     // semantics — must not roll back the parent edit if it hiccups).
     let createdScheduleId: number | null = null;
+
+    // [PR / 2026-04-30] Sentinel for the dry-run rollback path. Defined
+    // here so it's in scope for both the throw inside the tx callback
+    // and the catch around `await db.transaction(...)` below.
+    class DryRunRollback extends Error {
+      constructor(public summary: Record<string, unknown>) {
+        super("dry_run rollback");
+      }
+    }
+    let dryRunSummary: Record<string, unknown> | null = null;
 
     // ── Apply changes in a transaction ─────────────────────────────────────
     await db.transaction(async (tx) => {
@@ -1765,6 +1796,33 @@ router.patch("/:id", requireAuth, async (req, res) => {
       // Stash counters for the response (read after commit via closure).
       (req as any)._agFutureCount = futureCount;
       (req as any)._agFutureSkipped = futureClockedSkipped;
+
+      // [PR / 2026-04-30] Dry-run rollback. Throwing here forces
+      // Drizzle's tx wrapper to roll back every write that landed
+      // inside this callback (including the audit-log inserts above
+      // — intentional; we don't want a "real" audit row for a
+      // hypothetical edit). The outer try/catch matches on the
+      // sentinel class and returns counters to the caller.
+      if (dry_run) {
+        throw new DryRunRollback({
+          scope: cascade_scope,
+          current_job_would_update: true,
+          schedule_would_be_created: createdScheduleId != null,
+          future_jobs_would_be_updated: futureCount,
+          future_jobs_would_be_deleted: futureDeleted,
+          future_jobs_would_be_inserted_in_tx: futureInserted,
+          future_jobs_would_be_skipped_in_progress: futureClockedSkipped,
+        });
+      }
+    }).catch((err: unknown) => {
+      // [PR / 2026-04-30] Catch the dry-run sentinel here (the only
+      // expected throw). Re-throw anything else — the outer route
+      // catch handles real failures via its 500 response.
+      if (err instanceof DryRunRollback) {
+        dryRunSummary = err.summary;
+        return;
+      }
+      throw err;
     });
 
     // [recurring-on-save 2026-04-30] After-commit fan-out for the
@@ -1774,8 +1832,12 @@ router.patch("/:id", requireAuth, async (req, res) => {
     // back the parent edit (the schedule + linked job already exist;
     // the nightly 2 AM cron will catch any missed dates). Failures
     // get surfaced in the response so the operator sees them.
+    // [PR / 2026-04-30] Skip the post-commit fan-out under dry_run.
+    // generateJobsFromSchedule writes real INSERTs outside the
+    // transaction; rollback can't reverse them. v1 reports
+    // counters-only and omits the fan-out estimate (Sal Q3.1 = a).
     let createRecurringFanout: { jobs_generated: number; jobs_skipped: number; error?: string } | null = null;
-    if (createdScheduleId != null) {
+    if (createdScheduleId != null && !dry_run) {
       try {
         const { generateJobsFromSchedule, DAYS_AHEAD: HORIZON } = await import("../lib/recurring-jobs.js");
         const schedRow = await db.execute(sql`
@@ -1814,6 +1876,26 @@ router.patch("/:id", requireAuth, async (req, res) => {
           error: String(genErr?.message ?? genErr),
         };
       }
+    }
+
+    // [PR / 2026-04-30] Dry-run branch. The transaction rolled back
+    // before any writes committed, so we don't query the post-state
+    // (that's what the operator would normally see) — we return the
+    // captured summary instead. Production state is unchanged; the
+    // operator can re-run without dry_run when ready.
+    if (dry_run && dryRunSummary) {
+      const summary: Record<string, unknown> = dryRunSummary;
+      return res.json({
+        ok: true,
+        dry_run: true,
+        cascade: {
+          ...summary,
+          // Counters-only for v1 (Sal Q3.1 = a). Sample-row capture
+          // is a follow-up if v1 proves insufficient.
+          fan_out_simulated: false,
+          note: "Transaction rolled back. No production changes. Post-commit fan-out (forward 60-day inserts via generateJobsFromSchedule) NOT simulated in v1 — re-run without dry_run to see actual fan-out.",
+        },
+      });
     }
 
     // ── Build response ────────────────────────────────────────────────────

--- a/artifacts/qleno/src/components/edit-job-modal.tsx
+++ b/artifacts/qleno/src/components/edit-job-modal.tsx
@@ -279,6 +279,39 @@ export default function EditJobModal({
 
   const [saving, setSaving] = useState(false);
 
+  // [PR / 2026-04-30] Cascade dry-run preview. cascadePreviewEnabled
+  // gates the "Preview changes" button — fetched from
+  // /api/config/feature-flags on modal mount, default false. Sal
+  // flips CASCADE_PREVIEW_ENABLED=true in Railway env to expose the
+  // button. previewResult holds the dry-run counters (or null when
+  // no preview is active).
+  const [cascadePreviewEnabled, setCascadePreviewEnabled] = useState(false);
+  const [previewing, setPreviewing] = useState(false);
+  const [previewResult, setPreviewResult] = useState<Record<string, unknown> | null>(null);
+
+  // [PR / 2026-04-30] Fetch runtime feature flags once on mount.
+  // Cheap (single GET, single bool) and lets us flip
+  // CASCADE_PREVIEW_ENABLED in Railway without rebuilding the
+  // bundle. Failure-mode is silent: flag stays false, button stays
+  // hidden — same outcome as default-off.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const r = await fetch(`${API}/api/config/feature-flags`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!r.ok) return;
+        const d = await r.json();
+        if (cancelled) return;
+        setCascadePreviewEnabled(!!d?.cascade_preview);
+      } catch {
+        // Silent — flag stays default false.
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [API, token]);
+
   // [AH] Load client (resolve commercial vs residential) BEFORE scopes/addons.
   useEffect(() => {
     let cancelled = false;
@@ -626,8 +659,8 @@ export default function EditJobModal({
     submit(isFreqRecurring ? "create_recurring" : "this_job");
   }
 
-  async function submit(cascade: CascadeChoice, opts?: { force_unlock?: boolean }) {
-    setSaving(true);
+  async function submit(cascade: CascadeChoice, opts?: { force_unlock?: boolean; dry_run?: boolean }) {
+    if (opts?.dry_run) setPreviewing(true); else setSaving(true);
     try {
       // Build add-ons payload. We persist into job_add_ons via add_on_id (legacy
       // FK), but also pass pricing_addon_id for traceability per AG.
@@ -659,6 +692,12 @@ export default function EditJobModal({
         team_user_ids: selectedTechIds,
         instructions,
         cascade_scope: cascade,
+        // [PR / 2026-04-30] Dry-run flag forwarded when the operator
+        // clicked "Preview changes". Backend runs the cascade tx as
+        // normal, captures counters, then ROLLBACKs at the end of the
+        // tx. Production state stays untouched. Response shape carries
+        // `dry_run: true` and `cascade.future_jobs_would_be_*`.
+        dry_run: opts?.dry_run === true,
         // [edit-decouple 2026-04-29] When the route returned warn=true on
         // a previous attempt and the operator confirmed in the dialog,
         // we replay the request with this flag set so per-field warn
@@ -729,6 +768,15 @@ export default function EditJobModal({
         }
         return;
       }
+      // [PR / 2026-04-30] Dry-run branch: capture counters into the
+      // preview panel and return WITHOUT closing the modal — the
+      // operator reviews the projected effect, then either clicks
+      // Save changes (real commit) or Cancel preview (clear panel,
+      // continue editing). Modal stays open; nothing was persisted.
+      if (opts?.dry_run) {
+        setPreviewResult(d.cascade ?? {});
+        return;
+      }
       onSaved({
         future_jobs_updated: d.cascade?.future_jobs_updated ?? 0,
         future_jobs_skipped_in_progress: d.cascade?.future_jobs_skipped_in_progress ?? 0,
@@ -737,10 +785,10 @@ export default function EditJobModal({
       // [AI.6.2] Surface the real exception so a network/CORS/parse failure
       // doesn't silently disappear under the modal.
       console.error("[edit-job-modal] PATCH exception", err);
-      toast({ title: "Network error", description: "Could not save changes — see DevTools console", variant: "destructive" });
+      toast({ title: "Network error", description: opts?.dry_run ? "Preview failed — see DevTools console" : "Could not save changes — see DevTools console", variant: "destructive" });
     } finally {
-      setSaving(false);
-      setCascadePromptOpen(false);
+      if (opts?.dry_run) setPreviewing(false); else setSaving(false);
+      if (!opts?.dry_run) setCascadePromptOpen(false);
     }
   }
 
@@ -1267,14 +1315,57 @@ export default function EditJobModal({
           <div style={{ height: 16 }} />
         </div>
 
+        {/* [PR / 2026-04-30] Preview-result panel. Renders above the
+            footer when the operator has run a dry-run preview.
+            Counters-only for v1 — what the cascade WOULD do, broken
+            out by branch. Production state already untouched (the
+            dry_run rollback inside the PATCH route reversed any
+            writes); the panel just displays what was rolled back. */}
+        {previewResult && (
+          <div style={{ padding: "12px 20px", borderTop: "1px solid #E5E2DC", backgroundColor: "#FAFAF8", fontFamily: FF, fontSize: 13, color: "#1A1917" }}>
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 6 }}>
+              <strong style={{ fontSize: 13 }}>Preview — would change:</strong>
+              <button onClick={() => setPreviewResult(null)} style={{ fontSize: 12, color: "#6B7280", background: "none", border: "none", cursor: "pointer", fontFamily: FF }}>Clear</button>
+            </div>
+            <ul style={{ margin: 0, paddingLeft: 18, lineHeight: 1.5 }}>
+              <li>Scope: <code>{String(previewResult.scope ?? "—")}</code></li>
+              <li>Current job: {previewResult.current_job_would_update ? "update" : "no change"}</li>
+              <li>Recurring schedule: {previewResult.schedule_would_be_created ? "create new" : "no change"}</li>
+              <li>Future jobs in series — update: {String(previewResult.future_jobs_would_be_updated ?? 0)}, delete: {String(previewResult.future_jobs_would_be_deleted ?? 0)}, insert: {String(previewResult.future_jobs_would_be_inserted_in_tx ?? 0)}, skipped (clocked-in): {String(previewResult.future_jobs_would_be_skipped_in_progress ?? 0)}</li>
+              <li style={{ color: "#6B7280", fontSize: 12 }}>Forward 60-day fan-out NOT simulated in v1 — re-run without preview to see actual count.</li>
+            </ul>
+          </div>
+        )}
+
         {/* Footer */}
         <div style={{ padding: "12px 20px", borderTop: "1px solid #E5E2DC", backgroundColor: "#FFFFFF", flexShrink: 0, display: "flex", gap: 8 }}>
-          <button onClick={onClose} disabled={saving}
-            style={{ flex: 1, padding: "12px", border: "1px solid #E5E2DC", borderRadius: 10, background: "#FFFFFF", color: "#6B7280", fontSize: 14, fontWeight: 600, cursor: saving ? "wait" : "pointer", fontFamily: FF }}>
+          <button onClick={onClose} disabled={saving || previewing}
+            style={{ flex: 1, padding: "12px", border: "1px solid #E5E2DC", borderRadius: 10, background: "#FFFFFF", color: "#6B7280", fontSize: 14, fontWeight: 600, cursor: (saving || previewing) ? "wait" : "pointer", fontFamily: FF }}>
             Cancel
           </button>
-          <button onClick={onSaveClick} disabled={!canSave}
-            style={{ flex: 2, padding: "12px", border: "none", borderRadius: 10, background: canSave ? "var(--brand, #00C9A0)" : "#E5E2DC", color: canSave ? "#FFFFFF" : "#9E9B94", fontSize: 14, fontWeight: 700, cursor: canSave ? "pointer" : "not-allowed", fontFamily: FF }}>
+          {/* [PR / 2026-04-30] Preview Changes button. Gated behind
+              CASCADE_PREVIEW_ENABLED env var via /api/config/feature-
+              flags. When clicked, fires PATCH with dry_run: true; the
+              backend runs the cascade tx and rolls back, returning
+              counters. Result lands in the preview panel above. */}
+          {cascadePreviewEnabled && (
+            <button
+              onClick={() => {
+                setPreviewResult(null);
+                if (!canSave) return;
+                const isFreqRecurring = !!frequency && frequency !== "on_demand";
+                const previewScope: CascadeChoice = isRecurring
+                  ? "this_and_future"
+                  : (isFreqRecurring ? "create_recurring" : "this_job");
+                submit(previewScope, { dry_run: true });
+              }}
+              disabled={!canSave || previewing || saving}
+              style={{ flex: 1, padding: "12px", border: "1px solid #E5E2DC", borderRadius: 10, background: "#FFFFFF", color: canSave ? "#1A1917" : "#9E9B94", fontSize: 14, fontWeight: 600, cursor: (canSave && !previewing && !saving) ? "pointer" : "not-allowed", fontFamily: FF }}>
+              {previewing ? "Previewing…" : "Preview changes"}
+            </button>
+          )}
+          <button onClick={onSaveClick} disabled={!canSave || previewing}
+            style={{ flex: 2, padding: "12px", border: "none", borderRadius: 10, background: (canSave && !previewing) ? "var(--brand, #00C9A0)" : "#E5E2DC", color: (canSave && !previewing) ? "#FFFFFF" : "#9E9B94", fontSize: 14, fontWeight: 700, cursor: (canSave && !previewing) ? "pointer" : "not-allowed", fontFamily: FF }}>
             {saving ? "Saving…" : "Save changes"}
           </button>
         </div>


### PR DESCRIPTION
## What

Operational hardening — protect against destructive cascade bugs (PR #25-style array-binding crash, future scope-misclassification bugs) by giving operators a way to see what a cascade WOULD do before committing to a real save.

Three additive changes, no schema, no breaking API contract.

## Q&A recap

- **Q3.1 = (a)**: Counters-only for v1. Per-row sample changes deferred.
- **Q3.2**: Drop `/admin/cascade-dry-run`. PATCH with `dry_run: true` is the one path.
- **Q3.3**: Confirmed write-then-rollback is acceptable. Operator-initiated, brief, fine at our scale.
- **Q3.4**: Confirmed. Backend always live, frontend gated by `CASCADE_PREVIEW_ENABLED`.

## Diff

```
artifacts/api-server/src/routes/config.ts          |  23 +++++ (new endpoint)
artifacts/api-server/src/routes/jobs.ts            |  84 ++++++/- (dry_run plumbing)
artifacts/qleno/src/components/edit-job-modal.tsx  | 109 +++++/- (Preview button + panel)
3 files changed, 206 insertions(+), 10 deletions(-)
```

Net 196 lines. Within infra-PR envelope.

## File-by-file

### `routes/config.ts` — new GET `/api/config/feature-flags`

Auth-gated runtime flag endpoint. Exposes:

```json
{ "cascade_preview": true | false }
```

Backed by `process.env.CASCADE_PREVIEW_ENABLED === "true"`. Default off. Generic shape — future flags add sibling fields; one endpoint for all flags, not one per flag, to keep API surface tight.

### `routes/jobs.ts` PATCH `/:id` — `dry_run: true` body flag

When set:

1. The route runs the full cascade transaction as normal, accumulating in-tx counters: `future_jobs_would_be_updated`, `future_jobs_would_be_deleted`, `future_jobs_would_be_inserted_in_tx`, `future_jobs_would_be_skipped_in_progress`, plus `schedule_would_be_created` for the `create_recurring` path.
2. At the **end** of the tx callback, throws a `DryRunRollback` sentinel. Drizzle's tx wrapper catches → rolls back ALL writes (including audit-log inserts — intentional; no real audit row for a hypothetical edit).
3. The `.catch()` chain on the tx call traps the sentinel, stashes the summary in a closure var. The post-commit fan-out (`generateJobsFromSchedule` for `create_recurring`) is **skipped entirely** — it writes outside the tx and rollback can't reverse those.
4. Branches the response: dry-run returns `{ ok, dry_run: true, cascade: {...counters, fan_out_simulated: false, note: "..."} }`. Production state untouched.

**Implementation note**: chose `.catch()` chain over `try { await db.transaction(...) }` wrapping to avoid re-indenting ~600 lines of existing tx callback body.

Backend dry-run is always live — any JWT can hit `PATCH ?dry_run=true`. The DevTools test path Sal asked for (Q3.2) lands here without a separate `/admin/` endpoint.

### `edit-job-modal.tsx` — Preview Changes button + result panel

- On modal mount: fetch `/api/config/feature-flags`. Set `cascadePreviewEnabled` state. Silent failure → flag stays false, button hidden.
- New `Preview changes` button in footer (gated). Click fires `submit(scope, { dry_run: true })` — same code path as a real save, just with the flag.
- New inline result panel above footer when `previewResult` is set:

```
Preview — would change:                                [Clear]
• Scope: this_and_future
• Current job: update
• Recurring schedule: no change
• Future jobs in series — update: 4, delete: 0,
  insert: 0, skipped (clocked-in): 0
  Forward 60-day fan-out NOT simulated in v1 —
  re-run without preview to see actual count.
```

Operator clicks "Clear" to dismiss + continue editing, or "Save changes" to commit for real. Modal stays open during preview.

## Verification

Code-only per standing cadence:

- `pnpm run typecheck`: net-zero new errors in `jobs.ts` (54 pre, 54 post), 0 in `config.ts`, 0 in `edit-job-modal.tsx`
- Frontend `pnpm run build`: clean, 288.60 kB main bundle (effectively identical — preview UI is small + conditional)
- API-server `pnpm run build`: clean, 3.0mb `dist/index.mjs`

## Sal action items post-deploy

1. **Smoke-test the backend without flipping the flag**: in DevTools, hit `PATCH /api/jobs/4147` with `dry_run: true` and the same body you'd normally send. Verify the response includes `dry_run: true` + counters, AND that no DB writes landed (re-run the dispatch query to confirm Tue–Fri jobs untouched).
2. **When ready to expose the UI**: set `CASCADE_PREVIEW_ENABLED=true` in Railway env vars. Reload the dispatch board; modal opens with the Preview button visible.
3. **First real-world preview**: open Edit Job on any recurring commercial job, change one field, click Preview. Confirm counters match intuition. Click Save (or Clear).

## Out of scope (filed as v2 if v1 proves insufficient)

- Per-row sample changes (Q3.1 deferred). v1 reports counters; v2 captures `would_update: [{table, sample_changes}]` etc.
- Forward 60-day fan-out simulation. Would require re-implementing `generateJobsFromSchedule` as a dry-run-aware function (or wrapping its writes in the same tx + sentinel pattern). Defer until operator says counters aren't enough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016GqMSjAaG7gGDtiFSPKn5Q)_