### PR TITLE
fix(lms): hide '4 days remaining' deadline badge for owners/admins

### DIFF
--- a/artifacts/qleno/src/pages/training.tsx
+++ b/artifacts/qleno/src/pages/training.tsx
@@ -471,6 +471,7 @@ export default function TrainingPage() {
           locale={locale}
           setLocale={setLocale}
           daysRemaining={state?.days_remaining ?? null}
+          isOwner={!!state?.is_owner}
         />
         <div
           style={{
@@ -526,6 +527,7 @@ export default function TrainingPage() {
         locale={locale}
         setLocale={setLocale}
         daysRemaining={state.days_remaining}
+        isOwner={!!state.is_owner}
       />
       {view.kind === "home" && (
         <Home
@@ -665,11 +667,13 @@ function Header({
   locale,
   setLocale,
   daysRemaining,
+  isOwner = false,
 }: {
   tenantName: string;
   locale: Locale;
   setLocale: (l: Locale) => void;
   daysRemaining: number | null;
+  isOwner?: boolean;
 }) {
   return (
     <header
@@ -727,7 +731,9 @@ function Header({
         </div>
       </div>
       <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
-        {daysRemaining != null && <DeadlineBadge days={daysRemaining} locale={locale} />}
+        {daysRemaining != null && !isOwner && (
+          <DeadlineBadge days={daysRemaining} locale={locale} />
+        )}
         <LocaleToggle locale={locale} setLocale={setLocale} />
       </div>
     </header>


### PR DESCRIPTION
## Summary

User: *"also remove the 4 days remaining this is only for employee technicians."*

The deadline countdown is a learner-facing pressure cue — techs need to know how long they have to complete training before the office follows up. Owners and admins aren't learners; the badge is noise in their view and implies they're being timed against a deadline that doesn't apply to them.

## What changed

`artifacts/qleno/src/pages/training.tsx`:

- `Header` takes a new optional `isOwner` prop (default `false` for back-compat).
- `DeadlineBadge` render gated on `!isOwner` in addition to the existing `daysRemaining != null` check.
- Both Header call sites (the loading-state Header and the main-view Header) pass `isOwner={!!state.is_owner}` so the flag propagates correctly.

No data / API changes — `state.days_remaining` is still computed server-side; we just don't render the badge for privileged roles.

## Test plan

- [ ] Log in as Owner → `/training`: no "4 days remaining" green pill at the top. EN/ES toggle still on the right.
- [ ] Log in as a regular tech → `/training`: deadline badge still renders ("N days remaining", "today", or "N days overdue" depending on state).


---
_Generated by [Claude Code](https://claude.ai/code/session_01AxGiirnJ3dT4GAzHPNWhrx)_