### PR TITLE
fix(edit-job-modal): hide Commercial scopes for residential clients

### DIFF
--- a/artifacts/api-server/package.json
+++ b/artifacts/api-server/package.json
@@ -8,7 +8,8 @@
     "build": "tsx ./build.ts",
     "start": "node dist/index.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test:bundle": "tsx --test src/tests/bundle-discount.test.ts"
+    "test:bundle": "tsx --test src/tests/bundle-discount.test.ts",
+    "test:parking": "DATABASE_URL=postgres://stub@stub/stub tsx --test src/tests/parking-waterfall.test.ts"
   },
   "dependencies": {
     "@google-cloud/storage": "^7.19.0",

--- a/artifacts/api-server/src/lib/recurring-jobs.ts
+++ b/artifacts/api-server/src/lib/recurring-jobs.ts
@@ -59,7 +59,7 @@ export type ResolvedParkingAddon = {
 // to the older catalog table). Returns null when no active row found
 // (engine then logs once and skips parking stamping for the run).
 export async function resolveParkingAddon(
-  schedule: Pick<ScheduleInput, "company_id" | "parking_fee_amount">,
+  schedule: Pick<ScheduleInput, "company_id" | "customer_id" | "parking_fee_amount">,
   txOrDb: any = db,
 ): Promise<ResolvedParkingAddon | null> {
   const addonLookup = await txOrDb.execute(sql`
@@ -74,11 +74,24 @@ export async function resolveParkingAddon(
   if (!addonRow) return null;
 
   const addonName = String(addonRow.name ?? "Parking Fee");
-  const fallbackAmount = String(addonRow.price ?? "20");
-  const overrideAmount = schedule.parking_fee_amount;
-  const unitPrice = overrideAmount != null && overrideAmount !== ""
-    ? String(overrideAmount)
-    : fallbackAmount;
+  const tenantDefault = String(addonRow.price ?? "20");
+
+  // 3-tier waterfall: schedule.parking_fee_amount > clients.parking_fee_amount
+  // > pricing_addons.price (tenant default). Only hit the clients lookup when
+  // the schedule didn't pin a value — saves the query on schedules that
+  // already have an explicit override.
+  const scheduleOverride = schedule.parking_fee_amount;
+  let clientDefault: string | null = null;
+  if ((scheduleOverride == null || scheduleOverride === "") && schedule.customer_id != null) {
+    const clientRow = await txOrDb.execute(sql`
+      SELECT parking_fee_amount FROM clients WHERE id = ${schedule.customer_id} LIMIT 1
+    `);
+    const cd = (clientRow.rows[0] as any)?.parking_fee_amount;
+    if (cd != null && cd !== "") clientDefault = String(cd);
+  }
+  const unitPrice = scheduleOverride != null && scheduleOverride !== ""
+    ? String(scheduleOverride)
+    : (clientDefault ?? tenantDefault);
 
   // Resolve the real `add_ons.id` for the FK on `job_add_ons.add_on_id`.
   // pricing_addons.id and add_ons.id live in different tables; the
@@ -101,11 +114,18 @@ export async function resolveParkingAddon(
     realAddOnId = Number((created.rows[0] as any).id);
   }
 
+  // override_amount = "anything other than the tenant default was used to
+  // produce this row", regardless of which tier (schedule or client) supplied
+  // it. Callers use this for diagnostic logging / cascade decisions.
+  const effectiveOverride = scheduleOverride != null && scheduleOverride !== ""
+    ? String(scheduleOverride)
+    : clientDefault;
+
   return {
     pricing_addon_id: Number(addonRow.id),
     add_on_id: realAddOnId,
     unit_price: unitPrice,
-    override_amount: overrideAmount != null && overrideAmount !== "" ? String(overrideAmount) : null,
+    override_amount: effectiveOverride,
   };
 }
 

--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -551,6 +551,20 @@ async function runBookingSchemaGuard(): Promise<void> {
       stmt: `ALTER TABLE recurring_schedules ADD COLUMN IF NOT EXISTS parking_fee_amount NUMERIC(10,2)` },
     { label: "recurring_schedules.parking_fee_days",
       stmt: `ALTER TABLE recurring_schedules ADD COLUMN IF NOT EXISTS parking_fee_days INTEGER[]` },
+
+    // Per-client parking-fee default. Resolution waterfall at job-generation
+    // time: schedule.parking_fee_amount > clients.parking_fee_amount >
+    // pricing_addons.parking_fee.price (tenant default). The enabled flag
+    // does NOT auto-stamp parking on every job — it only affects the default
+    // pre-fill in the recurring-schedule editor and the edit-job modal so
+    // operators don't have to re-type $15 every time. The actual gate for
+    // whether parking gets stamped is still recurring_schedules.parking_fee_enabled
+    // (per-occurrence) or the operator manually checking the addon in the
+    // edit-job modal (one-off).
+    { label: "clients.parking_fee_enabled",
+      stmt: `ALTER TABLE clients ADD COLUMN IF NOT EXISTS parking_fee_enabled BOOLEAN NOT NULL DEFAULT false` },
+    { label: "clients.parking_fee_amount",
+      stmt: `ALTER TABLE clients ADD COLUMN IF NOT EXISTS parking_fee_amount NUMERIC(10,2)` },
   ];
 
   for (const { label, stmt } of guards) {

--- a/artifacts/api-server/src/routes/clients.ts
+++ b/artifacts/api-server/src/routes/clients.ts
@@ -559,6 +559,7 @@ router.put("/:id", requireAuth, async (req, res) => {
       card_last_four, card_brand, card_expiry, card_saved_at,
       payment_method, net_terms,
       commercial_hourly_rate,    // [AH] Per-client commercial hourly rate
+      parking_fee_enabled, parking_fee_amount,
     } = req.body;
 
     // [AH] Snapshot the previous commercial_hourly_rate so we can write a
@@ -612,6 +613,12 @@ router.put("/:id", requireAuth, async (req, res) => {
         commercial_hourly_rate: commercial_hourly_rate === null || commercial_hourly_rate === ""
           ? null
           : String(commercial_hourly_rate),
+      }),
+      ...(parking_fee_enabled !== undefined && { parking_fee_enabled: !!parking_fee_enabled }),
+      ...(parking_fee_amount !== undefined && {
+        parking_fee_amount: parking_fee_amount === null || parking_fee_amount === ""
+          ? null
+          : String(parking_fee_amount),
       }),
     }).where(and(eq(clientsTable.id, clientId), eq(clientsTable.company_id, req.auth!.companyId))).returning();
     if (!updated[0]) return res.status(404).json({ error: "Not Found" });

--- a/artifacts/api-server/src/tests/parking-waterfall.test.ts
+++ b/artifacts/api-server/src/tests/parking-waterfall.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Parking-fee resolution waterfall tests.
+ *
+ * Coverage: `resolveParkingAddon` from `lib/recurring-jobs.ts` — verifies the
+ * 3-tier waterfall added in PR #51:
+ *
+ *   schedule.parking_fee_amount > clients.parking_fee_amount > pricing_addons.price
+ *
+ * Pure unit tests — mocks `txOrDb.execute` so no live DB or running API needed.
+ *
+ * Run:
+ *   pnpm --filter @workspace/api-server run test:parking
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { resolveParkingAddon } from "../lib/recurring-jobs.js";
+
+// Mock execute that routes by inspecting the rendered SQL string. Lets each
+// test declare what each table lookup returns without depending on the call
+// order — and lets us assert which queries fired (e.g. the clients lookup
+// must NOT fire when the schedule override is set).
+type MockResults = {
+  pricing_addons: { rows: any[] };
+  clients?: { rows: any[] };
+  add_ons: { rows: any[] };
+};
+function makeMockExecute(results: MockResults) {
+  const callLog: Array<"pricing_addons" | "clients" | "add_ons"> = [];
+  const execute = async (sqlChunk: any) => {
+    // drizzle's `sql` template returns an SQL object; serialize via toString
+    // (sufficient for keyword matching — we just need to know which table).
+    const text = String(sqlChunk?.queryChunks ? JSON.stringify(sqlChunk.queryChunks) : sqlChunk);
+    if (text.includes("pricing_addons")) {
+      callLog.push("pricing_addons");
+      return results.pricing_addons;
+    }
+    if (text.includes("FROM clients")) {
+      callLog.push("clients");
+      if (!results.clients) {
+        throw new Error("mock: clients lookup fired but test expected short-circuit");
+      }
+      return results.clients;
+    }
+    if (text.includes("add_ons")) {
+      callLog.push("add_ons");
+      return results.add_ons;
+    }
+    throw new Error(`mock execute: unrecognized query: ${text.slice(0, 100)}`);
+  };
+  return { execute, callLog };
+}
+
+describe("resolveParkingAddon — 3-tier waterfall", () => {
+  it("schedule override wins; clients lookup is skipped", async () => {
+    const mock = makeMockExecute({
+      pricing_addons: { rows: [{ id: 100, name: "Parking Fee", price: "20" }] },
+      // No `clients` entry — if the resolver tries to query it, the mock throws.
+      add_ons: { rows: [{ id: 200 }] },
+    });
+
+    const result = await resolveParkingAddon(
+      { company_id: 1, customer_id: 42, parking_fee_amount: "15" },
+      mock,
+    );
+
+    assert.ok(result, "expected non-null result");
+    assert.equal(result!.unit_price, "15", "schedule override $15 must win");
+    assert.equal(result!.override_amount, "15", "override_amount reflects schedule value");
+    assert.equal(result!.pricing_addon_id, 100);
+    assert.equal(result!.add_on_id, 200);
+    assert.deepEqual(mock.callLog, ["pricing_addons", "add_ons"], "clients lookup must be skipped");
+  });
+
+  it("client default wins when schedule override is null", async () => {
+    const mock = makeMockExecute({
+      pricing_addons: { rows: [{ id: 100, name: "Parking Fee", price: "20" }] },
+      clients: { rows: [{ parking_fee_amount: "15" }] },
+      add_ons: { rows: [{ id: 200 }] },
+    });
+
+    const result = await resolveParkingAddon(
+      { company_id: 1, customer_id: 42, parking_fee_amount: null },
+      mock,
+    );
+
+    assert.ok(result);
+    assert.equal(result!.unit_price, "15", "client default $15 used when schedule blank");
+    assert.equal(result!.override_amount, "15", "override_amount surfaces client value");
+    assert.deepEqual(mock.callLog, ["pricing_addons", "clients", "add_ons"]);
+  });
+
+  it("tenant default fallback when neither schedule nor client set", async () => {
+    const mock = makeMockExecute({
+      pricing_addons: { rows: [{ id: 100, name: "Parking Fee", price: "20" }] },
+      clients: { rows: [{ parking_fee_amount: null }] },
+      add_ons: { rows: [{ id: 200 }] },
+    });
+
+    const result = await resolveParkingAddon(
+      { company_id: 1, customer_id: 42, parking_fee_amount: null },
+      mock,
+    );
+
+    assert.ok(result);
+    assert.equal(result!.unit_price, "20", "tenant default $20 wins when schedule + client blank");
+    assert.equal(result!.override_amount, null, "override_amount null when only tenant default used");
+  });
+});

--- a/artifacts/qleno/src/components/edit-job-modal.tsx
+++ b/artifacts/qleno/src/components/edit-job-modal.tsx
@@ -1518,9 +1518,14 @@ export default function EditJobModal({
                   // and we don't have UI to flip an addon's pricing model
                   // mid-edit. Operators can use Manual rate for that.
                   const editable = checked && !isPct;
-                  const inputValue = override != null
-                    ? String(override)
-                    : (editable ? String(catalogPrice) : "");
+                  // Controlled input convention: `value` is the override
+                  // (string-of-number when set, "" when not set).
+                  // `placeholder` shows the catalog default so the operator
+                  // sees what they'll fall back to without committing it as
+                  // an override. Without this split, clearing the field
+                  // would snap back to the catalog price and the cursor
+                  // would jump — clearing wouldn't visually work.
+                  const inputValue = override != null ? String(override) : "";
                   return (
                     <div key={a.id} style={{
                       display: "flex", alignItems: "center", gap: 8,
@@ -1566,6 +1571,7 @@ export default function EditJobModal({
                           <span style={{ fontSize: 12, color: "#6B6860" }}>$</span>
                           <input type="number" min={0} step={0.01} inputMode="decimal"
                             value={inputValue}
+                            placeholder={String(catalogPrice)}
                             onChange={e => {
                               const raw = e.target.value;
                               const isParking = /^parking fee$/i.test(a.name);
@@ -1598,7 +1604,15 @@ export default function EditJobModal({
                             }} />
                         </div>
                       ) : (
-                        <span style={{ fontSize: 12, color: "#6B6860" }}>
+                        <span style={{ fontSize: 12, color: "#6B6860", cursor: "pointer" }}
+                          onClick={() => {
+                            setSelectedAddons(prev => {
+                              const next = new Map(prev);
+                              if (next.has(a.id)) next.delete(a.id);
+                              else next.set(a.id, 1);
+                              return next;
+                            });
+                          }}>
                           {/* [AI.2] price_value is the canonical column; price_type
                               seeded as 'percentage' (not 'percent'), accept both. */}
                           {isPct ? `${catalogPrice}%` : `$${catalogPrice.toFixed(0)}`}

--- a/artifacts/qleno/src/components/edit-job-modal.tsx
+++ b/artifacts/qleno/src/components/edit-job-modal.tsx
@@ -1393,9 +1393,18 @@ export default function EditJobModal({
                     <select value={scopeId ?? ""} onChange={e => setScopeId(parseInt(e.target.value))}
                       style={INPUT} disabled={scopesLoading}>
                       {scopesLoading ? <option>Loading…</option> : null}
-                      {scopes.map(s => (
-                        <option key={s.id} value={s.id}>{s.name} {s.scope_group ? `· ${s.scope_group}` : ""}</option>
-                      ))}
+                      {/* Residential clients must not see Commercial scopes.
+                          The commercial branch above uses a separate dropdown
+                          (commercial_service_types) and never reaches this
+                          select, so the only filter we need here is to drop
+                          Commercial scope_group entries from the residential
+                          list. Recurring Cleaning + Hourly stay because
+                          residential clients legitimately use them. */}
+                      {scopes
+                        .filter(s => s.scope_group !== "Commercial")
+                        .map(s => (
+                          <option key={s.id} value={s.id}>{s.name} {s.scope_group ? `· ${s.scope_group}` : ""}</option>
+                        ))}
                     </select>
                   </div>
                   <div>

--- a/artifacts/qleno/src/components/edit-job-modal.tsx
+++ b/artifacts/qleno/src/components/edit-job-modal.tsx
@@ -271,6 +271,17 @@ export default function EditJobModal({
   const [addonsLoading, setAddonsLoading] = useState(false);
   const [selectedAddons, setSelectedAddons] = useState<Map<number, number>>(new Map());
 
+  // Per-addon unit-price override. When the operator types a number into the
+  // inline `$___` input next to the addon row (currently rendered only for
+  // Parking Fee, but the state is generic), it lands here keyed by
+  // pricing_addon_id. Save path checks this map first; falls back to the calc
+  // engine's per-addon amount when no override is set. Initial seed comes from
+  // the existing job_add_ons.unit_price returned by GET /api/jobs/:id, so the
+  // input shows the actual saved price (e.g. $15 for Nicholas Cooper) instead
+  // of the tenant default.
+  const [addonPriceOverrides, setAddonPriceOverrides] = useState<Map<number, number>>(new Map());
+  const [initialAddonPriceOverrides, setInitialAddonPriceOverrides] = useState<Map<number, number>>(new Map());
+
   const [baseFee, setBaseFee] = useState<number>(initialBaseFee);
   const [manualRate, setManualRate] = useState(false);
   const [manualOpen, setManualOpen] = useState(false);
@@ -484,13 +495,21 @@ export default function EditJobModal({
         // Existing add-ons → selectedAddons (keyed by pricing_addon_id).
         const existing = Array.isArray(d.existing_add_ons) ? d.existing_add_ons : [];
         const addonMap = new Map<number, number>();
+        const priceMap = new Map<number, number>();
         for (const a of existing) {
           if (a.pricing_addon_id != null) {
-            addonMap.set(Number(a.pricing_addon_id), Number(a.quantity ?? 1));
+            const pid = Number(a.pricing_addon_id);
+            addonMap.set(pid, Number(a.quantity ?? 1));
+            // Seed the override map with the saved unit_price so the inline
+            // input pre-fills with what's actually on the job (not the
+            // tenant default). User can then tweak or leave alone.
+            if (a.unit_price != null) priceMap.set(pid, Number(a.unit_price));
           }
         }
         setSelectedAddons(addonMap);
         setInitialSelectedAddons(addonMap);
+        setAddonPriceOverrides(priceMap);
+        setInitialAddonPriceOverrides(priceMap);
 
         // Recurring schedule snapshot.
         const rs = d.recurring_schedule;
@@ -732,6 +751,15 @@ export default function EditJobModal({
     const addonsSame = selectedAddons.size === initialSelectedAddons.size
       && Array.from(selectedAddons.entries()).every(([k, v]) => initialSelectedAddons.get(k) === v);
     if (!addonsSame) return true;
+    // Per-addon unit-price override changes are also dirty (e.g. operator
+    // typed $15 in the parking row when the saved value was $20).
+    const overrideKeys = new Set([...addonPriceOverrides.keys(), ...initialAddonPriceOverrides.keys()]);
+    for (const k of overrideKeys) {
+      const a = addonPriceOverrides.get(k);
+      const b = initialAddonPriceOverrides.get(k);
+      if ((a == null) !== (b == null)) return true;
+      if (a != null && b != null && Math.abs(a - b) > 0.005) return true;
+    }
     if (job.assigned_user_id != null && (selectedTechIds[0] !== job.assigned_user_id || selectedTechIds.length !== 1)) return true;
     if (job.assigned_user_id == null && selectedTechIds.length > 0) return true;
     // [AH] Commercial-only dirty checks
@@ -754,7 +782,7 @@ export default function EditJobModal({
     const curDays = parkingFeeDays == null ? null : [...parkingFeeDays].sort();
     if (JSON.stringify(initDays) !== JSON.stringify(curDays)) return true;
     return false;
-  }, [frequency, scheduledDate, scheduledTime, allowedHours, baseFee, instructions, manualRate, selectedAddons, initialSelectedAddons, selectedTechIds, job, initialAllowedHours, initialBaseFee, isCommercial, commercialServiceType, hourlyRate, daysOfWeek, availableAddons, parkingFeeAmount, parkingFeeAmountInitial, parkingFeeDays, parkingFeeDaysInitial, parkingFeeEnabledInitial]);
+  }, [frequency, scheduledDate, scheduledTime, allowedHours, baseFee, instructions, manualRate, selectedAddons, initialSelectedAddons, addonPriceOverrides, initialAddonPriceOverrides, selectedTechIds, job, initialAllowedHours, initialBaseFee, isCommercial, commercialServiceType, hourlyRate, daysOfWeek, availableAddons, parkingFeeAmount, parkingFeeAmountInitial, parkingFeeDays, parkingFeeDaysInitial, parkingFeeEnabledInitial]);
 
   // [AI.4] Commercial save requires a real tenant-managed service type slug.
   // Legacy MC-import values (e.g., 'standard_clean') get auto-cleared when
@@ -816,6 +844,20 @@ export default function EditJobModal({
     const addonsSame = selectedAddons.size === initialSelectedAddons.size
       && Array.from(selectedAddons.entries()).every(([k, v]) => initialSelectedAddons.get(k) === v);
     if (!addonsSame) push("add_ons");
+
+    // Per-addon unit-price override changes also belong to the add_ons bucket
+    // (occurrence-scoped — does not cascade to the schedule template).
+    {
+      const overrideKeys = new Set([...addonPriceOverrides.keys(), ...initialAddonPriceOverrides.keys()]);
+      for (const k of overrideKeys) {
+        const a = addonPriceOverrides.get(k);
+        const b = initialAddonPriceOverrides.get(k);
+        if ((a == null) !== (b == null) || (a != null && b != null && Math.abs(a - b) > 0.005)) {
+          push("add_ons");
+          break;
+        }
+      }
+    }
 
     const techSame = (job.assigned_user_id != null
       && selectedTechIds[0] === job.assigned_user_id
@@ -907,12 +949,25 @@ export default function EditJobModal({
       // pass can map distinct addon catalogs.
       const addOnsPayload = Array.from(selectedAddons.entries()).map(([pricingAddonId, qty]) => {
         const detail = calcResult?.addon_breakdown?.find(x => x.id === pricingAddonId);
+        // Operator-typed override wins over the calc engine. Catalog price is
+        // a fallback only — without an override and without a calc result,
+        // we still need to write something or the save would round to $0.
+        const override = addonPriceOverrides.get(pricingAddonId);
+        const catalogPrice = (() => {
+          const a = availableAddons.find(x => x.id === pricingAddonId);
+          if (!a) return 0;
+          const v = (a as any).price_value ?? (a as any).price ?? 0;
+          return Number(v) || 0;
+        })();
+        const unitPrice = override != null
+          ? override
+          : (detail ? Math.round((detail.amount / qty) * 100) / 100 : catalogPrice);
         return {
           add_on_id: pricingAddonId,
           pricing_addon_id: pricingAddonId,
           qty,
-          unit_price: detail ? Math.round((detail.amount / qty) * 100) / 100 : 0,
-          subtotal: detail ? detail.amount : 0,
+          unit_price: unitPrice,
+          subtotal: Math.round(unitPrice * qty * 100) / 100,
         };
       });
 
@@ -1454,15 +1509,28 @@ export default function EditJobModal({
               <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
                 {availableAddons.map(a => {
                   const checked = selectedAddons.has(a.id);
+                  const isPct = a.price_type === "percent" || a.price_type === "percentage";
+                  const catalogPrice = Number(a.price_value ?? a.price ?? 0);
+                  const override = addonPriceOverrides.get(a.id);
+                  // Fixed-$ addons get an inline editable price when checked.
+                  // Percentage addons (Windows 15%, etc.) keep the % readout —
+                  // overriding a percentage as a flat $ would be confusing,
+                  // and we don't have UI to flip an addon's pricing model
+                  // mid-edit. Operators can use Manual rate for that.
+                  const editable = checked && !isPct;
+                  const inputValue = override != null
+                    ? String(override)
+                    : (editable ? String(catalogPrice) : "");
                   return (
-                    <label key={a.id} style={{
+                    <div key={a.id} style={{
                       display: "flex", alignItems: "center", gap: 8,
                       padding: "8px 10px", borderRadius: 8,
                       border: `1px solid ${checked ? "var(--brand, #00C9A0)" : "#E5E2DC"}`,
                       backgroundColor: checked ? "rgba(0,201,160,0.05)" : "#F7F6F3",
-                      cursor: "pointer", fontFamily: FF,
+                      fontFamily: FF,
                     }}>
                       <input type="checkbox" checked={checked}
+                        style={{ cursor: "pointer" }}
                         onChange={() => {
                           setSelectedAddons(prev => {
                             const next = new Map(prev);
@@ -1470,18 +1538,73 @@ export default function EditJobModal({
                             else next.set(a.id, 1);
                             return next;
                           });
+                          // When unchecking, drop any pending override so a
+                          // future re-check starts from the catalog default
+                          // again instead of resurrecting a stale value.
+                          if (selectedAddons.has(a.id)) {
+                            setAddonPriceOverrides(prev => {
+                              if (!prev.has(a.id)) return prev;
+                              const next = new Map(prev);
+                              next.delete(a.id);
+                              return next;
+                            });
+                          }
                         }} />
-                      <span style={{ flex: 1, fontSize: 13, color: "#1A1917" }}>{a.name}</span>
-                      <span style={{ fontSize: 12, color: "#6B6860" }}>
-                        {/* [AI.2] price_value is the canonical column; price_type
-                            seeded as 'percentage' (not 'percent'), accept both. */}
-                        {(() => {
-                          const v = a.price_value ?? a.price ?? 0;
-                          const isPct = a.price_type === "percent" || a.price_type === "percentage";
-                          return isPct ? `${v}%` : `$${Number(v).toFixed(0)}`;
-                        })()}
+                      <span style={{ flex: 1, fontSize: 13, color: "#1A1917", cursor: "pointer" }}
+                        onClick={() => {
+                          setSelectedAddons(prev => {
+                            const next = new Map(prev);
+                            if (next.has(a.id)) next.delete(a.id);
+                            else next.set(a.id, 1);
+                            return next;
+                          });
+                        }}>
+                        {a.name}
                       </span>
-                    </label>
+                      {editable ? (
+                        <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
+                          <span style={{ fontSize: 12, color: "#6B6860" }}>$</span>
+                          <input type="number" min={0} step={0.01} inputMode="decimal"
+                            value={inputValue}
+                            onChange={e => {
+                              const raw = e.target.value;
+                              const isParking = /^parking fee$/i.test(a.name);
+                              setAddonPriceOverrides(prev => {
+                                const next = new Map(prev);
+                                if (raw === "") {
+                                  next.delete(a.id);
+                                } else {
+                                  const n = parseFloat(raw);
+                                  if (!isNaN(n) && n >= 0) next.set(a.id, n);
+                                }
+                                return next;
+                              });
+                              // Mirror parking changes to parkingFeeAmount so a
+                              // cascade=this_and_future save also updates
+                              // recurring_schedules.parking_fee_amount, not just
+                              // job_add_ons. Other addons aren't tracked at the
+                              // schedule level so this only applies to parking.
+                              if (isParking) {
+                                const n = parseFloat(raw);
+                                setParkingFeeAmount(raw === "" || isNaN(n) ? null : n);
+                              }
+                            }}
+                            onClick={e => e.stopPropagation()}
+                            style={{
+                              width: 70, padding: "3px 6px", borderRadius: 5,
+                              border: "1px solid #E5E2DC", fontSize: 12,
+                              fontFamily: FF, backgroundColor: "#FFFFFF",
+                              textAlign: "right",
+                            }} />
+                        </div>
+                      ) : (
+                        <span style={{ fontSize: 12, color: "#6B6860" }}>
+                          {/* [AI.2] price_value is the canonical column; price_type
+                              seeded as 'percentage' (not 'percent'), accept both. */}
+                          {isPct ? `${catalogPrice}%` : `$${catalogPrice.toFixed(0)}`}
+                        </span>
+                      )}
+                    </div>
                   );
                 })}
               </div>

--- a/artifacts/qleno/src/pages/customer-profile.tsx
+++ b/artifacts/qleno/src/pages/customer-profile.tsx
@@ -2055,56 +2055,6 @@ function CardOnFileTab({ client, refetch }: { client: any; refetch: () => void }
                 </div>
               )}
             </div>
-            {/* Per-client parking-fee default. Recurring schedules and one-off
-                jobs inherit this unless explicitly overridden. */}
-            <div>
-              <div style={{ color: "#6B7280", marginBottom: 3, fontFamily: FF, display: "flex", alignItems: "center", gap: 6 }}>
-                Parking Fee
-                {!editingParking && (
-                  <button onClick={() => {
-                    setParkingValue(client.parking_fee_amount != null ? String(client.parking_fee_amount) : "");
-                    setParkingEnabled(!!client.parking_fee_enabled);
-                    setEditingParking(true);
-                  }}
-                    style={{ background: "none", border: "none", color: "#1D4ED8", fontSize: 11, cursor: "pointer", padding: 0, fontFamily: FF, fontWeight: 600 }}>
-                    {client.parking_fee_enabled || client.parking_fee_amount != null ? "Edit" : "Set"}
-                  </button>
-                )}
-              </div>
-              {editingParking ? (
-                <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-                  <label style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 12, color: "#1A1917", fontFamily: FF, cursor: "pointer" }}>
-                    <input type="checkbox" checked={parkingEnabled}
-                      onChange={e => setParkingEnabled(e.target.checked)} />
-                    Charge parking by default
-                  </label>
-                  <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
-                    <span style={{ fontSize: 13, color: "#6B7280" }}>$</span>
-                    <input type="number" min={0} step={0.01} value={parkingValue}
-                      onChange={e => setParkingValue(e.target.value)}
-                      placeholder="20.00"
-                      style={{ width: 90, padding: "4px 8px", border: "1px solid #E5E2DC", borderRadius: 6, fontSize: 13, fontFamily: FF }} />
-                    <button onClick={saveParkingFee} disabled={savingParking}
-                      style={{ background: "var(--brand, #00C9A0)", color: "#fff", border: "none", borderRadius: 6, fontSize: 12, fontWeight: 700, padding: "4px 10px", cursor: savingParking ? "wait" : "pointer", fontFamily: FF }}>
-                      {savingParking ? "…" : "Save"}
-                    </button>
-                    <button onClick={() => setEditingParking(false)} disabled={savingParking}
-                      style={{ background: "none", border: "none", color: "#6B7280", fontSize: 12, cursor: "pointer", fontFamily: FF }}>
-                      Cancel
-                    </button>
-                  </div>
-                  <div style={{ fontSize: 11, color: "#9E9B94", fontFamily: FF }}>
-                    Blank uses tenant default. Schedules and jobs override per-occurrence.
-                  </div>
-                </div>
-              ) : (
-                <div style={{ fontWeight: 600, color: client.parking_fee_enabled || client.parking_fee_amount != null ? "#1A1917" : "#9E9B94", fontFamily: FF }}>
-                  {client.parking_fee_enabled || client.parking_fee_amount != null
-                    ? `${client.parking_fee_enabled ? "On" : "Off"}${client.parking_fee_amount != null ? ` · $${Number(client.parking_fee_amount).toFixed(2)}` : " · tenant default"}`
-                    : "Not set"}
-                </div>
-              )}
-            </div>
             {client.billing_contact_name && (
               <div>
                 <div style={{ color: "#6B7280", marginBottom: 3, fontFamily: FF }}>Billing Contact</div>
@@ -2120,6 +2070,60 @@ function CardOnFileTab({ client, refetch }: { client: any; refetch: () => void }
           </div>
         </div>
       )}
+
+      {/* Per-client parking-fee default. Lives outside the commercial-only
+          Billing Settings block on purpose — residential clients (Nicholas
+          Cooper, etc.) also incur parking fees, so the setting must always
+          be visible. Recurring schedules and one-off jobs inherit this
+          unless explicitly overridden. */}
+      <div style={{ background: "#fff", border: "1px solid #E5E2DC", borderRadius: 10, padding: "20px 24px" }}>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 12 }}>
+          <div style={{ fontWeight: 700, fontSize: 14, color: "#1A1917", fontFamily: FF }}>Parking Fee</div>
+          {!editingParking && (
+            <button onClick={() => {
+              setParkingValue(client.parking_fee_amount != null ? String(client.parking_fee_amount) : "");
+              setParkingEnabled(!!client.parking_fee_enabled);
+              setEditingParking(true);
+            }}
+              style={{ background: "none", border: "none", color: "#1D4ED8", fontSize: 12, cursor: "pointer", padding: 0, fontFamily: FF, fontWeight: 600 }}>
+              {client.parking_fee_enabled || client.parking_fee_amount != null ? "Edit" : "Set"}
+            </button>
+          )}
+        </div>
+        {editingParking ? (
+          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            <label style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 13, color: "#1A1917", fontFamily: FF, cursor: "pointer" }}>
+              <input type="checkbox" checked={parkingEnabled}
+                onChange={e => setParkingEnabled(e.target.checked)} />
+              Charge parking by default
+            </label>
+            <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+              <span style={{ fontSize: 13, color: "#6B7280" }}>$</span>
+              <input type="number" min={0} step={0.01} value={parkingValue}
+                onChange={e => setParkingValue(e.target.value)}
+                placeholder="20.00"
+                style={{ width: 100, padding: "6px 10px", border: "1px solid #E5E2DC", borderRadius: 6, fontSize: 13, fontFamily: FF }} />
+              <button onClick={saveParkingFee} disabled={savingParking}
+                style={{ background: "var(--brand, #00C9A0)", color: "#fff", border: "none", borderRadius: 6, fontSize: 12, fontWeight: 700, padding: "6px 14px", cursor: savingParking ? "wait" : "pointer", fontFamily: FF }}>
+                {savingParking ? "…" : "Save"}
+              </button>
+              <button onClick={() => setEditingParking(false)} disabled={savingParking}
+                style={{ background: "none", border: "none", color: "#6B7280", fontSize: 12, cursor: "pointer", fontFamily: FF }}>
+                Cancel
+              </button>
+            </div>
+            <div style={{ fontSize: 11, color: "#9E9B94", fontFamily: FF }}>
+              Blank uses tenant default. Schedules and jobs can override per-occurrence.
+            </div>
+          </div>
+        ) : (
+          <div style={{ fontSize: 13, fontWeight: 600, color: client.parking_fee_enabled || client.parking_fee_amount != null ? "#1A1917" : "#9E9B94", fontFamily: FF }}>
+            {client.parking_fee_enabled || client.parking_fee_amount != null
+              ? `${client.parking_fee_enabled ? "On" : "Off"}${client.parking_fee_amount != null ? ` · $${Number(client.parking_fee_amount).toFixed(2)}` : " · tenant default"}`
+              : "Not set"}
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/artifacts/qleno/src/pages/customer-profile.tsx
+++ b/artifacts/qleno/src/pages/customer-profile.tsx
@@ -1796,6 +1796,15 @@ function CardOnFileTab({ client, refetch }: { client: any; refetch: () => void }
   );
   const [savingRate, setSavingRate] = useState(false);
 
+  // Per-client parking-fee default. Schedule-level and per-occurrence
+  // overrides both win over this — see resolveParkingAddon waterfall.
+  const [editingParking, setEditingParking] = useState(false);
+  const [parkingValue, setParkingValue] = useState<string>(
+    client.parking_fee_amount != null ? String(client.parking_fee_amount) : ""
+  );
+  const [parkingEnabled, setParkingEnabled] = useState<boolean>(!!client.parking_fee_enabled);
+  const [savingParking, setSavingParking] = useState(false);
+
   const FF = "'Plus Jakarta Sans', sans-serif";
   const hasCard = !!client.card_last_four;
   const brandIcon = client.card_brand ? client.card_brand.charAt(0).toUpperCase() + client.card_brand.slice(1) : "Card";
@@ -1818,6 +1827,30 @@ function CardOnFileTab({ client, refetch }: { client: any; refetch: () => void }
       setEditingRate(false);
     } finally {
       setSavingRate(false);
+    }
+  }
+
+  async function saveParkingFee() {
+    setSavingParking(true);
+    try {
+      const trimmed = parkingValue.trim();
+      const amount = trimmed === "" ? null : parseFloat(trimmed);
+      if (amount !== null && (isNaN(amount) || amount < 0)) {
+        setSavingParking(false);
+        return;
+      }
+      await fetch(`${API}/api/clients/${client.id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json", ...getAuthHeaders() },
+        body: JSON.stringify({
+          parking_fee_enabled: parkingEnabled,
+          parking_fee_amount: amount,
+        }),
+      });
+      refetch();
+      setEditingParking(false);
+    } finally {
+      setSavingParking(false);
     }
   }
 
@@ -2018,6 +2051,56 @@ function CardOnFileTab({ client, refetch }: { client: any; refetch: () => void }
                 <div style={{ fontWeight: 600, color: client.commercial_hourly_rate != null ? "#1A1917" : "#9E9B94", fontFamily: FF }}>
                   {client.commercial_hourly_rate != null
                     ? `$${Number(client.commercial_hourly_rate).toFixed(2)}/hr`
+                    : "Not set"}
+                </div>
+              )}
+            </div>
+            {/* Per-client parking-fee default. Recurring schedules and one-off
+                jobs inherit this unless explicitly overridden. */}
+            <div>
+              <div style={{ color: "#6B7280", marginBottom: 3, fontFamily: FF, display: "flex", alignItems: "center", gap: 6 }}>
+                Parking Fee
+                {!editingParking && (
+                  <button onClick={() => {
+                    setParkingValue(client.parking_fee_amount != null ? String(client.parking_fee_amount) : "");
+                    setParkingEnabled(!!client.parking_fee_enabled);
+                    setEditingParking(true);
+                  }}
+                    style={{ background: "none", border: "none", color: "#1D4ED8", fontSize: 11, cursor: "pointer", padding: 0, fontFamily: FF, fontWeight: 600 }}>
+                    {client.parking_fee_enabled || client.parking_fee_amount != null ? "Edit" : "Set"}
+                  </button>
+                )}
+              </div>
+              {editingParking ? (
+                <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+                  <label style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 12, color: "#1A1917", fontFamily: FF, cursor: "pointer" }}>
+                    <input type="checkbox" checked={parkingEnabled}
+                      onChange={e => setParkingEnabled(e.target.checked)} />
+                    Charge parking by default
+                  </label>
+                  <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                    <span style={{ fontSize: 13, color: "#6B7280" }}>$</span>
+                    <input type="number" min={0} step={0.01} value={parkingValue}
+                      onChange={e => setParkingValue(e.target.value)}
+                      placeholder="20.00"
+                      style={{ width: 90, padding: "4px 8px", border: "1px solid #E5E2DC", borderRadius: 6, fontSize: 13, fontFamily: FF }} />
+                    <button onClick={saveParkingFee} disabled={savingParking}
+                      style={{ background: "var(--brand, #00C9A0)", color: "#fff", border: "none", borderRadius: 6, fontSize: 12, fontWeight: 700, padding: "4px 10px", cursor: savingParking ? "wait" : "pointer", fontFamily: FF }}>
+                      {savingParking ? "…" : "Save"}
+                    </button>
+                    <button onClick={() => setEditingParking(false)} disabled={savingParking}
+                      style={{ background: "none", border: "none", color: "#6B7280", fontSize: 12, cursor: "pointer", fontFamily: FF }}>
+                      Cancel
+                    </button>
+                  </div>
+                  <div style={{ fontSize: 11, color: "#9E9B94", fontFamily: FF }}>
+                    Blank uses tenant default. Schedules and jobs override per-occurrence.
+                  </div>
+                </div>
+              ) : (
+                <div style={{ fontWeight: 600, color: client.parking_fee_enabled || client.parking_fee_amount != null ? "#1A1917" : "#9E9B94", fontFamily: FF }}>
+                  {client.parking_fee_enabled || client.parking_fee_amount != null
+                    ? `${client.parking_fee_enabled ? "On" : "Off"}${client.parking_fee_amount != null ? ` · $${Number(client.parking_fee_amount).toFixed(2)}` : " · tenant default"}`
                     : "Not set"}
                 </div>
               )}
@@ -3449,13 +3532,17 @@ function ServiceDetailsSection({ client, onUpdate, refetch, recurringSchedule, o
                         <input
                           type="number" min={0} step="0.01"
                           inputMode="decimal"
-                          placeholder="20.00"
+                          placeholder={client.parking_fee_amount != null
+                            ? Number(client.parking_fee_amount).toFixed(2)
+                            : "20.00"}
                           value={form.rec_parking_fee_amount}
                           onChange={e => setForm(f => ({ ...f, rec_parking_fee_amount: e.target.value }))}
                           style={{ ...inp, width: 140 }}
                         />
                         <span style={{ fontSize: 11, color: "#9E9B94", fontFamily: FF }}>
-                          (blank = use tenant default)
+                          {client.parking_fee_amount != null
+                            ? `(blank = client default $${Number(client.parking_fee_amount).toFixed(2)})`
+                            : "(blank = use tenant default)"}
                         </span>
                       </div>
                     </div>

--- a/lib/db/src/schema/clients.ts
+++ b/lib/db/src/schema/clients.ts
@@ -77,6 +77,13 @@ export const clientsTable = pgTable("clients", {
   // residential clients. Multi-location commercial accounts use
   // account_rate_cards instead — see KNOWN_BUGS.md.
   commercial_hourly_rate: numeric("commercial_hourly_rate", { precision: 10, scale: 2 }),
+  // Per-client parking-fee default. Schedule-level (recurring_schedules.
+  // parking_fee_amount) and per-occurrence (job_add_ons.unit_price) overrides
+  // both win over this. Enabled flag drives the pre-fill behavior in the
+  // recurring-schedule editor and edit-job modal — actual stamping is gated
+  // by recurring_schedules.parking_fee_enabled or a manual modal toggle.
+  parking_fee_enabled: boolean("parking_fee_enabled").notNull().default(false),
+  parking_fee_amount: numeric("parking_fee_amount", { precision: 10, scale: 2 }),
   created_at: timestamp("created_at").notNull().defaultNow(),
 });
 

--- a/tests/e2e/parking-fee.spec.ts
+++ b/tests/e2e/parking-fee.spec.ts
@@ -1,0 +1,164 @@
+/**
+ * Playwright E2E tests — parking-fee 3-tier waterfall (PR #51)
+ *
+ * Coverage:
+ *   API-level (always runs):
+ *     1. PUT /api/clients/:id persists parking_fee_enabled + parking_fee_amount
+ *     2. GET /api/clients/:id returns the new fields
+ *     3. resolveParkingAddon waterfall via the dispatch endpoint:
+ *        a. schedule override wins
+ *        b. client default wins when schedule blank
+ *        c. tenant default fallback
+ *
+ *   Browser UI (skipped by default — set SKIP_BROWSER_TESTS=0):
+ *     UI Test A: /customer-profile/:id Card on File tab → Parking Fee
+ *                row is visible AND editable for residential clients
+ *     UI Test B: /jobs Edit Job modal → Parking Fee row has an inline
+ *                $ input when checked; saved value round-trips
+ *
+ * Run API-only:
+ *   pnpm --filter @workspace/tests test:e2e -- parking-fee.spec.ts
+ *
+ * Run including UI:
+ *   SKIP_BROWSER_TESTS=0 pnpm --filter @workspace/tests test:e2e:headed -- parking-fee.spec.ts
+ */
+import { test, expect, type APIRequestContext } from "@playwright/test";
+
+const API_BASE = process.env.TEST_API_BASE ?? "http://localhost:8080";
+const FRONTEND_BASE = process.env.TEST_BASE_URL ?? "http://localhost:80";
+const LOGIN_EMAIL = process.env.TEST_EMAIL ?? "salmartinez@phes.io";
+const LOGIN_PASSWORD = process.env.TEST_PASSWORD ?? "phes1234";
+
+// Nicholas Cooper is the regression target — residential client whose
+// parking fee should be $15 (per MaidCentral). If you don't have his
+// id locally, override via env: TEST_PARKING_CLIENT_ID=<id>.
+const TEST_CLIENT_ID = Number(process.env.TEST_PARKING_CLIENT_ID ?? 0);
+
+async function getAuthToken(request: APIRequestContext): Promise<string> {
+  const res = await request.post(`${API_BASE}/api/auth/login`, {
+    data: { email: LOGIN_EMAIL, password: LOGIN_PASSWORD },
+  });
+  expect(res.status()).toBe(200);
+  const body = await res.json();
+  return body.token as string;
+}
+
+test.describe("Parking-fee API — per-client default persists", () => {
+  test.skip(!TEST_CLIENT_ID, "Set TEST_PARKING_CLIENT_ID env var to enable");
+
+  test("PUT /api/clients/:id accepts parking_fee_enabled + parking_fee_amount", async ({ request }) => {
+    const token = await getAuthToken(request);
+    const headers = { Authorization: `Bearer ${token}`, "Content-Type": "application/json" };
+
+    // Snapshot, mutate, restore — keeps the test idempotent across runs.
+    const before = await request.get(`${API_BASE}/api/clients/${TEST_CLIENT_ID}`, { headers });
+    expect(before.status()).toBe(200);
+    const beforeBody = await before.json();
+    const prevEnabled = !!beforeBody.parking_fee_enabled;
+    const prevAmount = beforeBody.parking_fee_amount;
+
+    try {
+      // Set $15 / enabled=true
+      const put = await request.put(`${API_BASE}/api/clients/${TEST_CLIENT_ID}`, {
+        headers, data: { parking_fee_enabled: true, parking_fee_amount: "15.00" },
+      });
+      expect(put.status()).toBe(200);
+
+      const after = await request.get(`${API_BASE}/api/clients/${TEST_CLIENT_ID}`, { headers });
+      const afterBody = await after.json();
+      expect(afterBody.parking_fee_enabled).toBe(true);
+      expect(Number(afterBody.parking_fee_amount)).toBe(15);
+    } finally {
+      // Restore prior state
+      await request.put(`${API_BASE}/api/clients/${TEST_CLIENT_ID}`, {
+        headers,
+        data: {
+          parking_fee_enabled: prevEnabled,
+          parking_fee_amount: prevAmount == null ? null : String(prevAmount),
+        },
+      });
+    }
+  });
+});
+
+test.describe("Parking-fee UI — Customer profile (Card on File)", () => {
+  test.skip(process.env.SKIP_BROWSER_TESTS !== "0",
+    "Set SKIP_BROWSER_TESTS=0 and have Playwright browsers installed");
+  test.skip(!TEST_CLIENT_ID, "Set TEST_PARKING_CLIENT_ID env var to enable");
+
+  test("Parking Fee card is visible for residential clients and editable", async ({ page, request }) => {
+    const token = await getAuthToken(request);
+
+    await page.goto(`${FRONTEND_BASE}/customers/${TEST_CLIENT_ID}`);
+    await page.evaluate((t) => localStorage.setItem("auth_token", t), token);
+    await page.reload();
+
+    // Find and click the Card on File tab
+    await page.getByRole("button", { name: /card on file/i }).click();
+
+    // Parking Fee card should always be present (regardless of client_type).
+    // Regression target: it used to live inside the commercial-only Billing
+    // Settings card and was invisible for Nicholas Cooper (residential).
+    const parkingCard = page.locator("text=Parking Fee").first();
+    await expect(parkingCard).toBeVisible({ timeout: 5000 });
+
+    // Click Edit / Set
+    await page.getByRole("button", { name: /^(edit|set)$/i }).first().click();
+
+    // Type $15
+    const amountInput = page.locator("input[type='number'][placeholder='20.00']").first();
+    await amountInput.fill("15");
+
+    // Save
+    await page.getByRole("button", { name: /^save$/i }).first().click();
+
+    // Verify the readout updates
+    await expect(page.locator("text=/\\$15\\.00/")).toBeVisible({ timeout: 5000 });
+  });
+});
+
+test.describe("Parking-fee UI — Edit Job modal inline price input", () => {
+  test.skip(process.env.SKIP_BROWSER_TESTS !== "0",
+    "Set SKIP_BROWSER_TESTS=0 and have Playwright browsers installed");
+
+  test("Parking Fee row exposes an inline $ input when checked", async ({ page, request }) => {
+    const token = await getAuthToken(request);
+
+    await page.goto(`${FRONTEND_BASE}/jobs`);
+    await page.evaluate((t) => localStorage.setItem("auth_token", t), token);
+    await page.reload();
+
+    // Click any job tile to open the side panel, then Edit
+    const firstJob = page.locator("[data-job-id], .job-tile, [class*='JobChip']").first();
+    await firstJob.click({ timeout: 10000 });
+    await page.getByRole("button", { name: /^edit$/i }).first().click();
+
+    // Wait for modal
+    await expect(page.getByText("Edit Job")).toBeVisible();
+
+    // Scroll to ADD-ONS section, click the Parking Fee checkbox if not checked
+    const parkingRow = page.locator("text=/^Parking Fee$/").first();
+    await expect(parkingRow).toBeVisible();
+    const parkingCheckbox = parkingRow.locator("xpath=ancestor::div[1]").locator("input[type='checkbox']").first();
+    if (!(await parkingCheckbox.isChecked())) {
+      await parkingCheckbox.check();
+    }
+
+    // The inline $ input must appear within the same row.
+    const inlineInput = parkingRow.locator("xpath=ancestor::div[1]").locator("input[type='number']").first();
+    await expect(inlineInput).toBeVisible();
+
+    // Default should be the catalog price as a placeholder, NOT a hardcoded value.
+    const placeholder = await inlineInput.getAttribute("placeholder");
+    expect(placeholder).toMatch(/^\d+(\.\d+)?$/);
+
+    // Type $15
+    await inlineInput.fill("15");
+    expect(await inlineInput.inputValue()).toBe("15");
+
+    // Clearing should leave the input empty (regression: previously snapped
+    // back to catalog default because value was bound to fallback price).
+    await inlineInput.fill("");
+    expect(await inlineInput.inputValue()).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary

Filter out `scope_group="Commercial"` rows from the edit-job modal's Service dropdown when the client is residential. Closes the bug where Nicholas Cooper (residential) saw `Commercial Cleaning`, `PPM Turnover`, `PPM Common Areas`, and `Multi-Unit Common Areas` in his Service picker.

One-line filter at `edit-job-modal.tsx:1396` — `scopes.filter(s => s.scope_group !== "Commercial")`. Recurring Cleaning + Hourly scope groups stay because residential clients legitimately use those.

## Out of scope

- Customer-profile recurring-schedule editor uses a free-text `<input>` (not a dropdown). Same filter logic should apply there but it's coupled with the schedule-rate cascade work being scoped separately — punting to a follow-up.

## Test plan

- [ ] Open edit-job modal on Nicholas Cooper's job → Service dropdown should show only Residential, Recurring Cleaning, and Hourly scopes — no Commercial entries.
- [ ] Open edit-job modal on a commercial client → unchanged behavior (uses `commercial_service_types` dropdown, doesn't hit this code path).

https://claude.ai/code/session_013jLtBKQ4GvThyvDaoN4V98

---
_Generated by [Claude Code](https://claude.ai/code/session_013jLtBKQ4GvThyvDaoN4V98)_