### PR TITLE
feat(lms): owner bypass, attempt caps (3/4), Qleno logo, admin attempts grid

### DIFF
--- a/artifacts/api-server/src/routes/lms.ts
+++ b/artifacts/api-server/src/routes/lms.ts
@@ -50,6 +50,9 @@ import {
   FINAL_MODULE_ID,
   FINAL_TEST_SIZE,
   QUIZ_PASS_THRESHOLD,
+  MAX_MODULE_ATTEMPTS,
+  MAX_FINAL_ATTEMPTS,
+  maxAttemptsFor,
   isModuleUnlocked,
   isFinalUnlocked,
   sampleFinalQuestionIds,
@@ -291,12 +294,18 @@ router.get("/me", requireAuth, async (req, res) => {
     }
     unlocked[FINAL_MODULE_ID] = isFinalUnlocked(completed);
 
+    const limits: Record<string, number> = {};
+    for (const m of MODULE_ORDER) limits[m] = MAX_MODULE_ATTEMPTS;
+    limits[FINAL_MODULE_ID] = MAX_FINAL_ATTEMPTS;
+
     return res.json({
       data: {
         enrollment,
         progress,
         unlocked,
         days_remaining: daysUntil(enrollment.deadline_at, now),
+        limits,
+        is_owner: req.auth!.role === "owner",
       },
     });
   } catch (err) {
@@ -582,6 +591,26 @@ router.post("/quiz/submit", requireAuth, async (req, res) => {
       });
     }
 
+    // Attempts gate: 3 per module, 4 for the final. Owners are exempt — they
+    // can still submit but the cap doesn't apply to them. Already-passed
+    // modules are also exempt (re-takes for review).
+    const isOwner = req.auth!.role === "owner";
+    const existing = progress.find((p) => p.module_id === moduleId);
+    const attemptsSoFar = existing?.attempts ?? 0;
+    const alreadyPassed = existing?.status === "passed";
+    const maxAttempts = maxAttemptsFor(moduleId);
+    if (!isOwner && !alreadyPassed && attemptsSoFar >= maxAttempts) {
+      return res.status(403).json({
+        error: "Forbidden",
+        message:
+          moduleId === FINAL_MODULE_ID
+            ? `You've used all ${maxAttempts} final-exam attempts. Ask your admin to extend or bypass.`
+            : `You've used all ${maxAttempts} attempts on this module. Ask your admin to extend or bypass.`,
+        attempts_used: attemptsSoFar,
+        max_attempts: maxAttempts,
+      });
+    }
+
     // Server-authoritative scoring.
     const result = scoreQuiz(answers, questionIds, QUIZ_PASS_THRESHOLD, SERVER_ANSWER_KEY);
 
@@ -614,17 +643,19 @@ router.post("/quiz/submit", requireAuth, async (req, res) => {
       now,
     });
 
-    // Clear autosave state on a passing submission so the resume slate is fresh.
-    if (passedNow) {
-      await db
-        .delete(lmsQuizStateTable)
-        .where(
-          and(
-            eq(lmsQuizStateTable.enrollment_id, enrollment.id),
-            eq(lmsQuizStateTable.module_id, moduleId),
-          ),
-        );
-    }
+    // Clear autosave state after every submit — pass or fail — so the next
+    // entry to the module starts from a blank slate. Without this, a failed
+    // attempt's answers reload on the next visit (and on a different device)
+    // and the learner ends up re-submitting the same wrong answers without
+    // realizing it. (Bug surfaced by Dispatch 2026-05-11.)
+    await db
+      .delete(lmsQuizStateTable)
+      .where(
+        and(
+          eq(lmsQuizStateTable.enrollment_id, enrollment.id),
+          eq(lmsQuizStateTable.module_id, moduleId),
+        ),
+      );
     await touchEnrollment(enrollment.id, now);
 
     // Webhook fire — do this AFTER all DB writes commit, but before the
@@ -665,6 +696,7 @@ router.post("/quiz/submit", requireAuth, async (req, res) => {
       { module_id: moduleId, score: result.score },
     );
 
+    const attemptsAfter = attemptsSoFar + 1;
     return res.json({
       data: {
         score: result.score,
@@ -675,6 +707,9 @@ router.post("/quiz/submit", requireAuth, async (req, res) => {
         // sees them per spec. For per-module, it's already in the bundle so
         // there's no secret to keep.
         perQuestion: moduleId === FINAL_MODULE_ID ? undefined : result.perQuestion,
+        attempts_used: attemptsAfter,
+        max_attempts: maxAttempts,
+        attempts_remaining: Math.max(0, maxAttempts - attemptsAfter),
       },
     });
   } catch (err) {
@@ -961,6 +996,22 @@ router.get(
           currentModule = FINAL_MODULE_ID;
         }
 
+        // Per-module attempt + status snapshot keyed by module_id so the
+        // admin UI can render "2/3 attempts" or "passed" without an extra
+        // round trip. Includes `__final` if the learner has touched it.
+        const modules: Record<
+          string,
+          { status: string; best_score: number; attempts: number; max_attempts: number }
+        > = {};
+        for (const p of progress) {
+          modules[p.module_id] = {
+            status: p.status,
+            best_score: p.best_score,
+            attempts: p.attempts,
+            max_attempts: maxAttemptsFor(p.module_id),
+          };
+        }
+
         return {
           enrollment_id: e.id,
           user_id: e.user_id,
@@ -976,6 +1027,7 @@ router.get(
           completed_at: e.completed_at,
           last_activity_at: e.last_activity_at,
           enrolled_at: e.enrolled_at,
+          modules,
         };
       });
 
@@ -1075,6 +1127,123 @@ router.post(
       return res
         .status(500)
         .json({ error: "Internal Server Error", message: "Failed to extend deadline" });
+    }
+  },
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /admin/bypass-module — Owner+Admin only
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// Body: { moduleId, userId? }
+//
+// Marks the given module as passed (score 100) for the target user. Used by:
+//   - The business owner skipping their own training modules from /training.
+//     (They call this without `userId` — bypass applies to themselves.)
+//   - Admins unblocking a learner who hit the attempts cap or has a
+//     legitimate exemption (e.g. credentialed hire).
+//
+// If `userId` is omitted, the caller bypasses for themselves. Otherwise the
+// target user must belong to the caller's tenant.
+//
+// For the final mixed test, bypassing it also marks the enrollment as
+// `completed` (and stamps `completed_at`) — matching the natural pass path.
+
+router.post(
+  "/admin/bypass-module",
+  requireAuth,
+  requireRole("owner", "admin"),
+  async (req, res) => {
+    try {
+      const companyId = req.auth!.companyId;
+      if (companyId == null) {
+        return res
+          .status(400)
+          .json({ error: "Bad Request", message: "User has no company assignment" });
+      }
+      const moduleId: string | undefined = req.body?.moduleId;
+      if (typeof moduleId !== "string" || !KNOWN_MODULE_IDS.has(moduleId)) {
+        return res
+          .status(400)
+          .json({ error: "Bad Request", message: "Unknown moduleId" });
+      }
+      const targetUserId =
+        req.body?.userId != null ? Number(req.body.userId) : req.auth!.userId;
+      if (!Number.isFinite(targetUserId) || targetUserId <= 0) {
+        return res
+          .status(400)
+          .json({ error: "Bad Request", message: "Invalid userId" });
+      }
+
+      // Tenant gate when the target is someone else — caller can only bypass
+      // for users in their own company.
+      if (targetUserId !== req.auth!.userId) {
+        const targetUser = await db
+          .select({ company_id: usersTable.company_id })
+          .from(usersTable)
+          .where(eq(usersTable.id, targetUserId))
+          .limit(1);
+        if (!targetUser[0] || targetUser[0].company_id !== companyId) {
+          return res
+            .status(404)
+            .json({ error: "Not Found", message: "User not found in tenant" });
+        }
+      }
+
+      const now = new Date();
+      const enrollment = await getOrCreateEnrollment(companyId, targetUserId, now);
+
+      await upsertModuleProgress({
+        companyId,
+        enrollmentId: enrollment.id,
+        moduleId,
+        patch: {
+          status: "passed",
+          best_score: 100,
+          passed_at: now,
+        },
+        now,
+      });
+
+      // Bypassing the final mixed test completes the enrollment, matching the
+      // natural pass path so the learner doesn't get stranded.
+      if (moduleId === FINAL_MODULE_ID) {
+        await db
+          .update(lmsEnrollmentsTable)
+          .set({ status: "completed", completed_at: now, updated_at: now })
+          .where(eq(lmsEnrollmentsTable.id, enrollment.id));
+      }
+
+      // Clear any in-flight autosave for this module so a re-open shows clean.
+      await db
+        .delete(lmsQuizStateTable)
+        .where(
+          and(
+            eq(lmsQuizStateTable.enrollment_id, enrollment.id),
+            eq(lmsQuizStateTable.module_id, moduleId),
+          ),
+        );
+
+      await touchEnrollment(enrollment.id, now);
+      await logAudit(
+        req,
+        "lms.admin.bypass",
+        "lms_enrollment",
+        enrollment.id,
+        null,
+        {
+          module_id: moduleId,
+          target_user_id: targetUserId,
+          self: targetUserId === req.auth!.userId,
+        },
+      );
+
+      return res.json({ data: { ok: true, enrollment_id: enrollment.id } });
+    } catch (err) {
+      console.error("[lms] /admin/bypass-module error:", err);
+      return res
+        .status(500)
+        .json({ error: "Internal Server Error", message: "Failed to bypass module" });
     }
   },
 );

--- a/artifacts/api-server/src/tests/lms-curriculum.test.ts
+++ b/artifacts/api-server/src/tests/lms-curriculum.test.ts
@@ -13,6 +13,8 @@ import {
   ANSWER_KEY,
   FINAL_MODULE_ID,
   FINAL_TEST_SIZE,
+  MAX_FINAL_ATTEMPTS,
+  MAX_MODULE_ATTEMPTS,
   MODULE_BY_QUESTION,
   MODULE_ORDER,
   QUESTIONS_BY_MODULE,
@@ -20,6 +22,7 @@ import {
   QUIZ_PASS_THRESHOLD,
   isFinalUnlocked,
   isModuleUnlocked,
+  maxAttemptsFor,
   sampleFinalQuestionIds,
   scoreQuiz,
 } from "@workspace/lms-curriculum";
@@ -390,5 +393,38 @@ describe("sampleFinalQuestionIds", () => {
     const a = sampleFinalQuestionIds(50, seedRng(42));
     const b = sampleFinalQuestionIds(50, seedRng(42));
     assert.deepEqual(a, b);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Attempt limits (phes-lifecycle 2026-05-11): three per module, four for the
+// final exam. These constants are shared by server and client so the UI can
+// render "Attempt X of N" without an extra round trip.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("max attempt constants", () => {
+  it("MAX_MODULE_ATTEMPTS is 3 per spec (phes 2026-05-11)", () => {
+    assert.equal(MAX_MODULE_ATTEMPTS, 3);
+  });
+
+  it("MAX_FINAL_ATTEMPTS is 4 per spec (phes 2026-05-11)", () => {
+    assert.equal(MAX_FINAL_ATTEMPTS, 4);
+  });
+
+  it("maxAttemptsFor returns 3 for every per-module quiz id", () => {
+    for (const m of QUIZ_MODULE_IDS) {
+      assert.equal(maxAttemptsFor(m), 3, `expected 3 for ${m}`);
+    }
+  });
+
+  it("maxAttemptsFor returns 4 for the final mixed test", () => {
+    assert.equal(maxAttemptsFor(FINAL_MODULE_ID), 4);
+  });
+
+  it("maxAttemptsFor returns 3 for the acknowledgment module (no quiz, but symmetric)", () => {
+    // Acknowledgment is content-only; cap doesn't apply in /quiz/submit
+    // (different endpoint), but the helper still classifies it under the
+    // default 3-attempt bucket.
+    assert.equal(maxAttemptsFor("acknowledgment"), 3);
   });
 });

--- a/artifacts/qleno/src/components/layout/app-sidebar.tsx
+++ b/artifacts/qleno/src/components/layout/app-sidebar.tsx
@@ -89,6 +89,7 @@ const NAV_SECTIONS = [
       { title: "Settings",        url: "/company",         icon: Settings, roles: ["owner", "admin"] },
       { title: "Cleancyclopedia", url: "/cleancyclopedia", icon: BookOpen },
       { title: "Training",        url: "/training",        icon: GraduationCap },
+      { title: "Training Admin",  url: "/lms/admin",       icon: GraduationCap, roles: ["owner", "admin", "super_admin"] },
     ],
   },
 ];

--- a/artifacts/qleno/src/pages/lms-admin.tsx
+++ b/artifacts/qleno/src/pages/lms-admin.tsx
@@ -10,8 +10,14 @@
  *
  * Visual style matches training.tsx (Plus Jakarta Sans, NAVY/TEAL palette).
  */
-import { useEffect, useMemo, useState } from "react";
+import { Fragment, useEffect, useMemo, useState } from "react";
 import { useAuthStore } from "@/lib/auth";
+import { QlenoLogo } from "@/components/brand/QlenoLogo";
+import {
+  MODULE_ORDER,
+  FINAL_MODULE_ID,
+  maxAttemptsFor,
+} from "@workspace/lms-curriculum";
 import {
   CalendarClock,
   Loader2,
@@ -19,6 +25,8 @@ import {
   AlertTriangle,
   X,
   ChevronRight,
+  ChevronDown,
+  FastForward,
 } from "lucide-react";
 
 const NAVY = "#0A2342";
@@ -43,6 +51,13 @@ type AuthPayload = {
   first_name?: string;
 };
 
+type ModuleStat = {
+  status: string;
+  best_score: number;
+  attempts: number;
+  max_attempts: number;
+};
+
 type RosterRow = {
   enrollment_id: number;
   user_id: number;
@@ -58,6 +73,7 @@ type RosterRow = {
   completed_at: string | null;
   last_activity_at: string;
   enrolled_at: string;
+  modules?: Record<string, ModuleStat>;
 };
 
 const API_BASE = (import.meta.env.BASE_URL || "/").replace(/\/$/, "") + "/api";
@@ -114,12 +130,31 @@ export default function LmsAdminPage() {
   const [rows, setRows] = useState<RosterRow[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [extendOpen, setExtendOpen] = useState<RosterRow | null>(null);
+  const [expanded, setExpanded] = useState<Set<number>>(new Set());
+
+  function toggleExpand(enrollmentId: number) {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(enrollmentId)) next.delete(enrollmentId);
+      else next.add(enrollmentId);
+      return next;
+    });
+  }
 
   async function refresh() {
     try {
       const data = await api<RosterRow[]>("GET", "/lms/admin/learners", token);
       setRows(data);
       setError(null);
+    } catch (e) {
+      setError(String((e as Error).message));
+    }
+  }
+
+  async function bypassFor(userId: number, moduleId: string) {
+    try {
+      await api("POST", "/lms/admin/bypass-module", token, { userId, moduleId });
+      await refresh();
     } catch (e) {
       setError(String((e as Error).message));
     }
@@ -261,9 +296,21 @@ export default function LmsAdminPage() {
             up here automatically.
           </div>
         ) : isMobile ? (
-          <RosterCards rows={rows} onExtend={setExtendOpen} />
+          <RosterCards
+            rows={rows}
+            expanded={expanded}
+            onToggleExpand={toggleExpand}
+            onExtend={setExtendOpen}
+            onBypass={bypassFor}
+          />
         ) : (
-          <RosterTable rows={rows} onExtend={setExtendOpen} />
+          <RosterTable
+            rows={rows}
+            expanded={expanded}
+            onToggleExpand={toggleExpand}
+            onExtend={setExtendOpen}
+            onBypass={bypassFor}
+          />
         )}
       </div>
 
@@ -310,33 +357,28 @@ function Shell({ children }: { children: React.ReactNode }) {
             margin: "0 auto",
             display: "flex",
             alignItems: "center",
-            gap: 10,
+            gap: 12,
           }}
         >
+          <QlenoLogo size="md" theme="light" layout="horizontal" />
           <div
             style={{
-              width: 26,
-              height: 26,
-              borderRadius: 6,
-              background: NAVY,
-              color: "#fff",
-              fontWeight: 800,
-              fontSize: 12,
-              display: "grid",
-              placeItems: "center",
+              height: 22,
+              width: 1,
+              background: LINE,
             }}
-          >
-            Q
-          </div>
+            aria-hidden
+          />
           <div
             style={{
               fontWeight: 700,
-              fontSize: 14,
-              color: INK,
-              letterSpacing: "-0.01em",
+              fontSize: 13,
+              color: INK_MUTE,
+              letterSpacing: "0.04em",
+              textTransform: "uppercase",
             }}
           >
-            Qleno · Admin
+            LMS Admin
           </div>
         </div>
       </header>
@@ -347,10 +389,16 @@ function Shell({ children }: { children: React.ReactNode }) {
 
 function RosterTable({
   rows,
+  expanded,
+  onToggleExpand,
   onExtend,
+  onBypass,
 }: {
   rows: RosterRow[];
+  expanded: Set<number>;
+  onToggleExpand: (id: number) => void;
   onExtend: (r: RosterRow) => void;
+  onBypass: (userId: number, moduleId: string) => Promise<void>;
 }) {
   return (
     <div
@@ -372,6 +420,7 @@ function RosterTable({
         >
           <thead style={{ background: LINE_SOFT }}>
             <tr>
+              <Th></Th>
               <Th>Tech</Th>
               <Th>Status</Th>
               <Th>Progress</Th>
@@ -383,7 +432,30 @@ function RosterTable({
           </thead>
           <tbody>
             {rows.map((r) => (
-              <tr key={r.enrollment_id}>
+              <Fragment key={r.enrollment_id}>
+              <tr>
+                <Td>
+                  <button
+                    type="button"
+                    onClick={() => onToggleExpand(r.enrollment_id)}
+                    aria-label={expanded.has(r.enrollment_id) ? "Collapse" : "Expand"}
+                    style={{
+                      background: "transparent",
+                      border: `1px solid ${LINE}`,
+                      borderRadius: 6,
+                      padding: 4,
+                      cursor: "pointer",
+                      color: INK_MUTE,
+                      display: "inline-flex",
+                    }}
+                  >
+                    {expanded.has(r.enrollment_id) ? (
+                      <ChevronDown size={14} />
+                    ) : (
+                      <ChevronRight size={14} />
+                    )}
+                  </button>
+                </Td>
                 <Td>
                   <div style={{ fontWeight: 700, color: INK }}>
                     {r.tech_name}
@@ -455,6 +527,21 @@ function RosterTable({
                   </button>
                 </Td>
               </tr>
+              {expanded.has(r.enrollment_id) ? (
+                <tr>
+                  <td
+                    colSpan={8}
+                    style={{
+                      background: LINE_SOFT,
+                      padding: "12px 18px",
+                      borderBottom: `1px solid ${LINE_SOFT}`,
+                    }}
+                  >
+                    <ModuleAttemptsGrid row={r} onBypass={onBypass} />
+                  </td>
+                </tr>
+              ) : null}
+              </Fragment>
             ))}
           </tbody>
         </table>
@@ -463,12 +550,127 @@ function RosterTable({
   );
 }
 
+function ModuleAttemptsGrid({
+  row,
+  onBypass,
+}: {
+  row: RosterRow;
+  onBypass: (userId: number, moduleId: string) => Promise<void>;
+}) {
+  const allIds: string[] = [...MODULE_ORDER, FINAL_MODULE_ID];
+  return (
+    <div>
+      <div
+        style={{
+          fontSize: 11,
+          fontWeight: 800,
+          color: INK_MUTE,
+          textTransform: "uppercase",
+          letterSpacing: "0.06em",
+          marginBottom: 8,
+        }}
+      >
+        Module attempts · Bypass any module
+      </div>
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))",
+          gap: 8,
+        }}
+      >
+        {allIds.map((moduleId) => {
+          const stat = row.modules?.[moduleId];
+          const max = stat?.max_attempts ?? maxAttemptsFor(moduleId);
+          const attempts = stat?.attempts ?? 0;
+          const status = stat?.status ?? "not_started";
+          const atCap = status !== "passed" && attempts >= max;
+          const passed = status === "passed";
+          return (
+            <div
+              key={moduleId}
+              style={{
+                background: SURFACE,
+                border: `1px solid ${passed ? "#A7F3D0" : atCap ? "#FECACA" : LINE}`,
+                borderRadius: 8,
+                padding: "8px 10px",
+                fontSize: 12,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                gap: 8,
+              }}
+            >
+              <div style={{ minWidth: 0 }}>
+                <div
+                  style={{
+                    fontWeight: 800,
+                    color: INK,
+                    fontSize: 12,
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {humanModule(moduleId)}
+                </div>
+                <div
+                  style={{
+                    fontSize: 11,
+                    color: passed ? SUCCESS : atCap ? DANGER : INK_MUTE,
+                    fontWeight: 700,
+                    marginTop: 2,
+                  }}
+                >
+                  {passed
+                    ? `Passed · ${stat?.best_score ?? 100}%`
+                    : `${attempts}/${max} attempts${atCap ? " · at cap" : ""}`}
+                </div>
+              </div>
+              {!passed ? (
+                <button
+                  type="button"
+                  onClick={() => onBypass(row.user_id, moduleId)}
+                  title="Bypass — mark as passed"
+                  style={{
+                    background: NAVY,
+                    color: "#fff",
+                    border: 0,
+                    padding: "5px 8px",
+                    borderRadius: 6,
+                    fontSize: 11,
+                    fontWeight: 800,
+                    cursor: "pointer",
+                    fontFamily: FONT,
+                    display: "inline-flex",
+                    alignItems: "center",
+                    gap: 4,
+                    flexShrink: 0,
+                  }}
+                >
+                  <FastForward size={11} /> Bypass
+                </button>
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
 function RosterCards({
   rows,
+  expanded,
+  onToggleExpand,
   onExtend,
+  onBypass,
 }: {
   rows: RosterRow[];
+  expanded: Set<number>;
+  onToggleExpand: (id: number) => void;
   onExtend: (r: RosterRow) => void;
+  onBypass: (userId: number, moduleId: string) => Promise<void>;
 }) {
   return (
     <div style={{ display: "grid", gap: 10 }} data-testid="roster-cards">
@@ -540,7 +742,35 @@ function RosterCards({
           <div style={{ fontSize: 12, color: INK_MUTE }}>
             {humanModule(r.current_module)} · {humanDateTime(r.last_activity_at)}
           </div>
-          <div style={{ display: "flex", justifyContent: "flex-end" }}>
+          <div style={{ display: "flex", justifyContent: "space-between", gap: 8 }}>
+            <button
+              type="button"
+              onClick={() => onToggleExpand(r.enrollment_id)}
+              style={{
+                background: "transparent",
+                color: INK_MUTE,
+                border: `1px solid ${LINE}`,
+                padding: "6px 12px",
+                borderRadius: 6,
+                fontSize: 12,
+                fontWeight: 700,
+                cursor: "pointer",
+                fontFamily: FONT,
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 4,
+              }}
+            >
+              {expanded.has(r.enrollment_id) ? (
+                <>
+                  Hide modules <ChevronDown size={12} />
+                </>
+              ) : (
+                <>
+                  Show modules <ChevronRight size={12} />
+                </>
+              )}
+            </button>
             <button
               type="button"
               onClick={() => onExtend(r)}
@@ -559,13 +789,18 @@ function RosterCards({
               Extend deadline <ChevronRight size={12} />
             </button>
           </div>
+          {expanded.has(r.enrollment_id) ? (
+            <div style={{ marginTop: 6 }}>
+              <ModuleAttemptsGrid row={r} onBypass={onBypass} />
+            </div>
+          ) : null}
         </article>
       ))}
     </div>
   );
 }
 
-function Th({ children }: { children: React.ReactNode }) {
+function Th({ children }: { children?: React.ReactNode }) {
   return (
     <th
       style={{

--- a/artifacts/qleno/src/pages/my-jobs.tsx
+++ b/artifacts/qleno/src/pages/my-jobs.tsx
@@ -2,10 +2,12 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAuthStore } from "@/lib/auth";
 import { useToast } from "@/hooks/use-toast";
-import { Car, X, Check, Eye, Navigation, Phone } from "lucide-react";
+import { Car, X, Check, Eye, Navigation, Phone, GraduationCap } from "lucide-react";
+import { Link } from "wouter";
 import { useEmployeeView } from "@/contexts/employee-view-context";
 import { getJobVisualStatus, STATUS_VISUALS, ensureJobStatusStyles } from "@/lib/job-status";
 import { formatAddress } from "@/lib/format-address";
+import { QlenoMark } from "@/components/brand/QlenoMark";
 
 const BASE = import.meta.env.BASE_URL.replace(/\/$/, "");
 
@@ -766,16 +768,26 @@ export default function MyJobsPage() {
         <div style={{
           position: "sticky", top: 0, zIndex: 10,
           backgroundColor: "#FFFFFF", borderBottom: "1px solid #E5E2DC",
-          padding: "14px 18px", display: "flex", alignItems: "center", justifyContent: "space-between",
+          padding: "12px 16px", display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8,
         }}>
-          <div style={{ width: 28, height: 28, borderRadius: "50%", backgroundColor: "var(--brand-dim)", color: "var(--brand)", display: "flex", alignItems: "center", justifyContent: "center", fontSize: 11, fontWeight: 700 }}>
-            {initials}
+          <div style={{ display: "flex", alignItems: "center", gap: 8, minWidth: 0 }}>
+            <QlenoMark size={24} />
+            <span style={{ fontSize: 15, fontWeight: 700, color: "#1A1917", letterSpacing: "-0.01em" }}>My Jobs</span>
           </div>
-          <span style={{ fontSize: 15, fontWeight: 600, color: "#1A1917" }}>My Jobs</span>
-          <button onClick={() => setShowMileage(true)}
-            style={{ display: 'flex', alignItems: 'center', gap: 5, padding: '6px 10px', background: 'var(--brand-dim)', color: 'var(--brand)', border: '1px solid rgba(0,201,160,0.2)', borderRadius: 8, fontSize: 12, fontWeight: 600, cursor: 'pointer', fontFamily: 'inherit' }}>
-            <Car size={13}/> Mileage
-          </button>
+          <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+            <Link href="/training">
+              <a style={{ display: 'inline-flex', alignItems: 'center', gap: 4, padding: '6px 10px', background: '#FFFFFF', color: '#1A1917', border: '1px solid #E5E2DC', borderRadius: 8, fontSize: 12, fontWeight: 700, cursor: 'pointer', fontFamily: 'inherit', textDecoration: 'none' }}>
+                <GraduationCap size={13}/> Training
+              </a>
+            </Link>
+            <button onClick={() => setShowMileage(true)}
+              style={{ display: 'flex', alignItems: 'center', gap: 4, padding: '6px 10px', background: 'var(--brand-dim)', color: 'var(--brand)', border: '1px solid rgba(0,201,160,0.2)', borderRadius: 8, fontSize: 12, fontWeight: 700, cursor: 'pointer', fontFamily: 'inherit' }}>
+              <Car size={13}/> Mileage
+            </button>
+            <div title={initials} style={{ width: 28, height: 28, borderRadius: "50%", backgroundColor: "var(--brand-dim)", color: "var(--brand)", display: "flex", alignItems: "center", justifyContent: "center", fontSize: 11, fontWeight: 700, flexShrink: 0 }}>
+              {initials}
+            </div>
+          </div>
         </div>
 
         {employeeView && (

--- a/artifacts/qleno/src/pages/training.tsx
+++ b/artifacts/qleno/src/pages/training.tsx
@@ -42,10 +42,14 @@ import {
   QUIZ_MODULE_IDS,
   QUESTIONS_BY_MODULE,
   FINAL_MODULE_ID,
+  MAX_MODULE_ATTEMPTS,
+  MAX_FINAL_ATTEMPTS,
+  maxAttemptsFor,
   isModuleUnlocked,
   isFinalUnlocked,
   type ModuleId,
 } from "@workspace/lms-curriculum";
+import { QlenoLogo } from "@/components/brand/QlenoLogo";
 import {
   ChevronRight,
   ChevronLeft,
@@ -60,6 +64,7 @@ import {
   Award,
   Loader2,
   CalendarClock,
+  FastForward,
 } from "lucide-react";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -124,6 +129,8 @@ type LmsState = {
   progress: ModuleProgressRow[];
   unlocked: Record<string, boolean>;
   days_remaining: number;
+  limits?: Record<string, number>;
+  is_owner?: boolean;
 };
 
 type QuizStateRow = {
@@ -139,6 +146,9 @@ type SubmitResult = {
   correctCount: number;
   totalCount: number;
   perQuestion?: boolean[];
+  attempts_used?: number;
+  max_attempts?: number;
+  attempts_remaining?: number;
 };
 
 type View =
@@ -237,6 +247,13 @@ const lmsApi = {
       token,
       payload,
     ),
+  bypassModule: (token: string | null, moduleId: string) =>
+    api<{ ok: true; enrollment_id: number }>(
+      "POST",
+      "/lms/admin/bypass-module",
+      token,
+      { moduleId },
+    ),
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -307,6 +324,20 @@ const T = {
     es: "Gracias — tu supervisor ha sido notificado.",
   },
   start_first: { en: "Start your training", es: "Comenzar capacitación" },
+  attempt: { en: "Attempt", es: "Intento" },
+  of: { en: "of", es: "de" },
+  attemptsUsed: { en: "attempts used", es: "intentos usados" },
+  attemptsRemaining: { en: "attempts remaining", es: "intentos restantes" },
+  noAttemptsLeft: {
+    en: "No attempts remaining. Ask your admin to extend or bypass.",
+    es: "No quedan intentos. Pide al administrador que extienda o exente.",
+  },
+  bypassOwner: { en: "Skip (Owner)", es: "Saltar (Propietario)" },
+  bypassed: { en: "Bypassed by owner", es: "Exento por el propietario" },
+  resume_quiz: { en: "Resume quiz", es: "Continuar examen" },
+  retry_quiz: { en: "Try again", es: "Intentar de nuevo" },
+  start_quiz: { en: "Start quiz", es: "Comenzar examen" },
+  review_quiz: { en: "Review", es: "Revisar" },
 } as const;
 
 function tr(key: keyof typeof T, locale: Locale): string {
@@ -507,6 +538,10 @@ export default function TrainingPage() {
           onOpenModule={(moduleId) => setView({ kind: "module", moduleId })}
           onOpenFinal={() => setView({ kind: "final-intro" })}
           onOpenAck={() => setView({ kind: "ack" })}
+          onBypass={async (moduleId) => {
+            await lmsApi.bypassModule(token, moduleId);
+            await refresh();
+          }}
         />
       )}
       {view.kind === "module" && (
@@ -520,10 +555,16 @@ export default function TrainingPage() {
             QUIZ_MODULE_IDS.includes(view.moduleId as never)
           }
           progress={state.progress.find((p) => p.module_id === view.moduleId) ?? null}
+          isOwner={!!state.is_owner}
           onBack={() => setView({ kind: "home" })}
           onTakeQuiz={() => setView({ kind: "quiz", moduleId: view.moduleId })}
           onAcknowledge={async () => {
             await lmsApi.acknowledge(token, view.moduleId);
+            await refresh();
+            setView({ kind: "home" });
+          }}
+          onBypass={async () => {
+            await lmsApi.bypassModule(token, view.moduleId);
             await refresh();
             setView({ kind: "home" });
           }}
@@ -542,6 +583,9 @@ export default function TrainingPage() {
           moduleId={view.moduleId}
           locale={locale}
           token={token}
+          priorAttempts={
+            state.progress.find((p) => p.module_id === view.moduleId)?.attempts ?? 0
+          }
           onCancel={() => setView({ kind: "module", moduleId: view.moduleId })}
           onPassed={async () => {
             await refresh();
@@ -562,6 +606,9 @@ export default function TrainingPage() {
           moduleId={FINAL_MODULE_ID}
           locale={locale}
           token={token}
+          priorAttempts={
+            state.progress.find((p) => p.module_id === FINAL_MODULE_ID)?.attempts ?? 0
+          }
           onCancel={() => setView({ kind: "home" })}
           onPassed={async () => {
             await refresh();
@@ -640,11 +687,20 @@ function Header({
         style={{
           display: "flex",
           alignItems: "center",
-          gap: 10,
+          gap: 12,
           minWidth: 0,
         }}
       >
-        <PhesMark />
+        <QlenoLogo size="md" theme="light" layout="horizontal" />
+        <div
+          style={{
+            height: 24,
+            width: 1,
+            background: LINE,
+            margin: "0 2px",
+          }}
+          aria-hidden
+        />
         <div style={{ minWidth: 0 }}>
           <div
             style={{
@@ -675,27 +731,6 @@ function Header({
         <LocaleToggle locale={locale} setLocale={setLocale} />
       </div>
     </header>
-  );
-}
-
-function PhesMark() {
-  return (
-    <div
-      style={{
-        width: 28,
-        height: 28,
-        borderRadius: 6,
-        background: NAVY,
-        color: "#fff",
-        display: "grid",
-        placeItems: "center",
-        fontWeight: 800,
-        fontSize: 13,
-        letterSpacing: "0.04em",
-      }}
-    >
-      Q
-    </div>
   );
 }
 
@@ -823,6 +858,7 @@ function Home({
   onOpenModule,
   onOpenFinal,
   onOpenAck,
+  onBypass,
 }: {
   curriculum: Curriculum;
   state: LmsState;
@@ -833,7 +869,9 @@ function Home({
   onOpenModule: (id: string) => void;
   onOpenFinal: () => void;
   onOpenAck: () => void;
+  onBypass: (moduleId: string) => Promise<void>;
 }) {
+  const isOwner = !!state.is_owner;
   const completed = state.progress
     .filter((p) => p.status === "passed")
     .map((p) => p.module_id);
@@ -926,10 +964,18 @@ function Home({
               locale={locale}
               status={progress?.status ?? "not_started"}
               bestScore={progress?.best_score ?? 0}
+              attempts={progress?.attempts ?? 0}
+              maxAttempts={MAX_MODULE_ATTEMPTS}
               unlocked={isAck ? ackUnlocked : !!unlocked}
               isQuizModule={!isContent && !isAck}
               isAck={isAck}
+              isOwner={isOwner}
               onClick={handler}
+              onBypass={
+                !isAck && isOwner && progress?.status !== "passed"
+                  ? () => onBypass(moduleId)
+                  : undefined
+              }
             />
           );
         })}
@@ -941,7 +987,15 @@ function Home({
           locale={locale}
           unlocked={finalUnlocked}
           passed={finalPassed}
+          attempts={
+            state.progress.find((p) => p.module_id === FINAL_MODULE_ID)?.attempts ?? 0
+          }
+          maxAttempts={MAX_FINAL_ATTEMPTS}
+          isOwner={isOwner}
           onClick={finalUnlocked && !finalPassed ? onOpenFinal : undefined}
+          onBypass={
+            isOwner && !finalPassed ? () => onBypass(FINAL_MODULE_ID) : undefined
+          }
         />
       </div>
     </div>
@@ -990,46 +1044,56 @@ function ModuleRow({
   locale,
   status,
   bestScore,
+  attempts,
+  maxAttempts,
   unlocked,
   isQuizModule,
   isAck,
+  isOwner,
   onClick,
+  onBypass,
 }: {
   module: Module;
   locale: Locale;
   status: ModuleProgressRow["status"];
   bestScore: number;
+  attempts: number;
+  maxAttempts: number;
   unlocked: boolean;
   isQuizModule: boolean;
   isAck: boolean;
+  isOwner: boolean;
   onClick?: () => void;
+  onBypass?: () => void;
 }) {
+  const atCap = isQuizModule && status !== "passed" && attempts >= maxAttempts;
   const cta =
     status === "passed"
-      ? tr("review", locale)
-      : status === "in_progress" || status === "failed"
-      ? tr("resume", locale)
+      ? tr("review_quiz", locale)
+      : status === "failed"
+      ? tr("retry_quiz", locale)
+      : status === "in_progress"
+      ? tr("resume_quiz", locale)
+      : isQuizModule
+      ? tr("start_quiz", locale)
       : tr("start", locale);
 
   const stripeColor =
     status === "passed" ? SUCCESS : isAck ? NAVY : unlocked ? TEAL : LINE;
+  const effectiveOnClick = atCap && !isOwner ? undefined : onClick;
 
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={!unlocked || !onClick}
+    <div
       style={{
         display: "grid",
         gridTemplateColumns: "auto 1fr auto",
         alignItems: "center",
         gap: 14,
         background: SURFACE,
-        border: `1px solid ${LINE}`,
+        border: `1px solid ${atCap && !isOwner ? "#FECACA" : LINE}`,
         borderRadius: RADIUS,
         padding: "14px 16px",
         textAlign: "left",
-        cursor: unlocked && onClick ? "pointer" : "default",
         opacity: unlocked ? 1 : 0.5,
         fontFamily: FONT,
         position: "relative",
@@ -1049,7 +1113,21 @@ function ModuleRow({
       <div style={{ paddingLeft: 4 }}>
         <ModuleIcon kind={m.iconKind} size={44} />
       </div>
-      <div style={{ minWidth: 0 }}>
+      <button
+        type="button"
+        onClick={effectiveOnClick}
+        disabled={!unlocked || !effectiveOnClick}
+        style={{
+          minWidth: 0,
+          background: "transparent",
+          border: 0,
+          padding: 0,
+          margin: 0,
+          textAlign: "left",
+          cursor: unlocked && effectiveOnClick ? "pointer" : "default",
+          fontFamily: FONT,
+        }}
+      >
         <div
           style={{
             fontWeight: 700,
@@ -1085,8 +1163,31 @@ function ModuleRow({
           {m.estimatedMinutes} min
           {isQuizModule ? ` · ${tr("pass80", locale)}` : ""}
           {status === "passed" && bestScore > 0 ? ` · ${bestScore}%` : ""}
+          {isQuizModule && status !== "passed" ? (
+            <span
+              style={{
+                marginLeft: 6,
+                color: atCap ? DANGER : INK_LIGHT,
+              }}
+            >
+              · {attempts}/{maxAttempts} {tr("attempt", locale).toLowerCase()}
+              {attempts === 1 ? "" : "s"}
+            </span>
+          ) : null}
         </div>
-      </div>
+        {atCap && !isOwner ? (
+          <div
+            style={{
+              fontSize: 11,
+              color: DANGER,
+              marginTop: 4,
+              fontWeight: 700,
+            }}
+          >
+            {tr("noAttemptsLeft", locale)}
+          </div>
+        ) : null}
+      </button>
       <div
         style={{
           display: "flex",
@@ -1108,13 +1209,63 @@ function ModuleRow({
             <Lock size={14} />
             {tr("locked", locale)}
           </>
-        ) : (
+        ) : atCap && !isOwner ? (
           <>
-            {cta} <ChevronRight size={14} />
+            <Lock size={14} />
+            {tr("locked", locale)}
           </>
+        ) : (
+          <button
+            type="button"
+            onClick={effectiveOnClick}
+            disabled={!effectiveOnClick}
+            style={{
+              background: "transparent",
+              border: 0,
+              color: NAVY,
+              cursor: effectiveOnClick ? "pointer" : "default",
+              fontWeight: 700,
+              fontSize: 12,
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 4,
+              fontFamily: FONT,
+              padding: 0,
+            }}
+          >
+            {cta} <ChevronRight size={14} />
+          </button>
         )}
+        {onBypass ? (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onBypass();
+            }}
+            title={tr("bypassOwner", locale)}
+            style={{
+              marginLeft: 8,
+              background: "#EEF2F8",
+              color: NAVY,
+              border: `1px solid ${LINE}`,
+              padding: "5px 10px",
+              borderRadius: 6,
+              fontSize: 11,
+              fontWeight: 800,
+              cursor: "pointer",
+              fontFamily: FONT,
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 4,
+              whiteSpace: "nowrap",
+            }}
+          >
+            <FastForward size={11} /> {tr("bypassOwner", locale)}
+          </button>
+        ) : null}
       </div>
-    </button>
+    </div>
   );
 }
 
@@ -1122,18 +1273,25 @@ function FinalStepCard({
   locale,
   unlocked,
   passed,
+  attempts,
+  maxAttempts,
+  isOwner,
   onClick,
+  onBypass,
 }: {
   locale: Locale;
   unlocked: boolean;
   passed: boolean;
+  attempts: number;
+  maxAttempts: number;
+  isOwner: boolean;
   onClick?: () => void;
+  onBypass?: () => void;
 }) {
+  const atCap = !passed && attempts >= maxAttempts;
+  const effectiveOnClick = atCap && !isOwner ? undefined : onClick;
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={!unlocked || passed || !onClick}
+    <div
       style={{
         display: "grid",
         gridTemplateColumns: "auto 1fr auto",
@@ -1145,13 +1303,26 @@ function FinalStepCard({
         borderRadius: RADIUS,
         padding: "16px 18px",
         textAlign: "left",
-        cursor: unlocked && !passed && onClick ? "pointer" : "default",
         opacity: unlocked ? 1 : 0.55,
         fontFamily: FONT,
       }}
     >
       <Award size={28} />
-      <div>
+      <button
+        type="button"
+        onClick={effectiveOnClick}
+        disabled={!unlocked || passed || !effectiveOnClick}
+        style={{
+          background: "transparent",
+          color: "inherit",
+          border: 0,
+          padding: 0,
+          margin: 0,
+          textAlign: "left",
+          cursor: unlocked && !passed && effectiveOnClick ? "pointer" : "default",
+          fontFamily: FONT,
+        }}
+      >
         <div style={{ fontWeight: 800, fontSize: 14 }}>
           {tr("finalTest", locale)}
         </div>
@@ -1164,8 +1335,32 @@ function FinalStepCard({
         >
           {tr("finalIntro", locale)}
         </div>
-      </div>
-      <div style={{ fontWeight: 800, fontSize: 12, whiteSpace: "nowrap" }}>
+        {!passed ? (
+          <div
+            style={{
+              fontSize: 11,
+              marginTop: 6,
+              fontWeight: 700,
+              opacity: 0.9,
+              color: atCap ? "#FCA5A5" : "inherit",
+            }}
+          >
+            {attempts}/{maxAttempts} {tr("attempt", locale).toLowerCase()}
+            {attempts === 1 ? "" : "s"}
+            {atCap && !isOwner ? ` · ${tr("noAttemptsLeft", locale)}` : ""}
+          </div>
+        ) : null}
+      </button>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          fontWeight: 800,
+          fontSize: 12,
+          whiteSpace: "nowrap",
+        }}
+      >
         {passed ? (
           <>
             <CircleCheck size={14} style={{ verticalAlign: "middle" }} />{" "}
@@ -1176,14 +1371,58 @@ function FinalStepCard({
             <Lock size={14} style={{ verticalAlign: "middle" }} />{" "}
             {tr("locked", locale)}
           </>
-        ) : (
+        ) : atCap && !isOwner ? (
           <>
+            <Lock size={14} style={{ verticalAlign: "middle" }} />{" "}
+            {tr("locked", locale)}
+          </>
+        ) : (
+          <button
+            type="button"
+            onClick={effectiveOnClick}
+            disabled={!effectiveOnClick}
+            style={{
+              background: "transparent",
+              color: "#fff",
+              border: 0,
+              cursor: effectiveOnClick ? "pointer" : "default",
+              fontWeight: 800,
+              fontSize: 12,
+              padding: 0,
+              fontFamily: FONT,
+            }}
+          >
             {tr("start", locale)}{" "}
             <ChevronRight size={14} style={{ verticalAlign: "middle" }} />
-          </>
+          </button>
         )}
+        {onBypass ? (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onBypass();
+            }}
+            style={{
+              background: "rgba(255,255,255,0.15)",
+              color: "#fff",
+              border: `1px solid rgba(255,255,255,0.3)`,
+              padding: "5px 10px",
+              borderRadius: 6,
+              fontSize: 11,
+              fontWeight: 800,
+              cursor: "pointer",
+              fontFamily: FONT,
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 4,
+            }}
+          >
+            <FastForward size={11} /> {tr("bypassOwner", locale)}
+          </button>
+        ) : null}
       </div>
-    </button>
+    </div>
   );
 }
 
@@ -1196,20 +1435,36 @@ function ModuleView({
   locale,
   isQuizModule,
   progress,
+  isOwner,
   onBack,
   onTakeQuiz,
   onAcknowledge,
+  onBypass,
   onStart,
 }: {
   module: Module;
   locale: Locale;
   isQuizModule: boolean;
   progress: ModuleProgressRow | null;
+  isOwner: boolean;
   onBack: () => void;
   onTakeQuiz: () => void;
   onAcknowledge: () => void;
+  onBypass: () => void;
   onStart: () => void;
 }) {
+  const attempts = progress?.attempts ?? 0;
+  const maxAttempts = MAX_MODULE_ATTEMPTS;
+  const status = progress?.status ?? "not_started";
+  const atCap = isQuizModule && status !== "passed" && attempts >= maxAttempts;
+  const quizCta =
+    status === "passed"
+      ? tr("review_quiz", locale)
+      : status === "failed"
+      ? tr("retry_quiz", locale)
+      : status === "in_progress"
+      ? tr("resume_quiz", locale)
+      : tr("start_quiz", locale);
   useEffect(() => {
     onStart();
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -1248,6 +1503,37 @@ function ModuleView({
         {m.blocks.map((b, i) => (
           <Block key={i} block={b} locale={locale} />
         ))}
+        {isQuizModule ? (
+          <div
+            style={{
+              marginTop: 18,
+              padding: "10px 12px",
+              background: atCap && !isOwner ? "#FEF2F2" : LINE_SOFT,
+              border: `1px solid ${atCap && !isOwner ? "#FECACA" : LINE}`,
+              borderRadius: 8,
+              fontSize: 12,
+              color: atCap && !isOwner ? DANGER : INK_MUTE,
+              fontWeight: 700,
+              display: "flex",
+              justifyContent: "space-between",
+              gap: 10,
+              flexWrap: "wrap",
+            }}
+          >
+            <span>
+              {tr("attempt", locale)} {Math.min(attempts + 1, maxAttempts)}{" "}
+              {tr("of", locale)} {maxAttempts}
+              {progress?.best_score
+                ? ` · ${locale === "en" ? "best" : "mejor"}: ${progress.best_score}%`
+                : ""}
+            </span>
+            <span>
+              {atCap && !isOwner
+                ? tr("noAttemptsLeft", locale)
+                : `${Math.max(0, maxAttempts - attempts)} ${tr("attemptsRemaining", locale)}`}
+            </span>
+          </div>
+        ) : null}
         <div
           style={{
             marginTop: 22,
@@ -1257,11 +1543,17 @@ function ModuleView({
             flexWrap: "wrap",
           }}
         >
+          {isOwner && status !== "passed" ? (
+            <SecondaryButton onClick={onBypass}>
+              <FastForward size={14} /> {tr("bypassOwner", locale)}
+            </SecondaryButton>
+          ) : null}
           {isQuizModule ? (
-            <PrimaryButton onClick={onTakeQuiz}>
-              {progress?.status === "passed"
-                ? tr("review", locale)
-                : tr("start", locale) + " quiz"}
+            <PrimaryButton
+              onClick={onTakeQuiz}
+              disabled={atCap && !isOwner}
+            >
+              {quizCta}
               <ChevronRight size={14} style={{ marginLeft: 4 }} />
             </PrimaryButton>
           ) : (
@@ -1448,6 +1740,7 @@ function QuizView({
   moduleId,
   locale,
   token,
+  priorAttempts,
   onCancel,
   onPassed,
 }: {
@@ -1455,10 +1748,12 @@ function QuizView({
   moduleId: string;
   locale: Locale;
   token: string | null;
+  priorAttempts: number;
   onCancel: () => void;
   onPassed: () => Promise<void>;
 }) {
   const isFinal = moduleId === FINAL_MODULE_ID;
+  const maxAttempts = maxAttemptsFor(moduleId);
   const [questionIds, setQuestionIds] = useState<string[]>([]);
   const [answers, setAnswers] = useState<(number | null)[]>([]);
   const [cursor, setCursor] = useState(0);
@@ -1551,19 +1846,29 @@ function QuizView({
     );
   }
   if (result) {
+    const attemptsRemaining =
+      result.attempts_remaining ??
+      Math.max(0, maxAttempts - (result.attempts_used ?? priorAttempts + 1));
     return (
       <ResultView
         locale={locale}
         result={result}
+        attemptsRemaining={attemptsRemaining}
+        maxAttempts={result.max_attempts ?? maxAttempts}
         passThreshold={PASS_THRESHOLD_PCT}
         onContinue={async () => {
           if (result.passed) {
             await onPassed();
-          } else {
-            // Reset for retry
+          } else if (attemptsRemaining > 0) {
+            // Reset for retry — also clear server state so cross-device
+            // resume starts from a blank slate (server already deletes the
+            // row after every submit; this is belt-and-suspenders).
             setAnswers(new Array(questionIds.length).fill(null));
             setCursor(0);
             setResult(null);
+          } else {
+            // No retries left — bounce back home.
+            onCancel();
           }
         }}
       />
@@ -1590,25 +1895,50 @@ function QuizView({
 
   const allAnswered = answers.length === total && answers.every((a) => a != null);
 
+  const currentAttempt = Math.min(priorAttempts + 1, maxAttempts);
   return (
     <div style={{ maxWidth: 720, margin: "0 auto", padding: "20px 18px" }}>
       <BackLink label={tr("back", locale)} onClick={onCancel} />
       <div style={{ marginTop: 14 }}>
         <div
           style={{
-            fontSize: 11,
-            color: INK_LIGHT,
-            fontWeight: 800,
-            textTransform: "uppercase",
-            letterSpacing: "0.08em",
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            gap: 8,
+            flexWrap: "wrap",
           }}
         >
-          {isFinal
-            ? tr("finalTest", locale)
-            : curriculum.modules.find((m) => m.id === moduleId)?.title[locale] ??
-              moduleId}
-          {" · "}
-          {cursor + 1} / {total}
+          <div
+            style={{
+              fontSize: 11,
+              color: INK_LIGHT,
+              fontWeight: 800,
+              textTransform: "uppercase",
+              letterSpacing: "0.08em",
+            }}
+          >
+            {isFinal
+              ? tr("finalTest", locale)
+              : curriculum.modules.find((m) => m.id === moduleId)?.title[locale] ??
+                moduleId}
+            {" · "}
+            {cursor + 1} / {total}
+          </div>
+          <div
+            style={{
+              fontSize: 11,
+              color: INK_MUTE,
+              fontWeight: 800,
+              textTransform: "uppercase",
+              letterSpacing: "0.06em",
+              background: LINE_SOFT,
+              padding: "3px 8px",
+              borderRadius: 999,
+            }}
+          >
+            {tr("attempt", locale)} {currentAttempt} {tr("of", locale)} {maxAttempts}
+          </div>
         </div>
         <div
           style={{
@@ -1751,15 +2081,20 @@ function sampleClient(pool: string[], n: number): string[] {
 function ResultView({
   locale,
   result,
+  attemptsRemaining,
+  maxAttempts,
   passThreshold,
   onContinue,
 }: {
   locale: Locale;
   result: SubmitResult;
+  attemptsRemaining: number;
+  maxAttempts: number;
   passThreshold: number;
   onContinue: () => void;
 }) {
   const { passed, score } = result;
+  const noMoreRetries = !passed && attemptsRemaining <= 0;
   return (
     <div style={{ maxWidth: 480, margin: "60px auto", padding: 18 }}>
       <div
@@ -1782,9 +2117,29 @@ function ResultView({
         <div style={{ marginTop: 8, fontSize: 13, color: INK_MUTE }}>
           {score}% · {passThreshold}% {locale === "en" ? "to pass" : "para aprobar"}
         </div>
+        {!passed ? (
+          <div
+            style={{
+              marginTop: 10,
+              fontSize: 12,
+              fontWeight: 700,
+              color: noMoreRetries ? DANGER : INK_MUTE,
+            }}
+          >
+            {noMoreRetries
+              ? tr("noAttemptsLeft", locale)
+              : `${attemptsRemaining} ${tr("attemptsRemaining", locale)} (${
+                  maxAttempts - attemptsRemaining
+                }/${maxAttempts} ${tr("attemptsUsed", locale)})`}
+          </div>
+        ) : null}
         <div style={{ marginTop: 18 }}>
           <PrimaryButton onClick={onContinue}>
-            {passed ? tr("next", locale) : tr("retry", locale)}
+            {passed
+              ? tr("next", locale)
+              : noMoreRetries
+              ? tr("back", locale)
+              : tr("retry", locale)}
           </PrimaryButton>
         </div>
       </div>

--- a/lib/lms-curriculum/src/index.ts
+++ b/lib/lms-curriculum/src/index.ts
@@ -90,6 +90,20 @@ export const QUIZ_MODULE_IDS: readonly QuizModuleId[] = [
 export const QUIZ_PASS_THRESHOLD = 0.8;
 
 /**
+ * Maximum attempts a learner gets before a module locks. Spec (phes 2026-05-11):
+ * three shots at each module quiz, four at the final mixed test. Owners are
+ * exempt from this gate via `/lms/admin/bypass-module`. Admins can also
+ * extend the deadline or bypass on behalf of a learner from /lms/admin.
+ */
+export const MAX_MODULE_ATTEMPTS = 3;
+export const MAX_FINAL_ATTEMPTS = 4;
+
+/** Max attempts allowed for a given module id (module or `__final`). */
+export function maxAttemptsFor(moduleId: string): number {
+  return moduleId === FINAL_MODULE_ID ? MAX_FINAL_ATTEMPTS : MAX_MODULE_ATTEMPTS;
+}
+
+/**
  * Number of questions sampled for the final mixed test. Drawn at random
  * (without replacement) across every QUIZ_MODULE_IDS. If the curriculum has
  * fewer than this many total questions, the final uses every question.


### PR DESCRIPTION
## Summary

Closes the five gaps you flagged on the LMS:

1. **Owner bypass** — `POST /lms/admin/bypass-module` (owner/admin only) marks a module as passed for the caller or a target learner. Skip buttons render on the training home, module reader, and final card whenever the JWT's role is `owner`. Multi-tenant safe: admin can only bypass for users in their own company.
2. **Admin portal surfaced** — sidebar gains a "Training Admin" link under Company (owner/admin/super_admin gated). Existing `/lms/admin` roster now expands per learner into a per-module attempts grid with a "Bypass" button on every module.
3. **Real Qleno logo** — `/training`, `/lms/admin`, and the `/my-jobs` tech header now render `<QlenoLogo />` / `<QlenoMark />` in place of the navy "Q" placeholder. `/my-jobs` also picks up a Training link in the header.
4. **Attempt caps (3 module / 4 final)** — enforced server-side in `/quiz/submit` (returns 403 with `attempts_used` + `max_attempts` once the cap is reached). Owners are exempt. UI surfaces the count in five places:
   - Quiz header: `Attempt 2 of 3`
   - Module rows on home: `1/3 attempts`
   - Result screen: `2 attempts remaining (1/3 used)` on failure
   - Admin expand row: per-module attempts/max
   - Cap hit → row turns red, retry disabled, hint "Ask your admin to extend or bypass"
5. **Audit / lockout fix** — Dispatch flagged a failure lockout: backend wasn't clearing `lms_quiz_state` on a failed submit, so the next entry reloaded the wrong answers and re-failed. Now the state row is deleted on every submit (pass or fail). The CTA on the module reader also branches across `passed | failed | in_progress | not_started` instead of always saying "Start quiz".

## Files

| File | Notes |
|------|-------|
| `lib/lms-curriculum/src/index.ts` | New `MAX_MODULE_ATTEMPTS=3`, `MAX_FINAL_ATTEMPTS=4`, `maxAttemptsFor()` so server + client agree |
| `artifacts/api-server/src/routes/lms.ts` | Cap enforcement in `/quiz/submit`, new `/admin/bypass-module`, `/me` returns `is_owner` + `limits`, `/admin/learners` returns per-module `modules` map, lockout fix |
| `artifacts/qleno/src/pages/training.tsx` | QlenoLogo header, owner Skip buttons everywhere, attempt counter, retake gating, CTA labels |
| `artifacts/qleno/src/pages/lms-admin.tsx` | QlenoLogo header, expand-row attempts grid, per-module Bypass action |
| `artifacts/qleno/src/components/layout/app-sidebar.tsx` | "Training Admin" link gated to owner/admin/super_admin |
| `artifacts/qleno/src/pages/my-jobs.tsx` | QlenoMark + Training link in mobile tech header |
| `artifacts/api-server/src/tests/lms-curriculum.test.ts` | 5 new tests on the cap constants + helper |

## Test plan

- [x] `pnpm --filter @workspace/api-server run test:lms` — **68/68 pass** (5 new)
- [x] `pnpm run build` in `artifacts/qleno` — clean
- [x] `tsc --noEmit` on the LMS files — only pre-existing errors remain (badge union, IconKind), no new errors introduced
- [ ] Manual: sign in as `salmartinez@phes.io` (owner) on `/training` → confirm Qleno logo renders + "Skip (Owner)" button next to every unfinished module + final
- [ ] Manual: sign in as `salmartinez@phes.io` → `/lms/admin` → confirm logo renders, expand a learner → see per-module attempts grid, click Bypass → row turns green
- [ ] Manual: sign in as a tech, fail a quiz 3× → row locks with "No attempts remaining. Ask your admin to extend or bypass." Verify admin Bypass unblocks it.
- [ ] Manual: sign in as a tech → `/my-jobs` → confirm Qleno mark in header + Training link routes to `/training`
- [ ] Manual: fail a quiz once, navigate away, return → confirm fresh slate (no stale answers reloaded — lockout fix)

https://claude.ai/code/session_013rJ4N4vgqZWB986x8D6Ahh

---
_Generated by [Claude Code](https://claude.ai/code/session_013rJ4N4vgqZWB986x8D6Ahh)_