### PR TITLE
feat(auth): set all Phes techs to Chicago23 + bulk-reset admin tool

### DIFF
--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -11,6 +11,7 @@
 
 import { db } from "@workspace/db";
 import { sql } from "drizzle-orm";
+import bcrypt from "bcryptjs";
 import { geocodeWithComponents } from "./lib/geocode";
 
 const PHES = 1; // company_id
@@ -48,6 +49,12 @@ async function runBookingSchemaGuard(): Promise<void> {
     { label: "users.residential_pay_rate", stmt: "ALTER TABLE users ADD COLUMN IF NOT EXISTS residential_pay_rate NUMERIC(8,4) DEFAULT 0.35" },
     { label: "users.commercial_pay_type",  stmt: "ALTER TABLE users ADD COLUMN IF NOT EXISTS commercial_pay_type  TEXT DEFAULT 'hourly'" },
     { label: "users.commercial_pay_rate",  stmt: "ALTER TABLE users ADD COLUMN IF NOT EXISTS commercial_pay_rate  NUMERIC(8,4) DEFAULT 20.0000" },
+    // [phes-chicago23 2026-05-12] One-shot password reset gate. NULL means
+    // this user has not yet had their password set to Chicago23 by the
+    // cold-start runPhesPasswordResetChicago23() function below. After that
+    // function runs once per user, the timestamp is set and the user is
+    // never auto-reset again — even on subsequent deploys.
+    { label: "users.password_reset_to_chicago23_at", stmt: "ALTER TABLE users ADD COLUMN IF NOT EXISTS password_reset_to_chicago23_at TIMESTAMPTZ" },
     { label: "companies.default_residential_pay_type", stmt: "ALTER TABLE companies ADD COLUMN IF NOT EXISTS default_residential_pay_type TEXT DEFAULT 'commission'" },
     { label: "companies.default_residential_pay_rate", stmt: "ALTER TABLE companies ADD COLUMN IF NOT EXISTS default_residential_pay_rate NUMERIC(8,4) DEFAULT 0.35" },
     { label: "companies.default_commercial_pay_type",  stmt: "ALTER TABLE companies ADD COLUMN IF NOT EXISTS default_commercial_pay_type  TEXT DEFAULT 'hourly'" },
@@ -1204,8 +1211,53 @@ async function runDaysOfWeekBackfill(): Promise<void> {
   }
 }
 
+/**
+ * [phes-chicago23 2026-05-12] One-shot password reset for every Phes
+ * technician + office user. The user wanted every tech (Jose Ardila and
+ * the rest) to be able to log in with `Chicago23` while we figure out
+ * per-user invitations. Owners are excluded — sal's password stays
+ * whatever he set it to.
+ *
+ * Gating: the migration only fires for a user where
+ * `password_reset_to_chicago23_at IS NULL`. Once it runs, the timestamp
+ * is set and the user is NEVER auto-reset again — so future deploys
+ * leave a tech who has rotated their password alone, and the bulk-reset
+ * admin tool is the way to push a new password later if needed.
+ *
+ * Why not just put the bcrypt hash in a SQL string? Bcrypt is salted —
+ * we need the JS lib to generate the hash. Hence the JS function here
+ * rather than another sql.raw entry.
+ */
+async function runPhesPasswordResetChicago23(): Promise<void> {
+  const targets = await db.execute(sql`
+    SELECT id FROM users
+    WHERE company_id = ${PHES}
+      AND role IN ('technician', 'office')
+      AND password_reset_to_chicago23_at IS NULL
+  `);
+  const ids = (targets.rows as any[]).map((r) => r.id as number);
+  if (ids.length === 0) {
+    return; // Already reset every eligible user.
+  }
+  const hash = await bcrypt.hash("Chicago23", 10);
+  await db.execute(sql`
+    UPDATE users
+    SET password_hash = ${hash}, password_reset_to_chicago23_at = NOW()
+    WHERE id = ANY(${ids}::int[])
+  `);
+  console.log(
+    `[phes-migration] chicago23-password-reset: ${ids.length} user(s) set (ids: ${ids.join(", ")})`,
+  );
+}
+
 export async function runPhesDataMigration(): Promise<void> {
   await runBookingSchemaGuard();
+
+  try {
+    await runPhesPasswordResetChicago23();
+  } catch (err: any) {
+    console.warn("[phes-migration] chicago23-password-reset — non-fatal:", err?.message ?? err);
+  }
 
   try {
     await runPayMatrixBackfill();

--- a/artifacts/api-server/src/routes/users.ts
+++ b/artifacts/api-server/src/routes/users.ts
@@ -138,6 +138,70 @@ router.get("/techs-with-status", requireAuth, async (req, res) => {
   }
 });
 
+/**
+ * Bulk-reset password for multiple users at once. Owner / admin only.
+ *
+ * Body: { userIds: number[], newPassword: string }
+ *
+ * Tenant-scoped: every userId must belong to the caller's company_id, or
+ * the call returns 403 with the offending id. New password must be at
+ * least 6 chars (matches /auth/reset-password).
+ *
+ * Returns the count of users updated. Skips users whose id isn't found
+ * or belongs to a different company (defensive — no partial reset across
+ * tenants).
+ */
+router.post("/bulk-reset-password", requireAuth, requireRole("owner", "admin"), async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId!;
+    const { userIds, newPassword } = req.body as {
+      userIds?: unknown;
+      newPassword?: unknown;
+    };
+    if (!Array.isArray(userIds) || userIds.length === 0) {
+      return res.status(400).json({ error: "Bad Request", message: "userIds must be a non-empty array" });
+    }
+    if (typeof newPassword !== "string" || newPassword.length < 6) {
+      return res.status(400).json({ error: "Bad Request", message: "newPassword must be a string of 6+ chars" });
+    }
+    const ids = userIds.filter((v): v is number => typeof v === "number" && Number.isInteger(v));
+    if (ids.length === 0) {
+      return res.status(400).json({ error: "Bad Request", message: "userIds contained no valid integer ids" });
+    }
+
+    // Tenant guard: confirm every id belongs to the caller's company.
+    const tenantRows = await db
+      .select({ id: usersTable.id })
+      .from(usersTable)
+      .where(and(eq(usersTable.company_id, companyId), sql`${usersTable.id} = ANY(${ids}::int[])`));
+    const ownedIds = new Set(tenantRows.map((r) => r.id));
+    const foreign = ids.filter((id) => !ownedIds.has(id));
+    if (foreign.length > 0) {
+      return res.status(403).json({
+        error: "Forbidden",
+        message: `User(s) ${foreign.join(", ")} are not in your company`,
+      });
+    }
+
+    const hash = await bcrypt.hash(newPassword, 10);
+    const updated = await db
+      .update(usersTable)
+      .set({ password_hash: hash } as any)
+      .where(and(eq(usersTable.company_id, companyId), sql`${usersTable.id} = ANY(${ids}::int[])`))
+      .returning({ id: usersTable.id });
+
+    await logAudit(req, "bulk_password_reset", "user", null, {
+      user_ids: updated.map((u) => u.id),
+      count: updated.length,
+    });
+
+    return res.json({ data: { updated_count: updated.length, updated_ids: updated.map((u) => u.id) } });
+  } catch (err) {
+    console.error("Bulk password reset error:", err);
+    return res.status(500).json({ error: "Internal Server Error", message: "Failed to bulk-reset passwords" });
+  }
+});
+
 router.post("/", requireAuth, requireRole("owner", "admin"), async (req, res) => {
   try {
     const { email, first_name, last_name, role, pay_rate, pay_type, hire_date, phone } = req.body;

--- a/artifacts/qleno/src/pages/lms-admin.tsx
+++ b/artifacts/qleno/src/pages/lms-admin.tsx
@@ -141,6 +141,7 @@ export default function LmsAdminPage() {
   const [resetOpen, setResetOpen] = useState<RosterRow | null>(null);
   const [historyOpen, setHistoryOpen] = useState<RosterRow | null>(null);
   const [expanded, setExpanded] = useState<Set<number>>(new Set());
+  const [bulkPwOpen, setBulkPwOpen] = useState(false);
 
   function toggleExpand(enrollmentId: number) {
     setExpanded((prev) => {
@@ -244,23 +245,42 @@ export default function LmsAdminPage() {
               needed.
             </div>
           </div>
-          <button
-            type="button"
-            onClick={refresh}
-            style={{
-              background: "transparent",
-              color: NAVY,
-              border: `1px solid ${LINE}`,
-              padding: "8px 12px",
-              borderRadius: 8,
-              fontSize: 12,
-              fontWeight: 700,
-              cursor: "pointer",
-              fontFamily: FONT,
-            }}
-          >
-            Refresh
-          </button>
+          <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+            <button
+              type="button"
+              onClick={() => setBulkPwOpen(true)}
+              style={{
+                background: NAVY,
+                color: "#fff",
+                border: `1px solid ${NAVY}`,
+                padding: "8px 12px",
+                borderRadius: 8,
+                fontSize: 12,
+                fontWeight: 700,
+                cursor: "pointer",
+                fontFamily: FONT,
+              }}
+            >
+              Bulk reset password
+            </button>
+            <button
+              type="button"
+              onClick={refresh}
+              style={{
+                background: "transparent",
+                color: NAVY,
+                border: `1px solid ${LINE}`,
+                padding: "8px 12px",
+                borderRadius: 8,
+                fontSize: 12,
+                fontWeight: 700,
+                cursor: "pointer",
+                fontFamily: FONT,
+              }}
+            >
+              Refresh
+            </button>
+          </div>
         </div>
 
         {error && (
@@ -357,6 +377,15 @@ export default function LmsAdminPage() {
           row={historyOpen}
           token={token}
           onClose={() => setHistoryOpen(null)}
+        />
+      )}
+
+      {bulkPwOpen && rows && (
+        <BulkPasswordDialog
+          rows={rows}
+          token={token}
+          onClose={() => setBulkPwOpen(false)}
+          onSaved={() => setBulkPwOpen(false)}
         />
       )}
 
@@ -1975,6 +2004,296 @@ function AttemptHistoryDialog({
               );
             })}
           </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Bulk password reset dialog — owner-only tool to push a new password to a
+// subset of users in one call. Calls POST /api/users/bulk-reset-password.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function BulkPasswordDialog({
+  rows,
+  token,
+  onClose,
+  onSaved,
+}: {
+  rows: RosterRow[];
+  token: string | null;
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const [selected, setSelected] = useState<Set<number>>(
+    () => new Set(rows.map((r) => r.user_id)),
+  );
+  const [newPassword, setNewPassword] = useState("Chicago23");
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [doneCount, setDoneCount] = useState<number | null>(null);
+
+  const allChecked = selected.size === rows.length;
+  function toggleAll() {
+    if (allChecked) setSelected(new Set());
+    else setSelected(new Set(rows.map((r) => r.user_id)));
+  }
+  function toggleOne(userId: number) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(userId)) next.delete(userId);
+      else next.add(userId);
+      return next;
+    });
+  }
+
+  async function onSubmit() {
+    setErr(null);
+    if (selected.size === 0) {
+      setErr("Select at least one user.");
+      return;
+    }
+    if (newPassword.length < 6) {
+      setErr("Password must be at least 6 characters.");
+      return;
+    }
+    setBusy(true);
+    try {
+      const res = await fetch(`${API_BASE}/users/bulk-reset-password`, {
+        method: "POST",
+        headers: {
+          ...(token ? { authorization: `Bearer ${token}` } : {}),
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          userIds: Array.from(selected),
+          newPassword,
+        }),
+      });
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        throw new Error(text || `HTTP ${res.status}`);
+      }
+      const json = await res.json();
+      setDoneCount(json?.data?.updated_count ?? selected.size);
+      setTimeout(() => onSaved(), 1500);
+    } catch (e) {
+      setErr(String((e as Error).message));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "rgba(15, 23, 42, 0.55)",
+        display: "grid",
+        placeItems: "center",
+        zIndex: 100,
+        padding: 16,
+      }}
+    >
+      <div
+        style={{
+          background: SURFACE,
+          border: `1px solid ${LINE}`,
+          borderRadius: RADIUS,
+          padding: 22,
+          maxWidth: 520,
+          width: "100%",
+          maxHeight: "85vh",
+          overflow: "auto",
+          fontFamily: FONT,
+        }}
+      >
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", gap: 8 }}>
+          <div style={{ fontWeight: 800, fontSize: 18, color: INK }}>
+            Bulk reset password
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            style={{ background: "transparent", border: 0, cursor: "pointer", color: INK_MUTE }}
+          >
+            <X size={18} />
+          </button>
+        </div>
+        <div style={{ fontSize: 13, color: INK_MUTE, marginTop: 4 }}>
+          Sets the password for every selected user to the new password. Owners aren't affected unless explicitly selected.
+        </div>
+
+        {doneCount != null ? (
+          <div
+            style={{
+              marginTop: 18,
+              padding: "10px 12px",
+              background: "#ECFDF5",
+              border: `1px solid ${SUCCESS}`,
+              borderRadius: 8,
+              color: SUCCESS,
+              fontSize: 13,
+              fontWeight: 700,
+            }}
+          >
+            Reset {doneCount} {doneCount === 1 ? "user" : "users"}.
+          </div>
+        ) : (
+          <>
+            <div style={{ marginTop: 16 }}>
+              <label style={{ fontSize: 12, fontWeight: 700, color: INK_MUTE, textTransform: "uppercase", letterSpacing: "0.04em" }}>
+                New password
+              </label>
+              <input
+                type="text"
+                value={newPassword}
+                onChange={(e) => setNewPassword(e.target.value)}
+                disabled={busy}
+                style={{
+                  display: "block",
+                  width: "100%",
+                  marginTop: 6,
+                  padding: "8px 10px",
+                  border: `1px solid ${LINE}`,
+                  borderRadius: 6,
+                  fontSize: 14,
+                  fontFamily: FONT,
+                }}
+              />
+              <div style={{ fontSize: 11, color: INK_LIGHT, marginTop: 4 }}>
+                Default: <code>Chicago23</code>. Change for any single user later via the per-user reset.
+              </div>
+            </div>
+
+            <div style={{ marginTop: 16, display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+              <label style={{ fontSize: 12, fontWeight: 700, color: INK_MUTE, textTransform: "uppercase", letterSpacing: "0.04em" }}>
+                Users ({selected.size} / {rows.length})
+              </label>
+              <button
+                type="button"
+                onClick={toggleAll}
+                disabled={busy}
+                style={{
+                  background: "transparent",
+                  border: `1px solid ${LINE}`,
+                  borderRadius: 6,
+                  padding: "4px 10px",
+                  fontSize: 11,
+                  fontWeight: 700,
+                  cursor: "pointer",
+                  fontFamily: FONT,
+                  color: NAVY,
+                }}
+              >
+                {allChecked ? "Clear all" : "Select all"}
+              </button>
+            </div>
+            <div
+              style={{
+                marginTop: 8,
+                maxHeight: 260,
+                overflow: "auto",
+                border: `1px solid ${LINE}`,
+                borderRadius: 8,
+              }}
+            >
+              {rows.map((r) => {
+                const checked = selected.has(r.user_id);
+                return (
+                  <label
+                    key={r.user_id}
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 8,
+                      padding: "8px 12px",
+                      borderBottom: `1px solid ${LINE_SOFT}`,
+                      cursor: "pointer",
+                    }}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      disabled={busy}
+                      onChange={() => toggleOne(r.user_id)}
+                    />
+                    <span style={{ fontSize: 13, color: INK, fontWeight: 600 }}>
+                      {r.tech_name}
+                    </span>
+                    <span style={{ fontSize: 11, color: INK_LIGHT, marginLeft: "auto" }}>
+                      {r.role ?? "—"}
+                    </span>
+                  </label>
+                );
+              })}
+            </div>
+
+            {err && (
+              <div
+                style={{
+                  marginTop: 14,
+                  padding: "8px 10px",
+                  background: "#FEF2F2",
+                  border: `1px solid #FECACA`,
+                  color: DANGER,
+                  borderRadius: 6,
+                  fontSize: 12,
+                  fontWeight: 700,
+                }}
+              >
+                {err}
+              </div>
+            )}
+
+            <div style={{ display: "flex", justifyContent: "flex-end", gap: 8, marginTop: 18 }}>
+              <button
+                type="button"
+                onClick={onClose}
+                disabled={busy}
+                style={{
+                  background: "transparent",
+                  color: INK_MUTE,
+                  border: `1px solid ${LINE}`,
+                  padding: "8px 14px",
+                  borderRadius: 8,
+                  fontSize: 13,
+                  fontWeight: 700,
+                  cursor: "pointer",
+                  fontFamily: FONT,
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={onSubmit}
+                disabled={busy || selected.size === 0 || newPassword.length < 6}
+                style={{
+                  background: NAVY,
+                  color: "#fff",
+                  border: `1px solid ${NAVY}`,
+                  padding: "8px 14px",
+                  borderRadius: 8,
+                  fontSize: 13,
+                  fontWeight: 700,
+                  cursor: busy ? "default" : "pointer",
+                  fontFamily: FONT,
+                  opacity: busy || selected.size === 0 || newPassword.length < 6 ? 0.6 : 1,
+                }}
+              >
+                {busy ? "Resetting…" : `Reset ${selected.size} ${selected.size === 1 ? "user" : "users"}`}
+              </button>
+            </div>
+          </>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary

Two things in one PR:
1. **One-shot password reset** of every Phes technician + office user to `Chicago23`, so Jose Ardila and the rest of the team can log in without you having to set each password manually.
2. **Bulk-reset admin tool** on `/lms/admin` so you (owner) can push a new password to any subset of users from a UI later.

The seed currently plants `ChangeMe2026!` on Phes techs — that's why `Chicago23` doesn't work for them today. This PR fixes both the immediate case (deploy → all techs get `Chicago23`) and the long-term workflow (admin tool for future password changes).

## (1) Cold-start password reset

`artifacts/api-server/src/phes-data-migration.ts`:

- New column `users.password_reset_to_chicago23_at` (`TIMESTAMPTZ`, `IF NOT EXISTS`).
- New `runPhesPasswordResetChicago23()` function called from `runPhesDataMigration()`:
  - `SELECT id FROM users WHERE company_id = 1 AND role IN ('technician','office') AND password_reset_to_chicago23_at IS NULL`
  - bcrypt-hash `Chicago23`, `UPDATE password_hash + timestamp` for the matched rows
  - Owners not included — sal's password stays.
- Idempotent: after the timestamp is set on a user, that user is never auto-reset again. A tech who rotates their password later keeps their new one.

## (2) Bulk-reset admin tool

`artifacts/api-server/src/routes/users.ts`:

- New endpoint `POST /api/users/bulk-reset-password` (owner/admin only).
- Body: `{ userIds: number[], newPassword: string (>= 6 chars) }`.
- Tenant-guarded: every userId must belong to the caller's `company_id`; foreign ids return 403 with the offending ids.
- bcrypt-hashes once, `UPDATE` all matched, returns `{ updated_count, updated_ids }`.
- Audits via `logAudit('bulk_password_reset', 'user', null, ...)`.

`artifacts/qleno/src/pages/lms-admin.tsx`:

- New **Bulk reset password** button next to Refresh in the page header.
- Opens a modal with:
  - New-password input (default `Chicago23`)
  - Checklist of every learner on the roster (default: all selected)
  - Select-all / Clear-all toggle
  - Plural-aware submit label ("Reset 8 users")
- On submit: shows success state with the updated count, auto-closes after 1.5s.

## Why the timestamp column

If we just ran `UPDATE` on every cold-start, every deploy would clobber any password a tech had rotated themselves. The `password_reset_to_chicago23_at IS NULL` check makes the reset a one-time event per user — exactly what the user described as "force all techs to Chicago23 now."

## Test plan

- [ ] After deploy: log in as `joseardila7829@gmail.com` / `Chicago23` → works.
- [ ] Same for every tech in the Phes roster (Norma, Tatiana, Ana, Rosa, Diana, Alma, Guadalupe, Alejandra, Juliana, Juan, Jose) + Maribel + Francisco.
- [ ] Sal's password unchanged (owner role, not included).
- [ ] Visit `/lms/admin` as owner → "Bulk reset password" button visible. Click → modal opens with all techs selected and `Chicago23` pre-filled.
- [ ] Change password to something else, deselect half the techs, hit Reset → success message shows the right count.
- [ ] Try the endpoint with a userId from a different company → 403.
- [ ] Try with `newPassword: "abc"` → 400 (min 6 chars).

## Security notes

- Endpoint requires owner/admin role.
- New password is sent as JSON over HTTPS; bcrypted before storage.
- Audit log captures the user ids that were reset for traceability.
- The seed string `Chicago23` is in the migration source. If you want to rotate the default in the future, update the migration string and add a new timestamp column (or reuse with a different gate) — owners can also just use the bulk-reset UI manually instead of relying on the cold-start reset.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxGiirnJ3dT4GAzHPNWhrx)_