### PR TITLE
lms: Phase 3 drug & alcohol module + signed acknowledgment (PR #4 of 16)

### DIFF
--- a/artifacts/api-server/src/lib/lms-curriculum-titles.ts
+++ b/artifacts/api-server/src/lib/lms-curriculum-titles.ts
@@ -48,6 +48,10 @@ const MODULE_TITLES: Record<string, BilingualTitle> = {
     en: "Sexual Harassment Prevention (Illinois)",
     es: "Prevención del Acoso Sexual (Illinois)",
   },
+  "drug-alcohol": {
+    en: "Drug & Alcohol Policy",
+    es: "Política de Drogas y Alcohol",
+  },
   acknowledgment: {
     en: "Onboarding Acknowledgment",
     es: "Confirmación de Incorporación",

--- a/artifacts/api-server/src/lib/lms-signatures-db.ts
+++ b/artifacts/api-server/src/lib/lms-signatures-db.ts
@@ -12,11 +12,13 @@
  * two separate audit trails. Deleting one tenant's history can
  * never touch another's.
  */
-import { and, desc, eq } from "drizzle-orm";
+import { and, desc, eq, inArray } from "drizzle-orm";
 import { db } from "@workspace/db";
 import {
   lmsDocumentVersionsTable,
+  lmsSignedDocumentsTable,
   usersTable,
+  REQUIRED_PRE_FINAL_SIGNED_DOCS,
   type LmsDocumentVersion,
 } from "@workspace/db/schema";
 import { hashContent } from "./lms-signatures.js";
@@ -220,4 +222,45 @@ export async function markVersionMaterial(
         eq(lmsDocumentVersionsTable.company_id, companyId),
       ),
     );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Final-exam signed-document gate
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Return the subset of REQUIRED_PRE_FINAL_SIGNED_DOCS that the user has
+ * NOT yet signed (no active row in lms_signed_documents for that
+ * document_type). Tenant-scoped.
+ *
+ * Per PR #4 policy decision: the final mixed test does not unlock
+ * until this list is empty. The /quiz/submit endpoint rejects with
+ * 403 when called for FINAL_MODULE_ID while any required doc is still
+ * missing, and the /me endpoint echoes this list so the frontend can
+ * render the final-exam tile as locked with a "sign these first" hint.
+ *
+ * Returns an array of document_type strings, in the order defined by
+ * REQUIRED_PRE_FINAL_SIGNED_DOCS (stable across calls).
+ */
+export async function getMissingRequiredSignedDocs(
+  companyId: number,
+  userId: number,
+): Promise<string[]> {
+  const required = [...REQUIRED_PRE_FINAL_SIGNED_DOCS];
+  if (required.length === 0) return [];
+
+  const rows = await db
+    .select({ document_type: lmsSignedDocumentsTable.document_type })
+    .from(lmsSignedDocumentsTable)
+    .where(
+      and(
+        eq(lmsSignedDocumentsTable.company_id, companyId),
+        eq(lmsSignedDocumentsTable.user_id, userId),
+        eq(lmsSignedDocumentsTable.status, "active"),
+        inArray(lmsSignedDocumentsTable.document_type, required),
+      ),
+    );
+
+  const signed = new Set(rows.map((r) => r.document_type));
+  return required.filter((t) => !signed.has(t));
 }

--- a/artifacts/api-server/src/lib/lms-signed-documents-content.ts
+++ b/artifacts/api-server/src/lib/lms-signed-documents-content.ts
@@ -1,0 +1,236 @@
+/**
+ * Signed-Document Content Registry — server-side canonical text for
+ * each legally binding acknowledgment in the 2026 onboarding system.
+ *
+ * Why server-side:
+ *   - The signature must bind to the EXACT text the employee read. We
+ *     can't trust the client to send us the content. The server pulls
+ *     from this registry, renders it into the signing UI, AND uses
+ *     the same content to compute the version hash that goes into
+ *     lms_signed_documents. Round-trip: same canonical bytes → same
+ *     hash → audit-replay-safe.
+ *   - The frontend fetches the content via GET /api/lms/signatures/
+ *     content?documentType=X&locale=Y. The fetched text is rendered
+ *     verbatim. The signature payload is then sent back; the server
+ *     re-hashes the same text from this registry to assert the row
+ *     references the canonical version.
+ *
+ * Translation-review flag:
+ *   - Per Phase 16 spec: the four flagged legal documents (drug_alcohol,
+ *     non_solicitation, wage_deduction_notice, commission_consent) get
+ *     AI-translated initially but must be reviewed by a professional
+ *     human translator before going live. We set
+ *     `pendingTranslationReview: true` on the Spanish content so the
+ *     UI surfaces a banner: "This Spanish translation is under review.
+ *     The English version is binding until the final translation is
+ *     approved." This protects Phes legally.
+ *
+ * Adding a new document:
+ *   - Append a new key to SIGNED_DOCUMENT_CONTENT keyed by document_type
+ *     (must match @workspace/db/schema KNOWN_SIGNED_DOCUMENT_TYPES).
+ *   - Provide both `en` and `es`. Mark `pendingTranslationReview` on the
+ *     Spanish version when the legal binding requires human review.
+ *   - The version hash is auto-computed from the content body, so a
+ *     content edit creates a new version row automatically the next
+ *     time someone signs.
+ */
+
+import type { KnownSignedDocumentType } from "@workspace/db/schema";
+
+export interface SignedDocumentLocaleContent {
+  /**
+   * The canonical content for the document in this locale.
+   * IMPORTANT: this string is hashed verbatim. Reformat with care.
+   * No em dashes, no en dashes per Phase 1 spec.
+   */
+  contentHtml: string;
+  /**
+   * Human-readable title shown on the signing page and the signed PDF.
+   */
+  title: string;
+  /**
+   * When true, the UI must surface a "translation under review" banner
+   * and a notice that the English version is binding until human
+   * translation review completes. Set on Spanish entries for the four
+   * flagged legal documents.
+   */
+  pendingTranslationReview?: boolean;
+  /**
+   * Free-form change notes for the version registry. Kept short.
+   */
+  notes?: string;
+}
+
+export type SignedDocumentRegistry = Partial<
+  Record<
+    KnownSignedDocumentType,
+    {
+      en: SignedDocumentLocaleContent;
+      es: SignedDocumentLocaleContent;
+    }
+  >
+>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Document content — bilingual canonical text per document_type.
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// Format conventions:
+//   * One section per `## H2` line in the rendered output.
+//   * Use plain prose. No em dashes. No en dashes.
+//   * Use complete sentences. Use periods or colons instead of dashes.
+//   * Quoted text uses straight ASCII quotes.
+//   * Lists use plain `- ` prefix; the renderer handles styling.
+//
+// Hashes are computed over the raw string. Two whitespace-different
+// strings hash to different versions. Edit with care.
+
+const DRUG_ALCOHOL_EN: SignedDocumentLocaleContent = {
+  title: "Drug and Alcohol Policy Acknowledgment",
+  contentHtml: [
+    "PHES CLEANING SERVICES",
+    "DRUG AND ALCOHOL POLICY ACKNOWLEDGMENT",
+    "Effective Date: January 1, 2026",
+    "",
+    "By signing this acknowledgment, I confirm that I have read and understand the Phes Drug and Alcohol Policy contained in the 2026 Phes Employee Handbook and the Drug and Alcohol training module. I acknowledge and consent to the following terms:",
+    "",
+    "1. NO PRE-EMPLOYMENT TESTING.",
+    "Phes does not require pre-employment drug testing. I was not asked to submit to a drug test as a condition of being hired.",
+    "",
+    "2. IMPAIRMENT AT WORK IS PROHIBITED.",
+    "I will not work while impaired by alcohol, illegal drugs, cannabis, or any other substance (including over-the-counter or prescription medications) that affects my ability to perform my duties safely. This prohibition applies regardless of when or where I consumed the substance.",
+    "",
+    "3. CANNABIS AND OFF-DUTY ACTIVITY.",
+    "I understand that Phes does not discipline lawful off-duty cannabis use, in accordance with the Illinois Cannabis Regulation and Tax Act. I also understand that impairment AT WORK is treated separately from off-duty use, and that observable signs of impairment at work may result in discipline regardless of whether the underlying use was legal.",
+    "",
+    "4. REASONABLE-SUSPICION TESTING.",
+    "I consent to drug and alcohol testing when Phes has reasonable suspicion based on documented observable signs of impairment. I understand that the decision to test is made by the office, that Phes pays for the test, and that Phes pays my regular wages for the time spent testing.",
+    "",
+    "5. POST-ACCIDENT TESTING.",
+    "I consent to drug and alcohol testing after any workplace accident that results in (a) physical injury to anyone or (b) property damage of five hundred dollars or more. I understand that post-accident testing is a routine safety measure and is not a presumption of fault.",
+    "",
+    "6. PRESCRIPTION MEDICATION.",
+    "If I take a legally prescribed medication that may affect my ability to perform my duties safely, I will inform the office before starting the medication so that reasonable accommodation can be discussed. I understand that I am not required to disclose my diagnosis or the medication name.",
+    "",
+    "7. REFUSAL TO TEST.",
+    "I understand that refusing to submit to a properly requested test (reasonable suspicion or post-accident) is grounds for immediate termination of my employment.",
+    "",
+    "8. DRIVING VIOLATIONS REPORTING.",
+    "If I use my personal vehicle for any Phes work, I will report any DUI conviction, driver's license suspension or revocation, or major moving violation (reckless driving, leaving the scene of an accident, driving without insurance, driving with a suspended license) to the office within seventy-two hours of the event. I understand that failure to disclose may result in immediate termination.",
+    "",
+    "9. DISCIPLINE SCALE.",
+    "I have read the discipline scale for first-positive results, second-positive results, refusals, possession of alcohol or illegal drugs on Phes property or in Phes vehicles, and driving Phes-related routes while impaired, as set out in the Drug and Alcohol training module.",
+    "",
+    "10. EMPLOYEE ASSISTANCE PROGRAM (EAP).",
+    "I have been informed that Phes participates in an Employee Assistance Program. EAP use is confidential, voluntary, and does not trigger discipline.",
+    "",
+    "11. AT-WILL EMPLOYMENT.",
+    "Nothing in this acknowledgment alters my at-will employment status with Phes. Phes may terminate my employment at any time, with or without cause or notice, for any lawful reason.",
+    "",
+    "12. ELECTRONIC SIGNATURE CONSENT.",
+    "I consent to sign this acknowledgment electronically. I understand that my electronic signature has the same legal effect as a handwritten signature, in accordance with the federal Electronic Signatures in Global and National Commerce Act (E-SIGN) and the Illinois Uniform Electronic Transactions Act (UETA).",
+    "",
+    "By typing or drawing my signature below and clicking the I Agree button, I affirm that I have read, understood, and accept this Drug and Alcohol Policy Acknowledgment.",
+  ].join("\n"),
+  notes: "Phase 3 PR #4 — initial Phes drug & alcohol acknowledgment.",
+};
+
+const DRUG_ALCOHOL_ES: SignedDocumentLocaleContent = {
+  title: "Reconocimiento de la Política de Drogas y Alcohol",
+  pendingTranslationReview: true,
+  contentHtml: [
+    "PHES CLEANING SERVICES",
+    "RECONOCIMIENTO DE LA POLÍTICA DE DROGAS Y ALCOHOL",
+    "Fecha Efectiva: 1 de enero de 2026",
+    "",
+    "Al firmar este reconocimiento, confirmo que he leído y entiendo la Política de Drogas y Alcohol de Phes contenida en el Manual del Empleado de Phes 2026 y en el módulo de capacitación de Drogas y Alcohol. Reconozco y doy mi consentimiento a los siguientes términos:",
+    "",
+    "1. SIN PRUEBAS ANTES DEL EMPLEO.",
+    "Phes no exige una prueba de drogas antes del empleo. No se me pidió someterme a una prueba de drogas como condición para ser contratado.",
+    "",
+    "2. LA INTOXICACIÓN EN EL TRABAJO ESTÁ PROHIBIDA.",
+    "No trabajaré bajo los efectos del alcohol, drogas ilegales, cannabis o cualquier otra sustancia (incluyendo medicamentos de venta libre o recetados) que afecte mi capacidad de desempeñar mis funciones con seguridad. Esta prohibición aplica sin importar cuándo o dónde consumí la sustancia.",
+    "",
+    "3. CANNABIS Y ACTIVIDAD FUERA DEL TRABAJO.",
+    "Entiendo que Phes no disciplina el uso legal de cannabis fuera del trabajo, conforme a la Ley de Regulación e Impuestos del Cannabis de Illinois. También entiendo que la intoxicación EN EL TRABAJO se trata por separado del uso fuera del trabajo, y que los signos observables de intoxicación en el trabajo pueden resultar en disciplina sin importar si el uso subyacente era legal.",
+    "",
+    "4. PRUEBAS POR SOSPECHA RAZONABLE.",
+    "Doy mi consentimiento a las pruebas de drogas y alcohol cuando Phes tenga sospecha razonable basada en signos observables documentados de intoxicación. Entiendo que la decisión de hacer la prueba la toma la oficina, que Phes paga la prueba y que Phes me paga mi salario regular por el tiempo de la prueba.",
+    "",
+    "5. PRUEBAS DESPUÉS DE UN ACCIDENTE.",
+    "Doy mi consentimiento a las pruebas de drogas y alcohol después de cualquier accidente laboral que resulte en (a) lesión física a alguien o (b) daño a propiedad de quinientos dólares o más. Entiendo que las pruebas post-accidente son una medida rutinaria de seguridad y no una presunción de culpa.",
+    "",
+    "6. MEDICAMENTOS RECETADOS.",
+    "Si tomo un medicamento recetado legalmente que pueda afectar mi capacidad de desempeñar mis funciones con seguridad, informaré a la oficina antes de comenzar el medicamento para que podamos discutir una acomodación razonable. Entiendo que no estoy obligado a revelar mi diagnóstico ni el nombre del medicamento.",
+    "",
+    "7. NEGARSE A LA PRUEBA.",
+    "Entiendo que negarse a someterse a una prueba solicitada apropiadamente (sospecha razonable o post-accidente) es motivo para la terminación inmediata de mi empleo.",
+    "",
+    "8. REPORTE DE INFRACCIONES DE CONDUCIR.",
+    "Si uso mi vehículo personal para cualquier trabajo de Phes, reportaré a la oficina dentro de setenta y dos horas del evento cualquier condena por DUI, suspensión o revocación de mi licencia de conducir, o infracción mayor (conducción imprudente, abandonar el lugar de un accidente, conducir sin seguro, conducir con licencia suspendida). Entiendo que no divulgarlo puede resultar en terminación inmediata.",
+    "",
+    "9. ESCALA DE DISCIPLINA.",
+    "He leído la escala de disciplina para primeras pruebas positivas, segundas pruebas positivas, negativas a la prueba, posesión de alcohol o drogas ilegales en propiedad de Phes o vehículos de Phes, y conducir rutas relacionadas con Phes bajo intoxicación, según lo establecido en el módulo de capacitación de Drogas y Alcohol.",
+    "",
+    "10. PROGRAMA DE ASISTENCIA AL EMPLEADO (EAP).",
+    "He sido informado de que Phes participa en un Programa de Asistencia al Empleado. El uso del EAP es confidencial, voluntario y no activa disciplina.",
+    "",
+    "11. EMPLEO A VOLUNTAD.",
+    "Nada en este reconocimiento altera mi estatus de empleo a voluntad con Phes. Phes puede terminar mi empleo en cualquier momento, con o sin causa o aviso, por cualquier razón legal.",
+    "",
+    "12. CONSENTIMIENTO DE FIRMA ELECTRÓNICA.",
+    "Doy mi consentimiento para firmar este reconocimiento electrónicamente. Entiendo que mi firma electrónica tiene el mismo efecto legal que una firma manuscrita, conforme a la Ley federal de Firmas Electrónicas en el Comercio Global y Nacional (E-SIGN) y a la Ley Uniforme de Transacciones Electrónicas de Illinois (UETA).",
+    "",
+    "Al escribir o dibujar mi firma a continuación y hacer clic en el botón Acepto, afirmo que he leído, entendido y aceptado este Reconocimiento de la Política de Drogas y Alcohol.",
+  ].join("\n"),
+  notes:
+    "PENDING PROFESSIONAL TRANSLATION REVIEW. Initial AI translation. " +
+    "Human translator review required before final production sign-off.",
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Registry
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const SIGNED_DOCUMENT_CONTENT: SignedDocumentRegistry = {
+  drug_alcohol: {
+    en: DRUG_ALCOHOL_EN,
+    es: DRUG_ALCOHOL_ES,
+  },
+  // PR #5+ will add: code_of_conduct, video_photo_release, non_solicitation,
+  // supply_kit, social_media. Same shape, same conventions.
+};
+
+/**
+ * Resolve the canonical content for a (documentType, locale). Returns
+ * null when the document type has not been registered yet. The caller
+ * (signature route) treats null as 404.
+ */
+export function getSignedDocumentContent(
+  documentType: string,
+  locale: "en" | "es",
+): SignedDocumentLocaleContent | null {
+  const entry = SIGNED_DOCUMENT_CONTENT[documentType as KnownSignedDocumentType];
+  if (!entry) return null;
+  return entry[locale] ?? null;
+}
+
+/**
+ * Convenience: list every document type registered with canonical content.
+ * Used by tests + admin debugging endpoints to assert coverage.
+ */
+export function listRegisteredDocumentTypes(): string[] {
+  return Object.keys(SIGNED_DOCUMENT_CONTENT);
+}
+
+/**
+ * Convenience: true if the Spanish version of a registered document is
+ * still pending professional translation review. Drives the UI banner
+ * and the PDF watermark.
+ */
+export function isSpanishPendingTranslationReview(
+  documentType: string,
+): boolean {
+  const entry = SIGNED_DOCUMENT_CONTENT[documentType as KnownSignedDocumentType];
+  return entry?.es.pendingTranslationReview === true;
+}

--- a/artifacts/api-server/src/lib/pdf-gen.ts
+++ b/artifacts/api-server/src/lib/pdf-gen.ts
@@ -294,3 +294,502 @@ function formatDate(d: Date, locale: "en" | "es"): string {
 function truncate(s: string, max: number): string {
   return s.length <= max ? s : s.slice(0, max - 1) + "…";
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SignedDocument input + renderer
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// Multi-page legal-document PDF generated when a learner signs an
+// acknowledgment (Drug & Alcohol, Code of Conduct, Non-Solicit, Video /
+// Photo Release, Supply Kit, Social Media, etc.).
+//
+// Layout:
+//   - Page 1+: header banner, document title, body text (word-wrapped),
+//     auto-pagination when content overflows the page.
+//   - Last page: employee signature block + audit footer.
+//   - All pages: footer line with page X of Y + tenant brand + document
+//     type for tamper evidence (every page references the same context).
+//
+// Drawn signatures arrive as data URLs; we embed them as PNG images.
+// Typed signatures render as italic Helvetica at a larger size.
+
+export interface SignedDocumentInput {
+  /** Tenant brand name printed on the document, e.g. "Phes". */
+  tenantName: string;
+  /** Learner's full legal name. */
+  employeeName: string;
+  /** Display title of the document (already localized). */
+  documentTitle: string;
+  /** Slug, e.g. "drug_alcohol". Shown in the audit footer. */
+  documentType: string;
+  /** Canonical content the user agreed to (the same text that was hashed). */
+  contentBody: string;
+  /** Locale at signing ("en" | "es"). */
+  locale: string;
+  /** Whether the locale was pending professional translation review. */
+  pendingTranslationReview?: boolean;
+  /** Employee signature: data URL (drawn) or raw string (typed). */
+  employeeSignature: string;
+  /** Drawn vs typed. */
+  employeeSignatureMethod: "drawn" | "typed";
+  /** When signed. */
+  signedAt: Date;
+  /** Audit fields. */
+  ipAddress: string;
+  deviceInfo: string;
+  /** SHA-256 of the locale-prefixed content. */
+  versionHash: string;
+  /** Optional Phes representative co-signature (Non-Solicit, Video Release). */
+  representativeName?: string | null;
+  representativeSignature?: string | null;
+  representativeSignatureMethod?: "drawn" | "typed" | null;
+  representativeSignedAt?: Date | null;
+}
+
+export async function generateSignedDocumentPdf(
+  input: SignedDocumentInput,
+): Promise<Uint8Array> {
+  const doc = await PDFDocument.create();
+  const helv = await doc.embedFont(StandardFonts.Helvetica);
+  const helvBold = await doc.embedFont(StandardFonts.HelveticaBold);
+  const helvItalic = await doc.embedFont(StandardFonts.HelveticaOblique);
+
+  // Page geometry (US Letter portrait).
+  const PAGE_W = 612;
+  const PAGE_H = 792;
+  const MARGIN_X = 56;
+  const MARGIN_TOP = 100; // leave room for header
+  const MARGIN_BOTTOM = 90; // leave room for footer + page number
+  const BODY_W = PAGE_W - 2 * MARGIN_X;
+  const BODY_FONT_SIZE = 10.5;
+  const BODY_LINE_HEIGHT = 14;
+  const PARAGRAPH_GAP = 6;
+
+  // Pre-compute wrapped lines from the content body. Treat each
+  // newline-separated line as its own paragraph (preserves the
+  // existing canonical line breaks in the registry).
+  type RenderToken = { type: "h2" | "p" | "blank"; text: string };
+  const tokens: RenderToken[] = input.contentBody.split("\n").map((line) => {
+    if (line.trim() === "") return { type: "blank", text: "" };
+    // Heuristic: ALL-CAPS short lines are treated as H2 (section
+    // headings). Otherwise paragraph.
+    if (
+      line.length < 80 &&
+      line === line.toUpperCase() &&
+      /[A-Z]/.test(line) &&
+      !/^[0-9]+\./.test(line.trim())
+    ) {
+      return { type: "h2", text: line };
+    }
+    return { type: "p", text: line };
+  });
+
+  // Word-wrap a paragraph to fit BODY_W at the given font + size.
+  function wrapLine(
+    line: string,
+    font: PDFFont,
+    size: number,
+    maxWidth: number,
+  ): string[] {
+    const words = line.split(/\s+/);
+    const out: string[] = [];
+    let cur = "";
+    for (const word of words) {
+      const candidate = cur ? `${cur} ${word}` : word;
+      const w = font.widthOfTextAtSize(candidate, size);
+      if (w <= maxWidth) {
+        cur = candidate;
+      } else {
+        if (cur) out.push(cur);
+        cur = word;
+      }
+    }
+    if (cur) out.push(cur);
+    return out.length > 0 ? out : [""];
+  }
+
+  // Pre-flatten into render lines with type metadata so pagination is
+  // a single pass.
+  interface FlatLine {
+    type: "h2" | "p" | "blank";
+    text: string;
+    height: number;
+  }
+  const flat: FlatLine[] = [];
+  for (const tok of tokens) {
+    if (tok.type === "blank") {
+      flat.push({ type: "blank", text: "", height: PARAGRAPH_GAP });
+      continue;
+    }
+    const font = tok.type === "h2" ? helvBold : helv;
+    const size = tok.type === "h2" ? 11.5 : BODY_FONT_SIZE;
+    const wrapped = wrapLine(tok.text, font, size, BODY_W);
+    for (const w of wrapped) {
+      flat.push({ type: tok.type, text: w, height: BODY_LINE_HEIGHT });
+    }
+  }
+
+  // Paginate: greedily fill each page until next-line would overflow.
+  // The final signature page reserves extra space, so we end content
+  // earlier on it (handled by caller post-pagination).
+  const SIGNATURE_BLOCK_H = 180;
+
+  const pages: FlatLine[][] = [];
+  let curPage: FlatLine[] = [];
+  let yUsed = 0;
+  const bodyBudget = PAGE_H - MARGIN_TOP - MARGIN_BOTTOM;
+
+  for (let i = 0; i < flat.length; i++) {
+    const line = flat[i];
+    if (yUsed + line.height > bodyBudget) {
+      pages.push(curPage);
+      curPage = [];
+      yUsed = 0;
+    }
+    curPage.push(line);
+    yUsed += line.height;
+  }
+  if (curPage.length > 0) pages.push(curPage);
+
+  // Ensure room for the signature block on the LAST page; if it would
+  // overflow there, push it to a new last page.
+  if (
+    pages.length > 0 &&
+    pages[pages.length - 1].reduce((a, l) => a + l.height, 0) >
+      bodyBudget - SIGNATURE_BLOCK_H
+  ) {
+    pages.push([]);
+  }
+
+  const totalPages = Math.max(pages.length, 1);
+
+  for (let p = 0; p < totalPages; p++) {
+    const page = doc.addPage([PAGE_W, PAGE_H]);
+
+    // Header
+    drawSignedDocHeader(page, helvBold, helv, input, p + 1);
+
+    // Body
+    const linesOnPage = pages[p] ?? [];
+    let y = PAGE_H - MARGIN_TOP;
+    for (const line of linesOnPage) {
+      if (line.type === "blank") {
+        y -= line.height;
+        continue;
+      }
+      const font = line.type === "h2" ? helvBold : helv;
+      const size = line.type === "h2" ? 11.5 : BODY_FONT_SIZE;
+      page.drawText(line.text, {
+        x: MARGIN_X,
+        y,
+        size,
+        font,
+        color: COLORS.ink,
+      });
+      y -= line.height;
+    }
+
+    // Last page: signature block
+    if (p === totalPages - 1) {
+      drawSignedDocSignatureBlock(
+        doc,
+        page,
+        helv,
+        helvBold,
+        helvItalic,
+        input,
+        MARGIN_X,
+        MARGIN_BOTTOM + 10,
+      );
+    }
+
+    // Footer (every page)
+    drawSignedDocFooter(page, helv, input, p + 1, totalPages);
+  }
+
+  return doc.save();
+}
+
+function drawSignedDocHeader(
+  page: PDFPage,
+  helvBold: PDFFont,
+  helv: PDFFont,
+  input: SignedDocumentInput,
+  pageNumber: number,
+): void {
+  const { width } = page.getSize();
+  // Mint accent bar
+  page.drawRectangle({
+    x: 0,
+    y: 760,
+    width,
+    height: 8,
+    color: COLORS.mint,
+  });
+  // Tenant tag (upper left)
+  page.drawText(input.tenantName.toUpperCase(), {
+    x: 56,
+    y: 740,
+    size: 10,
+    font: helvBold,
+    color: COLORS.inkMute,
+  });
+  // Document title (upper right)
+  const titleW = helvBold.widthOfTextAtSize(input.documentTitle, 12);
+  page.drawText(input.documentTitle, {
+    x: width - 56 - titleW,
+    y: 740,
+    size: 12,
+    font: helvBold,
+    color: COLORS.navy,
+  });
+  // Translation-review banner on page 1 if applicable
+  if (pageNumber === 1 && input.pendingTranslationReview) {
+    page.drawRectangle({
+      x: 56,
+      y: 716,
+      width: width - 112,
+      height: 16,
+      color: rgb(0.997, 0.953, 0.78), // soft amber
+    });
+    const banner =
+      input.locale === "es"
+        ? "Esta traducción al español está bajo revisión. La versión en inglés es vinculante hasta que la traducción profesional sea aprobada."
+        : "This Spanish translation is under review. The English version is binding until professional translation is approved.";
+    page.drawText(truncate(banner, 110), {
+      x: 60,
+      y: 720,
+      size: 7.5,
+      font: helv,
+      color: COLORS.inkMute,
+    });
+  }
+}
+
+function drawSignedDocFooter(
+  page: PDFPage,
+  helv: PDFFont,
+  input: SignedDocumentInput,
+  pageNumber: number,
+  totalPages: number,
+): void {
+  const { width } = page.getSize();
+  const footerY = 40;
+  // Page indicator (center)
+  const pageLabel =
+    input.locale === "es"
+      ? `Página ${pageNumber} de ${totalPages}`
+      : `Page ${pageNumber} of ${totalPages}`;
+  const pageW = helv.widthOfTextAtSize(pageLabel, 8);
+  page.drawText(pageLabel, {
+    x: width / 2 - pageW / 2,
+    y: footerY,
+    size: 8,
+    font: helv,
+    color: COLORS.inkLight,
+  });
+  // Document slug + hash short (lower left)
+  page.drawText(
+    `${input.documentType} · ${input.versionHash.slice(0, 12)}…`,
+    {
+      x: 56,
+      y: footerY,
+      size: 7,
+      font: helv,
+      color: COLORS.inkLight,
+    },
+  );
+  // Tenant tag (lower right)
+  const tag = `${input.tenantName} 2026`;
+  const tagW = helv.widthOfTextAtSize(tag, 7);
+  page.drawText(tag, {
+    x: width - 56 - tagW,
+    y: footerY,
+    size: 7,
+    font: helv,
+    color: COLORS.inkLight,
+  });
+}
+
+async function drawSignedDocSignatureBlock(
+  doc: PDFDocument,
+  page: PDFPage,
+  helv: PDFFont,
+  helvBold: PDFFont,
+  helvItalic: PDFFont,
+  input: SignedDocumentInput,
+  marginX: number,
+  marginBottom: number,
+): Promise<void> {
+  const { width } = page.getSize();
+  const blockTop = marginBottom + 160;
+
+  page.drawLine({
+    start: { x: marginX, y: blockTop + 10 },
+    end: { x: width - marginX, y: blockTop + 10 },
+    thickness: 0.5,
+    color: COLORS.line,
+  });
+
+  // Employee name
+  page.drawText(input.locale === "es" ? "EMPLEADO" : "EMPLOYEE", {
+    x: marginX,
+    y: blockTop - 10,
+    size: 8,
+    font: helvBold,
+    color: COLORS.inkMute,
+  });
+  page.drawText(input.employeeName, {
+    x: marginX,
+    y: blockTop - 26,
+    size: 12,
+    font: helvBold,
+    color: COLORS.ink,
+  });
+
+  // Signed-at + IP + device
+  const dateStr = formatDate(input.signedAt, input.locale === "es" ? "es" : "en");
+  page.drawText(
+    `${input.locale === "es" ? "Firmado" : "Signed"}: ${dateStr} · ${input.signedAt.toISOString()}`,
+    {
+      x: marginX,
+      y: blockTop - 42,
+      size: 8,
+      font: helv,
+      color: COLORS.inkMute,
+    },
+  );
+  page.drawText(`IP: ${input.ipAddress} · ${input.deviceInfo}`, {
+    x: marginX,
+    y: blockTop - 54,
+    size: 8,
+    font: helv,
+    color: COLORS.inkMute,
+  });
+
+  // Signature itself (right column)
+  const sigX = width / 2 + 20;
+  const sigBoxW = width - sigX - marginX;
+  page.drawText(
+    input.locale === "es" ? "FIRMA" : "SIGNATURE",
+    { x: sigX, y: blockTop - 10, size: 8, font: helvBold, color: COLORS.inkMute },
+  );
+
+  if (input.employeeSignatureMethod === "drawn") {
+    // Embed the data URL as a PNG image.
+    try {
+      const base64 = input.employeeSignature.split(",", 2)[1] ?? "";
+      const bytes = Buffer.from(base64, "base64");
+      const img = input.employeeSignature.includes("image/png")
+        ? await doc.embedPng(bytes)
+        : await doc.embedJpg(bytes);
+      const scale = Math.min(sigBoxW / img.width, 60 / img.height, 1);
+      page.drawImage(img, {
+        x: sigX,
+        y: blockTop - 80,
+        width: img.width * scale,
+        height: img.height * scale,
+      });
+    } catch {
+      page.drawText("[drawn signature could not render]", {
+        x: sigX,
+        y: blockTop - 40,
+        size: 9,
+        font: helvItalic,
+        color: COLORS.inkMute,
+      });
+    }
+  } else {
+    page.drawText(`/s/ ${input.employeeSignature}`, {
+      x: sigX,
+      y: blockTop - 36,
+      size: 16,
+      font: helvItalic,
+      color: COLORS.ink,
+    });
+    page.drawText(
+      input.locale === "es"
+        ? "(firma electrónica tipo texto, vinculante bajo UETA y E-SIGN)"
+        : "(typed electronic signature, binding under UETA and E-SIGN)",
+      {
+        x: sigX,
+        y: blockTop - 50,
+        size: 7,
+        font: helvItalic,
+        color: COLORS.inkLight,
+      },
+    );
+  }
+
+  // Representative signature (if present)
+  if (input.representativeName && input.representativeSignature) {
+    const repY = blockTop - 95;
+    page.drawLine({
+      start: { x: marginX, y: repY + 6 },
+      end: { x: width - marginX, y: repY + 6 },
+      thickness: 0.3,
+      color: COLORS.line,
+    });
+    page.drawText(
+      input.locale === "es" ? "REPRESENTANTE DE PHES" : "PHES REPRESENTATIVE",
+      {
+        x: marginX,
+        y: repY - 10,
+        size: 8,
+        font: helvBold,
+        color: COLORS.inkMute,
+      },
+    );
+    page.drawText(input.representativeName, {
+      x: marginX,
+      y: repY - 24,
+      size: 11,
+      font: helvBold,
+      color: COLORS.ink,
+    });
+    if (input.representativeSignedAt) {
+      page.drawText(
+        `${input.locale === "es" ? "Firmado" : "Signed"}: ${formatDate(input.representativeSignedAt, input.locale === "es" ? "es" : "en")}`,
+        {
+          x: marginX,
+          y: repY - 36,
+          size: 7,
+          font: helv,
+          color: COLORS.inkMute,
+        },
+      );
+    }
+    if (input.representativeSignatureMethod === "drawn") {
+      try {
+        const base64 = input.representativeSignature.split(",", 2)[1] ?? "";
+        const bytes = Buffer.from(base64, "base64");
+        const img = input.representativeSignature.includes("image/png")
+          ? await doc.embedPng(bytes)
+          : await doc.embedJpg(bytes);
+        const scale = Math.min(sigBoxW / img.width, 50 / img.height, 1);
+        page.drawImage(img, {
+          x: sigX,
+          y: repY - 60,
+          width: img.width * scale,
+          height: img.height * scale,
+        });
+      } catch {
+        page.drawText("[representative drawn signature]", {
+          x: sigX,
+          y: repY - 30,
+          size: 9,
+          font: helvItalic,
+          color: COLORS.inkMute,
+        });
+      }
+    } else {
+      page.drawText(`/s/ ${input.representativeSignature}`, {
+        x: sigX,
+        y: repY - 30,
+        size: 14,
+        font: helvItalic,
+        color: COLORS.ink,
+      });
+    }
+  }
+}

--- a/artifacts/api-server/src/routes/index.ts
+++ b/artifacts/api-server/src/routes/index.ts
@@ -75,6 +75,7 @@ import geocodeRouter from "./geocode.js";
 import configRouter from "./config.js";
 import lmsRouter from "./lms.js";
 import lmsCertificatesRouter from "./lms-certificates.js";
+import lmsSignaturesRouter from "./lms-signatures.js";
 
 const router: IRouter = Router();
 
@@ -154,5 +155,6 @@ router.use("/geocode", geocodeRouter);
 router.use("/config", configRouter);
 router.use("/lms", lmsRouter);
 router.use("/lms/certificates", lmsCertificatesRouter);
+router.use("/lms/signatures", lmsSignaturesRouter);
 
 export default router;

--- a/artifacts/api-server/src/routes/lms-signatures.ts
+++ b/artifacts/api-server/src/routes/lms-signatures.ts
@@ -1,0 +1,628 @@
+/**
+ * LMS Signed Document signatures — routes (Phase 3+ PR #4 of 16).
+ *
+ * Generic surface used by every signed legal acknowledgment in the
+ * 2026 onboarding system. PR #4 wires the first document_type
+ * (drug_alcohol). PR #5+ add code_of_conduct, video_photo_release,
+ * non_solicitation, supply_kit, social_media without changing this
+ * file.
+ *
+ * Mounted at /api/lms/signatures.
+ *
+ * Endpoints:
+ *   GET  /content?documentType=X&locale=Y   render-ready content
+ *   POST /sign                              capture employee signature
+ *   POST /admin/co-sign                     capture rep co-signature
+ *                                            (owner / admin / office)
+ *   GET  /me                                list caller's signed docs
+ *   GET  /admin/learner/:userId             list signed docs for user
+ *   GET  /:id/pdf                           render + stream signed PDF
+ *
+ * Tenant gate: every read is scoped by company_id. Co-sign and admin
+ * list endpoints additionally gate on role (owner / admin / office).
+ *
+ * UETA / E-SIGN compliance:
+ *   - Affirmative-action: the POST /sign body MUST include
+ *     `affirmation: true` AND a non-empty signature payload. Server
+ *     rejects otherwise.
+ *   - Version binding: the content is fetched from the server-side
+ *     registry at sign time. The hash captured into the row IS the
+ *     hash of the exact bytes the user agreed to (registry is the
+ *     source of truth, not client-supplied).
+ *   - Audit: IP, device info, signed_at all stamped server-side.
+ */
+import { Router } from "express";
+import { and, desc, eq } from "drizzle-orm";
+import { db } from "@workspace/db";
+import {
+  lmsSignedDocumentsTable,
+  lmsSignatureEventsTable,
+  KNOWN_SIGNED_DOCUMENT_TYPES,
+  CO_SIGNED_DOCUMENT_TYPES,
+  type LmsSignedDocument,
+} from "@workspace/db/schema";
+import { requireAuth, requireRole } from "../lib/auth.js";
+import {
+  captureRequestMetadata,
+  parseMinimalDeviceInfo,
+  validateEmployeeSignature,
+} from "../lib/lms-signatures.js";
+import {
+  getOrCreateDocumentVersion,
+  getTenantOwnerForSignature,
+} from "../lib/lms-signatures-db.js";
+import {
+  getSignedDocumentContent,
+  isSpanishPendingTranslationReview,
+} from "../lib/lms-signed-documents-content.js";
+import {
+  getCertificateLearnerSummary,
+} from "../lib/lms-certificates.js";
+import { generateSignedDocumentPdf } from "../lib/pdf-gen.js";
+import { logAudit } from "../lib/audit.js";
+
+const router = Router();
+
+const KNOWN_TYPES = new Set<string>(KNOWN_SIGNED_DOCUMENT_TYPES);
+const CO_SIGNED_TYPES = new Set<string>(CO_SIGNED_DOCUMENT_TYPES);
+
+function isLocale(v: unknown): v is "en" | "es" {
+  return v === "en" || v === "es";
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /content — render-ready content for a (documentType, locale)
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// Used by the signing UI BEFORE the user signs. The response includes
+// the title, the canonical body text, and the translation-review flag
+// so the UI can render the amber banner.
+
+router.get("/content", requireAuth, async (req, res) => {
+  try {
+    const documentType = String(req.query.documentType ?? "");
+    const locale = String(req.query.locale ?? "en");
+    if (!KNOWN_TYPES.has(documentType)) {
+      return res
+        .status(400)
+        .json({ error: "Bad Request", message: "Unknown documentType" });
+    }
+    if (!isLocale(locale)) {
+      return res
+        .status(400)
+        .json({ error: "Bad Request", message: "locale must be 'en' or 'es'" });
+    }
+    const entry = getSignedDocumentContent(documentType, locale);
+    if (!entry) {
+      return res
+        .status(404)
+        .json({
+          error: "Not Found",
+          message: `No registered content for ${documentType}/${locale}`,
+        });
+    }
+    return res.json({
+      data: {
+        documentType,
+        locale,
+        title: entry.title,
+        contentHtml: entry.contentHtml,
+        pendingTranslationReview: entry.pendingTranslationReview ?? false,
+      },
+    });
+  } catch (err) {
+    console.error("[lms-signatures] GET /content error:", err);
+    return res
+      .status(500)
+      .json({ error: "Internal Server Error", message: "Failed to load content" });
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /sign — capture employee signature for a signed document
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// Body:
+//   {
+//     documentType: 'drug_alcohol' | etc.,
+//     locale: 'en' | 'es',
+//     signatureMethod: 'drawn' | 'typed',
+//     signature: string,
+//     affirmation: true   // E-SIGN affirmative-action gate
+//   }
+//
+// Server fetches the canonical content from the server-side registry,
+// hashes it, upserts a version row, then inserts a new
+// lms_signed_documents row scoped to the caller's tenant and userId.
+// Old signatures for the same (user, document_type) are auto-marked
+// 'superseded' so the latest active row is the binding one.
+
+router.post("/sign", requireAuth, async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    if (companyId == null) {
+      return res
+        .status(400)
+        .json({ error: "Bad Request", message: "User has no company assignment" });
+    }
+    const userId = req.auth!.userId;
+
+    const documentType: string | undefined = req.body?.documentType;
+    const locale: string | undefined = req.body?.locale;
+    const signatureMethod: string | undefined = req.body?.signatureMethod;
+    const signature: string | undefined = req.body?.signature;
+    const affirmation = req.body?.affirmation === true;
+
+    if (!documentType || !KNOWN_TYPES.has(documentType)) {
+      return res
+        .status(400)
+        .json({ error: "Bad Request", message: "Unknown documentType" });
+    }
+    if (!isLocale(locale)) {
+      return res
+        .status(400)
+        .json({ error: "Bad Request", message: "locale must be 'en' or 'es'" });
+    }
+    if (signatureMethod !== "drawn" && signatureMethod !== "typed") {
+      return res
+        .status(400)
+        .json({
+          error: "Bad Request",
+          message: "signatureMethod must be 'drawn' or 'typed'",
+        });
+    }
+    if (typeof signature !== "string") {
+      return res
+        .status(400)
+        .json({ error: "Bad Request", message: "signature is required" });
+    }
+    if (!affirmation) {
+      return res.status(400).json({
+        error: "Bad Request",
+        message:
+          "UETA / E-SIGN requires affirmative agreement. Send affirmation: true.",
+      });
+    }
+    const validationErr = validateEmployeeSignature(signatureMethod, signature);
+    if (validationErr) {
+      return res
+        .status(400)
+        .json({ error: "Bad Request", message: validationErr });
+    }
+
+    const content = getSignedDocumentContent(documentType, locale);
+    if (!content) {
+      return res.status(404).json({
+        error: "Not Found",
+        message: `No registered content for ${documentType}/${locale}`,
+      });
+    }
+
+    const version = await getOrCreateDocumentVersion({
+      companyId,
+      documentType,
+      locale,
+      contentHtml: content.contentHtml,
+      isMaterial: false,
+      notes: content.notes,
+    });
+
+    const meta = captureRequestMetadata(req);
+    const deviceInfo = parseMinimalDeviceInfo(meta.user_agent);
+    const now = new Date();
+
+    // Supersede any prior active signature for this (user, document_type).
+    await db
+      .update(lmsSignedDocumentsTable)
+      .set({ status: "superseded", superseded_at: now, updated_at: now })
+      .where(
+        and(
+          eq(lmsSignedDocumentsTable.company_id, companyId),
+          eq(lmsSignedDocumentsTable.user_id, userId),
+          eq(lmsSignedDocumentsTable.document_type, documentType),
+          eq(lmsSignedDocumentsTable.status, "active"),
+        ),
+      );
+
+    const inserted = await db
+      .insert(lmsSignedDocumentsTable)
+      .values({
+        company_id: companyId,
+        user_id: userId,
+        document_type: documentType,
+        document_version_id: version.id,
+        locale,
+        version_hash: version.version_hash,
+        employee_signature: signature,
+        employee_signature_method: signatureMethod,
+        signed_at: now,
+        ip_address: meta.ip_address,
+        device_info: deviceInfo,
+        status: "active",
+      })
+      .returning();
+    const newDoc = inserted[0];
+
+    // Audit log
+    await db.insert(lmsSignatureEventsTable).values({
+      company_id: companyId,
+      user_id: userId,
+      event_type: "sign_completed",
+      signed_document_id: newDoc.id,
+      document_type: documentType,
+      ip_address: meta.ip_address,
+      user_agent: meta.user_agent,
+      event_data: { locale, signature_method: signatureMethod },
+      event_at: now,
+    });
+    await logAudit(
+      req,
+      "lms.signature.sign",
+      "lms_signed_document",
+      newDoc.id,
+      null,
+      { document_type: documentType, locale },
+    );
+
+    return res.json({
+      data: {
+        id: newDoc.id,
+        document_type: documentType,
+        locale,
+        version_hash: version.version_hash,
+        signed_at: now.toISOString(),
+        requires_co_sign: CO_SIGNED_TYPES.has(documentType),
+      },
+    });
+  } catch (err) {
+    console.error("[lms-signatures] POST /sign error:", err);
+    return res
+      .status(500)
+      .json({ error: "Internal Server Error", message: "Failed to record signature" });
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /admin/co-sign — capture Phes representative co-signature
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// Body:
+//   { signed_document_id, signatureMethod, signature, affirmation }
+//
+// Used for Non-Solicitation Agreement (PR #7) and Video/Photo Release
+// (PR #6). PR #4 ships the endpoint scaffold; the first co-signed
+// document is PR #6. Caller must be owner / admin / office.
+
+router.post(
+  "/admin/co-sign",
+  requireAuth,
+  requireRole("owner", "admin", "office"),
+  async (req, res) => {
+    try {
+      const companyId = req.auth!.companyId;
+      if (companyId == null) {
+        return res
+          .status(400)
+          .json({ error: "Bad Request", message: "User has no company assignment" });
+      }
+      const signedDocumentId = Number(req.body?.signed_document_id);
+      const signatureMethod: string | undefined = req.body?.signatureMethod;
+      const signature: string | undefined = req.body?.signature;
+      const affirmation = req.body?.affirmation === true;
+      if (!Number.isFinite(signedDocumentId) || signedDocumentId <= 0) {
+        return res
+          .status(400)
+          .json({ error: "Bad Request", message: "signed_document_id is required" });
+      }
+      if (signatureMethod !== "drawn" && signatureMethod !== "typed") {
+        return res
+          .status(400)
+          .json({ error: "Bad Request", message: "signatureMethod must be drawn or typed" });
+      }
+      if (typeof signature !== "string") {
+        return res
+          .status(400)
+          .json({ error: "Bad Request", message: "signature is required" });
+      }
+      if (!affirmation) {
+        return res
+          .status(400)
+          .json({ error: "Bad Request", message: "affirmation: true required" });
+      }
+      const validationErr = validateEmployeeSignature(signatureMethod, signature);
+      if (validationErr) {
+        return res
+          .status(400)
+          .json({ error: "Bad Request", message: validationErr });
+      }
+
+      // Tenant gate via the signed_document row.
+      const existing = await db
+        .select()
+        .from(lmsSignedDocumentsTable)
+        .where(
+          and(
+            eq(lmsSignedDocumentsTable.id, signedDocumentId),
+            eq(lmsSignedDocumentsTable.company_id, companyId),
+          ),
+        )
+        .limit(1);
+      if (!existing[0]) {
+        return res
+          .status(404)
+          .json({ error: "Not Found", message: "Signed document not found" });
+      }
+      if (!CO_SIGNED_TYPES.has(existing[0].document_type)) {
+        return res.status(400).json({
+          error: "Bad Request",
+          message: `Document type '${existing[0].document_type}' does not require co-signature`,
+        });
+      }
+
+      const meta = captureRequestMetadata(req);
+      const deviceInfo = parseMinimalDeviceInfo(meta.user_agent);
+      const now = new Date();
+
+      const updated = await db
+        .update(lmsSignedDocumentsTable)
+        .set({
+          representative_user_id: req.auth!.userId,
+          representative_signature: signature,
+          representative_signature_method: signatureMethod,
+          representative_signed_at: now,
+          representative_ip_address: meta.ip_address,
+          representative_device_info: deviceInfo,
+          updated_at: now,
+        })
+        .where(eq(lmsSignedDocumentsTable.id, signedDocumentId))
+        .returning();
+
+      await db.insert(lmsSignatureEventsTable).values({
+        company_id: companyId,
+        user_id: req.auth!.userId,
+        event_type: "co_signed",
+        signed_document_id: signedDocumentId,
+        document_type: existing[0].document_type,
+        ip_address: meta.ip_address,
+        user_agent: meta.user_agent,
+        event_data: { signature_method: signatureMethod },
+        event_at: now,
+      });
+      await logAudit(
+        req,
+        "lms.signature.co_sign",
+        "lms_signed_document",
+        signedDocumentId,
+        null,
+        { document_type: existing[0].document_type },
+      );
+
+      return res.json({ data: updated[0] });
+    } catch (err) {
+      console.error("[lms-signatures] POST /admin/co-sign error:", err);
+      return res
+        .status(500)
+        .json({ error: "Internal Server Error", message: "Failed to record co-signature" });
+    }
+  },
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /me — caller's signed documents (newest first)
+// ─────────────────────────────────────────────────────────────────────────────
+
+router.get("/me", requireAuth, async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    if (companyId == null) {
+      return res
+        .status(400)
+        .json({ error: "Bad Request", message: "User has no company assignment" });
+    }
+    const userId = req.auth!.userId;
+    const rows = await db
+      .select()
+      .from(lmsSignedDocumentsTable)
+      .where(
+        and(
+          eq(lmsSignedDocumentsTable.company_id, companyId),
+          eq(lmsSignedDocumentsTable.user_id, userId),
+        ),
+      )
+      .orderBy(desc(lmsSignedDocumentsTable.signed_at));
+    return res.json({ data: rows });
+  } catch (err) {
+    console.error("[lms-signatures] GET /me error:", err);
+    return res
+      .status(500)
+      .json({ error: "Internal Server Error", message: "Failed to list signatures" });
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /admin/learner/:userId — admin: list signed docs for a user
+// ─────────────────────────────────────────────────────────────────────────────
+
+router.get(
+  "/admin/learner/:userId",
+  requireAuth,
+  requireRole("owner", "admin", "office"),
+  async (req, res) => {
+    try {
+      const companyId = req.auth!.companyId;
+      if (companyId == null) {
+        return res
+          .status(400)
+          .json({ error: "Bad Request", message: "User has no company assignment" });
+      }
+      const targetUserId = Number(req.params.userId);
+      if (!Number.isFinite(targetUserId) || targetUserId <= 0) {
+        return res
+          .status(400)
+          .json({ error: "Bad Request", message: "Invalid userId" });
+      }
+      const rows = await db
+        .select()
+        .from(lmsSignedDocumentsTable)
+        .where(
+          and(
+            eq(lmsSignedDocumentsTable.company_id, companyId),
+            eq(lmsSignedDocumentsTable.user_id, targetUserId),
+          ),
+        )
+        .orderBy(desc(lmsSignedDocumentsTable.signed_at));
+      return res.json({ data: rows });
+    } catch (err) {
+      console.error("[lms-signatures] GET /admin/learner error:", err);
+      return res
+        .status(500)
+        .json({
+          error: "Internal Server Error",
+          message: "Failed to list signed documents",
+        });
+    }
+  },
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /:id/pdf — render + stream the signed PDF
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// Caller must own the doc OR hold a privileged role. Revoked docs
+// return 410. Out-of-tenant returns 404.
+
+router.get("/:id/pdf", requireAuth, async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    if (companyId == null) {
+      return res
+        .status(400)
+        .json({ error: "Bad Request", message: "User has no company assignment" });
+    }
+    const docId = Number(req.params.id);
+    if (!Number.isFinite(docId) || docId <= 0) {
+      return res
+        .status(400)
+        .json({ error: "Bad Request", message: "Invalid id" });
+    }
+    const rows = await db
+      .select()
+      .from(lmsSignedDocumentsTable)
+      .where(
+        and(
+          eq(lmsSignedDocumentsTable.id, docId),
+          eq(lmsSignedDocumentsTable.company_id, companyId),
+        ),
+      )
+      .limit(1);
+    const doc = rows[0] as LmsSignedDocument | undefined;
+    if (!doc) {
+      return res
+        .status(404)
+        .json({ error: "Not Found", message: "Signed document not found" });
+    }
+
+    // Access gate: owner of the doc OR privileged role.
+    const callerRole = req.auth!.role;
+    const isPrivileged =
+      callerRole === "owner" ||
+      callerRole === "admin" ||
+      callerRole === "office" ||
+      callerRole === "super_admin";
+    if (!isPrivileged && doc.user_id !== req.auth!.userId) {
+      return res
+        .status(404)
+        .json({ error: "Not Found", message: "Signed document not found" });
+    }
+    if (doc.status === "revoked") {
+      return res
+        .status(410)
+        .json({ error: "Gone", message: "This signed document was revoked" });
+    }
+
+    // Resolve the canonical content again from the registry to render
+    // the body. This ensures the PDF reflects EXACTLY what was hashed,
+    // even if the version row's content_html in the DB drifts somehow.
+    const content = getSignedDocumentContent(
+      doc.document_type,
+      doc.locale === "es" ? "es" : "en",
+    );
+    if (!content) {
+      return res
+        .status(404)
+        .json({
+          error: "Not Found",
+          message: `Cannot render: ${doc.document_type}/${doc.locale} content not in registry`,
+        });
+    }
+
+    const learner = await getCertificateLearnerSummary(companyId, doc.user_id);
+    if (!learner) {
+      return res
+        .status(404)
+        .json({ error: "Not Found", message: "Learner not found" });
+    }
+
+    // Representative name for co-signed docs
+    let representativeName: string | null = null;
+    if (doc.representative_user_id) {
+      const owner = await getTenantOwnerForSignature(companyId);
+      if (owner && owner.user_id === doc.representative_user_id) {
+        representativeName =
+          `${owner.first_name ?? ""} ${owner.last_name ?? ""}`.trim() ||
+          owner.email;
+      }
+    }
+
+    const pdfBytes = await generateSignedDocumentPdf({
+      tenantName: "Phes",
+      employeeName: learner.fullName,
+      documentTitle: content.title,
+      documentType: doc.document_type,
+      contentBody: content.contentHtml,
+      locale: doc.locale,
+      pendingTranslationReview:
+        doc.locale === "es" && isSpanishPendingTranslationReview(doc.document_type),
+      employeeSignature: doc.employee_signature,
+      employeeSignatureMethod: doc.employee_signature_method as "drawn" | "typed",
+      signedAt: doc.signed_at,
+      ipAddress: doc.ip_address,
+      deviceInfo: doc.device_info,
+      versionHash: doc.version_hash,
+      representativeName,
+      representativeSignature: doc.representative_signature,
+      representativeSignatureMethod: doc.representative_signature_method as
+        | "drawn"
+        | "typed"
+        | null,
+      representativeSignedAt: doc.representative_signed_at,
+    });
+
+    // Audit the download
+    await db.insert(lmsSignatureEventsTable).values({
+      company_id: companyId,
+      user_id: req.auth!.userId,
+      event_type: "pdf_downloaded",
+      signed_document_id: doc.id,
+      document_type: doc.document_type,
+      ip_address: captureRequestMetadata(req).ip_address,
+      user_agent: captureRequestMetadata(req).user_agent,
+      event_data: { downloader_is_owner: doc.user_id !== req.auth!.userId },
+      event_at: new Date(),
+    });
+
+    const safeName = learner.fullName.replace(/[^a-zA-Z0-9_-]+/g, "_");
+    const filename = `phes-${doc.document_type}-${safeName}-${doc.id}.pdf`;
+    res.setHeader("Content-Type", "application/pdf");
+    res.setHeader("Content-Disposition", `attachment; filename="${filename}"`);
+    return res.end(Buffer.from(pdfBytes));
+  } catch (err) {
+    console.error("[lms-signatures] GET /:id/pdf error:", err);
+    return res.status(500).json({
+      error: "Internal Server Error",
+      message: "Failed to render signed document",
+    });
+  }
+});
+
+export default router;

--- a/artifacts/api-server/src/routes/lms.ts
+++ b/artifacts/api-server/src/routes/lms.ts
@@ -67,6 +67,7 @@ import {
   captureRequestMetadata,
   parseMinimalDeviceInfo,
 } from "../lib/lms-signatures.js";
+import { getMissingRequiredSignedDocs } from "../lib/lms-signatures-db.js";
 import { issueCertificate } from "../lib/lms-certificates.js";
 
 const router = Router();
@@ -297,15 +298,26 @@ router.get("/me", requireAuth, async (req, res) => {
     for (const m of MODULE_ORDER) {
       unlocked[m] = isModuleUnlocked(m, completed);
     }
-    unlocked[FINAL_MODULE_ID] = isFinalUnlocked(completed);
+    // PR #4: the final exam also requires every standalone signed
+    // acknowledgment to be in place. We compute the missing list and
+    // bake it into the unlocked flag too, so the existing frontend
+    // sequential-gating logic naturally treats the final card as
+    // locked when signed docs are pending. The frontend also reads
+    // missing_required_signed_docs directly to show WHAT'S missing.
+    const missingSignedDocs = await getMissingRequiredSignedDocs(
+      companyId,
+      userId,
+    );
+    unlocked[FINAL_MODULE_ID] =
+      isFinalUnlocked(completed) && missingSignedDocs.length === 0;
 
     const limits: Record<string, number> = {};
     for (const m of MODULE_ORDER) limits[m] = MAX_MODULE_ATTEMPTS;
     limits[FINAL_MODULE_ID] = MAX_FINAL_ATTEMPTS;
 
-    // Bypass capability: owners, admins, and office staff (Maribel, Francisco
-    // for Phes) can skip modules. This `is_owner` field is kept for the
-    // existing frontend prop name; semantically it now means "can_bypass".
+    // Bypass capability: owners, admins, and office staff can skip
+    // modules. This `is_owner` field is kept for the existing frontend
+    // prop name; semantically it now means "can_bypass".
     const canBypass =
       req.auth!.role === "owner" ||
       req.auth!.role === "admin" ||
@@ -319,6 +331,7 @@ router.get("/me", requireAuth, async (req, res) => {
         days_remaining: daysUntil(enrollment.deadline_at, now),
         limits,
         is_owner: canBypass,
+        missing_required_signed_docs: missingSignedDocs,
         can_bypass: canBypass,
       },
     });
@@ -597,6 +610,27 @@ router.post("/quiz/submit", requireAuth, async (req, res) => {
           error: "Forbidden",
           message: "Final mixed test is locked",
         });
+      }
+      // PR #4 policy: final exam additionally requires every standalone
+      // signed acknowledgment to be in place. Bypass: owners / admins /
+      // office are exempt from this gate (they don't need to sign their
+      // own training to take the exam).
+      const callerRole = req.auth!.role;
+      const exemptFromSignGate =
+        callerRole === "owner" ||
+        callerRole === "admin" ||
+        callerRole === "office" ||
+        callerRole === "super_admin";
+      if (!exemptFromSignGate) {
+        const missing = await getMissingRequiredSignedDocs(companyId, userId);
+        if (missing.length > 0) {
+          return res.status(403).json({
+            error: "Forbidden",
+            message:
+              "Final mixed test is locked: sign all required acknowledgments first",
+            missing_required_signed_docs: missing,
+          });
+        }
       }
     } else if (!isModuleUnlocked(moduleId, completed)) {
       return res.status(403).json({
@@ -1303,29 +1337,15 @@ router.post(
 
       await touchEnrollment(enrollment.id, now);
 
-      // Phase 12: issue a completion certificate for the bypassed module.
-      // The cert is for the TARGET learner (when admin/office bypasses on
-      // their behalf) or the caller themselves (when an owner bypasses
-      // their own training). score=100 because bypass is treated as a
-      // perfect-completion attestation by the granting admin.
-      let bypassCertId: number | null = null;
-      try {
-        const meta = captureRequestMetadata(req);
-        const cert = await issueCertificate({
-          companyId,
-          userId: targetUserId,
-          moduleId,
-          score: 100,
-          passed: true,
-          locale: enrollment.locale === "es" ? "es" : "en",
-          ipAddress: meta.ip_address,
-          deviceInfo: parseMinimalDeviceInfo(meta.user_agent),
-          quizAttemptId: null,
-        });
-        bypassCertId = cert.id;
-      } catch (err) {
-        console.error("[lms] cert issuance failed on bypass (non-fatal):", err);
-      }
+      // PR #4 policy decision: bypass marks the quiz passed for
+      // navigation purposes but does NOT issue a completion certificate
+      // and does NOT create a signed_document row. Certificates and
+      // signed documents represent ACTUAL employee action; admin bypass
+      // is a separate audit-logged event ("bypassed_by") that must stay
+      // distinct from a learner-driven "signed_by" / "certified" event.
+      // (This reverts the cert auto-issue that PR #3 wired in.)
+      const bypassingUserId = req.auth!.userId;
+      const self = targetUserId === bypassingUserId;
 
       await logAudit(
         req,
@@ -1336,13 +1356,20 @@ router.post(
         {
           module_id: moduleId,
           target_user_id: targetUserId,
-          self: targetUserId === req.auth!.userId,
-          certificate_id: bypassCertId,
+          bypassed_by_user_id: bypassingUserId,
+          self,
+          // Explicit marker so the audit dashboard can distinguish
+          // bypasses from actual sign / cert events at a glance.
+          source: "admin_bypass",
         },
       );
 
       return res.json({
-        data: { ok: true, enrollment_id: enrollment.id, certificate_id: bypassCertId },
+        data: {
+          ok: true,
+          enrollment_id: enrollment.id,
+          certificate_id: null,
+        },
       });
     } catch (err) {
       console.error("[lms] /admin/bypass-module error:", err);

--- a/artifacts/api-server/src/tests/lms-curriculum.test.ts
+++ b/artifacts/api-server/src/tests/lms-curriculum.test.ts
@@ -33,7 +33,7 @@ import {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("LMS curriculum — constants & catalog shape", () => {
-  it("MODULE_ORDER has all 7 modules in expected sequence (il-sexual-harassment added 2026-05-12)", () => {
+  it("MODULE_ORDER has all 8 modules in expected sequence (drug-alcohol added 2026-05-12 Phase 3)", () => {
     assert.deepEqual([...MODULE_ORDER], [
       "phes-policies",
       "compensation",
@@ -41,11 +41,12 @@ describe("LMS curriculum — constants & catalog shape", () => {
       "maidcentral",
       "products-tools",
       "il-sexual-harassment",
+      "drug-alcohol",
       "acknowledgment",
     ]);
   });
 
-  it("QUIZ_MODULE_IDS contains exactly the 6 quiz modules (no acknowledgment)", () => {
+  it("QUIZ_MODULE_IDS contains exactly the 7 quiz modules (no acknowledgment)", () => {
     assert.deepEqual([...QUIZ_MODULE_IDS], [
       "phes-policies",
       "compensation",
@@ -53,6 +54,7 @@ describe("LMS curriculum — constants & catalog shape", () => {
       "maidcentral",
       "products-tools",
       "il-sexual-harassment",
+      "drug-alcohol",
     ]);
   });
 
@@ -85,19 +87,30 @@ describe("LMS curriculum — constants & catalog shape", () => {
     );
   });
 
-  it("each non-policies module has exactly 15 questions (per Phes spec)", () => {
+  it("each non-policies module has its specified question count", () => {
+    // phes-policies: 40 (full handbook coverage)
+    // drug-alcohol: 10 (Phase 3 spec, legally-important concepts only)
+    // all others: 15 (per original Phes spec)
+    const expected: Record<string, number> = {
+      "phes-policies": 40,
+      "drug-alcohol": 10,
+      compensation: 15,
+      "cleaning-best-practices": 15,
+      maidcentral: 15,
+      "products-tools": 15,
+      "il-sexual-harassment": 15,
+    };
     for (const m of QUIZ_MODULE_IDS) {
-      if (m === "phes-policies") continue;
       assert.equal(
         QUESTIONS_BY_MODULE[m].length,
-        15,
-        `Module ${m} should have 15 questions; has ${QUESTIONS_BY_MODULE[m].length}`,
+        expected[m],
+        `Module ${m} should have ${expected[m]} questions; has ${QUESTIONS_BY_MODULE[m].length}`,
       );
     }
   });
 
-  it("ALL_QUESTION_IDS is 115 total (5 modules × 15 + phes-policies × 40)", () => {
-    assert.equal(ALL_QUESTION_IDS.length, 115);
+  it("ALL_QUESTION_IDS is 125 total (40 + 15*5 + 10)", () => {
+    assert.equal(ALL_QUESTION_IDS.length, 125);
   });
 
   it("ANSWER_KEY has exactly the keys enumerated by ALL_QUESTION_IDS", () => {

--- a/artifacts/api-server/src/tests/lms-signed-documents.test.ts
+++ b/artifacts/api-server/src/tests/lms-signed-documents.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Signed-document content registry — unit tests.
+ *
+ * Pure tests over the content registry + PDF render smoke. The DB-
+ * touching pieces (POST /sign, version registry) require a live
+ * Postgres + signed JWTs and are exercised by manual / integration
+ * testing.
+ *
+ * Run:
+ *   pnpm --filter @workspace/api-server run test:lms
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  SIGNED_DOCUMENT_CONTENT,
+  getSignedDocumentContent,
+  isSpanishPendingTranslationReview,
+  listRegisteredDocumentTypes,
+} from "../lib/lms-signed-documents-content.js";
+import { generateSignedDocumentPdf } from "../lib/pdf-gen.js";
+import { hashContent } from "../lib/lms-signatures.js";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Registry shape + content integrity
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("SIGNED_DOCUMENT_CONTENT registry", () => {
+  it("includes drug_alcohol (Phase 3 PR #4)", () => {
+    assert.ok(SIGNED_DOCUMENT_CONTENT.drug_alcohol);
+    assert.ok(SIGNED_DOCUMENT_CONTENT.drug_alcohol!.en);
+    assert.ok(SIGNED_DOCUMENT_CONTENT.drug_alcohol!.es);
+  });
+
+  it("every registered document has BOTH en and es entries", () => {
+    for (const [type, entry] of Object.entries(SIGNED_DOCUMENT_CONTENT)) {
+      assert.ok(entry?.en?.contentHtml, `${type}: missing en.contentHtml`);
+      assert.ok(entry?.en?.title, `${type}: missing en.title`);
+      assert.ok(entry?.es?.contentHtml, `${type}: missing es.contentHtml`);
+      assert.ok(entry?.es?.title, `${type}: missing es.title`);
+    }
+  });
+
+  it("contains no em dashes or en dashes in any user-facing field", () => {
+    for (const [type, entry] of Object.entries(SIGNED_DOCUMENT_CONTENT)) {
+      for (const locale of ["en", "es"] as const) {
+        const body = entry?.[locale]?.contentHtml ?? "";
+        const title = entry?.[locale]?.title ?? "";
+        assert.ok(
+          !body.includes("—"),
+          `${type} ${locale}: em dash in contentHtml`,
+        );
+        assert.ok(
+          !body.includes("–"),
+          `${type} ${locale}: en dash in contentHtml`,
+        );
+        assert.ok(
+          !title.includes("—"),
+          `${type} ${locale}: em dash in title`,
+        );
+        assert.ok(
+          !title.includes("–"),
+          `${type} ${locale}: en dash in title`,
+        );
+      }
+    }
+  });
+
+  it("drug_alcohol Spanish entry is flagged pendingTranslationReview", () => {
+    assert.equal(isSpanishPendingTranslationReview("drug_alcohol"), true);
+  });
+
+  it("drug_alcohol English entry is NOT flagged (English is binding)", () => {
+    assert.equal(
+      SIGNED_DOCUMENT_CONTENT.drug_alcohol!.en.pendingTranslationReview ?? false,
+      false,
+    );
+  });
+
+  it("Spanish content references the Illinois Cannabis Act with Spanish wording", () => {
+    const es = SIGNED_DOCUMENT_CONTENT.drug_alcohol!.es.contentHtml;
+    assert.ok(
+      es.includes("Ley de Regulación e Impuestos del Cannabis"),
+      "Spanish version must reference the Illinois Cannabis Act translation",
+    );
+  });
+
+  it("English content includes the 72-hour DUI reporting window verbatim", () => {
+    const en = SIGNED_DOCUMENT_CONTENT.drug_alcohol!.en.contentHtml;
+    assert.ok(
+      en.includes("seventy-two hours"),
+      "English version must include the 72-hour DUI reporting window",
+    );
+  });
+
+  it("English and Spanish content hash to DIFFERENT version hashes (legally distinct)", () => {
+    const en = SIGNED_DOCUMENT_CONTENT.drug_alcohol!.en.contentHtml;
+    const es = SIGNED_DOCUMENT_CONTENT.drug_alcohol!.es.contentHtml;
+    const hEn = hashContent(en, "en");
+    const hEs = hashContent(es, "es");
+    assert.notEqual(hEn, hEs);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Resolver helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("getSignedDocumentContent", () => {
+  it("returns en entry for known document type", () => {
+    const c = getSignedDocumentContent("drug_alcohol", "en");
+    assert.ok(c?.title);
+    assert.ok(c?.contentHtml);
+  });
+
+  it("returns es entry for known document type", () => {
+    const c = getSignedDocumentContent("drug_alcohol", "es");
+    assert.ok(c?.title);
+    assert.ok(c?.contentHtml);
+  });
+
+  it("returns null for unknown document type", () => {
+    assert.equal(getSignedDocumentContent("not_a_real_doc", "en"), null);
+  });
+});
+
+describe("listRegisteredDocumentTypes", () => {
+  it("includes drug_alcohol after PR #4", () => {
+    assert.ok(listRegisteredDocumentTypes().includes("drug_alcohol"));
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// generateSignedDocumentPdf smoke tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+const SAMPLE_INPUT = {
+  tenantName: "Phes",
+  employeeName: "Jose Ardila",
+  documentTitle: "Drug and Alcohol Policy Acknowledgment",
+  documentType: "drug_alcohol",
+  contentBody: SIGNED_DOCUMENT_CONTENT.drug_alcohol!.en.contentHtml,
+  locale: "en",
+  pendingTranslationReview: false,
+  employeeSignature: "Jose Ardila",
+  employeeSignatureMethod: "typed" as const,
+  signedAt: new Date("2026-05-12T20:00:00Z"),
+  ipAddress: "203.0.113.42",
+  deviceInfo: "Chrome 120 / macOS",
+  versionHash: "a".repeat(64),
+};
+
+describe("generateSignedDocumentPdf", () => {
+  it("renders a valid PDF for an English drug-alcohol acknowledgment", async () => {
+    const bytes = await generateSignedDocumentPdf(SAMPLE_INPUT);
+    assert.ok(bytes.byteLength > 2000, "PDF should be at least 2KB");
+    const header = Buffer.from(bytes.slice(0, 4)).toString("utf8");
+    assert.equal(header, "%PDF");
+  });
+
+  it("renders a Spanish acknowledgment with the translation-review banner", async () => {
+    const esBody = SIGNED_DOCUMENT_CONTENT.drug_alcohol!.es.contentHtml;
+    const bytes = await generateSignedDocumentPdf({
+      ...SAMPLE_INPUT,
+      contentBody: esBody,
+      locale: "es",
+      pendingTranslationReview: true,
+      documentTitle: "Reconocimiento de la Política de Drogas y Alcohol",
+    });
+    assert.ok(bytes.byteLength > 2000);
+  });
+
+  it("renders a co-signed document (representative signature block)", async () => {
+    const bytes = await generateSignedDocumentPdf({
+      ...SAMPLE_INPUT,
+      representativeName: "Sal Martinez",
+      representativeSignature: "Sal Martinez",
+      representativeSignatureMethod: "typed",
+      representativeSignedAt: new Date("2026-05-12T20:05:00Z"),
+    });
+    assert.ok(bytes.byteLength > 2000);
+  });
+});

--- a/artifacts/qleno/src/lib/training/curriculum.ts
+++ b/artifacts/qleno/src/lib/training/curriculum.ts
@@ -1685,6 +1685,212 @@ const BASE_MODULES: Module[] = [
       },
     ],
   },
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // 7. DRUG & ALCOHOL POLICY (Phase 3, PR #4)
+  // ═══════════════════════════════════════════════════════════════════════════
+  //
+  // Required by Illinois Cannabis Regulation & Tax Act (410 ILCS 705) and
+  // the Illinois Right to Privacy in the Workplace Act (820 ILCS 55).
+  // Quiz verifies comprehension; the legally binding signed acknowledgment
+  // is captured via the separate lms_signed_documents flow at document_type
+  // 'drug_alcohol' (PR #4 of 16).
+  {
+    id: "drug-alcohol",
+    number: 7,
+    iconKind: "shield",
+    title: {
+      en: "Drug & Alcohol Policy",
+      es: "Política de Drogas y Alcohol",
+    },
+    subtitle: {
+      en: "What we test for and when. Cannabis is legal off-duty in Illinois. Impairment at work never is.",
+      es: "Qué probamos y cuándo. El cannabis es legal fuera del trabajo en Illinois. La intoxicación en el trabajo nunca lo es.",
+    },
+    estimatedMinutes: 12,
+    blocks: [
+      {
+        type: "callout",
+        tone: "info",
+        text: {
+          en: "Why this module matters. Cleaning involves driving company routes, handling chemicals around clients' children and pets, climbing ladders, and entering homes you've been trusted to enter. Impairment in any of those situations puts people in danger. This policy explains what counts as impairment, when Phes may test you, what your rights are if you take prescription medication, and what happens if you refuse a test. You will sign a separate acknowledgment after the quiz that records your consent to this policy.",
+          es: "Por qué importa este módulo. La limpieza implica conducir rutas de la compañía, manejar productos químicos cerca de niños y mascotas de los clientes, subir escaleras y entrar a hogares en los que se le ha confiado. La intoxicación en cualquiera de esas situaciones pone a personas en peligro. Esta política explica qué cuenta como intoxicación, cuándo Phes puede examinarlo, cuáles son sus derechos si toma medicamentos recetados y qué ocurre si se rehúsa a una prueba. Firmará un reconocimiento separado después del examen que registra su consentimiento a esta política.",
+        },
+      },
+
+      { type: "h", text: { en: "No Pre-Employment Testing", es: "Sin Pruebas Antes del Empleo" } },
+      {
+        type: "p",
+        text: {
+          en: "Phes does NOT require pre-employment drug testing. You will not be asked to submit to a drug test as a condition of being hired. This is Phes policy. It is stricter than the law requires.",
+          es: "Phes NO exige pruebas de drogas antes del empleo. No se le pedirá someterse a una prueba de drogas como condición para ser contratado. Esta es la política de Phes. Es más estricta de lo que la ley requiere.",
+        },
+      },
+
+      { type: "h", text: { en: "What You Cannot Do at Work", es: "Lo Que No Puede Hacer en el Trabajo" } },
+      {
+        type: "bullets",
+        items: [
+          { en: "Work while impaired by alcohol.", es: "Trabajar bajo los efectos del alcohol." },
+          { en: "Work while impaired by illegal drugs.", es: "Trabajar bajo los efectos de drogas ilegales." },
+          { en: "Work while impaired by cannabis (regardless of whether you obtained it legally off-duty).", es: "Trabajar bajo los efectos del cannabis (sin importar si lo obtuvo legalmente fuera del trabajo)." },
+          { en: "Work while impaired by ANY other substance that affects your ability to perform safely (over-the-counter sleep aids that make you drowsy, prescription medications with sedating side effects, etc.).", es: "Trabajar bajo los efectos de CUALQUIER otra sustancia que afecte su capacidad de desempeñarse con seguridad (medicamentos de venta libre para dormir que causan somnolencia, recetas con efectos sedantes, etc.)." },
+          { en: "Possess open alcohol containers, illegal drugs, or any controlled substance not legally prescribed to YOU on Phes premises, in Phes vehicles, or on client property.", es: "Poseer envases abiertos de alcohol, drogas ilegales o cualquier sustancia controlada que no le haya sido recetada legalmente a USTED en las instalaciones de Phes, en vehículos de Phes o en la propiedad del cliente." },
+        ],
+      },
+
+      { type: "h", text: { en: "Cannabis Specifically (Illinois Law)", es: "Cannabis Específicamente (Ley de Illinois)" } },
+      {
+        type: "p",
+        text: {
+          en: "Cannabis is legal for adults 21 and over in Illinois. Phes does NOT discipline you for using cannabis legally on your own time. You have the same right to lawful off-duty cannabis use that you have for alcohol or any other legal off-duty activity.",
+          es: "El cannabis es legal para adultos mayores de 21 años en Illinois. Phes NO disciplina por usar cannabis legalmente en su tiempo libre. Tiene el mismo derecho al uso legal fuera del trabajo de cannabis que tiene para el alcohol o cualquier otra actividad legal fuera del trabajo.",
+        },
+      },
+      {
+        type: "callout",
+        tone: "warning",
+        text: {
+          en: "But: impairment AT WORK is different from off-duty use. If you arrive at work or show up to a client home showing observable signs of impairment, the policy applies regardless of when or where you consumed. This is true for cannabis, alcohol, prescription sedatives, and any other substance.",
+          es: "Pero: la intoxicación EN EL TRABAJO es distinta del uso fuera del trabajo. Si llega al trabajo o se presenta en un hogar de un cliente mostrando signos observables de intoxicación, la política aplica sin importar cuándo o dónde consumió. Esto es cierto para cannabis, alcohol, sedantes recetados y cualquier otra sustancia.",
+        },
+      },
+
+      { type: "h", text: { en: "Observable Signs of Impairment", es: "Signos Observables de Intoxicación" } },
+      {
+        type: "p",
+        text: {
+          en: "Phes only acts on OBSERVABLE signs of impairment. We do not guess; we do not assume; we document what we see. Signs that may indicate impairment include:",
+          es: "Phes solo actúa sobre signos OBSERVABLES de intoxicación. No suponemos; no asumimos; documentamos lo que vemos. Los signos que pueden indicar intoxicación incluyen:",
+        },
+      },
+      {
+        type: "bullets",
+        items: [
+          { en: "Bloodshot or glassy eyes.", es: "Ojos rojos o vidriosos." },
+          { en: "Slurred speech or unusually rapid or pressured speech.", es: "Habla arrastrada o anormalmente rápida o presionada." },
+          { en: "Smell of alcohol or cannabis on breath or clothes.", es: "Olor a alcohol o cannabis en aliento o ropa." },
+          { en: "Unsteady walking, swaying, stumbling.", es: "Caminar inestable, balancearse, tropezarse." },
+          { en: "Slowed reaction time, inability to follow simple instructions, difficulty maintaining a conversation.", es: "Tiempo de reacción lento, incapacidad para seguir instrucciones simples, dificultad para mantener una conversación." },
+          { en: "Dilated or constricted pupils unrelated to the lighting in the room.", es: "Pupilas dilatadas o contraídas no relacionadas con la iluminación del lugar." },
+          { en: "Inability to perform routine work tasks the employee normally performs without difficulty.", es: "Incapacidad para realizar tareas laborales rutinarias que el empleado normalmente realiza sin dificultad." },
+          { en: "Falling asleep or appearing to nod off on the job.", es: "Quedarse dormido o aparentar cabecear en el trabajo." },
+        ],
+      },
+      {
+        type: "callout",
+        tone: "info",
+        text: {
+          en: "What is NOT a sign of impairment, by itself: a positive cannabis drug test alone (THC remains detectable in urine days or weeks after use). Phes does not act on a drug test alone. We act on observable behavior in the moment, documented by a supervisor.",
+          es: "Lo que NO es un signo de intoxicación, por sí mismo: una prueba de cannabis positiva sola (el THC sigue siendo detectable en orina días o semanas después del uso). Phes no actúa solo con base en una prueba de drogas. Actuamos sobre la conducta observable en el momento, documentada por un supervisor.",
+        },
+      },
+
+      { type: "h", text: { en: "Reasonable Suspicion Testing", es: "Pruebas por Sospecha Razonable" } },
+      {
+        type: "bullets",
+        items: [
+          { en: "If a supervisor observes the signs above, they DOCUMENT what they saw, the date and time, and who else was present.", es: "Si un supervisor observa los signos anteriores, DOCUMENTA lo que vio, la fecha y hora, y quién más estaba presente." },
+          { en: "The decision to send the employee for testing is made by the OFFICE (not by coworkers, not by clients).", es: "La decisión de enviar al empleado a una prueba la toma la OFICINA (no los compañeros de trabajo, no los clientes)." },
+          { en: "The employee is removed from the job site immediately and sent for testing (urine, saliva, or breath, depending on the substance suspected).", es: "El empleado es retirado del lugar de trabajo inmediatamente y enviado a hacerse la prueba (orina, saliva o aliento, dependiendo de la sustancia sospechada)." },
+          { en: "Phes pays for the test and pays the employee's regular wages for the time spent being tested.", es: "Phes paga la prueba y paga el salario regular del empleado por el tiempo dedicado a la prueba." },
+          { en: "If the test is positive AND observable signs were documented at the time, the discipline scale below applies.", es: "Si la prueba es positiva Y se documentaron signos observables en el momento, aplica la escala de disciplina a continuación." },
+          { en: "If the test is negative, no record of the incident appears in the employee's personnel file other than the time worked and paid.", es: "Si la prueba es negativa, no aparece registro del incidente en el archivo del empleado más allá del tiempo trabajado y pagado." },
+        ],
+      },
+
+      { type: "h", text: { en: "Post-Accident Testing", es: "Pruebas Después de un Accidente" } },
+      {
+        type: "p",
+        text: {
+          en: "After any workplace accident that results in (a) physical injury to anyone (employee, client, third party) OR (b) property damage of $500 or more, the involved employee is required to submit to a drug and alcohol test. This is a routine workplace safety measure and is not a presumption of fault. Phes pays for the test and pays the employee's regular wages for the time spent.",
+          es: "Después de cualquier accidente laboral que resulte en (a) lesión física a alguien (empleado, cliente, tercero) O (b) daño a propiedad de $500 o más, el empleado involucrado debe someterse a una prueba de drogas y alcohol. Esta es una medida rutinaria de seguridad laboral y no es una presunción de culpa. Phes paga la prueba y paga el salario regular del empleado por el tiempo dedicado.",
+        },
+      },
+
+      { type: "h", text: { en: "Prescription Medication Accommodation", es: "Acomodación de Medicamentos Recetados" } },
+      {
+        type: "bullets",
+        items: [
+          { en: "Employees may take any LEGALLY PRESCRIBED medication. Phes does not ask you to disclose what the medication is or what condition you're treating.", es: "Los empleados pueden tomar cualquier medicamento RECETADO LEGALMENTE. Phes no le pide divulgar cuál es el medicamento ni qué condición está tratando." },
+          { en: "If a prescription medication you take has side effects that may impair your ability to perform safely (drowsiness, slowed reaction, etc.), inform the office BEFORE starting the medication so we can discuss accommodation.", es: "Si un medicamento recetado que toma tiene efectos secundarios que pueden afectar su capacidad de desempeñarse con seguridad (somnolencia, reacción lenta, etc.), informe a la oficina ANTES de empezar el medicamento para que podamos discutir acomodación." },
+          { en: "You are NOT required to disclose the diagnosis or the medication name. You only need to identify whether you can perform the essential functions of your role safely.", es: "NO está obligado a divulgar el diagnóstico ni el nombre del medicamento. Solo necesita identificar si puede realizar las funciones esenciales de su rol con seguridad." },
+          { en: "Reasonable accommodation may include schedule changes, modified duties, or short-term reassignment.", es: "La acomodación razonable puede incluir cambios de horario, tareas modificadas o reasignación a corto plazo." },
+        ],
+      },
+
+      { type: "h", text: { en: "Refusal to Test", es: "Negarse a la Prueba" } },
+      {
+        type: "callout",
+        tone: "warning",
+        text: {
+          en: "REFUSAL TO TEST when properly requested by the office (reasonable suspicion or post-accident) is grounds for IMMEDIATE TERMINATION. There is no negotiation. The refusal itself is treated the same as a positive test result, regardless of whether you would have actually tested positive.",
+          es: "NEGARSE A LA PRUEBA cuando la oficina la solicita apropiadamente (sospecha razonable o post-accidente) es motivo de TERMINACIÓN INMEDIATA. No hay negociación. La negativa en sí se trata igual que un resultado positivo, sin importar si efectivamente habría dado positivo.",
+        },
+      },
+
+      { type: "h", text: { en: "Discipline Scale", es: "Escala de Disciplina" } },
+      {
+        type: "table",
+        head: { en: ["Incident", "Action"], es: ["Incidente", "Acción"] },
+        rows: [
+          { en: ["1st positive test (observable signs documented)", "Final written warning. Last-chance agreement signed. EAP referral offered."],
+            es: ["1ª prueba positiva (con signos documentados)", "Advertencia final por escrito. Acuerdo de última oportunidad firmado. Referencia a EAP ofrecida."] },
+          { en: ["2nd positive test in any 12-month period", "Termination."],
+            es: ["2ª prueba positiva en cualquier periodo de 12 meses", "Terminación."] },
+          { en: ["Refusal to test", "Immediate termination."],
+            es: ["Negarse a la prueba", "Terminación inmediata."] },
+          { en: ["Possession of alcohol or illegal drugs on Phes property or in a Phes vehicle", "Immediate termination."],
+            es: ["Posesión de alcohol o drogas ilegales en propiedad de Phes o en vehículo de Phes", "Terminación inmediata."] },
+          { en: ["Driving a Phes-related route while impaired", "Immediate termination plus law-enforcement referral when applicable."],
+            es: ["Conducir una ruta relacionada con Phes bajo intoxicación", "Terminación inmediata más referencia a las autoridades cuando corresponda."] },
+        ],
+      },
+
+      { type: "h", text: { en: "Driving Violations Reporting (Personal Vehicles)", es: "Reporte de Infracciones de Conducir (Vehículos Personales)" } },
+      {
+        type: "p",
+        text: {
+          en: "If you use your PERSONAL vehicle for any Phes work (driving between client jobs, transporting Phes supplies, picking up a teammate), you MUST report the following to the office WITHIN 72 HOURS:",
+          es: "Si usa su vehículo PERSONAL para cualquier trabajo de Phes (manejar entre trabajos de clientes, transportar suministros de Phes, recoger a un compañero), DEBE reportar lo siguiente a la oficina DENTRO DE 72 HORAS:",
+        },
+      },
+      {
+        type: "bullets",
+        items: [
+          { en: "Any DUI conviction (Driving Under the Influence).", es: "Cualquier condena por DUI (Conducir Bajo los Efectos)." },
+          { en: "Any driver's license suspension or revocation.", es: "Cualquier suspensión o revocación de la licencia de conducir." },
+          { en: "Any major moving violation (reckless driving, leaving the scene of an accident, driving without insurance, driving with a suspended license).", es: "Cualquier infracción mayor de tránsito (conducción imprudente, abandonar el lugar de un accidente, conducir sin seguro, conducir con licencia suspendida)." },
+        ],
+      },
+      {
+        type: "callout",
+        tone: "warning",
+        text: {
+          en: "Failure to disclose any of the above within 72 hours of the conviction, suspension, or citation may result in immediate termination. This is a safety policy. Phes carries non-owned auto insurance that depends on your status as a lawfully-licensed driver.",
+          es: "No divulgar cualquiera de lo anterior dentro de 72 horas de la condena, suspensión o citación puede resultar en terminación inmediata. Esta es una política de seguridad. Phes tiene seguro automotor no propio que depende de su estado como conductor legalmente licenciado.",
+        },
+      },
+
+      { type: "h", text: { en: "Employee Assistance Program (EAP)", es: "Programa de Asistencia al Empleado (EAP)" } },
+      {
+        type: "p",
+        text: {
+          en: "Phes participates in an Employee Assistance Program that provides confidential support for substance use, mental health, and other personal concerns. The office will give you the contact information for the EAP when you join. Using the EAP is voluntary, confidential, and does NOT trigger any discipline. We encourage you to use it BEFORE a workplace incident, not after.",
+          es: "Phes participa en un Programa de Asistencia al Empleado que provee apoyo confidencial para uso de sustancias, salud mental y otras preocupaciones personales. La oficina le dará la información de contacto del EAP cuando se incorpore. Usar el EAP es voluntario, confidencial y NO activa ninguna disciplina. Le animamos a usarlo ANTES de un incidente laboral, no después.",
+        },
+      },
+
+      {
+        type: "callout",
+        tone: "info",
+        text: {
+          en: "After this quiz: you will sign a separate Drug & Alcohol Policy Acknowledgment that records your consent. The signed acknowledgment is a separate legal document tied to your employment, captured with your IP, device, and a hash of the exact policy text. You can re-download the signed PDF anytime from your training page.",
+          es: "Después de este examen: firmará un Reconocimiento de la Política de Drogas y Alcohol por separado que registra su consentimiento. El reconocimiento firmado es un documento legal separado vinculado a su empleo, capturado con su IP, dispositivo y un hash del texto exacto de la política. Puede volver a descargar el PDF firmado en cualquier momento desde su página de capacitación.",
+        },
+      },
+    ],
+  },
 ];
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -3219,6 +3425,160 @@ const BASE_QUIZ: QuizQuestion[] = [
       { en: "Yes — GOOD FAITH means you believed your report was true at the time you made it. The act of reporting in good faith is protected regardless of the outcome.", es: "Sí — BUENA FE significa que creyó que su reporte era verdadero al momento de hacerlo. El acto de reportar de buena fe está protegido sin importar el resultado." },
       { en: "Only if you reported in writing.", es: "Solo si reportó por escrito." },
       { en: "Only if the accused agrees you reported in good faith.", es: "Solo si el acusado acepta que reportó de buena fe." },
+    ],
+    correctIndex: 1,
+  },
+
+  // ═════════════════════════════════════════════════════════════════════════════
+  // Module 7: DRUG & ALCOHOL (10 questions, Phase 3 PR #4)
+  // ═════════════════════════════════════════════════════════════════════════════
+  {
+    id: "q-da-01-no-pre-employment-test",
+    moduleId: "drug-alcohol",
+    prompt: {
+      en: "Does Phes require pre-employment drug testing?",
+      es: "¿Phes exige una prueba de drogas antes del empleo?",
+    },
+    options: [
+      { en: "Yes. Every new hire is drug-tested before their first day.", es: "Sí. A cada nuevo empleado se le hace prueba de drogas antes de su primer día." },
+      { en: "No. Phes does not require pre-employment drug testing. This is Phes policy and is stricter than what the law requires.", es: "No. Phes no exige prueba de drogas antes del empleo. Esta es la política de Phes y es más estricta de lo que exige la ley." },
+      { en: "Only for techs over 25.", es: "Solo para técnicos mayores de 25 años." },
+      { en: "Only if the role involves driving.", es: "Solo si el rol implica conducir." },
+    ],
+    correctIndex: 1,
+  },
+  {
+    id: "q-da-02-impairment-not-cannabis-use",
+    moduleId: "drug-alcohol",
+    prompt: {
+      en: "You used cannabis legally at home on Saturday. You arrive at a Monday job with no observable signs of impairment. Are you in violation of policy?",
+      es: "Usó cannabis legalmente en casa el sábado. Llega a un trabajo el lunes sin signos observables de intoxicación. ¿Está en violación de la política?",
+    },
+    options: [
+      { en: "Yes. Any cannabis use is a policy violation.", es: "Sí. Cualquier uso de cannabis es una violación de la política." },
+      { en: "No. Phes does not discipline legal off-duty cannabis use. The policy applies only to OBSERVABLE impairment at work, regardless of when or where you consumed.", es: "No. Phes no disciplina el uso legal de cannabis fuera del trabajo. La política aplica solo a la intoxicación OBSERVABLE en el trabajo, sin importar cuándo o dónde consumió." },
+      { en: "Yes if you tested positive at random.", es: "Sí si dio positivo en una prueba al azar." },
+      { en: "Only if the client smelled it.", es: "Solo si el cliente lo olió." },
+    ],
+    correctIndex: 1,
+  },
+  {
+    id: "q-da-03-impairment-signs",
+    moduleId: "drug-alcohol",
+    prompt: {
+      en: "Which of the following is NOT, by itself, a sign of impairment Phes can act on?",
+      es: "¿Cuál de los siguientes NO es, por sí solo, un signo de intoxicación sobre el que Phes puede actuar?",
+    },
+    options: [
+      { en: "Slurred speech and unsteady walking.", es: "Habla arrastrada y caminar inestable." },
+      { en: "Bloodshot eyes plus smell of cannabis on breath.", es: "Ojos rojos más olor a cannabis en aliento." },
+      { en: "A positive drug test alone (THC stays detectable for days or weeks).", es: "Una prueba positiva sola (el THC se detecta por días o semanas)." },
+      { en: "Falling asleep on the job.", es: "Quedarse dormido en el trabajo." },
+    ],
+    correctIndex: 2,
+  },
+  {
+    id: "q-da-04-reasonable-suspicion-process",
+    moduleId: "drug-alcohol",
+    prompt: {
+      en: "A coworker tells you they think another tech is impaired. What does Phes policy say about how the decision to test is made?",
+      es: "Un compañero le dice que cree que otro técnico está intoxicado. ¿Qué dice la política de Phes sobre cómo se toma la decisión de hacer la prueba?",
+    },
+    options: [
+      { en: "Coworkers can request a test on each other.", es: "Los compañeros pueden solicitar una prueba entre sí." },
+      { en: "A supervisor documents observable signs and the decision to test is made by the OFFICE, not by coworkers or clients.", es: "Un supervisor documenta signos observables y la decisión de hacer la prueba la toma la OFICINA, no compañeros ni clientes." },
+      { en: "The client decides whether the tech should be tested.", es: "El cliente decide si se debe hacer la prueba al técnico." },
+      { en: "Whoever is in charge at the moment decides without documentation.", es: "Quien esté a cargo en el momento decide sin documentación." },
+    ],
+    correctIndex: 1,
+  },
+  {
+    id: "q-da-05-post-accident-threshold",
+    moduleId: "drug-alcohol",
+    prompt: {
+      en: "There's a small workplace accident — minor scratch on a client's wall, no one is hurt, repair would cost about $30. Are you required to take a drug and alcohol test?",
+      es: "Hay un pequeño accidente en el trabajo: un rasguño menor en la pared del cliente, nadie está lastimado, la reparación costaría unos $30. ¿Debe hacerse una prueba de drogas y alcohol?",
+    },
+    options: [
+      { en: "Yes — any property damage triggers a test.", es: "Sí — cualquier daño a la propiedad activa una prueba." },
+      { en: "No — post-accident testing is triggered by (a) physical injury to anyone OR (b) property damage of $500 or more. A $30 scratch with no injury does not meet the threshold.", es: "No — la prueba post-accidente se activa por (a) lesión física a alguien O (b) daño a propiedad de $500 o más. Un rasguño de $30 sin lesiones no cumple el umbral." },
+      { en: "Only if a supervisor saw the accident happen.", es: "Solo si un supervisor vio ocurrir el accidente." },
+      { en: "Only if the client asks for it.", es: "Solo si el cliente lo pide." },
+    ],
+    correctIndex: 1,
+  },
+  {
+    id: "q-da-06-prescription-meds",
+    moduleId: "drug-alcohol",
+    prompt: {
+      en: "Your doctor prescribes a new medication that may cause drowsiness as a side effect. What does Phes policy say you should do?",
+      es: "Su doctor le receta un nuevo medicamento que puede causar somnolencia como efecto secundario. ¿Qué dice la política de Phes que debe hacer?",
+    },
+    options: [
+      { en: "Tell the office your full diagnosis and the medication name before starting it.", es: "Decir a la oficina su diagnóstico completo y el nombre del medicamento antes de empezar." },
+      { en: "Inform the office BEFORE starting the medication that a prescribed medication may impair your ability to perform safely. You do NOT have to disclose the diagnosis or medication name. The office discusses accommodation (schedule changes, modified duties, etc.).", es: "Informar a la oficina ANTES de empezar el medicamento que una medicina recetada puede afectar su capacidad de desempeñarse con seguridad. NO tiene que divulgar el diagnóstico ni el nombre del medicamento. La oficina discute acomodación (cambios de horario, tareas modificadas, etc.)." },
+      { en: "Stop taking the medication while you work.", es: "Dejar de tomar el medicamento mientras trabaja." },
+      { en: "Nothing — prescription meds are your private business.", es: "Nada — los medicamentos recetados son su asunto privado." },
+    ],
+    correctIndex: 1,
+  },
+  {
+    id: "q-da-07-refusal-to-test",
+    moduleId: "drug-alcohol",
+    prompt: {
+      en: "The office sends you for a reasonable-suspicion drug test based on documented observable signs. You refuse. What is the consequence under Phes policy?",
+      es: "La oficina lo envía a una prueba de drogas por sospecha razonable basada en signos observables documentados. Usted se rehúsa. ¿Cuál es la consecuencia bajo la política de Phes?",
+    },
+    options: [
+      { en: "A written warning and you keep working.", es: "Una advertencia por escrito y sigue trabajando." },
+      { en: "Immediate termination. Refusal is treated the same as a positive test, regardless of whether you would have actually tested positive.", es: "Terminación inmediata. La negativa se trata igual que un resultado positivo, sin importar si efectivamente habría dado positivo." },
+      { en: "You may take the test the next day instead.", es: "Puede hacer la prueba al día siguiente." },
+      { en: "Nothing — refusing a test is your right.", es: "Nada — rehusarse a una prueba es su derecho." },
+    ],
+    correctIndex: 1,
+  },
+  {
+    id: "q-da-08-discipline-scale",
+    moduleId: "drug-alcohol",
+    prompt: {
+      en: "You test positive after an incident with documented observable signs. It is your FIRST positive. What happens under the Phes discipline scale?",
+      es: "Da positivo después de un incidente con signos observables documentados. Es su PRIMERA positiva. ¿Qué ocurre bajo la escala de disciplina de Phes?",
+    },
+    options: [
+      { en: "Immediate termination.", es: "Terminación inmediata." },
+      { en: "Final written warning plus a last-chance agreement signed plus an EAP (Employee Assistance Program) referral offered.", es: "Advertencia final por escrito, firmar acuerdo de última oportunidad y referencia ofrecida al EAP (Programa de Asistencia al Empleado)." },
+      { en: "Nothing because it's a first offense.", es: "Nada porque es la primera infracción." },
+      { en: "Verbal warning only.", es: "Solo advertencia verbal." },
+    ],
+    correctIndex: 1,
+  },
+  {
+    id: "q-da-09-dui-reporting-window",
+    moduleId: "drug-alcohol",
+    prompt: {
+      en: "You use your personal vehicle to drive between client jobs. On Saturday night you get a DUI conviction. By when must you report it to the office?",
+      es: "Usa su vehículo personal para conducir entre trabajos de clientes. El sábado por la noche recibe una condena por DUI. ¿Para cuándo debe reportarlo a la oficina?",
+    },
+    options: [
+      { en: "At your next quarterly review.", es: "En su próxima evaluación trimestral." },
+      { en: "Within 72 hours of the conviction. Failure to disclose may result in immediate termination because Phes carries non-owned auto insurance that depends on your status as a lawfully-licensed driver.", es: "Dentro de 72 horas de la condena. No divulgarlo puede resultar en terminación inmediata porque Phes lleva seguro automotor no propio que depende de su estado como conductor legalmente licenciado." },
+      { en: "Only if a client complains about your driving.", es: "Solo si un cliente se queja sobre su conducción." },
+      { en: "Never — DUIs in personal vehicles are private.", es: "Nunca — los DUIs en vehículos personales son privados." },
+    ],
+    correctIndex: 1,
+  },
+  {
+    id: "q-da-10-license-suspension-disclosure",
+    moduleId: "drug-alcohol",
+    prompt: {
+      en: "Your driver's license gets suspended because of unpaid tickets. You drive your personal vehicle between client jobs. Do you have to tell the office?",
+      es: "Su licencia de conducir es suspendida por multas impagas. Usa su vehículo personal entre trabajos de clientes. ¿Debe avisar a la oficina?",
+    },
+    options: [
+      { en: "No, because the suspension is for tickets, not a DUI.", es: "No, porque la suspensión es por multas, no por DUI." },
+      { en: "Yes. ANY license suspension or revocation must be reported within 72 hours. So must any major moving violation (reckless driving, leaving the scene, driving without insurance, driving with a suspended license).", es: "Sí. CUALQUIER suspensión o revocación de la licencia debe reportarse dentro de 72 horas. También cualquier infracción mayor (conducción imprudente, abandonar el lugar, conducir sin seguro, conducir con licencia suspendida)." },
+      { en: "Only if the office asks first.", es: "Solo si la oficina pregunta primero." },
+      { en: "Only if a client sees the suspension notice.", es: "Solo si un cliente ve el aviso de suspensión." },
     ],
     correctIndex: 1,
   },

--- a/artifacts/qleno/src/pages/lms-admin.tsx
+++ b/artifacts/qleno/src/pages/lms-admin.tsx
@@ -30,6 +30,7 @@ import {
   FastForward,
   Download,
   Award,
+  FileSignature,
   RotateCcw,
   History,
 } from "lucide-react";
@@ -654,6 +655,7 @@ function RosterTable({
                   >
                     <ModuleAttemptsGrid row={r} onBypass={onBypass} />
                     <LearnerCertificatesPanel row={r} />
+                    <LearnerSignedDocumentsPanel row={r} />
                   </td>
                 </tr>
               ) : null}
@@ -955,6 +957,7 @@ function RosterCards({
             <div style={{ marginTop: 6 }}>
               <ModuleAttemptsGrid row={r} onBypass={onBypass} />
               <LearnerCertificatesPanel row={r} />
+              <LearnerSignedDocumentsPanel row={r} />
             </div>
           ) : null}
         </article>
@@ -2499,6 +2502,253 @@ function LearnerCertificatesPanel({ row }: { row: RosterRow }) {
                   type="button"
                   onClick={() => handleDownload(c.id)}
                   title="Download certificate PDF"
+                  style={{
+                    background: NAVY,
+                    color: "#fff",
+                    border: 0,
+                    padding: "5px 10px",
+                    borderRadius: 6,
+                    fontSize: 11,
+                    fontWeight: 800,
+                    cursor: "pointer",
+                    fontFamily: FONT,
+                    display: "inline-flex",
+                    alignItems: "center",
+                    gap: 4,
+                    flexShrink: 0,
+                  }}
+                >
+                  <Download size={11} /> PDF
+                </button>
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// LearnerSignedDocumentsPanel — Phase 3+ PR #4+: signed legal docs
+// (Drug & Alcohol first; PR #5+ extend). Renders alongside the
+// LearnerCertificatesPanel in the admin expand row.
+// ─────────────────────────────────────────────────────────────────────────────
+
+type SignedDocumentRow = {
+  id: number;
+  document_type: string;
+  locale: string;
+  signed_at: string;
+  status: "active" | "superseded" | "revoked";
+  version_hash: string;
+  representative_user_id: number | null;
+  representative_signed_at: string | null;
+};
+
+function humanDocumentType(documentType: string): string {
+  const titles: Record<string, string> = {
+    drug_alcohol: "Drug & Alcohol Policy",
+    code_of_conduct: "Code of Conduct",
+    video_photo_release: "Video / Photo Release",
+    non_solicitation: "Non-Solicitation Agreement",
+    supply_kit: "Supply Kit Responsibility",
+    social_media: "Social Media Policy",
+    handbook: "Employee Handbook",
+  };
+  return (
+    titles[documentType] ??
+    documentType
+      .split(/[-_]/)
+      .map((w) => (w ? w[0].toUpperCase() + w.slice(1) : ""))
+      .join(" ")
+  );
+}
+
+function LearnerSignedDocumentsPanel({ row }: { row: RosterRow }) {
+  const token = useAuthStore((s) => s.token);
+  const [docs, setDocs] = useState<SignedDocumentRow[] | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const data = await api<SignedDocumentRow[]>(
+          "GET",
+          `/lms/signatures/admin/learner/${row.user_id}`,
+          token,
+        );
+        if (!cancelled) setDocs(data);
+      } catch (e) {
+        if (!cancelled) setErr(String((e as Error).message));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [row.user_id, token]);
+
+  async function handleDownload(docId: number) {
+    try {
+      const url = `${API_BASE}/lms/signatures/${docId}/pdf`;
+      const res = await fetch(url, {
+        headers: token ? { authorization: `Bearer ${token}` } : {},
+      });
+      if (!res.ok) throw new Error(`${res.status}`);
+      const blob = await res.blob();
+      const disposition = res.headers.get("content-disposition") ?? "";
+      const m = /filename="([^"]+)"/.exec(disposition);
+      const filename = m?.[1] ?? `phes-signed-${docId}.pdf`;
+      const objectUrl = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = objectUrl;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(objectUrl);
+    } catch (e) {
+      console.error("[lms-admin] download signed doc failed:", e);
+    }
+  }
+
+  if (err) {
+    return (
+      <div
+        style={{
+          marginTop: 12,
+          padding: 10,
+          background: "#FEF2F2",
+          border: `1px solid #FECACA`,
+          color: DANGER,
+          borderRadius: 8,
+          fontSize: 12,
+        }}
+      >
+        Failed to load signed documents: {err}
+      </div>
+    );
+  }
+
+  if (docs == null) {
+    return (
+      <div
+        style={{
+          marginTop: 12,
+          fontSize: 12,
+          color: INK_MUTE,
+          fontStyle: "italic",
+        }}
+      >
+        Loading signed documents...
+      </div>
+    );
+  }
+
+  if (docs.length === 0) {
+    return (
+      <div
+        style={{
+          marginTop: 12,
+          padding: 10,
+          background: LINE_SOFT,
+          borderRadius: 8,
+          fontSize: 12,
+          color: INK_MUTE,
+        }}
+      >
+        No legal acknowledgments signed yet. Phes-controlled signed
+        documents appear here as each is signed.
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ marginTop: 14 }}>
+      <div
+        style={{
+          fontSize: 11,
+          fontWeight: 800,
+          color: INK_MUTE,
+          textTransform: "uppercase",
+          letterSpacing: "0.06em",
+          marginBottom: 8,
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 6,
+        }}
+      >
+        <FileSignature size={12} /> Signed Acknowledgments ({docs.length})
+      </div>
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))",
+          gap: 8,
+        }}
+      >
+        {docs.map((d) => {
+          const isActive = d.status === "active";
+          const isRevoked = d.status === "revoked";
+          const tone = isRevoked
+            ? DANGER
+            : isActive
+            ? SUCCESS
+            : INK_LIGHT;
+          return (
+            <div
+              key={d.id}
+              style={{
+                background: SURFACE,
+                border: `1px solid ${isRevoked ? "#FECACA" : LINE}`,
+                borderLeft: `3px solid ${tone}`,
+                borderRadius: 8,
+                padding: "10px 12px",
+                fontSize: 12,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                gap: 8,
+              }}
+            >
+              <div style={{ minWidth: 0 }}>
+                <div style={{ fontWeight: 800, color: INK, fontSize: 12 }}>
+                  {humanDocumentType(d.document_type)}
+                </div>
+                <div
+                  style={{
+                    fontSize: 11,
+                    color: INK_MUTE,
+                    marginTop: 2,
+                    fontWeight: 600,
+                  }}
+                >
+                  {d.locale.toUpperCase()} · {humanDateTime(d.signed_at)} ·{" "}
+                  {d.status === "active"
+                    ? "Active"
+                    : d.status === "superseded"
+                    ? "Superseded"
+                    : "Revoked"}
+                </div>
+                {d.representative_signed_at ? (
+                  <div
+                    style={{
+                      fontSize: 10,
+                      color: SUCCESS,
+                      fontWeight: 700,
+                      marginTop: 2,
+                    }}
+                  >
+                    Co-signed by Phes representative
+                  </div>
+                ) : null}
+              </div>
+              {!isRevoked ? (
+                <button
+                  type="button"
+                  onClick={() => handleDownload(d.id)}
+                  title="Download signed PDF"
                   style={{
                     background: NAVY,
                     color: "#fff",

--- a/artifacts/qleno/src/pages/training.tsx
+++ b/artifacts/qleno/src/pages/training.tsx
@@ -133,6 +133,12 @@ type LmsState = {
   days_remaining: number;
   limits?: Record<string, number>;
   is_owner?: boolean;
+  /**
+   * PR #4 policy: standalone signed acknowledgments that the learner
+   * still owes before the final mixed test unlocks. Drives the locked
+   * state + "sign these first" hint on the FinalStepCard.
+   */
+  missing_required_signed_docs?: string[];
 };
 
 type QuizStateRow = {
@@ -1331,25 +1337,95 @@ function Home({
         );
       })()}
 
-      {/* Final mixed test card */}
-      <div style={{ marginTop: 22 }}>
-        <FinalStepCard
-          locale={locale}
-          unlocked={finalUnlocked}
-          passed={finalPassed}
-          attempts={
-            state.progress.find((p) => p.module_id === FINAL_MODULE_ID)?.attempts ?? 0
-          }
-          maxAttempts={MAX_FINAL_ATTEMPTS}
-          isOwner={isOwner}
-          onClick={finalUnlocked && !finalPassed ? onOpenFinal : undefined}
-          onBypass={
-            isOwner && !finalPassed ? () => onBypass(FINAL_MODULE_ID) : undefined
-          }
-        />
-      </div>
+      {/* Final mixed test card. PR #4: also gated on standalone signed
+          acknowledgments being in place. When modules are passed but
+          required signed docs are missing, the card stays locked with
+          a "sign these first" hint. */}
+      {(() => {
+        const missingSignedDocs = state.missing_required_signed_docs ?? [];
+        const fullyUnlocked =
+          finalUnlocked && (isOwner || missingSignedDocs.length === 0);
+        return (
+          <div style={{ marginTop: 22 }}>
+            <FinalStepCard
+              locale={locale}
+              unlocked={fullyUnlocked}
+              passed={finalPassed}
+              attempts={
+                state.progress.find((p) => p.module_id === FINAL_MODULE_ID)?.attempts ?? 0
+              }
+              maxAttempts={MAX_FINAL_ATTEMPTS}
+              isOwner={isOwner}
+              onClick={fullyUnlocked && !finalPassed ? onOpenFinal : undefined}
+              onBypass={
+                isOwner && !finalPassed ? () => onBypass(FINAL_MODULE_ID) : undefined
+              }
+            />
+            {/* When modules are done but signed docs are pending,
+                tell the learner exactly what to sign. Owners bypass
+                this hint because the gate doesn't apply to them. */}
+            {!isOwner &&
+            finalUnlocked &&
+            missingSignedDocs.length > 0 &&
+            !finalPassed ? (
+              <div
+                style={{
+                  marginTop: 8,
+                  padding: "10px 14px",
+                  background: "#FFFBEB",
+                  border: `1px solid #FDE68A`,
+                  borderLeft: `3px solid ${WARN}`,
+                  borderRadius: 8,
+                  fontSize: 12.5,
+                  color: INK,
+                  lineHeight: 1.55,
+                }}
+              >
+                <strong>
+                  {locale === "es"
+                    ? "El examen final se desbloquea cuando firme:"
+                    : "Final exam unlocks once you sign:"}
+                </strong>
+                <ul style={{ margin: "6px 0 0 18px", padding: 0 }}>
+                  {missingSignedDocs.map((dt) => (
+                    <li key={dt}>{humanSignedDocType(dt, locale)}</li>
+                  ))}
+                </ul>
+              </div>
+            ) : null}
+          </div>
+        );
+      })()}
     </div>
   );
+}
+
+/** Friendly localized name for a signed-document type slug. */
+function humanSignedDocType(documentType: string, locale: Locale): string {
+  const titles: Record<string, { en: string; es: string }> = {
+    drug_alcohol: {
+      en: "Drug & Alcohol Policy",
+      es: "Política de Drogas y Alcohol",
+    },
+    code_of_conduct: { en: "Code of Conduct", es: "Código de Conducta" },
+    video_photo_release: {
+      en: "Video / Photo Release",
+      es: "Autorización de Video / Foto",
+    },
+    non_solicitation: {
+      en: "Non-Solicitation Agreement",
+      es: "Acuerdo de No Solicitación",
+    },
+    social_media: {
+      en: "Social Media Policy",
+      es: "Política de Redes Sociales",
+    },
+    supply_kit: {
+      en: "Supply Kit Responsibility",
+      es: "Responsabilidad del Kit de Suministros",
+    },
+  };
+  return titles[documentType]?.[locale] ?? documentType;
 }
 
 function ProgressBar({ pct }: { pct: number }) {

--- a/artifacts/qleno/src/pages/training.tsx
+++ b/artifacts/qleno/src/pages/training.tsx
@@ -158,6 +158,7 @@ type View =
   | { kind: "home" }
   | { kind: "module"; moduleId: string }
   | { kind: "quiz"; moduleId: string }
+  | { kind: "sign-document"; documentType: string }
   | { kind: "final-intro" }
   | { kind: "final-quiz" }
   | { kind: "ack" }
@@ -259,6 +260,57 @@ const lmsApi = {
     ),
   listMyCertificates: (token: string | null) =>
     api<CertificateRow[]>("GET", "/lms/certificates/me", token),
+  getSignedDocumentContent: (
+    token: string | null,
+    documentType: string,
+    locale: Locale,
+  ) =>
+    api<SignedDocumentContent>(
+      "GET",
+      `/lms/signatures/content?documentType=${encodeURIComponent(
+        documentType,
+      )}&locale=${locale}`,
+      token,
+    ),
+  signDocument: (
+    token: string | null,
+    args: {
+      documentType: string;
+      locale: Locale;
+      signatureMethod: "drawn" | "typed";
+      signature: string;
+    },
+  ) =>
+    api<{
+      id: number;
+      document_type: string;
+      locale: Locale;
+      version_hash: string;
+      signed_at: string;
+      requires_co_sign: boolean;
+    }>("POST", "/lms/signatures/sign", token, {
+      ...args,
+      affirmation: true,
+    }),
+  listMySignedDocuments: (token: string | null) =>
+    api<SignedDocumentRow[]>("GET", "/lms/signatures/me", token),
+};
+
+type SignedDocumentContent = {
+  documentType: string;
+  locale: Locale;
+  title: string;
+  contentHtml: string;
+  pendingTranslationReview: boolean;
+};
+
+type SignedDocumentRow = {
+  id: number;
+  document_type: string;
+  locale: string;
+  signed_at: string;
+  status: "active" | "superseded" | "revoked";
+  version_hash: string;
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -444,6 +496,7 @@ export default function TrainingPage() {
   const [error, setError] = useState<string | null>(null);
   const [view, setView] = useState<View>({ kind: "home" });
   const [certificates, setCertificates] = useState<CertificateRow[]>([]);
+  const [signedDocs, setSignedDocs] = useState<SignedDocumentRow[]>([]);
 
   const curriculum = useMemo<Curriculum>(
     () => getCurriculum(learner?.companyId ?? null),
@@ -462,14 +515,28 @@ export default function TrainingPage() {
     return map;
   }, [certificates]);
 
+  /** document_type → most recent ACTIVE signed_document id. */
+  const signedDocByType = useMemo<Record<string, number>>(() => {
+    const map: Record<string, number> = {};
+    for (const d of signedDocs) {
+      if (d.status !== "active") continue;
+      if (!(d.document_type in map)) map[d.document_type] = d.id;
+    }
+    return map;
+  }, [signedDocs]);
+
   const refresh = useCallback(async () => {
     try {
-      const [next, certs] = await Promise.all([
+      const [next, certs, docs] = await Promise.all([
         lmsApi.me(token),
         lmsApi.listMyCertificates(token).catch(() => [] as CertificateRow[]),
+        lmsApi
+          .listMySignedDocuments(token)
+          .catch(() => [] as SignedDocumentRow[]),
       ]);
       setState(next);
       setCertificates(certs);
+      setSignedDocs(docs);
       // Sync locale from server if present
       if (next.enrollment.locale === "en" || next.enrollment.locale === "es") {
         setLocale(next.enrollment.locale);
@@ -607,9 +674,13 @@ export default function TrainingPage() {
           finalPassed={finalPassed}
           ackUnlocked={ackUnlocked}
           certByModule={certByModule}
+          signedDocByType={signedDocByType}
           onOpenModule={(moduleId) => setView({ kind: "module", moduleId })}
           onOpenFinal={() => setView({ kind: "final-intro" })}
           onOpenAck={() => setView({ kind: "ack" })}
+          onOpenSign={(documentType) =>
+            setView({ kind: "sign-document", documentType })
+          }
           onBypass={async (moduleId) => {
             await lmsApi.bypassModule(token, moduleId);
             await refresh();
@@ -709,6 +780,20 @@ export default function TrainingPage() {
           locale={locale}
           tenantName={curriculum.tenantName}
           onReturnHome={() => setLocation("/")}
+        />
+      )}
+      {view.kind === "sign-document" && (
+        <SignDocumentView
+          documentType={view.documentType}
+          locale={locale}
+          setLocale={setLocale}
+          learner={learner}
+          token={token}
+          onCancel={() => setView({ kind: "home" })}
+          onSigned={async () => {
+            await refresh();
+            setView({ kind: "home" });
+          }}
         />
       )}
       <ResponsiveStyles />
@@ -1006,9 +1091,11 @@ function Home({
   finalPassed,
   ackUnlocked,
   certByModule,
+  signedDocByType,
   onOpenModule,
   onOpenFinal,
   onOpenAck,
+  onOpenSign,
   onBypass,
   onDownloadCert,
 }: {
@@ -1019,9 +1106,11 @@ function Home({
   finalPassed: boolean;
   ackUnlocked: boolean;
   certByModule: Record<string, number>;
+  signedDocByType: Record<string, number>;
   onOpenModule: (id: string) => void;
   onOpenFinal: () => void;
   onOpenAck: () => void;
+  onOpenSign: (documentType: string) => void;
   onBypass: (moduleId: string) => Promise<void>;
   onDownloadCert: (certId: number) => Promise<void>;
 }) {
@@ -1139,6 +1228,108 @@ function Home({
           );
         })}
       </div>
+
+      {/* Required signed acknowledgments. One tile per quiz module that
+          has a registered signed-document type the learner still owes.
+          Phase 3 PR #4 ships the first: drug-alcohol. PRs #5+ extend. */}
+      {(() => {
+        const passedModuleIds = new Set(completed);
+        const tiles: Array<{
+          moduleId: string;
+          documentType: string;
+          title: { en: string; es: string };
+        }> = [
+          {
+            moduleId: "drug-alcohol",
+            documentType: "drug_alcohol",
+            title: {
+              en: "Drug & Alcohol Policy",
+              es: "Política de Drogas y Alcohol",
+            },
+          },
+        ];
+        const pending = tiles.filter(
+          (t) =>
+            passedModuleIds.has(t.moduleId) &&
+            !(t.documentType in signedDocByType),
+        );
+        if (pending.length === 0) return null;
+        return (
+          <div style={{ marginTop: 22 }}>
+            <div
+              style={{
+                fontSize: 11,
+                color: INK_MUTE,
+                fontWeight: 800,
+                textTransform: "uppercase",
+                letterSpacing: "0.08em",
+                marginBottom: 8,
+              }}
+            >
+              {locale === "es"
+                ? "Reconocimientos firmados requeridos"
+                : "Required Signed Acknowledgments"}
+            </div>
+            <div style={{ display: "grid", gap: 8 }}>
+              {pending.map((t) => (
+                <button
+                  key={t.documentType}
+                  type="button"
+                  onClick={() => onOpenSign(t.documentType)}
+                  style={{
+                    display: "grid",
+                    gridTemplateColumns: "auto 1fr auto",
+                    alignItems: "center",
+                    gap: 14,
+                    background: "#FFFBEB",
+                    border: `1px solid #FDE68A`,
+                    borderLeft: `4px solid ${WARN}`,
+                    borderRadius: RADIUS,
+                    padding: "14px 16px",
+                    textAlign: "left",
+                    cursor: "pointer",
+                    fontFamily: FONT,
+                  }}
+                >
+                  <AlertTriangle size={20} style={{ color: WARN }} />
+                  <div>
+                    <div
+                      style={{
+                        fontWeight: 800,
+                        fontSize: 14,
+                        color: INK,
+                      }}
+                    >
+                      {t.title[locale]}
+                    </div>
+                    <div
+                      style={{
+                        fontSize: 12,
+                        color: INK_MUTE,
+                        marginTop: 2,
+                      }}
+                    >
+                      {locale === "es"
+                        ? "Firme el reconocimiento legal para registrar su consentimiento."
+                        : "Sign the legal acknowledgment to record your consent."}
+                    </div>
+                  </div>
+                  <div
+                    style={{
+                      fontWeight: 800,
+                      fontSize: 12,
+                      color: WARN,
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    {locale === "es" ? "Firmar →" : "Sign →"}
+                  </div>
+                </button>
+              ))}
+            </div>
+          </div>
+        );
+      })()}
 
       {/* Final mixed test card */}
       <div style={{ marginTop: 22 }}>
@@ -2556,6 +2747,253 @@ function FinalIntroView({
             {tr("start", locale)} <ChevronRight size={14} />
           </PrimaryButton>
         </div>
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SignDocumentView — generic signed-acknowledgment flow (Phase 3+ PR #4)
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// Used for Drug & Alcohol (PR #4), Code of Conduct (PR #5), Video / Photo
+// Release (PR #6), Non-Solicit (PR #7), Social Media (PR #8), Supply Kit
+// (PR #10). The component is document-type-agnostic. It fetches the
+// canonical content from the server, renders an affirmation gate + typed
+// signature input, and POSTs to /api/lms/signatures/sign.
+
+function SignDocumentView({
+  documentType,
+  locale,
+  setLocale,
+  learner,
+  token,
+  onCancel,
+  onSigned,
+}: {
+  documentType: string;
+  locale: Locale;
+  setLocale: (l: Locale) => void;
+  learner: Learner | null;
+  token: string | null;
+  onCancel: () => void;
+  onSigned: () => Promise<void>;
+}) {
+  const [content, setContent] = useState<SignedDocumentContent | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const suggested = learner
+    ? `${learner.firstName} ${learner.lastName}`.trim()
+    : "";
+  const [name, setName] = useState(suggested);
+  const [affirmed, setAffirmed] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setContent(null);
+    setError(null);
+    (async () => {
+      try {
+        const data = await lmsApi.getSignedDocumentContent(
+          token,
+          documentType,
+          locale,
+        );
+        if (!cancelled) setContent(data);
+      } catch (e) {
+        if (!cancelled) setError(String((e as Error).message));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [documentType, locale, token]);
+
+  const canSubmit =
+    !busy && affirmed && name.trim().length >= 2 && content !== null;
+
+  return (
+    <div style={{ maxWidth: 760, margin: "0 auto", padding: "20px 18px" }}>
+      <BackLink label={tr("back", locale)} onClick={onCancel} />
+      <div
+        style={{
+          marginTop: 14,
+          background: SURFACE,
+          border: `1px solid ${LINE}`,
+          borderRadius: RADIUS,
+          padding: 24,
+        }}
+      >
+        {error ? (
+          <div style={{ color: DANGER, fontSize: 13 }}>{error}</div>
+        ) : !content ? (
+          <div
+            style={{ padding: 40, textAlign: "center", color: INK_MUTE }}
+          >
+            <Loader2 className="qleno-spin" size={20} />
+          </div>
+        ) : (
+          <>
+            <div
+              style={{
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "center",
+                gap: 10,
+                flexWrap: "wrap",
+                marginBottom: 10,
+              }}
+            >
+              <div style={{ fontWeight: 800, fontSize: 20, color: INK }}>
+                {content.title}
+              </div>
+              <LocaleToggle locale={locale} setLocale={setLocale} />
+            </div>
+
+            {content.pendingTranslationReview ? (
+              <div
+                style={{
+                  background: "#FFFBEB",
+                  border: `1px solid #FDE68A`,
+                  borderLeft: `3px solid ${WARN}`,
+                  padding: 12,
+                  borderRadius: 6,
+                  marginBottom: 14,
+                  display: "flex",
+                  gap: 10,
+                }}
+              >
+                <AlertTriangle
+                  size={16}
+                  style={{ color: WARN, flexShrink: 0, marginTop: 2 }}
+                />
+                <div style={{ fontSize: 12.5, color: INK, lineHeight: 1.55 }}>
+                  {locale === "es"
+                    ? "Esta traducción al español está bajo revisión profesional. La versión en inglés es vinculante hasta que la traducción final sea aprobada por la gerencia."
+                    : "This Spanish translation is under professional review. The English version is binding until the final translation is approved by management."}
+                </div>
+              </div>
+            ) : null}
+
+            <div
+              style={{
+                background: PAGE_BG,
+                border: `1px solid ${LINE_SOFT}`,
+                borderRadius: 8,
+                padding: "18px 20px",
+                maxHeight: 380,
+                overflowY: "auto",
+                fontSize: 13,
+                color: INK,
+                lineHeight: 1.6,
+                whiteSpace: "pre-wrap",
+                fontFamily: FONT,
+              }}
+            >
+              {content.contentHtml}
+            </div>
+
+            <label
+              style={{
+                display: "flex",
+                gap: 10,
+                alignItems: "flex-start",
+                marginTop: 18,
+                fontSize: 13,
+                color: INK,
+                lineHeight: 1.55,
+                cursor: "pointer",
+              }}
+            >
+              <input
+                type="checkbox"
+                checked={affirmed}
+                onChange={(e) => setAffirmed(e.target.checked)}
+                style={{ marginTop: 4, flexShrink: 0 }}
+              />
+              <span>
+                {locale === "es"
+                  ? `He leído y entendido la ${content.title}. Acepto sus términos y entiendo que mi firma electrónica tiene el mismo efecto legal que una firma manuscrita (UETA / E-SIGN).`
+                  : `I have read and understand the ${content.title}. I accept its terms and understand that my electronic signature has the same legal effect as a handwritten signature (UETA / E-SIGN).`}
+              </span>
+            </label>
+
+            <div
+              style={{
+                marginTop: 14,
+                fontSize: 12,
+                fontWeight: 700,
+                color: INK_MUTE,
+                textTransform: "uppercase",
+                letterSpacing: "0.06em",
+              }}
+            >
+              {locale === "es"
+                ? "Escriba su nombre legal completo"
+                : "Type your full legal name"}
+            </div>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder={
+                locale === "es" ? "Su nombre completo" : "Your full name"
+              }
+              style={{
+                width: "100%",
+                marginTop: 6,
+                padding: "10px 12px",
+                border: `1px solid ${LINE}`,
+                borderRadius: 8,
+                fontSize: 16,
+                fontFamily: FONT,
+                color: INK,
+                fontStyle: "italic",
+              }}
+            />
+
+            <div
+              style={{
+                marginTop: 16,
+                display: "flex",
+                gap: 10,
+                justifyContent: "flex-end",
+                flexWrap: "wrap",
+              }}
+            >
+              <SecondaryButton onClick={onCancel}>
+                {tr("back", locale)}
+              </SecondaryButton>
+              <PrimaryButton
+                disabled={!canSubmit}
+                onClick={async () => {
+                  setBusy(true);
+                  try {
+                    await lmsApi.signDocument(token, {
+                      documentType,
+                      locale,
+                      signatureMethod: "typed",
+                      signature: name.trim(),
+                    });
+                    await onSigned();
+                  } catch (e) {
+                    setError(String((e as Error).message));
+                  } finally {
+                    setBusy(false);
+                  }
+                }}
+              >
+                {busy ? (
+                  <Loader2 size={14} className="qleno-spin" />
+                ) : locale === "es" ? (
+                  "Firmar y enviar"
+                ) : (
+                  "Sign and submit"
+                )}
+              </PrimaryButton>
+            </div>
+          </>
+        )}
       </div>
     </div>
   );

--- a/lib/db/src/schema/lms-signatures.ts
+++ b/lib/db/src/schema/lms-signatures.ts
@@ -495,3 +495,30 @@ export const ANNUAL_DOCUMENT_TYPES = [
 ] as const;
 
 export type AnnualDocumentType = (typeof ANNUAL_DOCUMENT_TYPES)[number];
+
+/**
+ * Standalone legal acknowledgments that an employee must sign BEFORE
+ * the final mixed test unlocks. Per phes-2026-policy (PR #4 review):
+ * the final exam triggers the comprehensive handbook PDF flow and is
+ * not reachable until every legally binding standalone document is
+ * captured.
+ *
+ * `handbook` is NOT in this list — it is signed AFTER the final exam
+ * as part of the comprehensive PDF (PR #13).
+ *
+ * Each successive standalone-signed-document PR (#5 code_of_conduct,
+ * #6 video_photo_release, #7 non_solicitation, #8 social_media,
+ * #10 supply_kit) appends its slug to this array. Server gating reads
+ * directly from it.
+ */
+export const REQUIRED_PRE_FINAL_SIGNED_DOCS = [
+  "drug_alcohol",
+  // PR #5 will add: "code_of_conduct"
+  // PR #6 will add: "video_photo_release"
+  // PR #7 will add: "non_solicitation"
+  // PR #8 will add: "social_media"
+  // PR #10 will add: "supply_kit"
+] as const;
+
+export type RequiredPreFinalSignedDoc =
+  (typeof REQUIRED_PRE_FINAL_SIGNED_DOCS)[number];

--- a/lib/lms-curriculum/src/index.ts
+++ b/lib/lms-curriculum/src/index.ts
@@ -47,6 +47,7 @@ export type ModuleId =
   | "maidcentral"
   | "products-tools"
   | "il-sexual-harassment"
+  | "drug-alcohol"
   | "acknowledgment";
 
 export type QuizModuleId = Exclude<ModuleId, "acknowledgment">;
@@ -72,6 +73,7 @@ export const MODULE_ORDER: readonly ModuleId[] = [
   "maidcentral",
   "products-tools",
   "il-sexual-harassment",
+  "drug-alcohol",
   "acknowledgment",
 ] as const;
 
@@ -84,6 +86,11 @@ export const MODULE_ORDER: readonly ModuleId[] = [
  * (820 ILCS 96) requires comprehension verification, not just attestation.
  * Phes also re-runs this module annually — content is updated each January
  * and the office uses the admin Reset action to re-enroll the team.
+ *
+ * drug-alcohol (Phase 3, PR #4) follows the same pattern: quiz to verify
+ * comprehension, followed by a SEPARATE signed acknowledgment (legally
+ * binding e-signature) handled by lms_signed_documents — the quiz pass
+ * does NOT supersede the signed ack requirement.
  */
 export const QUIZ_MODULE_IDS: readonly QuizModuleId[] = [
   "phes-policies",
@@ -92,6 +99,7 @@ export const QUIZ_MODULE_IDS: readonly QuizModuleId[] = [
   "maidcentral",
   "products-tools",
   "il-sexual-harassment",
+  "drug-alcohol",
 ] as const;
 
 /** Pass threshold per module (and for the final mixed test). 80%. */
@@ -292,6 +300,23 @@ export const ANSWER_KEY: Readonly<Record<string, number>> = Object.freeze({
   "q-il-13-consent-withdrawn": 1,
   "q-il-14-investigation-rights": 1,
   "q-il-15-good-faith-protection": 1,
+
+  // ── Module 7: drug-alcohol (10, Phase 3 PR #4) ──────────────────────────
+  // Phes Drug & Alcohol Policy. Quiz verifies comprehension; the binding
+  // signed acknowledgment lives in lms_signed_documents (document_type
+  // 'drug_alcohol'). Both are required for legal compliance under Illinois
+  // Cannabis Regulation & Tax Act + the Illinois Right to Privacy in the
+  // Workplace Act (820 ILCS 55).
+  "q-da-01-no-pre-employment-test": 1,
+  "q-da-02-impairment-not-cannabis-use": 1,
+  "q-da-03-impairment-signs": 1,
+  "q-da-04-reasonable-suspicion-process": 1,
+  "q-da-05-post-accident-threshold": 1,
+  "q-da-06-prescription-meds": 1,
+  "q-da-07-refusal-to-test": 1,
+  "q-da-08-discipline-scale": 1,
+  "q-da-09-dui-reporting-window": 1,
+  "q-da-10-license-suspension-disclosure": 1,
 });
 
 /**
@@ -355,6 +380,13 @@ export const QUESTIONS_BY_MODULE: Readonly<Record<QuizModuleId, readonly string[
       "q-il-07-retaliation", "q-il-08-bystander-duty", "q-il-09-idhr-deadline",
       "q-il-10-eeoc-deadline", "q-il-11-annual-retraining", "q-il-12-severe-or-pervasive",
       "q-il-13-consent-withdrawn", "q-il-14-investigation-rights", "q-il-15-good-faith-protection",
+    ],
+    "drug-alcohol": [
+      "q-da-01-no-pre-employment-test", "q-da-02-impairment-not-cannabis-use",
+      "q-da-03-impairment-signs", "q-da-04-reasonable-suspicion-process",
+      "q-da-05-post-accident-threshold", "q-da-06-prescription-meds",
+      "q-da-07-refusal-to-test", "q-da-08-discipline-scale",
+      "q-da-09-dui-reporting-window", "q-da-10-license-suspension-disclosure",
     ],
   });
 

--- a/lib/training/src/answer-key.ts
+++ b/lib/training/src/answer-key.ts
@@ -153,6 +153,18 @@ export const SERVER_ANSWER_KEY: Readonly<Record<string, number>> = Object.freeze
   "q-il-13-consent-withdrawn": 1,
   "q-il-14-investigation-rights": 1,
   "q-il-15-good-faith-protection": 1,
+
+  // ── Module 7: drug-alcohol (10, Phase 3 PR #4) ─────────────────────────
+  "q-da-01-no-pre-employment-test": 1,
+  "q-da-02-impairment-not-cannabis-use": 1,
+  "q-da-03-impairment-signs": 1,
+  "q-da-04-reasonable-suspicion-process": 1,
+  "q-da-05-post-accident-threshold": 1,
+  "q-da-06-prescription-meds": 1,
+  "q-da-07-refusal-to-test": 1,
+  "q-da-08-discipline-scale": 1,
+  "q-da-09-dui-reporting-window": 1,
+  "q-da-10-license-suspension-disclosure": 1,
 });
 
 /**


### PR DESCRIPTION
## PR #4 of 16 — Phase 3: Drug & Alcohol Module + Signed Acknowledgment

**Establishes the pattern for PRs #5-#10.** Adds the Phes Drug & Alcohol Policy as LMS module #7 with a 10-question quiz and a separate UETA / E-SIGN binding signed acknowledgment. The 5 remaining signed-document modules (Code of Conduct, Video Release, Non-Solicit, Supply Kit, Social Media) will reuse exactly the same shape introduced here.

## Resolved open decisions (follow-up commit b48e097)

1. **Hard gating: YES.** Final exam locked until ALL standalone signed docs are in place. Owner / admin / office exempt (they're not the signer). Pattern applied via `REQUIRED_PRE_FINAL_SIGNED_DOCS` registry that PRs #5-#10 will append to.
2. **Bypass auto-sign: NO.** `/admin/bypass-module` marks the quiz passed for navigation only. Does NOT issue a completion certificate or create a `signed_document` row. Audit log distinguishes `bypassed_by_user_id` + `source: "admin_bypass"` from a real employee signature trail.

## Pattern this PR establishes

| Layer | What gets added per signed-document PR |
|-------|----------------------------------------|
| `@workspace/lms-curriculum` | ModuleId entry, MODULE_ORDER slot, QUIZ_MODULE_IDS, 10 answer key entries |
| `@workspace/training/answer-key` | Same 10 entries (drift-sync test enforces parity) |
| `artifacts/qleno/src/lib/training/curriculum.ts` | Module body (bilingual blocks) + 10 quiz questions |
| `artifacts/api-server/src/lib/lms-signed-documents-content.ts` | Bilingual canonical legal text + translation-review flag |
| `lib/db/src/schema/lms-signatures.ts` | Append doctype to `REQUIRED_PRE_FINAL_SIGNED_DOCS` |
| Routes | Use the generic `/api/lms/signatures` surface added in this PR (no new routes needed) |
| Frontend | Home tile auto-appears when quiz passed + signed-doc missing; final-exam tile shows locked state until all required docs signed |
| Admin | Per-learner panel auto-lists the new signed-doc type |

PRs #5-#10 will be small: just content + 10 questions + one-line append to the registry.

## What this PR ships

### A. `drug-alcohol` module (Phase 3 quiz)

Slot #7 between `il-sexual-harassment` and `acknowledgment`. Bilingual content covering:
- No pre-employment testing
- Impairment is the line, not use (cannabis off-duty is protected per IL Cannabis Reg & Tax Act)
- Observable signs of impairment (the only thing Phes acts on)
- Reasonable-suspicion process (office decides, not coworkers / clients)
- Post-accident testing threshold ($500 / injury)
- Prescription medication accommodation (no diagnosis required)
- Refusal to test = immediate termination
- Full discipline scale
- **72-hour DUI / license suspension / major moving violation disclosure** for techs using personal vehicles
- EAP reference

**10 quiz questions** (`q-da-01` through `q-da-10`), 80% to pass.

### B. `lms_signed_documents` content registry

New `lib/lms-signed-documents-content.ts`. Server-side canonical text keyed by `(documentType, locale)`. **Spanish drug_alcohol entry flagged `pendingTranslationReview: true`** — one of the four flagged for human translator review before production launch.

Content em-dash-free, en-dash-free, no hyphens as sentence separators. Test enforces this across the whole registry.

### C. Six signature endpoints (mounted at `/api/lms/signatures`)

| Method | Path | Notes |
|--------|------|-------|
| GET | `/content` | Render-ready content for a (docType, locale) |
| POST | `/sign` | Employee signature. **`affirmation: true` required** (UETA gate). Supersedes older active rows |
| POST | `/admin/co-sign` | Phes rep co-signature (owner / admin / office). Ready for PR #6 + #7 |
| GET | `/me` | Caller's signed docs + `missing_required_signed_docs` for final-exam gate |
| GET | `/admin/learner/:userId` | Admin: signed docs for any user in tenant |
| GET | `/:id/pdf` | Render + stream signed PDF |

**Tenant isolation verified at the schema layer** for every read / write — every query includes `company_id` in WHERE.

### D. Signed-document PDF renderer

`generateSignedDocumentPdf` paginates legal text across multi-page US Letter, renders employee signature (drawn data URL or typed italic name), tail-stamps every page with `slug + version hash + tenant + page X of Y`. Spanish + `pendingTranslationReview` triggers an amber banner on page 1: *"This Spanish translation is under review. The English version is binding until professional translation is approved."*

Co-signature block on last page when present.

### E. Frontend `SignDocumentView` (generic flow)

Document-type-agnostic. Fetches content, shows it inline (380px scrollable), affirmation checkbox + typed-name signature input, locale toggle, translation-review banner when relevant.

### F. Home tile: "Required Signed Acknowledgments"

Amber tile auto-appears when a learner has passed a quiz module but hasn't signed the matching legal document. Click → opens the SignDocumentView.

### G. Admin `LearnerSignedDocumentsPanel`

Sits beside `LearnerCertificatesPanel` in the per-learner expand row. Lists all signed docs (active / superseded / revoked) with download buttons. "Co-signed by Phes representative" badge when applicable.

### H. Final-exam lock (follow-up commit)

`FinalStepCard` renders locked when `missing_required_signed_docs` is non-empty. Lists missing docs with localized names + per-doc deep links into the signing flow. `/quiz/submit` rejects FINAL_MODULE_ID with 403 while the list is non-empty (owner / admin / office exempt).

## Tests

- **130 / 130 LMS tests pass**
- 15 new tests on content registry: shape, EN/ES coverage, em-dash defense, IL Cannabis Act citation in Spanish, 72-hour reporting window in English, EN vs ES hashes differ
- 3 new `generateSignedDocumentPdf` smoke tests (EN, ES + banner, co-signed)
- Updated module count assertions: 8 modules, 7 quiz modules, 125 total questions (40 + 15×5 + 10)
- Vite build clean. Only pre-existing IconKind warnings remain.

## Confirmed compliance items

- **Bilingual EN/ES**: every content block + quiz option + signed doc text
- **`pendingTranslationReview: true`** on Spanish drug_alcohol (one of the four flagged)
- **Owner / admin / office role-gating**: attempt counter, deadline UI, signature requirements all use the existing `shouldShowLearnerGating` predicate; new endpoints accept all four privileged roles consistently
- **Tenant isolation at schema layer**: confirmed. All `lms_signed_documents`, `lms_document_versions`, `lms_signature_events`, `lms_completion_certificates` queries scoped by `company_id`. Cross-tenant access returns 404.
- **UETA / E-SIGN compliance**: affirmation gate, IP capture, device info (browser + OS only — no fingerprinting), version hash, immutable audit log

## Test plan (manual)

- [ ] Log in as `jose.ardila@phes.io` → `/training` → module #7 "Drug & Alcohol Policy" appears
- [ ] Read content, take quiz (10 questions, 80% pass)
- [ ] On pass, Home shows new amber "Required Signed Acknowledgments" tile
- [ ] Click tile → SignDocumentView opens with canonical text + affirmation checkbox + typed name field
- [ ] Locale toggle to ES → see amber translation-review banner
- [ ] Sign → returns to Home, tile disappears
- [ ] Before signing, the final-exam tile is locked with "sign these first" hint listing Drug & Alcohol
- [ ] After signing, final-exam tile unlocks (assuming no other required docs added yet)
- [ ] As Sal / Maribel / Francisco: `/lms/admin` → expand Jose → new "Signed Acknowledgments" panel shows the drug_alcohol entry → Download → PDF opens with legal text + Jose's signature + audit footer
- [ ] Admin bypass on drug-alcohol: confirm NO certificate issued + NO signed_document row created; audit log shows `source: "admin_bypass"`
- [ ] Cross-tenant: try `GET /api/lms/signatures/<id>/pdf` for a doc in another tenant → 404

https://claude.ai/code/session_013rJ4N4vgqZWB986x8D6Ahh

---
_Generated by [Claude Code](https://claude.ai/code/session_013rJ4N4vgqZWB986x8D6Ahh)_