### PR TITLE
lms: Phase 12 per-module completion certificates (PR #3 of 16)

### DIFF
--- a/artifacts/api-server/src/lib/lms-certificates.ts
+++ b/artifacts/api-server/src/lib/lms-certificates.ts
@@ -1,0 +1,242 @@
+/**
+ * LMS Completion Certificates — DB-touching helpers + PDF orchestration.
+ *
+ * Phase 12 (PR #3 of 16). Wired into:
+ *   - POST /api/lms/quiz/submit  (on pass)
+ *   - POST /api/lms/module/acknowledge  (on content-only completion)
+ *   - POST /api/lms/admin/bypass-module  (on bypass)
+ *
+ * Behavior:
+ *   - Every successful pass / acknowledgment / bypass issues a NEW row
+ *     in lms_completion_certificates. Old rows for the same (user,
+ *     module) are NOT auto-revoked — the most recent active row is the
+ *     "current" cert, but the historical chain is preserved for audit.
+ *   - PDFs are rendered ON DEMAND when downloaded (no on-disk storage
+ *     this PR). pdf_storage_url stays null. The download endpoint
+ *     regenerates from the cert row + curriculum lookup.
+ *   - Tenant-scoped on every read.
+ */
+import { and, desc, eq, inArray } from "drizzle-orm";
+import { db } from "@workspace/db";
+import {
+  lmsCompletionCertificatesTable,
+  usersTable,
+  type LmsCompletionCertificate,
+} from "@workspace/db/schema";
+
+export interface IssueCertificateArgs {
+  companyId: number;
+  userId: number;
+  /** Curriculum module id, "__final" for the final mixed test. */
+  moduleId: string;
+  /** 0-100; pass null for content-only modules (acknowledgment). */
+  score: number | null;
+  /** Always true for issuance (failures don't issue certs). */
+  passed: boolean;
+  /**
+   * SHA-256 of the curriculum state at issuance. Optional — pass null
+   * if not yet wired. Future PRs (annual recurrence) will use this to
+   * detect outdated certs.
+   */
+  curriculumVersionHash?: string | null;
+  /** 'en' or 'es' — the locale the learner was using. */
+  locale: string;
+  /** IP captured from the request. */
+  ipAddress: string;
+  /** Already-parsed minimal device string (Browser / OS). */
+  deviceInfo: string;
+  /** Links the cert back to lms_quiz_attempts when applicable. */
+  quizAttemptId?: number | null;
+  /** Annual cycle context, populated by PR #14. */
+  cycleId?: number | null;
+}
+
+/**
+ * Issue a fresh certificate row. Idempotent at the call-site level —
+ * callers should not double-call within the same submission. This
+ * function itself just inserts.
+ *
+ * Returns the inserted row so the caller can return its id to the
+ * client (which then knows where to download from).
+ */
+export async function issueCertificate(
+  args: IssueCertificateArgs,
+): Promise<LmsCompletionCertificate> {
+  const inserted = await db
+    .insert(lmsCompletionCertificatesTable)
+    .values({
+      company_id: args.companyId,
+      user_id: args.userId,
+      module_id: args.moduleId,
+      quiz_attempt_id: args.quizAttemptId ?? null,
+      score: args.score,
+      passed: args.passed,
+      curriculum_version_hash: args.curriculumVersionHash ?? null,
+      locale: args.locale,
+      ip_address: args.ipAddress,
+      device_info: args.deviceInfo,
+      issued_at: new Date(),
+      cycle_id: args.cycleId ?? null,
+    })
+    .returning();
+  return inserted[0];
+}
+
+/**
+ * List all certificates for a user, scoped to a tenant. Newest first.
+ * Used by the learner's "my certificates" view and the admin's
+ * per-learner audit panel.
+ */
+export async function listCertificatesForUser(
+  companyId: number,
+  userId: number,
+): Promise<LmsCompletionCertificate[]> {
+  return db
+    .select()
+    .from(lmsCompletionCertificatesTable)
+    .where(
+      and(
+        eq(lmsCompletionCertificatesTable.company_id, companyId),
+        eq(lmsCompletionCertificatesTable.user_id, userId),
+      ),
+    )
+    .orderBy(desc(lmsCompletionCertificatesTable.issued_at));
+}
+
+/**
+ * Get the most recent NON-revoked certificate for a (user, module),
+ * scoped to a tenant. Returns null if no active cert exists.
+ *
+ * This is the "current" cert per module that the learner UI uses to
+ * decide whether to show a Download button next to a passed module.
+ */
+export async function getLatestActiveCertificate(
+  companyId: number,
+  userId: number,
+  moduleId: string,
+): Promise<LmsCompletionCertificate | null> {
+  const rows = await db
+    .select()
+    .from(lmsCompletionCertificatesTable)
+    .where(
+      and(
+        eq(lmsCompletionCertificatesTable.company_id, companyId),
+        eq(lmsCompletionCertificatesTable.user_id, userId),
+        eq(lmsCompletionCertificatesTable.module_id, moduleId),
+      ),
+    )
+    .orderBy(desc(lmsCompletionCertificatesTable.issued_at))
+    .limit(1);
+  const row = rows[0];
+  if (!row) return null;
+  // Treat revoked rows as no-active-cert. Caller can still query the
+  // full history via listCertificatesForUser.
+  if (row.revoked_at) return null;
+  return row;
+}
+
+/**
+ * Get a single certificate by id, tenant-scoped. Returns null when not
+ * found or out-of-tenant — caller treats both as 404.
+ */
+export async function getCertificateById(
+  companyId: number,
+  certificateId: number,
+): Promise<LmsCompletionCertificate | null> {
+  const rows = await db
+    .select()
+    .from(lmsCompletionCertificatesTable)
+    .where(
+      and(
+        eq(lmsCompletionCertificatesTable.id, certificateId),
+        eq(lmsCompletionCertificatesTable.company_id, companyId),
+      ),
+    )
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+/**
+ * Look up basic user identity for the cert PDF rendering. Tenant-
+ * scoped. Returns the learner's display name and the tenant company
+ * name (used to print the "Phes" header on the cert).
+ */
+export async function getCertificateLearnerSummary(
+  companyId: number,
+  userId: number,
+): Promise<{
+  fullName: string;
+  email: string;
+} | null> {
+  const rows = await db
+    .select({
+      first_name: usersTable.first_name,
+      last_name: usersTable.last_name,
+      email: usersTable.email,
+    })
+    .from(usersTable)
+    .where(
+      and(eq(usersTable.id, userId), eq(usersTable.company_id, companyId)),
+    )
+    .limit(1);
+  const row = rows[0];
+  if (!row) return null;
+  const fullName =
+    `${row.first_name ?? ""} ${row.last_name ?? ""}`.trim() ||
+    row.email ||
+    `User #${userId}`;
+  return { fullName, email: row.email };
+}
+
+/**
+ * Bulk lookup for admin views: latest active cert per (user, module)
+ * for every module a given user has. Returns a map keyed by
+ * module_id so the admin UI can build a "checklist" view.
+ *
+ * If the user has multiple historical certs per module, the most
+ * recent non-revoked one wins.
+ */
+export async function getLatestCertificateMapForUser(
+  companyId: number,
+  userId: number,
+): Promise<Record<string, LmsCompletionCertificate>> {
+  const all = await listCertificatesForUser(companyId, userId);
+  const map: Record<string, LmsCompletionCertificate> = {};
+  for (const cert of all) {
+    if (cert.revoked_at) continue;
+    // listCertificatesForUser is newest-first, so the FIRST insert
+    // wins per module_id.
+    if (!(cert.module_id in map)) {
+      map[cert.module_id] = cert;
+    }
+  }
+  return map;
+}
+
+/**
+ * Re-export a tiny utility so callers that already have the route's
+ * userIds list can fetch a batch of names without one query per user.
+ * Used by the admin roster expand panel.
+ */
+export async function getCertCountsForUsers(
+  companyId: number,
+  userIds: number[],
+): Promise<Record<number, number>> {
+  if (userIds.length === 0) return {};
+  const rows = await db
+    .select({
+      user_id: lmsCompletionCertificatesTable.user_id,
+    })
+    .from(lmsCompletionCertificatesTable)
+    .where(
+      and(
+        eq(lmsCompletionCertificatesTable.company_id, companyId),
+        inArray(lmsCompletionCertificatesTable.user_id, userIds),
+      ),
+    );
+  const counts: Record<number, number> = {};
+  for (const r of rows) {
+    counts[r.user_id] = (counts[r.user_id] ?? 0) + 1;
+  }
+  return counts;
+}

--- a/artifacts/api-server/src/lib/lms-curriculum-titles.ts
+++ b/artifacts/api-server/src/lib/lms-curriculum-titles.ts
@@ -1,0 +1,77 @@
+/**
+ * Module display title resolver — server side.
+ *
+ * The full module catalog with rich content blocks lives in the
+ * frontend curriculum (`artifacts/qleno/src/lib/training/curriculum.ts`).
+ * The server does not need that data to score quizzes (it uses the
+ * answer key + question id set from `@workspace/lms-curriculum`), but
+ * it DOES need the localized human title when rendering completion
+ * certificates server-side via pdf-lib.
+ *
+ * Rather than pull the whole curriculum bundle into the API server,
+ * we keep a small static map here. Locale-aware. Falls back to a
+ * humanized version of the module_id when the title is not registered.
+ *
+ * Keep in sync with the frontend curriculum's `title` field per
+ * module. When a new module is added, add an entry here too.
+ */
+
+import { FINAL_MODULE_ID } from "@workspace/lms-curriculum";
+
+interface BilingualTitle {
+  en: string;
+  es: string;
+}
+
+const MODULE_TITLES: Record<string, BilingualTitle> = {
+  "phes-policies": {
+    en: "Phes Policies & Procedures",
+    es: "Políticas y Procedimientos de Phes",
+  },
+  compensation: {
+    en: "Compensation",
+    es: "Compensación",
+  },
+  "cleaning-best-practices": {
+    en: "Cleaning Best Practices",
+    es: "Mejores Prácticas de Limpieza",
+  },
+  maidcentral: {
+    en: "MaidCentral",
+    es: "MaidCentral",
+  },
+  "products-tools": {
+    en: "Products & Tools",
+    es: "Productos y Herramientas",
+  },
+  "il-sexual-harassment": {
+    en: "Sexual Harassment Prevention (Illinois)",
+    es: "Prevención del Acoso Sexual (Illinois)",
+  },
+  acknowledgment: {
+    en: "Onboarding Acknowledgment",
+    es: "Confirmación de Incorporación",
+  },
+  [FINAL_MODULE_ID]: {
+    en: "Final Mixed Test",
+    es: "Examen Final Mixto",
+  },
+};
+
+/**
+ * Resolve a module's localized title for display on a certificate.
+ * Falls back to a sentence-cased version of the module_id when the
+ * id is not in the static map (defensive against curriculum drift).
+ */
+export function getCurriculumModuleTitle(
+  moduleId: string,
+  locale: "en" | "es",
+): string {
+  const entry = MODULE_TITLES[moduleId];
+  if (entry) return entry[locale];
+  // Fallback: "phes-policies" → "Phes Policies"
+  return moduleId
+    .split(/[-_]/)
+    .map((w) => (w ? w[0].toUpperCase() + w.slice(1) : ""))
+    .join(" ");
+}

--- a/artifacts/api-server/src/lib/lms-signatures.ts
+++ b/artifacts/api-server/src/lib/lms-signatures.ts
@@ -96,6 +96,83 @@ export function captureRequestMetadata(req: Request): SignatureRequestMetadata {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Minimal device info parser (PII minimization)
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// Per Phase 3 spec: certificates and signed-document audit rows capture
+// "device info" as Browser + OS only. Detailed fingerprinting data
+// (screen resolution, fonts, plugins, etc.) is NOT collected. The raw
+// user-agent string is the most we have to work with on the server, so
+// we parse a tight subset and store the resulting compact string.
+//
+// Pure regex matching. Lives here (not in -db helpers) so unit tests can
+// exercise it directly. Returns "unknown" only when the UA is empty.
+// Falls through to a permissive "Browser / OS" when no recognized brand
+// is found, rather than swallowing the data silently.
+
+interface ParsedDevice {
+  browser: string;
+  os: string;
+}
+
+function detectBrowser(ua: string): string {
+  // Order matters: Edge contains "Chrome" + "Safari"; Chrome contains "Safari".
+  // Match the more-specific brand first.
+  if (/Edg\//.test(ua)) {
+    const m = ua.match(/Edg\/(\d+)/);
+    return m ? `Edge ${m[1]}` : "Edge";
+  }
+  if (/OPR\//.test(ua)) {
+    const m = ua.match(/OPR\/(\d+)/);
+    return m ? `Opera ${m[1]}` : "Opera";
+  }
+  if (/Firefox\//.test(ua)) {
+    const m = ua.match(/Firefox\/(\d+)/);
+    return m ? `Firefox ${m[1]}` : "Firefox";
+  }
+  if (/Chrome\//.test(ua)) {
+    const m = ua.match(/Chrome\/(\d+)/);
+    return m ? `Chrome ${m[1]}` : "Chrome";
+  }
+  if (/Safari\//.test(ua) && /Version\//.test(ua)) {
+    const m = ua.match(/Version\/(\d+)/);
+    return m ? `Safari ${m[1]}` : "Safari";
+  }
+  return "Browser";
+}
+
+function detectOs(ua: string): string {
+  if (/iPad/.test(ua)) return "iPadOS";
+  if (/iPhone|iPod/.test(ua)) return "iOS";
+  if (/Android/.test(ua)) return "Android";
+  if (/Macintosh|Mac OS X/.test(ua)) return "macOS";
+  if (/Windows NT/.test(ua)) return "Windows";
+  if (/CrOS/.test(ua)) return "ChromeOS";
+  if (/X11; Linux|Linux/.test(ua)) return "Linux";
+  return "OS";
+}
+
+/**
+ * Compact, PII-minimized device descriptor for audit rows. Examples:
+ *   "Chrome 120 / macOS"
+ *   "Safari 17 / iOS"
+ *   "Firefox 121 / Windows"
+ *
+ * Returns the literal "unknown" only when the raw user-agent is empty
+ * or the literal "unknown" (the same fallback captureRequestMetadata
+ * uses when no UA header was sent).
+ */
+export function parseMinimalDeviceInfo(rawUserAgent: string): string {
+  if (!rawUserAgent || rawUserAgent === "unknown") return "unknown";
+  const ua = String(rawUserAgent);
+  const parsed: ParsedDevice = {
+    browser: detectBrowser(ua),
+    os: detectOs(ua),
+  };
+  return `${parsed.browser} / ${parsed.os}`;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Signature method validation
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/artifacts/api-server/src/routes/index.ts
+++ b/artifacts/api-server/src/routes/index.ts
@@ -74,6 +74,7 @@ import contactRouter from "./contact.js";
 import geocodeRouter from "./geocode.js";
 import configRouter from "./config.js";
 import lmsRouter from "./lms.js";
+import lmsCertificatesRouter from "./lms-certificates.js";
 
 const router: IRouter = Router();
 
@@ -152,5 +153,6 @@ router.use("/contact", contactRouter);
 router.use("/geocode", geocodeRouter);
 router.use("/config", configRouter);
 router.use("/lms", lmsRouter);
+router.use("/lms/certificates", lmsCertificatesRouter);
 
 export default router;

--- a/artifacts/api-server/src/routes/lms-certificates.ts
+++ b/artifacts/api-server/src/routes/lms-certificates.ts
@@ -1,0 +1,193 @@
+/**
+ * LMS Completion Certificates — routes (Phase 12, PR #3 of 16).
+ *
+ * Endpoints (mounted at /api/lms/certificates):
+ *   GET  /me                        list caller's certificates
+ *   GET  /:id/pdf                   download a specific cert as PDF
+ *                                   (tenant-gated; 404 if not in tenant
+ *                                   or if the cert was revoked)
+ *   GET  /admin/learner/:userId     list certs for a user in caller's
+ *                                   tenant (owner / admin / office)
+ *
+ * PDFs are rendered on-demand from the cert row + learner identity.
+ * No on-disk storage — pdf_storage_url stays null. This keeps Railway
+ * deploys disk-free and gives the renderer a single source of truth.
+ *
+ * Issuance happens elsewhere (routes/lms.ts on /quiz/submit,
+ * /module/acknowledge, /admin/bypass-module). This file only serves
+ * already-issued certs.
+ */
+import { Router } from "express";
+import { requireAuth, requireRole } from "../lib/auth.js";
+import {
+  getCertificateById,
+  getCertificateLearnerSummary,
+  listCertificatesForUser,
+} from "../lib/lms-certificates.js";
+import { generateCertificatePdf } from "../lib/pdf-gen.js";
+import { getCurriculumModuleTitle } from "../lib/lms-curriculum-titles.js";
+
+const router = Router();
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /me — caller's certificates (newest first)
+// ─────────────────────────────────────────────────────────────────────────────
+
+router.get("/me", requireAuth, async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    if (companyId == null) {
+      return res
+        .status(400)
+        .json({ error: "Bad Request", message: "User has no company assignment" });
+    }
+    const userId = req.auth!.userId;
+    const rows = await listCertificatesForUser(companyId, userId);
+    return res.json({ data: rows });
+  } catch (err) {
+    console.error("[lms-certificates] GET /me error:", err);
+    return res
+      .status(500)
+      .json({ error: "Internal Server Error", message: "Failed to list certificates" });
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /admin/learner/:userId — admin-side certificate audit
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// Owner / admin / office can list certs for any user in their tenant.
+// Used by /lms/admin per-learner detail panel.
+
+router.get(
+  "/admin/learner/:userId",
+  requireAuth,
+  requireRole("owner", "admin", "office"),
+  async (req, res) => {
+    try {
+      const companyId = req.auth!.companyId;
+      if (companyId == null) {
+        return res
+          .status(400)
+          .json({ error: "Bad Request", message: "User has no company assignment" });
+      }
+      const targetUserId = Number(req.params.userId);
+      if (!Number.isFinite(targetUserId) || targetUserId <= 0) {
+        return res
+          .status(400)
+          .json({ error: "Bad Request", message: "Invalid userId" });
+      }
+      const rows = await listCertificatesForUser(companyId, targetUserId);
+      return res.json({ data: rows });
+    } catch (err) {
+      console.error("[lms-certificates] GET /admin/learner error:", err);
+      return res
+        .status(500)
+        .json({ error: "Internal Server Error", message: "Failed to list certificates" });
+    }
+  },
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /:id/pdf — render and stream the certificate as a PDF
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// Tenant gate: the cert is fetched by (id, company_id). Anyone outside
+// the tenant gets 404. Within the tenant, both the learner themselves
+// AND any owner / admin / office user can download. The route does NOT
+// require the admin role; it requires that the caller either owns the
+// cert (caller.userId === cert.user_id) OR holds a privileged role.
+
+router.get("/:id/pdf", requireAuth, async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    if (companyId == null) {
+      return res
+        .status(400)
+        .json({ error: "Bad Request", message: "User has no company assignment" });
+    }
+    const certificateId = Number(req.params.id);
+    if (!Number.isFinite(certificateId) || certificateId <= 0) {
+      return res
+        .status(400)
+        .json({ error: "Bad Request", message: "Invalid certificate id" });
+    }
+
+    const cert = await getCertificateById(companyId, certificateId);
+    if (!cert) {
+      return res
+        .status(404)
+        .json({ error: "Not Found", message: "Certificate not found" });
+    }
+
+    // Access gate: caller is the cert owner OR a privileged role.
+    const callerRole = req.auth!.role;
+    const isPrivileged =
+      callerRole === "owner" ||
+      callerRole === "admin" ||
+      callerRole === "office" ||
+      callerRole === "super_admin";
+    if (!isPrivileged && cert.user_id !== req.auth!.userId) {
+      return res
+        .status(404)
+        .json({ error: "Not Found", message: "Certificate not found" });
+    }
+
+    if (cert.revoked_at) {
+      return res
+        .status(410)
+        .json({
+          error: "Gone",
+          message: "This certificate was revoked",
+          revoked_reason: cert.revoked_reason,
+        });
+    }
+
+    const learner = await getCertificateLearnerSummary(companyId, cert.user_id);
+    if (!learner) {
+      return res
+        .status(404)
+        .json({ error: "Not Found", message: "Learner not found" });
+    }
+
+    // Tenant brand name on the cert. For Phes that's "Phes"; future
+    // tenants would resolve from `companies.name` — for now we use the
+    // curriculum tenant label since that's already the source of truth
+    // for the LMS surface.
+    const tenantName = "Phes"; // TODO PR #15: resolve via companies.name
+
+    const moduleTitle = getCurriculumModuleTitle(
+      cert.module_id,
+      cert.locale === "es" ? "es" : "en",
+    );
+
+    const pdfBytes = await generateCertificatePdf({
+      tenantName,
+      employeeName: learner.fullName,
+      moduleTitle,
+      moduleId: cert.module_id,
+      score: cert.score,
+      issuedAt: cert.issued_at,
+      curriculumVersionHash: cert.curriculum_version_hash,
+      locale: cert.locale,
+      ipAddress: cert.ip_address,
+      deviceInfo: cert.device_info,
+    });
+
+    const safeName = learner.fullName.replace(/[^a-zA-Z0-9_-]+/g, "_");
+    const filename = `phes-${cert.module_id}-${safeName}-${cert.id}.pdf`;
+    res.setHeader("Content-Type", "application/pdf");
+    res.setHeader(
+      "Content-Disposition",
+      `attachment; filename="${filename}"`,
+    );
+    return res.end(Buffer.from(pdfBytes));
+  } catch (err) {
+    console.error("[lms-certificates] GET /:id/pdf error:", err);
+    return res
+      .status(500)
+      .json({ error: "Internal Server Error", message: "Failed to render certificate" });
+  }
+});
+
+export default router;

--- a/artifacts/api-server/src/routes/lms.ts
+++ b/artifacts/api-server/src/routes/lms.ts
@@ -63,6 +63,11 @@ import { SERVER_ANSWER_KEY } from "@workspace/training";
 import { requireAuth, requireRole } from "../lib/auth.js";
 import { logAudit } from "../lib/audit.js";
 import { addDays, daysUntil, fireLmsWebhook } from "../lib/lms-helpers.js";
+import {
+  captureRequestMetadata,
+  parseMinimalDeviceInfo,
+} from "../lib/lms-signatures.js";
+import { issueCertificate } from "../lib/lms-certificates.js";
 
 const router = Router();
 // Re-export so existing callers (and any future module that wants the
@@ -627,16 +632,20 @@ router.post("/quiz/submit", requireAuth, async (req, res) => {
     const result = scoreQuiz(answers, questionIds, QUIZ_PASS_THRESHOLD, SERVER_ANSWER_KEY);
 
     // Always insert the immutable attempt row first.
-    await db.insert(lmsQuizAttemptsTable).values({
-      company_id: companyId,
-      enrollment_id: enrollment.id,
-      module_id: moduleId,
-      answers,
-      question_ids: moduleId === FINAL_MODULE_ID ? questionIds : null,
-      score: result.score,
-      passed: result.passed,
-      attempted_at: now,
-    });
+    const attemptInsert = await db
+      .insert(lmsQuizAttemptsTable)
+      .values({
+        company_id: companyId,
+        enrollment_id: enrollment.id,
+        module_id: moduleId,
+        answers,
+        question_ids: moduleId === FINAL_MODULE_ID ? questionIds : null,
+        score: result.score,
+        passed: result.passed,
+        attempted_at: now,
+      })
+      .returning({ id: lmsQuizAttemptsTable.id });
+    const quizAttemptId = attemptInsert[0]?.id ?? null;
 
     // Update module_progress: bump attempts, update best_score, set passed_at
     // if this attempt cleared the bar (and the module wasn't already passed).
@@ -669,6 +678,32 @@ router.post("/quiz/submit", requireAuth, async (req, res) => {
         ),
       );
     await touchEnrollment(enrollment.id, now);
+
+    // Phase 12: issue a completion certificate on every successful pass.
+    // Historical rows stay (no auto-revoke); the most recent active row
+    // is the "current" cert. PDF is rendered on download, not stored
+    // here. Tenant-scoped by company_id at the row level.
+    let issuedCertId: number | null = null;
+    if (passedNow) {
+      try {
+        const meta = captureRequestMetadata(req);
+        const cert = await issueCertificate({
+          companyId,
+          userId,
+          moduleId,
+          score: result.score,
+          passed: true,
+          locale: enrollment.locale === "es" ? "es" : "en",
+          ipAddress: meta.ip_address,
+          deviceInfo: parseMinimalDeviceInfo(meta.user_agent),
+          quizAttemptId,
+        });
+        issuedCertId = cert.id;
+      } catch (err) {
+        // A cert-issue failure must not block the user's pass response.
+        console.error("[lms] cert issuance failed (non-fatal):", err);
+      }
+    }
 
     // Webhook fire — do this AFTER all DB writes commit, but before the
     // response so we can still surface a logged failure. Fire-and-forget so
@@ -722,6 +757,7 @@ router.post("/quiz/submit", requireAuth, async (req, res) => {
         attempts_used: attemptsAfter,
         max_attempts: maxAttempts,
         attempts_remaining: Math.max(0, maxAttempts - attemptsAfter),
+        certificate_id: issuedCertId,
       },
     });
   } catch (err) {
@@ -809,6 +845,28 @@ router.post("/module/acknowledge", requireAuth, async (req, res) => {
     }
 
     await touchEnrollment(enrollment.id, now);
+
+    // Phase 12: issue a completion certificate for content-only modules
+    // (e.g. qleno-app, acknowledgment). No score because there's no quiz.
+    let issuedCertId: number | null = null;
+    try {
+      const meta = captureRequestMetadata(req);
+      const cert = await issueCertificate({
+        companyId,
+        userId,
+        moduleId,
+        score: null,
+        passed: true,
+        locale: enrollment.locale === "es" ? "es" : "en",
+        ipAddress: meta.ip_address,
+        deviceInfo: parseMinimalDeviceInfo(meta.user_agent),
+        quizAttemptId: null,
+      });
+      issuedCertId = cert.id;
+    } catch (err) {
+      console.error("[lms] cert issuance failed on acknowledge (non-fatal):", err);
+    }
+
     await logAudit(
       req,
       "lms.module.acknowledge",
@@ -818,7 +876,7 @@ router.post("/module/acknowledge", requireAuth, async (req, res) => {
       { module_id: moduleId },
     );
 
-    return res.json({ data: { ok: true } });
+    return res.json({ data: { ok: true, certificate_id: issuedCertId } });
   } catch (err) {
     console.error("[lms] /module/acknowledge error:", err);
     return res
@@ -1244,6 +1302,31 @@ router.post(
         );
 
       await touchEnrollment(enrollment.id, now);
+
+      // Phase 12: issue a completion certificate for the bypassed module.
+      // The cert is for the TARGET learner (when admin/office bypasses on
+      // their behalf) or the caller themselves (when an owner bypasses
+      // their own training). score=100 because bypass is treated as a
+      // perfect-completion attestation by the granting admin.
+      let bypassCertId: number | null = null;
+      try {
+        const meta = captureRequestMetadata(req);
+        const cert = await issueCertificate({
+          companyId,
+          userId: targetUserId,
+          moduleId,
+          score: 100,
+          passed: true,
+          locale: enrollment.locale === "es" ? "es" : "en",
+          ipAddress: meta.ip_address,
+          deviceInfo: parseMinimalDeviceInfo(meta.user_agent),
+          quizAttemptId: null,
+        });
+        bypassCertId = cert.id;
+      } catch (err) {
+        console.error("[lms] cert issuance failed on bypass (non-fatal):", err);
+      }
+
       await logAudit(
         req,
         "lms.admin.bypass",
@@ -1254,10 +1337,13 @@ router.post(
           module_id: moduleId,
           target_user_id: targetUserId,
           self: targetUserId === req.auth!.userId,
+          certificate_id: bypassCertId,
         },
       );
 
-      return res.json({ data: { ok: true, enrollment_id: enrollment.id } });
+      return res.json({
+        data: { ok: true, enrollment_id: enrollment.id, certificate_id: bypassCertId },
+      });
     } catch (err) {
       console.error("[lms] /admin/bypass-module error:", err);
       return res

--- a/artifacts/api-server/src/tests/lms-certificates.test.ts
+++ b/artifacts/api-server/src/tests/lms-certificates.test.ts
@@ -1,0 +1,151 @@
+/**
+ * LMS Certificate helpers — unit tests.
+ *
+ * Pure-function tests. The DB-touching pieces (issueCertificate,
+ * listCertificatesForUser, etc.) live in lms-certificates.ts which
+ * imports from @workspace/db, so they cannot be exercised against a
+ * stub DATABASE_URL without spinning up Postgres. Instead we test:
+ *   - parseMinimalDeviceInfo (browser + OS detection)
+ *   - getCurriculumModuleTitle (server-side title lookup)
+ *
+ * Issuance flow is exercised indirectly via the API routes in
+ * integration tests (out of scope here).
+ *
+ * Run:
+ *   pnpm --filter @workspace/api-server run test:lms
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { parseMinimalDeviceInfo } from "../lib/lms-signatures.js";
+import { getCurriculumModuleTitle } from "../lib/lms-curriculum-titles.js";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// parseMinimalDeviceInfo
+// ─────────────────────────────────────────────────────────────────────────────
+
+const UA = {
+  chromeMac:
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+  safariMac:
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15",
+  firefoxLinux:
+    "Mozilla/5.0 (X11; Linux x86_64; rv:121.0) Gecko/20100101 Firefox/121.0",
+  edgeWindows:
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0",
+  safariIphone:
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 17_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.1 Mobile/15E148 Safari/604.1",
+  chromeAndroid:
+    "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36",
+  operaWindows:
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36 OPR/105.0.0.0",
+};
+
+describe("parseMinimalDeviceInfo", () => {
+  it("identifies Chrome + macOS", () => {
+    assert.equal(parseMinimalDeviceInfo(UA.chromeMac), "Chrome 120 / macOS");
+  });
+
+  it("identifies Safari + macOS (with Version/N)", () => {
+    assert.equal(parseMinimalDeviceInfo(UA.safariMac), "Safari 17 / macOS");
+  });
+
+  it("identifies Firefox + Linux", () => {
+    assert.equal(parseMinimalDeviceInfo(UA.firefoxLinux), "Firefox 121 / Linux");
+  });
+
+  it("identifies Edge + Windows (despite Chrome substring)", () => {
+    assert.equal(parseMinimalDeviceInfo(UA.edgeWindows), "Edge 120 / Windows");
+  });
+
+  it("identifies Safari + iOS on iPhone", () => {
+    assert.equal(parseMinimalDeviceInfo(UA.safariIphone), "Safari 17 / iOS");
+  });
+
+  it("identifies Chrome + Android", () => {
+    assert.equal(
+      parseMinimalDeviceInfo(UA.chromeAndroid),
+      "Chrome 120 / Android",
+    );
+  });
+
+  it("identifies Opera + Windows (despite OPR + Chrome substring)", () => {
+    assert.equal(parseMinimalDeviceInfo(UA.operaWindows), "Opera 105 / Windows");
+  });
+
+  it("returns 'unknown' on empty / 'unknown' input (column NOT NULL fallback)", () => {
+    assert.equal(parseMinimalDeviceInfo(""), "unknown");
+    assert.equal(parseMinimalDeviceInfo("unknown"), "unknown");
+  });
+
+  it("falls through to 'Browser / OS' on unrecognized UA rather than crashing", () => {
+    const result = parseMinimalDeviceInfo("Some custom crawler/1.0");
+    // We don't care exactly what string we get, only that it's truthy
+    // and contains a slash separator.
+    assert.ok(result.includes("/"), `unexpected fallback: ${result}`);
+    assert.notEqual(result, "unknown");
+  });
+
+  it("does NOT leak fingerprinting data (no screen, no fonts, no plugins)", () => {
+    const noisy =
+      UA.chromeMac +
+      " (custom: screen=2560x1440; fonts=Helvetica,Arial,sans-serif; plugins=PDF,Java)";
+    const parsed = parseMinimalDeviceInfo(noisy);
+    assert.ok(!parsed.includes("2560"), "screen size leaked");
+    assert.ok(!parsed.includes("Helvetica"), "font list leaked");
+    assert.ok(!parsed.includes("plugins"), "plugin list leaked");
+    assert.ok(!parsed.includes("PDF"), "plugin name leaked");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// getCurriculumModuleTitle
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("getCurriculumModuleTitle", () => {
+  it("returns the English title for phes-policies", () => {
+    assert.equal(
+      getCurriculumModuleTitle("phes-policies", "en"),
+      "Phes Policies & Procedures",
+    );
+  });
+
+  it("returns the Spanish title for phes-policies", () => {
+    assert.equal(
+      getCurriculumModuleTitle("phes-policies", "es"),
+      "Políticas y Procedimientos de Phes",
+    );
+  });
+
+  it("returns the English title for il-sexual-harassment", () => {
+    assert.equal(
+      getCurriculumModuleTitle("il-sexual-harassment", "en"),
+      "Sexual Harassment Prevention (Illinois)",
+    );
+  });
+
+  it("returns the Spanish title for il-sexual-harassment", () => {
+    assert.equal(
+      getCurriculumModuleTitle("il-sexual-harassment", "es"),
+      "Prevención del Acoso Sexual (Illinois)",
+    );
+  });
+
+  it("handles the final mixed test pseudo-id", () => {
+    assert.equal(getCurriculumModuleTitle("__final", "en"), "Final Mixed Test");
+    assert.equal(getCurriculumModuleTitle("__final", "es"), "Examen Final Mixto");
+  });
+
+  it("falls back to a sentence-cased version of an unknown id", () => {
+    assert.equal(
+      getCurriculumModuleTitle("brand-new-module", "en"),
+      "Brand New Module",
+    );
+  });
+
+  it("fallback handles snake_case ids", () => {
+    assert.equal(
+      getCurriculumModuleTitle("brand_new_module", "en"),
+      "Brand New Module",
+    );
+  });
+});

--- a/artifacts/qleno/src/pages/lms-admin.tsx
+++ b/artifacts/qleno/src/pages/lms-admin.tsx
@@ -28,6 +28,8 @@ import {
   ChevronRight,
   ChevronDown,
   FastForward,
+  Download,
+  Award,
   RotateCcw,
   History,
 } from "lucide-react";
@@ -651,6 +653,7 @@ function RosterTable({
                     }}
                   >
                     <ModuleAttemptsGrid row={r} onBypass={onBypass} />
+                    <LearnerCertificatesPanel row={r} />
                   </td>
                 </tr>
               ) : null}
@@ -951,6 +954,7 @@ function RosterCards({
           {expanded.has(r.enrollment_id) ? (
             <div style={{ marginTop: 6 }}>
               <ModuleAttemptsGrid row={r} onBypass={onBypass} />
+              <LearnerCertificatesPanel row={r} />
             </div>
           ) : null}
         </article>
@@ -2295,6 +2299,228 @@ function BulkPasswordDialog({
             </div>
           </>
         )}
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// LearnerCertificatesPanel — Phase 12: shows the per-learner cert audit
+// trail in the admin expand row. Fetches on first render via the
+// admin-side endpoint and renders the full chain (including historical
+// re-takes) with a download button per cert.
+// ─────────────────────────────────────────────────────────────────────────────
+
+type CertificateRow = {
+  id: number;
+  module_id: string;
+  score: number | null;
+  passed: boolean;
+  locale: string;
+  issued_at: string;
+  revoked_at: string | null;
+  revoked_reason: string | null;
+};
+
+function LearnerCertificatesPanel({ row }: { row: RosterRow }) {
+  const token = useAuthStore((s) => s.token);
+  const [certs, setCerts] = useState<CertificateRow[] | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const data = await api<CertificateRow[]>(
+          "GET",
+          `/lms/certificates/admin/learner/${row.user_id}`,
+          token,
+        );
+        if (!cancelled) setCerts(data);
+      } catch (e) {
+        if (!cancelled) setErr(String((e as Error).message));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [row.user_id, token]);
+
+  async function handleDownload(certId: number) {
+    try {
+      const url = `${API_BASE}/lms/certificates/${certId}/pdf`;
+      const res = await fetch(url, {
+        headers: token ? { authorization: `Bearer ${token}` } : {},
+      });
+      if (!res.ok) throw new Error(`${res.status}`);
+      const blob = await res.blob();
+      const disposition = res.headers.get("content-disposition") ?? "";
+      const m = /filename="([^"]+)"/.exec(disposition);
+      const filename = m?.[1] ?? `phes-cert-${certId}.pdf`;
+      const objectUrl = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = objectUrl;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(objectUrl);
+    } catch (e) {
+      console.error("[lms-admin] download cert failed:", e);
+    }
+  }
+
+  if (err) {
+    return (
+      <div
+        style={{
+          marginTop: 12,
+          padding: 10,
+          background: "#FEF2F2",
+          border: `1px solid #FECACA`,
+          color: DANGER,
+          borderRadius: 8,
+          fontSize: 12,
+        }}
+      >
+        Failed to load certificates: {err}
+      </div>
+    );
+  }
+
+  if (certs == null) {
+    return (
+      <div
+        style={{
+          marginTop: 12,
+          fontSize: 12,
+          color: INK_MUTE,
+          fontStyle: "italic",
+        }}
+      >
+        Loading certificates...
+      </div>
+    );
+  }
+
+  if (certs.length === 0) {
+    return (
+      <div
+        style={{
+          marginTop: 12,
+          padding: 10,
+          background: LINE_SOFT,
+          borderRadius: 8,
+          fontSize: 12,
+          color: INK_MUTE,
+        }}
+      >
+        No certificates issued yet. Certificates are auto-generated when a
+        learner passes a quiz, acknowledges a content module, or has a
+        module bypassed by an admin.
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ marginTop: 14 }}>
+      <div
+        style={{
+          fontSize: 11,
+          fontWeight: 800,
+          color: INK_MUTE,
+          textTransform: "uppercase",
+          letterSpacing: "0.06em",
+          marginBottom: 8,
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 6,
+        }}
+      >
+        <Award size={12} /> Completion Certificates ({certs.length})
+      </div>
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))",
+          gap: 8,
+        }}
+      >
+        {certs.map((c) => {
+          const isRevoked = !!c.revoked_at;
+          return (
+            <div
+              key={c.id}
+              style={{
+                background: SURFACE,
+                border: `1px solid ${isRevoked ? "#FECACA" : LINE}`,
+                borderLeft: `3px solid ${
+                  isRevoked ? DANGER : c.passed ? SUCCESS : INK_LIGHT
+                }`,
+                borderRadius: 8,
+                padding: "10px 12px",
+                fontSize: 12,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                gap: 8,
+              }}
+            >
+              <div style={{ minWidth: 0 }}>
+                <div style={{ fontWeight: 800, color: INK, fontSize: 12 }}>
+                  {humanModule(c.module_id)}
+                </div>
+                <div
+                  style={{
+                    fontSize: 11,
+                    color: INK_MUTE,
+                    marginTop: 2,
+                    fontWeight: 600,
+                  }}
+                >
+                  {c.score != null ? `${c.score}% · ` : ""}
+                  {c.locale.toUpperCase()} · {humanDateTime(c.issued_at)}
+                </div>
+                {isRevoked ? (
+                  <div
+                    style={{
+                      fontSize: 10,
+                      color: DANGER,
+                      fontWeight: 700,
+                      marginTop: 2,
+                    }}
+                  >
+                    REVOKED: {c.revoked_reason ?? "no reason given"}
+                  </div>
+                ) : null}
+              </div>
+              {!isRevoked ? (
+                <button
+                  type="button"
+                  onClick={() => handleDownload(c.id)}
+                  title="Download certificate PDF"
+                  style={{
+                    background: NAVY,
+                    color: "#fff",
+                    border: 0,
+                    padding: "5px 10px",
+                    borderRadius: 6,
+                    fontSize: 11,
+                    fontWeight: 800,
+                    cursor: "pointer",
+                    fontFamily: FONT,
+                    display: "inline-flex",
+                    alignItems: "center",
+                    gap: 4,
+                    flexShrink: 0,
+                  }}
+                >
+                  <Download size={11} /> PDF
+                </button>
+              ) : null}
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/artifacts/qleno/src/pages/training.tsx
+++ b/artifacts/qleno/src/pages/training.tsx
@@ -61,6 +61,7 @@ import {
   AlertTriangle,
   Info,
   CircleCheck,
+  Download,
   Lock,
   Award,
   Loader2,
@@ -150,6 +151,7 @@ type SubmitResult = {
   attempts_used?: number;
   max_attempts?: number;
   attempts_remaining?: number;
+  certificate_id?: number | null;
 };
 
 type View =
@@ -249,13 +251,59 @@ const lmsApi = {
       payload,
     ),
   bypassModule: (token: string | null, moduleId: string) =>
-    api<{ ok: true; enrollment_id: number }>(
+    api<{ ok: true; enrollment_id: number; certificate_id: number | null }>(
       "POST",
       "/lms/admin/bypass-module",
       token,
       { moduleId },
     ),
+  listMyCertificates: (token: string | null) =>
+    api<CertificateRow[]>("GET", "/lms/certificates/me", token),
 };
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Certificate download — opens the PDF in a new tab. The auth header is
+// passed via fetch + blob conversion so the cert id can stay in a same-
+// origin URL even when the API runs under /api/.
+// ─────────────────────────────────────────────────────────────────────────────
+
+type CertificateRow = {
+  id: number;
+  module_id: string;
+  score: number | null;
+  passed: boolean;
+  issued_at: string;
+  locale: string;
+  revoked_at: string | null;
+};
+
+async function downloadCertificatePdf(
+  token: string | null,
+  certificateId: number,
+): Promise<void> {
+  const url = `${API_BASE}/lms/certificates/${certificateId}/pdf`;
+  const res = await fetch(url, {
+    headers: token ? { authorization: `Bearer ${token}` } : {},
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `GET /lms/certificates/${certificateId}/pdf → ${res.status}: ${text}`,
+    );
+  }
+  const blob = await res.blob();
+  const dispositionHeader = res.headers.get("content-disposition") ?? "";
+  const filenameMatch = /filename="([^"]+)"/.exec(dispositionHeader);
+  const filename = filenameMatch?.[1] ?? `phes-certificate-${certificateId}.pdf`;
+  const objectUrl = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = objectUrl;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(objectUrl);
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Token helpers
@@ -339,6 +387,7 @@ const T = {
   retry_quiz: { en: "Try again", es: "Intentar de nuevo" },
   start_quiz: { en: "Start quiz", es: "Comenzar examen" },
   review_quiz: { en: "Review", es: "Revisar" },
+  downloadCert: { en: "Certificate", es: "Certificado" },
 } as const;
 
 function tr(key: keyof typeof T, locale: Locale): string {
@@ -394,16 +443,33 @@ export default function TrainingPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [view, setView] = useState<View>({ kind: "home" });
+  const [certificates, setCertificates] = useState<CertificateRow[]>([]);
 
   const curriculum = useMemo<Curriculum>(
     () => getCurriculum(learner?.companyId ?? null),
     [learner?.companyId],
   );
 
+  /** module_id → most recent ACTIVE certificate id (revoked rows skipped). */
+  const certByModule = useMemo<Record<string, number>>(() => {
+    const map: Record<string, number> = {};
+    // certificates are listed newest-first by the server, so the first
+    // non-revoked one per module wins.
+    for (const c of certificates) {
+      if (c.revoked_at) continue;
+      if (!(c.module_id in map)) map[c.module_id] = c.id;
+    }
+    return map;
+  }, [certificates]);
+
   const refresh = useCallback(async () => {
     try {
-      const next = await lmsApi.me(token);
+      const [next, certs] = await Promise.all([
+        lmsApi.me(token),
+        lmsApi.listMyCertificates(token).catch(() => [] as CertificateRow[]),
+      ]);
       setState(next);
+      setCertificates(certs);
       // Sync locale from server if present
       if (next.enrollment.locale === "en" || next.enrollment.locale === "es") {
         setLocale(next.enrollment.locale);
@@ -540,6 +606,7 @@ export default function TrainingPage() {
           finalUnlocked={finalUnlocked}
           finalPassed={finalPassed}
           ackUnlocked={ackUnlocked}
+          certByModule={certByModule}
           onOpenModule={(moduleId) => setView({ kind: "module", moduleId })}
           onOpenFinal={() => setView({ kind: "final-intro" })}
           onOpenAck={() => setView({ kind: "ack" })}
@@ -547,6 +614,7 @@ export default function TrainingPage() {
             await lmsApi.bypassModule(token, moduleId);
             await refresh();
           }}
+          onDownloadCert={(certId) => downloadCertificatePdf(token, certId)}
         />
       )}
       {view.kind === "module" && (
@@ -937,10 +1005,12 @@ function Home({
   finalUnlocked,
   finalPassed,
   ackUnlocked,
+  certByModule,
   onOpenModule,
   onOpenFinal,
   onOpenAck,
   onBypass,
+  onDownloadCert,
 }: {
   curriculum: Curriculum;
   state: LmsState;
@@ -948,10 +1018,12 @@ function Home({
   finalUnlocked: boolean;
   finalPassed: boolean;
   ackUnlocked: boolean;
+  certByModule: Record<string, number>;
   onOpenModule: (id: string) => void;
   onOpenFinal: () => void;
   onOpenAck: () => void;
   onBypass: (moduleId: string) => Promise<void>;
+  onDownloadCert: (certId: number) => Promise<void>;
 }) {
   const isOwner = !!state.is_owner;
   const completed = state.progress
@@ -1041,6 +1113,7 @@ function Home({
             ? () => onOpenModule(moduleId)
             : undefined;
 
+          const certId = certByModule[moduleId];
           return (
             <ModuleRow
               key={moduleId}
@@ -1060,6 +1133,8 @@ function Home({
                   ? () => onBypass(moduleId)
                   : undefined
               }
+              certId={certId}
+              onDownloadCert={onDownloadCert}
             />
           );
         })}
@@ -1136,6 +1211,8 @@ function ModuleRow({
   isOwner,
   onClick,
   onBypass,
+  certId,
+  onDownloadCert,
 }: {
   module: Module;
   locale: Locale;
@@ -1149,6 +1226,8 @@ function ModuleRow({
   isOwner: boolean;
   onClick?: () => void;
   onBypass?: () => void;
+  certId?: number;
+  onDownloadCert?: (certId: number) => Promise<void>;
 }) {
   const isMobile = useIsMobile();
   const atCap = isQuizModule && status !== "passed" && attempts >= maxAttempts;
@@ -1271,6 +1350,35 @@ function ModuleRow({
       >
         <CircleCheck size={14} />
         {tr("passed", locale)}
+        {certId && onDownloadCert ? (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onDownloadCert(certId).catch((err) =>
+                console.error("[training] download cert failed:", err),
+              );
+            }}
+            title={tr("downloadCert", locale)}
+            style={{
+              background: "transparent",
+              color: SUCCESS,
+              border: `1px solid ${SUCCESS}33`,
+              padding: "3px 8px",
+              borderRadius: 6,
+              fontSize: 11,
+              fontWeight: 700,
+              cursor: "pointer",
+              fontFamily: FONT,
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 4,
+              marginLeft: 4,
+            }}
+          >
+            <Download size={11} /> {tr("downloadCert", locale)}
+          </button>
+        ) : null}
       </span>
     ) : !unlocked && !isOwner ? (
       <span


### PR DESCRIPTION
## PR #3 of 16 — Phase 12: Per-Module Completion Certificates

Wires the `lms_completion_certificates` schema from PR #1 into the actual quiz / acknowledge / bypass flows, renders PDFs on demand via pdf-lib, and surfaces a Download button on every passed module in both the learner and admin views.

**DO NOT auto-merge.** Per agreed workflow — review the diff before approving + merging.

## A. Cert issuance — three trigger points (`routes/lms.ts`)

| Endpoint | When | Cert |
|----------|------|------|
| `POST /quiz/submit` | Every PASS attempt | score = quiz score, linked to `lms_quiz_attempts` row |
| `POST /module/acknowledge` | Content-only module completion (qleno-app, acknowledgment) | score = null, passed = true |
| `POST /admin/bypass-module` | Owner / admin / office bypass | score = 100 |

All three handlers echo `certificate_id` in their response so the frontend can offer immediate download. Historical certs are NOT auto-revoked — re-takes add a new row; the most recent non-revoked one wins in both UIs.

## B. PDF rendering — on demand, no on-disk storage

`pdf_storage_url` stays null. `GET /api/lms/certificates/:id/pdf` re-renders fresh from the cert row + curriculum title lookup. Keeps Railway disk-free, avoids stale cached PDFs, and means a content tweak (tenant logo change) reflows the next download without a backfill migration.

## C. Three new routes (mounted at `/api/lms/certificates`)

| Method | Path | Auth |
|--------|------|------|
| GET | `/me` | Any authenticated user — caller's own certs |
| GET | `/:id/pdf` | Tenant-scoped. Learner who owns it OR any privileged role |
| GET | `/admin/learner/:userId` | Owner / admin / office only |

Revoked certs return **410 Gone** with a reason. Out-of-tenant returns 404.

## D. PII-minimized device capture

Per your PR #1 review: **browser + OS only, no fingerprinting**. New `parseMinimalDeviceInfo(rawUserAgent)` in `lib/lms-signatures.ts` returns compact strings:

- `"Chrome 120 / macOS"`
- `"Safari 17 / iOS"`
- `"Firefox 121 / Windows"`
- `"Edge 120 / Windows"`

Tests verify the carve-out: a UA stuffed with `screen=2560x1440 / fonts=… / plugins=…` still produces only `"Browser / OS"` output.

## E. Learner UI

`pages/training.tsx`:
- TrainingPage fetches `/lms/certificates/me` alongside `/lms/me` on every refresh
- Builds a `module_id → latest-cert-id` map
- ModuleRow shows a green **Certificate** pill next to the Passed badge when a non-revoked cert exists
- Click streams the PDF via fetch + blob with `Authorization` header, downloads with server-provided filename

## F. Admin UI

`pages/lms-admin.tsx`:
- Per-learner expand row (both table + mobile card) now renders `<LearnerCertificatesPanel>` below the existing module attempts grid
- Panel fetches the full audit chain (including re-takes) with revoked rows clearly marked
- Download button per cert

## G. Tests

17 new unit tests in `lms-certificates.test.ts`:
- `parseMinimalDeviceInfo`: 9 tests (Chrome / Safari / Firefox / Edge / Opera / iOS / Android / unknown / **PII-leak defense**)
- `getCurriculumModuleTitle`: 7 tests (EN + ES for every seeded module + sentence-case fallback)
- 1 additional ad-hoc

**115 / 115 LMS tests pass.** Vite build clean. No new TS errors.

## Decisions for review

1. **Cert re-issue on re-take.** New cert row per pass; old one stays alive. If you want auto-revoke of older rows when a higher-score re-take happens, say so. One-line addition.
2. **Bypass certs.** Score = 100, looks identical to quiz pass on the PDF. Want a visual "Bypassed by admin" indicator on the cert? Easy to add.
3. **No backfill of existing passed modules.** Going forward they get certs; pre-existing passes do not. If you want a one-shot cold-start migration to issue certs for everyone's currently-passed modules, I'll do it as PR #3.5.
4. **IL Sexual Harassment retrofit.** Automatic via this PR — next pass / acknowledgment issues a cert. Existing passes covered by the backfill option above if you want it.

## Test plan (manual)

- [ ] Sign in as a tech (e.g. `jose.ardila@phes.io`) → take phes-policies quiz → on pass, see "Certificate" pill → click → PDF downloads
- [ ] PDF contents: tenant name "Phes", learner name, module title, score, issue date, version hash, IP, device info ("Chrome 120 / macOS")
- [ ] Locale toggle: take quiz in Spanish → cert renders in Spanish
- [ ] `/lms/admin` → expand a learner → see the new "Completion Certificates" panel listing all certs newest first
- [ ] Admin downloads any tech's cert → works
- [ ] Tech tries to download another tech's cert via direct URL → 404
- [ ] Bypass a module as owner → new cert appears with score 100
- [ ] Cold-start migration runs cleanly → `lms_completion_certificates` table populated only by going-forward activity (not backfilled this PR)

https://claude.ai/code/session_013rJ4N4vgqZWB986x8D6Ahh

---
_Generated by [Claude Code](https://claude.ai/code/session_013rJ4N4vgqZWB986x8D6Ahh)_