### PR TITLE
fix(lms): cold-start migration + attendance grace period (Phes policy)

### DIFF
--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -604,6 +604,105 @@ async function runBookingSchemaGuard(): Promise<void> {
         WHERE hourly_rate IS NULL
       `,
     },
+
+    // [PR #64] LMS — per-module quiz Learning Management System.
+    // Schema source of truth: lib/db/src/schema/lms.ts. Replicated here
+    // because the production deploy does NOT run drizzle-kit push — the
+    // cold-start hook in this file is the only schema-init mechanism
+    // wired into the Dockerfile. Without these guards, every /api/lms/*
+    // request 500s on prod. Idempotent (CREATE TABLE IF NOT EXISTS +
+    // DO/EXCEPTION blocks for the enums + CREATE INDEX IF NOT EXISTS).
+    { label: "enum enrollment_status",
+      stmt: `
+        DO $$ BEGIN
+          CREATE TYPE enrollment_status AS ENUM ('active', 'completed', 'expired');
+        EXCEPTION WHEN duplicate_object THEN NULL;
+        END $$
+      ` },
+    { label: "enum module_status",
+      stmt: `
+        DO $$ BEGIN
+          CREATE TYPE module_status AS ENUM ('not_started', 'in_progress', 'passed', 'failed');
+        EXCEPTION WHEN duplicate_object THEN NULL;
+        END $$
+      ` },
+    { label: "CREATE lms_enrollments", stmt: `
+      CREATE TABLE IF NOT EXISTS lms_enrollments (
+        id                       SERIAL PRIMARY KEY,
+        company_id               INTEGER NOT NULL REFERENCES companies(id),
+        user_id                  INTEGER NOT NULL REFERENCES users(id),
+        status                   enrollment_status NOT NULL DEFAULT 'active',
+        enrolled_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        deadline_at              TIMESTAMPTZ NOT NULL,
+        completed_at             TIMESTAMPTZ,
+        last_activity_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        locale                   TEXT,
+        acknowledgment_signature TEXT,
+        acknowledgment_at        TIMESTAMPTZ,
+        created_at               TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        updated_at               TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      )
+    ` },
+    { label: "lms_enrollments_company_user_uq",
+      stmt: `CREATE UNIQUE INDEX IF NOT EXISTS lms_enrollments_company_user_uq ON lms_enrollments(company_id, user_id)` },
+    { label: "lms_enrollments_company_status_idx",
+      stmt: `CREATE INDEX IF NOT EXISTS lms_enrollments_company_status_idx ON lms_enrollments(company_id, status)` },
+    { label: "lms_enrollments_deadline_idx",
+      stmt: `CREATE INDEX IF NOT EXISTS lms_enrollments_deadline_idx ON lms_enrollments(deadline_at)` },
+
+    { label: "CREATE lms_module_progress", stmt: `
+      CREATE TABLE IF NOT EXISTS lms_module_progress (
+        id               SERIAL PRIMARY KEY,
+        company_id       INTEGER NOT NULL REFERENCES companies(id),
+        enrollment_id    INTEGER NOT NULL REFERENCES lms_enrollments(id) ON DELETE CASCADE,
+        module_id        TEXT NOT NULL,
+        status           module_status NOT NULL DEFAULT 'not_started',
+        best_score       INTEGER NOT NULL DEFAULT 0,
+        attempts         INTEGER NOT NULL DEFAULT 0,
+        started_at       TIMESTAMPTZ,
+        passed_at        TIMESTAMPTZ,
+        last_attempt_at  TIMESTAMPTZ,
+        created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      )
+    ` },
+    { label: "lms_module_progress_enrollment_module_uq",
+      stmt: `CREATE UNIQUE INDEX IF NOT EXISTS lms_module_progress_enrollment_module_uq ON lms_module_progress(enrollment_id, module_id)` },
+    { label: "lms_module_progress_company_status_idx",
+      stmt: `CREATE INDEX IF NOT EXISTS lms_module_progress_company_status_idx ON lms_module_progress(company_id, status)` },
+
+    { label: "CREATE lms_quiz_state", stmt: `
+      CREATE TABLE IF NOT EXISTS lms_quiz_state (
+        id                      SERIAL PRIMARY KEY,
+        company_id              INTEGER NOT NULL REFERENCES companies(id),
+        enrollment_id           INTEGER NOT NULL REFERENCES lms_enrollments(id) ON DELETE CASCADE,
+        module_id               TEXT NOT NULL,
+        current_question_index  INTEGER NOT NULL DEFAULT 0,
+        answers                 JSONB NOT NULL DEFAULT '[]'::jsonb,
+        meta                    JSONB,
+        updated_at              TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      )
+    ` },
+    { label: "lms_quiz_state_enrollment_module_uq",
+      stmt: `CREATE UNIQUE INDEX IF NOT EXISTS lms_quiz_state_enrollment_module_uq ON lms_quiz_state(enrollment_id, module_id)` },
+
+    { label: "CREATE lms_quiz_attempts", stmt: `
+      CREATE TABLE IF NOT EXISTS lms_quiz_attempts (
+        id             SERIAL PRIMARY KEY,
+        company_id     INTEGER NOT NULL REFERENCES companies(id),
+        enrollment_id  INTEGER NOT NULL REFERENCES lms_enrollments(id) ON DELETE CASCADE,
+        module_id      TEXT NOT NULL,
+        answers        JSONB NOT NULL,
+        question_ids   JSONB,
+        score          INTEGER NOT NULL,
+        passed         BOOLEAN NOT NULL,
+        attempted_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      )
+    ` },
+    { label: "lms_quiz_attempts_enrollment_module_attempted_idx",
+      stmt: `CREATE INDEX IF NOT EXISTS lms_quiz_attempts_enrollment_module_attempted_idx ON lms_quiz_attempts(enrollment_id, module_id, attempted_at)` },
+    { label: "lms_quiz_attempts_company_attempted_idx",
+      stmt: `CREATE INDEX IF NOT EXISTS lms_quiz_attempts_company_attempted_idx ON lms_quiz_attempts(company_id, attempted_at)` },
   ];
 
   for (const { label, stmt } of guards) {

--- a/artifacts/qleno/src/lib/training/curriculum.ts
+++ b/artifacts/qleno/src/lib/training/curriculum.ts
@@ -195,8 +195,8 @@ const BASE_MODULES: Module[] = [
       {
         type: "p",
         text: {
-          en: "You have a 7-minute grace window after your scheduled clock-in time. Beyond 7 minutes, the visit is recorded as tardy.",
-          es: "Cuenta con un periodo de gracia de 7 minutos después de su hora programada para registrarse. Después de 7 minutos, la visita se registra como tardanza.",
+          en: "You have a 20-minute grace window after your scheduled clock-in time. Beyond 20 minutes, the visit is recorded as tardy.",
+          es: "Cuenta con un periodo de gracia de 20 minutos después de su hora programada para registrarse. Después de 20 minutos, la visita se registra como tardanza.",
         },
       },
       { type: "h", text: { en: "Tardiness Scale", es: "Escala de Tardanzas" } },
@@ -1008,7 +1008,7 @@ const BASE_MODULES: Module[] = [
         type: "bullets",
         items: [
           { en: "Phes is built on reliability, pride in craft, respect, honesty, and growth — and your employment is at-will.", es: "Phes se basa en confiabilidad, orgullo en el oficio, respeto, honestidad y crecimiento — y su empleo es a voluntad." },
-          { en: "You have a 7-minute grace period; the tardiness scale runs 1–2 recorded, 3rd written, 4th final, 5th termination.", es: "Tiene 7 minutos de gracia; la escala es 1ª–2ª registrada, 3ª escrita, 4ª última, 5ª terminación." },
+          { en: "You have a 20-minute grace period; the tardiness scale runs 1–2 recorded, 3rd written, 4th final, 5th termination.", es: "Tiene 20 minutos de gracia; la escala es 1ª–2ª registrada, 3ª escrita, 4ª última, 5ª terminación." },
           { en: "You accrue up to 40 hours of paid sick leave (PLAWA), and earn 40 hours of PTO at year 1 / 80 hours at year 2.", es: "Acumula hasta 40 horas de licencia por enfermedad (PLAWA), y gana 40 horas de PTO al año 1 / 80 horas al año 2." },
           { en: "Phes observes 6 paid holidays plus your birthday.", es: "Phes observa 6 feriados pagados más su cumpleaños." },
           { en: "Wear the Phes uniform with shoe covers in every home; personal phones stay out of sight during the visit.", es: "Use el uniforme Phes con cubrezapatos en cada hogar; los teléfonos personales se mantienen fuera de la vista durante la visita." },
@@ -1163,12 +1163,12 @@ const BASE_QUIZ: QuizQuestion[] = [
     id: "q-running-late",
     moduleId: "attendance",
     prompt: {
-      en: "You're stuck in traffic and will arrive 15 minutes after your scheduled time. What do you do?",
-      es: "Estás en el tráfico y llegarás 15 minutos después de tu hora programada. ¿Qué haces?",
+      en: "You're stuck in traffic and will arrive 30 minutes after your scheduled time. What do you do?",
+      es: "Estás en el tráfico y llegarás 30 minutos después de tu hora programada. ¿Qué haces?",
     },
     options: [
       { en: "Drive faster to make up time", es: "Manejas más rápido para recuperar el tiempo" },
-      { en: "Don't worry about it — 15 minutes is within the grace period", es: "No te preocupes — 15 minutos están dentro del periodo de gracia" },
+      { en: "Don't worry about it — 30 minutes is within the grace period", es: "No te preocupes — 30 minutos están dentro del periodo de gracia" },
       { en: "Call or text the office immediately so the client can be notified", es: "Llamas o envías mensaje a la oficina inmediatamente para que el cliente sea notificado" },
       { en: "Just show up when you get there — they'll figure it out", es: "Solo llegas cuando puedas — lo entenderán" },
     ],


### PR DESCRIPTION
Two LMS-prep fixes that need to land before PR #64 (per-module quizzes) is safe to merge.

## 1. Add LMS table + enum schema to cold-start migration

The Drizzle schema in `lib/db/src/schema/lms.ts` (added in PR #64) declares 4 new tables and 2 new enums, but the production deploy does NOT run `drizzle-kit push` — the cold-start hook in `phes-data-migration.ts` is the only schema-init mechanism wired into the Dockerfile. Without these guards, every `/api/lms/*` request 500s on prod the moment a tech opens `/training`.

`artifacts/api-server/src/phes-data-migration.ts`: append idempotent guards for the LMS schema.

- 2 enums: `enrollment_status`, `module_status` — `DO $$ BEGIN ... EXCEPTION WHEN duplicate_object THEN NULL END $$` (Postgres `CREATE TYPE` has no `IF NOT EXISTS`).
- 4 tables: `lms_enrollments`, `lms_module_progress`, `lms_quiz_state`, `lms_quiz_attempts` — `CREATE TABLE IF NOT EXISTS`.
- Indexes — `CREATE INDEX IF NOT EXISTS`.

Columns / index names mirror the Drizzle schema exactly so the ORM doesn't double-up.

## 2. Attendance grace period 7 → 20 minutes (Phes policy)

The curriculum hard-coded a 7-minute grace window in three spots — module body, recap line, and the running-late quiz prompt. Phes operational policy is **20 minutes** (matches `LATE_THRESHOLD_MINUTES = 20` in `lib/job-status.ts`, per CLAUDE.md "single 20-minute threshold for late_clockin"). The 7-min number set techs up to expect the dispatch board to mark them late ~13 minutes earlier than it actually does.

- attendance module body: `7-minute` → `20-minute` grace window (EN + ES)
- attendance recap line: `7-minute` → `20-minute` grace period (EN + ES)
- `q-running-late` prompt: scenario "15 minutes late" → "30 minutes late" so the grace-period distractor stays wrong under the new threshold; `correctIndex` unchanged.

No answer-key churn — `q-running-late` still resolves to option 2 in both `lib/training/answer-key.ts` and `lib/lms-curriculum/src/index.ts`.

## Merge order

This PR (migration + curriculum fix) should land **before** PR #64. After it merges, PR #64 picks up both via main and is safe to merge.

## Test plan

- [ ] Local cold-start runs the migration block without errors (idempotent — safe to run twice).
- [ ] After merge of this + PR #64, hitting `GET /api/lms/me` returns 200 with empty enrollment, not 500.
- [ ] Existing 60-test LMS unit suite (added in PR #64) still passes.
- [ ] Attendance module renders "20-minute grace window" in EN + ES.
- [ ] `q-running-late` prompt reads "30 minutes" and the grace-period distractor reads "30 minutes is within the grace period".
