### PR TITLE
fix(lms): make locale toggle prominent + show on sign-in fallback

### DIFF
--- a/artifacts/qleno/src/pages/training.tsx
+++ b/artifacts/qleno/src/pages/training.tsx
@@ -418,10 +418,15 @@ export default function TrainingPage() {
   if (!learner) {
     return (
       <PageShell>
-        <div style={{ padding: 24, color: INK_MUTE }}>
-          {locale === "en"
-            ? "Sign in to access training."
-            : "Inicia sesión para acceder a la capacitación."}
+        <div style={{ padding: 24, display: "flex", flexDirection: "column", gap: 16 }}>
+          <div style={{ alignSelf: "flex-end" }}>
+            <LocaleToggle locale={locale} setLocale={setLocale} />
+          </div>
+          <div style={{ color: INK_MUTE }}>
+            {locale === "en"
+              ? "Sign in to access training."
+              : "Inicia sesión para acceder a la capacitación."}
+          </div>
         </div>
       </PageShell>
     );
@@ -742,28 +747,65 @@ function LocaleToggle({
   locale: Locale;
   setLocale: (l: Locale) => void;
 }) {
+  const activeStyle = {
+    background: NAVY,
+    color: "#fff",
+    fontWeight: 700,
+  } as const;
+  const inactiveStyle = {
+    background: "transparent",
+    color: INK_MUTE,
+    fontWeight: 600,
+  } as const;
   return (
-    <button
-      type="button"
-      onClick={() => setLocale(locale === "en" ? "es" : "en")}
+    <div
+      role="group"
+      aria-label="Language toggle"
       style={{
         display: "inline-flex",
         alignItems: "center",
-        gap: 6,
-        background: "transparent",
+        gap: 0,
+        background: "#fff",
         border: `1px solid ${LINE}`,
-        color: INK_MUTE,
-        padding: "5px 10px",
         borderRadius: 999,
-        fontSize: 12,
-        fontWeight: 700,
-        cursor: "pointer",
+        padding: 2,
         fontFamily: FONT,
       }}
     >
-      <Globe2 size={12} />
-      {locale.toUpperCase()}
-    </button>
+      <Globe2 size={14} style={{ marginLeft: 8, marginRight: 4, color: INK_MUTE }} />
+      <button
+        type="button"
+        onClick={() => setLocale("en")}
+        style={{
+          border: "none",
+          padding: "5px 12px",
+          borderRadius: 999,
+          fontSize: 12,
+          letterSpacing: "0.04em",
+          cursor: "pointer",
+          fontFamily: FONT,
+          ...(locale === "en" ? activeStyle : inactiveStyle),
+        }}
+      >
+        ENGLISH
+      </button>
+      <button
+        type="button"
+        onClick={() => setLocale("es")}
+        style={{
+          border: "none",
+          padding: "5px 12px",
+          borderRadius: 999,
+          fontSize: 12,
+          letterSpacing: "0.04em",
+          cursor: "pointer",
+          fontFamily: FONT,
+          ...(locale === "es" ? activeStyle : inactiveStyle),
+        }}
+      >
+        ESPAÑOL
+      </button>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

User reported the EN/ES language toggle was missing from the LMS. The toggle code is actually intact in `training.tsx` (top-right header, Globe2 icon + "EN/ES" pill), but at 12px font alongside a long deadline badge it's easy to miss — and the unauthenticated fallback ("Sign in to access training") rendered without any header, so no toggle on that screen at all.

## What changed

`artifacts/qleno/src/pages/training.tsx`:

1. **LocaleToggle is now a segmented control** — `ENGLISH | ESPAÑOL` with the active language highlighted (NAVY background, white text). Same Globe2 icon. Labels are spelled out so the affordance is unmissable.
2. **Sign-in fallback now shows the toggle** — wrapping the "Sign in to access training" message in a flex column with the LocaleToggle in the top-right corner so a learner can flip language before authenticating.

## Out of scope

- No content / curriculum changes — `useState<Locale>("en")` default unchanged, persistence to `lms_enrollments.locale` unchanged, all bilingual strings unchanged.
- Mobile-specific layout untouched (the segmented control is narrow enough that it shouldn't push the deadline badge off the row on a typical phone width).

## Test plan

- [ ] Log into `/training` as a tech: see "ENGLISH | ESPAÑOL" segmented control top-right; click ESPAÑOL → all module titles + body switch to Spanish; click ENGLISH → back to English.
- [ ] Log out and visit `/training`: "Sign in to access training" message renders WITH the toggle. Click ESPAÑOL → message switches to "Inicia sesión..."
- [ ] Inside a module page or quiz: toggle still visible at the top.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AxGiirnJ3dT4GAzHPNWhrx)_