### PR TITLE
fix(jobs): GET /api/jobs/:id 500 — days_of_week wrong table

### DIFF
--- a/artifacts/api-server/src/routes/jobs.ts
+++ b/artifacts/api-server/src/routes/jobs.ts
@@ -627,9 +627,15 @@ router.get("/:id", requireAuth, async (req, res) => {
     // which caused the server to DELETE existing parking-fee rows on save
     // — i.e. "I hit save and parking disappeared" / "none of the changes
     // take place" reproduces. See edit-job-modal.tsx initial-load useEffect.
+    // days_of_week lives on recurring_schedules, not jobs — JOIN to read it
+    // through the schedule. Without the JOIN, this 500s the entire endpoint
+    // with `column "days_of_week" does not exist`. Applies to all jobs
+    // (schedule-attached or not) since the SELECT runs unconditionally.
     const jobMetaRows = await db.execute(sql`
-      SELECT recurring_schedule_id, hourly_rate, days_of_week, account_id
-      FROM jobs WHERE id = ${jobId} LIMIT 1
+      SELECT j.recurring_schedule_id, j.hourly_rate, rs.days_of_week, j.account_id
+      FROM jobs j
+      LEFT JOIN recurring_schedules rs ON rs.id = j.recurring_schedule_id
+      WHERE j.id = ${jobId} LIMIT 1
     `);
     const jobMeta = (jobMetaRows.rows[0] as any) ?? {};
 


### PR DESCRIPTION
## Summary
- Every `GET /api/jobs/:id` request throws **`column "days_of_week" does not exist`** and returns 500. The modal-preload SELECT queries `jobs.days_of_week`, but `days_of_week` lives on `recurring_schedules`.
- Bug has been latent since AI.7.1 (`0779a2b`, Apr 28) but surfaced at runtime today — affects every job (recurring or not) since the SELECT runs unconditionally before the `recurring_schedule_id != null` branch.
- Fix is one query: JOIN `recurring_schedules` and read `days_of_week` through the schedule. **Response shape unchanged** — `days_of_week` still surfaces at top level so the edit-job-modal's custom-day-picker hydration path is unaffected.

## Repro / verification
- Repro'd by running the route's exact SELECT sequence against live DB for jobs 4147, 4302, 4299, 4365, 4146 — all 5 throw the same Postgres error on q5.
- After fix, same sequence returns cleanly:
  - schedule-attached jobs (4147, 4302, 4365): `{recurring_schedule_id: 88, hourly_rate: "50.00", days_of_week: [1,2,3,4,5], account_id: null}`
  - non-recurring jobs (4299, 4146): `{recurring_schedule_id: null, hourly_rate: null, days_of_week: null, account_id: null}` (LEFT JOIN handles the null case correctly)

## Test plan
- [x] `pnpm run typecheck:libs` exits 0
- [x] api-server `tsc --noEmit` count — 758 (vs 757 baseline noted in PR #44; delta is not in the modified line range; unrelated drift)
- [ ] Railway redeploy completes
- [ ] Sal/operator hits `GET /api/jobs/4147` and `/api/jobs/4299` against deployed app — both return 200
- [ ] Edit-job modal opens and shows parking-fee state for Jaira (`schedule_id=88`) jobs

## Why a JOIN, not "drop days_of_week from this query"
The route already returns `days_of_week` at the response root (line ~660) and the frontend modal reads `response.days_of_week` for its custom-day-picker initial state (per the AI.7.1 comment block right above the SELECT). Removing the field would silently break the day picker on schedule-attached jobs. The JOIN preserves the contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)