### PR TITLE
fix: comprehensive array-bind audit on cascade path + parking architecture verify

### DIFF
--- a/artifacts/api-server/src/routes/jobs.ts
+++ b/artifacts/api-server/src/routes/jobs.ts
@@ -1,7 +1,7 @@
 import { Router } from "express";
 import { db } from "@workspace/db";
 import { jobsTable, clientsTable, usersTable, jobPhotosTable, timeclockTable, invoicesTable, scorecardsTable, serviceZonesTable, serviceZoneEmployeesTable, companiesTable, accountsTable, accountRateCardsTable, accountPropertiesTable, paymentsTable, recurringSchedulesTable } from "@workspace/db/schema";
-import { eq, and, gte, lte, count, desc, sql, notExists, inArray, isNotNull } from "drizzle-orm";
+import { eq, and, gte, lte, count, desc, sql, notExists, inArray, isNotNull, isNull } from "drizzle-orm";
 import { requireAuth } from "../lib/auth.js";
 import { logAudit } from "../lib/audit.js";
 import { generateJobCompletionPdf } from "../lib/generate-job-pdf.js";
@@ -1902,11 +1902,22 @@ router.patch("/:id", requireAuth, async (req, res) => {
           type Cand = { id: number; scheduled_date: string };
           const cands = (candidates.rows as unknown as Cand[]).map(r => ({ id: Number(r.id), scheduled_date: String(r.scheduled_date) }));
           const candIds = cands.map(c => c.id);
-          const clockedRows = candIds.length === 0 ? { rows: [] as any[] } : await tx.execute(sql`
-            SELECT DISTINCT job_id FROM timeclock
-            WHERE clock_out_at IS NULL AND job_id = ANY(${candIds}::int[])
-          `);
-          const clockedSet = new Set((clockedRows.rows as Array<{ job_id: number }>).map(r => Number(r.job_id)));
+          // [PR / 2026-05-01 — comprehensive array-bind audit fix]
+          // Was: tx.execute(sql`... = ANY(${candIds}::int[])`) which
+          // spreads candIds into N scalar parameters per the same bug
+          // that hit PR #25's INSERT (fixed in #26) and PR #38's
+          // recurring_schedules UPDATE (fixed in #40). Drizzle's
+          // inArray() helper binds the array as a single parameter.
+          const clockedRowsRes = candIds.length === 0
+            ? [] as Array<{ job_id: number }>
+            : await tx
+                .selectDistinct({ job_id: timeclockTable.job_id })
+                .from(timeclockTable)
+                .where(and(
+                  isNull(timeclockTable.clock_out_at),
+                  inArray(timeclockTable.job_id, candIds),
+                ));
+          const clockedSet = new Set(clockedRowsRes.map(r => Number(r.job_id)));
 
           // [AI] Hybrid cascade. Build the new pattern's valid future-date set
           // and bucket each candidate job:
@@ -1989,23 +2000,38 @@ router.patch("/:id", requireAuth, async (req, res) => {
           futureClockedSkipped = skippedClockedUpdate + skippedClockedDelete;
 
           // UPDATE matching jobs in place.
+          // [PR / 2026-05-01 — comprehensive array-bind audit fix]
+          // Was: hand-rolled `sql\`UPDATE jobs SET ${setSql} WHERE id =
+          // ANY(${toUpdate}::int[])\`` — same bug class as PR #25 /
+          // PR #40. Switched to Drizzle ORM `.update().set().where(
+          // inArray(...))`. The set fields are scalars (frequency,
+          // service_type, scheduled_time, allowed_hours, base_fee,
+          // hourly_rate, notes, manual_rate_override) — none are
+          // arrays — so they're safe in the parameterised set object.
+          // The WHERE id IN (...) is the array-bind risk; inArray()
+          // binds the JS number[] as ONE int[] parameter.
           if (toUpdate.length > 0 && futureJobsSet.length > 0) {
-            const setClauses = futureJobsSet.map((c, i) => sql`${sql.identifier(c)} = ${futureJobsVals[i]}`);
-            const setSql = sql.join(setClauses, sql`, `);
-            const updRes = await tx.execute(sql`
-              UPDATE jobs SET ${setSql}
-              WHERE id = ANY(${toUpdate}::int[])
-            `);
+            const updJobsSet: Record<string, unknown> = {};
+            for (let i = 0; i < futureJobsSet.length; i++) {
+              updJobsSet[futureJobsSet[i]] = futureJobsVals[i];
+            }
+            const updRes = await tx
+              .update(jobsTable)
+              .set(updJobsSet as any)
+              .where(inArray(jobsTable.id, toUpdate));
             futureCount = (updRes as any).rowCount ?? toUpdate.length;
           } else {
             futureCount = toUpdate.length;
           }
 
           // DELETE non-matching jobs (only when day pattern changed).
+          // [PR / 2026-05-01 — comprehensive array-bind audit fix]
+          // Same bug class. Drizzle .delete().where(inArray()) binds
+          // the array as a single int[] parameter.
           if (toDelete.length > 0) {
-            const delRes = await tx.execute(sql`
-              DELETE FROM jobs WHERE id = ANY(${toDelete}::int[])
-            `);
+            const delRes = await tx
+              .delete(jobsTable)
+              .where(inArray(jobsTable.id, toDelete));
             futureDeleted = (delRes as any).rowCount ?? toDelete.length;
           }
 


### PR DESCRIPTION
## Goal

Stop the patch-the-next-bug cycle. Audit + fix every array-bind site in the cascade path. Verify parking-fee day-of-week architecture end-to-end.

The user goal: parking fee with day-of-week selection works on recurring schedules. M-F selected on parking, save succeeds, future jobs get $20 parking on M-F dates only, weekend dates skip the fee.

## Bug class summary

Drizzle's `sql\`${arr}\`` template tag spreads JS arrays into N parameter placeholders, producing `($1, $2, ...)::int[]` row constructors instead of single `'{1,2,3}'::int[]` array binds. Same root cause hit:
- PR #25 (INSERT) → fixed in PR #26 by switching to Drizzle ORM `.insert().values()`
- PR #40 (UPDATE recurring_schedules cascade) → fixed by switching to `.update().set().where()`

## Phase 1 — array-bind audit

Three more sites discovered via comprehensive grep — all in the `this_and_future` / `all` cascade path that PR #39 unblocked. Each fixed:

### 1. `routes/jobs.ts:1907` — timeclock SELECT (Sal's failing query today)

```diff
- const clockedRows = await tx.execute(sql`
-   SELECT DISTINCT job_id FROM timeclock
-   WHERE clock_out_at IS NULL AND job_id = ANY(${candIds}::int[])
- `);
+ const clockedRowsRes = await tx
+   .selectDistinct({ job_id: timeclockTable.job_id })
+   .from(timeclockTable)
+   .where(and(
+     isNull(timeclockTable.clock_out_at),
+     inArray(timeclockTable.job_id, candIds),
+   ));
```

### 2. `routes/jobs.ts:1995` — UPDATE jobs SET cascade

```diff
- const setClauses = futureJobsSet.map((c, i) => sql`${sql.identifier(c)} = ${futureJobsVals[i]}`);
- const setSql = sql.join(setClauses, sql`, `);
- const updRes = await tx.execute(sql`
-   UPDATE jobs SET ${setSql}
-   WHERE id = ANY(${toUpdate}::int[])
- `);
+ const updJobsSet: Record<string, unknown> = {};
+ for (let i = 0; i < futureJobsSet.length; i++) {
+   updJobsSet[futureJobsSet[i]] = futureJobsVals[i];
+ }
+ const updRes = await tx
+   .update(jobsTable)
+   .set(updJobsSet as any)
+   .where(inArray(jobsTable.id, toUpdate));
```

### 3. `routes/jobs.ts:2007` — DELETE jobs

```diff
- const delRes = await tx.execute(sql`
-   DELETE FROM jobs WHERE id = ANY(${toDelete}::int[])
- `);
+ const delRes = await tx
+   .delete(jobsTable)
+   .where(inArray(jobsTable.id, toDelete));
```

### Out of scope (deliberate)

- **`routes/dispatch.ts:289/303/329/399/434`** use `sql.raw(idList)` with `idList = jobIds.join(",")`. That's NOT the spread bug — `sql.raw` bypasses parameterisation and inlines the comma-joined literal. Functionally correct (jobIds are integers fetched from the server, not user input), ugly. Cleanup deferred — none of those queries hit Sal's reported failure.
- **`lib/recurring-jobs.ts`** has zero raw sql array binds (audited; only scalar interpolations like `company_id`, `addonName`, etc.). All write operations already go through Drizzle ORM via `insertJobFromSchedule` + `stampParkingFeeOnJob`.
- **`routes/jobs.ts`** has many `tx.execute(sql\`\`)` calls with single-scalar interpolations elsewhere (e.g. `job_audit_log` writes, individual `add_ons` inserts inside loops). No array binds — safe.

## Phase 2 — parking architecture verification

All 5 spec points confirmed in code. **No fixes required.**

| # | Point | Location | Confirmed |
|---|---|---|---|
| 1 | Schema has 3 columns, `parking_fee_days` is `int[]` | `lib/db/src/schema/recurring_schedules.ts:59-61` | ✓ `parking_fee_enabled` boolean NOT NULL default false; `parking_fee_amount` numeric(10,2); `parking_fee_days` `integer().array()` |
| 2 | PATCH writes `parking_fee_days` via Drizzle | `routes/jobs.ts:1366` (create_recurring INSERT) + post-PR #40 cascade UPDATE | ✓ Drizzle `.insert(recurringSchedulesTable).values()` and `.update(recurringSchedulesTable).set()` — array binds as single int[] |
| 3 | Engine reads `parking_fee_days` for cascade-stamping | `lib/recurring-jobs.ts:115-122` (`parkingApplies`) + `:130` (`stampParkingFeeOnJob`) | ✓ `days.includes(date.getDay())` with `getDay()` returning 0=Sun..6=Sat (matches schema convention) |
| 4 | EditJobModal sends `parking_fee_days` as int array | `edit-job-modal.tsx:916` | ✓ `payload.parking_fee_days = parkingNowChecked && isMultiDayEffective ? [...parkingFeeDays].sort() : null` — state typed `number[] \| null` |
| 5 | Picker buttons highlight from `recurring_schedules.parking_fee_days` on modal open | `edit-job-modal.tsx:458-460` | ✓ `setParkingFeeDays(Array.isArray(rs.parking_fee_days) ? rs.parking_fee_days : null)` |

## Phase 3 — production verification

Sandbox cannot reach production Postgres or app.qleno.com (host_not_allowed standing constraint, no `DATABASE_URL` in env). Code-only verification on my end:

- `pnpm tsc --noEmit`: net-zero new errors in `routes/jobs.ts` (54 pre / 54 post)
- `pnpm run build` (api-server): clean, 3.0 MB `dist/index.mjs`

Sal's verification post-deploy — repro the exact M-F + parking scenario:

```sql
-- Pre-state
SELECT id, frequency, days_of_week, parking_fee_enabled,
       parking_fee_amount, parking_fee_days
  FROM recurring_schedules WHERE id = 88;

-- (Sal hits Save: frequency=Weekdays, parking M-F, cascade_scope=this_and_future)

-- Post-state — expect:
--   frequency='weekdays'
--   days_of_week='{1,2,3,4,5}'
--   parking_fee_enabled=true
--   parking_fee_amount=20.00
--   parking_fee_days='{1,2,3,4,5}'

-- Cascade fan-out — every Mon-Fri row should have $20 parking, weekend rows none:
SELECT j.id, j.scheduled_date, EXTRACT(DOW FROM j.scheduled_date) AS dow,
       (SELECT subtotal FROM job_add_ons jao
          JOIN add_ons a ON a.id = jao.add_on_id
         WHERE jao.job_id = j.id AND LOWER(a.name) = 'parking fee'
         LIMIT 1) AS parking_amount
  FROM jobs j
 WHERE j.recurring_schedule_id = 88
   AND j.scheduled_date >= '2026-04-28'
 ORDER BY j.scheduled_date LIMIT 14;
```

## Diff

```
artifacts/api-server/src/routes/jobs.ts | 56 ++++++++/--
1 file changed, 41 insertions(+), 15 deletions(-)
```

Net 26 lines, single file. Way under 400-line cap.

## If this still fails

Per Sal's directive: every raw SQL query in the entire api-server gets converted to Drizzle in a follow-up. No more whack-a-mole.

## Cadence

Opening Ready. Auto-merge per standing rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016GqMSjAaG7gGDtiFSPKn5Q)_