### PR TITLE
feat(lms): extend bypass + admin access to office role (Maribel, Francisco)

### DIFF
--- a/artifacts/api-server/src/routes/lms.ts
+++ b/artifacts/api-server/src/routes/lms.ts
@@ -298,6 +298,14 @@ router.get("/me", requireAuth, async (req, res) => {
     for (const m of MODULE_ORDER) limits[m] = MAX_MODULE_ATTEMPTS;
     limits[FINAL_MODULE_ID] = MAX_FINAL_ATTEMPTS;
 
+    // Bypass capability: owners, admins, and office staff (Maribel, Francisco
+    // for Phes) can skip modules. This `is_owner` field is kept for the
+    // existing frontend prop name; semantically it now means "can_bypass".
+    const canBypass =
+      req.auth!.role === "owner" ||
+      req.auth!.role === "admin" ||
+      req.auth!.role === "office";
+
     return res.json({
       data: {
         enrollment,
@@ -305,7 +313,8 @@ router.get("/me", requireAuth, async (req, res) => {
         unlocked,
         days_remaining: daysUntil(enrollment.deadline_at, now),
         limits,
-        is_owner: req.auth!.role === "owner",
+        is_owner: canBypass,
+        can_bypass: canBypass,
       },
     });
   } catch (err) {
@@ -591,15 +600,18 @@ router.post("/quiz/submit", requireAuth, async (req, res) => {
       });
     }
 
-    // Attempts gate: 3 per module, 4 for the final. Owners are exempt — they
-    // can still submit but the cap doesn't apply to them. Already-passed
-    // modules are also exempt (re-takes for review).
-    const isOwner = req.auth!.role === "owner";
+    // Attempts gate: 3 per module, 4 for the final. Owners / admins / office
+    // staff are exempt — they can still submit but the cap doesn't apply to
+    // them. Already-passed modules are also exempt (re-takes for review).
+    const canBypassCap =
+      req.auth!.role === "owner" ||
+      req.auth!.role === "admin" ||
+      req.auth!.role === "office";
     const existing = progress.find((p) => p.module_id === moduleId);
     const attemptsSoFar = existing?.attempts ?? 0;
     const alreadyPassed = existing?.status === "passed";
     const maxAttempts = maxAttemptsFor(moduleId);
-    if (!isOwner && !alreadyPassed && attemptsSoFar >= maxAttempts) {
+    if (!canBypassCap && !alreadyPassed && attemptsSoFar >= maxAttempts) {
       return res.status(403).json({
         error: "Forbidden",
         message:
@@ -920,7 +932,7 @@ router.post("/grandfather", requireAuth, async (req, res) => {
 router.get(
   "/admin/learners",
   requireAuth,
-  requireRole("owner", "admin"),
+  requireRole("owner", "admin", "office"),
   async (req, res) => {
     try {
       const companyId = req.auth!.companyId;
@@ -1059,7 +1071,7 @@ router.get(
 router.post(
   "/admin/extend",
   requireAuth,
-  requireRole("owner", "admin"),
+  requireRole("owner", "admin", "office"),
   async (req, res) => {
     try {
       const companyId = req.auth!.companyId;
@@ -1159,7 +1171,7 @@ router.post(
 router.post(
   "/admin/bypass-module",
   requireAuth,
-  requireRole("owner", "admin"),
+  requireRole("owner", "admin", "office"),
   async (req, res) => {
     try {
       const companyId = req.auth!.companyId;
@@ -1275,7 +1287,7 @@ router.post(
 router.post(
   "/admin/reset",
   requireAuth,
-  requireRole("owner", "admin"),
+  requireRole("owner", "admin", "office"),
   async (req, res) => {
     try {
       const companyId = req.auth!.companyId;
@@ -1406,7 +1418,7 @@ router.post(
 router.get(
   "/admin/learners/:userId/attempts",
   requireAuth,
-  requireRole("owner", "admin"),
+  requireRole("owner", "admin", "office"),
   async (req, res) => {
     try {
       const companyId = req.auth!.companyId;

--- a/artifacts/qleno/src/components/layout/app-sidebar.tsx
+++ b/artifacts/qleno/src/components/layout/app-sidebar.tsx
@@ -89,7 +89,7 @@ const NAV_SECTIONS = [
       { title: "Settings",        url: "/company",         icon: Settings, roles: ["owner", "admin"] },
       { title: "Cleancyclopedia", url: "/cleancyclopedia", icon: BookOpen },
       { title: "Training",        url: "/training",        icon: GraduationCap },
-      { title: "Training Admin",  url: "/lms/admin",       icon: GraduationCap, roles: ["owner", "admin", "super_admin"] },
+      { title: "Training Admin",  url: "/lms/admin",       icon: GraduationCap, roles: ["owner", "admin", "super_admin", "office"] },
     ],
   },
 ];

--- a/artifacts/qleno/src/pages/lms-admin.tsx
+++ b/artifacts/qleno/src/pages/lms-admin.tsx
@@ -129,7 +129,11 @@ function useViewportIsMobile(): boolean {
 export default function LmsAdminPage() {
   const token = useAuthStore((s) => s.token);
   const auth = useMemo(() => readRoleFromToken(token), [token]);
-  const isAuthorized = auth?.role === "owner" || auth?.role === "admin" || auth?.role === "super_admin";
+  const isAuthorized =
+    auth?.role === "owner" ||
+    auth?.role === "admin" ||
+    auth?.role === "super_admin" ||
+    auth?.role === "office";
   const isMobile = useViewportIsMobile();
   const [rows, setRows] = useState<RosterRow[] | null>(null);
   const [error, setError] = useState<string | null>(null);


### PR DESCRIPTION
## Summary

Extends LMS bypass capability + admin portal access to the `office` role so Maribel and Francisco at Phes can use the same shortcuts the owner uses.

### Backend changes

- `POST /lms/admin/bypass-module` now `requireRole('owner','admin','office')`
- Same for `/admin/learners`, `/admin/extend`, `/admin/reset`, `/admin/learners/:userId/attempts` — the full admin surface
- `GET /lms/me` returns `can_bypass: true` for office roles too. Adds a new `can_bypass` field alongside the legacy `is_owner` field for semantic clarity; both are set so existing frontend Skip-button logic keeps working without a UI change
- Attempt cap exemption in `/quiz/submit` extended from owner-only to owner/admin/office

### Frontend changes

- Sidebar **Training Admin** link visible to office role
- `/lms/admin` authorization check accepts office role

### Tenant gating unchanged

Office staff can only bypass / reset users in their own company. No cross-tenant leakage.

## Test plan

- [x] `pnpm --filter @workspace/api-server run test:lms` — 69/69 pass
- [x] `pnpm run build` — clean
- [ ] Manual: sign in as `maribel@phes.io` → sidebar shows **Training Admin** → click → roster loads
- [ ] Manual: same user → `/training` → Skip (Owner) buttons render on every unfinished module
- [ ] Manual: same user → click Skip on a module → marks passed
- [ ] Manual: tenant guard — Maribel cannot reset/bypass a user in another tenant (404)

https://claude.ai/code/session_013rJ4N4vgqZWB986x8D6Ahh

---
_Generated by [Claude Code](https://claude.ai/code/session_013rJ4N4vgqZWB986x8D6Ahh)_