### PR TITLE
fix(lms): roster 117% bug + add admin Reset action

### DIFF
--- a/artifacts/api-server/src/routes/lms.ts
+++ b/artifacts/api-server/src/routes/lms.ts
@@ -979,7 +979,14 @@ router.get(
 
       const rows = enrollments.map((e) => {
         const progress = progressByEnrollment.get(e.id) ?? [];
-        const passedCount = progress.filter((p) => p.status === "passed").length;
+        // Count only modules in MODULE_ORDER toward the percentage — the
+        // final mixed test is a SEPARATE gate. Without this filter a learner
+        // who passed all 6 modules + the final test reported 7/6 = 117%.
+        const passedCount = progress.filter(
+          (p) =>
+            p.status === "passed" &&
+            (MODULE_ORDER as readonly string[]).includes(p.module_id),
+        ).length;
         const passedRatio = totalModules > 0 ? passedCount / totalModules : 0;
         const completed = progress
           .filter((p) => p.status === "passed")
@@ -1244,6 +1251,126 @@ router.post(
       return res
         .status(500)
         .json({ error: "Internal Server Error", message: "Failed to bypass module" });
+    }
+  },
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /admin/reset — Owner+Admin only
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// Body: { userId, mode?: 'progress' | 'full' }
+//
+// `progress` (default): wipes every module_progress row, quiz_state row, and
+//   quiz_attempts row for the learner. Resets the enrollment to status='active',
+//   bumps deadline_at to now+7d, clears completed_at + acknowledgment fields.
+//   The learner keeps their enrollment row id but starts fresh on every module.
+//
+// `full`: deletes the enrollment outright (cascades via FK ON DELETE CASCADE,
+//   so progress/state/attempts go with it). The learner's next visit to
+//   /training lazy-creates a brand-new enrollment with a fresh 7-day deadline.
+//
+// Either mode also writes an audit log row.
+
+router.post(
+  "/admin/reset",
+  requireAuth,
+  requireRole("owner", "admin"),
+  async (req, res) => {
+    try {
+      const companyId = req.auth!.companyId;
+      if (companyId == null) {
+        return res
+          .status(400)
+          .json({ error: "Bad Request", message: "User has no company assignment" });
+      }
+      const targetUserId = Number(req.body?.userId);
+      const mode: "progress" | "full" =
+        req.body?.mode === "full" ? "full" : "progress";
+
+      if (!Number.isFinite(targetUserId) || targetUserId <= 0) {
+        return res
+          .status(400)
+          .json({ error: "Bad Request", message: "userId is required" });
+      }
+
+      // Tenant gate — caller can only reset users in their own tenant.
+      const targetUser = await db
+        .select({ company_id: usersTable.company_id })
+        .from(usersTable)
+        .where(eq(usersTable.id, targetUserId))
+        .limit(1);
+      if (!targetUser[0] || targetUser[0].company_id !== companyId) {
+        return res
+          .status(404)
+          .json({ error: "Not Found", message: "User not found in tenant" });
+      }
+
+      const existing = await db
+        .select()
+        .from(lmsEnrollmentsTable)
+        .where(
+          and(
+            eq(lmsEnrollmentsTable.company_id, companyId),
+            eq(lmsEnrollmentsTable.user_id, targetUserId),
+          ),
+        )
+        .limit(1);
+      if (!existing[0]) {
+        return res
+          .status(404)
+          .json({ error: "Not Found", message: "No enrollment to reset" });
+      }
+      const enrollmentId = existing[0].id;
+      const now = new Date();
+
+      if (mode === "full") {
+        // FK ON DELETE CASCADE wipes progress, state, and attempts.
+        await db
+          .delete(lmsEnrollmentsTable)
+          .where(eq(lmsEnrollmentsTable.id, enrollmentId));
+      } else {
+        // Progress-only reset: clear children, keep the enrollment row but
+        // reset all its lifecycle fields so the learner sees a clean slate.
+        await db
+          .delete(lmsModuleProgressTable)
+          .where(eq(lmsModuleProgressTable.enrollment_id, enrollmentId));
+        await db
+          .delete(lmsQuizStateTable)
+          .where(eq(lmsQuizStateTable.enrollment_id, enrollmentId));
+        await db
+          .delete(lmsQuizAttemptsTable)
+          .where(eq(lmsQuizAttemptsTable.enrollment_id, enrollmentId));
+        await db
+          .update(lmsEnrollmentsTable)
+          .set({
+            status: "active",
+            enrolled_at: now,
+            deadline_at: addDays(now, DEFAULT_DEADLINE_DAYS),
+            completed_at: null,
+            acknowledgment_signature: null,
+            acknowledgment_at: null,
+            last_activity_at: now,
+            updated_at: now,
+          })
+          .where(eq(lmsEnrollmentsTable.id, enrollmentId));
+      }
+
+      await logAudit(
+        req,
+        mode === "full" ? "lms.admin.reset.full" : "lms.admin.reset.progress",
+        "lms_enrollment",
+        enrollmentId,
+        { previous_status: existing[0].status },
+        { target_user_id: targetUserId, mode },
+      );
+
+      return res.json({ data: { ok: true, mode } });
+    } catch (err) {
+      console.error("[lms] /admin/reset error:", err);
+      return res
+        .status(500)
+        .json({ error: "Internal Server Error", message: "Failed to reset enrollment" });
     }
   },
 );

--- a/artifacts/qleno/src/pages/lms-admin.tsx
+++ b/artifacts/qleno/src/pages/lms-admin.tsx
@@ -27,6 +27,7 @@ import {
   ChevronRight,
   ChevronDown,
   FastForward,
+  RotateCcw,
 } from "lucide-react";
 
 const NAVY = "#0A2342";
@@ -130,6 +131,7 @@ export default function LmsAdminPage() {
   const [rows, setRows] = useState<RosterRow[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [extendOpen, setExtendOpen] = useState<RosterRow | null>(null);
+  const [resetOpen, setResetOpen] = useState<RosterRow | null>(null);
   const [expanded, setExpanded] = useState<Set<number>>(new Set());
 
   function toggleExpand(enrollmentId: number) {
@@ -301,6 +303,7 @@ export default function LmsAdminPage() {
             expanded={expanded}
             onToggleExpand={toggleExpand}
             onExtend={setExtendOpen}
+            onReset={setResetOpen}
             onBypass={bypassFor}
           />
         ) : (
@@ -309,6 +312,7 @@ export default function LmsAdminPage() {
             expanded={expanded}
             onToggleExpand={toggleExpand}
             onExtend={setExtendOpen}
+            onReset={setResetOpen}
             onBypass={bypassFor}
           />
         )}
@@ -321,6 +325,18 @@ export default function LmsAdminPage() {
           onClose={() => setExtendOpen(null)}
           onSaved={async () => {
             setExtendOpen(null);
+            await refresh();
+          }}
+        />
+      )}
+
+      {resetOpen && (
+        <ResetEnrollmentDialog
+          row={resetOpen}
+          token={token}
+          onClose={() => setResetOpen(null)}
+          onSaved={async () => {
+            setResetOpen(null);
             await refresh();
           }}
         />
@@ -392,12 +408,14 @@ function RosterTable({
   expanded,
   onToggleExpand,
   onExtend,
+  onReset,
   onBypass,
 }: {
   rows: RosterRow[];
   expanded: Set<number>;
   onToggleExpand: (id: number) => void;
   onExtend: (r: RosterRow) => void;
+  onReset: (r: RosterRow) => void;
   onBypass: (userId: number, moduleId: string) => Promise<void>;
 }) {
   return (
@@ -507,24 +525,48 @@ function RosterTable({
                   </span>
                 </Td>
                 <Td>
-                  <button
-                    type="button"
-                    onClick={() => onExtend(r)}
-                    style={{
-                      background: "transparent",
-                      color: NAVY,
-                      border: `1px solid ${LINE}`,
-                      padding: "5px 10px",
-                      borderRadius: 6,
-                      fontSize: 12,
-                      fontWeight: 700,
-                      cursor: "pointer",
-                      fontFamily: FONT,
-                      whiteSpace: "nowrap",
-                    }}
-                  >
-                    Extend
-                  </button>
+                  <div style={{ display: "inline-flex", gap: 6 }}>
+                    <button
+                      type="button"
+                      onClick={() => onExtend(r)}
+                      style={{
+                        background: "transparent",
+                        color: NAVY,
+                        border: `1px solid ${LINE}`,
+                        padding: "5px 10px",
+                        borderRadius: 6,
+                        fontSize: 12,
+                        fontWeight: 700,
+                        cursor: "pointer",
+                        fontFamily: FONT,
+                        whiteSpace: "nowrap",
+                      }}
+                    >
+                      Extend
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => onReset(r)}
+                      title="Reset enrollment"
+                      style={{
+                        background: "transparent",
+                        color: DANGER,
+                        border: `1px solid ${LINE}`,
+                        padding: "5px 10px",
+                        borderRadius: 6,
+                        fontSize: 12,
+                        fontWeight: 700,
+                        cursor: "pointer",
+                        fontFamily: FONT,
+                        whiteSpace: "nowrap",
+                        display: "inline-flex",
+                        alignItems: "center",
+                        gap: 4,
+                      }}
+                    >
+                      <RotateCcw size={11} /> Reset
+                    </button>
+                  </div>
                 </Td>
               </tr>
               {expanded.has(r.enrollment_id) ? (
@@ -664,12 +706,14 @@ function RosterCards({
   expanded,
   onToggleExpand,
   onExtend,
+  onReset,
   onBypass,
 }: {
   rows: RosterRow[];
   expanded: Set<number>;
   onToggleExpand: (id: number) => void;
   onExtend: (r: RosterRow) => void;
+  onReset: (r: RosterRow) => void;
   onBypass: (userId: number, moduleId: string) => Promise<void>;
 }) {
   return (
@@ -771,23 +815,45 @@ function RosterCards({
                 </>
               )}
             </button>
-            <button
-              type="button"
-              onClick={() => onExtend(r)}
-              style={{
-                background: "transparent",
-                color: NAVY,
-                border: `1px solid ${LINE}`,
-                padding: "6px 12px",
-                borderRadius: 6,
-                fontSize: 12,
-                fontWeight: 700,
-                cursor: "pointer",
-                fontFamily: FONT,
-              }}
-            >
-              Extend deadline <ChevronRight size={12} />
-            </button>
+            <div style={{ display: "inline-flex", gap: 6 }}>
+              <button
+                type="button"
+                onClick={() => onReset(r)}
+                style={{
+                  background: "transparent",
+                  color: DANGER,
+                  border: `1px solid ${LINE}`,
+                  padding: "6px 10px",
+                  borderRadius: 6,
+                  fontSize: 12,
+                  fontWeight: 700,
+                  cursor: "pointer",
+                  fontFamily: FONT,
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: 4,
+                }}
+              >
+                <RotateCcw size={11} /> Reset
+              </button>
+              <button
+                type="button"
+                onClick={() => onExtend(r)}
+                style={{
+                  background: "transparent",
+                  color: NAVY,
+                  border: `1px solid ${LINE}`,
+                  padding: "6px 12px",
+                  borderRadius: 6,
+                  fontSize: 12,
+                  fontWeight: 700,
+                  cursor: "pointer",
+                  fontFamily: FONT,
+                }}
+              >
+                Extend deadline <ChevronRight size={12} />
+              </button>
+            </div>
           </div>
           {expanded.has(r.enrollment_id) ? (
             <div style={{ marginTop: 6 }}>
@@ -1117,6 +1183,247 @@ function ExtendDeadlineDialog({
             }}
           >
             {busy ? <Loader2 size={13} className="qleno-admin-spin" /> : "Extend"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Reset enrollment dialog
+// ─────────────────────────────────────────────────────────────────────────────
+
+function ResetEnrollmentDialog({
+  row,
+  token,
+  onClose,
+  onSaved,
+}: {
+  row: RosterRow;
+  token: string | null;
+  onClose: () => void;
+  onSaved: () => Promise<void>;
+}) {
+  const [mode, setMode] = useState<"progress" | "full">("progress");
+  const [confirm, setConfirm] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const expectedConfirm = "RESET";
+  const valid = confirm.trim().toUpperCase() === expectedConfirm;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Reset enrollment"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "rgba(15, 23, 42, 0.55)",
+        display: "grid",
+        placeItems: "center",
+        zIndex: 100,
+        padding: 16,
+      }}
+    >
+      <div
+        style={{
+          background: SURFACE,
+          borderRadius: RADIUS,
+          maxWidth: 460,
+          width: "100%",
+          padding: 22,
+          fontFamily: FONT,
+          color: INK,
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            fontSize: 16,
+            fontWeight: 800,
+            color: INK,
+          }}
+        >
+          <AlertTriangle size={18} style={{ color: DANGER }} /> Reset enrollment —{" "}
+          {row.tech_name}
+        </div>
+        <div style={{ fontSize: 12, color: INK_MUTE, marginTop: 4, lineHeight: 1.55 }}>
+          This wipes the learner's LMS data. They start over from module 1
+          with a fresh 7-day deadline. Their next visit to /training will look
+          like a brand-new enrollment.
+        </div>
+
+        <div
+          style={{
+            marginTop: 14,
+            display: "grid",
+            gap: 8,
+          }}
+        >
+          <label
+            style={{
+              display: "flex",
+              gap: 8,
+              alignItems: "flex-start",
+              padding: 10,
+              border: `1px solid ${mode === "progress" ? NAVY : LINE}`,
+              borderRadius: 8,
+              cursor: "pointer",
+              background: mode === "progress" ? "#EEF2F8" : "transparent",
+            }}
+          >
+            <input
+              type="radio"
+              name="reset-mode"
+              checked={mode === "progress"}
+              onChange={() => setMode("progress")}
+              style={{ marginTop: 2 }}
+            />
+            <div>
+              <div style={{ fontWeight: 800, fontSize: 13, color: INK }}>
+                Reset progress (recommended)
+              </div>
+              <div style={{ fontSize: 12, color: INK_MUTE, marginTop: 2 }}>
+                Deletes all module progress, quiz attempts, and autosave. Keeps
+                the enrollment row, resets deadline to today + 7 days.
+              </div>
+            </div>
+          </label>
+          <label
+            style={{
+              display: "flex",
+              gap: 8,
+              alignItems: "flex-start",
+              padding: 10,
+              border: `1px solid ${mode === "full" ? DANGER : LINE}`,
+              borderRadius: 8,
+              cursor: "pointer",
+              background: mode === "full" ? "#FEF2F2" : "transparent",
+            }}
+          >
+            <input
+              type="radio"
+              name="reset-mode"
+              checked={mode === "full"}
+              onChange={() => setMode("full")}
+              style={{ marginTop: 2 }}
+            />
+            <div>
+              <div style={{ fontWeight: 800, fontSize: 13, color: INK }}>
+                Delete enrollment fully
+              </div>
+              <div style={{ fontSize: 12, color: INK_MUTE, marginTop: 2 }}>
+                Removes the enrollment record entirely. A fresh one is
+                lazy-created on the learner's next /training visit. Use only
+                if the row is corrupted.
+              </div>
+            </div>
+          </label>
+        </div>
+
+        <label
+          style={{
+            display: "block",
+            marginTop: 14,
+            fontSize: 12,
+            fontWeight: 700,
+            color: INK_MUTE,
+            textTransform: "uppercase",
+            letterSpacing: "0.06em",
+          }}
+        >
+          Type RESET to confirm
+        </label>
+        <input
+          type="text"
+          value={confirm}
+          onChange={(e) => setConfirm(e.target.value)}
+          placeholder="RESET"
+          style={{
+            width: "100%",
+            marginTop: 6,
+            padding: "10px 12px",
+            border: `1px solid ${LINE}`,
+            borderRadius: 8,
+            fontSize: 14,
+            fontFamily: FONT,
+          }}
+        />
+        {err && (
+          <div style={{ color: DANGER, fontSize: 12, marginTop: 8 }}>{err}</div>
+        )}
+        <div
+          style={{
+            marginTop: 18,
+            display: "flex",
+            gap: 8,
+            justifyContent: "flex-end",
+          }}
+        >
+          <button
+            type="button"
+            onClick={onClose}
+            style={{
+              background: "transparent",
+              color: INK_MUTE,
+              border: `1px solid ${LINE}`,
+              padding: "8px 14px",
+              borderRadius: 8,
+              fontSize: 13,
+              fontWeight: 700,
+              fontFamily: FONT,
+              cursor: "pointer",
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            disabled={!valid || busy}
+            onClick={async () => {
+              setBusy(true);
+              setErr(null);
+              try {
+                await api("POST", "/lms/admin/reset", token, {
+                  userId: row.user_id,
+                  mode,
+                });
+                await onSaved();
+              } catch (e) {
+                setErr(String((e as Error).message));
+              } finally {
+                setBusy(false);
+              }
+            }}
+            style={{
+              background: !valid || busy ? INK_LIGHT : DANGER,
+              color: "#fff",
+              border: 0,
+              padding: "8px 14px",
+              borderRadius: 8,
+              fontSize: 13,
+              fontWeight: 700,
+              fontFamily: FONT,
+              cursor: !valid || busy ? "default" : "pointer",
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 4,
+            }}
+          >
+            {busy ? (
+              <Loader2 size={13} className="qleno-admin-spin" />
+            ) : (
+              <>
+                <RotateCcw size={12} /> Reset
+              </>
+            )}
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Two follow-ups from PR #69 surfaced once the admin roster loaded real data:

1. **117% (7/6) bug** — Jose Ardila showed `117% · (7/6)` because `passedCount` in `/api/lms/admin/learners` was counting every passed row, including `__final` (which isn't in `MODULE_ORDER`). Now filtered to only count rows whose `module_id` ∈ `MODULE_ORDER`. The final mixed test stays its own gate, rendered separately in the expand row.

2. **Reset action** — there was no way to undo a learner's progress when grandfather-migrated data was wrong or a legacy localStorage leak got POSTed at first login. New `POST /lms/admin/reset` (owner/admin only):
   - `mode: 'progress'` (default) — wipes module_progress, quiz_state, quiz_attempts. Resets enrollment to active with a fresh +7-day deadline. Keeps enrollment id (audit history stays linked).
   - `mode: 'full'` — deletes the enrollment outright (FK CASCADE wipes children). A fresh enrollment lazy-creates on next /training visit.
   - Tenant-gated; admin can only reset users in their own company.
   - Each call writes an audit row (`lms.admin.reset.progress` or `lms.admin.reset.full`).

Admin UI: a `Reset` button now sits next to `Extend` on every roster row (table + mobile card). Opens a confirmation dialog with the mode picker (progress-only is recommended, full is offered for corrupted rows) and requires the operator to type `RESET` before the button enables.

## Test plan

- [x] `pnpm --filter @workspace/api-server run test:lms` — 68/68 pass
- [x] `pnpm run build` — clean
- [x] `tsc --noEmit` on changed files — no new errors
- [ ] Manual: load /lms/admin → confirm Jose's row now reads `100% (6/6)` (or `83% (5/6)` if final test counted) instead of 117%
- [ ] Manual: click `Reset` on a learner → confirm dialog, pick `progress`, type RESET, submit → row resets to 0% with fresh deadline
- [ ] Manual: pick `full` mode → confirm enrollment row disappears, then have the user visit /training → confirms lazy re-create with day 0

https://claude.ai/code/session_013rJ4N4vgqZWB986x8D6Ahh

---
_Generated by [Claude Code](https://claude.ai/code/session_013rJ4N4vgqZWB986x8D6Ahh)_