### PR TITLE
fix: re-implement PR #34 (cascade-scope-aware lock + error banner)

### DIFF
--- a/artifacts/api-server/src/routes/jobs.ts
+++ b/artifacts/api-server/src/routes/jobs.ts
@@ -906,27 +906,58 @@ router.patch("/:id", requireAuth, async (req, res) => {
       });
     }
 
-    if (isCompleted) {
-      // Hard locks on completed jobs.
+    // [PR / 2026-05-01 — re-implementation of yesterday's PR #34
+    // (reverted in #35 during the unrelated #31 boot-time outage)]
+    //
+    // Cascade-scope-aware lock: the legacy hard-lock returned 409 when
+    // an operator tried to change frequency / service_type / price on
+    // a completed job — regardless of cascade_scope. That conflated:
+    //   (1) "edit this completed job's fields"   (this_job)
+    //   (2) "edit the schedule TEMPLATE via this completed job as
+    //        anchor; future jobs inherit, this one stays as-is in the
+    //        audit trail" (this_and_future / all)
+    //
+    // (2) is the operator's right workflow when the client completes
+    // Monday + calls Tuesday morning to change the schedule going
+    // forward. Pre-fix this 409'd. Post-fix the route strips the
+    // locked fields from the anchor's `setParts` UPDATE (audit record
+    // stays clean) but proceeds with the schedule-template UPDATE +
+    // future-jobs cascade (which already filters `j.id != ${jobId}`
+    // and respects the per-row status / paid / invoice skip rules
+    // shipped in PR #38).
+    const cascadesToTemplate = cascade_scope === "this_and_future" || cascade_scope === "all";
+    const skipAnchorLockedFields = isCompleted && cascadesToTemplate;
+
+    if (isCompleted && !cascadesToTemplate) {
+      // Editing only this completed job — hard-lock service_type /
+      // frequency. Changing them rewrites commission routing and
+      // recurrence semantics on already-billed work. Operator must
+      // void-and-rebook for those.
       if (service_type !== undefined && service_type !== before.service_type) {
         return res.status(409).json({
           error: "Field locked",
           field: "service_type",
-          message: "Service type can't change on a completed job. Cancel and re-book if the wrong type was billed.",
+          message: "Service type can't change on a completed job. Cancel and re-book if the wrong type was billed, or use 'This and all future' to update the schedule template.",
         });
       }
       if (frequency !== undefined && frequency !== before.frequency) {
         return res.status(409).json({
           error: "Field locked",
           field: "frequency",
-          message: "Frequency can't change on a completed job. Cancel and re-book if the recurrence was wrong.",
+          message: "Frequency can't change on a completed job. Cancel and re-book if the recurrence was wrong, or use 'This and all future' to update the schedule template.",
         });
       }
+    }
+    if (isCompleted) {
       // Warn-locked: pricing on completed jobs. Hard-locked when paid.
+      // For cascadesToTemplate: skip the warn/hard-lock entirely. The
+      // price change applies to the schedule template + future jobs;
+      // the anchor's `jobs.base_fee` / `jobs.hourly_rate` stay frozen
+      // (stripped from setParts below).
       const priceChanged =
         (base_fee !== undefined && String(base_fee) !== String(before.base_fee ?? "")) ||
         (hourly_rate !== undefined && String(hourly_rate ?? "") !== String(before.hourly_rate ?? ""));
-      if (priceChanged) {
+      if (priceChanged && !cascadesToTemplate) {
         if (isPaid) {
           return res.status(409).json({
             error: "Field locked",
@@ -1185,6 +1216,27 @@ router.patch("/:id", requireAuth, async (req, res) => {
       if (hourly_rate !== undefined) setParts.hourly_rate = hourly_rate === null ? null : String(hourly_rate);
       if (nextManualOverride !== undefined) setParts.manual_rate_override = nextManualOverride;
       if (instructions !== undefined) setParts.notes = instructions;
+
+      // [PR / 2026-05-01 — re-implementation of yesterday's PR #34]
+      // When the anchor is a completed job AND the operator picked a
+      // cascade scope that propagates to the schedule template +
+      // future jobs (this_and_future / all), strip the lock-protected
+      // fields from setParts. The schedule UPDATE + future-jobs
+      // cascade further down apply the changes to the right rows; the
+      // anchor's `jobs` row keeps its original frequency / service_type
+      // / base_fee / hourly_rate as part of the completed-work audit
+      // trail. Surfaced in the response as anchor_protected +
+      // anchor_skipped_fields so the modal can render an honest
+      // success summary ("This visit is unchanged. Schedule updated.
+      // 4 future jobs reflect new times.").
+      const anchorSkippedFields: string[] = [];
+      if (skipAnchorLockedFields) {
+        if ("frequency" in setParts) { delete setParts.frequency; anchorSkippedFields.push("frequency"); }
+        if ("service_type" in setParts) { delete setParts.service_type; anchorSkippedFields.push("service_type"); }
+        if ("base_fee" in setParts) { delete setParts.base_fee; anchorSkippedFields.push("base_fee"); }
+        if ("hourly_rate" in setParts) { delete setParts.hourly_rate; anchorSkippedFields.push("hourly_rate"); }
+      }
+      (req as any)._anchorSkippedFields = anchorSkippedFields;
 
       // [recurring-on-save 2026-04-30] create_recurring branch — INSERT
       // the new recurring_schedules row, anchored to the current job's
@@ -1792,6 +1844,11 @@ router.patch("/:id", requireAuth, async (req, res) => {
           const setClauses = rsSet.map((c, i) => sql`${sql.identifier(c)} = ${rsVals[i]}`);
           const setSql = sql.join(setClauses, sql`, `);
           await tx.execute(sql`UPDATE recurring_schedules SET ${setSql} WHERE id = ${scheduleId} AND company_id = ${companyId}`);
+          // [PR / 2026-05-01 — re-implementation of yesterday's PR #34]
+          // Stash for the response so the modal can compose an honest
+          // success summary ("Schedule updated. 4 future jobs reflect
+          // new times. This visit is unchanged.")
+          (req as any)._scheduleUpdated = true;
         }
 
         // ── Future-jobs cascade: branch by whether day pattern changed ────
@@ -2141,6 +2198,14 @@ router.patch("/:id", requireAuth, async (req, res) => {
         scope: cascade_scope,
         future_jobs_updated: (req as any)._agFutureCount ?? 0,
         future_jobs_skipped_in_progress: (req as any)._agFutureSkipped ?? 0,
+        // [PR / 2026-05-01 — re-implementation of yesterday's PR #34]
+        // Anchor-protection signals so the modal can render an honest
+        // success summary ("Schedule updated. 4 future jobs reflect
+        // new times. This visit is unchanged (frequency, base_fee
+        // stayed frozen).") instead of a generic "saved".
+        anchor_protected: ((req as any)._anchorSkippedFields ?? []).length > 0,
+        anchor_skipped_fields: (req as any)._anchorSkippedFields ?? [],
+        schedule_updated: !!(req as any)._scheduleUpdated,
         // [PR #27] create_recurring metadata. Null when this PATCH
         // didn't create a schedule. When present, includes the new
         // schedule_id + the in-tx cascade result: jobs_overwritten

--- a/artifacts/qleno/src/components/edit-job-modal.tsx
+++ b/artifacts/qleno/src/components/edit-job-modal.tsx
@@ -348,6 +348,16 @@ export default function EditJobModal({
 
   const [saving, setSaving] = useState(false);
 
+  // [PR / 2026-05-01 — re-implementation of yesterday's PR #34]
+  // Persistent in-modal banner for the last save error. Toast
+  // machinery is fleeting + easy to miss when the operator's eye is
+  // on the cascade prompt. Banner sits above the footer until the
+  // operator's next save attempt clears it OR they click Dismiss.
+  // Banner copy = verbatim API error message (so the operator
+  // distinguishes field-lock vs network vs validation), not a
+  // generic "save failed".
+  const [lastSaveError, setLastSaveError] = useState<{ title: string; message: string } | null>(null);
+
   // [PR / 2026-04-30] Cascade dry-run preview. cascadePreviewEnabled
   // gates the "Preview changes" button — fetched from
   // /api/config/feature-flags on modal mount, default false. Sal
@@ -817,6 +827,9 @@ export default function EditJobModal({
 
   async function submit(cascade: CascadeChoice, opts?: { force_unlock?: boolean; dry_run?: boolean }) {
     if (opts?.dry_run) setPreviewing(true); else setSaving(true);
+    // [PR / 2026-05-01] Clear stale error banner at the start of every
+    // save attempt so retries don't show outdated messages.
+    setLastSaveError(null);
     try {
       // Build add-ons payload. We persist into job_add_ons via add_on_id (legacy
       // FK), but also pass pricing_addon_id for traceability per AG.
@@ -922,10 +935,17 @@ export default function EditJobModal({
         if (r.status === 409 && d.warn === true) {
           setWarnPrompt({ message: d.message || "This change requires confirmation.", field: d.field });
           setCascadePromptOpen(false);
-        } else if (r.status === 409) {
-          toast({ title: "Cannot edit", description: d.message || "Job is locked or a tech is clocked in.", variant: "destructive" });
         } else {
-          toast({ title: "Save failed", description: d.message || d.error || `HTTP ${r.status}`, variant: "destructive" });
+          // [PR / 2026-05-01 — re-implementation of yesterday's PR #34]
+          // Persistent in-modal banner mirrors the toast (transient
+          // confirmation) but stays put until the operator's next save
+          // attempt clears it OR they click Dismiss. Verbatim API
+          // message — no information loss between "field locked" and
+          // "tech clocked in" and "validation failed".
+          const apiMessage = d.message || d.error || `HTTP ${r.status}`;
+          const title = r.status === 409 ? "Cannot edit" : "Save failed";
+          if (!opts?.dry_run) setLastSaveError({ title, message: apiMessage });
+          toast({ title, description: apiMessage, variant: "destructive" });
         }
         return;
       }
@@ -938,15 +958,42 @@ export default function EditJobModal({
         setPreviewResult(d.cascade ?? {});
         return;
       }
+      // [PR / 2026-05-01 — re-implementation of yesterday's PR #34]
+      // Compose an honest success summary from the route's response.
+      // Examples:
+      //   "Schedule updated. 4 future jobs reflect new times."
+      //   "Schedule updated. 4 future jobs reflect new times. This
+      //    visit is unchanged (frequency, base_fee stayed frozen)."
+      // The anchor_protected piece only renders when the route stripped
+      // lock-protected fields from the anchor's setParts (completed
+      // anchor + cascade_scope=this_and_future / all).
+      const summaryParts: string[] = [];
+      if (d.cascade?.schedule_updated) summaryParts.push("Schedule updated.");
+      const futureN = Number(d.cascade?.future_jobs_updated ?? 0);
+      if (futureN > 0) summaryParts.push(`${futureN} future job${futureN === 1 ? "" : "s"} reflect new times.`);
+      if (d.cascade?.anchor_protected) {
+        const fields: string[] = Array.isArray(d.cascade?.anchor_skipped_fields) ? d.cascade.anchor_skipped_fields : [];
+        const fieldList = fields.length > 0 ? ` (${fields.join(", ")} stayed frozen)` : "";
+        summaryParts.push(`This visit is unchanged${fieldList}.`);
+      }
+      if (summaryParts.length > 0) {
+        toast({ title: "Saved", description: summaryParts.join(" ") });
+      }
       onSaved({
-        future_jobs_updated: d.cascade?.future_jobs_updated ?? 0,
+        future_jobs_updated: futureN,
         future_jobs_skipped_in_progress: d.cascade?.future_jobs_skipped_in_progress ?? 0,
       });
     } catch (err) {
       // [AI.6.2] Surface the real exception so a network/CORS/parse failure
       // doesn't silently disappear under the modal.
       console.error("[edit-job-modal] PATCH exception", err);
-      toast({ title: "Network error", description: opts?.dry_run ? "Preview failed — see DevTools console" : "Could not save changes — see DevTools console", variant: "destructive" });
+      const networkMsg = opts?.dry_run ? "Preview failed — see DevTools console" : "Could not save changes — see DevTools console";
+      // [PR / 2026-05-01 — re-implementation of yesterday's PR #34]
+      // Pin a network-error banner the same way as an HTTP error — same
+      // persistence semantics so an operator who wandered off doesn't
+      // miss the failure.
+      if (!opts?.dry_run) setLastSaveError({ title: "Network error", message: networkMsg });
+      toast({ title: "Network error", description: networkMsg, variant: "destructive" });
     } finally {
       if (opts?.dry_run) setPreviewing(false); else setSaving(false);
       if (!opts?.dry_run) {
@@ -1508,6 +1555,28 @@ export default function EditJobModal({
               <li>Future jobs in series — update: {String(previewResult.future_jobs_would_be_updated ?? 0)}, delete: {String(previewResult.future_jobs_would_be_deleted ?? 0)}, insert: {String(previewResult.future_jobs_would_be_inserted_in_tx ?? 0)}, skipped (clocked-in): {String(previewResult.future_jobs_would_be_skipped_in_progress ?? 0)}</li>
               <li style={{ color: "#6B7280", fontSize: 12 }}>Forward 60-day fan-out NOT simulated in v1 — re-run without preview to see actual count.</li>
             </ul>
+          </div>
+        )}
+
+        {/* [PR / 2026-05-01 — re-implementation of yesterday's PR #34]
+            Persistent error banner. Sits above the footer until the
+            operator's next save attempt clears it (submit() →
+            setLastSaveError(null) at start) OR they click Dismiss.
+            Pulls the verbatim API message — distinguishes field-lock
+            vs network vs validation without flattening to "save
+            failed". Toast still fires on the same event for
+            transient confirmation; the banner is the persistent
+            audit trail of the failure. Color tokens use existing
+            destructive palette — no new colors. */}
+        {lastSaveError && (
+          <div style={{ padding: "12px 20px", borderTop: "1px solid #FECACA", backgroundColor: "#FEF2F2", fontFamily: FF, fontSize: 13, color: "#991B1B" }}>
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 12 }}>
+              <div style={{ flex: 1 }}>
+                <div style={{ fontWeight: 700, marginBottom: 2 }}>{lastSaveError.title}</div>
+                <div style={{ lineHeight: 1.4 }}>{lastSaveError.message}</div>
+              </div>
+              <button onClick={() => setLastSaveError(null)} style={{ fontSize: 12, color: "#991B1B", background: "none", border: "none", cursor: "pointer", fontFamily: FF, padding: 0 }}>Dismiss</button>
+            </div>
           </div>
         )}
 


### PR DESCRIPTION
## What

Re-implementation of yesterday's PR #34, reverted via PR #35 during the prod-down triage. Yesterday's outage root cause was **PR #31** (schema-drift verification at boot — top-level await + dynamic introspection). PR #34 was reverted as part of newest-first triage even though its request-time logic was code-clean.

This re-applies the same approach on top of post-#38 main, validated against the new in-tx cascade overwrite logic.

## Two pieces

### 1. Backend cascade-scope-aware lock (`routes/jobs.ts`, +63 lines)

The legacy hard-lock returned 409 when an operator tried to change `frequency` / `service_type` / price on a completed job — regardless of `cascade_scope`. That conflated:

- `cascade_scope='this_job'` → "edit this completed job's fields" (legitimate guardrail; 409 stays)
- `cascade_scope='this_and_future'` / `'all'` → "edit the schedule TEMPLATE via this completed job as anchor" (the operator's right workflow when the client completes Mon + calls Tue morning to change going forward; 409 here blocks the schedule-template UPDATE + future-jobs cascade)

Fix:
- `cascadesToTemplate = cascade_scope === "this_and_future" || cascade_scope === "all"`
- `skipAnchorLockedFields = isCompleted && cascadesToTemplate`
- Hard-lock 409 only fires when `isCompleted && !cascadesToTemplate`
- Inside the transaction: when `skipAnchorLockedFields`, strip `frequency` / `service_type` / `base_fee` / `hourly_rate` from `setParts` **before** the anchor `UPDATE jobs` runs. Schedule template UPDATE + future-jobs cascade still apply the changes to the right rows. Anchor's audit trail stays clean.
- Response `cascade` adds:
  - `anchor_protected: boolean`
  - `anchor_skipped_fields: string[]`
  - `schedule_updated: boolean`

### 2. Frontend persistent error banner (`edit-job-modal.tsx`, +71 lines)

- New `lastSaveError = { title; message } | null` state
- `submit()` clears at start — retries don't show stale messages
- On any non-2xx (except `409 + warn=true` which opens the existing confirm dialog): set `lastSaveError` with verbatim API message + title (`"Cannot edit"` for 409, `"Save failed"` otherwise). Toast still fires for transient confirmation.
- On network exception: set `lastSaveError` too — same persistence
- Red banner above footer with Dismiss button. Style uses existing destructive palette (`#FEF2F2` / `#991B1B` / `#FECACA`) — no new colors, no emojis.
- On success: compose summary toast from `cascade` response — `"Schedule updated. 4 future jobs reflect new times. This visit is unchanged (frequency, base_fee stayed frozen)."` Anchor-protected sentence only renders when route stripped fields.

## Self-verify (code-only)

- `pnpm tsc --noEmit`: net-zero new errors per file (54 pre/post in `jobs.ts`, 0 in `edit-job-modal.tsx`)
- `pnpm run build` (frontend): clean, 288.60 kB main bundle
- `pnpm run build` (api-server): clean, 3.0 MB `dist/index.mjs`

## Diff

```
artifacts/api-server/src/routes/jobs.ts           | 75 +/-
artifacts/qleno/src/components/edit-job-modal.tsx | 79 +/-
2 files changed, 144 insertions(+), 10 deletions(-)
```

Net 134 lines. Within 200 cap; same scope as yesterday's PR #34.

## Constraints respected

- Drizzle ORM `.update()` only — no raw SQL template tags for table writes (the `setParts` strip operates on the existing Drizzle update path)
- Mutations stay within the existing transaction (same `db.transaction(...)` block)
- Job IDs preserved (anchor row UPDATE in place; no DELETE+INSERT)
- Skip rules unchanged from PR #38: `status IN ('complete','cancelled')` OR `charge_succeeded_at IS NOT NULL` OR linked invoice
- No new env vars, deps, or schema
- No emojis, no new colors, Plus Jakarta Sans, no dark mode

## Fields the lock matrix adjusts

When `isCompleted && cascadesToTemplate`, these are stripped from the anchor's `setParts` UPDATE (per the comment matrix at `routes/jobs.ts:872`):

- `frequency` — was hard-locked, now stripped from anchor only
- `service_type` — was hard-locked, now stripped from anchor only
- `base_fee` — was warn-locked (or hard-lock when paid), now stripped from anchor only
- `hourly_rate` — same as base_fee

The "free fields" (notes, address, scheduled_date/time, allowed_hours, instructions, manual_rate_override, team_user_ids, add_ons, parking_*, days_of_week) keep updating on the anchor as before.

## Sal post-deploy verification

Sandbox cannot reach Railway or generate JWTs. Verification curl:

```bash
# Pre-fix (current main): 409 Field locked
# Post-fix: 200, response includes cascade.anchor_protected:true,
#                cascade.anchor_skipped_fields containing the changed
#                locked fields, cascade.schedule_updated:true.
curl -X PATCH https://app.qleno.com/api/jobs/4147 \
  -H "Authorization: Bearer $JWT" \
  -H "Content-Type: application/json" \
  -d '{
    "frequency":"weekdays",
    "days_of_week":[1,2,3,4,5],
    "scheduled_time":"08:00",
    "cascade_scope":"this_and_future"
  }'

# Anchor (4147) jobs row: frequency stays as it was at completion
SELECT id, frequency, status FROM jobs WHERE id = 4147;

# Schedule template: frequency=weekdays, days_of_week={1,2,3,4,5}
SELECT id, frequency, days_of_week FROM recurring_schedules WHERE id = 88;

# Tue-Fri this week: frequency=weekdays via cascade overwrite
SELECT id, scheduled_date, frequency FROM jobs
 WHERE client_id = 21
   AND scheduled_date BETWEEN '2026-04-28' AND '2026-05-01'
 ORDER BY scheduled_date;
```

Banner verification (DevTools): trigger any 4xx/5xx response (e.g. malformed `scheduled_time`), red banner appears above Save button with verbatim API message + Dismiss button. Successful save clears banner.

## Cadence

Opening Ready. Auto-merge per standing rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016GqMSjAaG7gGDtiFSPKn5Q)_