### PR TITLE
fix: cascade enum cast (save failure) + reorder Service Details

### DIFF
--- a/artifacts/api-server/src/routes/clients.ts
+++ b/artifacts/api-server/src/routes/clients.ts
@@ -1435,23 +1435,60 @@ router.patch("/:id/recurring-schedule", requireAuth, async (req, res) => {
         setFragments.push(sql`allowed_hours = ${hrs}`);
       }
       if (service_type !== undefined) {
-        // Pass the raw value — the jobs.service_type enum is the same
-        // as recurring_schedules.service_type so no mapping needed.
-        setFragments.push(sql`service_type = ${service_type}::service_type`);
+        // [PR #61] After PR #57 the Service Type dropdown stores the
+        // readable scope name ("Standard Clean") instead of the slug
+        // ("standard_clean"). The jobs.service_type enum only accepts
+        // slug values — casting "Standard Clean"::service_type fails
+        // and aborts the entire save with "Failed to save changes."
+        // Convert to slug + validate against the enum allowlist before
+        // cascading. If the value isn't a recognized enum, skip the
+        // cascade for service_type (the schedule template still updates
+        // — just doesn't rewrite existing jobs' service_type).
+        const validEnumSlugs = new Set([
+          "standard_clean", "deep_clean", "move_out", "recurring",
+          "post_construction", "move_in", "office_cleaning",
+          "common_areas", "retail_store", "medical_office",
+          "ppm_turnover", "post_event", "ppm_common_areas",
+          "commercial_cleaning", "recurring_commercial_cleaning",
+        ]);
+        const slugify = (s: string) => String(s).toLowerCase().trim().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+        const candidate = service_type ? slugify(String(service_type)) : "";
+        if (candidate && validEnumSlugs.has(candidate)) {
+          setFragments.push(sql`service_type = ${candidate}::service_type`);
+        } else if (service_type) {
+          console.warn(`[recurring-schedule cascade] skipping service_type cast — "${service_type}" doesn't match a known enum slug. Schedule template updated; jobs.service_type left unchanged.`);
+        }
       }
       if (frequency !== undefined) {
-        setFragments.push(sql`frequency = ${frequency}::frequency`);
+        // [PR #61] Defensive cast for frequency too. Belt-and-suspenders
+        // against future UI changes that might pass non-canonical values.
+        const validFreqs = new Set([
+          "weekly", "biweekly", "every_3_weeks", "monthly", "on_demand",
+          "daily", "weekdays", "custom_days", "semi_monthly",
+        ]);
+        if (frequency && validFreqs.has(String(frequency))) {
+          setFragments.push(sql`frequency = ${frequency}::frequency`);
+        } else if (frequency) {
+          console.warn(`[recurring-schedule cascade] skipping frequency cast — "${frequency}" not in enum. Schedule template updated; jobs.frequency left unchanged.`);
+        }
       }
-      const setSql = setFragments.reduce((acc: any, frag: any, i: number) => i === 0 ? frag : sql`${acc}, ${frag}`);
-      const cascadeRes = await db.execute(sql`
-        UPDATE jobs
-        SET ${setSql}
-        WHERE company_id = ${companyId}
-          AND recurring_schedule_id = ${updated[0].id}
-          AND status = 'scheduled'
-          AND scheduled_date >= ${today}
-      `);
-      cascadeUpdated = (cascadeRes as any).rowCount ?? 0;
+      // [PR #61] Skip the cascade UPDATE entirely when no fragments
+      // survived validation — happens when the only changed field is
+      // service_type or frequency and the value didn't match a valid
+      // enum slug. Otherwise we'd build "UPDATE jobs SET WHERE ..."
+      // and Postgres would error on the empty SET clause.
+      if (setFragments.length > 0) {
+        const setSql = setFragments.reduce((acc: any, frag: any, i: number) => i === 0 ? frag : sql`${acc}, ${frag}`);
+        const cascadeRes = await db.execute(sql`
+          UPDATE jobs
+          SET ${setSql}
+          WHERE company_id = ${companyId}
+            AND recurring_schedule_id = ${updated[0].id}
+            AND status = 'scheduled'
+            AND scheduled_date >= ${today}
+        `);
+        cascadeUpdated = (cascadeRes as any).rowCount ?? 0;
+      }
     }
 
     // [parking-cascade] Cascade parking config to existing future scheduled

--- a/artifacts/qleno/src/pages/customer-profile.tsx
+++ b/artifacts/qleno/src/pages/customer-profile.tsx
@@ -3576,34 +3576,11 @@ function ServiceDetailsSection({ client, onUpdate, refetch, recurringSchedule, o
         )}
       </div>
 
-      {/* [PR #59] Property + access details. The redundant Frequency /
-          Service Type / Base Rate / Allowed Hours fields used to live here
-          AND on the Recurring Schedule below — operators saw two of each
-          and assumed they were different concepts. They aren't: the
-          schedule is the single source of truth. We dropped the duplicate
-          fields and kept only the actually-property-level info (entry
-          instructions, alarm code, pets, internal notes). The schedule
-          editor below now mirrors its values back to the legacy clients.*
-          columns on save so any old code path that still reads them stays
-          correct. */}
-      {editing ? (
-        <div style={{ border: "1px solid #E5E2DC", borderRadius: 10, padding: 16, display: "flex", flexDirection: "column", gap: 14 }}>
-          <div style={{ fontSize: 12, fontWeight: 700, color: "#6B6860", textTransform: "uppercase" as const, letterSpacing: "0.07em" }}>Access &amp; Notes</div>
-          <div>{lbl("Entry Instructions")}<textarea value={form.home_access_notes} onChange={upd("home_access_notes")} rows={2} style={{ ...inp, resize: "vertical" as const }} /></div>
-          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
-            <div>{lbl("Alarm / Lockbox Code")}<input value={form.alarm_code} onChange={upd("alarm_code")} style={inp} /></div>
-            <div>{lbl("Pets / Equipment Notes")}<input value={form.pets} onChange={upd("pets")} style={inp} /></div>
-          </div>
-          <div>{lbl("Internal Notes")}<textarea value={form.notes} onChange={upd("notes")} rows={2} style={{ ...inp, resize: "vertical" as const }} /></div>
-        </div>
-      ) : (
-        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: 14 }}>
-          {client.home_access_notes && <DL label="Entry Instructions" value={client.home_access_notes} />}
-          {client.alarm_code && <DL label="Alarm Code" value="••••••" />}
-          {client.pets && <DL label="Pets / Equipment" value={client.pets} />}
-          {client.notes && <DL label="Notes" value={client.notes} />}
-        </div>
-      )}
+      {/* [PR #61] Recurring Schedule moved ABOVE Access & Notes — operator
+          works in this section first when setting up or reviewing a
+          client; access/notes are reference fields they touch less
+          often. Property fields (entry instructions, alarm, pets,
+          internal notes) now live below. */}
 
       {/* [PR #59] Recurring Schedule — now ALWAYS rendered. When the
           client has no schedule yet, the read-only view shows a "Set Up
@@ -4009,6 +3986,29 @@ function ServiceDetailsSection({ client, onUpdate, refetch, recurringSchedule, o
             </div>
           ) : null}
         </div>
+
+      {/* [PR #59] Access & Notes — property-level fields (entry, alarm,
+          pets, internal notes). [PR #61] Moved here, below Recurring
+          Schedule, since operators reference these less often than the
+          recurring service config. */}
+      {editing ? (
+        <div style={{ border: "1px solid #E5E2DC", borderRadius: 10, padding: 16, display: "flex", flexDirection: "column", gap: 14 }}>
+          <div style={{ fontSize: 12, fontWeight: 700, color: "#6B6860", textTransform: "uppercase" as const, letterSpacing: "0.07em" }}>Access &amp; Notes</div>
+          <div>{lbl("Entry Instructions")}<textarea value={form.home_access_notes} onChange={upd("home_access_notes")} rows={2} style={{ ...inp, resize: "vertical" as const }} /></div>
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
+            <div>{lbl("Alarm / Lockbox Code")}<input value={form.alarm_code} onChange={upd("alarm_code")} style={inp} /></div>
+            <div>{lbl("Pets / Equipment Notes")}<input value={form.pets} onChange={upd("pets")} style={inp} /></div>
+          </div>
+          <div>{lbl("Internal Notes")}<textarea value={form.notes} onChange={upd("notes")} rows={2} style={{ ...inp, resize: "vertical" as const }} /></div>
+        </div>
+      ) : (
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: 14 }}>
+          {client.home_access_notes && <DL label="Entry Instructions" value={client.home_access_notes} />}
+          {client.alarm_code && <DL label="Alarm Code" value="••••••" />}
+          {client.pets && <DL label="Pets / Equipment" value={client.pets} />}
+          {client.notes && <DL label="Notes" value={client.notes} />}
+        </div>
+      )}
 
       {/* Rate History */}
       <div style={{ border: "1px solid #E5E2DC", borderRadius: 10, padding: 16 }}>


### PR DESCRIPTION
## Summary

Two issues from the user testing PR #60:

### 1. "Failed to save changes" on the recurring schedule editor

**Root cause:** PR #57 changed the Service Type dropdown to store the readable scope name (`"Standard Clean"`) instead of the slug (`"standard_clean"`). The cascade `UPDATE jobs SET service_type = ${value}::service_type` casts to the enum, which only accepts slug values. `"Standard Clean"::service_type` raises a Postgres error and aborts the entire save → operator sees "Failed to save changes."

**Fix:** Convert to slug + validate against the enum allowlist before cascading. If invalid, skip the service_type cascade (schedule template still updates; existing jobs.service_type left alone). Same defensive pattern applied to frequency. Also guards the empty-`SET` case so we don't run `UPDATE jobs SET WHERE ...` when all candidate fields got dropped.

### 2. Reorder — Recurring Schedule above Access & Notes

Operator works in the recurring service config first when reviewing a client; access/notes are reference fields touched less often. Moved the Access & Notes block (~25 lines) to render after Recurring Schedule.

## Test plan

- [ ] Open Nicholas Cooper → Edit. Recurring Schedule is the FIRST section under the header. Access & Notes follows.
- [ ] Type Hourly Rate `60`, Allowed Hours `3.5` → Schedule Rate auto-calcs `210.00`. Click Save → toast confirms (no "Failed to save changes" error). Reload → fields stick.
- [ ] Pick a different Service Type from the dropdown → Save → no failure even though the dropdown stores readable names.
- [ ] Server logs show `[recurring-schedule cascade] skipping service_type cast — "Standard Clean" doesn't match a known enum slug` when the slug doesn't validate (silent fallback, save succeeds).
- [ ] Existing 3 parking-waterfall unit tests still pass.

https://claude.ai/code/session_013jLtBKQ4GvThyvDaoN4V98

---
_Generated by [Claude Code](https://claude.ai/code/session_013jLtBKQ4GvThyvDaoN4V98)_