### PR TITLE
fix(edit-modal): show cascade picker on template edits + Match schedule reads dirty state

### DIFF
--- a/artifacts/qleno/src/components/edit-job-modal.tsx
+++ b/artifacts/qleno/src/components/edit-job-modal.tsx
@@ -825,18 +825,24 @@ export default function EditJobModal({
       return;
     }
 
-    // [PR / 2026-04-30] Recurring job — classify the diff and branch:
-    //   template-only → auto-cascade (this_and_future), no picker.
-    //                   Editing schedule-template fields IS editing
-    //                   the schedule; the second screen would just ask
-    //                   the same question wearing different clothes.
+    // [PR / 2026-05-03] Recurring job — classify the diff and branch:
+    //   template-only → picker WITH "this_and_future" preselected.
+    //                   Default click-through matches the prior auto-cascade
+    //                   behavior, but the picker is now visible so the
+    //                   operator can pick "all" to backfill past unpaid
+    //                   completed jobs (engine skips paid past per audit
+    //                   policy). Hiding the picker entirely meant `cascade=all`
+    //                   was unreachable for pure template edits — the case
+    //                   that actually motivates a backfill.
     //   occurrence-only → existing 4-option picker.
     //   mixed → picker WITH footnote per Sal's Q1 = (c). Single
     //           cascade_scope on the wire; operator picks with full
     //           context about the trade-off.
     const { template, occurrence } = getChangedFieldsByScope();
     if (template.length > 0 && occurrence.length === 0) {
-      submit("this_and_future");
+      setMixedEditWarning(null);
+      setCascadeChoice("this_and_future");
+      setCascadePromptOpen(true);
       return;
     }
     if (occurrence.length > 0 && template.length === 0) {
@@ -1536,11 +1542,29 @@ export default function EditJobModal({
                         always-enabled because it doesn't depend on
                         daysOfWeek. */}
                     {(() => {
-                      const matchDisabled = daysOfWeek.length === 0;
+                      // [PR / 2026-05-03] Disable Match-schedule when parking
+                      // days already equal schedule days. Closes the
+                      // perception gap from the null-fallback case: when
+                      // parkingFeeDays is null, effectiveDays at the day-
+                      // toggle row already falls back to daysOfWeek, so
+                      // tapping Match-schedule fires setParkingFeeDays
+                      // correctly but produces no visible UI delta — feels
+                      // broken. Greying the button when there's nothing to
+                      // do (no-op vs effective state) makes the control
+                      // honest about its work.
+                      const sortedDow = [...daysOfWeek].sort();
+                      const sortedPark = parkingFeeDays == null ? null : [...parkingFeeDays].sort();
+                      const alreadyMatches = sortedPark != null
+                        && sortedPark.length === sortedDow.length
+                        && sortedPark.every((v, i) => v === sortedDow[i]);
+                      const matchDisabled = daysOfWeek.length === 0 || alreadyMatches;
+                      const matchTitle = daysOfWeek.length === 0
+                        ? "Pick schedule days first"
+                        : alreadyMatches ? "Parking already matches schedule" : undefined;
                       return (
                         <button type="button"
                           disabled={matchDisabled}
-                          title={matchDisabled ? "Pick schedule days first" : undefined}
+                          title={matchTitle}
                           onClick={() => setParkingFeeDays([...daysOfWeek].sort())}
                           style={{
                             fontSize: 11, fontWeight: 600, padding: "5px 10px", borderRadius: 6,


### PR DESCRIPTION
## Summary

Two related edit-modal fixes bundled into one PR. Both confirmed via investigation report; Sal greenlit both before implementation.

### Fix 1 — Cascade picker on template-only edits

**File:** `artifacts/qleno/src/components/edit-job-modal.tsx` (around lines 837–852)

Before: edits that touched only schedule-template fields (frequency, parking toggle/amount/days, base_fee) auto-routed to `cascade=this_and_future` and never opened the picker. That made `cascade=all` unreachable for the case it actually serves — backfilling past unpaid completed jobs (engine skips paid past per audit policy from PR #44).

**Real-world repro:** Sal opens a past Monday's completed job (Apr 27), changes frequency to M-F or adjusts parking, hits save. He wants the change to also backfill that week's past completed jobs (Apr 28, 29, 30, May 1). On `main` this only updated 63 future jobs because the modal forced `this_and_future`.

After: the picker opens with `this_and_future` preselected. Default click-through behavior is unchanged (one extra click for muscle-memory users). `cascade=all` is now reachable for template edits.

### Fix 2 — Match schedule disabled when already matching

**File:** `artifacts/qleno/src/components/edit-job-modal.tsx` (parking-days IIFE around lines 1538–1556)

The closure at the Match-schedule onClick correctly reads live `daysOfWeek` state — confirmed via static trace (single useState at line 299, no shadowing, no memo, IIFE re-runs every parent render). So Hypothesis A from the original report (stale closure) is ruled out, and Hypothesis B (non-reactive UI) is also ruled out — `effectiveDays` recomputes every render.

What's actually happening: when `parkingFeeDays` is `null` (common on single-day clients whose schedule never persisted a per-day array), the day-toggle UI falls back to displaying `daysOfWeek` as effective (line 1490). Tapping Match-schedule correctly fires `setParkingFeeDays(daysOfWeek)` but produces no visible UI delta — the days were already showing as checked via the fallback. Reads as a broken button.

After: Match-schedule is disabled when parking days already equal schedule days, with tooltip `"Parking already matches schedule"`. The control is now honest about when it has work to do.

## Note

Sal already approved both fixes via screenshot diagnosis before this PR was opened.

## Test plan

- [ ] Open a recurring job, change ONLY a template field (e.g. frequency M-F → daily, or toggle parking) → cascade picker now appears with "This and all future visits" preselected
- [ ] In that picker, select "All visits in the series" → submit fires with `cascade_scope=all` and backfills past unpaid completed jobs (engine skips paid past)
- [ ] Default click-through (just hit Apply on the preselected option) → behavior matches the prior auto-route
- [ ] Open a Monday-only client, switch to custom_days, pick Tue–Fri → Match-schedule button is enabled, label shows "(TWThF)"; tapping it sets parking to [2,3,4,5]; immediately re-tapping it is now disabled with tooltip "Parking already matches schedule"
- [ ] Mixed edits (template + occurrence fields touched together) → existing 4-option picker with mixed-edit warning continues to render unchanged
- [ ] Occurrence-only edits (e.g. one-off allowed_hours) → existing picker with "Just this visit" preselected continues to render unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)