### PR TITLE
fix(lms): hide '3/3 attempts' counter for owners/admins

### DIFF
--- a/artifacts/qleno/src/pages/training.tsx
+++ b/artifacts/qleno/src/pages/training.tsx
@@ -1163,7 +1163,7 @@ function ModuleRow({
           {m.estimatedMinutes} min
           {isQuizModule ? ` · ${tr("pass80", locale)}` : ""}
           {status === "passed" && bestScore > 0 ? ` · ${bestScore}%` : ""}
-          {isQuizModule && status !== "passed" ? (
+          {isQuizModule && status !== "passed" && !isOwner ? (
             <span
               style={{
                 marginLeft: 6,
@@ -1335,7 +1335,7 @@ function FinalStepCard({
         >
           {tr("finalIntro", locale)}
         </div>
-        {!passed ? (
+        {!passed && !isOwner ? (
           <div
             style={{
               fontSize: 11,
@@ -1347,7 +1347,7 @@ function FinalStepCard({
           >
             {attempts}/{maxAttempts} {tr("attempt", locale).toLowerCase()}
             {attempts === 1 ? "" : "s"}
-            {atCap && !isOwner ? ` · ${tr("noAttemptsLeft", locale)}` : ""}
+            {atCap ? ` · ${tr("noAttemptsLeft", locale)}` : ""}
           </div>
         ) : null}
       </button>


### PR DESCRIPTION
## Summary

User logged in as Owner saw `3/3 ATTEMPTS` in red on the "Phes Policies & Procedures" module — misleading because the server already exempts owners / admins / office staff from the attempt cap (`canBypassCap` in `routes/lms.ts` ~line 605-614). The visual contradicts the actual behavior.

## What changed

`artifacts/qleno/src/pages/training.tsx`:

1. **Module roster card** (line ~1166): the `· N/maxAttempts attempts` span is now hidden when `isOwner` is true. Privileged users see the module description + duration + pass threshold but no attempt counter.
2. **Final-exam intro card** (line ~1338): same treatment — the attempts row + "no attempts left" callout are wrapped in `!isOwner`.

`isOwner` is sourced from `state.is_owner` which the server sets via the `canBypass` check (owner / admin / office). No backend change needed.

## What's preserved

- The "Skip (Owner)" bypass button still renders — that's a different control that lets the owner skip a module entirely, which is intentional UX for previewing.
- Regular techs still see "0/3", "1/3", "2/3", "3/3" as they should.
- The "Ask your admin to extend or bypass" message is unchanged on the regular-user path.

## Test plan

- [ ] Log in as Owner / Admin → `/training`: module cards show no attempt counter; can keep retrying a quiz with no "you've used all attempts" lockout.
- [ ] Log in as a regular tech → `/training`: still see `0/3 attempts`, `1/3`, etc. After 3 fails the lockout copy appears as before.
- [ ] Final-exam intro card: same split — owners see no counter, techs see `N/4 attempts`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AxGiirnJ3dT4GAzHPNWhrx)_