### PR TITLE
feat(edit-modal + jobs): M-F/Every day presets, smart auto-fill, parking match-schedule fix, free editing of completed jobs

### DIFF
--- a/artifacts/api-server/src/routes/jobs.ts
+++ b/artifacts/api-server/src/routes/jobs.ts
@@ -870,111 +870,31 @@ router.patch("/:id", requireAuth, async (req, res) => {
     if (!jobRows.rows.length) return res.status(404).json({ error: "Job not found" });
     const before = jobRows.rows[0] as Record<string, unknown>;
 
-    // [edit-decouple 2026-04-29] Per-field lock matrix replaces the prior
-    // blanket "completed/cancelled/locked = no edits". Operators need to
-    // fix tech assignments and clock-in timestamps after the fact for
-    // payroll, and surfacing edits via the audit log is more useful than
-    // hiding the door entirely.
+    // [PR / 2026-05-03] Completed-job edits are fully unlocked per Sal's
+    // directive — notes, tech, time, price, parking, frequency,
+    // service_type, anything. Money movement (refunds, surcharges) is
+    // handled manually outside the app. Reports query the live row so
+    // figures retroactively reflect any edit. Audit log writes capture
+    // every change for traceability. Cancelled stays hard-locked
+    // (uncancel flow handles restoration).
     //
-    //   Free fields:        notes, address, scheduled_date/time,
-    //                       allowed_hours, instructions, manual_rate_override,
-    //                       team_user_ids, add_ons, parking_*, days_of_week
-    //   Hard-locked fields on completed: service_type, frequency
-    //                       (changing these changes commission routing /
-    //                        recurrence semantics — use void-and-rebook)
-    //   Warn-then-unlock:   base_fee on completed (warn if invoiced),
-    //                       hourly_rate on completed
-    //   Hard-locked when paid: base_fee, hourly_rate
-    //                       (charge_succeeded_at IS NOT NULL means money
-    //                        moved — refund flow, not edit)
-    //   Always free:        team_user_ids, instructions, address fields,
-    //                       notes, add_ons (audit-trailed in all cases)
-    //
-    // Caller signals "I see the warning, proceed" via `force_unlock: true`
-    // in the body. Without it, warn-locked field edits return 409.
-    const force_unlock = req.body?.force_unlock === true;
+    // `skipAnchorLockedFields` below still freezes the anchor row's
+    // frequency / service_type / price columns when cascade='this_and_future'
+    // or 'all', so the historical anchor keeps the values that actually
+    // fired. To overwrite the anchor itself, the operator picks
+    // cascade='this_job'.
     const isCompleted = before.status === "complete";
     const isCancelled = before.status === "cancelled";
-    const isPaid = before.charge_succeeded_at != null;
 
     if (isCancelled) {
-      // Cancelled jobs stay locked. Restore-from-cancelled is a different
-      // flow (uncancel route, not editor).
       return res.status(409).json({
         error: "Cancelled job",
         message: "Cancelled jobs cannot be edited. Restore the job first.",
       });
     }
 
-    // [PR / 2026-05-01 — re-implementation of yesterday's PR #34
-    // (reverted in #35 during the unrelated #31 boot-time outage)]
-    //
-    // Cascade-scope-aware lock: the legacy hard-lock returned 409 when
-    // an operator tried to change frequency / service_type / price on
-    // a completed job — regardless of cascade_scope. That conflated:
-    //   (1) "edit this completed job's fields"   (this_job)
-    //   (2) "edit the schedule TEMPLATE via this completed job as
-    //        anchor; future jobs inherit, this one stays as-is in the
-    //        audit trail" (this_and_future / all)
-    //
-    // (2) is the operator's right workflow when the client completes
-    // Monday + calls Tuesday morning to change the schedule going
-    // forward. Pre-fix this 409'd. Post-fix the route strips the
-    // locked fields from the anchor's `setParts` UPDATE (audit record
-    // stays clean) but proceeds with the schedule-template UPDATE +
-    // future-jobs cascade (which already filters `j.id != ${jobId}`
-    // and respects the per-row status / paid / invoice skip rules
-    // shipped in PR #38).
     const cascadesToTemplate = cascade_scope === "this_and_future" || cascade_scope === "all";
     const skipAnchorLockedFields = isCompleted && cascadesToTemplate;
-
-    if (isCompleted && !cascadesToTemplate) {
-      // Editing only this completed job — hard-lock service_type /
-      // frequency. Changing them rewrites commission routing and
-      // recurrence semantics on already-billed work. Operator must
-      // void-and-rebook for those.
-      if (service_type !== undefined && service_type !== before.service_type) {
-        return res.status(409).json({
-          error: "Field locked",
-          field: "service_type",
-          message: "Service type can't change on a completed job. Cancel and re-book if the wrong type was billed, or use 'This and all future' to update the schedule template.",
-        });
-      }
-      if (frequency !== undefined && frequency !== before.frequency) {
-        return res.status(409).json({
-          error: "Field locked",
-          field: "frequency",
-          message: "Frequency can't change on a completed job. Cancel and re-book if the recurrence was wrong, or use 'This and all future' to update the schedule template.",
-        });
-      }
-    }
-    if (isCompleted) {
-      // Warn-locked: pricing on completed jobs. Hard-locked when paid.
-      // For cascadesToTemplate: skip the warn/hard-lock entirely. The
-      // price change applies to the schedule template + future jobs;
-      // the anchor's `jobs.base_fee` / `jobs.hourly_rate` stay frozen
-      // (stripped from setParts below).
-      const priceChanged =
-        (base_fee !== undefined && String(base_fee) !== String(before.base_fee ?? "")) ||
-        (hourly_rate !== undefined && String(hourly_rate ?? "") !== String(before.hourly_rate ?? ""));
-      if (priceChanged && !cascadesToTemplate) {
-        if (isPaid) {
-          return res.status(409).json({
-            error: "Field locked",
-            field: "base_fee",
-            message: "Job is already paid. Issue a refund or surcharge instead of editing the price.",
-          });
-        }
-        if (!force_unlock) {
-          return res.status(409).json({
-            error: "Confirmation required",
-            field: "base_fee",
-            warn: true,
-            message: "This job is completed. Changing the price may require manual invoice adjustment. Re-submit with force_unlock=true to confirm.",
-          });
-        }
-      }
-    }
 
     if (cascade_scope === "this_and_future" && before.recurring_schedule_id == null) {
       return res.status(400).json({
@@ -1075,28 +995,10 @@ router.patch("/:id", requireAuth, async (req, res) => {
       });
     }
 
-    // [cascade-scope 2026-04-29] cascade='all' warns when any past
-    // occurrence in the series has been paid. Operator must confirm
-    // via force_unlock=true to proceed (same flag used by the
-    // per-field warn-then-unlock above).
-    if (cascade_scope === "all" && before.recurring_schedule_id != null) {
-      const paidPast = await db.execute(sql`
-        SELECT COUNT(*)::int AS n FROM jobs
-         WHERE recurring_schedule_id = ${Number(before.recurring_schedule_id)}
-           AND company_id = ${companyId}
-           AND charge_succeeded_at IS NOT NULL
-           AND scheduled_date < ${String(before.scheduled_date)}
-      `);
-      const n = Number((paidPast.rows[0] as any)?.n ?? 0);
-      if (n > 0 && !force_unlock) {
-        return res.status(409).json({
-          error: "Confirmation required",
-          warn: true,
-          paid_past_count: n,
-          message: `This recurring series has ${n} past paid occurrence${n === 1 ? "" : "s"}. Backfilling 'all' will leave those paid jobs untouched but template + past unpaid will update. Re-submit with force_unlock=true to confirm.`,
-        });
-      }
-    }
+    // [PR / 2026-05-03] cascade='all' previously warned when past
+    // occurrences were paid. Removed alongside the completion gates —
+    // the cascade engine itself silently skips paid past jobs further
+    // down (audit-trail preserved), so the heads-up was just friction.
 
     // ── In-progress guard: open timeclock blocks date/time/team edits ──────
     const tcRows = await db.execute(sql`

--- a/artifacts/qleno/src/components/edit-job-modal.tsx
+++ b/artifacts/qleno/src/components/edit-job-modal.tsx
@@ -1157,8 +1157,13 @@ export default function EditJobModal({
                         return (
                           <button key={p.label} type="button"
                             onClick={() => {
-                              setFrequency(p.frequency);
-                              setDaysOfWeek([...p.days]);
+                              if (active) {
+                                setFrequency("custom_days");
+                                setDaysOfWeek([]);
+                              } else {
+                                setFrequency(p.frequency);
+                                setDaysOfWeek([...p.days]);
+                              }
                             }}
                             style={{
                               fontSize: 11, fontWeight: 600, padding: "5px 10px", borderRadius: 6,

--- a/artifacts/qleno/src/components/edit-job-modal.tsx
+++ b/artifacts/qleno/src/components/edit-job-modal.tsx
@@ -354,11 +354,6 @@ export default function EditJobModal({
   // the cascade prompt explaining what "Just this visit" will and
   // won't do. See FIELD_SCOPE_CLASSIFICATION at the top of this file.
   const [mixedEditWarning, setMixedEditWarning] = useState<{ template: string[]; occurrence: string[] } | null>(null);
-  // [edit-decouple 2026-04-29] When the route returns warn=true, we
-  // open this confirmation dialog. User confirms → we re-submit with
-  // force_unlock: true so per-field warn locks pass through.
-  const [warnPrompt, setWarnPrompt] = useState<{ message: string; field?: string } | null>(null);
-
   const [saving, setSaving] = useState(false);
 
   // [PR / 2026-05-01 — re-implementation of yesterday's PR #34]
@@ -856,7 +851,7 @@ export default function EditJobModal({
     setCascadePromptOpen(true);
   }
 
-  async function submit(cascade: CascadeChoice, opts?: { force_unlock?: boolean; dry_run?: boolean }) {
+  async function submit(cascade: CascadeChoice, opts?: { dry_run?: boolean }) {
     if (opts?.dry_run) setPreviewing(true); else setSaving(true);
     // [PR / 2026-05-01] Clear stale error banner at the start of every
     // save attempt so retries don't show outdated messages.
@@ -898,11 +893,6 @@ export default function EditJobModal({
         // tx. Production state stays untouched. Response shape carries
         // `dry_run: true` and `cascade.future_jobs_would_be_*`.
         dry_run: opts?.dry_run === true,
-        // [edit-decouple 2026-04-29] When the route returned warn=true on
-        // a previous attempt and the operator confirmed in the dialog,
-        // we replay the request with this flag set so per-field warn
-        // locks (price-on-completed, all-with-paid-past) pass through.
-        force_unlock: opts?.force_unlock === true,
       };
       // [AH] Commercial-only fields. service_type is a real enum value the
       // user picked from the commercial dropdown; hourly_rate persists to
@@ -959,14 +949,7 @@ export default function EditJobModal({
       const d = await r.json().catch(() => ({}));
       if (!r.ok) {
         console.error("[edit-job-modal] PATCH failed", { status: r.status, body: d, payload });
-        // [edit-decouple 2026-04-29] 409 + warn=true is a "are you sure"
-        // signal — surface a confirm dialog and let the operator re-submit
-        // with force_unlock: true. Other 409s stay as terminal errors
-        // (cancelled job, hard-locked field, tech clocked in).
-        if (r.status === 409 && d.warn === true) {
-          setWarnPrompt({ message: d.message || "This change requires confirmation.", field: d.field });
-          setCascadePromptOpen(false);
-        } else {
+        {
           // [PR / 2026-05-01 — re-implementation of yesterday's PR #34]
           // Persistent in-modal banner mirrors the toast (transient
           // confirmation) but stays put until the operator's next save
@@ -1861,40 +1844,6 @@ export default function EditJobModal({
         </>
       )}
 
-      {/* [edit-decouple 2026-04-29] Confirmation dialog for warn-locked
-          edits. Opens when the route returns 409 + warn=true. The
-          operator's "Confirm and save" re-submits the same payload with
-          force_unlock: true so the per-field warn lock passes through. */}
-      {warnPrompt && (
-        <>
-          <div onClick={() => setWarnPrompt(null)}
-            style={{ position: "fixed", inset: 0, backgroundColor: "rgba(15,16,18,0.55)", zIndex: 220 }} />
-          <div style={{
-            position: "fixed", top: "50%", left: "50%", transform: "translate(-50%, -50%)",
-            zIndex: 221, width: 440, maxWidth: "92vw",
-            backgroundColor: "#FFFFFF", border: "1px solid #E5E2DC", borderRadius: 12,
-            boxShadow: "0 16px 48px rgba(0,0,0,0.18)", padding: "20px 22px",
-            fontFamily: FF,
-          }}>
-            <div style={{ fontSize: 16, fontWeight: 800, color: "#1A1917", marginBottom: 8 }}>
-              Confirm change
-            </div>
-            <div style={{ fontSize: 13, color: "#1A1917", lineHeight: 1.5, marginBottom: 18 }}>
-              {warnPrompt.message}
-            </div>
-            <div style={{ display: "flex", gap: 8 }}>
-              <button onClick={() => setWarnPrompt(null)} disabled={saving}
-                style={{ flex: 1, padding: "10px", borderRadius: 8, border: "1px solid #E5E2DC", background: "#FFFFFF", color: "#6B7280", fontSize: 13, fontWeight: 600, cursor: "pointer", fontFamily: FF }}>
-                Cancel
-              </button>
-              <button onClick={() => { setWarnPrompt(null); submit(cascadeChoice, { force_unlock: true }); }} disabled={saving}
-                style={{ flex: 2, padding: "10px", borderRadius: 8, border: "none", background: "#D97706", color: "#FFFFFF", fontSize: 13, fontWeight: 700, cursor: saving ? "wait" : "pointer", fontFamily: FF }}>
-                {saving ? "Saving…" : "Confirm and save"}
-              </button>
-            </div>
-          </div>
-        </>
-      )}
     </>
   );
 }

--- a/artifacts/qleno/src/components/edit-job-modal.tsx
+++ b/artifacts/qleno/src/components/edit-job-modal.tsx
@@ -192,6 +192,19 @@ const DAY_PICKER: Array<{ value: number; short: string }> = [
   { value: 6, short: "Sat" },
 ];
 
+// [feature/edit-modal-frequency-presets] Single-tap presets for the two
+// common cleaning cadences PHES actually runs. Each preset writes
+// frequency + days_of_week atomically. Other custom-day patterns (T–F,
+// M–W, Th–F, M & F) are reachable via the custom_days checkbox grid below
+// — its smart auto-fill expands a tapped business day through Friday on
+// first tap, so users get one-tap shortcuts to those patterns without
+// cluttering this row. Active state highlights when the current
+// (frequency, daysOfWeek) tuple matches a preset.
+const SCHEDULE_PRESETS: Array<{ label: string; frequency: string; days: number[] }> = [
+  { label: "M–F",       frequency: "weekdays", days: [1, 2, 3, 4, 5] },
+  { label: "Every day", frequency: "daily",    days: [0, 1, 2, 3, 4, 5, 6] },
+];
+
 const SECTION: React.CSSProperties = {
   margin: "14px 20px 0",
   backgroundColor: "#FFFFFF",
@@ -1121,6 +1134,68 @@ export default function EditJobModal({
                     </select>
                   </div>
                 </div>
+                {/* [feature/edit-modal-frequency-presets] Convenience preset
+                    buttons + visual day confirmation. Tap a preset → set
+                    frequency + days_of_week atomically. The chip strip below
+                    renders the resolved firing days when frequency is
+                    'weekdays' or 'daily' so the user gets visible feedback
+                    that was missing when only the dropdown changed. The
+                    custom-days picker below still owns interactive editing
+                    for that frequency. */}
+                {frequency !== "on_demand" && (
+                  <div style={{ marginTop: 10 }}>
+                    <span style={{ fontSize: 12, color: "#6B6860", display: "block", marginBottom: 6 }}>
+                      Quick presets
+                    </span>
+                    <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+                      {SCHEDULE_PRESETS.map(p => {
+                        const sortedCurrent = [...daysOfWeek].sort();
+                        const sortedPreset = [...p.days].sort();
+                        const active = frequency === p.frequency
+                          && sortedCurrent.length === sortedPreset.length
+                          && sortedCurrent.every((v, i) => v === sortedPreset[i]);
+                        return (
+                          <button key={p.label} type="button"
+                            onClick={() => {
+                              setFrequency(p.frequency);
+                              setDaysOfWeek([...p.days]);
+                            }}
+                            style={{
+                              fontSize: 11, fontWeight: 600, padding: "5px 10px", borderRadius: 6,
+                              border: `1px solid ${active ? "var(--brand, #00C9A0)" : "#E5E2DC"}`,
+                              background: active ? "rgba(0,201,160,0.08)" : "#FFFFFF",
+                              color: active ? "var(--brand, #00C9A0)" : "#6B6860",
+                              cursor: "pointer", fontFamily: FF,
+                            }}>
+                            {p.label}
+                          </button>
+                        );
+                      })}
+                    </div>
+                    {(frequency === "weekdays" || frequency === "daily") && (
+                      <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginTop: 8 }}>
+                        {DAY_PICKER.map(d => {
+                          const firingDays = frequency === "weekdays" ? [1, 2, 3, 4, 5] : [0, 1, 2, 3, 4, 5, 6];
+                          const firing = firingDays.includes(d.value);
+                          return (
+                            <span key={d.value}
+                              style={{
+                                display: "inline-flex", alignItems: "center",
+                                padding: "6px 10px", borderRadius: 6,
+                                border: `1.5px solid ${firing ? "var(--brand, #00C9A0)" : "#E5E2DC"}`,
+                                backgroundColor: firing ? "rgba(0,201,160,0.07)" : "#F7F6F3",
+                                fontSize: 12, fontFamily: FF,
+                                color: firing ? "var(--brand, #00C9A0)" : "#9E9B94",
+                                fontWeight: firing ? 700 : 500,
+                              }}>
+                              {d.short}
+                            </span>
+                          );
+                        })}
+                      </div>
+                    )}
+                  </div>
+                )}
                 {/* [AI] Custom-days picker — 7 checkboxes, only when frequency='custom_days' */}
                 {frequency === "custom_days" && (
                   <div style={{ marginTop: 10 }}>
@@ -1145,9 +1220,26 @@ export default function EditJobModal({
                             }}>
                             <input type="checkbox" checked={checked}
                               onChange={() => {
-                                setDaysOfWeek(prev =>
-                                  prev.includes(d.value) ? prev.filter(x => x !== d.value) : [...prev, d.value]
-                                );
+                                setDaysOfWeek(prev => {
+                                  // Toggling off — works for any day, no auto-fill.
+                                  if (prev.includes(d.value)) return prev.filter(x => x !== d.value);
+                                  // [feature/edit-modal-frequency-presets] Smart auto-fill:
+                                  // tapping a business day (Mon–Fri = 1..5) when no business
+                                  // day is already selected fills [tappedDay..5]. This makes
+                                  // tapping Tue → [2,3,4,5], tapping Wed → [3,4,5], etc.
+                                  // Tapping Sat/Sun, or tapping a business day when at least
+                                  // one business day is already checked, behaves as a normal
+                                  // toggle so users can fine-tune without the auto-fill
+                                  // fighting them. Existing weekend selections are preserved.
+                                  const isBusinessDay = d.value >= 1 && d.value <= 5;
+                                  const hasBusinessDay = prev.some(v => v >= 1 && v <= 5);
+                                  if (isBusinessDay && !hasBusinessDay) {
+                                    const range: number[] = [];
+                                    for (let i = d.value; i <= 5; i++) range.push(i);
+                                    return [...prev.filter(v => v < 1 || v > 5), ...range].sort();
+                                  }
+                                  return [...prev, d.value].sort();
+                                });
                               }} />
                             {d.short}
                           </label>
@@ -1317,7 +1409,16 @@ export default function EditJobModal({
                 <Loader2 size={12} className="animate-spin" /> Loading add-ons…
               </div>
             ) : availableAddons.length === 0 ? (
-              <span style={{ fontSize: 12, color: "#9E9B94" }}>No add-ons configured for this scope.</span>
+              // [feature/edit-modal-frequency-presets] Diagnostic empty-state
+              // for commercial recurring jobs — when the parking add-on is
+              // missing for this company, the parking-fee day picker further
+              // down can never render. Surface that explicitly so operators
+              // can self-diagnose instead of guessing why parking UI is gone.
+              <span style={{ fontSize: 12, color: "#9E9B94" }}>
+                {isCommercial && isRecurring
+                  ? "No add-ons available — check that a 'Parking Fee' row exists in pricing_addons for this company."
+                  : "No add-ons configured for this scope."}
+              </span>
             ) : (
               <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
                 {availableAddons.map(a => {
@@ -1439,11 +1540,33 @@ export default function EditJobModal({
                     })}
                   </div>
                   <div style={{ display: "flex", gap: 8 }}>
-                    <button type="button"
-                      onClick={() => setParkingFeeDays([...daysOfWeek].sort())}
-                      style={{ fontSize: 11, fontWeight: 600, padding: "5px 10px", borderRadius: 6, border: "1px solid #E5E2DC", background: "#FFFFFF", color: "#6B6860", cursor: "pointer", fontFamily: FF }}>
-                      Match schedule ({daysOfWeek.length > 0 ? daysOfWeek.map(d => dayLabels[d].l.slice(0,1)).join("") : "—"})
-                    </button>
+                    {/* [feature/edit-modal-frequency-presets] Match-schedule
+                        is disabled when there are no schedule days to copy
+                        — instead of rendering a clickable em-dash that
+                        does nothing, we grey it out and surface a tooltip
+                        explaining what to do first. "All days" stays
+                        always-enabled because it doesn't depend on
+                        daysOfWeek. */}
+                    {(() => {
+                      const matchDisabled = daysOfWeek.length === 0;
+                      return (
+                        <button type="button"
+                          disabled={matchDisabled}
+                          title={matchDisabled ? "Pick schedule days first" : undefined}
+                          onClick={() => setParkingFeeDays([...daysOfWeek].sort())}
+                          style={{
+                            fontSize: 11, fontWeight: 600, padding: "5px 10px", borderRadius: 6,
+                            border: "1px solid #E5E2DC",
+                            background: matchDisabled ? "#F7F6F3" : "#FFFFFF",
+                            color: matchDisabled ? "#9E9B94" : "#6B6860",
+                            cursor: matchDisabled ? "not-allowed" : "pointer",
+                            opacity: matchDisabled ? 0.6 : 1,
+                            fontFamily: FF,
+                          }}>
+                          Match schedule ({daysOfWeek.length > 0 ? daysOfWeek.map(d => dayLabels[d].l.slice(0,1)).join("") : "—"})
+                        </button>
+                      );
+                    })()}
                     <button type="button"
                       onClick={() => setParkingFeeDays([0,1,2,3,4,5,6])}
                       style={{


### PR DESCRIPTION
## What this PR ships (3 stacked features)

### 1. M-F + Every day presets, smart auto-fill
- New "M–F" preset button (sets frequency=weekdays, days=[1,2,3,4,5])
- New "Every day" preset button (frequency=daily, days=[0..6])
- Smart business-day auto-fill: tap any business day in the custom-days picker when no business days are selected → fills `[tappedDay..5]` (e.g., tap Wed → W Th F)
- Read-only chip strip preserved for weekdays/daily modes

### 2. Toggle behavior on M-F + Every day presets
- Tap M-F when `weekdays` is already active → deselect (clears days, flips to custom_days mode)
- Same for Every day
- Different (inactive) preset still applies normally
- canSave gate prevents half-toggled saves on empty custom_days

### 3. Free editing of completed jobs
- Drops 4 server-side 409 gates on completed jobs in `artifacts/api-server/src/routes/jobs.ts`:
  - service_type change blocked
  - frequency change blocked
  - price change blocked when paid
  - price warn dialog
- Strips the warn dialog + `force_unlock` plumbing from `edit-job-modal.tsx`
- Completed status is now purely a visual indicator for dispatch/VA team
- **Audit log still fires on every edit** — every change traceable
- Reports requery the live DB row, so historical figures retroactively reflect edits
- Cancelled-job 409 untouched (separate uncancel flow)

### Plus the parking match-schedule UX fix from the original cherry-pick (already in c6d67b3)

## Test plan
- Open Jaira's recurring job (commercial, M-F): preset buttons render, parking shows \$20, Match schedule populates parking days from schedule days
- Tap M-F when active → days clear, can pick custom days
- Open a completed past job (e.g., Apr 27): all fields editable, save works, no prompts
- Save propagates per existing cascade selector (this/this+future/all)

## What stays the same
- Cancelled-job 409 (uncancel flow)
- Anchor lock for \`this_and_future\`/\`all\` cascades (skipAnchorLockedFields)
- Audit log on every edit

## Branch state
- 948f2ca feat(jobs): allow free editing of completed jobs
- 83c06f6 fix(edit-modal): toggle behavior on M-F + Every day presets
- c6d67b3 feat(edit-modal): M-F + Every day presets, smart auto-fill, parking-button UX fix
- ac7c9c8 (origin/main)

Net diff: +18 / -167 lines vs origin/main.