### PR TITLE
feat(tech): login redirect to /my-jobs + tap-to-navigate/call + dispatch sidebar persistence

### DIFF
--- a/artifacts/api-server/src/routes/jobs.ts
+++ b/artifacts/api-server/src/routes/jobs.ts
@@ -251,6 +251,7 @@ router.get("/my-jobs", requireAuth, async (req, res) => {
         job_lat: jobsTable.job_lat,
         job_lng: jobsTable.job_lng,
         geocode_failed: jobsTable.geocode_failed,
+        client_phone: clientsTable.phone,
         client_notes: clientsTable.notes,
         service_type: jobsTable.service_type,
         status: jobsTable.status,

--- a/artifacts/qleno/public/manifest.json
+++ b/artifacts/qleno/public/manifest.json
@@ -24,17 +24,17 @@
   "categories": ["business", "productivity"],
   "shortcuts": [
     {
+      "name": "My Jobs",
+      "short_name": "My Jobs",
+      "description": "Today's assigned jobs",
+      "url": "/my-jobs",
+      "icons": [{ "src": "/images/phes-logo.jpeg", "sizes": "96x96" }]
+    },
+    {
       "name": "Dashboard",
       "short_name": "Dashboard",
       "description": "Go to dashboard",
       "url": "/dashboard",
-      "icons": [{ "src": "/images/phes-logo.jpeg", "sizes": "96x96" }]
-    },
-    {
-      "name": "Jobs",
-      "short_name": "Jobs",
-      "description": "View all jobs",
-      "url": "/jobs",
       "icons": [{ "src": "/images/phes-logo.jpeg", "sizes": "96x96" }]
     }
   ]

--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -3905,7 +3905,7 @@ export default function JobsPage() {
                 })()}
               </div>
             </div>
-            {loading ? (
+            {loading && !data ? (
               <div style={{ textAlign: "center", padding: 32, color: "#9E9B94", fontSize: 13 }}>Loading...</div>
             ) : allJobs.length === 0 ? (
               <div style={{ textAlign: "center", padding: 32 }}>
@@ -4115,7 +4115,7 @@ export default function JobsPage() {
 
             <div style={{ display: "flex", gap: 8, marginLeft: "auto", alignItems: "center", flexWrap: "nowrap" }}>
               {/* Stats pills */}
-              {!loading && data && [
+              {data && [
                 { label: `${stats.total} jobs`, color: "#1A1917", bg: "#F7F6F3" },
                 { label: `${stats.complete} done`, color: "#16A34A", bg: "#DCFCE7" },
                 ...(stats.inProgress > 0 ? [{ label: `${stats.inProgress} active`, color: "#D97706", bg: "#FEF3C7" }] : []),
@@ -4190,7 +4190,7 @@ export default function JobsPage() {
           </div>
 
           {/* KPI STRIP */}
-          {!loading && data && (() => {
+          {data && (() => {
             const techsWorking = filteredData?.employees?.filter(e => e.jobs?.length > 0).length ?? 0;
             const totalTechs = filteredData?.employees?.length ?? 0;
             const scheduledHrs = allJobs.reduce((s, j) => s + (j.duration_minutes || 120) / 60, 0);
@@ -4253,7 +4253,7 @@ export default function JobsPage() {
           {/* GANTT / LIST — fills remaining height */}
           <div style={{ flex: 1, overflow: "hidden", display: "flex", flexDirection: "column" }}>
             {/* Timeline or list */}
-            {loading ? (
+            {loading && !data ? (
               <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", color: "#9E9B94", fontSize: 13 }}>Loading schedule...</div>
             ) : desktopView === "timeline" ? (
               <div ref={timelineRef} style={{ flex: 1, overflow: "auto" }}>

--- a/artifacts/qleno/src/pages/login.tsx
+++ b/artifacts/qleno/src/pages/login.tsx
@@ -46,6 +46,8 @@ export default function Login() {
           toast({ title: "Welcome back", description: `Logged in as ${res.user.first_name}` });
           if (res.user.role === 'super_admin') {
             setLocation("/admin");
+          } else if (res.user.role === 'technician' || res.user.role === 'team_lead') {
+            setLocation("/my-jobs");
           } else {
             setLocation("/dashboard");
           }

--- a/artifacts/qleno/src/pages/my-jobs.tsx
+++ b/artifacts/qleno/src/pages/my-jobs.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAuthStore } from "@/lib/auth";
 import { useToast } from "@/hooks/use-toast";
-import { Car, X, Check, Eye } from "lucide-react";
+import { Car, X, Check, Eye, Navigation, Phone } from "lucide-react";
 import { useEmployeeView } from "@/contexts/employee-view-context";
 import { getJobVisualStatus, STATUS_VISUALS, ensureJobStatusStyles } from "@/lib/job-status";
 import { formatAddress } from "@/lib/format-address";
@@ -77,6 +77,7 @@ type Job = {
   job_lat: number | null;
   job_lng: number | null;
   geocode_failed: boolean;
+  client_phone: string | null;
   client_notes: string | null;
   service_type: string;
   status: string;
@@ -418,9 +419,38 @@ function JobCard({ job, empPos, onRefresh, isPreviewMode }: { job: Job; empPos: 
         <p style={{ fontSize: 12, color: "#9E9B94", margin: "0 0 2px" }}>Est. {job.estimated_hours.toFixed(1)} hrs</p>
       )}
       {job.address && (
-        <p style={{ fontSize: 12, color: "#6B6860", margin: 0 }}>
+        <a
+          href={`https://maps.apple.com/?address=${encodeURIComponent(formatAddress(job.address, job.city, job.state, job.zip))}`}
+          target="_blank"
+          rel="noreferrer"
+          style={{
+            display: "inline-flex", alignItems: "center", gap: 6,
+            fontSize: 12, color: "var(--brand)", fontWeight: 600,
+            textDecoration: "underline", margin: "2px 0 0",
+            padding: "4px 0", minHeight: 28,
+          }}
+        >
+          <Navigation size={14} aria-hidden="true" />
           {formatAddress(job.address, job.city, job.state, job.zip)}
-        </p>
+        </a>
+      )}
+      {job.client_phone && (
+        <div style={{ marginTop: 6 }}>
+          <a
+            href={`tel:${job.client_phone.replace(/[^\d+]/g, "")}`}
+            style={{
+              display: "inline-flex", alignItems: "center", gap: 6,
+              fontSize: 12, color: "var(--brand)", fontWeight: 600,
+              textDecoration: "underline",
+              padding: "6px 10px", borderRadius: 999,
+              backgroundColor: "var(--brand-dim, #EBF4FF)",
+              minHeight: 32,
+            }}
+          >
+            <Phone size={14} aria-hidden="true" />
+            {job.client_phone}
+          </a>
+        </div>
       )}
       {job.account_id && job.property_name && (
         <p style={{ fontSize: 11, color: "#9E9B94", margin: "2px 0 0" }}>


### PR DESCRIPTION
## Summary

Three quick wins from the 2026-05-04 tech-side audit, bundled as one focused PR.

### Fix 1 — Tech login routing + PWA shortcut
- `pages/login.tsx`: technicians and team_leads now redirect to `/my-jobs` after login (super_admin still → `/admin`; owners/admin/office → `/dashboard`)
- `public/manifest.json`: primary PWA shortcut is now **My Jobs**; old owner-side **Jobs** shortcut removed (Dashboard remains)

Result: techs who log in (or open the home-screen icon) land on the field-tech screen, not Sal's KPI dashboard.

### Fix 2 — Tap-to-navigate + tap-to-call on tech job card
- API: added `client_phone: clientsTable.phone` to the `/api/jobs/my-jobs` SELECT (was previously dropped vs. the dispatch endpoint)
- UI (`pages/my-jobs.tsx`):
  - Address → wrapped in `https://maps.apple.com/?address=...` link with a `Navigation` icon, brand-colored + underlined (Apple Maps universal link; falls back to Google Maps in browser on Android)
  - Phone → new `tel:` chip (pill-shaped, brand-tinted background, `Phone` icon) just below the address — only renders when `client_phone` is present (account-based jobs without a client still hide it cleanly)
  - Phone digits stripped of non-digit chars before being placed in the `tel:` href

### Fix 3 — Dispatch sidebar empty-state flash
- `pages/jobs.tsx`: replaced `loading ?` with `loading && !data ?` (and dropped `!loading &&` from the stats / unassigned-rail branches)
- Result: refetches keep the previous payload visible. The first-ever load still shows the spinner. No more "no employees" ghost when the page refocuses or branches change.

## Test plan

- [ ] **Tech login**: log in as a `technician` user → should land directly at `/my-jobs`
- [ ] **Owner login**: log in as Sal (owner) → should still land at `/dashboard`
- [ ] **Super admin login**: still goes to `/admin`
- [ ] **PWA shortcut**: long-press home-screen icon (after re-installing as PWA) → top shortcut is "My Jobs"
- [ ] **Tap-to-navigate** (iPhone field test): tap address on a job card → opens Apple Maps with the address pinned
- [ ] **Tap-to-call**: tap phone chip on a job card → opens dialer pre-filled with client number
- [ ] **No phone case**: jobs without a client phone (commercial/account jobs) render the address link only — no broken phone chip
- [ ] **Dispatch sidebar persistence**: open `/jobs` → switch branch (or click another date) → tech rows in the sidebar should stay visible during the refetch (no blank "no employees" frame)
- [ ] **First load**: hard reload `/jobs` with empty cache → "Loading schedule…" spinner shows on first paint, then resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)