### PR TITLE
fix(calc-engine): sqft optional when caller supplies hours

### DIFF
--- a/artifacts/api-server/src/routes/pricing.ts
+++ b/artifacts/api-server/src/routes/pricing.ts
@@ -552,16 +552,39 @@ router.post("/calculate", requireAuth, async (req, res) => {
     let used_sqft: number | null = null;
 
     if (method === "sqft") {
-      if (!sqft) return res.status(400).json({ error: "sqft is required for sqft-based scopes" });
-      const tiers = await db.select().from(pricingTiersTable)
-        .where(and(eq(pricingTiersTable.scope_id, scope_id), eq(pricingTiersTable.company_id, companyId)));
-      const sortedTiers = [...tiers].sort((a, b) => a.min_sqft - b.min_sqft);
-      const tier = sortedTiers.find(t => sqft >= t.min_sqft && sqft <= t.max_sqft)
-        ?? (sqft < Number(sortedTiers[0]?.min_sqft) ? sortedTiers[0] : sortedTiers[sortedTiers.length - 1]);
-      if (!tier) return res.status(422).json({ error: "No tier found for the given sqft" });
-      base_hours = parseFloat(String(tier.hours));
-      tier_id = tier.id;
-      used_sqft = sqft;
+      // [PR #62] Prefer caller-supplied hours over sqft tier lookup. The
+      // edit-job modal opens on legacy MC-migrated clients with no sqft
+      // on file but a known allowed_hours. Before this change the engine
+      // refused to compute (400 "sqft is required") which froze the
+      // modal — operators couldn't reconcile rate / parking / addons
+      // because the New total wouldn't move. Now: if the caller passes
+      // hours, use them directly with hours × hourly_rate (skip tier
+      // lookup). Sqft is still optional UI input — when provided it
+      // populates `used_sqft` for downstream %-based sqft addons. When
+      // both sqft and hours are missing, we still 400 — at that point
+      // the engine genuinely can't compute.
+      const hoursProvided = hours != null && hours !== "" && Number(hours) > 0;
+      if (!sqft && !hoursProvided) {
+        return res.status(400).json({ error: "sqft is required for sqft-based scopes" });
+      }
+      if (hoursProvided) {
+        // Use the explicit hours value, no tier lookup. used_sqft stays
+        // null (unless sqft was also passed) so sqft-based %-addons that
+        // depend on actual square footage compute to 0 — consistent with
+        // the no-sqft-known reality.
+        base_hours = parseFloat(String(hours));
+        used_sqft = sqft ?? null;
+      } else {
+        const tiers = await db.select().from(pricingTiersTable)
+          .where(and(eq(pricingTiersTable.scope_id, scope_id), eq(pricingTiersTable.company_id, companyId)));
+        const sortedTiers = [...tiers].sort((a, b) => a.min_sqft - b.min_sqft);
+        const tier = sortedTiers.find(t => sqft! >= t.min_sqft && sqft! <= t.max_sqft)
+          ?? (sqft! < Number(sortedTiers[0]?.min_sqft) ? sortedTiers[0] : sortedTiers[sortedTiers.length - 1]);
+        if (!tier) return res.status(422).json({ error: "No tier found for the given sqft" });
+        base_hours = parseFloat(String(tier.hours));
+        tier_id = tier.id;
+        used_sqft = sqft!;
+      }
     } else {
       if (!hours || Number(hours) <= 0) return res.status(400).json({ error: "hours is required for hourly/simplified scopes" });
       base_hours = parseFloat(String(hours));


### PR DESCRIPTION
## Summary

Closes the "system is useless" reconciliation blocker. The calc engine refused to compute for any sqft-based scope when sqft was missing, regardless of whether the caller already knew the hours. That froze the edit-job modal for every legacy MC-migrated client (none have sqft on file). Operators couldn't reconcile MC's per-job revenue because they couldn't get the modal's New total to update.

## Fix

`/api/pricing/calculate` (`routes/pricing.ts:554-587`):
- If sqft is null/missing AND `hours` > 0 was passed → use `hours × scope.hourly_rate`, skip the tier lookup
- If both sqft AND hours are missing → still return 400 (genuine "can't compute" case)
- Sqft-based %-addons (Windows 15%) still compute against `used_sqft` — when sqft isn't supplied they return $0, which is consistent with "we don't know the sqft." Operator uses the W1 flat-$ override on %-addons in that case.

## What this unblocks

For Nicholas Cooper:
- Edit modal opens
- 3 hrs × $60/hr = $180 base
- + $15 parking = $195 total ← matches MC
- New total updates as the operator changes hours / parking / rate

Same applies to every other legacy client with no sqft. Reconciliation through the modal now works.

## Out of scope

- Public booking widget (`public.ts runCalculate`) — unchanged. Booking widget always collects sqft from the customer.
- Past completed jobs cascade — separate concern. After this lands, schedule edits naturally cascade to future scheduled jobs (PR #55) and the operator can manually edit past jobs through the now-working modal.

## Test plan

- [ ] Open Nicholas Cooper's edit-job modal. New = $180 (was $215). Toggle parking → New = $195.
- [ ] Open any legacy client without sqft on file → modal computes a value, no red "sqft is required" error.
- [ ] New client booking via widget at /book/phes → unchanged (always passes sqft).
- [ ] Existing 3 parking-waterfall unit tests still pass.

https://claude.ai/code/session_013jLtBKQ4GvThyvDaoN4V98

---
_Generated by [Claude Code](https://claude.ai/code/session_013jLtBKQ4GvThyvDaoN4V98)_