### PR TITLE
feat(lms): handbook reconciliation — expanded scope + leave policies + 8 quiz qs

### DIFF
--- a/artifacts/api-server/src/routes/lms.ts
+++ b/artifacts/api-server/src/routes/lms.ts
@@ -1375,4 +1375,138 @@ router.post(
   },
 );
 
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /admin/learners/:userId/attempts — Owner+Admin only
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// Returns the full quiz-attempt history for one learner in the caller's
+// tenant. Per spec, admins use this to spot comprehension gaps ("Carlos
+// failed compensation 3× — which question keeps tripping him?") and to
+// resolve disputes ("I passed!" / "I never took that").
+//
+// Response shape:
+//   {
+//     learner: { user_id, tech_name, enrollment_id },
+//     attempts: [
+//       {
+//         attempt_id, module_id, score, passed, attempted_at,
+//         answers: (number | null)[],       // parallel to question_ids
+//         question_ids: string[],            // for per-module = the fixed
+//                                            //   list; for __final = the
+//                                            //   random sample served
+//         correct_indexes: number[],         // server-authoritative
+//         per_question_correct: boolean[],   // convenience for the UI
+//       },
+//       ...
+//     ]
+//   }
+//
+// Tenant-gated. Sorted attempted_at DESC so newest is first.
+
+router.get(
+  "/admin/learners/:userId/attempts",
+  requireAuth,
+  requireRole("owner", "admin"),
+  async (req, res) => {
+    try {
+      const companyId = req.auth!.companyId;
+      if (companyId == null) {
+        return res
+          .status(400)
+          .json({ error: "Bad Request", message: "User has no company assignment" });
+      }
+      const targetUserId = Number(req.params.userId);
+      if (!Number.isFinite(targetUserId) || targetUserId <= 0) {
+        return res
+          .status(400)
+          .json({ error: "Bad Request", message: "Invalid userId" });
+      }
+
+      // Tenant gate + locate the enrollment.
+      const enrollmentRow = await db
+        .select({
+          id: lmsEnrollmentsTable.id,
+          user_id: lmsEnrollmentsTable.user_id,
+          first_name: usersTable.first_name,
+          last_name: usersTable.last_name,
+        })
+        .from(lmsEnrollmentsTable)
+        .innerJoin(usersTable, eq(usersTable.id, lmsEnrollmentsTable.user_id))
+        .where(
+          and(
+            eq(lmsEnrollmentsTable.company_id, companyId),
+            eq(lmsEnrollmentsTable.user_id, targetUserId),
+          ),
+        )
+        .limit(1);
+      if (!enrollmentRow[0]) {
+        return res
+          .status(404)
+          .json({ error: "Not Found", message: "Enrollment not found in tenant" });
+      }
+      const enrollment = enrollmentRow[0];
+
+      const rows = await db
+        .select()
+        .from(lmsQuizAttemptsTable)
+        .where(eq(lmsQuizAttemptsTable.enrollment_id, enrollment.id))
+        .orderBy(desc(lmsQuizAttemptsTable.attempted_at));
+
+      const attempts = rows.map((r) => {
+        // For per-module quizzes the question_ids column is null because
+        // the set is fixed; resolve it from QUESTIONS_BY_MODULE. For the
+        // final mixed test, the column carries the random sample served.
+        const isFinal = r.module_id === FINAL_MODULE_ID;
+        const questionIds: string[] = isFinal
+          ? Array.isArray(r.question_ids)
+            ? (r.question_ids as string[])
+            : []
+          : [
+              ...((QUESTIONS_BY_MODULE as Record<string, readonly string[]>)[
+                r.module_id
+              ] ?? []),
+            ];
+        const correctIndexes = questionIds.map(
+          (qid) => SERVER_ANSWER_KEY[qid] ?? -1,
+        );
+        const answers = Array.isArray(r.answers) ? (r.answers as (number | null)[]) : [];
+        const perQuestionCorrect = questionIds.map((_qid, i) => {
+          const exp = correctIndexes[i];
+          const got = answers[i];
+          return exp !== -1 && got === exp;
+        });
+        return {
+          attempt_id: r.id,
+          module_id: r.module_id,
+          score: r.score,
+          passed: r.passed,
+          attempted_at: r.attempted_at,
+          answers,
+          question_ids: questionIds,
+          correct_indexes: correctIndexes,
+          per_question_correct: perQuestionCorrect,
+        };
+      });
+
+      return res.json({
+        data: {
+          learner: {
+            user_id: enrollment.user_id,
+            tech_name:
+              `${enrollment.first_name ?? ""} ${enrollment.last_name ?? ""}`.trim() ||
+              `User #${enrollment.user_id}`,
+            enrollment_id: enrollment.id,
+          },
+          attempts,
+        },
+      });
+    } catch (err) {
+      console.error("[lms] /admin/learners/:userId/attempts error:", err);
+      return res
+        .status(500)
+        .json({ error: "Internal Server Error", message: "Failed to load attempt history" });
+    }
+  },
+);
+
 export default router;

--- a/artifacts/api-server/src/tests/lms-curriculum.test.ts
+++ b/artifacts/api-server/src/tests/lms-curriculum.test.ts
@@ -74,8 +74,17 @@ describe("LMS curriculum — constants & catalog shape", () => {
     assert.equal(FINAL_TEST_SIZE, 50);
   });
 
-  it("each module has exactly 15 questions (per Phes spec)", () => {
+  it("phes-policies has 23 questions (handbook reconciliation 2026-05-11)", () => {
+    assert.equal(
+      QUESTIONS_BY_MODULE["phes-policies"].length,
+      23,
+      `phes-policies should have 23 questions; has ${QUESTIONS_BY_MODULE["phes-policies"].length}`,
+    );
+  });
+
+  it("each non-policies module has exactly 15 questions (per Phes spec)", () => {
     for (const m of QUIZ_MODULE_IDS) {
+      if (m === "phes-policies") continue;
       assert.equal(
         QUESTIONS_BY_MODULE[m].length,
         15,
@@ -84,8 +93,8 @@ describe("LMS curriculum — constants & catalog shape", () => {
     }
   });
 
-  it("ALL_QUESTION_IDS is 75 total (5 modules × 15 each)", () => {
-    assert.equal(ALL_QUESTION_IDS.length, 75);
+  it("ALL_QUESTION_IDS is 83 total (4 modules × 15 + phes-policies × 23)", () => {
+    assert.equal(ALL_QUESTION_IDS.length, 83);
   });
 
   it("ANSWER_KEY has exactly the keys enumerated by ALL_QUESTION_IDS", () => {
@@ -195,8 +204,9 @@ describe("scoreQuiz", () => {
   });
 
   it("passes at exactly the 80% boundary on a 15-question quiz (12/15 = 80%)", () => {
-    // 15-question phes-policies quiz: 12 correct = 80% → passes (boundary).
-    const qids: string[] = [...QUESTIONS_BY_MODULE["phes-policies"]];
+    // Use compensation (15) — phes-policies is now 23 after the 2026-05-11
+    // handbook reconciliation, so it no longer hits the 12/15 boundary.
+    const qids: string[] = [...QUESTIONS_BY_MODULE["compensation"]];
     const answers: number[] = qids.map((q: string, i: number) =>
       i < 12 ? ANSWER_KEY[q] : (ANSWER_KEY[q] + 1) % 3,
     );
@@ -206,8 +216,7 @@ describe("scoreQuiz", () => {
   });
 
   it("fails below 80% (11/15 = 73%)", () => {
-    // 15-question phes-policies quiz: 11 correct = 73% → fails (below 80%).
-    const qids: string[] = [...QUESTIONS_BY_MODULE["phes-policies"]];
+    const qids: string[] = [...QUESTIONS_BY_MODULE["compensation"]];
     const answers: number[] = qids.map((q: string, i: number) =>
       i < 11 ? ANSWER_KEY[q] : (ANSWER_KEY[q] + 1) % 3,
     );

--- a/artifacts/qleno/src/lib/training/curriculum.ts
+++ b/artifacts/qleno/src/lib/training/curriculum.ts
@@ -112,7 +112,19 @@ const BASE_MODULES: Module[] = [
           { en: "Pet waste, including litter boxes (we clean around them, not into them).", es: "Desechos de mascotas, incluyendo cajas de arena (limpiamos alrededor, no dentro)." },
           { en: "Cash transactions on site — all payment goes through the office.", es: "Transacciones en efectivo en el sitio — todo pago pasa por la oficina." },
           { en: "Climbing higher than the company-issued step stool — we do not stand on furniture.", es: "Subir más alto que el banquito de la compañía — no nos paramos sobre muebles." },
+          { en: "Wash dishes.", es: "Lavar platos." },
+          { en: "Make beds.", es: "Tender camas." },
+          { en: "Move heavy furniture (we clean around it, never lift or relocate).", es: "Mover muebles pesados (limpiamos alrededor, nunca levantamos ni movemos)." },
+          { en: "Clean window tracks.", es: "Limpiar rieles de ventanas." },
         ],
+      },
+      {
+        type: "callout",
+        tone: "info",
+        text: {
+          en: "These are STANDARD guidelines. The office may grant exceptions — for a slower week, a loyal client, or a company partner — and will communicate them via app notes or a direct message. If you see an exception note in the app, follow it. If a client asks you to do something on this list and there's NO note, decline politely and tell them you'll let the office know — never improvise outside scope.",
+          es: "Estas son guías ESTÁNDAR. La oficina puede otorgar excepciones — para una semana más lenta, un cliente leal o un socio de la compañía — y las comunicará por notas en la aplicación o un mensaje directo. Si ve una nota de excepción en la aplicación, sígala. Si un cliente le pide hacer algo de esta lista y NO hay nota, rechace cortésmente y dígale que le informará a la oficina — nunca improvise fuera del alcance.",
+        },
       },
       { type: "h", text: { en: "Tipping", es: "Propinas" } },
       {
@@ -164,9 +176,27 @@ const BASE_MODULES: Module[] = [
       {
         type: "bullets",
         items: [
-          { en: "After 1 year: 40 hours PTO per year.", es: "Después de 1 año: 40 horas de PTO por año." },
-          { en: "After 2 years: 80 hours PTO per year.", es: "Después de 2 años: 80 horas de PTO por año." },
-          { en: "Requested in advance and approved by office.", es: "Se solicita con anticipación y debe ser aprobado por la oficina." },
+          { en: "After 1 year (first work anniversary): 40 hours PTO per year.", es: "Después de 1 año (primer aniversario): 40 horas de PTO por año." },
+          { en: "After 2 years and beyond: bank is topped up to 80 hours each anniversary.", es: "Después de 2 años en adelante: el banco se rellena hasta 80 horas en cada aniversario." },
+          { en: "Hard cap: PTO does NOT exceed 80 hours total at any time. Unused PTO does NOT stack — we top up to the cap, we do not add on top.", es: "Tope estricto: el PTO NUNCA excede 80 horas totales. El PTO no usado NO se acumula — rellenamos hasta el tope, no agregamos encima." },
+          { en: "Request through the app in advance; approval depends on staffing.", es: "Se solicita con anticipación por la aplicación; la aprobación depende del personal disponible." },
+        ],
+      },
+      {
+        type: "callout",
+        tone: "info",
+        text: {
+          en: "Example: in your first PTO year you used only 20 of your 40 hours. At your 2-year anniversary, the office tops your bank up to 80 hours — NOT 20 carried over plus 80 = 100. The maximum balance is always 80.",
+          es: "Ejemplo: en su primer año de PTO usó solo 20 de sus 40 horas. En su aniversario de 2 años, la oficina rellena su banco hasta 80 horas — NO 20 acumuladas + 80 = 100. El balance máximo siempre es 80.",
+        },
+      },
+      { type: "h", text: { en: "What Gets Paid Out When You Leave", es: "Qué Se Paga al Salir" } },
+      {
+        type: "bullets",
+        items: [
+          { en: "PTO (vacation): any unused PTO IS paid out at separation, per Illinois Wage Payment & Collection Act.", es: "PTO (vacaciones): el PTO no usado SÍ se paga al separarse, conforme a la Ley de Pago y Cobranza de Salarios de Illinois." },
+          { en: "PLAWA (paid sick leave): NOT paid out at separation. PLAWA has no cash value.", es: "PLAWA (licencia por enfermedad pagada): NO se paga al separarse. PLAWA no tiene valor en efectivo." },
+          { en: "Holidays: not banked — only paid for the holiday itself, see eligibility below.", es: "Feriados: no se acumulan — solo se pagan en el día del feriado, vea la elegibilidad abajo." },
         ],
       },
       { type: "h", text: { en: "Time-Off Requests Go Through the System", es: "Solicitudes de Tiempo Libre — Por el Sistema" } },
@@ -195,6 +225,47 @@ const BASE_MODULES: Module[] = [
         text: {
           en: "Phes observes 6 paid holidays plus your birthday: New Year's Day, Memorial Day, Independence Day, Labor Day, Thanksgiving, Christmas Day, and your birthday (taken any day that month).",
           es: "Phes observa 6 feriados pagados más su cumpleaños: Año Nuevo, Memorial Day, Día de la Independencia, Día del Trabajo, Acción de Gracias, Navidad, y su cumpleaños (cualquier día de ese mes).",
+        },
+      },
+      {
+        type: "callout",
+        tone: "warning",
+        text: {
+          en: "Eligibility: holiday pay starts AFTER 90 days of employment. Any holiday that falls in your first 90 days is unpaid for you, even if it's an observed Phes holiday.",
+          es: "Elegibilidad: el pago por feriados comienza DESPUÉS de 90 días de empleo. Cualquier feriado que caiga en sus primeros 90 días es no pagado para usted, incluso si es un feriado observado por Phes.",
+        },
+      },
+      // ── Other Leave Types ──────────────────────────────────────────────────
+      { type: "h", text: { en: "Bereavement Leave", es: "Licencia por Duelo" } },
+      {
+        type: "p",
+        text: {
+          en: "If an immediate family member passes away — spouse, child, parent, or sibling — Phes provides up to 3 paid days at your regular rate. Notify the office as soon as practicable. Extended family (grandparent, in-law, aunt/uncle) is handled case-by-case as unpaid time off; ask the office.",
+          es: "Si un familiar inmediato fallece — cónyuge, hijo/a, padre/madre o hermano/a — Phes ofrece hasta 3 días pagados a su tarifa regular. Notifique a la oficina lo antes posible. Familiares extendidos (abuelo/a, suegros, tíos) se manejan caso por caso como tiempo libre no pagado; pregunte a la oficina.",
+        },
+      },
+      { type: "h", text: { en: "Jury Duty", es: "Servicio de Jurado" } },
+      {
+        type: "p",
+        text: {
+          en: "Jury service is unpaid by Phes. Your job is protected — you cannot be disciplined or terminated for attending — and you keep any juror compensation the court provides. Bring your summons or proof of service to the office before the date and notify your dispatcher.",
+          es: "El servicio de jurado no es pagado por Phes. Su empleo está protegido — no puede ser disciplinado ni despedido por asistir — y se queda con la compensación del tribunal. Traiga la citación o comprobante a la oficina antes de la fecha y notifique al despachador.",
+        },
+      },
+      { type: "h", text: { en: "Lactation Breaks", es: "Pausas de Lactancia" } },
+      {
+        type: "p",
+        text: {
+          en: "Reasonable lactation breaks are PAID at your regular rate and do NOT deduct from PLAWA or PTO. The office will work with you on timing and a private location at the office or between jobs. This is mandatory under Illinois law and the Phes handbook.",
+          es: "Las pausas de lactancia razonables se PAGAN a su tarifa regular y NO se descuentan de PLAWA ni PTO. La oficina coordinará con usted el tiempo y un lugar privado en la oficina o entre trabajos. Es obligatorio bajo la ley de Illinois y el manual de Phes.",
+        },
+      },
+      { type: "h", text: { en: "Pregnancy Accommodation", es: "Acomodación por Embarazo" } },
+      {
+        type: "p",
+        text: {
+          en: "Illinois requires Phes to provide reasonable accommodations during pregnancy — examples: lighter duties, more frequent breaks, adjusted lifting limits, modified schedule, or temporary reassignment. Ask the office; we'll work out an accommodation that keeps you safely working as long as you choose to.",
+          es: "Illinois requiere que Phes brinde acomodaciones razonables durante el embarazo — ejemplos: tareas más ligeras, pausas más frecuentes, límites ajustados de carga, horario modificado o reasignación temporal. Pregunte a la oficina; coordinaremos una acomodación que la mantenga trabajando con seguridad mientras usted decida hacerlo.",
         },
       },
 
@@ -986,6 +1057,126 @@ const BASE_QUIZ: QuizQuestion[] = [
       { en: "Yes if you only photograph the surface, not the family", es: "Sí si solo fotografía la superficie, no a la familia" },
     ],
     correctIndex: 2,
+  },
+  {
+    id: "q-pp-16-dishes-beds",
+    moduleId: "phes-policies",
+    prompt: {
+      en: "Mid-clean, the client asks if you can wash the dishes in the sink and make the kids' beds before you leave. There's no note in the app authorizing extra work. What do you do?",
+      es: "Durante la limpieza, el cliente le pide lavar los platos y tender las camas de los niños antes de irse. No hay nota en la app que autorice trabajo extra. ¿Qué hace?",
+    },
+    options: [
+      { en: "Do it as a courtesy — it'll only take 10 minutes.", es: "Hágalo por cortesía — solo toma 10 minutos." },
+      { en: "Decline politely; dishes and beds are not standard Phes scope. Tell the client you'll let the office know.", es: "Rechace cortésmente; lavar platos y tender camas no es parte del alcance estándar. Dígale al cliente que informará a la oficina." },
+      { en: "Charge the client cash for the extra work.", es: "Cobre al cliente en efectivo por el trabajo extra." },
+      { en: "Make the beds (it's quick) but skip the dishes.", es: "Tienda las camas (es rápido) pero no lave los platos." },
+    ],
+    correctIndex: 1,
+  },
+  {
+    id: "q-pp-17-office-exception",
+    moduleId: "phes-policies",
+    prompt: {
+      en: "You open today's job in the app and see a note from the office: 'Mrs. Johnson is a loyal client — please make the master bed today as a one-time courtesy.' Are you allowed to make the bed?",
+      es: "Abre el trabajo de hoy en la app y ve una nota de la oficina: 'La Sra. Johnson es cliente leal — por favor tienda la cama principal hoy como cortesía única.' ¿Puede tender la cama?",
+    },
+    options: [
+      { en: "No — standard guidelines never bend.", es: "No — las guías estándar nunca cambian." },
+      { en: "Yes — the office grants exceptions, and they communicate them via app notes or a direct message. Follow the note.", es: "Sí — la oficina otorga excepciones, y las comunica por notas en la app o mensaje directo. Siga la nota." },
+      { en: "Only if Mrs. Johnson asks me personally.", es: "Solo si la Sra. Johnson me pide en persona." },
+      { en: "Yes, but only if I call the office first to double-check.", es: "Sí, pero solo si llamo a la oficina primero para confirmar." },
+    ],
+    correctIndex: 1,
+  },
+  {
+    id: "q-pp-18-bereavement",
+    moduleId: "phes-policies",
+    prompt: {
+      en: "Your father passes away. What's the Phes bereavement policy?",
+      es: "Su padre fallece. ¿Cuál es la política de duelo de Phes?",
+    },
+    options: [
+      { en: "Up to 3 unpaid days off — use PLAWA to get paid.", es: "Hasta 3 días no pagados — use PLAWA para recibir pago." },
+      { en: "Up to 3 paid days at your regular rate (immediate family: spouse, child, parent, sibling).", es: "Hasta 3 días pagados a su tarifa regular (familia inmediata: cónyuge, hijo/a, padre/madre, hermano/a)." },
+      { en: "Up to 5 paid days plus travel time.", es: "Hasta 5 días pagados más tiempo de viaje." },
+      { en: "Phes does not offer bereavement leave.", es: "Phes no ofrece licencia por duelo." },
+    ],
+    correctIndex: 1,
+  },
+  {
+    id: "q-pp-19-jury-duty",
+    moduleId: "phes-policies",
+    prompt: {
+      en: "You receive a jury summons for next Wednesday. How does Phes handle the time and pay?",
+      es: "Recibe una citación de jurado para el próximo miércoles. ¿Cómo maneja Phes el tiempo y el pago?",
+    },
+    options: [
+      { en: "Phes pays your regular wage for jury days.", es: "Phes paga su salario regular en días de jurado." },
+      { en: "Jury leave is UNPAID by Phes, your job is protected, and you keep any juror compensation the court provides. Bring the summons to the office and notify dispatch.", es: "La licencia de jurado NO es pagada por Phes, su empleo está protegido, y se queda con la compensación del tribunal. Lleve la citación a la oficina y avise a despacho." },
+      { en: "You must use PTO to cover it.", es: "Debe usar PTO para cubrirlo." },
+      { en: "Ignore the summons — Phes will write a letter excusing you.", es: "Ignore la citación — Phes le escribirá una carta de excusa." },
+    ],
+    correctIndex: 1,
+  },
+  {
+    id: "q-pp-20-lactation",
+    moduleId: "phes-policies",
+    prompt: {
+      en: "Returning from maternity leave, you ask about pumping breaks during the workday. What's the policy?",
+      es: "Al regresar de licencia maternal, pregunta sobre pausas para extraer leche durante el día. ¿Cuál es la política?",
+    },
+    options: [
+      { en: "Use PLAWA hours.", es: "Use horas de PLAWA." },
+      { en: "Reasonable lactation breaks are PAID at your regular rate and do NOT deduct from PLAWA or PTO. The office coordinates timing and a private location.", es: "Las pausas de lactancia razonables se PAGAN a su tarifa regular y NO se descuentan de PLAWA ni PTO. La oficina coordina el horario y un lugar privado." },
+      { en: "Unpaid 15-minute breaks only.", es: "Solo pausas no pagadas de 15 minutos." },
+      { en: "Lactation breaks are not allowed during scheduled jobs.", es: "Las pausas de lactancia no se permiten durante trabajos programados." },
+    ],
+    correctIndex: 1,
+  },
+  {
+    id: "q-pp-21-pto-cap",
+    moduleId: "phes-policies",
+    prompt: {
+      en: "In your first PTO year you used only 20 of your 40 hours. Tomorrow is your 2-year anniversary. How many PTO hours will be in your bank?",
+      es: "En su primer año de PTO usó solo 20 de sus 40 horas. Mañana es su aniversario de 2 años. ¿Cuántas horas de PTO tendrá en su banco?",
+    },
+    options: [
+      { en: "100 hours — 20 carried over plus the new 80.", es: "100 horas — las 20 acumuladas más las 80 nuevas." },
+      { en: "80 hours — Phes tops up your bank to the 80-hour cap. PTO never exceeds 80 hours.", es: "80 horas — Phes rellena su banco hasta el tope de 80 horas. El PTO nunca excede 80 horas." },
+      { en: "60 hours — your remaining 20 plus 40 more.", es: "60 horas — sus 20 restantes más 40 más." },
+      { en: "40 hours — second-year accrual only.", es: "40 horas — solo la acumulación del segundo año." },
+    ],
+    correctIndex: 1,
+  },
+  {
+    id: "q-pp-22-separation-payout",
+    moduleId: "phes-policies",
+    prompt: {
+      en: "You give your 2-week notice. You have 20 unused PTO hours and 15 unused PLAWA (sick) hours. What gets paid out at separation?",
+      es: "Da su aviso de 2 semanas. Tiene 20 horas de PTO sin usar y 15 horas de PLAWA (enfermedad) sin usar. ¿Qué se paga al separarse?",
+    },
+    options: [
+      { en: "Both — all unused leave is cashed out.", es: "Ambas — toda la licencia sin usar se paga." },
+      { en: "PTO only (20 hours). PLAWA has no cash value and is not paid out.", es: "Solo PTO (20 horas). PLAWA no tiene valor en efectivo y no se paga." },
+      { en: "PLAWA only — PTO is forfeited at separation.", es: "Solo PLAWA — el PTO se pierde al separarse." },
+      { en: "Neither — Phes does not pay out unused leave.", es: "Ninguna — Phes no paga licencia sin usar." },
+    ],
+    correctIndex: 1,
+  },
+  {
+    id: "q-pp-23-holiday-90day",
+    moduleId: "phes-policies",
+    prompt: {
+      en: "You were hired on November 1 and Thanksgiving falls 3 weeks later. Do you receive paid holiday pay for Thanksgiving?",
+      es: "Fue contratado el 1 de noviembre y Acción de Gracias cae 3 semanas después. ¿Recibe pago por feriado en Acción de Gracias?",
+    },
+    options: [
+      { en: "Yes — Phes observes Thanksgiving as a paid holiday.", es: "Sí — Phes observa Acción de Gracias como feriado pagado." },
+      { en: "No — holiday pay eligibility begins AFTER 90 days of employment. Holidays in your first 90 days are unpaid.", es: "No — la elegibilidad para pago por feriado comienza DESPUÉS de 90 días de empleo. Los feriados en sus primeros 90 días no son pagados." },
+      { en: "Yes — but only at half rate during the first 90 days.", es: "Sí — pero solo a media tarifa durante los primeros 90 días." },
+      { en: "Only if the client cancels and you would have worked that day.", es: "Solo si el cliente cancela y habría trabajado ese día." },
+    ],
+    correctIndex: 1,
   },
 
   // ═════════════════════════════════════════════════════════════════════════════

--- a/artifacts/qleno/src/pages/lms-admin.tsx
+++ b/artifacts/qleno/src/pages/lms-admin.tsx
@@ -18,6 +18,7 @@ import {
   FINAL_MODULE_ID,
   maxAttemptsFor,
 } from "@workspace/lms-curriculum";
+import { getCurriculum, type QuizQuestion } from "@/lib/training/curriculum";
 import {
   CalendarClock,
   Loader2,
@@ -28,6 +29,7 @@ import {
   ChevronDown,
   FastForward,
   RotateCcw,
+  History,
 } from "lucide-react";
 
 const NAVY = "#0A2342";
@@ -50,6 +52,7 @@ const MOBILE_BREAKPOINT = 768;
 type AuthPayload = {
   role?: string;
   first_name?: string;
+  companyId?: number | null;
 };
 
 type ModuleStat = {
@@ -132,6 +135,7 @@ export default function LmsAdminPage() {
   const [error, setError] = useState<string | null>(null);
   const [extendOpen, setExtendOpen] = useState<RosterRow | null>(null);
   const [resetOpen, setResetOpen] = useState<RosterRow | null>(null);
+  const [historyOpen, setHistoryOpen] = useState<RosterRow | null>(null);
   const [expanded, setExpanded] = useState<Set<number>>(new Set());
 
   function toggleExpand(enrollmentId: number) {
@@ -304,6 +308,7 @@ export default function LmsAdminPage() {
             onToggleExpand={toggleExpand}
             onExtend={setExtendOpen}
             onReset={setResetOpen}
+            onHistory={setHistoryOpen}
             onBypass={bypassFor}
           />
         ) : (
@@ -313,6 +318,7 @@ export default function LmsAdminPage() {
             onToggleExpand={toggleExpand}
             onExtend={setExtendOpen}
             onReset={setResetOpen}
+            onHistory={setHistoryOpen}
             onBypass={bypassFor}
           />
         )}
@@ -339,6 +345,14 @@ export default function LmsAdminPage() {
             setResetOpen(null);
             await refresh();
           }}
+        />
+      )}
+
+      {historyOpen && (
+        <AttemptHistoryDialog
+          row={historyOpen}
+          token={token}
+          onClose={() => setHistoryOpen(null)}
         />
       )}
 
@@ -409,6 +423,7 @@ function RosterTable({
   onToggleExpand,
   onExtend,
   onReset,
+  onHistory,
   onBypass,
 }: {
   rows: RosterRow[];
@@ -416,6 +431,7 @@ function RosterTable({
   onToggleExpand: (id: number) => void;
   onExtend: (r: RosterRow) => void;
   onReset: (r: RosterRow) => void;
+  onHistory: (r: RosterRow) => void;
   onBypass: (userId: number, moduleId: string) => Promise<void>;
 }) {
   return (
@@ -525,7 +541,29 @@ function RosterTable({
                   </span>
                 </Td>
                 <Td>
-                  <div style={{ display: "inline-flex", gap: 6 }}>
+                  <div style={{ display: "inline-flex", gap: 6, flexWrap: "wrap" }}>
+                    <button
+                      type="button"
+                      onClick={() => onHistory(r)}
+                      title="View attempt history"
+                      style={{
+                        background: "transparent",
+                        color: NAVY,
+                        border: `1px solid ${LINE}`,
+                        padding: "5px 10px",
+                        borderRadius: 6,
+                        fontSize: 12,
+                        fontWeight: 700,
+                        cursor: "pointer",
+                        fontFamily: FONT,
+                        whiteSpace: "nowrap",
+                        display: "inline-flex",
+                        alignItems: "center",
+                        gap: 4,
+                      }}
+                    >
+                      <History size={11} /> History
+                    </button>
                     <button
                       type="button"
                       onClick={() => onExtend(r)}
@@ -707,6 +745,7 @@ function RosterCards({
   onToggleExpand,
   onExtend,
   onReset,
+  onHistory,
   onBypass,
 }: {
   rows: RosterRow[];
@@ -714,6 +753,7 @@ function RosterCards({
   onToggleExpand: (id: number) => void;
   onExtend: (r: RosterRow) => void;
   onReset: (r: RosterRow) => void;
+  onHistory: (r: RosterRow) => void;
   onBypass: (userId: number, moduleId: string) => Promise<void>;
 }) {
   return (
@@ -815,7 +855,27 @@ function RosterCards({
                 </>
               )}
             </button>
-            <div style={{ display: "inline-flex", gap: 6 }}>
+            <div style={{ display: "inline-flex", gap: 6, flexWrap: "wrap" }}>
+              <button
+                type="button"
+                onClick={() => onHistory(r)}
+                style={{
+                  background: "transparent",
+                  color: NAVY,
+                  border: `1px solid ${LINE}`,
+                  padding: "6px 10px",
+                  borderRadius: 6,
+                  fontSize: 12,
+                  fontWeight: 700,
+                  cursor: "pointer",
+                  fontFamily: FONT,
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: 4,
+                }}
+              >
+                <History size={11} /> History
+              </button>
               <button
                 type="button"
                 onClick={() => onReset(r)}
@@ -1426,6 +1486,492 @@ function ResetEnrollmentDialog({
             )}
           </button>
         </div>
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Attempt history dialog
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// Surfaces every per-module + final quiz attempt for one learner. Used by the
+// owner to spot comprehension gaps ("Carlos failed compensation 3× — which
+// question keeps tripping him?") and resolve disputes.
+//
+// Backend returns answers + question_ids + correct_indexes (server-
+// authoritative). Prompt text + option labels are looked up locally from the
+// frontend curriculum bundle keyed by company_id.
+
+type Locale = "en" | "es";
+
+type AttemptRow = {
+  attempt_id: number;
+  module_id: string;
+  score: number;
+  passed: boolean;
+  attempted_at: string;
+  answers: (number | null)[];
+  question_ids: string[];
+  correct_indexes: number[];
+  per_question_correct: boolean[];
+};
+
+function humanModuleLabel(id: string): string {
+  if (id === "__final") return "Final mixed test";
+  return id
+    .split("-")
+    .map((w) => w[0]?.toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+function AttemptHistoryDialog({
+  row,
+  token,
+  onClose,
+}: {
+  row: RosterRow;
+  token: string | null;
+  onClose: () => void;
+}) {
+  const auth = useMemo(() => readRoleFromToken(token), [token]);
+  const companyId = auth?.companyId ?? null;
+  const curriculum = useMemo(
+    () => getCurriculum(companyId),
+    [companyId],
+  );
+  const questionLookup = useMemo<Map<string, QuizQuestion>>(() => {
+    const map = new Map<string, QuizQuestion>();
+    for (const q of curriculum.quiz) map.set(q.id, q);
+    return map;
+  }, [curriculum]);
+
+  const [attempts, setAttempts] = useState<AttemptRow[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [expandedAttempt, setExpandedAttempt] = useState<number | null>(null);
+  const [locale, setLocale] = useState<Locale>("en");
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const data = await api<{ learner: unknown; attempts: AttemptRow[] }>(
+          "GET",
+          `/lms/admin/learners/${row.user_id}/attempts`,
+          token,
+        );
+        if (!cancelled) setAttempts(data.attempts);
+      } catch (e) {
+        if (!cancelled) setError(String((e as Error).message));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [row.user_id, token]);
+
+  // Group attempts by module_id, preserving newest-first order from server.
+  const byModule = useMemo(() => {
+    const map = new Map<string, AttemptRow[]>();
+    for (const a of attempts ?? []) {
+      const arr = map.get(a.module_id) ?? [];
+      arr.push(a);
+      map.set(a.module_id, arr);
+    }
+    return map;
+  }, [attempts]);
+
+  const moduleIds: string[] = [...MODULE_ORDER, FINAL_MODULE_ID];
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Attempt history"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "rgba(15, 23, 42, 0.55)",
+        display: "grid",
+        placeItems: "center",
+        zIndex: 100,
+        padding: 16,
+      }}
+    >
+      <div
+        style={{
+          background: SURFACE,
+          borderRadius: RADIUS,
+          maxWidth: 820,
+          width: "100%",
+          maxHeight: "90vh",
+          overflow: "auto",
+          padding: 22,
+          fontFamily: FONT,
+          color: INK,
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            gap: 8,
+            marginBottom: 4,
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+              fontSize: 16,
+              fontWeight: 800,
+              color: INK,
+            }}
+          >
+            <History size={16} /> Attempt history — {row.tech_name}
+          </div>
+          <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+            <div
+              role="group"
+              aria-label="Language toggle"
+              style={{
+                display: "inline-flex",
+                background: LINE_SOFT,
+                borderRadius: 999,
+                padding: 2,
+                fontSize: 11,
+                fontWeight: 700,
+              }}
+            >
+              <button
+                type="button"
+                onClick={() => setLocale("en")}
+                style={{
+                  border: 0,
+                  borderRadius: 999,
+                  padding: "3px 10px",
+                  background: locale === "en" ? NAVY : "transparent",
+                  color: locale === "en" ? "#fff" : INK_MUTE,
+                  cursor: "pointer",
+                  fontFamily: FONT,
+                }}
+              >
+                EN
+              </button>
+              <button
+                type="button"
+                onClick={() => setLocale("es")}
+                style={{
+                  border: 0,
+                  borderRadius: 999,
+                  padding: "3px 10px",
+                  background: locale === "es" ? NAVY : "transparent",
+                  color: locale === "es" ? "#fff" : INK_MUTE,
+                  cursor: "pointer",
+                  fontFamily: FONT,
+                }}
+              >
+                ES
+              </button>
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close"
+              style={{
+                background: "transparent",
+                border: `1px solid ${LINE}`,
+                borderRadius: 6,
+                padding: 4,
+                cursor: "pointer",
+                color: INK_MUTE,
+                display: "inline-flex",
+              }}
+            >
+              <X size={14} />
+            </button>
+          </div>
+        </div>
+        <div style={{ fontSize: 12, color: INK_MUTE, marginBottom: 14 }}>
+          Every per-module quiz and final-mixed-test submission, newest first.
+          Click an attempt to see each question and the answer they picked.
+        </div>
+
+        {error && (
+          <div
+            style={{
+              background: "#FEF2F2",
+              border: `1px solid #FECACA`,
+              color: DANGER,
+              padding: 10,
+              borderRadius: 8,
+              fontSize: 12,
+              marginBottom: 10,
+            }}
+          >
+            {error}
+          </div>
+        )}
+
+        {attempts == null && !error ? (
+          <div style={{ padding: 40, textAlign: "center", color: INK_MUTE }}>
+            <Loader2 size={18} className="qleno-admin-spin" />
+          </div>
+        ) : attempts && attempts.length === 0 ? (
+          <div
+            style={{
+              padding: 24,
+              background: LINE_SOFT,
+              borderRadius: 8,
+              textAlign: "center",
+              fontSize: 13,
+              color: INK_MUTE,
+            }}
+          >
+            No quiz attempts yet — this learner hasn't submitted any quiz.
+          </div>
+        ) : (
+          <div style={{ display: "grid", gap: 12 }}>
+            {moduleIds.map((moduleId) => {
+              const moduleAttempts = byModule.get(moduleId) ?? [];
+              if (moduleAttempts.length === 0) return null;
+              return (
+                <div
+                  key={moduleId}
+                  style={{
+                    background: SURFACE,
+                    border: `1px solid ${LINE}`,
+                    borderRadius: 8,
+                    overflow: "hidden",
+                  }}
+                >
+                  <div
+                    style={{
+                      padding: "10px 12px",
+                      background: LINE_SOFT,
+                      fontWeight: 800,
+                      fontSize: 12,
+                      color: INK,
+                      letterSpacing: "0.04em",
+                      textTransform: "uppercase",
+                      display: "flex",
+                      justifyContent: "space-between",
+                    }}
+                  >
+                    <span>{humanModuleLabel(moduleId)}</span>
+                    <span style={{ color: INK_MUTE, fontWeight: 700 }}>
+                      {moduleAttempts.length}{" "}
+                      {moduleAttempts.length === 1 ? "attempt" : "attempts"}
+                    </span>
+                  </div>
+                  {moduleAttempts.map((a, idx) => {
+                    const open = expandedAttempt === a.attempt_id;
+                    const ordinal = moduleAttempts.length - idx;
+                    return (
+                      <div
+                        key={a.attempt_id}
+                        style={{
+                          borderTop: `1px solid ${LINE_SOFT}`,
+                        }}
+                      >
+                        <button
+                          type="button"
+                          onClick={() =>
+                            setExpandedAttempt(open ? null : a.attempt_id)
+                          }
+                          style={{
+                            width: "100%",
+                            background: "transparent",
+                            border: 0,
+                            padding: "10px 12px",
+                            display: "flex",
+                            alignItems: "center",
+                            justifyContent: "space-between",
+                            cursor: "pointer",
+                            fontFamily: FONT,
+                            fontSize: 13,
+                            color: INK,
+                            textAlign: "left",
+                          }}
+                        >
+                          <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+                            {open ? (
+                              <ChevronDown size={14} />
+                            ) : (
+                              <ChevronRight size={14} />
+                            )}
+                            <span style={{ fontWeight: 700 }}>
+                              Attempt {ordinal}
+                            </span>
+                            <span style={{ color: INK_MUTE, fontSize: 12 }}>
+                              {humanDateTime(a.attempted_at)}
+                            </span>
+                          </div>
+                          <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+                            <span
+                              style={{
+                                fontVariantNumeric: "tabular-nums",
+                                fontWeight: 800,
+                                color: a.passed ? SUCCESS : DANGER,
+                              }}
+                            >
+                              {a.score}%
+                            </span>
+                            <span
+                              style={{
+                                background: a.passed ? "#ECFDF5" : "#FEF2F2",
+                                color: a.passed ? SUCCESS : DANGER,
+                                border: `1px solid ${a.passed ? "#A7F3D0" : "#FECACA"}`,
+                                padding: "2px 8px",
+                                borderRadius: 999,
+                                fontSize: 11,
+                                fontWeight: 800,
+                              }}
+                            >
+                              {a.passed ? "Passed" : "Failed"}
+                            </span>
+                          </div>
+                        </button>
+                        {open ? (
+                          <div
+                            style={{
+                              padding: "0 12px 12px",
+                              display: "grid",
+                              gap: 8,
+                            }}
+                          >
+                            {a.question_ids.length === 0 ? (
+                              <div style={{ color: INK_MUTE, fontSize: 12 }}>
+                                Question text not available (curriculum may have
+                                changed since this attempt).
+                              </div>
+                            ) : (
+                              a.question_ids.map((qid, i) => {
+                                const q = questionLookup.get(qid);
+                                const picked = a.answers[i];
+                                const correctIdx = a.correct_indexes[i];
+                                const ok = a.per_question_correct[i];
+                                return (
+                                  <div
+                                    key={qid + "-" + i}
+                                    style={{
+                                      background: ok ? "#F0FDF4" : "#FEF2F2",
+                                      border: `1px solid ${ok ? "#BBF7D0" : "#FECACA"}`,
+                                      borderLeft: `3px solid ${ok ? SUCCESS : DANGER}`,
+                                      borderRadius: 6,
+                                      padding: "8px 10px",
+                                      fontSize: 12,
+                                    }}
+                                  >
+                                    <div
+                                      style={{
+                                        fontWeight: 800,
+                                        color: INK,
+                                        marginBottom: 4,
+                                      }}
+                                    >
+                                      {i + 1}.{" "}
+                                      {q?.prompt[locale] ?? `(Question ${qid} not found)`}
+                                    </div>
+                                    {q ? (
+                                      <div style={{ display: "grid", gap: 3 }}>
+                                        {q.options.map((opt, optIdx) => {
+                                          const isPicked = picked === optIdx;
+                                          const isCorrect = correctIdx === optIdx;
+                                          const tone = isCorrect
+                                            ? SUCCESS
+                                            : isPicked
+                                            ? DANGER
+                                            : INK_MUTE;
+                                          return (
+                                            <div
+                                              key={optIdx}
+                                              style={{
+                                                display: "flex",
+                                                gap: 6,
+                                                alignItems: "flex-start",
+                                                color: tone,
+                                                fontWeight:
+                                                  isPicked || isCorrect ? 700 : 500,
+                                              }}
+                                            >
+                                              <span
+                                                style={{
+                                                  display: "inline-flex",
+                                                  width: 14,
+                                                  flexShrink: 0,
+                                                  marginTop: 2,
+                                                }}
+                                              >
+                                                {isCorrect ? (
+                                                  <CircleCheck size={12} />
+                                                ) : isPicked ? (
+                                                  <X size={12} />
+                                                ) : null}
+                                              </span>
+                                              <span>{opt[locale]}</span>
+                                              {isPicked && !isCorrect ? (
+                                                <span
+                                                  style={{
+                                                    marginLeft: 4,
+                                                    fontSize: 10,
+                                                    color: DANGER,
+                                                    fontWeight: 800,
+                                                    textTransform: "uppercase",
+                                                  }}
+                                                >
+                                                  picked
+                                                </span>
+                                              ) : null}
+                                              {isCorrect ? (
+                                                <span
+                                                  style={{
+                                                    marginLeft: 4,
+                                                    fontSize: 10,
+                                                    color: SUCCESS,
+                                                    fontWeight: 800,
+                                                    textTransform: "uppercase",
+                                                  }}
+                                                >
+                                                  correct
+                                                </span>
+                                              ) : null}
+                                            </div>
+                                          );
+                                        })}
+                                        {picked == null ? (
+                                          <div
+                                            style={{
+                                              color: WARN,
+                                              fontSize: 11,
+                                              fontWeight: 700,
+                                              marginTop: 2,
+                                            }}
+                                          >
+                                            Left unanswered
+                                          </div>
+                                        ) : null}
+                                      </div>
+                                    ) : null}
+                                  </div>
+                                );
+                              })
+                            )}
+                          </div>
+                        ) : null}
+                      </div>
+                    );
+                  })}
+                </div>
+              );
+            })}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/lib/lms-curriculum/src/index.ts
+++ b/lib/lms-curriculum/src/index.ts
@@ -128,7 +128,10 @@ export const FINAL_TEST_SIZE = 50;
  * compares lms-curriculum to lib/training.
  */
 export const ANSWER_KEY: Readonly<Record<string, number>> = Object.freeze({
-  // ── Module 1: phes-policies (15) ─────────────────────────────────────────
+  // ── Module 1: phes-policies (23) ─────────────────────────────────────────
+  // 15 original + 8 added 2026-05-11 (handbook reconciliation: expanded
+  // "what we don't do", bereavement/jury/lactation/pregnancy, PTO cap +
+  // top-up, separation payout rules, 90-day holiday eligibility).
   "q-pp-01-w2": 1,
   "q-pp-02-guarantee": 2,
   "q-pp-03-scope-oven": 1,
@@ -144,6 +147,14 @@ export const ANSWER_KEY: Readonly<Record<string, number>> = Object.freeze({
   "q-pp-13-shoe-covers": 2,
   "q-pp-14-phone-use": 2,
   "q-pp-15-photos": 2,
+  "q-pp-16-dishes-beds": 1,
+  "q-pp-17-office-exception": 1,
+  "q-pp-18-bereavement": 1,
+  "q-pp-19-jury-duty": 1,
+  "q-pp-20-lactation": 1,
+  "q-pp-21-pto-cap": 1,
+  "q-pp-22-separation-payout": 1,
+  "q-pp-23-holiday-90day": 1,
 
   // ── Module 2: compensation (15) ──────────────────────────────────────────
   "q-cm-01-training-pay": 1,
@@ -226,6 +237,9 @@ export const QUESTIONS_BY_MODULE: Readonly<Record<QuizModuleId, readonly string[
       "q-pp-07-grace-window", "q-pp-08-tardy-progression", "q-pp-09-sick-tomorrow",
       "q-pp-10-pto-request", "q-pp-11-unexcused-fourth", "q-pp-12-uniform-forgot",
       "q-pp-13-shoe-covers", "q-pp-14-phone-use", "q-pp-15-photos",
+      "q-pp-16-dishes-beds", "q-pp-17-office-exception", "q-pp-18-bereavement",
+      "q-pp-19-jury-duty", "q-pp-20-lactation", "q-pp-21-pto-cap",
+      "q-pp-22-separation-payout", "q-pp-23-holiday-90day",
     ],
     compensation: [
       "q-cm-01-training-pay", "q-cm-02-standard-rate", "q-cm-03-deep-clean-rate",

--- a/lib/training/src/answer-key.ts
+++ b/lib/training/src/answer-key.ts
@@ -27,7 +27,7 @@
  * order of keys — it compares the maps as sets of (key, value) pairs.
  */
 export const SERVER_ANSWER_KEY: Readonly<Record<string, number>> = Object.freeze({
-  // ── Module 1: phes-policies ──────────────────────────────────────────────
+  // ── Module 1: phes-policies (23, handbook reconciliation 2026-05-11) ──────
   "q-pp-01-w2": 1,
   "q-pp-02-guarantee": 2,
   "q-pp-03-scope-oven": 1,
@@ -43,6 +43,14 @@ export const SERVER_ANSWER_KEY: Readonly<Record<string, number>> = Object.freeze
   "q-pp-13-shoe-covers": 2,
   "q-pp-14-phone-use": 2,
   "q-pp-15-photos": 2,
+  "q-pp-16-dishes-beds": 1,
+  "q-pp-17-office-exception": 1,
+  "q-pp-18-bereavement": 1,
+  "q-pp-19-jury-duty": 1,
+  "q-pp-20-lactation": 1,
+  "q-pp-21-pto-cap": 1,
+  "q-pp-22-separation-payout": 1,
+  "q-pp-23-holiday-90day": 1,
 
   // ── Module 2: compensation ───────────────────────────────────────────────
   "q-cm-01-training-pay": 1,


### PR DESCRIPTION
## Summary

Reconciles the LMS curriculum with the 2026 Employee Handbook + Attendance Policy after cross-checking both PDFs. Adds content + 8 new quiz questions to the `phes-policies` module (15 → 23 questions; total bank 75 → 83). The final mixed test still samples 50 — distribution just got broader.

### Content additions in phes-policies

**What Phes Does NOT Do — expanded list**
- Original 5 bullets retained (bodily fluids, oven/fridge, pet waste, cash on site, climbing furniture)
- New 4 bullets: wash dishes, make beds, move heavy furniture, clean window tracks
- New callout: standard guidelines; the office may grant exceptions for slower weeks / loyal clients / partners via app notes or direct message. If a client asks outside scope and there's no note, decline politely and inform the office.

**PTO — clarified rules**
- 1 year: 40h. 2 years+: bank topped up to 80h each anniversary.
- HARD CAP at 80h. Unused PTO does not stack — Phes tops UP to the cap, does not add ON TOP.
- Worked example: used 20 of 40 in year 1 → at 2-yr anniversary, bank is 80 (not 100).

**What gets paid out at separation (new section)**
- PTO: paid out per Illinois Wage Payment & Collection Act.
- PLAWA (sick): NOT paid out. No cash value.
- Holidays: not banked.

**Paid Holidays — 90-day eligibility callout**
- Holiday pay starts AFTER 90 days of employment. Any holiday in the first 90 days is unpaid.

**Other leave types (new sections)**
- Bereavement: up to 3 paid days at regular rate for immediate family (spouse, child, parent, sibling). Extended family handled case-by-case as unpaid.
- Jury duty: unpaid by Phes, job protected, tech keeps court juror pay. Illinois legal minimum.
- Lactation: paid at regular rate, not deducted from PLAWA/PTO. Office coordinates timing + private location.
- Pregnancy accommodation: Illinois reasonable accommodation (lighter duties, more breaks, modified schedule, temporary reassignment).

### 8 new quiz questions (q-pp-16 through q-pp-23)

| ID | Topic |
|----|-------|
| `q-pp-16-dishes-beds` | Scope handling when client asks outside scope |
| `q-pp-17-office-exception` | How to handle app-note exceptions |
| `q-pp-18-bereavement` | 3 paid days for immediate family |
| `q-pp-19-jury-duty` | Unpaid, job protected, keep court pay |
| `q-pp-20-lactation` | Paid at regular rate, not deducted from PLAWA/PTO |
| `q-pp-21-pto-cap` | 80h cap, top-up not stack-up |
| `q-pp-22-separation-payout` | PTO yes, PLAWA no |
| `q-pp-23-holiday-90day` | Holiday pay starts after 90 days |

All keyed identically across the three answer-key sources (frontend `curriculum.ts`, shared `lms-curriculum`, server `training/answer-key`). The drift-sync test ensures they stay in sync.

### Test updates

- `phes-policies` count check: 23 (new test)
- Non-policies modules: still exactly 15 each
- Total `ALL_QUESTION_IDS`: 83 (was 75)
- 12/15 and 11/15 boundary tests switched to `compensation` module (still 15 questions) so the math remains unchanged

### Decisions captured this session

| Topic | Decision |
|-------|----------|
| Attendance thresholds | Handbook (5 / Benefit Year) — canonical |
| Discipline progression | Handbook (1–2 recorded, 3 written, 4 final, 5 termination) |
| Bereavement | 3 paid days, immediate family |
| Jury duty | Unpaid (IL legal minimum) |
| PTO cap | 80h hard cap, top-up not stack-up |
| Separation payout | PTO paid out, PLAWA NOT paid out |
| Holidays | 90-day waiting period before eligibility |

## Outstanding (NOT in this PR — doc side, not code)

The two source PDFs **still disagree** with each other and with the LMS on:

1. **Tardy/absence cadence** — Attendance Policy says 3 tardies/quarter and 4 absences/calendar year. Per our decision, this needs to be rewritten to match the Handbook (5 / Benefit Year).
2. **Discipline progression** — Attendance Policy starts with "verbal warning at offense 1" and mentions "loss of scheduling flexibility" + "suspension". Per our decision, rewrite to match the Handbook (offenses 1–2 recorded, 3 written, 4 final, 5 termination).
3. **Bereavement / lactation / jury duty / pregnancy accommodation** — neither doc fully defines these. The Handbook references VESSA and lactation but not bereavement or jury duty. The Attendance Policy references "bereavement, jury duty, pregnancy accommodation" as protected absences without specifics.

You'll need to amend the Handbook and the Attendance Policy PDFs to mirror what's now in the LMS so all three say the same thing. The LMS quiz answer keys are the new source of truth.

## Test plan

- [x] `pnpm --filter @workspace/api-server run test:lms` — 69/69 pass
- [x] `pnpm run build` — clean
- [x] `tsc --noEmit` on changed files — no new errors
- [ ] Manual: open /training in EN → confirm "What Phes Does NOT Do" lists 9 items + the exception callout
- [ ] Manual: scroll to PTO → confirm 80h-cap example callout renders
- [ ] Manual: switch locale to ES → all new content renders translated
- [ ] Manual: take the phes-policies quiz → confirm 23 questions, the 8 new ones surface in order

https://claude.ai/code/session_013rJ4N4vgqZWB986x8D6Ahh

---
_Generated by [Claude Code](https://claude.ai/code/session_013rJ4N4vgqZWB986x8D6Ahh)_