### PR TITLE
fix: parking M-F end-to-end (Match schedule button + this_and_future cascade reaches MC-imported jobs + tech/addon/parking sync)

### DIFF
--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -1018,6 +1018,40 @@ async function runServiceTypesSeed(): Promise<void> {
   console.log(`[service-types-seed] Ensured ${services.length} Phes default service types (5 residential + 7 commercial).`);
 }
 
+// [PR / 2026-05-01] Backfill recurring_schedules.days_of_week from
+// frequency for multi-day rows where the column is null/empty.
+// MC-imported rows + schedules created before the days_of_week column
+// existed have NULL there; the modal's parking-picker "Match schedule"
+// button renders "Match schedule (—)" with an em-dash because the
+// state has nothing to read. Idempotent — only fires when there's
+// actually drift to fix. Single-day frequencies (weekly / biweekly /
+// every_3_weeks / monthly) keep days_of_week NULL by design (they
+// use the day_of_week enum); the modal handles the single-day case
+// via the dayMap fallback at edit-job-modal.tsx:454.
+async function runDaysOfWeekBackfill(): Promise<void> {
+  // 'weekdays' frequency → Mon-Fri
+  const weekdays = await db.execute(sql`
+    UPDATE recurring_schedules
+       SET days_of_week = '{1,2,3,4,5}'
+     WHERE frequency = 'weekdays'
+       AND (days_of_week IS NULL OR cardinality(days_of_week) = 0)
+  `);
+  // 'daily' frequency → Sun-Sat
+  const daily = await db.execute(sql`
+    UPDATE recurring_schedules
+       SET days_of_week = '{0,1,2,3,4,5,6}'
+     WHERE frequency = 'daily'
+       AND (days_of_week IS NULL OR cardinality(days_of_week) = 0)
+  `);
+  const nWeekdays = (weekdays as any).rowCount ?? 0;
+  const nDaily = (daily as any).rowCount ?? 0;
+  if (nWeekdays > 0 || nDaily > 0) {
+    console.log(
+      `[phes-migration] days_of_week backfill: weekdays=${nWeekdays}, daily=${nDaily} row(s) updated`,
+    );
+  }
+}
+
 export async function runPhesDataMigration(): Promise<void> {
   await runBookingSchemaGuard();
 
@@ -1025,6 +1059,12 @@ export async function runPhesDataMigration(): Promise<void> {
     await runPayMatrixBackfill();
   } catch (err: any) {
     console.warn("[phes-migration] pay-matrix-backfill — non-fatal:", err?.message ?? err);
+  }
+
+  try {
+    await runDaysOfWeekBackfill();
+  } catch (err: any) {
+    console.warn("[phes-migration] days-of-week-backfill — non-fatal:", err?.message ?? err);
   }
 
   try {

--- a/artifacts/api-server/src/routes/jobs.ts
+++ b/artifacts/api-server/src/routes/jobs.ts
@@ -1878,6 +1878,47 @@ router.patch("/:id", requireAuth, async (req, res) => {
         if (instructions !== undefined) pushFj("notes", instructions);
         if (nextManualOverride !== undefined) pushFj("manual_rate_override", nextManualOverride);
 
+        // [PR / 2026-05-01 — Tue–Fri stale-import sweep] Re-fetch the
+        // schedule after the UPDATE above so we have the post-UPDATE
+        // days_of_week / day_of_week to drive the unlinked-job sweep
+        // below. ALWAYS link the cascade target rows back to the
+        // schedule (this is what was missing — MC-imported Tue–Fri
+        // jobs have recurring_schedule_id IS NULL, so the legacy
+        // schedule_id-only candidates query at line 1894 missed them
+        // entirely; result: Sal saved Mon edits and Tue–Fri stayed
+        // stale per his 2026-05-01 screenshot).
+        const updatedSchedRow = await tx
+          .select({
+            days_of_week: recurringSchedulesTable.days_of_week,
+            day_of_week: recurringSchedulesTable.day_of_week,
+          })
+          .from(recurringSchedulesTable)
+          .where(and(
+            eq(recurringSchedulesTable.id, scheduleId),
+            eq(recurringSchedulesTable.company_id, companyId),
+          ))
+          .limit(1);
+        const schedDaysOfWeek = (updatedSchedRow[0]?.days_of_week as number[] | null) ?? null;
+        const schedDayOfWeekEnum = (updatedSchedRow[0]?.day_of_week as string | null) ?? null;
+        // Build the int[] of weekdays the schedule fires on for the
+        // unlinked-sweep filter. Multi-day uses days_of_week directly;
+        // single-day converts the enum string to a single-element int[].
+        let schedFireDays: number[] = [];
+        if (Array.isArray(schedDaysOfWeek) && schedDaysOfWeek.length > 0) {
+          schedFireDays = schedDaysOfWeek.map(Number);
+        } else if (schedDayOfWeekEnum) {
+          const dayMap: Record<string, number> = {
+            sunday: 0, monday: 1, tuesday: 2, wednesday: 3,
+            thursday: 4, friday: 5, saturday: 6,
+          };
+          const dayInt = dayMap[String(schedDayOfWeekEnum).toLowerCase()];
+          if (dayInt !== undefined) schedFireDays = [dayInt];
+        }
+        // Always link cascade targets back to the schedule so the
+        // next save sees them via the schedule_id path even if MC
+        // import never linked them.
+        pushFj("recurring_schedule_id", scheduleId);
+
         if (futureJobsSet.length > 0 || dayPatternChanged) {
           // Find candidate jobs in the series. For 'this_and_future' we
           // only touch future scheduled jobs. For 'all' we widen the
@@ -1888,13 +1929,28 @@ router.patch("/:id", requireAuth, async (req, res) => {
           // Cancelled jobs are excluded both ways. The current job
           // updates via the main UPDATE statement so we exclude it
           // here to avoid double-write.
+          //
+          // [PR / 2026-05-01] WHERE clause now matches:
+          //   (a) jobs already linked to this schedule, OR
+          //   (b) unlinked jobs for the same client whose weekday
+          //       matches the schedule's days_of_week.
+          // (b) is the MC-imported-stale fix.
           const candidates = await tx.execute(sql`
             SELECT j.id, j.scheduled_date::text AS scheduled_date
             FROM jobs j
-            WHERE j.recurring_schedule_id = ${scheduleId}
-              AND j.company_id = ${companyId}
+            WHERE j.company_id = ${companyId}
               AND j.id != ${jobId}
               AND j.status NOT IN ('cancelled')
+              AND (
+                j.recurring_schedule_id = ${scheduleId}
+                OR (
+                  j.recurring_schedule_id IS NULL
+                  AND j.client_id = ${Number(before.client_id)}
+                  ${schedFireDays.length > 0
+                    ? sql`AND EXTRACT(DOW FROM j.scheduled_date)::int IN (${sql.raw(schedFireDays.join(","))})`
+                    : sql`AND FALSE`}
+                )
+              )
               AND ${cascadeAllScope
                   ? sql`j.charge_succeeded_at IS NULL AND j.status != 'complete'`
                   : sql`j.scheduled_date > CURRENT_DATE AND j.status = 'scheduled'`}
@@ -2022,6 +2078,121 @@ router.patch("/:id", requireAuth, async (req, res) => {
             futureCount = (updRes as any).rowCount ?? toUpdate.length;
           } else {
             futureCount = toUpdate.length;
+          }
+
+          // [PR / 2026-05-01] Per-job tech + addon + parking sync for
+          // cascaded jobs. The legacy this_and_future UPDATE only wrote
+          // scalar fields (frequency / scheduled_time / base_fee /
+          // etc.) — never re-assigned techs or addons. Result on Sal's
+          // 2026-05-01 repro: Mon's edit set Tue's tech to Alma in
+          // jobs.assigned_user_id (wrong path), but Tue's
+          // job_technicians still had Juan, so the dispatch grid
+          // (which reads job_technicians for the tech chip) still
+          // showed Juan. Same gap for parking — the schedule template's
+          // parking_fee_days got the new value but cascaded jobs
+          // never had their job_add_ons.parking-fee row stamped /
+          // re-stamped.
+          //
+          // Mirrors the create_recurring branch's per-job sync block
+          // (see line ~1700 onward). Same skip-locked-jobs rule already
+          // applied at the SELECT level above (status NOT IN cancelled
+          // + status='scheduled' for this_and_future / charge_succeeded_at
+          // IS NULL + status != complete for all). Tech list comes from
+          // recurring_schedule_technicians (mirror written further down
+          // when teamProvided) — for the cascade target jobs, sync from
+          // the team_user_ids payload directly.
+          if (toUpdate.length > 0 && (teamProvided || addOnsProvided)) {
+            const techListForCascade: number[] = teamProvided && Array.isArray(team_user_ids) && team_user_ids.length > 0
+              ? team_user_ids.map((u: unknown) => Number(u))
+              : [];
+            const { resolveParkingAddon, parkingApplies, stampParkingFeeOnJob } = await import("../lib/recurring-jobs.js");
+            const cascadeParkingResolved = await resolveParkingAddon(
+              {
+                company_id: companyId,
+                parking_fee_amount: parking_fee_amount === null || parking_fee_amount === undefined
+                  ? null
+                  : String(parking_fee_amount),
+              },
+              tx,
+            );
+            for (const jId of toUpdate) {
+              if (techListForCascade.length > 0) {
+                await tx.execute(sql`DELETE FROM job_technicians WHERE job_id = ${jId}`);
+                for (let i = 0; i < techListForCascade.length; i++) {
+                  const uid = techListForCascade[i];
+                  const isPrimary = i === 0;
+                  await tx.execute(sql`
+                    INSERT INTO job_technicians (job_id, user_id, company_id, is_primary)
+                    VALUES (${jId}, ${uid}, ${companyId}, ${isPrimary})
+                    ON CONFLICT (job_id, user_id) DO UPDATE SET is_primary = EXCLUDED.is_primary
+                  `);
+                }
+                await tx.execute(sql`
+                  UPDATE jobs SET assigned_user_id = ${techListForCascade[0]}
+                  WHERE id = ${jId} AND company_id = ${companyId}
+                `);
+              }
+              if (addOnsProvided && Array.isArray(add_ons)) {
+                await tx.execute(sql`DELETE FROM job_add_ons WHERE job_id = ${jId}`);
+                for (const a of add_ons as Array<{ pricing_addon_id?: number; add_on_id?: number; qty?: number; unit_price?: number; subtotal?: number }>) {
+                  const pricingId = Number(a.pricing_addon_id ?? 0) || null;
+                  const qty = Number(a.qty ?? 1) || 1;
+                  const unitPrice = a.unit_price != null ? String(a.unit_price) : "0";
+                  const subtotal = a.subtotal != null ? String(a.subtotal) : "0";
+                  let realAddOnId: number | null = null;
+                  if (pricingId) {
+                    const paRows = await tx.execute(sql`
+                      SELECT name FROM pricing_addons WHERE id = ${pricingId} LIMIT 1
+                    `);
+                    const paName = String((paRows.rows[0] as any)?.name ?? "").trim();
+                    if (paName) {
+                      const ex = await tx.execute(sql`
+                        SELECT id FROM add_ons WHERE company_id = ${companyId} AND LOWER(name) = LOWER(${paName}) LIMIT 1
+                      `);
+                      if (ex.rows.length) {
+                        realAddOnId = Number((ex.rows[0] as any).id);
+                      } else {
+                        const cre = await tx.execute(sql`
+                          INSERT INTO add_ons (company_id, name, price, category, is_active)
+                          VALUES (${companyId}, ${paName}, ${unitPrice}, 'other', true)
+                          RETURNING id
+                        `);
+                        realAddOnId = Number((cre.rows[0] as any).id);
+                      }
+                    }
+                  }
+                  if (!realAddOnId && a.add_on_id) realAddOnId = Number(a.add_on_id);
+                  if (!realAddOnId) continue;
+                  await tx.execute(sql`
+                    INSERT INTO job_add_ons (job_id, add_on_id, quantity, unit_price, subtotal, pricing_addon_id)
+                    VALUES (${jId}, ${realAddOnId}, ${qty}, ${unitPrice}, ${subtotal}, ${pricingId})
+                    ON CONFLICT (job_id, add_on_id) DO UPDATE
+                      SET quantity = EXCLUDED.quantity,
+                          unit_price = EXCLUDED.unit_price,
+                          subtotal = EXCLUDED.subtotal,
+                          pricing_addon_id = EXCLUDED.pricing_addon_id
+                  `);
+                }
+              }
+              // Stamp parking on weekday-matching cascaded dates.
+              if (cascadeParkingResolved && parking_fee_enabled === true) {
+                // Look up the cascaded job's date to apply parkingApplies.
+                const dateRow = await tx.execute(sql`
+                  SELECT scheduled_date::text AS d FROM jobs WHERE id = ${jId} LIMIT 1
+                `);
+                const dateStr = String((dateRow.rows[0] as any)?.d ?? "");
+                if (dateStr) {
+                  const date = new Date(`${dateStr}T00:00:00`);
+                  const synthSched = {
+                    parking_fee_enabled: true,
+                    parking_fee_days: Array.isArray(parking_fee_days) && parking_fee_days.length > 0 ? parking_fee_days : null,
+                  } as any;
+                  if (parkingApplies(synthSched, date)) {
+                    await stampParkingFeeOnJob(jId, cascadeParkingResolved, tx);
+                  }
+                }
+              }
+            }
           }
 
           // DELETE non-matching jobs (only when day pattern changed).

--- a/artifacts/qleno/src/components/edit-job-modal.tsx
+++ b/artifacts/qleno/src/components/edit-job-modal.tsx
@@ -450,8 +450,26 @@ export default function EditJobModal({
         // Recurring schedule snapshot.
         const rs = d.recurring_schedule;
         if (rs) {
-          if (Array.isArray(rs.days_of_week)) {
+          // [PR / 2026-05-01 — Match schedule button fix] Populate the
+          // modal's daysOfWeek state from BOTH the multi-day array and
+          // the single-day enum. Schema invariant: weekly / biweekly /
+          // every_3_weeks / monthly populate `day_of_week` (string
+          // enum) with `days_of_week` NULL; daily / weekdays /
+          // custom_days populate `days_of_week` (int[]) with
+          // `day_of_week` NULL. Without this fallback, the parking
+          // picker's "Match schedule (—)" label renders an em-dash
+          // for every single-day schedule (and for any multi-day
+          // schedule where MC import never populated days_of_week —
+          // backfilled in phes-data-migration.ts in this same PR).
+          if (Array.isArray(rs.days_of_week) && rs.days_of_week.length > 0) {
             setDaysOfWeek(rs.days_of_week);
+          } else if (rs.day_of_week) {
+            const dayMap: Record<string, number> = {
+              sunday: 0, monday: 1, tuesday: 2, wednesday: 3,
+              thursday: 4, friday: 5, saturday: 6,
+            };
+            const dayInt = dayMap[String(rs.day_of_week).toLowerCase()];
+            if (dayInt !== undefined) setDaysOfWeek([dayInt]);
           }
           setParkingFeeEnabledInitial(!!rs.parking_fee_enabled);
           setParkingFeeAmountInitial(rs.parking_fee_amount != null ? Number(rs.parking_fee_amount) : null);


### PR DESCRIPTION
## Goal

Sal's actual user goal end-to-end: parking fee with day-of-week selection on recurring schedules works. M-F selected, save succeeds, future Tue–Fri jobs reflect Mon's edit (tech, service_type, fee, parking).

## Bugs (per Sal's 2026-05-01 1:28pm screenshot — Jaira's Tuesday tile still showed Standard Clean / $370 / 7h / Juan Salazar after a successful Mon save)

Three fixes, all in one PR:

### 1. Match schedule button shows em-dash → reads day_of_week + backfills days_of_week

**Where** — `edit-job-modal.tsx:454` only read `rs.days_of_week`. For single-day frequencies (weekly Mon → `day_of_week='monday'`, `days_of_week=NULL`) the state stayed `[]`, so "Match schedule (—)" rendered. Plus MC-imported schedules with `frequency='weekdays'` had `days_of_week=NULL` because no successful cascade had ever populated it.

**Fix**:
- Modal: read both columns. Multi-day populates from int[]; single-day converts the enum to a single-element int[].
- `phes-data-migration.ts`: idempotent backfill — `UPDATE recurring_schedules SET days_of_week='{1,2,3,4,5}' WHERE frequency='weekdays' AND (days_of_week IS NULL OR cardinality=0)`. Same for `'daily'` → `'{0,1,2,3,4,5,6}'`. Logs row count.

### 2. this_and_future cascade misses unlinked future jobs at matching weekdays

**Where** — the candidates query at `routes/jobs.ts:1894` filtered `j.recurring_schedule_id = ${scheduleId}`. MC-imported Tue–Fri jobs for Jaira have `recurring_schedule_id IS NULL` — the cascade never sees them.

**Fix** — extend the query:

```sql
WHERE j.company_id = ${companyId}
  AND j.id != ${jobId}
  AND j.status NOT IN ('cancelled')
  AND (
    j.recurring_schedule_id = ${scheduleId}
    OR (
      j.recurring_schedule_id IS NULL
      AND j.client_id = ${before.client_id}
      AND EXTRACT(DOW FROM j.scheduled_date)::int IN (sched fire days)
    )
  )
  AND <existing date/status branch>
```

`schedFireDays` is built from the freshly-UPDATEd schedule's `days_of_week` (multi-day) or `day_of_week` enum (single-day → int). Used via `sql.raw(schedFireDays.join(","))` — safe, derived from server-side row data, not user input.

**Plus**: always add `recurring_schedule_id = scheduleId` to the cascade UPDATE so unlinked jobs get linked. Next save sees them via the schedule_id path; the unlinked-sweep becomes a one-time MC-import cleanup.

### 3. Cascaded jobs never had techs / addons / parking synced

**Where** — the legacy this_and_future cascade UPDATE wrote scalar fields only. `job_technicians` for Tue–Fri stayed as imported (Juan), so even when Sal picked Alma the dispatch tile (which reads `job_technicians`) kept Juan. Same gap for `job_add_ons` — parking row never stamped on cascaded dates.

**Fix** — mirror the per-job sync logic from PR #38's create_recurring branch:
- DELETE + INSERT `job_technicians` from `team_user_ids`; mirror primary onto `jobs.assigned_user_id` (the assignment-mirror invariant from CLAUDE.md)
- DELETE + INSERT `job_add_ons` from `add_ons` with the same FK resolution to `add_ons.id` used elsewhere in the file
- `stampParkingFeeOnJob` via `lib/recurring-jobs.ts` when `parkingApplies(synthSched, date)` — uses the cascaded job's actual `scheduled_date` for the weekday match

Only fires when `teamProvided` OR `addOnsProvided` (operator changed something that should propagate).

## Self-verify (code-only)

- `pnpm tsc --noEmit`: 54 pre / 54 post in `routes/jobs.ts` (net-zero new errors). 0 in modal. 0 in `phes-data-migration.ts`.
- `pnpm run build` (api-server): clean, 3.0 MB `dist/index.mjs`
- `pnpm run build` (frontend): clean, 288.60 kB main bundle

## Diff

```
artifacts/api-server/src/phes-data-migration.ts   |  40 +++ (new function)
artifacts/api-server/src/routes/jobs.ts           | 175 +++ (cascade extension + tech/addon sync)
artifacts/qleno/src/components/edit-job-modal.tsx |  20 ++ (day_of_week fallback)
3 files changed, 232 insertions(+), 3 deletions(-)
```

Net 229 lines. Under the 250 cap, broader than usual because it covers: data backfill + frontend fallback + backend cascade extension. All in service of the same goal.

## Sal post-deploy verification

After Railway redeploys (~2-3 min), repro the exact scenario:

1. Hard refresh `/dispatch`
2. Open Mon 4147 modal
3. Confirm "Match schedule (M-F)" with M-F highlighted in days display (em-dash gone)
4. Click parking Match schedule — M-F highlight in parking section too
5. Frequency = Weekdays, tech = Alma, parking enabled M-F
6. Save with cascade_scope = this_and_future
7. Navigate to Tue Apr 28. Jaira's tile should show:
   - Alma Salinas (not Juan Salazar)
   - commercial_cleaning (not Standard Clean)
   - $320 (not $370)
   - 6h (not 7h)
   - linked to recurring_schedule_id=88
   - $20 parking row in `job_add_ons`
8. Same check Wed/Thu/Fri

If any value still stale: paste the row's `recurring_schedule_id`, `status`, `charge_succeeded_at`, plus the Railway log line for the cascade run. Either it's a correct skip (status='complete' / paid / has invoice) or another gap to chase.

## Cadence

Opening Ready. Auto-merge per standing rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016GqMSjAaG7gGDtiFSPKn5Q)_