### PR TITLE
fix(lms): swap generic 'Q' mark for the actual Phes logo

### DIFF
--- a/artifacts/qleno/src/pages/lms-admin.tsx
+++ b/artifacts/qleno/src/pages/lms-admin.tsx
@@ -313,21 +313,16 @@ function Shell({ children }: { children: React.ReactNode }) {
             gap: 10,
           }}
         >
-          <div
+          <img
+            src="/phes-logo.jpeg"
+            alt="Phes"
             style={{
-              width: 26,
-              height: 26,
-              borderRadius: 6,
-              background: NAVY,
-              color: "#fff",
-              fontWeight: 800,
-              fontSize: 12,
-              display: "grid",
-              placeItems: "center",
+              height: 32,
+              width: "auto",
+              display: "block",
+              objectFit: "contain",
             }}
-          >
-            Q
-          </div>
+          />
           <div
             style={{
               fontWeight: 700,

--- a/artifacts/qleno/src/pages/training.tsx
+++ b/artifacts/qleno/src/pages/training.tsx
@@ -680,22 +680,16 @@ function Header({
 
 function PhesMark() {
   return (
-    <div
+    <img
+      src="/phes-logo.jpeg"
+      alt="Phes"
       style={{
-        width: 28,
-        height: 28,
-        borderRadius: 6,
-        background: NAVY,
-        color: "#fff",
-        display: "grid",
-        placeItems: "center",
-        fontWeight: 800,
-        fontSize: 13,
-        letterSpacing: "0.04em",
+        height: 36,
+        width: "auto",
+        display: "block",
+        objectFit: "contain",
       }}
-    >
-      Q
-    </div>
+    />
   );
 }
 
@@ -1964,6 +1958,17 @@ function DoneView({
           textAlign: "center",
         }}
       >
+        <img
+          src="/phes-logo.jpeg"
+          alt={tenantName}
+          style={{
+            height: 64,
+            width: "auto",
+            display: "block",
+            margin: "0 auto 12px",
+            objectFit: "contain",
+          }}
+        />
         <Award size={42} style={{ color: SUCCESS }} />
         <div style={{ fontWeight: 800, fontSize: 22, marginTop: 8, color: INK }}>
           {tr("doneTitle", locale)}


### PR DESCRIPTION
## Summary

User: *"add our logo it doesnt feel like its ours it feels generic."*

The `PhesMark` component on the training header (and the matching mark on the LMS admin page) was a 28×28 navy square with the literal letter **"Q"** inside — that's what the user was seeing as "generic." The actual Phes logo (red wing + blue P, with "phes" wordmark) already shipped in `artifacts/qleno/public/phes-logo.jpeg` and just wasn't wired in.

## Three swaps

1. **`training.tsx` `PhesMark`** — navy 'Q' tile → `<img src="/phes-logo.jpeg">` at 36px height. Renders at the top-left of every LMS screen (home, module, quiz, final intro, acknowledgment).
2. **`lms-admin.tsx` header** — same navy 'Q' tile → same `<img>`, 32px.
3. **Completion screen** (the "Done! / ¡Listo!" state after the final acknowledgment) — adds the Phes logo above the existing Award icon at 64px so the certificate moment reads as Phes-branded.

## Out of scope

- No content / curriculum / behavior changes. Pure visual identity.
- I didn't replace the existing Award icon on the completion / final-intro screens — that's part of the visual design language and reads as "achievement" not as a generic brand mark. The Phes logo is now ABOVE the Award on the completion screen.
- Tenant-specific logo override (multi-tenant theming) — out of scope. Today every tenant gets `/phes-logo.jpeg` because Phes is the only live tenant.

## Test plan

- [ ] Reload `/training` after deploy. Top-left of the header shows the Phes logo (red wing + blue P) instead of a navy 'Q' tile. EN/ES toggle still on the right.
- [ ] Visit `/lms/admin` (owner/admin role). Top-left header shows the same Phes logo.
- [ ] Complete the final exam + acknowledgment to reach the "Done!" screen. Logo appears above the Award icon.
- [ ] Sign out and visit `/training`. The "Sign in to access training" fallback unaffected (no header rendered there — the locale toggle landed in PR #67 still shows).


---
_Generated by [Claude Code](https://claude.ai/code/session_01AxGiirnJ3dT4GAzHPNWhrx)_