### PR TITLE
revert: PR #34 (production-down triage)

### DIFF
--- a/artifacts/api-server/src/routes/jobs.ts
+++ b/artifacts/api-server/src/routes/jobs.ts
@@ -899,57 +899,27 @@ router.patch("/:id", requireAuth, async (req, res) => {
       });
     }
 
-    // [PR / 2026-04-30] Cascade-scope-aware completed-job lock.
-    //
-    // The legacy hard-lock returned 409 when an operator tried to
-    // change frequency / service_type / price on a completed job —
-    // regardless of cascade_scope. That conflated two intents:
-    //   (1) "edit this completed job's fields"   (cascade_scope=this_job)
-    //   (2) "edit the schedule TEMPLATE via this completed job as
-    //        the anchor; future jobs should inherit, this one stays
-    //        as-is in the audit trail" (cascade_scope=this_and_future)
-    //
-    // (2) is a real workflow — most common trigger: client completes
-    // Monday, calls Tuesday morning to change the schedule going
-    // forward. Operator opens Monday (the only edit surface they have
-    // for this client's schedule), changes frequency, picks
-    // 'this and all future'. Pre-fix this 409'd. Post-fix the route
-    // strips the locked fields from the anchor's `setParts` UPDATE
-    // (audit record stays clean) but proceeds with the schedule-
-    // template UPDATE + future-jobs cascade.
-    const cascadesToTemplate = cascade_scope === "this_and_future" || cascade_scope === "all";
-    const skipAnchorLockedFields = isCompleted && cascadesToTemplate;
-
-    if (isCompleted && !cascadesToTemplate) {
-      // Editing only this completed job — hard-lock service_type /
-      // frequency. Changing them rewrites commission routing and
-      // recurrence semantics on already-billed work. Operator must
-      // void-and-rebook for those.
+    if (isCompleted) {
+      // Hard locks on completed jobs.
       if (service_type !== undefined && service_type !== before.service_type) {
         return res.status(409).json({
           error: "Field locked",
           field: "service_type",
-          message: "Service type can't change on a completed job. Cancel and re-book if the wrong type was billed, or use 'This and all future' to update the schedule template.",
+          message: "Service type can't change on a completed job. Cancel and re-book if the wrong type was billed.",
         });
       }
       if (frequency !== undefined && frequency !== before.frequency) {
         return res.status(409).json({
           error: "Field locked",
           field: "frequency",
-          message: "Frequency can't change on a completed job. Cancel and re-book if the recurrence was wrong, or use 'This and all future' to update the schedule template.",
+          message: "Frequency can't change on a completed job. Cancel and re-book if the recurrence was wrong.",
         });
       }
-    }
-    if (isCompleted) {
       // Warn-locked: pricing on completed jobs. Hard-locked when paid.
-      // For cascadesToTemplate: skip the warn/hard-lock entirely. The
-      // price change applies to the schedule template + future jobs;
-      // the anchor's `jobs.base_fee` / `jobs.hourly_rate` stay frozen
-      // (stripped from setParts below).
       const priceChanged =
         (base_fee !== undefined && String(base_fee) !== String(before.base_fee ?? "")) ||
         (hourly_rate !== undefined && String(hourly_rate ?? "") !== String(before.hourly_rate ?? ""));
-      if (priceChanged && !cascadesToTemplate) {
+      if (priceChanged) {
         if (isPaid) {
           return res.status(409).json({
             error: "Field locked",
@@ -1208,24 +1178,6 @@ router.patch("/:id", requireAuth, async (req, res) => {
       if (hourly_rate !== undefined) setParts.hourly_rate = hourly_rate === null ? null : String(hourly_rate);
       if (nextManualOverride !== undefined) setParts.manual_rate_override = nextManualOverride;
       if (instructions !== undefined) setParts.notes = instructions;
-
-      // [PR / 2026-04-30] When the anchor is a completed job AND the
-      // operator picked a cascade scope that propagates to the
-      // schedule template + future jobs, strip the lock-protected
-      // fields from setParts. The schedule UPDATE + future-jobs
-      // cascade further down apply the changes to the right rows;
-      // the anchor's `jobs` row keeps its original frequency /
-      // service_type / base_fee / hourly_rate as part of the
-      // completed-work audit trail.
-      const anchorSkippedFields: string[] = [];
-      if (skipAnchorLockedFields) {
-        if ("frequency" in setParts) { delete setParts.frequency; anchorSkippedFields.push("frequency"); }
-        if ("service_type" in setParts) { delete setParts.service_type; anchorSkippedFields.push("service_type"); }
-        if ("base_fee" in setParts) { delete setParts.base_fee; anchorSkippedFields.push("base_fee"); }
-        if ("hourly_rate" in setParts) { delete setParts.hourly_rate; anchorSkippedFields.push("hourly_rate"); }
-      }
-      // Stash for the response (read after commit via closure).
-      (req as any)._anchorSkippedFields = anchorSkippedFields;
 
       // [recurring-on-save 2026-04-30] create_recurring branch — INSERT
       // the new recurring_schedules row, anchored to the current job's
@@ -1585,11 +1537,6 @@ router.patch("/:id", requireAuth, async (req, res) => {
           const setClauses = rsSet.map((c, i) => sql`${sql.identifier(c)} = ${rsVals[i]}`);
           const setSql = sql.join(setClauses, sql`, `);
           await tx.execute(sql`UPDATE recurring_schedules SET ${setSql} WHERE id = ${scheduleId} AND company_id = ${companyId}`);
-          // [PR / 2026-04-30] Surface "schedule was touched" so the
-          // response can render an honest summary ("Schedule updated.
-          // 4 future jobs reflect new times.") rather than the
-          // generic save-confirmation toast.
-          (req as any)._scheduleUpdated = true;
         }
 
         // ── Future-jobs cascade: branch by whether day pattern changed ────
@@ -1975,18 +1922,6 @@ router.patch("/:id", requireAuth, async (req, res) => {
         // result (created / skipped / optional error).
         created_schedule_id: createdScheduleId,
         create_recurring: createRecurringFanout,
-        // [PR / 2026-04-30] Anchor-protection signals for the modal's
-        // success banner. anchor_protected=true means the operator
-        // edited a completed job with cascade_scope=this_and_future|all
-        // and the route stripped lock-protected fields from the
-        // anchor's `setParts` UPDATE. anchor_skipped_fields lists
-        // exactly which fields were stripped — modal shows them in
-        // the success summary so the operator sees what stayed
-        // frozen. schedule_updated=true means the recurring_schedules
-        // template row was UPDATEd in the cascade block.
-        anchor_protected: ((req as any)._anchorSkippedFields ?? []).length > 0,
-        anchor_skipped_fields: (req as any)._anchorSkippedFields ?? [],
-        schedule_updated: !!(req as any)._scheduleUpdated,
       },
     });
   } catch (err: any) {

--- a/artifacts/qleno/src/components/edit-job-modal.tsx
+++ b/artifacts/qleno/src/components/edit-job-modal.tsx
@@ -331,15 +331,6 @@ export default function EditJobModal({
 
   const [saving, setSaving] = useState(false);
 
-  // [PR / 2026-04-30] Persistent in-modal banner for the last save
-  // error. Toast machinery is fleeting + easy to miss when the
-  // operator's eye is on the cascade prompt. Banner sits above the
-  // footer until the next save attempt clears it. Banner copy =
-  // verbatim API error message (so the operator distinguishes
-  // field-lock vs network vs validation), not a generic "save
-  // failed" — no information loss.
-  const [lastSaveError, setLastSaveError] = useState<{ title: string; message: string } | null>(null);
-
   // [PR / 2026-04-30] Cascade dry-run preview. cascadePreviewEnabled
   // gates the "Preview changes" button — fetched from
   // /api/config/feature-flags on modal mount, default false. Sal
@@ -809,9 +800,6 @@ export default function EditJobModal({
 
   async function submit(cascade: CascadeChoice, opts?: { force_unlock?: boolean; dry_run?: boolean }) {
     if (opts?.dry_run) setPreviewing(true); else setSaving(true);
-    // [PR / 2026-04-30] Clear stale error banner at the start of
-    // every save attempt so retries don't show outdated messages.
-    setLastSaveError(null);
     try {
       // Build add-ons payload. We persist into job_add_ons via add_on_id (legacy
       // FK), but also pass pricing_addon_id for traceability per AG.
@@ -912,16 +900,10 @@ export default function EditJobModal({
         if (r.status === 409 && d.warn === true) {
           setWarnPrompt({ message: d.message || "This change requires confirmation.", field: d.field });
           setCascadePromptOpen(false);
+        } else if (r.status === 409) {
+          toast({ title: "Cannot edit", description: d.message || "Job is locked or a tech is clocked in.", variant: "destructive" });
         } else {
-          // [PR / 2026-04-30] Persistent in-modal banner. Mirrors
-          // the toast (transient confirmation) but stays put until
-          // the operator's next save attempt clears it. Verbatim
-          // API message — no information loss between "field locked"
-          // and "tech clocked in" and "validation failed".
-          const apiMessage = d.message || d.error || `HTTP ${r.status}`;
-          const title = r.status === 409 ? "Cannot edit" : "Save failed";
-          setLastSaveError({ title, message: apiMessage });
-          toast({ title, description: apiMessage, variant: "destructive" });
+          toast({ title: "Save failed", description: d.message || d.error || `HTTP ${r.status}`, variant: "destructive" });
         }
         return;
       }
@@ -934,42 +916,15 @@ export default function EditJobModal({
         setPreviewResult(d.cascade ?? {});
         return;
       }
-      // [PR / 2026-04-30] Compose an honest success summary from the
-      // route's response. Examples:
-      //   "Schedule updated. 4 future jobs reflect new times."
-      //   "Schedule updated. 4 future jobs reflect new times.
-      //    Monday's completed job is unchanged (frequency, base_fee
-      //    stayed frozen)."
-      // The anchor_protected piece only renders when the route
-      // stripped lock-protected fields from the anchor's setParts
-      // (completed-anchor + cascadesToTemplate). Everything else
-      // gets the simpler version.
-      const summaryParts: string[] = [];
-      if (d.cascade?.schedule_updated) summaryParts.push("Schedule updated.");
-      const futureN = Number(d.cascade?.future_jobs_updated ?? 0);
-      if (futureN > 0) summaryParts.push(`${futureN} future job${futureN === 1 ? "" : "s"} reflect new times.`);
-      if (d.cascade?.anchor_protected) {
-        const fields: string[] = Array.isArray(d.cascade?.anchor_skipped_fields) ? d.cascade.anchor_skipped_fields : [];
-        const fieldList = fields.length > 0 ? ` (${fields.join(", ")} stayed frozen)` : "";
-        summaryParts.push(`This visit is unchanged${fieldList}.`);
-      }
-      if (summaryParts.length > 0) {
-        toast({ title: "Saved", description: summaryParts.join(" ") });
-      }
       onSaved({
-        future_jobs_updated: futureN,
+        future_jobs_updated: d.cascade?.future_jobs_updated ?? 0,
         future_jobs_skipped_in_progress: d.cascade?.future_jobs_skipped_in_progress ?? 0,
       });
     } catch (err) {
       // [AI.6.2] Surface the real exception so a network/CORS/parse failure
       // doesn't silently disappear under the modal.
       console.error("[edit-job-modal] PATCH exception", err);
-      const networkMsg = opts?.dry_run ? "Preview failed — see DevTools console" : "Could not save changes — see DevTools console";
-      // [PR / 2026-04-30] Pin a network-error banner the same way as
-      // an HTTP error — same persistence semantics so an operator
-      // who wandered off doesn't miss the failure.
-      if (!opts?.dry_run) setLastSaveError({ title: "Network error", message: networkMsg });
-      toast({ title: "Network error", description: networkMsg, variant: "destructive" });
+      toast({ title: "Network error", description: opts?.dry_run ? "Preview failed — see DevTools console" : "Could not save changes — see DevTools console", variant: "destructive" });
     } finally {
       if (opts?.dry_run) setPreviewing(false); else setSaving(false);
       if (!opts?.dry_run) {
@@ -1521,26 +1476,6 @@ export default function EditJobModal({
               <li>Future jobs in series — update: {String(previewResult.future_jobs_would_be_updated ?? 0)}, delete: {String(previewResult.future_jobs_would_be_deleted ?? 0)}, insert: {String(previewResult.future_jobs_would_be_inserted_in_tx ?? 0)}, skipped (clocked-in): {String(previewResult.future_jobs_would_be_skipped_in_progress ?? 0)}</li>
               <li style={{ color: "#6B7280", fontSize: 12 }}>Forward 60-day fan-out NOT simulated in v1 — re-run without preview to see actual count.</li>
             </ul>
-          </div>
-        )}
-
-        {/* [PR / 2026-04-30] Persistent error banner. Sits above the
-            footer until the operator's next save attempt clears it
-            (submit() → setLastSaveError(null) at start). Pulls the
-            verbatim API message — distinguishes field-lock vs
-            network vs validation without flattening to "save
-            failed". Toast still fires on the same event for
-            transient confirmation; the banner is the persistent
-            audit trail of the failure. */}
-        {lastSaveError && (
-          <div style={{ padding: "12px 20px", borderTop: "1px solid #FECACA", backgroundColor: "#FEF2F2", fontFamily: FF, fontSize: 13, color: "#991B1B" }}>
-            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 12 }}>
-              <div style={{ flex: 1 }}>
-                <div style={{ fontWeight: 700, marginBottom: 2 }}>{lastSaveError.title}</div>
-                <div style={{ lineHeight: 1.4 }}>{lastSaveError.message}</div>
-              </div>
-              <button onClick={() => setLastSaveError(null)} style={{ fontSize: 12, color: "#991B1B", background: "none", border: "none", cursor: "pointer", fontFamily: FF, padding: 0 }}>Dismiss</button>
-            </div>
           </div>
         )}
 


### PR DESCRIPTION
## Production-down revert

Sal reports `app.qleno.com` returning Railway "Application failed to respond" (502). Reverting PR #34 first per Sal's instruction order (#34 → #33 → #32 → #31).

## Code-side analysis (for prioritization if #34 alone doesn't restore service)

Of the five PRs that landed in close succession today, my probability ranking for boot-blocker by code analysis:

1. **PR #31 (schema drift)** — HIGHEST PROBABILITY. Adds top-level `await` + dynamic `await import("./scripts/verify-schema.js")` to `index.ts` BEFORE `app.listen()`. New env var `SCHEMA_VERIFY_MODE` defaults to `'warn'`; if Railway env was set to `'strict'` AND introspection found drift, `process.exit(1)` fires at boot. Even in `'warn'` mode, the schema-introspection queries against `information_schema` are new boot-time work that didn't exist before.
2. **PR #32 (cascade dry-run)** — adds dry-run sentinel inside PATCH route + `/api/config/feature-flags` endpoint. Both request-time only; no boot impact unless ESM module-load fails.
3. **PR #34 (this revert target)** — modifies cascade lock check + setParts strip, all inside PATCH route handler. Request-time only; build was clean. **Lowest boot-blocker probability of the four.**
4. **PR #33 (picker-skip)** — frontend only. Zero api-server impact.
5. **PR #30 (DR docs)** — single `console.log` in boot. Trivial.

If reverting #34 doesn't fix it (which I don't expect), my recommendation would be to skip #33 (frontend-only) and revert #31 next instead of strict chronological order — that's where the boot-time risk concentrates.

But this PR follows your explicit instruction: revert #34 first.

## What this revert does

`git revert c0937de` — backs out the cascade-409-on-completed-anchor fix from PR #34. After this lands:
- PATCH `/api/jobs/4147` with `cascade_scope='this_and_future'` returns to its pre-#34 behavior (409 "Field locked" on a completed anchor)
- Frontend persistent error banner is removed
- Response shape rolls back to the pre-#34 cascade fields

The "client completes Monday + calls Tuesday to change schedule" workflow is broken again under this revert. Acceptable trade-off vs. production-down.

## Cadence

Opening Ready. Auto-merge attempt → manual merge fallback. As soon as it lands and Railway redeploys, please test `app.qleno.com` — if still 502, ping back and I'll revert PR #31 next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016GqMSjAaG7gGDtiFSPKn5Q)_