### PR TITLE
feat: Service Type dropdown + rename + parking cascade to existing jobs

### DIFF
--- a/artifacts/api-server/src/routes/clients.ts
+++ b/artifacts/api-server/src/routes/clients.ts
@@ -1350,9 +1350,111 @@ router.patch("/:id/recurring-schedule", requireAuth, async (req, res) => {
       cascadeUpdated = (cascadeRes as any).rowCount ?? 0;
     }
 
+    // [parking-cascade] Cascade parking config to existing future scheduled
+    // jobs. The recurring engine stamps parking on NEW occurrences via
+    // stampParkingFeeOnJob, but existing jobs created before the operator
+    // toggled parking on (or before they changed the amount) carry no
+    // job_add_ons row OR carry a stale unit_price. The user-reported repro:
+    // saved parking $15 on Nicholas Cooper's profile, May 11 job stayed at
+    // base $180 with no parking row. Now we:
+    //  - Resolve the tenant's Parking Fee addon once (3-tier waterfall)
+    //  - For each existing future scheduled job linked to this schedule
+    //    where parking_fee_days matches the job's weekday:
+    //      enabled  -> UPSERT job_add_ons with the new unit_price
+    //      disabled -> DELETE the job_add_ons parking row
+    let parkingCascadeUpserted = 0;
+    let parkingCascadeRemoved = 0;
+    const parkingTouched = parking_fee_enabled !== undefined
+      || parking_fee_amount !== undefined
+      || parking_fee_days !== undefined;
+    if (shouldCascade && parkingTouched && updated[0]) {
+      const today = new Date().toISOString().slice(0, 10);
+      const sched = updated[0] as any;
+      if (sched.parking_fee_enabled) {
+        // UPSERT path. Pull the resolved parking addon (handles 3-tier
+        // waterfall: schedule.parking_fee_amount > clients.parking_fee_amount
+        // > pricing_addons.parking_fee.price). Reuse the engine helper so
+        // the resolution logic stays single-sourced.
+        const { resolveParkingAddon } = await import("../lib/recurring-jobs.js");
+        const resolved = await resolveParkingAddon({
+          company_id: companyId,
+          customer_id: clientId,
+          parking_fee_amount: sched.parking_fee_amount,
+        });
+        if (resolved) {
+          // Day filter: NULL parking_fee_days = "every visit"; populated
+          // array = "only matching weekdays". Postgres EXTRACT(DOW...)
+          // returns 0=Sun..6=Sat which matches our 0=Sun..6=Sat
+          // convention for parking_fee_days.
+          const dayFilter = sched.parking_fee_days == null
+            ? sql`TRUE`
+            : sql`EXTRACT(DOW FROM scheduled_date)::int = ANY(${sched.parking_fee_days as number[]})`;
+          // INSERT ... ON CONFLICT (job_id, add_on_id) DO UPDATE so amount
+          // changes propagate to already-stamped jobs.
+          const upsertRes = await db.execute(sql`
+            INSERT INTO job_add_ons (job_id, add_on_id, quantity, unit_price, subtotal, pricing_addon_id)
+            SELECT j.id, ${resolved.add_on_id}, 1, ${resolved.unit_price}, ${resolved.unit_price}, ${resolved.pricing_addon_id}
+            FROM jobs j
+            WHERE j.company_id = ${companyId}
+              AND j.recurring_schedule_id = ${sched.id}
+              AND j.status = 'scheduled'
+              AND j.scheduled_date >= ${today}
+              AND ${dayFilter}
+            ON CONFLICT (job_id, add_on_id) DO UPDATE
+              SET unit_price = EXCLUDED.unit_price,
+                  subtotal = EXCLUDED.subtotal
+          `);
+          parkingCascadeUpserted = (upsertRes as any).rowCount ?? 0;
+          // Also DELETE parking from jobs whose weekday is NOT in the day
+          // filter (when parking_fee_days is set to a partial subset and
+          // some jobs previously had parking stamped via "every visit").
+          if (sched.parking_fee_days != null) {
+            const removeRes = await db.execute(sql`
+              DELETE FROM job_add_ons
+              WHERE add_on_id = ${resolved.add_on_id}
+                AND job_id IN (
+                  SELECT j.id
+                  FROM jobs j
+                  WHERE j.company_id = ${companyId}
+                    AND j.recurring_schedule_id = ${sched.id}
+                    AND j.status = 'scheduled'
+                    AND j.scheduled_date >= ${today}
+                    AND NOT (EXTRACT(DOW FROM scheduled_date)::int = ANY(${sched.parking_fee_days as number[]}))
+                )
+            `);
+            parkingCascadeRemoved = (removeRes as any).rowCount ?? 0;
+          }
+        }
+      } else {
+        // Parking toggled OFF — DELETE parking rows from all future
+        // scheduled jobs linked to this schedule. Use a name-based
+        // lookup to find the add_on row (no schedule-amount required).
+        const removeRes = await db.execute(sql`
+          DELETE FROM job_add_ons
+          WHERE add_on_id IN (
+            SELECT id FROM add_ons
+            WHERE company_id = ${companyId} AND LOWER(name) = 'parking fee'
+          )
+          AND job_id IN (
+            SELECT j.id
+            FROM jobs j
+            WHERE j.company_id = ${companyId}
+              AND j.recurring_schedule_id = ${sched.id}
+              AND j.status = 'scheduled'
+              AND j.scheduled_date >= ${today}
+          )
+        `);
+        parkingCascadeRemoved = (removeRes as any).rowCount ?? 0;
+      }
+    }
+
     return res.json({
       ...(updated[0] || {}),
-      cascade: { updated_jobs: cascadeUpdated },
+      cascade: {
+        updated_jobs: cascadeUpdated,
+        parking_upserted: parkingCascadeUpserted,
+        parking_removed: parkingCascadeRemoved,
+      },
     });
   } catch (err) {
     console.error("Patch recurring schedule error:", err);

--- a/artifacts/qleno/src/components/edit-job-modal.tsx
+++ b/artifacts/qleno/src/components/edit-job-modal.tsx
@@ -1457,7 +1457,7 @@ export default function EditJobModal({
               <>
                 <div style={{ display: "grid", gridTemplateColumns: mobile ? "1fr" : "1fr 1fr", gap: 10 }}>
                   <div>
-                    <span style={{ fontSize: 12, color: "#6B6860", display: "block", marginBottom: 4 }}>Scope</span>
+                    <span style={{ fontSize: 12, color: "#6B6860", display: "block", marginBottom: 4 }}>Service Type</span>
                     <select value={scopeId ?? ""} onChange={e => setScopeId(parseInt(e.target.value))}
                       style={INPUT} disabled={scopesLoading}>
                       {scopesLoading ? <option>Loading…</option> : null}

--- a/artifacts/qleno/src/pages/customer-profile.tsx
+++ b/artifacts/qleno/src/pages/customer-profile.tsx
@@ -3089,7 +3089,7 @@ function JobDetailSlideOver({ row, profile, onClose }: { row: any; profile?: any
           </div>
 
           <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16 }}>
-            {row.service_type && <Field label="Scope" value={row.service_type} />}
+            {row.service_type && <Field label="Service Type" value={row.service_type} />}
             {duration && <Field label="Duration" value={`${duration} hours`} />}
             {addOn && <Field label="Add-On" value={addOn} />}
             {address && <Field label="Service Address" value={address} />}
@@ -3327,6 +3327,43 @@ function ServiceDetailsSection({ client, onUpdate, refetch, recurringSchedule, o
   const qc = useQueryClient();
   const [editing, setEditing] = useState(false);
   const [saving, setSaving] = useState(false);
+
+  // Tenant pricing_scopes for the Service Type dropdown. Filter rule
+  // matches the edit-job modal (PR #52): residential clients drop
+  // scope_group="Commercial", commercial clients drop scope_group=
+  // "Residential". Recurring Cleaning + Hourly stay for both. Storage
+  // convention: dropdown value = scope.name (readable), engine's
+  // mapServiceType handles both readable names and slug-style values
+  // via case-insensitive substring matching, so the round-trip works
+  // for legacy slug data ("standard_clean") as well.
+  const [scopes, setScopes] = useState<Array<{ id: number; name: string; scope_group: string | null }>>([]);
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const data = await apiFetch("/api/pricing/scopes");
+        if (cancelled) return;
+        const list = Array.isArray(data) ? data : (data?.data ?? []);
+        setScopes(list);
+      } catch { /* non-fatal — falls back to free-text "(current)" option */ }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+  const isCommercialClient = client.client_type === "commercial" || client.account_id != null;
+  const filteredScopes = scopes.filter(s => isCommercialClient
+    ? s.scope_group !== "Residential"
+    : s.scope_group !== "Commercial");
+  const scopeToSlug = (name: string) => name.toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+  // Match a saved value (slug-style "standard_clean" OR readable
+  // "Standard Clean") against the filtered scope list. Used for the
+  // (current) fallback option so legacy data isn't silently swapped
+  // when the editor opens.
+  const findMatchingScope = (saved: string) => {
+    if (!saved) return undefined;
+    const target = saved.toLowerCase();
+    return filteredScopes.find(s => s.name.toLowerCase() === target || scopeToSlug(s.name) === target);
+  };
+
   const [form, setForm] = useState({
     // [audit BUG #4] Fall back to the recurring schedule's values when the
     // client-level fields are empty. Migrated MC clients have the schedule
@@ -3406,11 +3443,13 @@ function ServiceDetailsSection({ client, onUpdate, refetch, recurringSchedule, o
         // [audit BUG #3] Surface the cascade count in the toast so the
         // operator sees that "save and stick" actually propagated.
         const cascadeCount = patchRes?.cascade?.updated_jobs ?? 0;
-        if (cascadeCount > 0) {
-          onToast(`Service details saved · ${cascadeCount} future job${cascadeCount === 1 ? "" : "s"} updated`);
-        } else {
-          onToast("Service details saved");
-        }
+        const parkingUpserted = patchRes?.cascade?.parking_upserted ?? 0;
+        const parkingRemoved = patchRes?.cascade?.parking_removed ?? 0;
+        const parts = [];
+        if (cascadeCount > 0) parts.push(`${cascadeCount} future job${cascadeCount === 1 ? "" : "s"} updated`);
+        if (parkingUpserted > 0) parts.push(`parking added/updated on ${parkingUpserted}`);
+        if (parkingRemoved > 0) parts.push(`parking removed from ${parkingRemoved}`);
+        onToast(parts.length ? `Service details saved · ${parts.join(", ")}` : "Service details saved");
         refetch();
         setEditing(false);
         return;
@@ -3478,7 +3517,17 @@ function ServiceDetailsSection({ client, onUpdate, refetch, recurringSchedule, o
                 {Object.entries(FREQ_LABELS).map(([v, l]) => <option key={v} value={v}>{l}</option>)}
               </select>
             </div>
-            <div>{lbl("Scope / Service Type")}<input value={form.service_type} onChange={upd("service_type")} style={inp} /></div>
+            <div>{lbl("Service Type")}
+              <select value={form.service_type} onChange={upd("service_type")} style={inp}>
+                <option value="">— Select —</option>
+                {filteredScopes.map(s => (
+                  <option key={s.id} value={s.name}>{s.name}{s.scope_group ? ` · ${s.scope_group}` : ""}</option>
+                ))}
+                {form.service_type && !findMatchingScope(form.service_type) && (
+                  <option value={form.service_type}>(current) {form.service_type}</option>
+                )}
+              </select>
+            </div>
           </div>
           <div>{lbl("Entry Instructions")}<textarea value={form.home_access_notes} onChange={upd("home_access_notes")} rows={2} style={{ ...inp, resize: "vertical" as const }} /></div>
           <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
@@ -3491,7 +3540,7 @@ function ServiceDetailsSection({ client, onUpdate, refetch, recurringSchedule, o
         <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: 14 }}>
           {client.base_fee && <DL label="Base Rate" value={fmtCurrency(client.base_fee)} />}
           {client.frequency && <DL label="Frequency" value={FREQ_LABELS[client.frequency] || client.frequency} />}
-          {client.service_type && <DL label="Scope" value={client.service_type} />}
+          {client.service_type && <DL label="Service Type" value={client.service_type} />}
           {client.allowed_hours && <DL label="Allowed Hours" value={`${client.allowed_hours} hrs`} />}
           {client.home_access_notes && <DL label="Entry Instructions" value={client.home_access_notes} />}
           {client.alarm_code && <DL label="Alarm Code" value="••••••" />}
@@ -3538,7 +3587,17 @@ function ServiceDetailsSection({ client, onUpdate, refetch, recurringSchedule, o
                 <div>{lbl("Duration (min)")}<input value={form.rec_duration} onChange={upd("rec_duration")} type="number" min="0" style={inp} /></div>
                 <div>{lbl("Schedule Rate ($)")}<input value={form.rec_base_fee} onChange={upd("rec_base_fee")} type="number" min="0" step="0.01" style={inp} /></div>
               </div>
-              <div>{lbl("Scope")}<input value={form.rec_service_type} onChange={upd("rec_service_type")} style={inp} /></div>
+              <div>{lbl("Service Type")}
+                <select value={form.rec_service_type} onChange={upd("rec_service_type")} style={inp}>
+                  <option value="">— Select —</option>
+                  {filteredScopes.map(s => (
+                    <option key={s.id} value={s.name}>{s.name}{s.scope_group ? ` · ${s.scope_group}` : ""}</option>
+                  ))}
+                  {form.rec_service_type && !findMatchingScope(form.rec_service_type) && (
+                    <option value={form.rec_service_type}>(current) {form.rec_service_type}</option>
+                  )}
+                </select>
+              </div>
 
               {/* [AI.6] Parking Fee subsection. Toggle + amount + (multi-day only) day picker.
                   Day picker uses 0=Sun..6=Sat to match recurring_schedules.days_of_week. */}


### PR DESCRIPTION
## Summary

Three closely-related fixes for issues the user hit on Nicholas Cooper:

### 1. Rename "Scope" → "Service Type" everywhere

Customer profile + edit-job modal now use one consistent label. Fewer mental bridges for non-technical operators.

### 2. Customer-profile scope field becomes a residential-filtered dropdown

Both scope fields (CLIENT SERVICE SETTINGS + RECURRING SCHEDULE) were free-text inputs. Now they're `<select>` populated from `/api/pricing/scopes`, filtered by `client_type` like the edit-job modal (residential drops `scope_group="Commercial"`, commercial drops `"Residential"`).

**Storage convention:** dropdown value is the readable scope name. The engine's `mapServiceType` helper handles both readable names and slug-style values via case-insensitive substring matching, so legacy `"standard_clean"` data round-trips as `"Standard Clean"` without forcing a backfill. Saved values not in the filtered list surface as `"(current) <value>"` so legacy data isn't silently swapped.

### 3. Parking cascade to existing future jobs

`PATCH /api/clients/:id/recurring-schedule` now cascades parking config to existing future scheduled jobs linked to the schedule. The user repro: saved parking $15 on Nicholas's profile, May 11 future job stayed at base $180 with NO parking row in `job_add_ons`. The recurring engine stamps parking only on NEW occurrences via `stampParkingFeeOnJob`; existing jobs needed individual fixes via the edit-job modal.

Now:
- `parking_fee_enabled=true` → UPSERT `job_add_ons` rows for all future scheduled jobs whose weekday is in `parking_fee_days` (NULL = every visit). Reuses `resolveParkingAddon` for the 3-tier waterfall.
- `parking_fee_enabled=true` + partial `parking_fee_days` → also DELETE parking from jobs whose weekday is NOT in the list (operator narrowed scope).
- `parking_fee_enabled=false` → DELETE parking from all future scheduled jobs linked to this schedule.

Toast surfaces the cascade summary: `"Service details saved · 4 future jobs updated, parking added/updated on 4"`.

## Test plan

- [ ] Open Nicholas Cooper's profile → Edit recurring schedule. Service Type dropdown shows residential + recurring + hourly options only (no Commercial).
- [ ] Set Service Type to `Standard Clean`, Schedule Rate $180, parking enabled $15. Save → toast shows `"… · N future jobs updated, parking added/updated on N"`.
- [ ] Open his May 11 future job in edit-job modal → base $180 + Parking Fee row $15 already checked.
- [ ] Toggle parking off on schedule → save → existing future jobs lose parking rows.
- [ ] Commercial client → dropdown shows Commercial + Recurring Cleaning + Hourly only.

https://claude.ai/code/session_013jLtBKQ4GvThyvDaoN4V98

---
_Generated by [Claude Code](https://claude.ai/code/session_013jLtBKQ4GvThyvDaoN4V98)_