### PR TITLE
fix(audit): parking fields missing from GET + silent sqft PATCH failure

### DIFF
--- a/artifacts/api-server/src/routes/clients.ts
+++ b/artifacts/api-server/src/routes/clients.ts
@@ -1337,6 +1337,19 @@ router.get("/:id/recurring-schedule", requireAuth, async (req, res) => {
       notes: recurringSchedulesTable.notes,
       is_active: recurringSchedulesTable.is_active,
       assigned_employee_id: recurringSchedulesTable.assigned_employee_id,
+      // [audit BUG #1] Parking-fee config columns (added in PR #51) were
+      // missing from this SELECT. Customer-profile editor seeds
+      // form.rec_parking_fee_* from these — without them, the editor opens
+      // with parking unchecked + amount blank even when the DB has saved
+      // values, and saving wipes the schedule's parking config because the
+      // form thinks nothing was set.
+      parking_fee_enabled: recurringSchedulesTable.parking_fee_enabled,
+      parking_fee_amount: recurringSchedulesTable.parking_fee_amount,
+      parking_fee_days: recurringSchedulesTable.parking_fee_days,
+      // [audit BUG #4 prep] days_of_week needed by the parking-day picker
+      // gate; surface here so the customer-profile editor matches the
+      // edit-job modal's behavior. NULL for single-day frequencies.
+      days_of_week: recurringSchedulesTable.days_of_week,
       tech_first: usersTable.first_name,
       tech_last: usersTable.last_name,
     })

--- a/artifacts/qleno/src/components/edit-job-modal.tsx
+++ b/artifacts/qleno/src/components/edit-job-modal.tsx
@@ -1075,16 +1075,33 @@ export default function EditJobModal({
       // home row exists; rare, but we don't auto-create one here).
       if (!opts?.dry_run && primaryHomeId != null && propertySqft !== initialPropertySqft && !isCommercial) {
         try {
-          await fetch(`${API}/api/clients/${job.client_id}/homes/${primaryHomeId}`, {
+          const sqftRes = await fetch(`${API}/api/clients/${job.client_id}/homes/${primaryHomeId}`, {
             method: "PATCH",
             headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
             body: JSON.stringify({ sq_footage: propertySqft }),
           });
+          // [audit BUG #5] Previously the response wasn't checked, so a
+          // 4xx/5xx silently passed and the operator thought the sqft
+          // saved. Now we throw on non-2xx so the catch surfaces an
+          // error to the operator and the modal stays open with the
+          // unsaved value visible.
+          if (!sqftRes.ok) {
+            const errBody = await sqftRes.json().catch(() => ({}));
+            throw new Error(errBody.error || `HTTP ${sqftRes.status}`);
+          }
           // Update the snapshot locally so a subsequent save in the
           // same modal session doesn't re-PATCH the same value.
           setInitialPropertySqft(propertySqft);
-        } catch (e) {
-          console.warn("[edit-job-modal] sqft PATCH failed (non-fatal):", e);
+        } catch (e: any) {
+          // [audit BUG #5] Surface the failure. The job PATCH below
+          // still runs (sqft is a property-level update, independent
+          // of the job edit's success), but the operator now sees that
+          // the property record didn't update and can retry.
+          console.warn("[edit-job-modal] sqft PATCH failed:", e);
+          setLastSaveError({
+            title: "Couldn't save sqft to property",
+            message: `${e?.message ?? "unknown error"}. Job changes still saved — retry sqft from the customer profile.`,
+          });
         }
       }
 


### PR DESCRIPTION
## Summary

Two **BLOCKER**-class data-integrity bugs caught in the post-merge audit of PRs #51–53.

### BUG #1 — Parking fields missing from GET response

`GET /api/clients/:id/recurring-schedule` was omitting `parking_fee_enabled`, `parking_fee_amount`, and `parking_fee_days` from its SELECT. The customer-profile editor seeds `form.rec_parking_fee_*` from these fields — without them, the editor opens with parking unchecked + amount blank **even when the schedule has saved values**, and saving overwrites the schedule's parking config to NULL.

**Repro:**
1. Edit Nicholas Cooper's schedule, set parking $15, save → works
2. Reload the page → editor shows parking unchecked
3. Save → `parking_fee_amount` silently set to NULL in DB

**Fix:** include the three `parking_fee_*` columns + `days_of_week` (needed by the day-picker gate) in `clients.ts:1328` SELECT.

### BUG #5 — Silent sqft PATCH failure

When the operator types a sqft value in the new edit-job modal Property field and saves, the modal PATCHes `/api/clients/:id/homes/:homeId` with `sq_footage`. The response wasn't being checked — a 4xx/5xx fell through silently, so the operator believed it saved.

**Fix:** check `r.ok`, throw on non-2xx, surface via `setLastSaveError` toast. Job edit still saves separately so the operator just needs to retry the sqft from the profile.

## Test plan

- [ ] Set Nicholas Cooper's schedule parking to $15, save, **reload page**, open editor again → parking checkbox is checked, amount shows $15.
- [ ] Type a sqft on a job, save with the homes endpoint mocked to return 500 → toast appears `"Couldn't save sqft to property"`. Job PATCH still succeeds.
- [ ] Existing 3 unit tests still pass: `pnpm --filter @workspace/api-server run test:parking` → 3/3.

https://claude.ai/code/session_013jLtBKQ4GvThyvDaoN4V98

---
_Generated by [Claude Code](https://claude.ai/code/session_013jLtBKQ4GvThyvDaoN4V98)_