### PR TITLE
feat(pricing): hourly_rate column + Schedule Rate auto-calc + drop One-Time from recurring filter

### DIFF
--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -576,6 +576,34 @@ async function runBookingSchemaGuard(): Promise<void> {
       stmt: `ALTER TYPE recurring_frequency ADD VALUE IF NOT EXISTS 'semi_monthly'` },
     { label: "recurring_schedules.days_of_month",
       stmt: `ALTER TABLE recurring_schedules ADD COLUMN IF NOT EXISTS days_of_month INTEGER[]` },
+
+    // [PR #60] Per-client hourly rate. Drives the recurring-schedule
+    // editor's Schedule Rate auto-calc (hourly_rate × allowed_hours =
+    // schedule_rate). Distinct from commercial_hourly_rate (commission
+    // engine). Backfill below populates it for existing clients.
+    { label: "clients.hourly_rate",
+      stmt: `ALTER TABLE clients ADD COLUMN IF NOT EXISTS hourly_rate NUMERIC(10,2)` },
+    // [PR #60] Backfill clients.hourly_rate. Priority order:
+    // 1) commercial_hourly_rate (already-set commercial value)
+    // 2) base_fee / allowed_hours (residential — implied rate)
+    // Skip rows that already have hourly_rate populated. Idempotent —
+    // safe to run on every cold-start.
+    { label: "clients.hourly_rate backfill",
+      stmt: `
+        UPDATE clients
+        SET hourly_rate = COALESCE(
+          commercial_hourly_rate,
+          CASE
+            WHEN base_fee IS NOT NULL
+              AND allowed_hours IS NOT NULL
+              AND allowed_hours::numeric > 0
+            THEN ROUND((base_fee::numeric / allowed_hours::numeric)::numeric, 2)
+            ELSE NULL
+          END
+        )
+        WHERE hourly_rate IS NULL
+      `,
+    },
   ];
 
   for (const { label, stmt } of guards) {

--- a/artifacts/api-server/src/routes/clients.ts
+++ b/artifacts/api-server/src/routes/clients.ts
@@ -558,7 +558,8 @@ router.put("/:id", requireAuth, async (req, res) => {
       po_number_required, default_po_number, payment_terms, auto_charge,
       card_last_four, card_brand, card_expiry, card_saved_at,
       payment_method, net_terms,
-      commercial_hourly_rate,    // [AH] Per-client commercial hourly rate
+      commercial_hourly_rate,    // [AH] Per-client commercial hourly rate (commission engine)
+      hourly_rate,               // [PR #60] Per-client hourly rate (Schedule Rate auto-calc)
       parking_fee_enabled, parking_fee_amount,
     } = req.body;
 
@@ -613,6 +614,14 @@ router.put("/:id", requireAuth, async (req, res) => {
         commercial_hourly_rate: commercial_hourly_rate === null || commercial_hourly_rate === ""
           ? null
           : String(commercial_hourly_rate),
+      }),
+      // [PR #60] Per-client hourly rate. Persisted explicitly so the
+      // recurring-schedule editor's Schedule Rate auto-calc has a
+      // first-class field rather than inferring from base_fee/allowed_hours.
+      ...(hourly_rate !== undefined && {
+        hourly_rate: hourly_rate === null || hourly_rate === ""
+          ? null
+          : String(hourly_rate),
       }),
       ...(parking_fee_enabled !== undefined && { parking_fee_enabled: !!parking_fee_enabled }),
       ...(parking_fee_amount !== undefined && {
@@ -1356,18 +1365,31 @@ router.patch("/:id/recurring-schedule", requireAuth, async (req, res) => {
     // profile UI no longer surfaces these — the schedule is the single
     // source of truth — but the data drift from old code reading
     // clients.frequency would surface stale values otherwise.
+    //
+    // [PR #60] Also recompute clients.hourly_rate when base_fee or
+    // duration_minutes change. The recurring-schedule editor's Schedule
+    // Rate auto-calc treats hourly_rate as first-class, so keep it in
+    // sync with whatever (rate, hours) the operator just saved.
     if (updated[0]) {
       const sched = updated[0] as any;
+      const newBaseFee = base_fee === "" || base_fee == null ? null : Number(base_fee);
+      const newAllowedHours = duration_minutes === "" || duration_minutes == null
+        ? null
+        : Number(duration_minutes) / 60;
+      const computedHourlyRate = newBaseFee != null && newAllowedHours != null && newAllowedHours > 0
+        ? Number((newBaseFee / newAllowedHours).toFixed(2))
+        : null;
       await db.update(clientsTable).set({
         ...(frequency && { frequency: String(frequency) }),
         ...(service_type !== undefined && { service_type: service_type ?? null }),
         ...(base_fee !== undefined && {
-          base_fee: base_fee === "" || base_fee == null ? null : String(base_fee),
+          base_fee: newBaseFee == null ? null : String(newBaseFee),
         }),
         ...(duration_minutes !== undefined && {
-          allowed_hours: duration_minutes === "" || duration_minutes == null
-            ? null
-            : String((Number(duration_minutes) / 60).toFixed(2)),
+          allowed_hours: newAllowedHours == null ? null : String(newAllowedHours.toFixed(2)),
+        }),
+        ...((base_fee !== undefined || duration_minutes !== undefined) && computedHourlyRate != null && {
+          hourly_rate: String(computedHourlyRate),
         }),
       }).where(and(
         eq(clientsTable.id, clientId),

--- a/artifacts/qleno/src/pages/customer-profile.tsx
+++ b/artifacts/qleno/src/pages/customer-profile.tsx
@@ -3423,6 +3423,14 @@ function ServiceDetailsSection({ client, onUpdate, refetch, recurringSchedule, o
     rec_duration: recurringSchedule?.duration_minutes
       ? String(Number(recurringSchedule.duration_minutes) / 60)
       : "",
+    // [PR #60] Per-client hourly rate. Sourced from clients.hourly_rate
+    // (backfilled at deploy from base_fee/allowed_hours). Drives the
+    // Schedule Rate auto-calc: typing a new Hourly Rate or Allowed Hours
+    // updates Schedule Rate to (hourly × hours). Editing Schedule Rate
+    // directly stays as a flat override.
+    rec_hourly_rate: client.hourly_rate
+      ? String(client.hourly_rate)
+      : "",
     rec_base_fee: recurringSchedule?.base_fee || "",
     rec_service_type: recurringSchedule?.service_type || "",
     rec_notes: recurringSchedule?.notes || "",
@@ -3781,9 +3789,59 @@ function ServiceDetailsSection({ client, onUpdate, refetch, recurringSchedule, o
                   </div>
                 </div>
               )}
-              <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
-                <div>{lbl("Allowed Hours")}<input value={form.rec_duration} onChange={upd("rec_duration")} type="number" min="0" step="0.5" placeholder="3" style={inp} /></div>
-                <div>{lbl("Schedule Rate ($)")}<input value={form.rec_base_fee} onChange={upd("rec_base_fee")} type="number" min="0" step="0.01" style={inp} /></div>
+              {/* [PR #60] Three-field rate row. Type Hourly OR Hours →
+                  Schedule Rate auto-recalcs (hourly × hours). Edit Schedule
+                  Rate directly → stays as a flat override (operator's
+                  intent: discount visit, special rate). Helper text below
+                  surfaces the implied formula so operator sees the math. */}
+              <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: 12 }}>
+                <div>{lbl("Hourly Rate ($)")}
+                  <input value={form.rec_hourly_rate}
+                    onChange={e => {
+                      const newHourly = e.target.value;
+                      setForm(f => {
+                        const hours = parseFloat(String(f.rec_duration));
+                        const hourly = parseFloat(newHourly);
+                        const next: any = { ...f, rec_hourly_rate: newHourly };
+                        if (!isNaN(hourly) && !isNaN(hours) && hours > 0) {
+                          next.rec_base_fee = (hourly * hours).toFixed(2);
+                        }
+                        return next;
+                      });
+                    }}
+                    type="number" min="0" step="0.01" placeholder="60" style={inp} />
+                </div>
+                <div>{lbl("Allowed Hours")}
+                  <input value={form.rec_duration}
+                    onChange={e => {
+                      const newHours = e.target.value;
+                      setForm(f => {
+                        const hourly = parseFloat(String(f.rec_hourly_rate));
+                        const hours = parseFloat(newHours);
+                        const next: any = { ...f, rec_duration: newHours };
+                        if (!isNaN(hourly) && !isNaN(hours) && hours > 0) {
+                          next.rec_base_fee = (hourly * hours).toFixed(2);
+                        }
+                        return next;
+                      });
+                    }}
+                    type="number" min="0" step="0.5" placeholder="3" style={inp} />
+                </div>
+                <div>{lbl("Schedule Rate ($)")}
+                  <input value={form.rec_base_fee} onChange={upd("rec_base_fee")} type="number" min="0" step="0.01" style={inp} />
+                  {(() => {
+                    const h = parseFloat(String(form.rec_hourly_rate));
+                    const d = parseFloat(String(form.rec_duration));
+                    if (!isNaN(h) && !isNaN(d) && d > 0) {
+                      return (
+                        <div style={{ fontSize: 11, color: "#6B6860", marginTop: 4, fontFamily: FF }}>
+                          ${h.toFixed(2)}/hr × {d} hrs = ${(h * d).toFixed(2)}
+                        </div>
+                      );
+                    }
+                    return null;
+                  })()}
+                </div>
               </div>
               <div>{lbl("Service Type")}
                 {(() => {
@@ -3802,7 +3860,16 @@ function ServiceDetailsSection({ client, onUpdate, refetch, recurringSchedule, o
                   const isRecurring = recurringFreqs.has(form.rec_frequency);
                   const isOneTime = oneTimeFreqs.has(form.rec_frequency);
                   const recurringNoise = /^recurring cleaning\s*[-–—]/i;
-                  const recurringOk = (n: string) => /standard|hourly recurring/i.test(n) && !recurringNoise.test(n);
+                  // [PR #60] Also drop scopes whose name explicitly says
+                  // "one-time" when the operator picked a recurring
+                  // frequency. The user pointed out "Standard Clean" and
+                  // "One-Time Standard Clean" are the same scope from a
+                  // recurring-client POV — only the recurring variant
+                  // should appear.
+                  const oneTimeMarker = /one[- ]?time/i;
+                  const recurringOk = (n: string) => /standard|hourly recurring/i.test(n)
+                    && !recurringNoise.test(n)
+                    && !oneTimeMarker.test(n);
                   const oneTimeOk = (n: string) => /standard clean|deep clean|move in|move out|hourly standard|hourly deep/i.test(n) && !recurringNoise.test(n);
                   const scopeFiltered = filteredScopes.filter(s => {
                     if (recurringNoise.test(s.name)) return false;

--- a/lib/db/src/schema/clients.ts
+++ b/lib/db/src/schema/clients.ts
@@ -77,6 +77,13 @@ export const clientsTable = pgTable("clients", {
   // residential clients. Multi-location commercial accounts use
   // account_rate_cards instead — see KNOWN_BUGS.md.
   commercial_hourly_rate: numeric("commercial_hourly_rate", { precision: 10, scale: 2 }),
+  // [PR #60] Per-client hourly rate. Drives the recurring-schedule editor's
+  // Schedule Rate auto-calc (hourly_rate × allowed_hours = schedule_rate).
+  // Distinct from commercial_hourly_rate (which is consumed by the
+  // commission engine / edit-job modal commercial branch). Set for both
+  // residential and commercial clients. Backfilled at cold-start from
+  // base_fee / allowed_hours when null.
+  hourly_rate: numeric("hourly_rate", { precision: 10, scale: 2 }),
   // Per-client parking-fee default. Schedule-level (recurring_schedules.
   // parking_fee_amount) and per-occurrence (job_add_ons.unit_price) overrides
   // both win over this. Enabled flag drives the pre-fill behavior in the


### PR DESCRIPTION
## Summary

Closes the user's "the math didn't change" complaint when changing Allowed Hours, plus the "One-Time Standard Clean and Standard Clean are the same thing" duplicate-filter feedback.

## What changed

### Hourly rate is now first-class on the client

- New `clients.hourly_rate NUMERIC(10,2)` column.
- Cold-start backfill: `COALESCE(commercial_hourly_rate, base_fee/allowed_hours)` for every client where `hourly_rate IS NULL`. Idempotent.
- `PUT /api/clients/:id` accepts and persists `hourly_rate`.
- `PATCH /api/clients/:id/recurring-schedule` recomputes `hourly_rate = base_fee / allowed_hours` when either changes — keeps the column in sync.

### Customer profile editor — three-field rate row

```
Hourly Rate ($)   Allowed Hours    Schedule Rate ($)
[ 60.00 ]         [ 3.5 ]          [ 210.00 ]
                                   ↳ $60.00/hr × 3.5 hrs = $210.00
```

- Type **Hourly** OR **Hours** → Schedule Rate **auto-recalcs**.
- Edit **Schedule Rate** directly → stays as a flat override (discount visit, trip charge, etc.).
- Helper text below Schedule Rate surfaces the implied formula in plain English.

### Service Type filter — drop "One-Time" scopes for recurring frequencies

When the operator picks a recurring frequency (Every week / Every 2 weeks / Twice a month / Monthly / Custom), the dropdown now hides any scope whose name matches `/one[- ]?time/i`. So "One-Time Standard Clean" disappears when frequency is recurring; only "Standard Clean" + "Hourly Recurring" remain. Closes the duplicate-feeling complaint.

### Alignment with booking widget

The booking widget's `/api/pricing/calculate` already uses `hours × scope.hourly_rate = base_price`. This PR makes the customer-profile manual editor follow the same formula. One pricing model, one mental model.

## Test plan

- [ ] Open Nicholas Cooper's profile after deploy. Hourly Rate field pre-fills with $71.67 (backfilled from $215/3). Operator can correct to $60.
- [ ] Set Hourly Rate = 60, Allowed Hours = 3.5 → Schedule Rate auto-fills to $210.00. Helper says "$60.00/hr × 3.5 hrs = $210.00".
- [ ] Type 200 directly into Schedule Rate → it stays at $200 (flat override). Now type 4 in Allowed Hours → Schedule Rate jumps to $240 (auto-calc resumes from new hours × current hourly).
- [ ] Pick Frequency = "Every 2 weeks" → Service Type dropdown shows "Standard Clean", "Hourly Recurring" (or similar). NOT "One-Time Standard Clean".
- [ ] Pick Frequency = "One-time" → "One-Time Standard Clean" reappears.
- [ ] Existing 3 parking-waterfall unit tests still pass.

## Out of scope

- Apr 27 – May 3 revenue reconciliation script.
- Wider rollout of `hourly_rate` to other surfaces (commission engine still uses `commercial_hourly_rate` — separate concern).

https://claude.ai/code/session_013jLtBKQ4GvThyvDaoN4V98

---
_Generated by [Claude Code](https://claude.ai/code/session_013jLtBKQ4GvThyvDaoN4V98)_