### PR TITLE
lms: Phase 5 video & photo release improved + co-sign UI (PR #6 of 16)

### DIFF
--- a/artifacts/api-server/src/lib/lms-curriculum-titles.ts
+++ b/artifacts/api-server/src/lib/lms-curriculum-titles.ts
@@ -56,6 +56,10 @@ const MODULE_TITLES: Record<string, BilingualTitle> = {
     en: "Code of Conduct",
     es: "Código de Conducta",
   },
+  "video-photo-release": {
+    en: "Video & Photo Release",
+    es: "Autorización de Video y Foto",
+  },
   acknowledgment: {
     en: "Onboarding Acknowledgment",
     es: "Confirmación de Incorporación",

--- a/artifacts/api-server/src/lib/lms-signed-documents-content.ts
+++ b/artifacts/api-server/src/lib/lms-signed-documents-content.ts
@@ -298,6 +298,118 @@ const CODE_OF_CONDUCT_ES: SignedDocumentLocaleContent = {
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
+// video_photo_release (Phase 5, PR #6)
+//
+// CO-SIGNED release governed by the Illinois Right of Publicity Act
+// (765 ILCS 1075). Improved version that replaces the broad legacy
+// release with explicit limits:
+//   1. 5-year post-separation cap on NEW uses (existing content in
+//      active distribution may continue).
+//   2. AI training / deepfake / synthetic-media carve-out (requires
+//      separate written consent).
+//   3. Withdrawal at any time. 30-day removal effort for Phes-controlled
+//      channels. Third-party shares cannot be recalled.
+//   4. Courtesy preview before publication where feasible (not a veto).
+//
+// NOT in the four flagged docs for human translator review. Spanish
+// goes live without the pending-review banner.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const VIDEO_PHOTO_RELEASE_EN: SignedDocumentLocaleContent = {
+  title: "Video and Photo Release",
+  contentHtml: [
+    "PHES CLEANING SERVICES",
+    "VIDEO AND PHOTO RELEASE",
+    "Effective Date: January 1, 2026",
+    "",
+    "By signing this release, I authorize Phes Cleaning Services to record, store, and use photographs and video of me captured in the course of my employment, subject to the limits described below. This release is given voluntarily and is consistent with the Illinois Right of Publicity Act, 765 ILCS 1075, which requires my affirmative written consent before Phes may use my identity for any commercial purpose.",
+    "",
+    "1. VOLUNTARY CONSENT.",
+    "I understand that signing this release is voluntary. I may decline without any change to my job duties, schedule, pay, or standing with Phes. If I decline, Phes will not photograph or record me for commercial use.",
+    "",
+    "2. SCOPE OF AUTHORIZED USE.",
+    "I authorize Phes to use photographs and video of me captured in my work environment (homes I clean as part of my Phes shift, the Phes office, training sessions, and team events) in the following Phes-controlled materials and channels: Phes recruiting and marketing materials, Phes training and onboarding materials, the Phes website, and Phes-operated social media channels. Phes is the sole commercial user authorized by this release.",
+    "",
+    "3. THIRD-PARTY USE NOT AUTHORIZED.",
+    "This release does not authorize any third party (other businesses, news outlets, advertising partners) to use my likeness. If a third party requests footage of me from Phes for the third party's own use, Phes must seek my separate written consent before sharing.",
+    "",
+    "4. AI TRAINING AND SYNTHETIC-MEDIA CARVE-OUT.",
+    "Phes will not use my photographs or video for the training of any artificial-intelligence model, for deepfake creation, or for any other synthetic-media generation featuring my likeness, without my SEPARATE WRITTEN CONSENT. This release does not authorize any such use under any circumstances. Any future request for AI-training consent will be a different document with its own signature.",
+    "",
+    "5. POST-SEPARATION LIMIT ON NEW USES.",
+    "If my employment with Phes ends (voluntary or involuntary), Phes may continue to use content featuring my likeness after my employment ends, with a 5-year limit on new uses of content featuring my likeness post-separation, except for content already in active distribution. Practical effect: existing content (training videos, recruiting graphics, social-media posts already in rotation) may continue to play, but Phes may not launch new uses of content featuring my likeness more than 5 years after my last day, with the exception of content that was in active distribution at separation.",
+    "",
+    "6. COURTESY PREVIEW BEFORE PUBLICATION.",
+    "Phes will make reasonable effort to provide a courtesy preview of content featuring my likeness before publication when feasible. Courtesy preview is not a veto and pre-approval is not a condition of publication under this release. I may flag concerns and Phes will consider them.",
+    "",
+    "7. WITHDRAWAL OF CONSENT.",
+    "I may withdraw my consent at any time, for any reason or no reason, by giving written notice to the office. Upon withdrawal, Phes will make reasonable efforts to remove content from active Phes-controlled distribution within 30 days. Content distributed through third parties (shared or re-posted by others, downloads, screenshots, news references) cannot be recalled. Phes will not use the withdrawn content in new campaigns or new publications after the withdrawal date. Withdrawing consent does not affect my job, schedule, pay, or standing with Phes.",
+    "",
+    "8. PHES REPRESENTATIVE CO-SIGNATURE.",
+    "Because this release is a two-way commitment, the Phes representative co-signs it. The co-signature binds Phes to the limits set out in sections 4 through 7 above. The co-signature is added after my signature; I do not need to be present.",
+    "",
+    "9. NO COMPENSATION FOR USE.",
+    "I understand that Phes does not pay residuals, royalties, or any additional compensation for use of content featuring my likeness under this release. The release is granted as part of my employment relationship and is not tied to any wage or bonus.",
+    "",
+    "10. AT-WILL EMPLOYMENT.",
+    "Nothing in this release alters my at-will employment status with Phes. Phes may terminate my employment at any time, with or without cause or notice, for any lawful reason.",
+    "",
+    "11. ELECTRONIC SIGNATURE CONSENT.",
+    "I consent to sign this release electronically. I understand that my electronic signature has the same legal effect as a handwritten signature, in accordance with the federal Electronic Signatures in Global and National Commerce Act (E-SIGN) and the Illinois Uniform Electronic Transactions Act (UETA).",
+    "",
+    "By typing or drawing my signature below and clicking the I Agree button, I affirm that I have read, understood, and accept this Video and Photo Release.",
+  ].join("\n"),
+  notes: "Phase 5 PR #6 — improved Phes video/photo release with AI carve-out + 5-year post-separation limit + 30-day withdrawal removal effort. Cites 765 ILCS 1075.",
+};
+
+const VIDEO_PHOTO_RELEASE_ES: SignedDocumentLocaleContent = {
+  title: "Autorización de Video y Foto",
+  contentHtml: [
+    "PHES CLEANING SERVICES",
+    "AUTORIZACIÓN DE VIDEO Y FOTO",
+    "Fecha Efectiva: 1 de enero de 2026",
+    "",
+    "Al firmar esta autorización, autorizo a Phes Cleaning Services a grabar, almacenar y usar fotografías y videos míos capturados en el curso de mi empleo, sujeto a los límites descritos a continuación. Esta autorización se da voluntariamente y es consistente con la Ley del Derecho de Publicidad de Illinois, 765 ILCS 1075, que requiere mi consentimiento afirmativo por escrito antes de que Phes pueda usar mi identidad para cualquier propósito comercial.",
+    "",
+    "1. CONSENTIMIENTO VOLUNTARIO.",
+    "Entiendo que firmar esta autorización es voluntario. Puedo rechazarlo sin ningún cambio en mis funciones, horario, pago o posición con Phes. Si rechazo, Phes no me fotografiará ni grabará para uso comercial.",
+    "",
+    "2. ALCANCE DEL USO AUTORIZADO.",
+    "Autorizo a Phes a usar fotografías y videos míos capturados en mi entorno de trabajo (hogares que limpio como parte de mi turno de Phes, la oficina de Phes, sesiones de capacitación y eventos del equipo) en los siguientes materiales y canales controlados por Phes: materiales de reclutamiento y mercadotecnia de Phes, materiales de capacitación y orientación de Phes, la página web de Phes y los canales de redes sociales operados por Phes. Phes es el único usuario comercial autorizado por esta autorización.",
+    "",
+    "3. USO POR TERCEROS NO AUTORIZADO.",
+    "Esta autorización no permite a ningún tercero (otros negocios, medios de noticias, socios publicitarios) usar mi semejanza. Si un tercero solicita imágenes mías a Phes para uso propio del tercero, Phes debe pedir mi consentimiento separado por escrito antes de compartirlas.",
+    "",
+    "4. EXCLUSIÓN DE ENTRENAMIENTO DE IA Y MEDIOS SINTÉTICOS.",
+    "Phes no usará mis fotografías o videos para el entrenamiento de ningún modelo de inteligencia artificial, para la creación de deepfakes, ni para ninguna otra generación de medios sintéticos con mi semejanza, sin mi CONSENTIMIENTO SEPARADO POR ESCRITO. Esta autorización no permite ningún uso así bajo ninguna circunstancia. Cualquier solicitud futura de consentimiento para entrenamiento de IA será un documento distinto con su propia firma.",
+    "",
+    "5. LÍMITE DESPUÉS DE LA SEPARACIÓN PARA NUEVOS USOS.",
+    "Si mi empleo con Phes termina (voluntaria o involuntariamente), Phes podrá continuar usando contenido que muestre mi semejanza después del término de mi empleo, con un límite de 5 años para nuevos usos de contenido que muestre mi semejanza después de la separación, excepto para contenido que ya estaba en distribución activa. Efecto práctico: el contenido existente (videos de capacitación, gráficos de reclutamiento, publicaciones en redes sociales ya en rotación) puede continuar reproduciéndose, pero Phes no podrá iniciar nuevos usos de contenido con mi semejanza más de 5 años después de mi último día, con la excepción del contenido que estaba en distribución activa al momento de la separación.",
+    "",
+    "6. VISTA PREVIA DE CORTESÍA ANTES DE LA PUBLICACIÓN.",
+    "Phes hará un esfuerzo razonable por proveer una vista previa de cortesía del contenido con mi semejanza antes de la publicación cuando sea factible. La vista previa de cortesía no es un veto y la pre-aprobación no es condición de la publicación bajo esta autorización. Puedo señalar inquietudes y Phes las considerará.",
+    "",
+    "7. RETIRO DEL CONSENTIMIENTO.",
+    "Puedo retirar mi consentimiento en cualquier momento, por cualquier razón o sin razón, dando aviso por escrito a la oficina. Al retirarlo, Phes hará esfuerzos razonables por retirar el contenido de la distribución activa controlada por Phes dentro de los 30 días. El contenido distribuido a través de terceros (compartido o republicado por otros, descargas, capturas de pantalla, referencias de noticias) no puede ser recuperado. Phes no usará el contenido retirado en nuevas campañas o nuevas publicaciones después de la fecha de retiro. Retirar el consentimiento no afecta mi trabajo, horario, pago o posición con Phes.",
+    "",
+    "8. CO-FIRMA DEL REPRESENTANTE DE PHES.",
+    "Como esta autorización es un compromiso de dos vías, el representante de Phes la co-firma. La co-firma vincula a Phes a los límites establecidos en las secciones 4 a 7 anteriores. La co-firma se agrega después de mi firma; no necesito estar presente.",
+    "",
+    "9. SIN COMPENSACIÓN POR EL USO.",
+    "Entiendo que Phes no paga residuales, regalías o ninguna compensación adicional por el uso de contenido con mi semejanza bajo esta autorización. La autorización se otorga como parte de mi relación laboral y no está vinculada a ningún salario o bono.",
+    "",
+    "10. EMPLEO A VOLUNTAD.",
+    "Nada en esta autorización altera mi estatus de empleo a voluntad con Phes. Phes puede terminar mi empleo en cualquier momento, con o sin causa o aviso, por cualquier razón legal.",
+    "",
+    "11. CONSENTIMIENTO DE FIRMA ELECTRÓNICA.",
+    "Doy mi consentimiento para firmar esta autorización electrónicamente. Entiendo que mi firma electrónica tiene el mismo efecto legal que una firma manuscrita, conforme a la Ley federal de Firmas Electrónicas en el Comercio Global y Nacional (E-SIGN) y a la Ley Uniforme de Transacciones Electrónicas de Illinois (UETA).",
+    "",
+    "Al escribir o dibujar mi firma a continuación y hacer clic en el botón Acepto, afirmo que he leído, entendido y aceptado esta Autorización de Video y Foto.",
+  ].join("\n"),
+  notes: "Phase 5 PR #6 — Phes video/photo release, Spanish version. Not in the four flagged docs.",
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Registry
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -310,8 +422,12 @@ export const SIGNED_DOCUMENT_CONTENT: SignedDocumentRegistry = {
     en: CODE_OF_CONDUCT_EN,
     es: CODE_OF_CONDUCT_ES,
   },
-  // PR #6+ will add: video_photo_release, non_solicitation, supply_kit,
-  // social_media. Same shape, same conventions.
+  video_photo_release: {
+    en: VIDEO_PHOTO_RELEASE_EN,
+    es: VIDEO_PHOTO_RELEASE_ES,
+  },
+  // PR #7+ will add: non_solicitation, supply_kit, social_media. Same shape,
+  // same conventions.
 };
 
 /**

--- a/artifacts/api-server/src/tests/lms-curriculum.test.ts
+++ b/artifacts/api-server/src/tests/lms-curriculum.test.ts
@@ -33,7 +33,7 @@ import {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("LMS curriculum — constants & catalog shape", () => {
-  it("MODULE_ORDER has all 9 modules in expected sequence (code-of-conduct added 2026-05-12 Phase 4)", () => {
+  it("MODULE_ORDER has all 10 modules in expected sequence (video-photo-release added 2026-05-12 Phase 5)", () => {
     assert.deepEqual([...MODULE_ORDER], [
       "phes-policies",
       "compensation",
@@ -43,11 +43,12 @@ describe("LMS curriculum — constants & catalog shape", () => {
       "il-sexual-harassment",
       "drug-alcohol",
       "code-of-conduct",
+      "video-photo-release",
       "acknowledgment",
     ]);
   });
 
-  it("QUIZ_MODULE_IDS contains exactly the 8 quiz modules (no acknowledgment)", () => {
+  it("QUIZ_MODULE_IDS contains exactly the 9 quiz modules (no acknowledgment)", () => {
     assert.deepEqual([...QUIZ_MODULE_IDS], [
       "phes-policies",
       "compensation",
@@ -57,6 +58,7 @@ describe("LMS curriculum — constants & catalog shape", () => {
       "il-sexual-harassment",
       "drug-alcohol",
       "code-of-conduct",
+      "video-photo-release",
     ]);
   });
 
@@ -93,11 +95,13 @@ describe("LMS curriculum — constants & catalog shape", () => {
     // phes-policies: 40 (full handbook coverage)
     // drug-alcohol: 10 (Phase 3 spec, legally-important concepts only)
     // code-of-conduct: 10 (Phase 4 spec, behavior-comprehension)
+    // video-photo-release: 9 (Phase 5 spec, release-rights comprehension)
     // all others: 15 (per original Phes spec)
     const expected: Record<string, number> = {
       "phes-policies": 40,
       "drug-alcohol": 10,
       "code-of-conduct": 10,
+      "video-photo-release": 9,
       compensation: 15,
       "cleaning-best-practices": 15,
       maidcentral: 15,
@@ -113,8 +117,8 @@ describe("LMS curriculum — constants & catalog shape", () => {
     }
   });
 
-  it("ALL_QUESTION_IDS is 135 total (40 + 15*5 + 10 + 10)", () => {
-    assert.equal(ALL_QUESTION_IDS.length, 135);
+  it("ALL_QUESTION_IDS is 144 total (40 + 15*5 + 10 + 10 + 9)", () => {
+    assert.equal(ALL_QUESTION_IDS.length, 144);
   });
 
   it("ANSWER_KEY has exactly the keys enumerated by ALL_QUESTION_IDS", () => {

--- a/artifacts/api-server/src/tests/lms-signed-documents.test.ts
+++ b/artifacts/api-server/src/tests/lms-signed-documents.test.ts
@@ -37,6 +37,12 @@ describe("SIGNED_DOCUMENT_CONTENT registry", () => {
     assert.ok(SIGNED_DOCUMENT_CONTENT.code_of_conduct!.es);
   });
 
+  it("includes video_photo_release (Phase 5 PR #6)", () => {
+    assert.ok(SIGNED_DOCUMENT_CONTENT.video_photo_release);
+    assert.ok(SIGNED_DOCUMENT_CONTENT.video_photo_release!.en);
+    assert.ok(SIGNED_DOCUMENT_CONTENT.video_photo_release!.es);
+  });
+
   it("every registered document has BOTH en and es entries", () => {
     for (const [type, entry] of Object.entries(SIGNED_DOCUMENT_CONTENT)) {
       assert.ok(entry?.en?.contentHtml, `${type}: missing en.contentHtml`);
@@ -136,6 +142,119 @@ describe("listRegisteredDocumentTypes", () => {
 
   it("includes code_of_conduct after PR #5", () => {
     assert.ok(listRegisteredDocumentTypes().includes("code_of_conduct"));
+  });
+
+  it("includes video_photo_release after PR #6", () => {
+    assert.ok(listRegisteredDocumentTypes().includes("video_photo_release"));
+  });
+});
+
+describe("video_photo_release content shape (PR #6 spec checks)", () => {
+  it("English entry is NOT flagged pendingTranslationReview (not in the four flagged docs)", () => {
+    assert.equal(
+      SIGNED_DOCUMENT_CONTENT.video_photo_release!.en.pendingTranslationReview ?? false,
+      false,
+    );
+  });
+
+  it("Spanish entry is NOT flagged pendingTranslationReview", () => {
+    assert.equal(
+      SIGNED_DOCUMENT_CONTENT.video_photo_release!.es.pendingTranslationReview ?? false,
+      false,
+    );
+    assert.equal(isSpanishPendingTranslationReview("video_photo_release"), false);
+  });
+
+  it("English content cites the Illinois Right of Publicity Act with the 765 ILCS 1075 citation", () => {
+    const en = SIGNED_DOCUMENT_CONTENT.video_photo_release!.en.contentHtml;
+    assert.ok(
+      en.includes("Illinois Right of Publicity Act"),
+      "English version must reference the Illinois Right of Publicity Act by name",
+    );
+    assert.ok(
+      en.includes("765 ILCS 1075"),
+      "English version must include the 765 ILCS 1075 citation",
+    );
+  });
+
+  it("Spanish content cites the Illinois Right of Publicity Act translation + the 765 ILCS 1075 citation", () => {
+    const es = SIGNED_DOCUMENT_CONTENT.video_photo_release!.es.contentHtml;
+    assert.ok(
+      es.includes("Ley del Derecho de Publicidad de Illinois"),
+      "Spanish version must reference the IL Right of Publicity Act translation",
+    );
+    assert.ok(
+      es.includes("765 ILCS 1075"),
+      "Spanish version must include the 765 ILCS 1075 citation",
+    );
+  });
+
+  it("English content includes the AI-training carve-out verbatim", () => {
+    const en = SIGNED_DOCUMENT_CONTENT.video_photo_release!.en.contentHtml;
+    assert.ok(
+      en.includes("SEPARATE WRITTEN CONSENT"),
+      "English must require SEPARATE WRITTEN CONSENT for AI training",
+    );
+    assert.ok(
+      en.includes("deepfake"),
+      "English must mention deepfake carve-out",
+    );
+    assert.ok(
+      en.includes("synthetic-media"),
+      "English must mention synthetic-media carve-out",
+    );
+  });
+
+  it("English content includes the 5-year post-separation limit verbatim", () => {
+    const en = SIGNED_DOCUMENT_CONTENT.video_photo_release!.en.contentHtml;
+    assert.ok(
+      en.includes("5-year limit on new uses"),
+      "English must include the 5-year limit on new uses",
+    );
+    assert.ok(
+      en.includes("already in active distribution"),
+      "English must call out the active-distribution exception",
+    );
+  });
+
+  it("English content includes the 30-day withdrawal removal effort", () => {
+    const en = SIGNED_DOCUMENT_CONTENT.video_photo_release!.en.contentHtml;
+    assert.ok(
+      en.includes("within 30 days"),
+      "English must include the 30-day withdrawal removal effort",
+    );
+    assert.ok(
+      en.includes("Content distributed through third parties"),
+      "English must call out the third-party limitation on withdrawal",
+    );
+  });
+
+  it("English content includes the courtesy preview language", () => {
+    const en = SIGNED_DOCUMENT_CONTENT.video_photo_release!.en.contentHtml;
+    assert.ok(
+      en.includes("courtesy preview"),
+      "English must mention courtesy preview",
+    );
+    assert.ok(
+      en.includes("not a veto"),
+      "English must clarify that courtesy preview is not a veto",
+    );
+  });
+
+  it("English content states the release is voluntary", () => {
+    const en = SIGNED_DOCUMENT_CONTENT.video_photo_release!.en.contentHtml;
+    assert.ok(
+      en.includes("voluntary") || en.includes("voluntarily"),
+      "English must call out that signing is voluntary",
+    );
+  });
+
+  it("English and Spanish content hash to DIFFERENT version hashes (legally distinct)", () => {
+    const en = SIGNED_DOCUMENT_CONTENT.video_photo_release!.en.contentHtml;
+    const es = SIGNED_DOCUMENT_CONTENT.video_photo_release!.es.contentHtml;
+    const hEn = hashContent(en, "en");
+    const hEs = hashContent(es, "es");
+    assert.notEqual(hEn, hEs);
   });
 });
 

--- a/artifacts/qleno/src/lib/training/curriculum.ts
+++ b/artifacts/qleno/src/lib/training/curriculum.ts
@@ -2097,6 +2097,139 @@ const BASE_MODULES: Module[] = [
       },
     ],
   },
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // 9. VIDEO / PHOTO RELEASE (Phase 5, PR #6)
+  // ═══════════════════════════════════════════════════════════════════════════
+  //
+  // CO-SIGNED release. The signed acknowledgment lives in lms_signed_documents
+  // at document_type 'video_photo_release', is registered in
+  // CO_SIGNED_DOCUMENT_TYPES, and is co-signed by the Phes representative
+  // (tenant owner by default, resolved via getTenantOwnerForSignature).
+  //
+  // Governed by the Illinois Right of Publicity Act (765 ILCS 1075), which
+  // requires affirmative consent to use a person's identity for commercial
+  // purposes. The release captures that consent in writing, bounded by:
+  //   1. 5-year limit on NEW uses after employment ends (content already
+  //      in active distribution may continue).
+  //   2. AI training / deepfake / synthetic media is carved out (requires
+  //      separate written consent).
+  //   3. Withdrawal at any time. 30-day removal effort for Phes-controlled
+  //      channels. Third-party shares cannot be recalled.
+  //   4. Courtesy preview before publication where feasible.
+  {
+    id: "video-photo-release",
+    number: 9,
+    iconKind: "shield",
+    title: {
+      en: "Video & Photo Release",
+      es: "Autorización de Video y Foto",
+    },
+    subtitle: {
+      en: "Phes may take photos or video of you at work. This module explains your rights, your AI carve-out, and how to withdraw consent.",
+      es: "Phes puede tomar fotos o videos de usted en el trabajo. Este módulo explica sus derechos, la exclusión de IA y cómo retirar el consentimiento.",
+    },
+    estimatedMinutes: 10,
+    blocks: [
+      {
+        type: "callout",
+        tone: "info",
+        text: {
+          en: "Why this module matters. Phes uses photos and short videos of crews at work to recruit techs, train new hires, and grow the business through social media and the website. The Illinois Right of Publicity Act (765 ILCS 1075) requires Phes to get your AFFIRMATIVE WRITTEN CONSENT before using your identity for any commercial purpose. This release is how we capture that consent and the limits you set on it. Signing is VOLUNTARY. You may decline without any change to your job duties, schedule, or pay.",
+          es: "Por qué importa este módulo. Phes usa fotos y videos cortos de equipos en el trabajo para reclutar técnicos, entrenar nuevas contrataciones y hacer crecer el negocio a través de redes sociales y la página web. La Ley del Derecho de Publicidad de Illinois (765 ILCS 1075) requiere que Phes obtenga su CONSENTIMIENTO AFIRMATIVO POR ESCRITO antes de usar su identidad para cualquier propósito comercial. Esta autorización es cómo capturamos ese consentimiento y los límites que usted ponga. Firmar es VOLUNTARIO. Puede rechazarlo sin cambios en sus funciones, horario o pago.",
+        },
+      },
+
+      { type: "h", text: { en: "What This Release Does and Does Not Cover", es: "Lo Que Esta Autorización Cubre y No Cubre" } },
+      {
+        type: "p",
+        text: {
+          en: "By signing, you give Phes permission to capture photos and video of you in your work environment (homes you clean as part of your Phes shift, the Phes office, training sessions, and team events), and to use those photos and videos in Phes recruiting materials, training materials, the Phes website, and Phes social-media channels.",
+          es: "Al firmar, usted da permiso a Phes para capturar fotos y videos suyos en su entorno de trabajo (hogares que limpia como parte de su turno de Phes, la oficina de Phes, sesiones de capacitación y eventos del equipo), y para usar esas fotos y videos en materiales de reclutamiento de Phes, materiales de capacitación, la página web de Phes y los canales de redes sociales de Phes.",
+        },
+      },
+      {
+        type: "bullets",
+        items: [
+          { en: "Phes is the COMMERCIAL USER. The release covers Phes-internal uses (training) and Phes-external uses (recruiting, marketing).", es: "Phes es el USUARIO COMERCIAL. La autorización cubre usos internos de Phes (capacitación) y externos de Phes (reclutamiento, mercadotecnia)." },
+          { en: "The release does NOT permit any third party to use your likeness. If a magazine, news outlet, or another business asks Phes to share footage of you, Phes must ask for your separate consent before sharing.", es: "La autorización NO permite a ningún tercero usar su semejanza. Si una revista, medio de noticias u otro negocio pide a Phes compartir imágenes suyas, Phes debe pedirle su consentimiento separado antes de compartirlas." },
+          { en: "The release does NOT permit AI training, deepfake generation, or any synthetic-media use. This is carved out below and requires a separate written consent.", es: "La autorización NO permite el entrenamiento de IA, generación de deepfakes ni ningún uso de medios sintéticos. Esto se excluye más abajo y requiere un consentimiento separado por escrito." },
+        ],
+      },
+
+      { type: "h", text: { en: "5-Year Post-Separation Limit on New Uses", es: "Límite de 5 Años para Nuevos Usos Después de la Separación" } },
+      {
+        type: "p",
+        text: {
+          en: "If your employment with Phes ends (voluntary or involuntary), Phes may continue to use content featuring your likeness that was ALREADY IN ACTIVE DISTRIBUTION at the time you left (for example, a training video posted on the website before your last day, or a recruiting graphic already in rotation). Phes may NOT launch new uses of content featuring your likeness after the 5-year mark following your last day, except for content that was in active distribution at separation.",
+          es: "Si su empleo con Phes termina (voluntaria o involuntariamente), Phes puede continuar usando contenido que muestre su semejanza que YA ESTABA EN DISTRIBUCIÓN ACTIVA cuando se fue (por ejemplo, un video de capacitación publicado en el sitio web antes de su último día, o un gráfico de reclutamiento ya en rotación). Phes NO podrá iniciar nuevos usos de contenido que muestre su semejanza después del límite de 5 años siguientes a su último día, excepto para contenido que estaba en distribución activa al momento de la separación.",
+        },
+      },
+      {
+        type: "callout",
+        tone: "info",
+        text: {
+          en: "Practical effect: after you leave, your face does not appear in NEW Phes recruiting campaigns once 5 years have passed. Existing assets may continue to play.",
+          es: "Efecto práctico: después de irse, su rostro no aparece en NUEVAS campañas de reclutamiento de Phes una vez transcurridos 5 años. Los recursos existentes pueden seguir reproduciéndose.",
+        },
+      },
+
+      { type: "h", text: { en: "AI Training and Synthetic-Media Carve-Out", es: "Exclusión de Entrenamiento de IA y Medios Sintéticos" } },
+      {
+        type: "callout",
+        tone: "warning",
+        text: {
+          en: "Phes WILL NOT use your photos or video to train any AI model, to generate deepfakes, or to produce any synthetic media featuring your likeness, without your SEPARATE WRITTEN CONSENT. This release does not authorize any such use, no matter how the request is framed. If Phes ever asks for an AI-training-specific consent in the future, the request will be a different document with its own signature.",
+          es: "Phes NO USARÁ sus fotos o video para entrenar ningún modelo de IA, generar deepfakes ni producir ningún medio sintético que muestre su semejanza, sin su CONSENTIMIENTO SEPARADO POR ESCRITO. Esta autorización no permite ningún uso así, sin importar cómo se plantee la petición. Si Phes alguna vez pide un consentimiento específico para entrenamiento de IA en el futuro, la solicitud será un documento distinto con su propia firma.",
+        },
+      },
+
+      { type: "h", text: { en: "Courtesy Preview Before Publication", es: "Vista Previa de Cortesía Antes de la Publicación" } },
+      {
+        type: "p",
+        text: {
+          en: "When feasible, Phes will provide you a courtesy preview of content featuring your likeness BEFORE we publish it. Courtesy preview is not a veto. You may flag concerns, and we will consider them. Phes commits to making reasonable effort, but pre-approval is not a condition of publication under this release.",
+          es: "Cuando sea factible, Phes le proveerá una vista previa de cortesía del contenido que muestre su semejanza ANTES de publicarlo. La vista previa de cortesía no es un veto. Puede señalar inquietudes y las consideraremos. Phes se compromete a hacer un esfuerzo razonable, pero la pre-aprobación no es una condición de la publicación bajo esta autorización.",
+        },
+      },
+
+      { type: "h", text: { en: "How to Withdraw Consent", es: "Cómo Retirar el Consentimiento" } },
+      {
+        type: "p",
+        text: {
+          en: "You may withdraw your consent at any time, for any reason or no reason, by giving written notice to the office. Withdrawal works prospectively. Here is what Phes will and will not do:",
+          es: "Puede retirar su consentimiento en cualquier momento, por cualquier razón o sin razón, dando aviso por escrito a la oficina. El retiro funciona hacia adelante. Esto es lo que Phes hará y no hará:",
+        },
+      },
+      {
+        type: "bullets",
+        items: [
+          { en: "Phes WILL take reasonable steps to remove content featuring your likeness from active Phes-controlled distribution channels (website, Phes social-media pages, recruiting materials we control) within 30 days of receiving your written withdrawal.", es: "Phes TOMARÁ medidas razonables para retirar contenido que muestre su semejanza de los canales de distribución activos controlados por Phes (página web, páginas de redes sociales de Phes, materiales de reclutamiento que controlamos) dentro de los 30 días de recibir su retiro por escrito." },
+          { en: "Phes CANNOT recall content already distributed by third parties (re-posts, downloads, screenshots, news articles that referenced our content). Once content has left Phes-controlled distribution, third-party copies are outside Phes's control.", es: "Phes NO PUEDE recuperar contenido ya distribuido por terceros (republicaciones, descargas, capturas de pantalla, artículos de noticias que hayan referido nuestro contenido). Una vez que el contenido salió de la distribución controlada por Phes, las copias de terceros están fuera del control de Phes." },
+          { en: "Phes WILL NOT use the withdrawn content in NEW campaigns or NEW publications after the withdrawal date.", es: "Phes NO USARÁ el contenido retirado en NUEVAS campañas o NUEVAS publicaciones después de la fecha de retiro." },
+          { en: "Withdrawing consent does not affect your job, your schedule, your pay, or your standing with Phes in any way.", es: "Retirar el consentimiento no afecta su trabajo, su horario, su pago ni su posición con Phes de ninguna manera." },
+        ],
+      },
+
+      { type: "h", text: { en: "Phes Representative Co-Signature", es: "Co-Firma del Representante de Phes" } },
+      {
+        type: "p",
+        text: {
+          en: "Because this release is a two-way commitment (you grant rights; Phes commits to specific limits), the signed acknowledgment is CO-SIGNED by the Phes representative (by default the owner). The co-signature appears on the final PDF after you sign. You do not need to be present for the co-signature; it is added later by the office.",
+          es: "Como esta autorización es un compromiso de dos partes (usted otorga derechos; Phes se compromete a límites específicos), el reconocimiento firmado es CO-FIRMADO por el representante de Phes (por defecto el dueño). La co-firma aparece en el PDF final después de que usted firme. No necesita estar presente para la co-firma; la oficina la añade después.",
+        },
+      },
+
+      {
+        type: "callout",
+        tone: "info",
+        text: {
+          en: "After this quiz: you will sign a separate Video and Photo Release that records the rights you grant and the limits Phes commits to. The release is co-signed by the Phes representative. You can re-download the signed PDF anytime from your training page. If you decline to sign, your job is not affected; Phes simply will not photograph or record you for commercial use.",
+          es: "Después de este examen: firmará una Autorización de Video y Foto por separado que registra los derechos que otorga y los límites a los que Phes se compromete. La autorización es co-firmada por el representante de Phes. Puede volver a descargar el PDF firmado en cualquier momento desde su página de capacitación. Si decide no firmar, su trabajo no se ve afectado; Phes simplemente no lo fotografiará ni grabará para uso comercial.",
+        },
+      },
+    ],
+  },
 ];
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -3939,6 +4072,145 @@ const BASE_QUIZ: QuizQuestion[] = [
       { en: "You can contact the owner directly, file with the Illinois Department of Human Rights (IDHR) or the federal EEOC. You are not required to report internally first.", es: "Puede contactar al dueño directamente, presentar ante el Departamento de Derechos Humanos de Illinois (IDHR) o ante la EEOC federal. No está obligado a reportar internamente primero." },
       { en: "You must report to the accused person first.", es: "Debe reportar primero a la persona acusada." },
       { en: "You can post about it on social media so other employees can see.", es: "Puede publicarlo en redes sociales para que otros empleados lo vean." },
+    ],
+    correctIndex: 1,
+  },
+
+  // ═════════════════════════════════════════════════════════════════════════════
+  // Module 9: VIDEO / PHOTO RELEASE (9 questions, Phase 5 PR #6)
+  // ═════════════════════════════════════════════════════════════════════════════
+  {
+    id: "q-vpr-01-voluntary",
+    moduleId: "video-photo-release",
+    prompt: {
+      en: "You don't want your photo on Phes social media. What happens if you decline to sign the Video & Photo Release?",
+      es: "No quiere que su foto aparezca en las redes sociales de Phes. ¿Qué pasa si decide no firmar la Autorización de Video y Foto?",
+    },
+    options: [
+      { en: "You can be terminated for refusing to sign.", es: "Pueden despedirlo por negarse a firmar." },
+      { en: "Nothing happens to your job. Signing is voluntary. Phes simply will not photograph or record you for commercial use.", es: "No pasa nada con su trabajo. Firmar es voluntario. Phes simplemente no lo fotografiará ni grabará para uso comercial." },
+      { en: "Your hours are reduced.", es: "Le reducen las horas." },
+      { en: "You lose your annual raise.", es: "Pierde su aumento anual." },
+    ],
+    correctIndex: 1,
+  },
+  {
+    id: "q-vpr-02-5-year-limit",
+    moduleId: "video-photo-release",
+    prompt: {
+      en: "You sign the release. Two years later you leave Phes. What can Phes do with the existing photos and video of you?",
+      es: "Firma la autorización. Dos años después se va de Phes. ¿Qué puede hacer Phes con las fotos y videos existentes suyos?",
+    },
+    options: [
+      { en: "Use them forever, no time limit.", es: "Usarlos para siempre, sin límite de tiempo." },
+      { en: "Continue using content that was already in active distribution at the time you left, but Phes may not launch NEW uses of content featuring your likeness more than 5 years after your last day.", es: "Continuar usando contenido que ya estaba en distribución activa al momento de irse, pero Phes no podrá iniciar NUEVOS usos de contenido con su semejanza más de 5 años después de su último día." },
+      { en: "Phes must remove all content immediately on your last day.", es: "Phes debe retirar todo el contenido inmediatamente en su último día." },
+      { en: "Phes must pay you a residual for any continued use.", es: "Phes debe pagarle un residual por cualquier uso continuado." },
+    ],
+    correctIndex: 1,
+  },
+  {
+    id: "q-vpr-03-ai-carve-out",
+    moduleId: "video-photo-release",
+    prompt: {
+      en: "Phes wants to use your photos to train an AI model that generates new recruiting graphics. Does this release authorize that?",
+      es: "Phes quiere usar sus fotos para entrenar un modelo de IA que genera nuevos gráficos de reclutamiento. ¿Esta autorización permite eso?",
+    },
+    options: [
+      { en: "Yes, recruiting is a covered use.", es: "Sí, el reclutamiento es un uso cubierto." },
+      { en: "No. AI training, deepfake creation, and synthetic-media generation are carved out and require a SEPARATE written consent. This release does not authorize them under any circumstances.", es: "No. El entrenamiento de IA, la creación de deepfakes y la generación de medios sintéticos están excluidos y requieren un consentimiento separado por escrito. Esta autorización no los permite bajo ninguna circunstancia." },
+      { en: "Yes, but only for internal use.", es: "Sí, pero solo para uso interno." },
+      { en: "Yes, because it's still your image.", es: "Sí, porque sigue siendo su imagen." },
+    ],
+    correctIndex: 1,
+  },
+  {
+    id: "q-vpr-04-withdrawal-30-day",
+    moduleId: "video-photo-release",
+    prompt: {
+      en: "You signed the release a year ago. Today you want to withdraw consent. What does the release commit Phes to do?",
+      es: "Firmó la autorización hace un año. Hoy quiere retirar su consentimiento. ¿A qué se compromete Phes según la autorización?",
+    },
+    options: [
+      { en: "Phes is not obligated to do anything; consent is permanent.", es: "Phes no está obligado a hacer nada; el consentimiento es permanente." },
+      { en: "Phes will take reasonable steps to remove content featuring your likeness from active Phes-controlled distribution channels within 30 days of receiving your written withdrawal. Phes will not use the withdrawn content in NEW campaigns after the withdrawal date.", es: "Phes tomará medidas razonables para retirar contenido con su semejanza de los canales de distribución activos controlados por Phes dentro de los 30 días de recibir su retiro por escrito. Phes no usará el contenido retirado en NUEVAS campañas después de la fecha de retiro." },
+      { en: "Phes must pay you to release the content.", es: "Phes debe pagarle para liberar el contenido." },
+      { en: "Phes must remove all content within 24 hours, no exceptions.", es: "Phes debe retirar todo el contenido en 24 horas, sin excepciones." },
+    ],
+    correctIndex: 1,
+  },
+  {
+    id: "q-vpr-05-third-party-limits",
+    moduleId: "video-photo-release",
+    prompt: {
+      en: "You withdrew consent. A former client had previously screenshot a Phes Instagram post that featured you and reposted it on their own account. Can Phes force the client to take down their repost?",
+      es: "Retiró su consentimiento. Un cliente anterior había hecho captura de pantalla de una publicación de Instagram de Phes con su imagen y la republicó en su propia cuenta. ¿Puede Phes obligar al cliente a retirar su republicación?",
+    },
+    options: [
+      { en: "Yes, Phes has full control over any copy of the content.", es: "Sí, Phes tiene control total sobre cualquier copia del contenido." },
+      { en: "No. Phes cannot recall content already distributed by third parties (re-posts, downloads, screenshots, news references). Once content left Phes-controlled distribution, third-party copies are outside Phes's control. The release acknowledges this explicitly.", es: "No. Phes no puede recuperar contenido ya distribuido por terceros (republicaciones, descargas, capturas, referencias de noticias). Una vez que el contenido salió de la distribución controlada por Phes, las copias de terceros están fuera del control de Phes. La autorización reconoce esto explícitamente." },
+      { en: "Only with a court order.", es: "Solo con una orden judicial." },
+      { en: "Only if the client charges money for the repost.", es: "Solo si el cliente cobra dinero por la republicación." },
+    ],
+    correctIndex: 1,
+  },
+  {
+    id: "q-vpr-06-il-right-of-publicity",
+    moduleId: "video-photo-release",
+    prompt: {
+      en: "Which Illinois law requires Phes to get your AFFIRMATIVE WRITTEN CONSENT before using your identity for commercial purposes?",
+      es: "¿Qué ley de Illinois requiere que Phes obtenga su CONSENTIMIENTO AFIRMATIVO POR ESCRITO antes de usar su identidad para propósitos comerciales?",
+    },
+    options: [
+      { en: "Illinois Cannabis Regulation and Tax Act.", es: "Ley de Regulación e Impuestos del Cannabis de Illinois." },
+      { en: "Illinois Right of Publicity Act, 765 ILCS 1075. The Video & Photo Release is the document where Phes captures that affirmative consent in writing.", es: "Ley del Derecho de Publicidad de Illinois, 765 ILCS 1075. La Autorización de Video y Foto es el documento donde Phes captura ese consentimiento afirmativo por escrito." },
+      { en: "Illinois Workplace Transparency Act.", es: "Ley de Transparencia Laboral de Illinois." },
+      { en: "Illinois Paid Leave for All Workers Act.", es: "Ley de Licencia Pagada para Todos los Trabajadores de Illinois." },
+    ],
+    correctIndex: 1,
+  },
+  {
+    id: "q-vpr-07-co-signature",
+    moduleId: "video-photo-release",
+    prompt: {
+      en: "Why is the Video & Photo Release CO-SIGNED by the Phes representative, unlike other Phes acknowledgments?",
+      es: "¿Por qué la Autorización de Video y Foto es CO-FIRMADA por el representante de Phes, a diferencia de otros reconocimientos de Phes?",
+    },
+    options: [
+      { en: "Because the office wants more signatures on file.", es: "Porque la oficina quiere más firmas archivadas." },
+      { en: "Because the release is a TWO-WAY commitment: you grant rights, and Phes commits to specific limits (5-year post-separation cap, AI carve-out, 30-day withdrawal removal effort, courtesy preview). The co-signature binds Phes to those commitments.", es: "Porque la autorización es un compromiso DE DOS VÍAS: usted otorga derechos y Phes se compromete a límites específicos (límite de 5 años después de la separación, exclusión de IA, esfuerzo de retiro en 30 días, vista previa de cortesía). La co-firma vincula a Phes a esos compromisos." },
+      { en: "Because Illinois law requires two signatures on every release.", es: "Porque la ley de Illinois exige dos firmas en cada autorización." },
+      { en: "Because it makes the document harder to forge.", es: "Porque hace el documento más difícil de falsificar." },
+    ],
+    correctIndex: 1,
+  },
+  {
+    id: "q-vpr-08-courtesy-preview",
+    moduleId: "video-photo-release",
+    prompt: {
+      en: "Does the release give you the right to APPROVE every photo or video before Phes uses it?",
+      es: "¿La autorización le da el derecho a APROBAR cada foto o video antes de que Phes lo use?",
+    },
+    options: [
+      { en: "Yes. Approval is required for every publication.", es: "Sí. La aprobación es requerida para cada publicación." },
+      { en: "No. Phes commits to a COURTESY PREVIEW where feasible, meaning Phes will make reasonable effort to show you content before publication. Courtesy preview is not a veto; pre-approval is not a condition of publication. You may flag concerns, and we will consider them.", es: "No. Phes se compromete a una VISTA PREVIA DE CORTESÍA cuando sea factible, lo que significa que Phes hará un esfuerzo razonable para mostrarle el contenido antes de la publicación. La vista previa de cortesía no es un veto; la pre-aprobación no es condición de publicación. Puede señalar inquietudes y las consideraremos." },
+      { en: "Yes, but only for video, not photo.", es: "Sí, pero solo para video, no foto." },
+      { en: "No, you have no input at all.", es: "No, no tiene ninguna participación." },
+    ],
+    correctIndex: 1,
+  },
+  {
+    id: "q-vpr-09-active-distribution",
+    moduleId: "video-photo-release",
+    prompt: {
+      en: "You're leaving Phes next month. A training video posted to the Phes website 6 months ago features you. After your last day, Phes plans to keep the training video live on the site. Is that allowed under the release?",
+      es: "Se va de Phes el próximo mes. Un video de capacitación publicado en el sitio web de Phes hace 6 meses lo muestra. Después de su último día, Phes planea mantener el video de capacitación en el sitio. ¿Es permitido bajo la autorización?",
+    },
+    options: [
+      { en: "No. Phes must take down all content featuring you on your last day.", es: "No. Phes debe retirar todo contenido suyo en su último día." },
+      { en: "Yes. Content already in ACTIVE DISTRIBUTION at the time of separation may continue. The 5-year limit applies to NEW uses, not existing assets. If you want it taken down anyway, you can withdraw consent in writing and Phes will remove it from Phes-controlled channels within 30 days.", es: "Sí. El contenido que ya está en DISTRIBUCIÓN ACTIVA al momento de la separación puede continuar. El límite de 5 años aplica a NUEVOS usos, no a los recursos existentes. Si aun así quiere que se retire, puede retirar el consentimiento por escrito y Phes lo retirará de los canales controlados por Phes dentro de los 30 días." },
+      { en: "Only if Phes pays you a continued-use fee.", es: "Solo si Phes le paga una tarifa por uso continuado." },
+      { en: "Yes, but only for one year.", es: "Sí, pero solo por un año." },
     ],
     correctIndex: 1,
   },

--- a/artifacts/qleno/src/pages/lms-admin.tsx
+++ b/artifacts/qleno/src/pages/lms-admin.tsx
@@ -2546,6 +2546,18 @@ type SignedDocumentRow = {
   representative_signed_at: string | null;
 };
 
+/**
+ * Document types that require a Phes representative co-signature.
+ * Mirrors CO_SIGNED_DOCUMENT_TYPES in @workspace/db/schema. Kept as a
+ * Set here so the admin panel can decide when to render the Co-sign
+ * action without round-tripping the server. PR #7 (non-solicit) will
+ * use this same set.
+ */
+const CO_SIGNED_DOCUMENT_TYPES = new Set<string>([
+  "video_photo_release",
+  "non_solicitation",
+]);
+
 function humanDocumentType(documentType: string): string {
   const titles: Record<string, string> = {
     drug_alcohol: "Drug & Alcohol Policy",
@@ -2569,6 +2581,24 @@ function LearnerSignedDocumentsPanel({ row }: { row: RosterRow }) {
   const token = useAuthStore((s) => s.token);
   const [docs, setDocs] = useState<SignedDocumentRow[] | null>(null);
   const [err, setErr] = useState<string | null>(null);
+  const [coSignOpen, setCoSignOpen] = useState<number | null>(null);
+  const [coSignName, setCoSignName] = useState("");
+  const [coSignAffirm, setCoSignAffirm] = useState(false);
+  const [coSignSaving, setCoSignSaving] = useState(false);
+  const [coSignErr, setCoSignErr] = useState<string | null>(null);
+
+  async function loadDocs() {
+    try {
+      const data = await api<SignedDocumentRow[]>(
+        "GET",
+        `/lms/signatures/admin/learner/${row.user_id}`,
+        token,
+      );
+      setDocs(data);
+    } catch (e) {
+      setErr(String((e as Error).message));
+    }
+  }
 
   useEffect(() => {
     let cancelled = false;
@@ -2588,6 +2618,34 @@ function LearnerSignedDocumentsPanel({ row }: { row: RosterRow }) {
       cancelled = true;
     };
   }, [row.user_id, token]);
+
+  function openCoSign(docId: number) {
+    setCoSignOpen(docId);
+    setCoSignName("");
+    setCoSignAffirm(false);
+    setCoSignErr(null);
+  }
+
+  async function submitCoSign(docId: number) {
+    setCoSignSaving(true);
+    setCoSignErr(null);
+    try {
+      await api("POST", `/lms/signatures/admin/co-sign`, token, {
+        signedDocumentId: docId,
+        affirmation: coSignAffirm,
+        signature: coSignName.trim(),
+        signatureMethod: "typed",
+      });
+      setCoSignOpen(null);
+      setCoSignName("");
+      setCoSignAffirm(false);
+      await loadDocs();
+    } catch (e) {
+      setCoSignErr(String((e as Error).message));
+    } finally {
+      setCoSignSaving(false);
+    }
+  }
 
   async function handleDownload(docId: number) {
     try {
@@ -2696,6 +2754,11 @@ function LearnerSignedDocumentsPanel({ row }: { row: RosterRow }) {
             : isActive
             ? SUCCESS
             : INK_LIGHT;
+          const needsCoSign =
+            isActive &&
+            CO_SIGNED_DOCUMENT_TYPES.has(d.document_type) &&
+            d.representative_signed_at == null;
+          const expanded = coSignOpen === d.id;
           return (
             <div
               key={d.id}
@@ -2706,67 +2769,231 @@ function LearnerSignedDocumentsPanel({ row }: { row: RosterRow }) {
                 borderRadius: 8,
                 padding: "10px 12px",
                 fontSize: 12,
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "space-between",
-                gap: 8,
               }}
             >
-              <div style={{ minWidth: 0 }}>
-                <div style={{ fontWeight: 800, color: INK, fontSize: 12 }}>
-                  {humanDocumentType(d.document_type)}
-                </div>
-                <div
-                  style={{
-                    fontSize: 11,
-                    color: INK_MUTE,
-                    marginTop: 2,
-                    fontWeight: 600,
-                  }}
-                >
-                  {d.locale.toUpperCase()} · {humanDateTime(d.signed_at)} ·{" "}
-                  {d.status === "active"
-                    ? "Active"
-                    : d.status === "superseded"
-                    ? "Superseded"
-                    : "Revoked"}
-                </div>
-                {d.representative_signed_at ? (
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  gap: 8,
+                }}
+              >
+                <div style={{ minWidth: 0 }}>
+                  <div style={{ fontWeight: 800, color: INK, fontSize: 12 }}>
+                    {humanDocumentType(d.document_type)}
+                  </div>
                   <div
                     style={{
-                      fontSize: 10,
-                      color: SUCCESS,
-                      fontWeight: 700,
+                      fontSize: 11,
+                      color: INK_MUTE,
                       marginTop: 2,
+                      fontWeight: 600,
                     }}
                   >
-                    Co-signed by Phes representative
+                    {d.locale.toUpperCase()} · {humanDateTime(d.signed_at)} ·{" "}
+                    {d.status === "active"
+                      ? "Active"
+                      : d.status === "superseded"
+                      ? "Superseded"
+                      : "Revoked"}
                   </div>
-                ) : null}
+                  {d.representative_signed_at ? (
+                    <div
+                      style={{
+                        fontSize: 10,
+                        color: SUCCESS,
+                        fontWeight: 700,
+                        marginTop: 2,
+                      }}
+                    >
+                      Co-signed by Phes representative
+                    </div>
+                  ) : null}
+                  {needsCoSign ? (
+                    <div
+                      style={{
+                        fontSize: 10,
+                        color: "#BA7517",
+                        fontWeight: 700,
+                        marginTop: 2,
+                      }}
+                    >
+                      Awaiting Phes representative co-signature
+                    </div>
+                  ) : null}
+                </div>
+                <div style={{ display: "flex", gap: 6, flexShrink: 0 }}>
+                  {needsCoSign && !expanded ? (
+                    <button
+                      type="button"
+                      onClick={() => openCoSign(d.id)}
+                      title="Co-sign as Phes representative"
+                      style={{
+                        background: "#BA7517",
+                        color: "#fff",
+                        border: 0,
+                        padding: "5px 10px",
+                        borderRadius: 6,
+                        fontSize: 11,
+                        fontWeight: 800,
+                        cursor: "pointer",
+                        fontFamily: FONT,
+                      }}
+                    >
+                      Co-sign
+                    </button>
+                  ) : null}
+                  {!isRevoked ? (
+                    <button
+                      type="button"
+                      onClick={() => handleDownload(d.id)}
+                      title="Download signed PDF"
+                      style={{
+                        background: NAVY,
+                        color: "#fff",
+                        border: 0,
+                        padding: "5px 10px",
+                        borderRadius: 6,
+                        fontSize: 11,
+                        fontWeight: 800,
+                        cursor: "pointer",
+                        fontFamily: FONT,
+                        display: "inline-flex",
+                        alignItems: "center",
+                        gap: 4,
+                      }}
+                    >
+                      <Download size={11} /> PDF
+                    </button>
+                  ) : null}
+                </div>
               </div>
-              {!isRevoked ? (
-                <button
-                  type="button"
-                  onClick={() => handleDownload(d.id)}
-                  title="Download signed PDF"
+              {expanded ? (
+                <div
                   style={{
-                    background: NAVY,
-                    color: "#fff",
-                    border: 0,
-                    padding: "5px 10px",
+                    marginTop: 10,
+                    padding: 10,
+                    background: LINE_SOFT,
                     borderRadius: 6,
-                    fontSize: 11,
-                    fontWeight: 800,
-                    cursor: "pointer",
-                    fontFamily: FONT,
-                    display: "inline-flex",
-                    alignItems: "center",
-                    gap: 4,
-                    flexShrink: 0,
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: 8,
                   }}
                 >
-                  <Download size={11} /> PDF
-                </button>
+                  <div
+                    style={{
+                      fontSize: 11,
+                      fontWeight: 700,
+                      color: INK,
+                    }}
+                  >
+                    Co-sign as Phes representative
+                  </div>
+                  <input
+                    type="text"
+                    placeholder="Type your full legal name"
+                    value={coSignName}
+                    onChange={(e) => setCoSignName(e.target.value)}
+                    disabled={coSignSaving}
+                    style={{
+                      padding: "8px 10px",
+                      borderRadius: 6,
+                      border: `1px solid ${LINE}`,
+                      fontSize: 12,
+                      fontFamily: FONT,
+                      background: SURFACE,
+                      color: INK,
+                    }}
+                  />
+                  <label
+                    style={{
+                      display: "flex",
+                      gap: 8,
+                      alignItems: "flex-start",
+                      fontSize: 11,
+                      color: INK,
+                      lineHeight: 1.4,
+                    }}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={coSignAffirm}
+                      onChange={(e) => setCoSignAffirm(e.target.checked)}
+                      disabled={coSignSaving}
+                      style={{ marginTop: 2 }}
+                    />
+                    <span>
+                      I affirm that I am the Phes representative authorized
+                      to co-sign this acknowledgment on behalf of the
+                      company, and that my electronic signature has the same
+                      legal effect as a handwritten signature.
+                    </span>
+                  </label>
+                  {coSignErr ? (
+                    <div
+                      style={{
+                        fontSize: 11,
+                        color: DANGER,
+                        fontWeight: 600,
+                      }}
+                    >
+                      {coSignErr}
+                    </div>
+                  ) : null}
+                  <div style={{ display: "flex", gap: 6 }}>
+                    <button
+                      type="button"
+                      onClick={() => submitCoSign(d.id)}
+                      disabled={
+                        coSignSaving ||
+                        !coSignAffirm ||
+                        coSignName.trim().length < 2
+                      }
+                      style={{
+                        background:
+                          coSignSaving ||
+                          !coSignAffirm ||
+                          coSignName.trim().length < 2
+                            ? INK_LIGHT
+                            : SUCCESS,
+                        color: "#fff",
+                        border: 0,
+                        padding: "6px 12px",
+                        borderRadius: 6,
+                        fontSize: 11,
+                        fontWeight: 800,
+                        cursor:
+                          coSignSaving ||
+                          !coSignAffirm ||
+                          coSignName.trim().length < 2
+                            ? "not-allowed"
+                            : "pointer",
+                        fontFamily: FONT,
+                      }}
+                    >
+                      {coSignSaving ? "Co-signing..." : "Co-sign"}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setCoSignOpen(null)}
+                      disabled={coSignSaving}
+                      style={{
+                        background: SURFACE,
+                        color: INK,
+                        border: `1px solid ${LINE}`,
+                        padding: "6px 12px",
+                        borderRadius: 6,
+                        fontSize: 11,
+                        fontWeight: 700,
+                        cursor: "pointer",
+                        fontFamily: FONT,
+                      }}
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
               ) : null}
             </div>
           );

--- a/lib/db/src/schema/lms-signatures.ts
+++ b/lib/db/src/schema/lms-signatures.ts
@@ -514,7 +514,7 @@ export type AnnualDocumentType = (typeof ANNUAL_DOCUMENT_TYPES)[number];
 export const REQUIRED_PRE_FINAL_SIGNED_DOCS = [
   "drug_alcohol",
   "code_of_conduct",
-  // PR #6 will add: "video_photo_release"
+  "video_photo_release",
   // PR #7 will add: "non_solicitation"
   // PR #8 will add: "social_media"
   // PR #10 will add: "supply_kit"

--- a/lib/lms-curriculum/src/index.ts
+++ b/lib/lms-curriculum/src/index.ts
@@ -49,6 +49,7 @@ export type ModuleId =
   | "il-sexual-harassment"
   | "drug-alcohol"
   | "code-of-conduct"
+  | "video-photo-release"
   | "acknowledgment";
 
 export type QuizModuleId = Exclude<ModuleId, "acknowledgment">;
@@ -76,6 +77,7 @@ export const MODULE_ORDER: readonly ModuleId[] = [
   "il-sexual-harassment",
   "drug-alcohol",
   "code-of-conduct",
+  "video-photo-release",
   "acknowledgment",
 ] as const;
 
@@ -100,6 +102,15 @@ export const MODULE_ORDER: readonly ModuleId[] = [
  * anti-harassment, anti-discrimination (IL Human Rights Act protected
  * classes), anti-retaliation, reporting channels, conflict of interest,
  * and key / property handling.
+ *
+ * video-photo-release (Phase 5, PR #6) adds a CO-SIGNED legal release.
+ * 9-question comprehension quiz + separate signed acknowledgment at
+ * document_type 'video_photo_release'. References Illinois Right of
+ * Publicity Act (765 ILCS 1075), includes a 5-year limit on new uses
+ * after separation, AI training carve-out, 30-day removal-effort
+ * withdrawal clause, and courtesy preview language. Co-signed by the
+ * tenant Phes representative (default-resolved by
+ * getTenantOwnerForSignature).
  */
 export const QUIZ_MODULE_IDS: readonly QuizModuleId[] = [
   "phes-policies",
@@ -110,6 +121,7 @@ export const QUIZ_MODULE_IDS: readonly QuizModuleId[] = [
   "il-sexual-harassment",
   "drug-alcohol",
   "code-of-conduct",
+  "video-photo-release",
 ] as const;
 
 /** Pass threshold per module (and for the final mixed test). 80%. */
@@ -347,6 +359,24 @@ export const ANSWER_KEY: Readonly<Record<string, number>> = Object.freeze({
   "q-coc-08-key-handling": 1,
   "q-coc-09-cooperation-investigation": 1,
   "q-coc-10-reporting-channels": 1,
+
+  // ── Module 9: video-photo-release (9, Phase 5 PR #6) ────────────────────
+  // Phes Video / Photo Release. Co-signed by the Phes representative
+  // (tenant owner by default). References Illinois Right of Publicity
+  // Act (765 ILCS 1075) for the limits on commercial use of a person's
+  // identity. Includes a 5-year post-separation limit on NEW uses,
+  // AI-training carve-out, and a 30-day removal-effort withdrawal
+  // clause. Spanish translation is NOT in the four flagged docs and
+  // ships without a translator-review banner.
+  "q-vpr-01-voluntary": 1,
+  "q-vpr-02-5-year-limit": 1,
+  "q-vpr-03-ai-carve-out": 1,
+  "q-vpr-04-withdrawal-30-day": 1,
+  "q-vpr-05-third-party-limits": 1,
+  "q-vpr-06-il-right-of-publicity": 1,
+  "q-vpr-07-co-signature": 1,
+  "q-vpr-08-courtesy-preview": 1,
+  "q-vpr-09-active-distribution": 1,
 });
 
 /**
@@ -424,6 +454,13 @@ export const QUESTIONS_BY_MODULE: Readonly<Record<QuizModuleId, readonly string[
       "q-coc-05-protected-classes", "q-coc-06-retaliation-good-faith",
       "q-coc-07-conflict-of-interest", "q-coc-08-key-handling",
       "q-coc-09-cooperation-investigation", "q-coc-10-reporting-channels",
+    ],
+    "video-photo-release": [
+      "q-vpr-01-voluntary", "q-vpr-02-5-year-limit",
+      "q-vpr-03-ai-carve-out", "q-vpr-04-withdrawal-30-day",
+      "q-vpr-05-third-party-limits", "q-vpr-06-il-right-of-publicity",
+      "q-vpr-07-co-signature", "q-vpr-08-courtesy-preview",
+      "q-vpr-09-active-distribution",
     ],
   });
 

--- a/lib/training/src/answer-key.ts
+++ b/lib/training/src/answer-key.ts
@@ -177,6 +177,17 @@ export const SERVER_ANSWER_KEY: Readonly<Record<string, number>> = Object.freeze
   "q-coc-08-key-handling": 1,
   "q-coc-09-cooperation-investigation": 1,
   "q-coc-10-reporting-channels": 1,
+
+  // ── Module 9: video-photo-release (9, Phase 5 PR #6) ───────────────────
+  "q-vpr-01-voluntary": 1,
+  "q-vpr-02-5-year-limit": 1,
+  "q-vpr-03-ai-carve-out": 1,
+  "q-vpr-04-withdrawal-30-day": 1,
+  "q-vpr-05-third-party-limits": 1,
+  "q-vpr-06-il-right-of-publicity": 1,
+  "q-vpr-07-co-signature": 1,
+  "q-vpr-08-courtesy-preview": 1,
+  "q-vpr-09-active-distribution": 1,
 });
 
 /**


### PR DESCRIPTION
## PR #6 of 16 — Phase 5: Video & Photo Release Improved + Co-Sign UI

**First CO-SIGNED legal document in the LMS.** Adds the improved Phes Video & Photo Release as LMS module #9 with a 9-question comprehension quiz + a UETA / E-SIGN binding release at `document_type 'video_photo_release'`. The release is co-signed by the Phes representative (tenant owner by default, resolved via the `getTenantOwnerForSignature` infrastructure shipped in PR #87). Adds an admin co-sign UI in the LearnerSignedDocumentsPanel.

**DO NOT auto-merge.** Review the diff before approving + merging.

## Spec deltas vs. a typical legacy release

Per your written spec, all 10 items applied:

| Spec item | Where it lands |
|-----------|----------------|
| 1. Replace broad "post-employment use" with 5-year limit on NEW uses, except content already in active distribution | Section 5 of the release, English + Spanish, verbatim test enforces wording |
| 2. Replace "waive any right to review" with courtesy preview where feasible | Section 6 of the release; courtesy preview explicitly NOT a veto |
| 3. Strengthen withdrawal: 30-day Phes-controlled removal effort; third-party shares cannot be recalled | Section 7 of the release |
| 4. Add AI training / deepfake / synthetic-media carve-out — separate written consent required | Section 4 of the release |
| 5. Reference Illinois Right of Publicity Act (765 ILCS 1075) prominently | Preamble + section header — both bilingual; tests enforce 765 ILCS 1075 citation in both EN and ES |
| 6. Phes Representative co-signature required (configurable tenant owner lookup) | Section 8 of the release + admin Co-sign button (new UI) |
| 7. 8-10 quiz questions on rights, withdrawal, AI carve-out | 9 quiz questions (`q-vpr-01` through `q-vpr-09`) |
| 8. NOT flagged for human translator review | Spanish entry has no pendingTranslationReview flag; test enforces |
| 9. Hard-gate final exam on Video/Photo Release signed | `REQUIRED_PRE_FINAL_SIGNED_DOCS` now includes video_photo_release |
| 10. Bypass marks quiz passed; does NOT create signed_document row | Unchanged from PR #4 — `/admin/bypass-module` already implements this for ALL standalone signed-doc modules |

## What this PR ships

### A. `video-photo-release` module (Phase 5 quiz)

Slot #9 between `code-of-conduct` and `acknowledgment`. Bilingual content covering:
- **Voluntary consent** — declining to sign does not affect job
- Scope of authorized use (Phes-only commercial user)
- Third-party use NOT authorized
- **AI training / deepfake / synthetic-media carve-out** (separate consent required)
- **5-year post-separation cap on NEW uses**, active-distribution exception
- **Courtesy preview** before publication where feasible (not a veto)
- **Withdrawal of consent** — 30-day Phes-controlled removal effort; third-party shares outside Phes's control
- Phes Representative co-signature rationale (two-way commitment)
- No compensation for use

**9 quiz questions** (`q-vpr-01` through `q-vpr-09`), 80% to pass.

### B. `video_photo_release` content registry

Bilingual canonical text in `lib/lms-signed-documents-content.ts`. Server-authoritative — PDF and version hash bind to the exact bytes.

**11 sections** mirroring the module body. Em-dash-free, en-dash-free.

### C. Final-exam gate extension

Appends `"video_photo_release"` to `REQUIRED_PRE_FINAL_SIGNED_DOCS`. `/quiz/submit` for FINAL_MODULE_ID now requires drug_alcohol + code_of_conduct + video_photo_release. Owner / admin / office exempt.

### D. Admin Co-sign UI (NEW)

In `LearnerSignedDocumentsPanel`:
- For documents whose `document_type` is in `CO_SIGNED_DOCUMENT_TYPES` (video_photo_release, non_solicitation) and that have no `representative_signed_at` yet, an amber **Co-sign** button appears next to the **PDF** button.
- Clicking opens an inline affirmation form with typed-name input + affirmation checkbox + Co-sign / Cancel buttons.
- Co-sign hits the existing `POST /api/lms/signatures/admin/co-sign` endpoint (scaffolded in PR #4 with the schema migration).
- On success, the panel re-fetches and shows the green "Co-signed by Phes representative" badge.
- Awaiting-co-sign state renders as an amber pill on the card.

### E. Schema-layer + drift coverage

- `lib/lms-curriculum/src/index.ts`: ModuleId union, MODULE_ORDER (10 entries now), QUIZ_MODULE_IDS (9 entries), ANSWER_KEY (9 new q-vpr-* keys), QUESTIONS_BY_MODULE
- `lib/training/src/answer-key.ts`: mirrors the same 9 keys; drift-sync test enforces parity
- `lib/lms-curriculum-titles.ts`: bilingual title for certificate PDF rendering
- Frontend `humanSignedDocType` already includes video_photo_release from prior PRs — locked-final-exam tile + Required-Signed-Acks tile pick it up automatically

## Tests

- **150 / 150 LMS tests pass** (was 138 — 11 new content tests + drift-sync auto-extends + curriculum-shape counts updated)
- Curriculum counts: MODULE_ORDER = 10, QUIZ_MODULE_IDS = 9, ALL_QUESTION_IDS = 144 (40 + 15×5 + 10 + 10 + 9)
- 11 new video_photo_release content tests covering: registry shape, no pendingTranslationReview flag (EN + ES), 765 ILCS 1075 citation in both locales, AI carve-out language verbatim (deepfake, synthetic-media, SEPARATE WRITTEN CONSENT), 5-year limit verbatim, active-distribution exception, 30-day withdrawal removal effort, third-party limitation on withdrawal, courtesy-preview / not-a-veto clauses, voluntary consent, and EN vs ES hashes differ
- Vite build clean. tsc-libs (CI `tsc-check`) clean.

## Test plan (manual)

**Learner flow:**
- [ ] Log in as `jose.ardila@phes.io` → `/training` → module #9 "Video & Photo Release" appears after module #8
- [ ] Read content (cover Phes-only-commercial-user, AI carve-out, 5-year cap, withdrawal, courtesy preview)
- [ ] Take quiz (9 questions, 80% pass)
- [ ] On pass, Home tile "Required Signed Acknowledgments" lists drug_alcohol + code_of_conduct + video_photo_release (until each is signed)
- [ ] Click → SignDocumentView opens with the full release text + affirmation checkbox + typed name
- [ ] Sign → returns to Home
- [ ] Final-exam tile is locked with "sign these first" listing remaining unsigned docs

**Admin co-sign flow:**
- [ ] As Sal (owner): `/lms/admin` → expand Jose → "Signed Acknowledgments" panel shows the new video_photo_release entry with the amber **"Awaiting Phes representative co-signature"** pill + **Co-sign** button
- [ ] Click Co-sign → inline form expands → type "Sal Martinez" → check affirmation → Co-sign
- [ ] Card refreshes; pill flips to green "Co-signed by Phes representative"
- [ ] Download PDF → see employee signature block + Phes-representative co-signature block on the last page
- [ ] As `office` role: confirm same Co-sign button is visible (per `requireRole("owner","admin","office")` on the route)

**Negative paths:**
- [ ] Try to submit final exam while video_photo_release is unsigned → 403 with `missing_required_signed_docs` echoed
- [ ] Same flow as owner/admin/office → final exam unlocks (exempt path)
- [ ] Admin bypass on video-photo-release quiz: confirm NO certificate issued + NO signed_document row created; audit log shows `source: "admin_bypass"`
- [ ] Cross-tenant: try `GET /api/lms/signatures/<id>/pdf` for another tenant's video_photo_release → 404

https://claude.ai/code/session_013rJ4N4vgqZWB986x8D6Ahh

---
_Generated by [Claude Code](https://claude.ai/code/session_013rJ4N4vgqZWB986x8D6Ahh)_