### PR TITLE
feat: cascade-overwrite-existing-future-jobs (PR #27 conflict-resolved)

### DIFF
--- a/artifacts/api-server/src/lib/recurring-jobs.ts
+++ b/artifacts/api-server/src/lib/recurring-jobs.ts
@@ -43,6 +43,147 @@ function mapFrequency(freq: string): string {
   return "biweekly";
 }
 
+// [recurring-on-save 2026-04-30 / PR #27] Resolved parking config for a
+// schedule. Cached by the caller so we look up `pricing_addons` /
+// `add_ons` once per generation run, not once per occurrence. Null
+// when the tenant has no active "Parking Fee" pricing_addon.
+export type ResolvedParkingAddon = {
+  pricing_addon_id: number;
+  add_on_id: number;
+  unit_price: string;
+  override_amount: string | null;
+};
+
+// [recurring-on-save 2026-04-30 / PR #27] Look up the tenant's Parking
+// Fee pricing_addons row + the matching add_ons.id (resolving the FK
+// to the older catalog table). Returns null when no active row found
+// (engine then logs once and skips parking stamping for the run).
+export async function resolveParkingAddon(
+  schedule: Pick<ScheduleInput, "company_id" | "parking_fee_amount">,
+  txOrDb: any = db,
+): Promise<ResolvedParkingAddon | null> {
+  const addonLookup = await txOrDb.execute(sql`
+    SELECT id, name, COALESCE(price_value, price, '0')::numeric AS price
+    FROM pricing_addons
+    WHERE company_id = ${schedule.company_id}
+      AND LOWER(name) = 'parking fee'
+      AND is_active = true
+    LIMIT 1
+  `);
+  const addonRow = addonLookup.rows[0] as { id: number; name: string; price: string } | undefined;
+  if (!addonRow) return null;
+
+  const addonName = String(addonRow.name ?? "Parking Fee");
+  const fallbackAmount = String(addonRow.price ?? "20");
+  const overrideAmount = schedule.parking_fee_amount;
+  const unitPrice = overrideAmount != null && overrideAmount !== ""
+    ? String(overrideAmount)
+    : fallbackAmount;
+
+  // Resolve the real `add_ons.id` for the FK on `job_add_ons.add_on_id`.
+  // pricing_addons.id and add_ons.id live in different tables; the
+  // older PATCH code naively reused the pricing id as the FK and threw
+  // FK violations whenever the IDs didn't coincide.
+  const existing = await txOrDb.execute(sql`
+    SELECT id FROM add_ons
+    WHERE company_id = ${schedule.company_id} AND LOWER(name) = LOWER(${addonName})
+    LIMIT 1
+  `);
+  let realAddOnId: number;
+  if (existing.rows.length) {
+    realAddOnId = Number((existing.rows[0] as any).id);
+  } else {
+    const created = await txOrDb.execute(sql`
+      INSERT INTO add_ons (company_id, name, price, category, is_active)
+      VALUES (${schedule.company_id}, ${addonName}, ${unitPrice}, 'other', true)
+      RETURNING id
+    `);
+    realAddOnId = Number((created.rows[0] as any).id);
+  }
+
+  return {
+    pricing_addon_id: Number(addonRow.id),
+    add_on_id: realAddOnId,
+    unit_price: unitPrice,
+    override_amount: overrideAmount != null && overrideAmount !== "" ? String(overrideAmount) : null,
+  };
+}
+
+// [recurring-on-save 2026-04-30 / PR #27] Returns true if the schedule's
+// parking config applies to the given weekday. NULL `parking_fee_days`
+// = "every visit"; non-null = "only the listed weekdays" (0=Sun..6=Sat).
+export function parkingApplies(
+  schedule: Pick<ScheduleInput, "parking_fee_enabled" | "parking_fee_days">,
+  date: Date,
+): boolean {
+  if (!schedule.parking_fee_enabled) return false;
+  const days = schedule.parking_fee_days ?? null;
+  if (days == null) return true;
+  return days.includes(date.getDay());
+}
+
+// [recurring-on-save 2026-04-30 / PR #27] Stamp a parking-fee row onto
+// `job_add_ons` for `jobId`. Idempotent via ON CONFLICT (job_id,
+// add_on_id) DO NOTHING — safe to call after either an INSERT or an
+// UPDATE of the parent job. Caller is responsible for checking
+// `parkingApplies` first.
+export async function stampParkingFeeOnJob(
+  jobId: number,
+  resolved: ResolvedParkingAddon,
+  txOrDb: any = db,
+): Promise<void> {
+  await txOrDb.execute(sql`
+    INSERT INTO job_add_ons
+      (job_id, add_on_id, quantity, unit_price, subtotal, pricing_addon_id)
+    VALUES
+      (${jobId}, ${resolved.add_on_id}, 1, ${resolved.unit_price},
+       ${resolved.unit_price}, ${resolved.pricing_addon_id})
+    ON CONFLICT (job_id, add_on_id) DO NOTHING
+  `);
+}
+
+// [recurring-on-save 2026-04-30 / PR #27] Insert ONE job row from a
+// schedule template at the given date, returning the new id. Pure
+// INSERT — no dedupe, no parking stamping. Caller decides whether to
+// dedupe (PATCH cascade does its own existing-job lookup) and whether
+// to call `stampParkingFeeOnJob` after.
+//
+// Reused by the nightly engine path (looped from
+// `generateJobsFromSchedule`) and by the EditJobModal cascade path
+// (`PATCH /api/jobs/:id` cascade_scope='create_recurring' empty-day
+// inserts). Drizzle ORM `.insert().values()` only — no raw `sql` for
+// table writes (PR #25 array-binding bug, fixed in PR #26).
+export async function insertJobFromSchedule(
+  schedule: ScheduleInput,
+  date: Date,
+  txOrDb: any = db,
+  bookingLocation: string | null = null,
+  clientZip: string | null = null,
+): Promise<number> {
+  const [row] = await txOrDb
+    .insert(jobsTable)
+    .values({
+      company_id: schedule.company_id,
+      client_id: schedule.customer_id,
+      assigned_user_id: schedule.assigned_employee_id ?? null,
+      service_type: mapServiceType(schedule.service_type) as any,
+      status: "scheduled" as const,
+      scheduled_date: toDateStr(date),
+      scheduled_time: null as any,
+      frequency: mapFrequency(schedule.frequency) as any,
+      base_fee: schedule.base_fee ? String(parseFloat(schedule.base_fee).toFixed(2)) : "0.00",
+      allowed_hours: schedule.duration_minutes
+        ? String((schedule.duration_minutes / 60).toFixed(2))
+        : null as any,
+      notes: schedule.notes ?? null,
+      recurring_schedule_id: schedule.id,
+      booking_location: (bookingLocation ?? null) as any,
+      address_zip: (clientZip ?? null) as any,
+    })
+    .returning({ id: jobsTable.id });
+  return Number(row.id);
+}
+
 function addDays(date: Date, days: number): Date {
   const d = new Date(date);
   d.setDate(d.getDate() + days);
@@ -287,76 +428,21 @@ export async function generateJobsFromSchedule(
   );
   if (!rows.length) return { created: 0, skipped };
 
-  // [AI.6] Strip the sidecar parking flag before INSERT (it's not a jobs
-  // column). Track per-row decision separately so we can stamp job_add_ons
-  // after the insert returns IDs.
-  const parkingDecisions = rows.map(r => Boolean((r as any)._parking_fee_applies));
-  const insertRows = rows.map(({ _parking_fee_applies: _strip, ...rest }: any) => rest);
-
-  // .returning() so we get IDs aligned with the input row order.
-  const inserted = await db
-    .insert(jobsTable)
-    .values(insertRows as any[])
-    .returning({ id: jobsTable.id, scheduled_date: jobsTable.scheduled_date });
-
-  // [AI.6] Stamp job_add_ons (parking) for jobs whose weekday matched.
-  // Lookup the tenant's Parking Fee pricing_addons row by name once per run.
-  // If absent (tenant has no Parking Fee addon), skip silently — engine
-  // doesn't fail the job creation just because parking config can't resolve.
-  let parkingStamped = 0;
-  const anyParking = parkingDecisions.some(Boolean);
+  // [recurring-on-save 2026-04-30 / PR #27] Refactor: per-date inserts
+  // via the shared `insertJobFromSchedule` helper instead of one bulk
+  // INSERT. Cost: N round trips instead of 1 (acceptable on the
+  // nightly cron — runs once per day, dedupe in compute means N is
+  // small per-schedule). Benefit: single source of truth for the
+  // INSERT shape so the EditJobModal cascade path can use the same
+  // helper without forking divergent column lists.
+  //
+  // Parking lookup is hoisted OUT of the loop (one query per run, not
+  // one per occurrence) via `resolveParkingAddon`.
+  const anyParking = rows.some(r => Boolean((r as any)._parking_fee_applies));
+  let resolved: ResolvedParkingAddon | null = null;
   if (anyParking) {
-    const addonLookup = await db.execute(sql`
-      SELECT id, name, COALESCE(price_value, price, '0')::numeric AS price
-      FROM pricing_addons
-      WHERE company_id = ${schedule.company_id}
-        AND LOWER(name) = 'parking fee'
-        AND is_active = true
-      LIMIT 1
-    `);
-    const addonRow = addonLookup.rows[0] as { id: number; name: string; price: string } | undefined;
-    if (addonRow) {
-      const pricingAddonId = Number(addonRow.id);
-      const addonName = String(addonRow.name ?? "Parking Fee");
-      const fallbackAmount = String(addonRow.price ?? "20");
-      const overrideAmount = schedule.parking_fee_amount;
-      const unitPrice = overrideAmount != null && overrideAmount !== "" ? String(overrideAmount) : fallbackAmount;
-
-      // [AI.6.3] Resolve a real add_ons.id for the FK on job_add_ons.add_on_id.
-      // pricing_addons.id and add_ons.id live in different tables; the older
-      // PATCH code naively reused the pricing id as the FK and threw FK
-      // violations whenever the IDs didn't coincide. Look up by name; create
-      // if absent.
-      const existing = await db.execute(sql`
-        SELECT id FROM add_ons
-        WHERE company_id = ${schedule.company_id} AND LOWER(name) = LOWER(${addonName})
-        LIMIT 1
-      `);
-      let realAddOnId: number;
-      if (existing.rows.length) {
-        realAddOnId = Number((existing.rows[0] as any).id);
-      } else {
-        const created = await db.execute(sql`
-          INSERT INTO add_ons (company_id, name, price, category, is_active)
-          VALUES (${schedule.company_id}, ${addonName}, ${unitPrice}, 'other', true)
-          RETURNING id
-        `);
-        realAddOnId = Number((created.rows[0] as any).id);
-      }
-
-      for (let i = 0; i < inserted.length; i++) {
-        if (!parkingDecisions[i]) continue;
-        const jobId = Number(inserted[i].id);
-        await db.execute(sql`
-          INSERT INTO job_add_ons
-            (job_id, add_on_id, quantity, unit_price, subtotal, pricing_addon_id)
-          VALUES
-            (${jobId}, ${realAddOnId}, 1, ${unitPrice}, ${unitPrice}, ${pricingAddonId})
-          ON CONFLICT (job_id, add_on_id) DO NOTHING
-        `);
-        parkingStamped++;
-      }
-    } else {
+    resolved = await resolveParkingAddon(schedule);
+    if (!resolved) {
       console.warn(
         `[recurring-engine] schedule ${schedule.id} has parking_fee_enabled but ` +
         `company ${schedule.company_id} has no active Parking Fee pricing_addon — skipping stamp`,
@@ -364,7 +450,29 @@ export async function generateJobsFromSchedule(
     }
   }
 
-  return { created: rows.length, skipped, parking_stamped: parkingStamped };
+  let parkingStamped = 0;
+  let created = 0;
+  for (const row of rows) {
+    // Reconstruct the Date from the YYYY-MM-DD string stamped by
+    // computeOccurrencesForSchedule. Use a midnight-local construction
+    // so DOW math matches the engine's existing behavior (avoids the
+    // UTC-vs-local landing case from KNOWN_BUGS.md #4).
+    const date = new Date(`${String(row.scheduled_date)}T00:00:00`);
+    const newId = await insertJobFromSchedule(
+      schedule,
+      date,
+      db,
+      bookingLocation ?? null,
+      clientZip ?? null,
+    );
+    created++;
+    if (resolved && (row as any)._parking_fee_applies) {
+      await stampParkingFeeOnJob(newId, resolved);
+      parkingStamped++;
+    }
+  }
+
+  return { created, skipped, parking_stamped: parkingStamped };
 }
 
 type SkippedSchedule = {

--- a/artifacts/api-server/src/routes/dispatch.ts
+++ b/artifacts/api-server/src/routes/dispatch.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import { db } from "@workspace/db";
-import { jobsTable, usersTable, clientsTable, timeclockTable, jobPhotosTable, serviceZonesTable, serviceZoneEmployeesTable, accountsTable, accountPropertiesTable, employeeAttendanceLogTable, employeeLeaveUsageTable, branchesTable } from "@workspace/db/schema";
+import { jobsTable, usersTable, clientsTable, timeclockTable, jobPhotosTable, serviceZonesTable, serviceZoneEmployeesTable, accountsTable, accountPropertiesTable, employeeAttendanceLogTable, employeeLeaveUsageTable, branchesTable, recurringSchedulesTable } from "@workspace/db/schema";
 import { eq, and, count, sql, inArray } from "drizzle-orm";
 import { requireAuth } from "../lib/auth.js";
 
@@ -169,6 +169,12 @@ router.get("/", requireAuth, async (req, res) => {
         // as cascade_scope='this_job' — operators never see the
         // "this and all future" option.
         recurring_schedule_id: jobsTable.recurring_schedule_id,
+        // [PR #27] Surfaced for the parking-fee day picker render gate
+        // in edit-job-modal.tsx. When a job is attached to a multi-day
+        // recurring schedule (daily/weekdays/custom_days), the modal
+        // renders the picker even if the job's local form-level
+        // frequency state lags. Null when no schedule attached.
+        recurring_schedule_days_of_week: recurringSchedulesTable.days_of_week,
         charge_failed_at: jobsTable.charge_failed_at,
         charge_succeeded_at: jobsTable.charge_succeeded_at,
         account_property_id: jobsTable.account_property_id,
@@ -197,6 +203,10 @@ router.get("/", requireAuth, async (req, res) => {
       .leftJoin(accountPropertiesTable, eq(jobsTable.account_property_id, accountPropertiesTable.id))
       .leftJoin(serviceZonesTable, eq(jobsTable.zone_id, serviceZonesTable.id))
       .leftJoin(branchesTable, eq(jobsTable.branch_id, branchesTable.id))
+      // [PR #27] Surfaces recurring_schedule_days_of_week for the
+      // edit-modal parking picker gate. LEFT JOIN — null when the
+      // job has no schedule attached.
+      .leftJoin(recurringSchedulesTable, eq(jobsTable.recurring_schedule_id, recurringSchedulesTable.id))
       .where(and(
         eq(jobsTable.company_id, companyId),
         eq(jobsTable.scheduled_date, date),
@@ -585,6 +595,11 @@ router.get("/", requireAuth, async (req, res) => {
         // [AI.6.2] Surface schedule linkage so the edit modal's cascade
         // prompt fires for recurring jobs.
         recurring_schedule_id: (j as any).recurring_schedule_id ?? null,
+        // [PR #27] Drives the parking-fee day picker render gate in
+        // edit-job-modal.tsx — the picker shows when the attached
+        // schedule is multi-day, regardless of the modal's local
+        // form-level frequency state. Null when no schedule attached.
+        recurring_schedule_days_of_week: (j as any).recurring_schedule_days_of_week ?? null,
         billing_method: j.billing_method ?? null,
         hourly_rate: j.hourly_rate ? parseFloat(j.hourly_rate) : null,
         estimated_hours: j.estimated_hours ? parseFloat(j.estimated_hours) : null,

--- a/artifacts/api-server/src/routes/jobs.ts
+++ b/artifacts/api-server/src/routes/jobs.ts
@@ -565,10 +565,17 @@ router.get("/:id", requireAuth, async (req, res) => {
         actual_hours: jobsTable.actual_hours,
         notes: jobsTable.notes,
         created_at: jobsTable.created_at,
+        // [PR #27] Schedule linkage + days_of_week so consumers
+        // (job detail page, my-jobs view) match the dispatch
+        // payload's shape and the edit-modal parking picker gate
+        // works regardless of which surface opens the modal.
+        recurring_schedule_id: jobsTable.recurring_schedule_id,
+        recurring_schedule_days_of_week: recurringSchedulesTable.days_of_week,
       })
       .from(jobsTable)
       .leftJoin(clientsTable, eq(jobsTable.client_id, clientsTable.id))
       .leftJoin(usersTable, eq(jobsTable.assigned_user_id, usersTable.id))
+      .leftJoin(recurringSchedulesTable, eq(jobsTable.recurring_schedule_id, recurringSchedulesTable.id))
       .where(and(
         eq(jobsTable.id, jobId),
         eq(jobsTable.company_id, req.auth!.companyId)
@@ -1424,8 +1431,13 @@ router.patch("/:id", requireAuth, async (req, res) => {
             ON CONFLICT (recurring_schedule_id, user_id) DO UPDATE SET is_primary = EXCLUDED.is_primary
           `);
         }
+        // [PR #27] Capture the addon list separately from the per-job
+        // job_add_ons writes above so the per-date cascade loop below
+        // can reuse it for in-place UPDATE'd jobs and freshly INSERTed
+        // empty-day jobs alike.
+        const cascadeAddonList: Array<{ pricing_addon_id: number; qty: number; unit_price: string; subtotal: string }> = [];
         if (addOnsProvided && Array.isArray(add_ons)) {
-          for (const a of add_ons as Array<{ pricing_addon_id?: number; qty?: number }>) {
+          for (const a of add_ons as Array<{ pricing_addon_id?: number; qty?: number; unit_price?: number; subtotal?: number }>) {
             const pricingId = Number(a.pricing_addon_id ?? 0);
             const qty = Number(a.qty ?? 1) || 1;
             if (!pricingId) continue;
@@ -1433,8 +1445,251 @@ router.patch("/:id", requireAuth, async (req, res) => {
               INSERT INTO recurring_schedule_add_ons (recurring_schedule_id, pricing_addon_id, qty)
               VALUES (${newSchedId}, ${pricingId}, ${qty})
             `);
+            cascadeAddonList.push({
+              pricing_addon_id: pricingId,
+              qty,
+              unit_price: a.unit_price != null ? String(a.unit_price) : "0",
+              subtotal: a.subtotal != null ? String(a.subtotal) : "0",
+            });
           }
         }
+
+        // [PR #27] Per-date cascade — overwrite existing future jobs in
+        // place + insert on empty days. This is the difference between
+        // PR #25/#26 (which only inserted on empty days, leaving
+        // imported MaidCentral Tue–Fri jobs untouched with stale
+        // service_type/duration/tech/etc.) and the production
+        // expectation: edit Monday → expect Tue–Fri to inherit the
+        // schedule's settings.
+        //
+        // Money may have been collected or invoiced; never overwrite
+        // billed work. A job is "locked" against overwrite when ANY of
+        //   status = 'complete'                       (job marked done)
+        //   status = 'cancelled'                      (job killed)
+        //   charge_succeeded_at IS NOT NULL           (Stripe/Square paid)
+        //   exists(invoices.job_id = jobs.id)         (invoice issued)
+        // is true. Locked jobs emit a console log and stay untouched.
+        //
+        // Tech assignment on update overwrites with the schedule's
+        // default crew — mid-week per-day tech swap with "apply to all
+        // future" prompt is PR #28, out of scope here.
+        const { computeOccurrencesForSchedule, insertJobFromSchedule, resolveParkingAddon, stampParkingFeeOnJob, parkingApplies, DAYS_AHEAD: HORIZON } = await import("../lib/recurring-jobs.js");
+        const cascadeSched = await tx.execute(sql`
+          SELECT id, company_id, customer_id, frequency, day_of_week, days_of_week,
+                 custom_frequency_weeks, start_date, end_date, scheduled_time,
+                 assigned_employee_id, service_type, duration_minutes, base_fee,
+                 commercial_hourly_rate, notes, instructions,
+                 parking_fee_enabled, parking_fee_amount, parking_fee_days
+          FROM recurring_schedules WHERE id = ${newSchedId} LIMIT 1
+        `);
+        const sched = cascadeSched.rows[0] as any;
+        const cascadeClient = await tx.execute(sql`
+          SELECT zip FROM clients WHERE id = ${Number(before.client_id)} LIMIT 1
+        `);
+        const cascadeClientZip = ((cascadeClient.rows[0] as any)?.zip ?? null) as string | null;
+        const cascadeToday = new Date();
+        const cascadeHorizon = new Date(cascadeToday.getTime() + HORIZON * 24 * 60 * 60 * 1000);
+
+        // computeOccurrencesForSchedule returns the matching dates in
+        // the window. Its dedupe filters jobs whose
+        // recurring_schedule_id = sched.id — but the freshly-INSERTed
+        // schedule has zero linked rows in the *committed* state
+        // visible to db.select() (this transaction hasn't committed),
+        // so the result includes every matching weekday including the
+        // current Monday. We skip the current jobId explicitly in the
+        // loop below to avoid double-processing.
+        const { rows: candidateRows } = await computeOccurrencesForSchedule(
+          sched, cascadeToday, cascadeHorizon, null, cascadeClientZip,
+        );
+
+        const cascadeParking = sched.parking_fee_enabled === true
+          ? await resolveParkingAddon(sched, tx)
+          : null;
+        if (sched.parking_fee_enabled === true && !cascadeParking) {
+          console.warn(
+            `[cascade-create-recurring] schedule ${newSchedId} has parking_fee_enabled but ` +
+            `company ${companyId} has no active Parking Fee pricing_addon — skipping stamp`,
+          );
+        }
+
+        // Helper: resolve a real `add_ons.id` for the FK on
+        // `job_add_ons.add_on_id` from a pricing_addons.id. Mirrors
+        // the resolution logic in the per-job add-ons write above
+        // (lines ~1316-1346) — same pricing_addons → add_ons name
+        // lookup with create-if-absent fallback.
+        const resolveRealAddOnId = async (pricingId: number): Promise<number | null> => {
+          const paRows = await tx.execute(sql`
+            SELECT name FROM pricing_addons WHERE id = ${pricingId} LIMIT 1
+          `);
+          const paName = String((paRows.rows[0] as any)?.name ?? "").trim();
+          if (!paName) return null;
+          const ex = await tx.execute(sql`
+            SELECT id FROM add_ons
+            WHERE company_id = ${companyId} AND LOWER(name) = LOWER(${paName})
+            LIMIT 1
+          `);
+          if (ex.rows.length) return Number((ex.rows[0] as any).id);
+          const cre = await tx.execute(sql`
+            INSERT INTO add_ons (company_id, name, price, category, is_active)
+            VALUES (${companyId}, ${paName}, '0', 'other', true)
+            RETURNING id
+          `);
+          return Number((cre.rows[0] as any).id);
+        };
+
+        // Pre-resolve add_ons FK ids for the schedule's addon list
+        // so we don't repeat the lookup per-date.
+        const cascadeAddonsResolved: Array<{ pricing_addon_id: number; add_on_id: number; qty: number; unit_price: string; subtotal: string }> = [];
+        for (const a of cascadeAddonList) {
+          const aid = await resolveRealAddOnId(a.pricing_addon_id);
+          if (aid != null) {
+            cascadeAddonsResolved.push({ ...a, add_on_id: aid });
+          }
+        }
+
+        let cascadeOverwritten = 0;
+        let cascadeInserted = 0;
+        let cascadeSkippedLocked = 0;
+
+        for (const row of candidateRows) {
+          const dateStr = String(row.scheduled_date);
+          const date = new Date(`${dateStr}T00:00:00`);
+
+          // Find existing jobs at this date for this client EXCEPT the
+          // current job (already updated via setParts above). FOR
+          // UPDATE locks the rows so concurrent edits don't race.
+          const existingJobs = await tx.execute(sql`
+            SELECT j.id, j.status, j.charge_succeeded_at,
+                   EXISTS(SELECT 1 FROM invoices i WHERE i.job_id = j.id) AS has_invoice
+            FROM jobs j
+            WHERE j.company_id = ${companyId}
+              AND j.client_id = ${Number(before.client_id)}
+              AND j.scheduled_date = ${dateStr}::date
+              AND j.id != ${jobId}
+            FOR UPDATE
+          `);
+          const existingRows = existingJobs.rows as Array<{
+            id: number; status: string;
+            charge_succeeded_at: string | null;
+            has_invoice: boolean;
+          }>;
+
+          if (existingRows.length === 0) {
+            // Empty day — INSERT a fresh job from the schedule template.
+            const newJobId = await insertJobFromSchedule(
+              sched, date, tx, null, cascadeClientZip,
+            );
+            cascadeInserted++;
+            for (let i = 0; i < techList.length; i++) {
+              const uid = techList[i];
+              const isPrimary = i === 0;
+              await tx.execute(sql`
+                INSERT INTO job_technicians (job_id, user_id, company_id, is_primary)
+                VALUES (${newJobId}, ${uid}, ${companyId}, ${isPrimary})
+                ON CONFLICT (job_id, user_id) DO UPDATE SET is_primary = EXCLUDED.is_primary
+              `);
+            }
+            if (techList.length > 0) {
+              await tx.execute(sql`
+                UPDATE jobs SET assigned_user_id = ${techList[0]}
+                WHERE id = ${newJobId} AND company_id = ${companyId}
+              `);
+            }
+            for (const a of cascadeAddonsResolved) {
+              await tx.execute(sql`
+                INSERT INTO job_add_ons (job_id, add_on_id, quantity, unit_price, subtotal, pricing_addon_id)
+                VALUES (${newJobId}, ${a.add_on_id}, ${a.qty}, ${a.unit_price}, ${a.subtotal}, ${a.pricing_addon_id})
+                ON CONFLICT (job_id, add_on_id) DO UPDATE
+                  SET quantity = EXCLUDED.quantity,
+                      unit_price = EXCLUDED.unit_price,
+                      subtotal = EXCLUDED.subtotal,
+                      pricing_addon_id = EXCLUDED.pricing_addon_id
+              `);
+            }
+            if (cascadeParking && parkingApplies(sched, date)) {
+              await stampParkingFeeOnJob(newJobId, cascadeParking, tx);
+            }
+            continue;
+          }
+
+          // 1+ existing jobs at this date. Decide overwrite or skip
+          // per row — locked jobs are never overwritten.
+          for (const ex of existingRows) {
+            const isLocked = ex.status === "complete"
+              || ex.status === "cancelled"
+              || ex.charge_succeeded_at != null
+              || ex.has_invoice === true;
+            if (isLocked) {
+              console.log(`[cascade-create-recurring] skipped job_id=${ex.id} reason=status_locked`);
+              cascadeSkippedLocked++;
+              continue;
+            }
+            // UPDATE in place — preserve job id (audit log + history
+            // references depend on stable ids per the spec). Drizzle
+            // ORM .update().set() handles the column codecs.
+            await tx
+              .update(jobsTable)
+              .set({
+                scheduled_time: sched.scheduled_time as any,
+                allowed_hours: sched.duration_minutes
+                  ? String((Number(sched.duration_minutes) / 60).toFixed(2))
+                  : null as any,
+                service_type: sched.service_type as any,
+                base_fee: sched.base_fee != null ? String(sched.base_fee) : null as any,
+                hourly_rate: sched.commercial_hourly_rate != null
+                  ? String(sched.commercial_hourly_rate)
+                  : null as any,
+                frequency: sched.frequency as any,
+                recurring_schedule_id: newSchedId,
+                notes: (sched.notes ?? sched.instructions ?? null) as any,
+              })
+              .where(and(
+                eq(jobsTable.id, Number(ex.id)),
+                eq(jobsTable.company_id, companyId),
+              ));
+            // Sync techs: replace job_technicians with the schedule's crew.
+            await tx.execute(sql`DELETE FROM job_technicians WHERE job_id = ${Number(ex.id)}`);
+            for (let i = 0; i < techList.length; i++) {
+              const uid = techList[i];
+              const isPrimary = i === 0;
+              await tx.execute(sql`
+                INSERT INTO job_technicians (job_id, user_id, company_id, is_primary)
+                VALUES (${Number(ex.id)}, ${uid}, ${companyId}, ${isPrimary})
+                ON CONFLICT (job_id, user_id) DO UPDATE SET is_primary = EXCLUDED.is_primary
+              `);
+            }
+            if (techList.length > 0) {
+              await tx.execute(sql`
+                UPDATE jobs SET assigned_user_id = ${techList[0]}
+                WHERE id = ${Number(ex.id)} AND company_id = ${companyId}
+              `);
+            }
+            // Sync add-ons: replace job_add_ons with the schedule's set.
+            await tx.execute(sql`DELETE FROM job_add_ons WHERE job_id = ${Number(ex.id)}`);
+            for (const a of cascadeAddonsResolved) {
+              await tx.execute(sql`
+                INSERT INTO job_add_ons (job_id, add_on_id, quantity, unit_price, subtotal, pricing_addon_id)
+                VALUES (${Number(ex.id)}, ${a.add_on_id}, ${a.qty}, ${a.unit_price}, ${a.subtotal}, ${a.pricing_addon_id})
+                ON CONFLICT (job_id, add_on_id) DO UPDATE
+                  SET quantity = EXCLUDED.quantity,
+                      unit_price = EXCLUDED.unit_price,
+                      subtotal = EXCLUDED.subtotal,
+                      pricing_addon_id = EXCLUDED.pricing_addon_id
+              `);
+            }
+            // Stamp parking on top if the schedule says so for this DOW.
+            // Idempotent via stampParkingFeeOnJob's ON CONFLICT.
+            if (cascadeParking && parkingApplies(sched, date)) {
+              await stampParkingFeeOnJob(Number(ex.id), cascadeParking, tx);
+            }
+            cascadeOverwritten++;
+          }
+        }
+
+        // Stash counts for the response.
+        (req as any)._cascadeOverwritten = cascadeOverwritten;
+        (req as any)._cascadeInserted = cascadeInserted;
+        (req as any)._cascadeSkippedLocked = cascadeSkippedLocked;
       }
 
       // ── Cascade: this_and_future or all ──────────────────────────────────
@@ -1825,58 +2080,28 @@ router.patch("/:id", requireAuth, async (req, res) => {
       throw err;
     });
 
-    // [recurring-on-save 2026-04-30] After-commit fan-out for the
-    // create_recurring path. Mirrors POST /api/recurring's pattern:
-    // synchronously generate the next 60 days so the dispatch board
-    // populates immediately. Best-effort — engine hiccups don't roll
-    // back the parent edit (the schedule + linked job already exist;
-    // the nightly 2 AM cron will catch any missed dates). Failures
-    // get surfaced in the response so the operator sees them.
-    // [PR / 2026-04-30] Skip the post-commit fan-out under dry_run.
-    // generateJobsFromSchedule writes real INSERTs outside the
-    // transaction; rollback can't reverse them. v1 reports
-    // counters-only and omits the fan-out estimate (Sal Q3.1 = a).
-    let createRecurringFanout: { jobs_generated: number; jobs_skipped: number; error?: string } | null = null;
-    if (createdScheduleId != null && !dry_run) {
-      try {
-        const { generateJobsFromSchedule, DAYS_AHEAD: HORIZON } = await import("../lib/recurring-jobs.js");
-        const schedRow = await db.execute(sql`
-          SELECT id, company_id, customer_id, frequency, day_of_week, days_of_week,
-                 custom_frequency_weeks, start_date, end_date, scheduled_time,
-                 assigned_employee_id, service_type, duration_minutes, base_fee,
-                 commercial_hourly_rate, notes, instructions,
-                 parking_fee_enabled, parking_fee_amount, parking_fee_days
-          FROM recurring_schedules WHERE id = ${Number(createdScheduleId)} LIMIT 1
-        `);
-        const sched = schedRow.rows[0];
-        // Pull the client's zip for the booking_location/address_zip
-        // stamping the engine does on each generated job.
-        const cl = await db.execute(sql`
-          SELECT zip FROM clients WHERE id = ${Number(before.client_id)} LIMIT 1
-        `);
-        const clientZip = (cl.rows[0] as any)?.zip ?? null;
-        const today = new Date();
-        const horizon = new Date(today.getTime() + HORIZON * 24 * 60 * 60 * 1000);
-        const result = await generateJobsFromSchedule(
-          sched as any,
-          today,
-          horizon,
-          null,
-          clientZip,
-        );
-        createRecurringFanout = {
-          jobs_generated: result.created,
-          jobs_skipped: result.skipped,
-        };
-      } catch (genErr: any) {
-        console.warn("[PATCH /jobs/:id create_recurring] sync fan-out failed:", genErr?.message ?? genErr);
-        createRecurringFanout = {
-          jobs_generated: 0,
-          jobs_skipped: 0,
-          error: String(genErr?.message ?? genErr),
-        };
-      }
-    }
+    // [PR #27] The post-commit fan-out from PR #25/#26 is removed —
+    // the cascade now runs INSIDE the transaction (see the
+    // wantsCreateRecurring block above). Atomicity: any failure
+    // during the per-date overwrite loop rolls the entire create
+    // back, so we never leave a half-written schedule + linked
+    // Monday with un-cascaded Tue–Fri rows.
+    //
+    // Dry-run interaction (PR #32 + PR #27): under dry_run=true the
+    // tx callback throws DryRunRollback at its end, so the in-tx
+    // cascade's writes are reverted along with the schedule INSERT
+    // + Monday link. The closure-stashed counters (req._cascade*)
+    // were set BEFORE the throw, so they still reflect what would
+    // have been written. The dry-run response branch below picks
+    // them up via dryRunSummary; the create_recurring counters
+    // shape here is for the COMMIT path only.
+    const createRecurringFanout = createdScheduleId != null
+      ? {
+          jobs_overwritten: (req as any)._cascadeOverwritten ?? 0,
+          jobs_inserted: (req as any)._cascadeInserted ?? 0,
+          jobs_skipped_locked: (req as any)._cascadeSkippedLocked ?? 0,
+        }
+      : null;
 
     // [PR / 2026-04-30] Dry-run branch. The transaction rolled back
     // before any writes committed, so we don't query the post-state
@@ -1916,10 +2141,12 @@ router.patch("/:id", requireAuth, async (req, res) => {
         scope: cascade_scope,
         future_jobs_updated: (req as any)._agFutureCount ?? 0,
         future_jobs_skipped_in_progress: (req as any)._agFutureSkipped ?? 0,
-        // [recurring-on-save 2026-04-30] create_recurring metadata.
-        // Null when this PATCH didn't create a schedule. Otherwise
-        // includes the new schedule_id + the synchronous fan-out
-        // result (created / skipped / optional error).
+        // [PR #27] create_recurring metadata. Null when this PATCH
+        // didn't create a schedule. When present, includes the new
+        // schedule_id + the in-tx cascade result: jobs_overwritten
+        // (existing future rows updated in place, ids preserved) +
+        // jobs_inserted (empty-day inserts) + jobs_skipped_locked
+        // (rows untouched because complete/cancelled/paid/invoiced).
         created_schedule_id: createdScheduleId,
         create_recurring: createRecurringFanout,
       },

--- a/artifacts/qleno/src/components/edit-job-modal.tsx
+++ b/artifacts/qleno/src/components/edit-job-modal.tsx
@@ -29,6 +29,12 @@ export interface EditableJob {
   client_id: number;
   client_name: string;
   recurring_schedule_id?: number | null;
+  // [PR #27] Surfaced from the dispatch + GET /:id LEFT JOIN on
+  // recurring_schedules. Drives the parking-fee day-picker render
+  // gate when the modal opens on a job whose attached schedule is
+  // multi-day (daily/weekdays/custom_days), even if the modal's
+  // local form-level frequency state hasn't synced yet.
+  recurring_schedule_days_of_week?: number[] | null;
   service_type: string;
   frequency: string;
   scheduled_date: string;
@@ -279,6 +285,17 @@ export default function EditJobModal({
   // to whatever the user re-picked.
   const [daysOfWeek, setDaysOfWeek] = useState<number[]>([]);
   const isMultiDayFreq = frequency === "daily" || frequency === "weekdays" || frequency === "custom_days";
+
+  // [PR #27] When the modal opens on a job that's already attached to
+  // a recurring schedule, the parking day picker should respect the
+  // schedule's days_of_week (surfaced from the dispatch / GET /:id
+  // LEFT JOIN on recurring_schedules) — not just the modal's local
+  // form-level frequency state, which lags until the user touches the
+  // dropdown. Without this, freshly cascade-created jobs would render
+  // with the picker collapsed even though they're on a 5-day schedule.
+  const attachedScheduleDays = (job as any).recurring_schedule_days_of_week as number[] | null | undefined;
+  const isMultiDayBySchedule = Array.isArray(attachedScheduleDays) && attachedScheduleDays.length > 1;
+  const isMultiDayEffective = isMultiDayFreq || isMultiDayBySchedule;
 
   // [AI.7.1] Parking-fee schedule-level config. Mirrors the three columns
   // on recurring_schedules. parkingFeeDays is an int[] of weekdays (0=Sun..
@@ -878,7 +895,12 @@ export default function EditJobModal({
         const parkingNowChecked = !!parkingAddon && selectedAddons.has(parkingAddon.id);
         payload.parking_fee_enabled = parkingNowChecked;
         payload.parking_fee_amount = parkingFeeAmount;
-        payload.parking_fee_days = parkingNowChecked && isMultiDayFreq
+        // [PR #27] Use the effective multi-day signal (form-level OR
+        // attached-schedule-derived) so freshly cascade-created jobs
+        // can save a parking_fee_days array immediately, before the
+        // operator's next round-trip refreshes the form's local
+        // `frequency` state.
+        payload.parking_fee_days = parkingNowChecked && isMultiDayEffective
           ? (parkingFeeDays != null && parkingFeeDays.length < 7 ? [...parkingFeeDays].sort() : null)
           : null;
       }
@@ -1295,7 +1317,17 @@ export default function EditJobModal({
               // (lines 3281–3287). Sibling logic in the recurring-schedule
               // editor (customer-profile.tsx:3466) already gates on
               // frequency the same way; this closes the parity gap.
-              if (!isCommercial || !parkingAddon || !isParkingChecked || !isRecurring || !isMultiDayFreq) return null;
+              // [PR #27] Two changes from PR #24: (1) `isRecurring`
+              // now passes when the job is attached to a schedule
+              // (job.recurring_schedule_id != null) — same condition
+              // it always was, but documented here for clarity since
+              // PR #27's cascade can attach a schedule mid-edit. (2)
+              // `isMultiDayEffective` widens the gate to also pass
+              // when the attached schedule is multi-day even if the
+              // modal's local `frequency` state still reads the
+              // pre-edit value (e.g. open the modal on a job that
+              // was just promoted to weekdays via cascade).
+              if (!isCommercial || !parkingAddon || !isParkingChecked || !isRecurring || !isMultiDayEffective) return null;
               const dayLabels: { v: number; l: string }[] = [
                 { v: 0, l: "Sun" }, { v: 1, l: "Mon" }, { v: 2, l: "Tue" },
                 { v: 3, l: "Wed" }, { v: 4, l: "Thu" }, { v: 5, l: "Fri" }, { v: 6, l: "Sat" },


### PR DESCRIPTION
## What

Conflict-resolved version of PR #27 (cascade-overwrite-existing-future-jobs + dispatch LEFT JOIN + days_of_week field + parking picker gate). Same scope as #27, rebased onto current main with conflicts resolved against PR #32 (cascade dry-run) and PR #33 (picker-skip / FIELD_SCOPE_CLASSIFICATION).

**Closes Sal's screenshot bug**: parking day picker shows "Match schedule (—)" with no days highlighted because dispatch payload doesn't return `recurring_schedule_days_of_week`. This PR adds the LEFT JOIN that surfaces it. Also lets parking_fee_days actually propagate to Tue–Fri in place via the in-tx cascade overwrite loop.

## Diff

```
artifacts/api-server/src/lib/recurring-jobs.ts    | 248 +++/--  (helper extraction + engine refactor)
artifacts/api-server/src/routes/dispatch.ts       |  17 +/-     (LEFT JOIN + days_of_week field)
artifacts/api-server/src/routes/jobs.ts           | 341 +++/--  (in-tx cascade overwrite loop, conflict-resolved)
artifacts/qleno/src/components/edit-job-modal.tsx |  36 +/-     (parking picker gate widening)
4 files changed, 512 insertions(+), 130 deletions(-)
```

Net 382 lines. Same as original PR #27 (+5 from clarifying comment in the conflict resolution).

## Conflict resolution summary

Auto-merged cleanly:
- `lib/recurring-jobs.ts` — additive helpers (resolveParkingAddon, parkingApplies, stampParkingFeeOnJob, insertJobFromSchedule)
- `routes/dispatch.ts` — `recurringSchedulesTable` import + LEFT JOIN + `recurring_schedule_days_of_week` field on the response shape
- `edit-job-modal.tsx` — `isMultiDayBySchedule` / `isMultiDayEffective` derived state + parking-picker render gate widening (PR #27) coexists cleanly with `FIELD_SCOPE_CLASSIFICATION` + auto-cascade routing + `mixedEditWarning` (PR #33). They sit in different code regions; no semantic overlap.

**Single conflict zone in `routes/jobs.ts`** (lines 2083–2150 pre-resolution):

The post-commit fan-out block. HEAD had PR #32's `generateJobsFromSchedule` call (inserts on empty days only) gated by `!dry_run`. PR #27 removes the post-commit fan-out entirely because the in-tx cascade overwrite loop (added earlier in the same PR) now handles UPDATE-in-place INSIDE the transaction.

**Resolution: take PR #27's side** — remove the post-commit fan-out, return counters from the in-tx cascade. Added a clarifying comment about dry-run interaction:

> Under dry_run=true the tx callback throws DryRunRollback at its end, so the in-tx cascade's writes are reverted along with the schedule INSERT + Monday link. The closure-stashed counters (`req._cascade*`) were set BEFORE the throw, so they still reflect what would have been written.

The in-tx cascade is atomic — any failure during the per-date overwrite loop rolls the entire create back.

## Self-verify (code-only)

- `pnpm run typecheck`: net-zero new errors per file vs. main baseline (54 / 5 / 0 in api-server, 0 in modal)
- `pnpm run build` (frontend): clean, 288.60 kB main bundle (+24 bytes vs main, expected from added gate logic)
- `pnpm run build` (api-server): clean, 3.0mb dist/index.mjs

## What this fixes for Sal's morning screenshot

1. **"Match schedule (—)" em-dash** → dispatch payload now returns `recurring_schedule_days_of_week` for Jaira's job. Picker reads from it; em-dash becomes "M-T-W-T-F" or whatever the schedule's `days_of_week` array actually contains.
2. **Empty parking day buttons** → with `recurring_schedule_days_of_week=[1,2,3,4,5]` available, the M-F buttons render filled.
3. **Parking_fee_days not propagating to Tue–Fri** → in-tx cascade overwrite loop now UPDATEs existing Tue–Fri jobs in place (preserving job ids, syncing techs/addons, stamping parking on matching weekdays), instead of the prior "INSERT-on-empty-day-only" behavior that left imported MC jobs untouched.
4. **MC-imported Tue–Fri jobs with stale service_type / time / fees** → same fix; in-tx UPDATE in place.

## Sequencing reminder

After this merges + Railway deploys, **PR #34's fix (cascade_scope=this_and_future on completed anchor) is still REVERTED** per yesterday's outage triage. The "client completes Mon + calls Tue to change schedule" workflow will still 409 until that fix is re-implemented carefully on top of this. Per yesterday's handoff, that's the second task today.

## Cadence

Opening Ready. Will merge after open per the standing auto-merge rule.

Closes #27 (this PR is the conflict-resolved replacement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016GqMSjAaG7gGDtiFSPKn5Q)_