### PR TITLE
fix(customer-profile): reset Service Details form from props on Edit click

### DIFF
--- a/artifacts/qleno/src/pages/customer-profile.tsx
+++ b/artifacts/qleno/src/pages/customer-profile.tsx
@@ -3327,7 +3327,14 @@ function ServiceDetailsSection({ client, onUpdate, refetch, recurringSchedule, o
   const qc = useQueryClient();
   const [editing, setEditing] = useState(false);
   const [saving, setSaving] = useState(false);
-  const [form, setForm] = useState({
+
+  // [audit follow-up] Build form values from current props. Reused by both
+  // the useState initializer and the Edit-click handler so the form always
+  // reflects the LATEST props when the operator opens the editor — fixes
+  // the "Schedule Rate field is blank but view shows $215" repro where the
+  // form was initialized once at mount (before recurringSchedule had
+  // loaded) and stayed stale across re-renders.
+  const buildFormFromProps = () => ({
     // [audit BUG #4] Fall back to the recurring schedule's values when the
     // client-level fields are empty. Migrated MC clients have the schedule
     // populated but `clients.frequency` / `clients.service_type` /
@@ -3365,6 +3372,7 @@ function ServiceDetailsSection({ client, onUpdate, refetch, recurringSchedule, o
       ? recurringSchedule.parking_fee_days
       : (recurringSchedule?.days_of_week ?? [])) as number[],
   });
+  const [form, setForm] = useState(buildFormFromProps);
 
   const save = async () => {
     setSaving(true);
@@ -3456,7 +3464,7 @@ function ServiceDetailsSection({ client, onUpdate, refetch, recurringSchedule, o
             <button onClick={save} disabled={saving} style={{ padding: "7px 14px", background: "var(--brand)", border: "none", borderRadius: 7, color: "#FFFFFF", fontSize: 13, fontWeight: 600, cursor: "pointer", fontFamily: FF, opacity: saving ? 0.6 : 1 }}>{saving ? "Saving..." : "Save"}</button>
           </div>
         ) : (
-          <button onClick={() => setEditing(true)} style={{ display: "flex", alignItems: "center", gap: 6, padding: "7px 14px", border: "1px solid #E5E2DC", borderRadius: 7, background: "#FFFFFF", color: "#1A1917", fontSize: 13, cursor: "pointer", fontFamily: FF }}>
+          <button onClick={() => { setForm(buildFormFromProps()); setEditing(true); }} style={{ display: "flex", alignItems: "center", gap: 6, padding: "7px 14px", border: "1px solid #E5E2DC", borderRadius: 7, background: "#FFFFFF", color: "#1A1917", fontSize: 13, cursor: "pointer", fontFamily: FF }}>
             <Edit2 size={13} /> Edit Service Details
           </button>
         )}


### PR DESCRIPTION
## Summary

Closes the "view shows $215 but Edit field is blank" repro the user just hit on Nicholas Cooper. The customer-profile Service Details form was initialized once at mount when `recurringSchedule` was still loading (null). The form fields locked in as empty. View mode then re-rendered with the loaded schedule (showing RATE $215), but the form state never re-synced — clicking Edit just toggled visibility, leaving the input blank.

## Fix

Extract the form-init logic into `buildFormFromProps()` and call it from BOTH the `useState` initializer AND the Edit button's onClick. Now clicking Edit always re-pulls the latest props so fields reflect what's actually saved.

## Test plan

- [ ] Open Nicholas Cooper's profile → view mode shows RATE $215.00 → click Edit → SCHEDULE RATE input pre-fills with `215`.
- [ ] Change to `180`, save with cascade → toast confirms N future jobs updated. Reload → field stays at $180.
- [ ] Open a fresh profile (different client) → same behavior — fields populated from saved data on every Edit click.

https://claude.ai/code/session_013jLtBKQ4GvThyvDaoN4V98

---
_Generated by [Claude Code](https://claude.ai/code/session_013jLtBKQ4GvThyvDaoN4V98)_