### PR TITLE
fix: cascade_scope=this_and_future on completed anchor returns 200

### DIFF
--- a/artifacts/api-server/src/routes/jobs.ts
+++ b/artifacts/api-server/src/routes/jobs.ts
@@ -899,27 +899,57 @@ router.patch("/:id", requireAuth, async (req, res) => {
       });
     }
 
-    if (isCompleted) {
-      // Hard locks on completed jobs.
+    // [PR / 2026-04-30] Cascade-scope-aware completed-job lock.
+    //
+    // The legacy hard-lock returned 409 when an operator tried to
+    // change frequency / service_type / price on a completed job —
+    // regardless of cascade_scope. That conflated two intents:
+    //   (1) "edit this completed job's fields"   (cascade_scope=this_job)
+    //   (2) "edit the schedule TEMPLATE via this completed job as
+    //        the anchor; future jobs should inherit, this one stays
+    //        as-is in the audit trail" (cascade_scope=this_and_future)
+    //
+    // (2) is a real workflow — most common trigger: client completes
+    // Monday, calls Tuesday morning to change the schedule going
+    // forward. Operator opens Monday (the only edit surface they have
+    // for this client's schedule), changes frequency, picks
+    // 'this and all future'. Pre-fix this 409'd. Post-fix the route
+    // strips the locked fields from the anchor's `setParts` UPDATE
+    // (audit record stays clean) but proceeds with the schedule-
+    // template UPDATE + future-jobs cascade.
+    const cascadesToTemplate = cascade_scope === "this_and_future" || cascade_scope === "all";
+    const skipAnchorLockedFields = isCompleted && cascadesToTemplate;
+
+    if (isCompleted && !cascadesToTemplate) {
+      // Editing only this completed job — hard-lock service_type /
+      // frequency. Changing them rewrites commission routing and
+      // recurrence semantics on already-billed work. Operator must
+      // void-and-rebook for those.
       if (service_type !== undefined && service_type !== before.service_type) {
         return res.status(409).json({
           error: "Field locked",
           field: "service_type",
-          message: "Service type can't change on a completed job. Cancel and re-book if the wrong type was billed.",
+          message: "Service type can't change on a completed job. Cancel and re-book if the wrong type was billed, or use 'This and all future' to update the schedule template.",
         });
       }
       if (frequency !== undefined && frequency !== before.frequency) {
         return res.status(409).json({
           error: "Field locked",
           field: "frequency",
-          message: "Frequency can't change on a completed job. Cancel and re-book if the recurrence was wrong.",
+          message: "Frequency can't change on a completed job. Cancel and re-book if the recurrence was wrong, or use 'This and all future' to update the schedule template.",
         });
       }
+    }
+    if (isCompleted) {
       // Warn-locked: pricing on completed jobs. Hard-locked when paid.
+      // For cascadesToTemplate: skip the warn/hard-lock entirely. The
+      // price change applies to the schedule template + future jobs;
+      // the anchor's `jobs.base_fee` / `jobs.hourly_rate` stay frozen
+      // (stripped from setParts below).
       const priceChanged =
         (base_fee !== undefined && String(base_fee) !== String(before.base_fee ?? "")) ||
         (hourly_rate !== undefined && String(hourly_rate ?? "") !== String(before.hourly_rate ?? ""));
-      if (priceChanged) {
+      if (priceChanged && !cascadesToTemplate) {
         if (isPaid) {
           return res.status(409).json({
             error: "Field locked",
@@ -1178,6 +1208,24 @@ router.patch("/:id", requireAuth, async (req, res) => {
       if (hourly_rate !== undefined) setParts.hourly_rate = hourly_rate === null ? null : String(hourly_rate);
       if (nextManualOverride !== undefined) setParts.manual_rate_override = nextManualOverride;
       if (instructions !== undefined) setParts.notes = instructions;
+
+      // [PR / 2026-04-30] When the anchor is a completed job AND the
+      // operator picked a cascade scope that propagates to the
+      // schedule template + future jobs, strip the lock-protected
+      // fields from setParts. The schedule UPDATE + future-jobs
+      // cascade further down apply the changes to the right rows;
+      // the anchor's `jobs` row keeps its original frequency /
+      // service_type / base_fee / hourly_rate as part of the
+      // completed-work audit trail.
+      const anchorSkippedFields: string[] = [];
+      if (skipAnchorLockedFields) {
+        if ("frequency" in setParts) { delete setParts.frequency; anchorSkippedFields.push("frequency"); }
+        if ("service_type" in setParts) { delete setParts.service_type; anchorSkippedFields.push("service_type"); }
+        if ("base_fee" in setParts) { delete setParts.base_fee; anchorSkippedFields.push("base_fee"); }
+        if ("hourly_rate" in setParts) { delete setParts.hourly_rate; anchorSkippedFields.push("hourly_rate"); }
+      }
+      // Stash for the response (read after commit via closure).
+      (req as any)._anchorSkippedFields = anchorSkippedFields;
 
       // [recurring-on-save 2026-04-30] create_recurring branch — INSERT
       // the new recurring_schedules row, anchored to the current job's
@@ -1537,6 +1585,11 @@ router.patch("/:id", requireAuth, async (req, res) => {
           const setClauses = rsSet.map((c, i) => sql`${sql.identifier(c)} = ${rsVals[i]}`);
           const setSql = sql.join(setClauses, sql`, `);
           await tx.execute(sql`UPDATE recurring_schedules SET ${setSql} WHERE id = ${scheduleId} AND company_id = ${companyId}`);
+          // [PR / 2026-04-30] Surface "schedule was touched" so the
+          // response can render an honest summary ("Schedule updated.
+          // 4 future jobs reflect new times.") rather than the
+          // generic save-confirmation toast.
+          (req as any)._scheduleUpdated = true;
         }
 
         // ── Future-jobs cascade: branch by whether day pattern changed ────
@@ -1922,6 +1975,18 @@ router.patch("/:id", requireAuth, async (req, res) => {
         // result (created / skipped / optional error).
         created_schedule_id: createdScheduleId,
         create_recurring: createRecurringFanout,
+        // [PR / 2026-04-30] Anchor-protection signals for the modal's
+        // success banner. anchor_protected=true means the operator
+        // edited a completed job with cascade_scope=this_and_future|all
+        // and the route stripped lock-protected fields from the
+        // anchor's `setParts` UPDATE. anchor_skipped_fields lists
+        // exactly which fields were stripped — modal shows them in
+        // the success summary so the operator sees what stayed
+        // frozen. schedule_updated=true means the recurring_schedules
+        // template row was UPDATEd in the cascade block.
+        anchor_protected: ((req as any)._anchorSkippedFields ?? []).length > 0,
+        anchor_skipped_fields: (req as any)._anchorSkippedFields ?? [],
+        schedule_updated: !!(req as any)._scheduleUpdated,
       },
     });
   } catch (err: any) {

--- a/artifacts/qleno/src/components/edit-job-modal.tsx
+++ b/artifacts/qleno/src/components/edit-job-modal.tsx
@@ -331,6 +331,15 @@ export default function EditJobModal({
 
   const [saving, setSaving] = useState(false);
 
+  // [PR / 2026-04-30] Persistent in-modal banner for the last save
+  // error. Toast machinery is fleeting + easy to miss when the
+  // operator's eye is on the cascade prompt. Banner sits above the
+  // footer until the next save attempt clears it. Banner copy =
+  // verbatim API error message (so the operator distinguishes
+  // field-lock vs network vs validation), not a generic "save
+  // failed" — no information loss.
+  const [lastSaveError, setLastSaveError] = useState<{ title: string; message: string } | null>(null);
+
   // [PR / 2026-04-30] Cascade dry-run preview. cascadePreviewEnabled
   // gates the "Preview changes" button — fetched from
   // /api/config/feature-flags on modal mount, default false. Sal
@@ -800,6 +809,9 @@ export default function EditJobModal({
 
   async function submit(cascade: CascadeChoice, opts?: { force_unlock?: boolean; dry_run?: boolean }) {
     if (opts?.dry_run) setPreviewing(true); else setSaving(true);
+    // [PR / 2026-04-30] Clear stale error banner at the start of
+    // every save attempt so retries don't show outdated messages.
+    setLastSaveError(null);
     try {
       // Build add-ons payload. We persist into job_add_ons via add_on_id (legacy
       // FK), but also pass pricing_addon_id for traceability per AG.
@@ -900,10 +912,16 @@ export default function EditJobModal({
         if (r.status === 409 && d.warn === true) {
           setWarnPrompt({ message: d.message || "This change requires confirmation.", field: d.field });
           setCascadePromptOpen(false);
-        } else if (r.status === 409) {
-          toast({ title: "Cannot edit", description: d.message || "Job is locked or a tech is clocked in.", variant: "destructive" });
         } else {
-          toast({ title: "Save failed", description: d.message || d.error || `HTTP ${r.status}`, variant: "destructive" });
+          // [PR / 2026-04-30] Persistent in-modal banner. Mirrors
+          // the toast (transient confirmation) but stays put until
+          // the operator's next save attempt clears it. Verbatim
+          // API message — no information loss between "field locked"
+          // and "tech clocked in" and "validation failed".
+          const apiMessage = d.message || d.error || `HTTP ${r.status}`;
+          const title = r.status === 409 ? "Cannot edit" : "Save failed";
+          setLastSaveError({ title, message: apiMessage });
+          toast({ title, description: apiMessage, variant: "destructive" });
         }
         return;
       }
@@ -916,15 +934,42 @@ export default function EditJobModal({
         setPreviewResult(d.cascade ?? {});
         return;
       }
+      // [PR / 2026-04-30] Compose an honest success summary from the
+      // route's response. Examples:
+      //   "Schedule updated. 4 future jobs reflect new times."
+      //   "Schedule updated. 4 future jobs reflect new times.
+      //    Monday's completed job is unchanged (frequency, base_fee
+      //    stayed frozen)."
+      // The anchor_protected piece only renders when the route
+      // stripped lock-protected fields from the anchor's setParts
+      // (completed-anchor + cascadesToTemplate). Everything else
+      // gets the simpler version.
+      const summaryParts: string[] = [];
+      if (d.cascade?.schedule_updated) summaryParts.push("Schedule updated.");
+      const futureN = Number(d.cascade?.future_jobs_updated ?? 0);
+      if (futureN > 0) summaryParts.push(`${futureN} future job${futureN === 1 ? "" : "s"} reflect new times.`);
+      if (d.cascade?.anchor_protected) {
+        const fields: string[] = Array.isArray(d.cascade?.anchor_skipped_fields) ? d.cascade.anchor_skipped_fields : [];
+        const fieldList = fields.length > 0 ? ` (${fields.join(", ")} stayed frozen)` : "";
+        summaryParts.push(`This visit is unchanged${fieldList}.`);
+      }
+      if (summaryParts.length > 0) {
+        toast({ title: "Saved", description: summaryParts.join(" ") });
+      }
       onSaved({
-        future_jobs_updated: d.cascade?.future_jobs_updated ?? 0,
+        future_jobs_updated: futureN,
         future_jobs_skipped_in_progress: d.cascade?.future_jobs_skipped_in_progress ?? 0,
       });
     } catch (err) {
       // [AI.6.2] Surface the real exception so a network/CORS/parse failure
       // doesn't silently disappear under the modal.
       console.error("[edit-job-modal] PATCH exception", err);
-      toast({ title: "Network error", description: opts?.dry_run ? "Preview failed — see DevTools console" : "Could not save changes — see DevTools console", variant: "destructive" });
+      const networkMsg = opts?.dry_run ? "Preview failed — see DevTools console" : "Could not save changes — see DevTools console";
+      // [PR / 2026-04-30] Pin a network-error banner the same way as
+      // an HTTP error — same persistence semantics so an operator
+      // who wandered off doesn't miss the failure.
+      if (!opts?.dry_run) setLastSaveError({ title: "Network error", message: networkMsg });
+      toast({ title: "Network error", description: networkMsg, variant: "destructive" });
     } finally {
       if (opts?.dry_run) setPreviewing(false); else setSaving(false);
       if (!opts?.dry_run) {
@@ -1476,6 +1521,26 @@ export default function EditJobModal({
               <li>Future jobs in series — update: {String(previewResult.future_jobs_would_be_updated ?? 0)}, delete: {String(previewResult.future_jobs_would_be_deleted ?? 0)}, insert: {String(previewResult.future_jobs_would_be_inserted_in_tx ?? 0)}, skipped (clocked-in): {String(previewResult.future_jobs_would_be_skipped_in_progress ?? 0)}</li>
               <li style={{ color: "#6B7280", fontSize: 12 }}>Forward 60-day fan-out NOT simulated in v1 — re-run without preview to see actual count.</li>
             </ul>
+          </div>
+        )}
+
+        {/* [PR / 2026-04-30] Persistent error banner. Sits above the
+            footer until the operator's next save attempt clears it
+            (submit() → setLastSaveError(null) at start). Pulls the
+            verbatim API message — distinguishes field-lock vs
+            network vs validation without flattening to "save
+            failed". Toast still fires on the same event for
+            transient confirmation; the banner is the persistent
+            audit trail of the failure. */}
+        {lastSaveError && (
+          <div style={{ padding: "12px 20px", borderTop: "1px solid #FECACA", backgroundColor: "#FEF2F2", fontFamily: FF, fontSize: 13, color: "#991B1B" }}>
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 12 }}>
+              <div style={{ flex: 1 }}>
+                <div style={{ fontWeight: 700, marginBottom: 2 }}>{lastSaveError.title}</div>
+                <div style={{ lineHeight: 1.4 }}>{lastSaveError.message}</div>
+              </div>
+              <button onClick={() => setLastSaveError(null)} style={{ fontSize: 12, color: "#991B1B", background: "none", border: "none", cursor: "pointer", fontFamily: FF, padding: 0 }}>Dismiss</button>
+            </div>
           </div>
         )}
 


### PR DESCRIPTION
## Bug

Sal's "client completes Monday's job + pays, calls Tuesday morning to change schedule going forward" workflow was failing silently in EditJobModal. Operator opens Mon Apr 27 (`status='complete'`, `charge_succeeded_at != null`), changes frequency to weekdays, picks "this and all future", clicks Save — cascade prompt closes, no visible change. The route was returning 409 ("Frequency can't change on a completed job") and the toast was firing too transient/too far from the picker for the operator to catch.

## Root cause

`routes/jobs.ts:902-917` hard-locks `frequency` / `service_type` changes on completed jobs and returns 409 **before the cascade block runs** — regardless of `cascade_scope`. The lock conflates two distinct intents the operator picks between via the cascade picker:

- **`cascade_scope='this_job'`** — "edit this completed job's fields." Legitimate guardrail; 409 stays.
- **`cascade_scope='this_and_future'` / `'all'`** — "edit the schedule TEMPLATE via this completed job as anchor; future jobs inherit, this one stays as-is." 409 here blocks the schedule-template UPDATE + future-jobs cascade from running. Both would have correctly excluded the anchor anyway (the existing future-jobs query already filters `j.id != ${jobId}`).

**Note: PR #27 is NOT on main.** The hypotheses about an overwrite loop / anchor-skip rule don't apply; the bug is older and simpler. Per agreed sequence: merge this fix → Sal verifies → merge PR #27 → Sal verifies Tue-Fri overwrite.

## Fix

### Backend (`routes/jobs.ts`, +60 lines)

- Compute `cascadesToTemplate = cascade_scope === "this_and_future" || cascade_scope === "all"` and `skipAnchorLockedFields = isCompleted && cascadesToTemplate`.
- Hard-lock 409 for `service_type` / `frequency` now only fires when `isCompleted && !cascadesToTemplate`. Error message extended: "...or use 'This and all future' to update the schedule template."
- Price warn-lock + paid hard-lock same gating.
- Inside the transaction, when `skipAnchorLockedFields`, strip `frequency` / `service_type` / `base_fee` / `hourly_rate` from `setParts` **before** the anchor `UPDATE jobs` runs. Schedule-template UPDATE + future-jobs cascade still apply the changes to the right rows.
- Stash `anchor_skipped_fields[]` on `req` for the response.
- Stash `schedule_updated=true` when `UPDATE recurring_schedules` actually fires.
- Response `cascade` adds:
  ```
  anchor_protected: boolean
  anchor_skipped_fields: string[]
  schedule_updated: boolean
  ```

### Frontend (`edit-job-modal.tsx`, +60 lines)

- New `lastSaveError = { title; message } | null` state.
- `submit()` clears at start — retries don't show stale messages.
- On non-2xx (any 409 that isn't `warn=true`, plus 4xx/5xx general): set `lastSaveError` to `{ title: "Cannot edit" | "Save failed", message: <verbatim API message> }`. Toast still fires for transient confirmation.
- On network exception: set `lastSaveError` too — same persistence.
- New persistent **red banner above the footer** renders `lastSaveError` with a Dismiss button. Verbatim API copy — no generic "save failed", operator sees field-lock vs network vs validation without information loss.
- On success: compose summary toast from `cascade` response —
  > "Schedule updated. 4 future jobs reflect new times. This visit is unchanged (frequency, base_fee stayed frozen)."

  The anchor-protected sentence only renders when the route stripped fields.

## Diff

```
artifacts/api-server/src/routes/jobs.ts           | 75 +++/-
artifacts/qleno/src/components/edit-job-modal.tsx | 75 +++/-
2 files changed, 140 insertions(+), 10 deletions(-)
```

Net 130 lines, mostly comments + the new banner JSX.

## Self-verify (code-only)

- `pnpm tsc --noEmit`: net-zero new errors in `jobs.ts` (54 pre, 54 post) + 0 in `edit-job-modal.tsx`
- `pnpm run build` (frontend): clean, 288.60 kB main bundle (effectively identical — additions are conditional + comment-heavy)

## Sal post-deploy curl repro

```bash
curl -X PATCH https://workspaceapi-server-production-b9d4.up.railway.app/api/jobs/4147 \
  -H "Authorization: Bearer <jwt>" \
  -H "Content-Type: application/json" \
  -d '{
    "frequency": "weekdays",
    "days_of_week": [1,2,3,4,5],
    "scheduled_time": "08:00",
    "duration_minutes": 360,
    "service_type": "commercial_cleaning",
    "base_fee": 320,
    "commercial_hourly_rate": 50,
    "parking_fee_enabled": true,
    "parking_fee_amount": 20,
    "parking_fee_days": [1,2,3,4,5],
    "cascade_scope": "this_and_future"
  }'
```

Expect:
- HTTP 200
- `response.cascade.anchor_protected === true`
- `response.cascade.anchor_skipped_fields` includes `frequency` (and likely `base_fee` / `hourly_rate` / `service_type` if those changed too)
- `response.cascade.schedule_updated === true`
- `response.cascade.future_jobs_updated` ≥ 4

DB sanity:
```sql
SELECT id, frequency, days_of_week FROM recurring_schedules WHERE id = 88;
-- expect: frequency='weekdays', days_of_week={1,2,3,4,5}

SELECT id, frequency, service_type, base_fee FROM jobs WHERE id = 4147;
-- expect: anchor unchanged from pre-PATCH state (audit trail preserved)

SELECT id, scheduled_date, frequency FROM jobs
WHERE client_id = 21 AND scheduled_date BETWEEN '2026-04-28' AND '2026-05-01';
-- expect: frequency='weekdays' on Tue/Wed/Thu/Fri (template field cascade
-- via existing PR #25 future-jobs cascade block).
```

**Note:** Tue-Fri jobs' service_type / scheduled_time / base_fee will only fully UPDATE in place after **PR #27** merges (the cascade-overwrite-in-place + dispatch JOIN PR). This fix unblocks the 409; PR #27 finishes the picture.

## Cadence

Opening Ready with auto-merge attempt. Will fall back to manual merge per the standing "no CI = clean" issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016GqMSjAaG7gGDtiFSPKn5Q)_