### PR TITLE
fix(audit): schedule cascade + frequency backfill + recurring tech mirror

### DIFF
--- a/artifacts/api-server/src/lib/recurring-jobs.ts
+++ b/artifacts/api-server/src/lib/recurring-jobs.ts
@@ -470,6 +470,31 @@ export async function generateJobsFromSchedule(
     }
   }
 
+  // [audit BUG #8] Hoist the schedule's tech roster once per generation
+  // run so we can mirror it to job_technicians on each newly-inserted job.
+  // Without this, a schedule with multiple techs (helper / trainee on top
+  // of the primary) silently lost everyone except the primary on every
+  // generated occurrence — assigned_user_id was set by insertJobFromSchedule
+  // but job_technicians was never populated. Dispatch grid + commission
+  // engine both read job_technicians, so the helpers vanished from
+  // pay reports until the office manually re-added them per job.
+  // Fallback chain matches the cascade path at jobs.ts:2188+:
+  // recurring_schedule_technicians > schedule.assigned_employee_id alone.
+  type ScheduleTech = { user_id: number; is_primary: boolean };
+  const scheduleTechRows = await db.execute(sql`
+    SELECT user_id, is_primary
+    FROM recurring_schedule_technicians
+    WHERE recurring_schedule_id = ${schedule.id}
+    ORDER BY is_primary DESC NULLS LAST, user_id ASC
+  `);
+  let scheduleTechs: ScheduleTech[] = (scheduleTechRows.rows as any[]).map(r => ({
+    user_id: Number(r.user_id),
+    is_primary: !!r.is_primary,
+  }));
+  if (scheduleTechs.length === 0 && schedule.assigned_employee_id != null) {
+    scheduleTechs = [{ user_id: Number(schedule.assigned_employee_id), is_primary: true }];
+  }
+
   let parkingStamped = 0;
   let created = 0;
   for (const row of rows) {
@@ -486,6 +511,19 @@ export async function generateJobsFromSchedule(
       clientZip ?? null,
     );
     created++;
+    // [audit BUG #8] Mirror the schedule's tech roster onto
+    // job_technicians. Idempotent via ON CONFLICT — safe even if a
+    // concurrent path also wrote the rows. assigned_user_id is already
+    // set by insertJobFromSchedule (single primary mirror); this adds
+    // helpers + trainees so the grid and commission engine see the
+    // full crew.
+    for (const t of scheduleTechs) {
+      await db.execute(sql`
+        INSERT INTO job_technicians (job_id, user_id, company_id, is_primary)
+        VALUES (${newId}, ${t.user_id}, ${schedule.company_id}, ${t.is_primary})
+        ON CONFLICT (job_id, user_id) DO NOTHING
+      `);
+    }
     if (resolved && (row as any)._parking_fee_applies) {
       await stampParkingFeeOnJob(newId, resolved);
       parkingStamped++;

--- a/artifacts/api-server/src/routes/clients.ts
+++ b/artifacts/api-server/src/routes/clients.ts
@@ -1264,6 +1264,12 @@ router.patch("/:id/recurring-schedule", requireAuth, async (req, res) => {
       // [AI.6] Parking fee per-occurrence config. days uses 0=Sun..6=Sat;
       // null/empty days = "apply to every scheduled occurrence."
       parking_fee_enabled, parking_fee_amount, parking_fee_days,
+      // [audit BUG #3] cascade flag — default true. When true, the
+      // schedule's rate / hours / service_type / frequency changes
+      // also propagate to existing future scheduled jobs linked to
+      // this schedule. Operator can pass cascade=false to update only
+      // the template (used by silent backfills and tests).
+      cascade,
     } = req.body;
     const updated = await db.update(recurringSchedulesTable).set({
       ...(frequency && { frequency }),
@@ -1286,7 +1292,68 @@ router.patch("/:id/recurring-schedule", requireAuth, async (req, res) => {
       eq(recurringSchedulesTable.company_id, companyId),
       eq(recurringSchedulesTable.is_active, true),
     )).returning();
-    return res.json(updated[0] || null);
+
+    // [audit BUG #3] Cascade rate / hours / service_type / frequency
+    // changes to existing future scheduled jobs. Without this, operators
+    // editing the customer-profile schedule saw their changes vanish on
+    // "next visit" because the existing job rows were frozen at their
+    // original migration-time values. Mirrors the edit-job modal's
+    // cascade=this_and_future behavior, scoped to the same client +
+    // schedule.
+    //
+    // NOT cascaded: parking_fee_*, day_of_week, notes. Parking has its
+    // own per-job stamping flow (job_add_ons rows are added by the
+    // engine at generation time; updating the template doesn't
+    // retroactively stamp existing jobs — operator opens the edit-job
+    // modal to flip parking on individual occurrences). day_of_week
+    // changes the *scheduled_date* of future visits, which is the
+    // engine's job, not a row update. Notes are template-only.
+    let cascadeUpdated = 0;
+    const shouldCascade = cascade !== false && updated[0];
+    const hasCascadableField = base_fee !== undefined
+      || duration_minutes !== undefined
+      || service_type !== undefined
+      || frequency !== undefined;
+    if (shouldCascade && hasCascadableField) {
+      const today = new Date().toISOString().slice(0, 10);
+      // Build the SET clause dynamically — only include fields the
+      // operator actually changed, mirror jobs columns from the new
+      // schedule values. allowed_hours is the per-job analogue of
+      // duration_minutes (jobs stores hours, not minutes).
+      const setFragments: any[] = [];
+      if (base_fee !== undefined) {
+        const v = base_fee === "" ? null : String(base_fee);
+        setFragments.push(sql`base_fee = ${v}`);
+      }
+      if (duration_minutes !== undefined) {
+        const mins = duration_minutes === "" ? null : parseInt(String(duration_minutes)) || null;
+        const hrs = mins == null ? null : (mins / 60).toFixed(2);
+        setFragments.push(sql`allowed_hours = ${hrs}`);
+      }
+      if (service_type !== undefined) {
+        // Pass the raw value — the jobs.service_type enum is the same
+        // as recurring_schedules.service_type so no mapping needed.
+        setFragments.push(sql`service_type = ${service_type}::service_type`);
+      }
+      if (frequency !== undefined) {
+        setFragments.push(sql`frequency = ${frequency}::frequency`);
+      }
+      const setSql = setFragments.reduce((acc: any, frag: any, i: number) => i === 0 ? frag : sql`${acc}, ${frag}`);
+      const cascadeRes = await db.execute(sql`
+        UPDATE jobs
+        SET ${setSql}
+        WHERE company_id = ${companyId}
+          AND recurring_schedule_id = ${updated[0].id}
+          AND status = 'scheduled'
+          AND scheduled_date >= ${today}
+      `);
+      cascadeUpdated = (cascadeRes as any).rowCount ?? 0;
+    }
+
+    return res.json({
+      ...(updated[0] || {}),
+      cascade: { updated_jobs: cascadeUpdated },
+    });
   } catch (err) {
     console.error("Patch recurring schedule error:", err);
     return res.status(500).json({ error: "Internal Server Error" });

--- a/artifacts/qleno/src/pages/customer-profile.tsx
+++ b/artifacts/qleno/src/pages/customer-profile.tsx
@@ -3328,10 +3328,24 @@ function ServiceDetailsSection({ client, onUpdate, refetch, recurringSchedule, o
   const [editing, setEditing] = useState(false);
   const [saving, setSaving] = useState(false);
   const [form, setForm] = useState({
-    base_fee: client.base_fee || "",
-    frequency: client.frequency || "",
-    service_type: client.service_type || "",
-    allowed_hours: client.allowed_hours || "",
+    // [audit BUG #4] Fall back to the recurring schedule's values when the
+    // client-level fields are empty. Migrated MC clients have the schedule
+    // populated but `clients.frequency` / `clients.service_type` /
+    // `clients.base_fee` / `clients.allowed_hours` blank — operators saw
+    // CLIENT SERVICE SETTINGS as empty even though the schedule below it
+    // had real values, then assumed the data was missing. The fallback
+    // does NOT overwrite client fields on save (that would silently mutate
+    // historical data) — it only prefills the editor so the operator sees
+    // and can confirm/edit the effective values. Clean separation: client
+    // fields are the LEGACY default, schedule is the active template.
+    base_fee: client.base_fee || recurringSchedule?.base_fee || "",
+    frequency: client.frequency || recurringSchedule?.frequency || "",
+    service_type: client.service_type || recurringSchedule?.service_type || "",
+    allowed_hours: client.allowed_hours
+      || (recurringSchedule?.duration_minutes
+        ? String((Number(recurringSchedule.duration_minutes) / 60).toFixed(2))
+        : "")
+      || "",
     home_access_notes: client.home_access_notes || "",
     alarm_code: client.alarm_code || "",
     pets: client.pets || "",
@@ -3372,7 +3386,7 @@ function ServiceDetailsSection({ client, onUpdate, refetch, recurringSchedule, o
         const parkingDaysToSend = form.rec_parking_fee_enabled && isMultiDayFreq
           ? form.rec_parking_fee_days
           : null;
-        await apiFetch(`/api/clients/${client.id}/recurring-schedule`, {
+        const patchRes = await apiFetch(`/api/clients/${client.id}/recurring-schedule`, {
           method: "PATCH",
           body: JSON.stringify({
             frequency: form.rec_frequency || undefined, day_of_week: form.rec_day || undefined,
@@ -3383,9 +3397,23 @@ function ServiceDetailsSection({ client, onUpdate, refetch, recurringSchedule, o
               ? (form.rec_parking_fee_amount === "" ? null : form.rec_parking_fee_amount)
               : null,
             parking_fee_days: parkingDaysToSend,
+            // [audit BUG #3] Cascade rate / hours / service_type / frequency
+            // changes to existing future scheduled jobs. Default true.
+            cascade: true,
           }),
         });
         qc.invalidateQueries({ queryKey: ["client-recurring", client.id] });
+        // [audit BUG #3] Surface the cascade count in the toast so the
+        // operator sees that "save and stick" actually propagated.
+        const cascadeCount = patchRes?.cascade?.updated_jobs ?? 0;
+        if (cascadeCount > 0) {
+          onToast(`Service details saved · ${cascadeCount} future job${cascadeCount === 1 ? "" : "s"} updated`);
+        } else {
+          onToast("Service details saved");
+        }
+        refetch();
+        setEditing(false);
+        return;
       }
       refetch();
       setEditing(false);


### PR DESCRIPTION
## Summary

Three IMPORTANT-severity bugs from the post-merge audit of PRs #51–53. Sibling to PR #54 (which closed the two BLOCKERS).

### BUG #3 — Customer profile schedule rate edit didn't cascade

Operator edits Schedule Rate $180 on Nicholas Cooper's profile → existing future jobs stay frozen at $195 (MC-migration value). Edit-job modal had `cascade=this_and_future`; customer profile had no equivalent.

**Fix:** `PATCH /api/clients/:id/recurring-schedule` now cascades `base_fee`, `duration_minutes` (→ `allowed_hours`), `service_type`, `frequency` to `status='scheduled'` jobs with `scheduled_date >= today` linked via `recurring_schedule_id`. Cascade is **on by default** (matches user's "save and stick" expectation). Toast shows `"… · N future jobs updated"`.

Not cascaded: `parking_fee_*` (separate stamping flow), `day_of_week` (drives scheduled_date generation), `notes` (template-only).

### BUG #4 — `clients.frequency` / `clients.service_type` not backfilled from schedule

Migrated MC clients have schedule populated but client-level fields blank. Operator sees CLIENT SERVICE SETTINGS as empty even though there's a real schedule below.

**Fix:** form initializer falls back to schedule values when client fields empty. Does **not** silently mutate client data on save — fallback is for display only.

### BUG #8 — Recurring engine doesn't mirror multi-tech team

`generateJobsFromSchedule` inserted the job + `assigned_user_id` but never wrote `job_technicians` rows. A schedule with helper/trainee on top of primary lost the helpers on every generated occurrence. Commission engine + dispatch grid read `job_technicians`, so helpers vanished from pay reports.

**Fix:** hoist schedule's tech roster once per generation run via `recurring_schedule_technicians` SELECT (with `assigned_employee_id` fallback). After each `insertJobFromSchedule`, INSERT each tech to `job_technicians` with `ON CONFLICT (job_id, user_id) DO NOTHING`.

## Test plan

- [ ] Open Nicholas Cooper's profile → edit Schedule Rate to a new value → save. Toast shows `"… · N future jobs updated"`. Open one of his future jobs → base_fee reflects the new rate.
- [ ] Customer with no `clients.frequency` but has a schedule → CLIENT SERVICE SETTINGS shows the schedule's frequency / scope as fallback (italicized or not — just visible).
- [ ] Schedule with a primary + helper → wait for nightly engine OR force regeneration → check `job_technicians` for the new occurrence has both rows.
- [ ] Existing 3 unit tests still pass: `pnpm --filter @workspace/api-server run test:parking` → 3/3.

## Out of scope

- BUG #2 (duplicate Frequency fields confusing UX) — UI-only nice-to-have, deferred
- BUG #6 (hardcoded $20 parking fallback) — defensive default, not a violation
- BUG #7 (no lint rule for branch invariants) — meta-tooling, deferred

https://claude.ai/code/session_013jLtBKQ4GvThyvDaoN4V98

---
_Generated by [Claude Code](https://claude.ai/code/session_013jLtBKQ4GvThyvDaoN4V98)_