### PR TITLE
fix(lms): hide attempt UI from owners across all surfaces

### DIFF
--- a/artifacts/api-server/src/tests/lms-curriculum.test.ts
+++ b/artifacts/api-server/src/tests/lms-curriculum.test.ts
@@ -25,6 +25,7 @@ import {
   maxAttemptsFor,
   sampleFinalQuestionIds,
   scoreQuiz,
+  shouldShowLearnerGating,
 } from "@workspace/lms-curriculum";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -435,5 +436,32 @@ describe("max attempt constants", () => {
     // (different endpoint), but the helper still classifies it under the
     // default 3-attempt bucket.
     assert.equal(maxAttemptsFor("acknowledgment"), 3);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// shouldShowLearnerGating — the "hide learner-only UI from owners" predicate
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("shouldShowLearnerGating", () => {
+  it("returns true for a regular learner (isOwner=false)", () => {
+    // Techs see the attempt counter, attempts-remaining text, deadline
+    // badge, and lockout messages. Default LMS behavior.
+    assert.equal(shouldShowLearnerGating(false), true);
+  });
+
+  it("returns false for an owner (isOwner=true)", () => {
+    // Owners are exempt from the cap on the server (canBypassCap in
+    // routes/lms.ts), so the gating UI must not render for them either.
+    assert.equal(shouldShowLearnerGating(true), false);
+  });
+
+  it("is the single inversion of isOwner — used as the named UI predicate", () => {
+    // Documents the intended call sites: anywhere a `!isOwner` check
+    // appears in a `&&` chain guarding learner-only gating UI, swap in
+    // shouldShowLearnerGating(isOwner) so the predicate is the greppable
+    // surface for future "hide this from owners" requests.
+    assert.equal(shouldShowLearnerGating(false), !false);
+    assert.equal(shouldShowLearnerGating(true), !true);
   });
 });

--- a/artifacts/qleno/src/pages/training.tsx
+++ b/artifacts/qleno/src/pages/training.tsx
@@ -45,6 +45,7 @@ import {
   MAX_MODULE_ATTEMPTS,
   MAX_FINAL_ATTEMPTS,
   maxAttemptsFor,
+  shouldShowLearnerGating,
   isModuleUnlocked,
   isFinalUnlocked,
   type ModuleId,
@@ -588,6 +589,7 @@ export default function TrainingPage() {
           priorAttempts={
             state.progress.find((p) => p.module_id === view.moduleId)?.attempts ?? 0
           }
+          isOwner={!!state.is_owner}
           onCancel={() => setView({ kind: "module", moduleId: view.moduleId })}
           onPassed={async () => {
             await refresh();
@@ -611,6 +613,7 @@ export default function TrainingPage() {
           priorAttempts={
             state.progress.find((p) => p.module_id === FINAL_MODULE_ID)?.attempts ?? 0
           }
+          isOwner={!!state.is_owner}
           onCancel={() => setView({ kind: "home" })}
           onPassed={async () => {
             await refresh();
@@ -667,6 +670,10 @@ function useIsMobile(): boolean {
   }, []);
   return isMobile;
 }
+
+// shouldShowLearnerGating(isOwner) is imported from @workspace/lms-curriculum
+// so the predicate has a single home and stays unit-tested. See the imports
+// block at the top of this file.
 
 function PageShell({ children }: { children: React.ReactNode }) {
   return (
@@ -765,7 +772,7 @@ function Header({
           justifyContent: isMobile ? "flex-end" : "flex-start",
         }}
       >
-        {daysRemaining != null && !isOwner && (
+        {daysRemaining != null && shouldShowLearnerGating(isOwner) && (
           <DeadlineBadge days={daysRemaining} locale={locale} />
         )}
         <LocaleToggle locale={locale} setLocale={setLocale} compact={isMobile} />
@@ -1202,7 +1209,7 @@ function ModuleRow({
         {m.estimatedMinutes} min
         {isQuizModule ? ` · ${tr("pass80", locale)}` : ""}
         {status === "passed" && bestScore > 0 ? ` · ${bestScore}%` : ""}
-        {isQuizModule && status !== "passed" && !isOwner ? (
+        {isQuizModule && status !== "passed" && shouldShowLearnerGating(isOwner) ? (
           <span
             style={{
               marginLeft: 6,
@@ -1214,7 +1221,7 @@ function ModuleRow({
           </span>
         ) : null}
       </div>
-      {atCap && !isOwner ? (
+      {atCap && shouldShowLearnerGating(isOwner) ? (
         <div
           style={{
             fontSize: 11,
@@ -1465,7 +1472,7 @@ function FinalStepCard({
             <div style={{ fontSize: 12, opacity: 0.85, marginTop: 3, lineHeight: 1.4 }}>
               {tr("finalIntro", locale)}
             </div>
-            {!passed && !isOwner ? (
+            {!passed && shouldShowLearnerGating(isOwner) ? (
               <div
                 style={{
                   fontSize: 11,
@@ -1513,7 +1520,7 @@ function FinalStepCard({
             >
               {tr("finalIntro", locale)}
             </div>
-            {!passed && !isOwner ? (
+            {!passed && shouldShowLearnerGating(isOwner) ? (
               <div
                 style={{
                   fontSize: 11,
@@ -1717,16 +1724,16 @@ function ModuleView({
         {m.blocks.map((b, i) => (
           <Block key={i} block={b} locale={locale} />
         ))}
-        {isQuizModule ? (
+        {isQuizModule && shouldShowLearnerGating(isOwner) ? (
           <div
             style={{
               marginTop: 18,
               padding: "10px 12px",
-              background: atCap && !isOwner ? "#FEF2F2" : LINE_SOFT,
-              border: `1px solid ${atCap && !isOwner ? "#FECACA" : LINE}`,
+              background: atCap ? "#FEF2F2" : LINE_SOFT,
+              border: `1px solid ${atCap ? "#FECACA" : LINE}`,
               borderRadius: 8,
               fontSize: 12,
-              color: atCap && !isOwner ? DANGER : INK_MUTE,
+              color: atCap ? DANGER : INK_MUTE,
               fontWeight: 700,
               display: "flex",
               justifyContent: "space-between",
@@ -1742,7 +1749,7 @@ function ModuleView({
                 : ""}
             </span>
             <span>
-              {atCap && !isOwner
+              {atCap
                 ? tr("noAttemptsLeft", locale)
                 : `${Math.max(0, maxAttempts - attempts)} ${tr("attemptsRemaining", locale)}`}
             </span>
@@ -1955,6 +1962,7 @@ function QuizView({
   locale,
   token,
   priorAttempts,
+  isOwner,
   onCancel,
   onPassed,
 }: {
@@ -1963,6 +1971,7 @@ function QuizView({
   locale: Locale;
   token: string | null;
   priorAttempts: number;
+  isOwner: boolean;
   onCancel: () => void;
   onPassed: () => Promise<void>;
 }) {
@@ -2070,6 +2079,7 @@ function QuizView({
         attemptsRemaining={attemptsRemaining}
         maxAttempts={result.max_attempts ?? maxAttempts}
         passThreshold={PASS_THRESHOLD_PCT}
+        isOwner={isOwner}
         onContinue={async () => {
           if (result.passed) {
             await onPassed();
@@ -2139,20 +2149,22 @@ function QuizView({
             {" · "}
             {cursor + 1} / {total}
           </div>
-          <div
-            style={{
-              fontSize: 11,
-              color: INK_MUTE,
-              fontWeight: 800,
-              textTransform: "uppercase",
-              letterSpacing: "0.06em",
-              background: LINE_SOFT,
-              padding: "3px 8px",
-              borderRadius: 999,
-            }}
-          >
-            {tr("attempt", locale)} {currentAttempt} {tr("of", locale)} {maxAttempts}
-          </div>
+          {shouldShowLearnerGating(isOwner) ? (
+            <div
+              style={{
+                fontSize: 11,
+                color: INK_MUTE,
+                fontWeight: 800,
+                textTransform: "uppercase",
+                letterSpacing: "0.06em",
+                background: LINE_SOFT,
+                padding: "3px 8px",
+                borderRadius: 999,
+              }}
+            >
+              {tr("attempt", locale)} {currentAttempt} {tr("of", locale)} {maxAttempts}
+            </div>
+          ) : null}
         </div>
         <div
           style={{
@@ -2298,6 +2310,7 @@ function ResultView({
   attemptsRemaining,
   maxAttempts,
   passThreshold,
+  isOwner,
   onContinue,
 }: {
   locale: Locale;
@@ -2305,10 +2318,14 @@ function ResultView({
   attemptsRemaining: number;
   maxAttempts: number;
   passThreshold: number;
+  isOwner: boolean;
   onContinue: () => void;
 }) {
   const { passed, score } = result;
-  const noMoreRetries = !passed && attemptsRemaining <= 0;
+  // Owners are never "out of attempts" — the server bypasses the cap
+  // and the UI matches that. Treat as if attempts remain.
+  const noMoreRetries =
+    !passed && shouldShowLearnerGating(isOwner) && attemptsRemaining <= 0;
   return (
     <div style={{ maxWidth: 480, margin: "60px auto", padding: 18 }}>
       <div
@@ -2331,7 +2348,7 @@ function ResultView({
         <div style={{ marginTop: 8, fontSize: 13, color: INK_MUTE }}>
           {score}% · {passThreshold}% {locale === "en" ? "to pass" : "para aprobar"}
         </div>
-        {!passed ? (
+        {!passed && shouldShowLearnerGating(isOwner) ? (
           <div
             style={{
               marginTop: 10,

--- a/lib/lms-curriculum/src/index.ts
+++ b/lib/lms-curriculum/src/index.ts
@@ -104,6 +104,27 @@ export function maxAttemptsFor(moduleId: string): number {
 }
 
 /**
+ * Returns true when this user should see learner-only UI: attempt
+ * counters, "attempts remaining" copy, lockout messages, deadline
+ * countdowns — anything that exists to pressure a learner toward
+ * completing the module on a schedule.
+ *
+ * Owners and admins always return false. They get the bypass /
+ * preview path instead; the attempt cap is never enforced against
+ * them on the server (see canBypassCap in routes/lms.ts), so the
+ * UI must match.
+ *
+ * Lives here (not in training.tsx) so it can be unit-tested with the
+ * existing lms-curriculum.test.ts harness without spinning up React.
+ * Any new learner-gating widget added to training.tsx, the LMS admin
+ * surface, or the field app should consume this predicate so the
+ * next "hide this from owners" request has one place to extend.
+ */
+export function shouldShowLearnerGating(isOwner: boolean): boolean {
+  return !isOwner;
+}
+
+/**
  * Number of questions sampled for the final mixed test. Drawn at random
  * (without replacement) across every QUIZ_MODULE_IDS. If the curriculum has
  * fewer than this many total questions, the final uses every question.


### PR DESCRIPTION
## Summary

User screenshot showed an owner viewing the Phes Policies module with **"Attempt 3 of 3 · best: 100% · 0 attempts remaining"** rendered alongside the "Skip (Owner)" button. Owners are exempt from the attempt cap on the server (`canBypassCap` in `routes/lms.ts`), so the UI must match: no counter, no "attempts remaining" text, no lockout messaging.

## Audit — 3 leak surfaces found

PR #75 already gated the Home roster card. Three remaining UIs still rendered attempt-state to owners:

1. **ModuleView attempt panel** ("Attempt X of Y · best: N%") inside every module reading view — the widget from the screenshot.
2. **QuizView "Attempt X of Y" pill** on the running quiz screen.
3. **ResultView "N attempts remaining" / "No attempts left"** after a failed submission.

All three now check `shouldShowLearnerGating(isOwner)` before rendering.

## Shared predicate

Added `shouldShowLearnerGating(isOwner)` to `@workspace/lms-curriculum` so it can be unit-tested in the existing `node:test` harness AND consumed by both the LMS admin surface and `training.tsx` without duplication. Existing `!isOwner` checks at the four pure UI-hide sites (deadline badge, home metadata, home "no attempts" badge, final-step attempt counter) swapped to use the predicate for consistency. Behavior-gate sites (`atCap` disable, `unlocked` navigation) intentionally left as `!isOwner` since they encode different semantics.

## Wiring

`QuizView` and `ResultView` now take an `isOwner` prop, passed down from the top-level `state.is_owner`. Both `QuizView` call sites (regular and final-exam) updated.

## Tests

3 new unit tests in `lms-curriculum.test.ts` covering the predicate (learner sees gating, owner doesn't, predicate equals `!isOwner`).

**72/72 LMS unit tests pass. Production build clean.**

## Test plan

- [ ] Log in as Owner → open any module: no attempt panel inside the reading view; no "Attempt X of Y" pill when taking the quiz; no "N attempts remaining" after submit
- [ ] Log in as a regular tech → all the above still render
- [ ] Mobile + desktop both verified — single JSX path

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxGiirnJ3dT4GAzHPNWhrx)_