### PR TITLE
fix(lms): owners can click into any module to preview content

### DIFF
--- a/artifacts/qleno/src/pages/training.tsx
+++ b/artifacts/qleno/src/pages/training.tsx
@@ -948,12 +948,14 @@ function Home({
           const isAck = moduleId === "acknowledgment";
           const isContent = !QUIZ_MODULE_IDS.includes(moduleId as never) && !isAck;
 
-          // The acknowledgment card has its own gating + handler
+          // The acknowledgment card has its own gating + handler.
+          // Owners and admins can open any module to preview the content,
+          // regardless of the sequential gate — they're not learners.
           const handler = isAck
-            ? ackUnlocked
+            ? (ackUnlocked || isOwner)
               ? onOpenAck
               : undefined
-            : unlocked
+            : (unlocked || isOwner)
             ? () => onOpenModule(moduleId)
             : undefined;
 
@@ -1094,7 +1096,7 @@ function ModuleRow({
         borderRadius: RADIUS,
         padding: "14px 16px",
         textAlign: "left",
-        opacity: unlocked ? 1 : 0.5,
+        opacity: (unlocked || isOwner) ? 1 : 0.5,
         fontFamily: FONT,
         position: "relative",
         overflow: "hidden",
@@ -1204,7 +1206,7 @@ function ModuleRow({
             <CircleCheck size={14} />
             {tr("passed", locale)}
           </>
-        ) : !unlocked ? (
+        ) : !unlocked && !isOwner ? (
           <>
             <Lock size={14} />
             {tr("locked", locale)}
@@ -1366,7 +1368,7 @@ function FinalStepCard({
             <CircleCheck size={14} style={{ verticalAlign: "middle" }} />{" "}
             {tr("passed", locale)}
           </>
-        ) : !unlocked ? (
+        ) : !unlocked && !isOwner ? (
           <>
             <Lock size={14} style={{ verticalAlign: "middle" }} />{" "}
             {tr("locked", locale)}


### PR DESCRIPTION
## Summary

User: *"as the owner and admins we should be able to click into any module and see whats in it. I hit skipped and it just marked it as done but did not let me skip."*

The Home roster gated module clicks on the sequential `unlocked` flag. Even after the row visually showed a **Skip (Owner)** button, the row title itself was non-clickable for owners when the preceding module hadn't been passed — and Skip immediately marked the module done with no chance to read the content first.

## What changed

`artifacts/qleno/src/pages/training.tsx` — three small spots:

1. **Click handler** — `(unlocked || isOwner) ? openModule : undefined` for both the regular module rows and the acknowledgment card. Owners can now click any tile to read the module body + preview the quiz questions.
2. **Visual opacity** — rows are full-opacity for owners regardless of the sequential gate (was 0.5 dim when locked).
3. **'Locked' badge** with the padlock no longer renders for owners on either the home row or the final-card variant — the action chip flips to an interactive button instead, exposing both *Start / Resume* and the existing *Skip (Owner)* button.

Skip behavior unchanged (POST `/lms/admin/bypass-module` still marks the module passed) — the difference is owners can now enter and read before deciding whether to skip.

## Test plan

- [ ] Log in as Owner → `/training`: every module row is clickable, full-opacity, no "Locked" pill.
- [ ] Click Module 5 (Products & Tools) without finishing Module 1: opens the module content view; can scroll, see callouts, read all content; the "Skip (Owner)" button is still available at the bottom.
- [ ] Hit "Take quiz" inside that module as Owner: quiz loads, can submit; on fail can retry (no attempt lockout — confirmed in earlier PR #75).
- [ ] Log in as regular tech → `/training`: locked modules still show the padlock + are non-clickable until prior modules pass. No behavior regression for learners.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AxGiirnJ3dT4GAzHPNWhrx)_