### PR TITLE
lms: Phase 6 non-solicitation agreement + co-sign (PR #7 of 16)

### DIFF
--- a/artifacts/api-server/src/lib/lms-curriculum-titles.ts
+++ b/artifacts/api-server/src/lib/lms-curriculum-titles.ts
@@ -60,6 +60,10 @@ const MODULE_TITLES: Record<string, BilingualTitle> = {
     en: "Video & Photo Release",
     es: "Autorización de Video y Foto",
   },
+  "non-solicitation": {
+    en: "Non-Solicitation Agreement",
+    es: "Acuerdo de No Solicitación",
+  },
   acknowledgment: {
     en: "Onboarding Acknowledgment",
     es: "Confirmación de Incorporación",

--- a/artifacts/api-server/src/lib/lms-signed-documents-content.ts
+++ b/artifacts/api-server/src/lib/lms-signed-documents-content.ts
@@ -410,6 +410,132 @@ const VIDEO_PHOTO_RELEASE_ES: SignedDocumentLocaleContent = {
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
+// non_solicitation (Phase 6, PR #7)
+//
+// CO-SIGNED agreement bound by the Illinois Freedom to Work Act (820 ILCS 90).
+// Phes intentionally narrows the agreement to stay well within IL reasonableness:
+//   - 12-month post-separation duration
+//   - CLIENTS ONLY (coworkers explicitly carved out)
+//   - inbound-contact carve-out (former clients may contact YOU)
+//   - general advertising carve-out
+//   - no liquidated-damages or penalty clauses (IL courts disfavor)
+//   - injunctive relief + documented damages + reasonable attorney fees only
+//
+// Spanish version is one of the FOUR FLAGGED docs requiring professional
+// translator review. UI shows a banner: English version is binding until
+// human translation review is approved.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const NON_SOLICITATION_EN: SignedDocumentLocaleContent = {
+  title: "Non-Solicitation Agreement",
+  contentHtml: [
+    "PHES CLEANING SERVICES",
+    "NON-SOLICITATION AGREEMENT",
+    "Effective Date: January 1, 2026",
+    "",
+    "This Non-Solicitation Agreement is entered into between Phes Cleaning Services and me as a condition of my employment. The Agreement is governed by the Illinois Freedom to Work Act, 820 ILCS 90, and is intentionally narrowed to remain reasonable in scope, duration, and protected interest.",
+    "",
+    "1. RESTRICTION (CLIENTS ONLY).",
+    "During my employment with Phes and for TWELVE MONTHS after my last day of employment, I will not directly or indirectly solicit any Phes client for cleaning services, whether for my own account, for a future employer, or for any other business.",
+    "",
+    "2. DEFINITION OF PHES CLIENT.",
+    "Phes Client means any household, person, or business that has received cleaning services from Phes Cleaning Services in the twenty-four months prior to my last day with Phes.",
+    "",
+    "3. COWORKERS ARE NOT RESTRICTED.",
+    "This Agreement does not restrict me in any way from recruiting Phes coworkers to join me at a new employer or in any new venture. Phes does not impose a coworker non-solicitation covenant on hourly employees, consistent with the spirit of the Illinois Freedom to Work Act.",
+    "",
+    "4. WHAT COUNTS AS SOLICITATION.",
+    "Solicitation under this Agreement means me reaching out to a Phes Client to offer cleaning services. Specifically: calling, texting, emailing, direct-messaging, mailing, or visiting a Phes Client to offer cleaning services; asking a current Phes coworker to pass a flyer or business card to a Phes Client; or posting a service offer in a private channel that I joined because I knew Phes Clients use it.",
+    "",
+    "5. GENERAL ADVERTISING AND INBOUND CONTACT ARE NOT SOLICITATION.",
+    "Nothing in this Agreement restricts me from: (a) running general advertising (Craigslist, neighborhood bulletin boards, public-facing Facebook pages, the open web) that targets the public at large, even if a Phes Client happens to see it; or (b) accepting INBOUND CONTACT from a Phes Client who finds me on their own initiative without me having approached them, invited contact, or taken any step to trigger the contact. If a Phes Client contacts me first under those conditions, I may discuss and accept the work.",
+    "",
+    "6. NO NON-COMPETE.",
+    "This Agreement does not prevent me from accepting employment with another cleaning company in the Chicagoland area or anywhere else. I am free to continue working in cleaning at any time, with any employer.",
+    "",
+    "7. CONSIDERATION.",
+    "Phes provides the following consideration in exchange for my acceptance of this Agreement: paid training, regular scheduled shifts, paid time off accruing under the Illinois Paid Leave for All Workers Act, holiday pay, and the other benefits described in the Compensation module of the Phes Employee Handbook. Continued employment past two years also constitutes adequate consideration under Illinois law.",
+    "",
+    "8. REASONABLE SCOPE.",
+    "I acknowledge that the twelve-month duration, the clients-only scope, the inbound-contact carve-out, and the absence of any geographic territory restriction collectively make this Agreement reasonable and necessary to protect Phes's legitimate business interest in client relationships, consistent with the Illinois Freedom to Work Act.",
+    "",
+    "9. REMEDIES.",
+    "If Phes believes I have violated this Agreement, Phes may seek injunctive relief (a court order requiring me to stop the prohibited conduct) and may recover documented damages and reasonable attorney fees, as permitted by Illinois law. Phes does not impose liquidated damages or penalty clauses under this Agreement.",
+    "",
+    "10. SEVERABILITY AND BLUE-PENCIL.",
+    "If any court finds any portion of this Agreement to be unenforceable as written, the parties intend that the court apply the Illinois blue-pencil doctrine to narrow the restriction to the maximum extent enforceable rather than strike it entirely.",
+    "",
+    "11. PHES REPRESENTATIVE CO-SIGNATURE.",
+    "This Agreement is a two-way commitment. I agree to the twelve-month client non-solicit; Phes commits to the consideration described in section 7. The signed instrument is co-signed by the Phes representative. The co-signature appears on the final PDF after my signature.",
+    "",
+    "12. AT-WILL EMPLOYMENT.",
+    "Nothing in this Agreement alters my at-will employment status with Phes. Phes may terminate my employment at any time, with or without cause or notice, for any lawful reason. My obligations under this Agreement survive termination of employment.",
+    "",
+    "13. ELECTRONIC SIGNATURE CONSENT.",
+    "I consent to sign this Agreement electronically. I understand that my electronic signature has the same legal effect as a handwritten signature, in accordance with the federal Electronic Signatures in Global and National Commerce Act (E-SIGN) and the Illinois Uniform Electronic Transactions Act (UETA).",
+    "",
+    "By typing or drawing my signature below and clicking the I Agree button, I affirm that I have read, understood, and accept this Non-Solicitation Agreement.",
+  ].join("\n"),
+  notes: "Phase 6 PR #7 — Phes non-solicitation agreement. 12 months, clients only, IL Freedom to Work Act compliant.",
+};
+
+const NON_SOLICITATION_ES: SignedDocumentLocaleContent = {
+  title: "Acuerdo de No Solicitación",
+  pendingTranslationReview: true,
+  contentHtml: [
+    "PHES CLEANING SERVICES",
+    "ACUERDO DE NO SOLICITACIÓN",
+    "Fecha Efectiva: 1 de enero de 2026",
+    "",
+    "Este Acuerdo de No Solicitación se celebra entre Phes Cleaning Services y yo como condición de mi empleo. El Acuerdo se rige por la Ley de Libertad para Trabajar de Illinois, 820 ILCS 90, y se restringe intencionalmente para permanecer razonable en alcance, duración e interés protegido.",
+    "",
+    "1. RESTRICCIÓN (SOLO CLIENTES).",
+    "Durante mi empleo con Phes y por DOCE MESES después de mi último día de empleo, no solicitaré directa o indirectamente a ningún cliente de Phes para servicios de limpieza, ya sea para mi propia cuenta, para un futuro empleador o para cualquier otro negocio.",
+    "",
+    "2. DEFINICIÓN DE CLIENTE DE PHES.",
+    "Cliente de Phes significa cualquier hogar, persona o negocio que haya recibido servicios de limpieza de Phes Cleaning Services en los veinticuatro meses anteriores a mi último día con Phes.",
+    "",
+    "3. LOS COMPAÑEROS NO ESTÁN RESTRINGIDOS.",
+    "Este Acuerdo no me restringe de ninguna manera para reclutar a compañeros de Phes para que se me unan en un nuevo empleador o en cualquier nueva empresa. Phes no impone un acuerdo de no solicitación de compañeros sobre empleados por hora, consistente con el espíritu de la Ley de Libertad para Trabajar de Illinois.",
+    "",
+    "4. LO QUE CUENTA COMO SOLICITACIÓN.",
+    "Solicitación bajo este Acuerdo significa que yo me acerque a un Cliente de Phes para ofrecer servicios de limpieza. Específicamente: llamar, enviar mensajes de texto, correo electrónico, mensaje directo, correo postal o visitar a un Cliente de Phes para ofrecer servicios de limpieza; pedirle a un compañero actual de Phes que pase un volante o tarjeta de presentación a un Cliente de Phes; o publicar una oferta de servicio en un canal privado al que me uní porque sabía que Clientes de Phes lo usan.",
+    "",
+    "5. LA PUBLICIDAD GENERAL Y EL CONTACTO INICIADO POR EL CLIENTE NO SON SOLICITACIÓN.",
+    "Nada en este Acuerdo me restringe de: (a) manejar publicidad general (Craigslist, tableros de anuncios del vecindario, páginas de Facebook públicas, la web abierta) dirigida al público en general, aunque un Cliente de Phes la vea por casualidad; o (b) aceptar CONTACTO INICIADO POR EL CLIENTE de un Cliente de Phes que me encuentre por iniciativa propia sin que yo lo haya buscado, invitado el contacto o realizado paso alguno para provocar el contacto. Si un Cliente de Phes me contacta primero bajo esas condiciones, puedo discutir y aceptar el trabajo.",
+    "",
+    "6. SIN ACUERDO DE NO COMPETENCIA.",
+    "Este Acuerdo no me impide aceptar empleo en otra empresa de limpieza en el área de Chicago ni en ningún otro lugar. Soy libre de continuar trabajando en limpieza en cualquier momento, con cualquier empleador.",
+    "",
+    "7. CONSIDERACIÓN.",
+    "Phes provee la siguiente consideración a cambio de mi aceptación de este Acuerdo: capacitación pagada, turnos programados regulares, tiempo libre pagado que se acumula bajo la Ley de Licencia Pagada para Todos los Trabajadores de Illinois, pago por feriados y los demás beneficios descritos en el módulo de Compensación del Manual del Empleado de Phes. El empleo continuo por más de dos años también constituye consideración adecuada bajo la ley de Illinois.",
+    "",
+    "8. ALCANCE RAZONABLE.",
+    "Reconozco que la duración de doce meses, el alcance limitado a clientes, la exclusión de contacto iniciado por el cliente y la ausencia de cualquier restricción de territorio geográfico hacen, en conjunto, que este Acuerdo sea razonable y necesario para proteger el interés comercial legítimo de Phes en las relaciones con los clientes, consistente con la Ley de Libertad para Trabajar de Illinois.",
+    "",
+    "9. REMEDIOS.",
+    "Si Phes cree que he violado este Acuerdo, Phes puede buscar alivio por orden judicial (una orden de la corte que me exija detener la conducta prohibida) y puede recuperar daños documentados y honorarios razonables de abogado, según lo permita la ley de Illinois. Phes no impone daños liquidados ni cláusulas de penalización bajo este Acuerdo.",
+    "",
+    "10. SEPARABILIDAD Y LÁPIZ AZUL.",
+    "Si cualquier corte encuentra que alguna parte de este Acuerdo no es exigible tal como está escrita, las partes pretenden que la corte aplique la doctrina del lápiz azul de Illinois para reducir la restricción al alcance máximo exigible en lugar de eliminarla por completo.",
+    "",
+    "11. CO-FIRMA DEL REPRESENTANTE DE PHES.",
+    "Este Acuerdo es un compromiso de dos vías. Yo acepto la no solicitación de clientes de doce meses; Phes se compromete con la consideración descrita en la sección 7. El instrumento firmado es co-firmado por el representante de Phes. La co-firma aparece en el PDF final después de mi firma.",
+    "",
+    "12. EMPLEO A VOLUNTAD.",
+    "Nada en este Acuerdo altera mi estatus de empleo a voluntad con Phes. Phes puede terminar mi empleo en cualquier momento, con o sin causa o aviso, por cualquier razón legal. Mis obligaciones bajo este Acuerdo sobreviven a la terminación del empleo.",
+    "",
+    "13. CONSENTIMIENTO DE FIRMA ELECTRÓNICA.",
+    "Doy mi consentimiento para firmar este Acuerdo electrónicamente. Entiendo que mi firma electrónica tiene el mismo efecto legal que una firma manuscrita, conforme a la Ley federal de Firmas Electrónicas en el Comercio Global y Nacional (E-SIGN) y a la Ley Uniforme de Transacciones Electrónicas de Illinois (UETA).",
+    "",
+    "Al escribir o dibujar mi firma a continuación y hacer clic en el botón Acepto, afirmo que he leído, entendido y aceptado este Acuerdo de No Solicitación.",
+  ].join("\n"),
+  notes:
+    "PENDING PROFESSIONAL TRANSLATION REVIEW. Initial AI translation. " +
+    "Human translator review required before final production sign-off.",
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Registry
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -426,8 +552,11 @@ export const SIGNED_DOCUMENT_CONTENT: SignedDocumentRegistry = {
     en: VIDEO_PHOTO_RELEASE_EN,
     es: VIDEO_PHOTO_RELEASE_ES,
   },
-  // PR #7+ will add: non_solicitation, supply_kit, social_media. Same shape,
-  // same conventions.
+  non_solicitation: {
+    en: NON_SOLICITATION_EN,
+    es: NON_SOLICITATION_ES,
+  },
+  // PR #8+ will add: supply_kit, social_media. Same shape, same conventions.
 };
 
 /**

--- a/artifacts/api-server/src/tests/lms-curriculum.test.ts
+++ b/artifacts/api-server/src/tests/lms-curriculum.test.ts
@@ -33,7 +33,7 @@ import {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("LMS curriculum — constants & catalog shape", () => {
-  it("MODULE_ORDER has all 10 modules in expected sequence (video-photo-release added 2026-05-12 Phase 5)", () => {
+  it("MODULE_ORDER has all 11 modules in expected sequence (non-solicitation added 2026-05-12 Phase 6)", () => {
     assert.deepEqual([...MODULE_ORDER], [
       "phes-policies",
       "compensation",
@@ -44,11 +44,12 @@ describe("LMS curriculum — constants & catalog shape", () => {
       "drug-alcohol",
       "code-of-conduct",
       "video-photo-release",
+      "non-solicitation",
       "acknowledgment",
     ]);
   });
 
-  it("QUIZ_MODULE_IDS contains exactly the 9 quiz modules (no acknowledgment)", () => {
+  it("QUIZ_MODULE_IDS contains exactly the 10 quiz modules (no acknowledgment)", () => {
     assert.deepEqual([...QUIZ_MODULE_IDS], [
       "phes-policies",
       "compensation",
@@ -59,6 +60,7 @@ describe("LMS curriculum — constants & catalog shape", () => {
       "drug-alcohol",
       "code-of-conduct",
       "video-photo-release",
+      "non-solicitation",
     ]);
   });
 
@@ -96,12 +98,14 @@ describe("LMS curriculum — constants & catalog shape", () => {
     // drug-alcohol: 10 (Phase 3 spec, legally-important concepts only)
     // code-of-conduct: 10 (Phase 4 spec, behavior-comprehension)
     // video-photo-release: 9 (Phase 5 spec, release-rights comprehension)
+    // non-solicitation: 10 (Phase 6 spec, agreement-scope comprehension)
     // all others: 15 (per original Phes spec)
     const expected: Record<string, number> = {
       "phes-policies": 40,
       "drug-alcohol": 10,
       "code-of-conduct": 10,
       "video-photo-release": 9,
+      "non-solicitation": 10,
       compensation: 15,
       "cleaning-best-practices": 15,
       maidcentral: 15,
@@ -117,8 +121,8 @@ describe("LMS curriculum — constants & catalog shape", () => {
     }
   });
 
-  it("ALL_QUESTION_IDS is 144 total (40 + 15*5 + 10 + 10 + 9)", () => {
-    assert.equal(ALL_QUESTION_IDS.length, 144);
+  it("ALL_QUESTION_IDS is 154 total (40 + 15*5 + 10 + 10 + 9 + 10)", () => {
+    assert.equal(ALL_QUESTION_IDS.length, 154);
   });
 
   it("ANSWER_KEY has exactly the keys enumerated by ALL_QUESTION_IDS", () => {

--- a/artifacts/api-server/src/tests/lms-signed-documents.test.ts
+++ b/artifacts/api-server/src/tests/lms-signed-documents.test.ts
@@ -43,6 +43,12 @@ describe("SIGNED_DOCUMENT_CONTENT registry", () => {
     assert.ok(SIGNED_DOCUMENT_CONTENT.video_photo_release!.es);
   });
 
+  it("includes non_solicitation (Phase 6 PR #7)", () => {
+    assert.ok(SIGNED_DOCUMENT_CONTENT.non_solicitation);
+    assert.ok(SIGNED_DOCUMENT_CONTENT.non_solicitation!.en);
+    assert.ok(SIGNED_DOCUMENT_CONTENT.non_solicitation!.es);
+  });
+
   it("every registered document has BOTH en and es entries", () => {
     for (const [type, entry] of Object.entries(SIGNED_DOCUMENT_CONTENT)) {
       assert.ok(entry?.en?.contentHtml, `${type}: missing en.contentHtml`);
@@ -146,6 +152,111 @@ describe("listRegisteredDocumentTypes", () => {
 
   it("includes video_photo_release after PR #6", () => {
     assert.ok(listRegisteredDocumentTypes().includes("video_photo_release"));
+  });
+
+  it("includes non_solicitation after PR #7", () => {
+    assert.ok(listRegisteredDocumentTypes().includes("non_solicitation"));
+  });
+});
+
+describe("non_solicitation content shape (PR #7 spec checks)", () => {
+  it("Spanish entry IS flagged pendingTranslationReview (one of the four flagged docs)", () => {
+    assert.equal(
+      SIGNED_DOCUMENT_CONTENT.non_solicitation!.es.pendingTranslationReview ?? false,
+      true,
+    );
+    assert.equal(isSpanishPendingTranslationReview("non_solicitation"), true);
+  });
+
+  it("English entry is NOT flagged pendingTranslationReview (English is binding)", () => {
+    assert.equal(
+      SIGNED_DOCUMENT_CONTENT.non_solicitation!.en.pendingTranslationReview ?? false,
+      false,
+    );
+  });
+
+  it("English content cites the Illinois Freedom to Work Act with the 820 ILCS 90 citation", () => {
+    const en = SIGNED_DOCUMENT_CONTENT.non_solicitation!.en.contentHtml;
+    assert.ok(
+      en.includes("Illinois Freedom to Work Act"),
+      "English version must reference the Illinois Freedom to Work Act by name",
+    );
+    assert.ok(
+      en.includes("820 ILCS 90"),
+      "English version must include the 820 ILCS 90 citation",
+    );
+  });
+
+  it("Spanish content cites the Illinois Freedom to Work Act translation + the 820 ILCS 90 citation", () => {
+    const es = SIGNED_DOCUMENT_CONTENT.non_solicitation!.es.contentHtml;
+    assert.ok(
+      es.includes("Ley de Libertad para Trabajar de Illinois"),
+      "Spanish version must reference the IL Freedom to Work Act translation",
+    );
+    assert.ok(
+      es.includes("820 ILCS 90"),
+      "Spanish version must include the 820 ILCS 90 citation",
+    );
+  });
+
+  it("English content states a 12-MONTH duration verbatim", () => {
+    const en = SIGNED_DOCUMENT_CONTENT.non_solicitation!.en.contentHtml;
+    assert.ok(
+      en.includes("TWELVE MONTHS"),
+      "English must state the 12-month duration explicitly",
+    );
+  });
+
+  it("English content explicitly carves out coworkers from the restriction", () => {
+    const en = SIGNED_DOCUMENT_CONTENT.non_solicitation!.en.contentHtml;
+    assert.ok(
+      en.includes("COWORKERS ARE NOT RESTRICTED"),
+      "English must include the coworker carve-out section header",
+    );
+  });
+
+  it("English content includes the inbound-contact carve-out", () => {
+    const en = SIGNED_DOCUMENT_CONTENT.non_solicitation!.en.contentHtml;
+    assert.ok(
+      en.includes("INBOUND CONTACT"),
+      "English must include the INBOUND CONTACT carve-out language",
+    );
+  });
+
+  it("English content includes the general-advertising carve-out", () => {
+    const en = SIGNED_DOCUMENT_CONTENT.non_solicitation!.en.contentHtml;
+    assert.ok(
+      en.includes("GENERAL ADVERTISING"),
+      "English must include the general-advertising carve-out section header",
+    );
+  });
+
+  it("English content explicitly disclaims being a non-compete", () => {
+    const en = SIGNED_DOCUMENT_CONTENT.non_solicitation!.en.contentHtml;
+    assert.ok(
+      en.includes("NO NON-COMPETE"),
+      "English must include the NO NON-COMPETE section",
+    );
+  });
+
+  it("English content describes remedies as injunctive + documented damages + attorney fees only (no liquidated damages)", () => {
+    const en = SIGNED_DOCUMENT_CONTENT.non_solicitation!.en.contentHtml;
+    assert.ok(
+      en.includes("injunctive relief"),
+      "English must state injunctive relief as the primary remedy",
+    );
+    assert.ok(
+      en.includes("does not impose liquidated damages"),
+      "English must explicitly disclaim liquidated damages / penalty clauses",
+    );
+  });
+
+  it("English and Spanish content hash to DIFFERENT version hashes (legally distinct)", () => {
+    const en = SIGNED_DOCUMENT_CONTENT.non_solicitation!.en.contentHtml;
+    const es = SIGNED_DOCUMENT_CONTENT.non_solicitation!.es.contentHtml;
+    const hEn = hashContent(en, "en");
+    const hEs = hashContent(es, "es");
+    assert.notEqual(hEn, hEs);
   });
 });
 

--- a/artifacts/qleno/src/lib/training/curriculum.ts
+++ b/artifacts/qleno/src/lib/training/curriculum.ts
@@ -2230,6 +2230,144 @@ const BASE_MODULES: Module[] = [
       },
     ],
   },
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // 10. NON-SOLICITATION AGREEMENT (Phase 6, PR #7)
+  // ═══════════════════════════════════════════════════════════════════════════
+  //
+  // CO-SIGNED agreement. The signed instrument lives in lms_signed_documents
+  // at document_type 'non_solicitation' and is co-signed by the Phes
+  // representative (tenant owner by default).
+  //
+  // Governed by the Illinois Freedom to Work Act (820 ILCS 90). Under IL law,
+  // a non-solicit covenant is enforceable only when it is:
+  //   1. Supported by adequate CONSIDERATION (continued employment of 2+
+  //      years, or other consideration explicitly stated).
+  //   2. REASONABLE in scope, duration, and geography.
+  //   3. NECESSARY to protect a LEGITIMATE BUSINESS INTEREST (Phes client
+  //      relationships, not the general labor market).
+  // Phes intentionally narrows the agreement: 12 months, CLIENTS only
+  // (not coworkers), and inbound-contact carve-out. This is intentionally
+  // conservative because IL courts blue-pencil aggressively.
+  //
+  // Spanish version is one of the FOUR FLAGGED docs requiring professional
+  // translator review. The Spanish UI will show a banner warning that the
+  // English version is binding until human translation is approved.
+  {
+    id: "non-solicitation",
+    number: 10,
+    iconKind: "shield",
+    title: {
+      en: "Non-Solicitation Agreement",
+      es: "Acuerdo de No Solicitación",
+    },
+    subtitle: {
+      en: "What you may not do with Phes clients during your employment and for 12 months after you leave. You may freely solicit coworkers and the general public.",
+      es: "Lo que no puede hacer con los clientes de Phes durante su empleo y por 12 meses después de irse. Puede solicitar libremente a compañeros y al público general.",
+    },
+    estimatedMinutes: 12,
+    blocks: [
+      {
+        type: "callout",
+        tone: "info",
+        text: {
+          en: "Why this module matters. Phes spends years building relationships with its clients. The client list is the most valuable asset of the business. The Non-Solicitation Agreement protects those relationships from being taken away after an employee leaves. It does NOT restrict your ability to look for other work, to recruit coworkers to a new opportunity, or to advertise services to the general public. It is narrowly aimed at Phes CLIENTS only.",
+          es: "Por qué importa este módulo. Phes pasa años construyendo relaciones con sus clientes. La lista de clientes es el activo más valioso del negocio. El Acuerdo de No Solicitación protege esas relaciones de ser arrebatadas después de que un empleado se va. NO restringe su habilidad de buscar otro trabajo, de reclutar compañeros para una nueva oportunidad, ni de anunciar servicios al público general. Apunta de forma estrecha solo a los CLIENTES de Phes.",
+        },
+      },
+
+      { type: "h", text: { en: "What the Agreement Restricts (Clients Only)", es: "Lo Que el Acuerdo Restringe (Solo Clientes)" } },
+      {
+        type: "p",
+        text: {
+          en: "The agreement says that during your employment and for 12 months after your last day with Phes, you will NOT directly or indirectly solicit Phes clients for cleaning services (whether for yourself, for a future employer, or for any other business). Phes CLIENTS means any household or business that has used Phes services in the 24 months before you left.",
+          es: "El acuerdo dice que durante su empleo y por 12 meses después de su último día con Phes, NO solicitará directa o indirectamente a clientes de Phes para servicios de limpieza (ya sea para usted, para un empleador futuro o para cualquier otro negocio). CLIENTES de Phes significa cualquier hogar o negocio que haya usado servicios de Phes en los 24 meses anteriores a su salida.",
+        },
+      },
+
+      { type: "h", text: { en: "What the Agreement Does NOT Restrict", es: "Lo Que el Acuerdo NO Restringe" } },
+      {
+        type: "bullets",
+        items: [
+          { en: "Working for another cleaning company in the Chicagoland area. The agreement is not a non-compete; you may take another job in cleaning at any time.", es: "Trabajar para otra empresa de limpieza en el área de Chicago. El acuerdo no es un acuerdo de no competencia; puede tomar otro trabajo en limpieza en cualquier momento." },
+          { en: "Recruiting Phes coworkers to join you at a new employer. Phes does not restrict coworker solicitation. The Illinois Freedom to Work Act discourages coworker non-solicits for hourly workers, and Phes does not include one.", es: "Reclutar a compañeros de Phes para que se unan a usted en un nuevo empleador. Phes no restringe la solicitación de compañeros. La Ley de Libertad para Trabajar de Illinois desalienta los acuerdos de no solicitación de compañeros para trabajadores por hora, y Phes no incluye uno." },
+          { en: "General advertising. Posting on Craigslist, putting flyers on a neighborhood bulletin board, running a Facebook page that targets the public at large. None of that is solicitation under this agreement, even if a Phes client happens to see it.", es: "Publicidad general. Publicar en Craigslist, poner volantes en un tablero de anuncios del vecindario, manejar una página de Facebook dirigida al público en general. Nada de eso es solicitación bajo este acuerdo, aunque un cliente de Phes la vea por casualidad." },
+          { en: "Accepting INBOUND contact from a former Phes client who finds you on their own. If a client contacts you first, without you having approached them, you may discuss work with them. You may not have done anything to invite or trigger the contact.", es: "Aceptar contacto INICIADO POR EL CLIENTE de un antiguo cliente de Phes que lo encuentre por su cuenta. Si un cliente lo contacta primero, sin que usted lo haya buscado, puede discutir el trabajo con él. No debe haber hecho nada para invitar o provocar el contacto." },
+        ],
+      },
+
+      { type: "h", text: { en: "What Counts as Solicitation", es: "Lo Que Cuenta Como Solicitación" } },
+      {
+        type: "p",
+        text: {
+          en: "Solicitation means YOU reaching out to a Phes client. Specifically:",
+          es: "Solicitación significa que USTED se acerque a un cliente de Phes. Específicamente:",
+        },
+      },
+      {
+        type: "bullets",
+        items: [
+          { en: "Calling, texting, emailing, DMing, or mailing a Phes client to offer them cleaning services.", es: "Llamar, enviar mensaje de texto, correo electrónico, mensaje directo o correo postal a un cliente de Phes para ofrecerle servicios de limpieza." },
+          { en: "Knocking on the door of a Phes client to offer them cleaning services.", es: "Tocar la puerta de un cliente de Phes para ofrecerle servicios de limpieza." },
+          { en: "Asking a current Phes coworker to pass along a flyer or business card to a Phes client.", es: "Pedirle a un compañero actual de Phes que pase un volante o tarjeta de presentación a un cliente de Phes." },
+          { en: "Posting a service offer to a private channel (a neighborhood Facebook group, a WhatsApp group, a Slack workspace) that you joined because you knew Phes clients use it.", es: "Publicar una oferta de servicio en un canal privado (un grupo de Facebook del vecindario, un grupo de WhatsApp, un espacio de Slack) al que se unió porque sabía que clientes de Phes lo usan." },
+        ],
+      },
+
+      { type: "h", text: { en: "Duration: 12 Months", es: "Duración: 12 Meses" } },
+      {
+        type: "p",
+        text: {
+          en: "The restriction runs for TWELVE months from your last day at Phes. After 12 months you may solicit anyone, including former Phes clients, without restriction under this agreement.",
+          es: "La restricción dura DOCE meses a partir de su último día en Phes. Después de 12 meses puede solicitar a cualquiera, incluidos antiguos clientes de Phes, sin restricción bajo este acuerdo.",
+        },
+      },
+
+      { type: "h", text: { en: "Illinois Freedom to Work Act (820 ILCS 90)", es: "Ley de Libertad para Trabajar de Illinois (820 ILCS 90)" } },
+      {
+        type: "p",
+        text: {
+          en: "Illinois law is friendlier to workers than many other states. Under the Illinois Freedom to Work Act (820 ILCS 90), a non-solicitation covenant is enforceable only when it is REASONABLE in scope, supported by adequate CONSIDERATION (something of value given in exchange for the promise), and NECESSARY to protect a LEGITIMATE business interest. Phes intentionally narrows the agreement to 12 months, to clients only, with the inbound-contact carve-out, so it stays well within what Illinois courts have found reasonable for an hourly cleaning workforce.",
+          es: "La ley de Illinois es más amigable con los trabajadores que muchos otros estados. Bajo la Ley de Libertad para Trabajar de Illinois (820 ILCS 90), un acuerdo de no solicitación es exigible solo cuando es RAZONABLE en alcance, está apoyado por una CONSIDERACIÓN adecuada (algo de valor dado a cambio de la promesa) y es NECESARIO para proteger un interés comercial LEGÍTIMO. Phes restringe el acuerdo intencionalmente a 12 meses, solo a clientes, con la exclusión de contacto iniciado por el cliente, para que se mantenga claramente dentro de lo que los tribunales de Illinois han encontrado razonable para una fuerza laboral de limpieza por hora.",
+        },
+      },
+      {
+        type: "callout",
+        tone: "info",
+        text: {
+          en: "Consideration for this agreement: Phes provides paid training, regular scheduled shifts, paid time off, holiday pay, and the other benefits described in the Compensation module. Continued employment past 2 years is also recognized as consideration under Illinois law.",
+          es: "Consideración por este acuerdo: Phes provee capacitación pagada, turnos programados regulares, tiempo libre pagado, pago por feriados y los demás beneficios descritos en el módulo de Compensación. El empleo continuo por más de 2 años también se reconoce como consideración bajo la ley de Illinois.",
+        },
+      },
+
+      { type: "h", text: { en: "Phes Representative Co-Signature", es: "Co-Firma del Representante de Phes" } },
+      {
+        type: "p",
+        text: {
+          en: "Like the Video & Photo Release, the Non-Solicitation Agreement is a two-way commitment: you agree to the restriction; Phes commits to the consideration described above. The signed instrument is CO-SIGNED by the Phes representative (by default the owner). The co-signature appears on the final PDF after you sign. You do not need to be present.",
+          es: "Como la Autorización de Video y Foto, el Acuerdo de No Solicitación es un compromiso de dos vías: usted acepta la restricción; Phes se compromete con la consideración descrita arriba. El instrumento firmado es CO-FIRMADO por el representante de Phes (por defecto el dueño). La co-firma aparece en el PDF final después de que usted firme. No necesita estar presente.",
+        },
+      },
+
+      { type: "h", text: { en: "If You Violate the Agreement", es: "Si Viola el Acuerdo" } },
+      {
+        type: "p",
+        text: {
+          en: "If Phes believes you are soliciting Phes clients in violation of the agreement, Phes may seek INJUNCTIVE RELIEF (a court order requiring you to stop) and recover documented damages plus reasonable attorney fees, as permitted by Illinois law. Phes does NOT impose liquidated damages or penalty clauses, because IL courts disfavor them in employee non-solicits.",
+          es: "Si Phes cree que está solicitando clientes de Phes en violación del acuerdo, Phes puede buscar ALIVIO POR ORDEN JUDICIAL (una orden de la corte que le exija detenerse) y recuperar daños documentados más honorarios razonables de abogado, según lo permita la ley de Illinois. Phes NO impone daños liquidados ni cláusulas de penalización, porque los tribunales de IL no las favorecen en acuerdos de no solicitación con empleados.",
+        },
+      },
+
+      {
+        type: "callout",
+        tone: "info",
+        text: {
+          en: "After this quiz: you will sign a separate Non-Solicitation Agreement that records the commitment. The agreement is co-signed by the Phes representative. You can re-download the signed PDF anytime from your training page. If you have questions about whether a specific situation would count as solicitation, ask the office before you act, not after.",
+          es: "Después de este examen: firmará un Acuerdo de No Solicitación por separado que registra el compromiso. El acuerdo es co-firmado por el representante de Phes. Puede volver a descargar el PDF firmado en cualquier momento desde su página de capacitación. Si tiene preguntas sobre si una situación específica contaría como solicitación, pregunte a la oficina antes de actuar, no después.",
+        },
+      },
+    ],
+  },
 ];
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -4211,6 +4349,160 @@ const BASE_QUIZ: QuizQuestion[] = [
       { en: "Yes. Content already in ACTIVE DISTRIBUTION at the time of separation may continue. The 5-year limit applies to NEW uses, not existing assets. If you want it taken down anyway, you can withdraw consent in writing and Phes will remove it from Phes-controlled channels within 30 days.", es: "Sí. El contenido que ya está en DISTRIBUCIÓN ACTIVA al momento de la separación puede continuar. El límite de 5 años aplica a NUEVOS usos, no a los recursos existentes. Si aun así quiere que se retire, puede retirar el consentimiento por escrito y Phes lo retirará de los canales controlados por Phes dentro de los 30 días." },
       { en: "Only if Phes pays you a continued-use fee.", es: "Solo si Phes le paga una tarifa por uso continuado." },
       { en: "Yes, but only for one year.", es: "Sí, pero solo por un año." },
+    ],
+    correctIndex: 1,
+  },
+
+  // ═════════════════════════════════════════════════════════════════════════════
+  // Module 10: NON-SOLICITATION AGREEMENT (10 questions, Phase 6 PR #7)
+  // ═════════════════════════════════════════════════════════════════════════════
+  {
+    id: "q-ns-01-clients-not-coworkers",
+    moduleId: "non-solicitation",
+    prompt: {
+      en: "Does the Non-Solicitation Agreement restrict you from recruiting Phes coworkers to a new job?",
+      es: "¿El Acuerdo de No Solicitación le impide reclutar a compañeros de Phes para un nuevo trabajo?",
+    },
+    options: [
+      { en: "Yes. The agreement covers both clients and coworkers.", es: "Sí. El acuerdo cubre tanto clientes como compañeros." },
+      { en: "No. The agreement restricts soliciting Phes CLIENTS only. You may freely recruit Phes coworkers. The Illinois Freedom to Work Act discourages coworker non-solicits for hourly workers, and Phes does not include one.", es: "No. El acuerdo restringe solicitar solo a CLIENTES de Phes. Puede reclutar libremente a compañeros de Phes. La Ley de Libertad para Trabajar de Illinois desalienta los acuerdos de no solicitación de compañeros para trabajadores por hora, y Phes no incluye uno." },
+      { en: "Only if the coworker is a primary tech.", es: "Solo si el compañero es técnico principal." },
+      { en: "Only if you give 30 days notice.", es: "Solo si da aviso de 30 días." },
+    ],
+    correctIndex: 1,
+  },
+  {
+    id: "q-ns-02-12-month-duration",
+    moduleId: "non-solicitation",
+    prompt: {
+      en: "You leave Phes today. How long does the Non-Solicitation Agreement restrict you from soliciting Phes clients?",
+      es: "Se va de Phes hoy. ¿Por cuánto tiempo le restringe el Acuerdo de No Solicitación solicitar a clientes de Phes?",
+    },
+    options: [
+      { en: "Forever.", es: "Para siempre." },
+      { en: "12 months from your last day at Phes. After 12 months you may solicit anyone, including former Phes clients, without restriction under this agreement.", es: "12 meses desde su último día en Phes. Después de 12 meses puede solicitar a cualquiera, incluidos antiguos clientes de Phes, sin restricción bajo este acuerdo." },
+      { en: "5 years.", es: "5 años." },
+      { en: "10 years.", es: "10 años." },
+    ],
+    correctIndex: 1,
+  },
+  {
+    id: "q-ns-03-what-counts-as-solicit",
+    moduleId: "non-solicitation",
+    prompt: {
+      en: "Which of the following IS solicitation under the agreement?",
+      es: "¿Cuál de los siguientes ES solicitación bajo el acuerdo?",
+    },
+    options: [
+      { en: "Running a Facebook page that advertises cleaning to the public at large.", es: "Manejar una página de Facebook que anuncia limpieza al público en general." },
+      { en: "Sending a DM to a Phes client offering to clean their home next Saturday.", es: "Enviar un mensaje directo a un cliente de Phes ofreciendo limpiar su casa el próximo sábado." },
+      { en: "Putting a flyer on a neighborhood bulletin board.", es: "Poner un volante en un tablero de anuncios del vecindario." },
+      { en: "Posting on Craigslist for cleaning work in Oak Lawn.", es: "Publicar en Craigslist trabajo de limpieza en Oak Lawn." },
+    ],
+    correctIndex: 1,
+  },
+  {
+    id: "q-ns-04-general-advertising-ok",
+    moduleId: "non-solicitation",
+    prompt: {
+      en: "After leaving Phes you start a small cleaning side business. You post on Craigslist offering services to anyone in Oak Lawn. A Phes client happens to see the post and contacts you. Is this a violation?",
+      es: "Después de dejar Phes inicia un pequeño negocio paralelo de limpieza. Publica en Craigslist ofreciendo servicios a cualquiera en Oak Lawn. Un cliente de Phes ve la publicación por casualidad y lo contacta. ¿Es una violación?",
+    },
+    options: [
+      { en: "Yes — any work with a former Phes client is forbidden.", es: "Sí — cualquier trabajo con un antiguo cliente de Phes está prohibido." },
+      { en: "No. General advertising is not solicitation under the agreement, even if a Phes client happens to see it. The client contacted you, not the other way around (inbound-contact carve-out applies).", es: "No. La publicidad general no es solicitación bajo el acuerdo, aunque un cliente de Phes la vea por casualidad. El cliente lo contactó a usted, no al revés (aplica la exclusión de contacto iniciado por el cliente)." },
+      { en: "Only if you charge less than Phes.", es: "Solo si cobra menos que Phes." },
+      { en: "Only if you took photos of Phes job sites.", es: "Solo si tomó fotos de lugares de trabajo de Phes." },
+    ],
+    correctIndex: 1,
+  },
+  {
+    id: "q-ns-05-il-freedom-to-work",
+    moduleId: "non-solicitation",
+    prompt: {
+      en: "Which Illinois law governs the enforceability of the Non-Solicitation Agreement and requires that any restriction be reasonable, supported by consideration, and tied to a legitimate business interest?",
+      es: "¿Qué ley de Illinois rige la exigibilidad del Acuerdo de No Solicitación y requiere que cualquier restricción sea razonable, apoyada por consideración y vinculada a un interés comercial legítimo?",
+    },
+    options: [
+      { en: "Illinois Cannabis Regulation and Tax Act.", es: "Ley de Regulación e Impuestos del Cannabis de Illinois." },
+      { en: "Illinois Freedom to Work Act, 820 ILCS 90.", es: "Ley de Libertad para Trabajar de Illinois, 820 ILCS 90." },
+      { en: "Illinois Right of Publicity Act.", es: "Ley del Derecho de Publicidad de Illinois." },
+      { en: "Illinois Paid Leave for All Workers Act.", es: "Ley de Licencia Pagada para Todos los Trabajadores de Illinois." },
+    ],
+    correctIndex: 1,
+  },
+  {
+    id: "q-ns-06-during-employment-too",
+    moduleId: "non-solicitation",
+    prompt: {
+      en: "You're currently employed at Phes. A Phes client asks if you would clean their home this Saturday on the side, paid in cash. The agreement says:",
+      es: "Actualmente está empleado en Phes. Un cliente de Phes le pregunta si podría limpiar su casa este sábado por su cuenta, pagado en efectivo. El acuerdo dice:",
+    },
+    options: [
+      { en: "You may accept because the agreement is only post-employment.", es: "Puede aceptar porque el acuerdo es solo después del empleo." },
+      { en: "The restriction applies DURING employment AND for 12 months after. While employed, you must decline and refer the client to the office. This is also a Code of Conduct conflict-of-interest issue.", es: "La restricción aplica DURANTE el empleo Y por 12 meses después. Mientras esté empleado, debe rechazar y referir al cliente a la oficina. Esto también es un problema de conflicto de interés del Código de Conducta." },
+      { en: "You may accept if you charge less than Phes does.", es: "Puede aceptar si cobra menos que Phes." },
+      { en: "You may accept if the client insists.", es: "Puede aceptar si el cliente insiste." },
+    ],
+    correctIndex: 1,
+  },
+  {
+    id: "q-ns-07-consideration",
+    moduleId: "non-solicitation",
+    prompt: {
+      en: "Under Illinois law, a non-solicitation agreement must be supported by CONSIDERATION — something of value given in exchange for the promise. What does Phes offer as consideration for this agreement?",
+      es: "Bajo la ley de Illinois, un acuerdo de no solicitación debe estar apoyado por CONSIDERACIÓN — algo de valor dado a cambio de la promesa. ¿Qué ofrece Phes como consideración por este acuerdo?",
+    },
+    options: [
+      { en: "Phes pays a $5,000 signing bonus.", es: "Phes paga un bono de $5,000 al firmar." },
+      { en: "Paid training, regular scheduled shifts, paid time off, holiday pay, and the other benefits described in the Compensation module. Continued employment past 2 years is also recognized as consideration under Illinois law.", es: "Capacitación pagada, turnos programados regulares, tiempo libre pagado, pago por feriados y los demás beneficios descritos en el módulo de Compensación. El empleo continuo por más de 2 años también se reconoce como consideración bajo la ley de Illinois." },
+      { en: "Phes promises lifetime employment.", es: "Phes promete empleo de por vida." },
+      { en: "Phes pays you to sign and that's it.", es: "Phes le paga por firmar y nada más." },
+    ],
+    correctIndex: 1,
+  },
+  {
+    id: "q-ns-08-remedy-injunctive",
+    moduleId: "non-solicitation",
+    prompt: {
+      en: "If Phes believes you have violated the agreement, what remedies does Phes pursue under this agreement?",
+      es: "Si Phes cree que ha violado el acuerdo, ¿qué remedios busca Phes bajo este acuerdo?",
+    },
+    options: [
+      { en: "A flat $50,000 penalty per violation.", es: "Una multa fija de $50,000 por cada violación." },
+      { en: "Injunctive relief (a court order to stop) plus documented damages plus reasonable attorney fees. Phes does NOT impose liquidated damages or penalty clauses because Illinois courts disfavor them in employee non-solicits.", es: "Alivio por orden judicial (una orden de la corte que exija detenerse) más daños documentados más honorarios razonables de abogado. Phes NO impone daños liquidados ni cláusulas de penalización porque los tribunales de Illinois no las favorecen en acuerdos de no solicitación con empleados." },
+      { en: "Phes immediately reports you to the police.", es: "Phes lo reporta inmediatamente a la policía." },
+      { en: "Phes garnishes your wages at your new job.", es: "Phes embarga sus salarios en su nuevo trabajo." },
+    ],
+    correctIndex: 1,
+  },
+  {
+    id: "q-ns-09-co-signature",
+    moduleId: "non-solicitation",
+    prompt: {
+      en: "Why is the Non-Solicitation Agreement CO-SIGNED by the Phes representative?",
+      es: "¿Por qué el Acuerdo de No Solicitación es CO-FIRMADO por el representante de Phes?",
+    },
+    options: [
+      { en: "Because the office wants more signatures on file.", es: "Porque la oficina quiere más firmas archivadas." },
+      { en: "Because the agreement is a TWO-WAY commitment: you agree to the 12-month restriction; Phes commits to the consideration (paid training, benefits, continued employment). The co-signature binds both sides.", es: "Porque el acuerdo es un compromiso DE DOS VÍAS: usted acepta la restricción de 12 meses; Phes se compromete a la consideración (capacitación pagada, beneficios, empleo continuo). La co-firma vincula a ambas partes." },
+      { en: "Because Illinois law requires two signatures on every non-solicit.", es: "Porque la ley de Illinois exige dos firmas en cada acuerdo de no solicitación." },
+      { en: "Because it makes the document harder to forge.", es: "Porque hace el documento más difícil de falsificar." },
+    ],
+    correctIndex: 1,
+  },
+  {
+    id: "q-ns-10-inbound-clients-exception",
+    moduleId: "non-solicitation",
+    prompt: {
+      en: "You left Phes three months ago. A former Phes client found your personal Instagram (which has nothing to do with cleaning) and messaged you asking if you do cleaning work. You had not contacted or invited them. Under the agreement, may you take the work?",
+      es: "Se fue de Phes hace tres meses. Un antiguo cliente de Phes encontró su Instagram personal (que no tiene nada que ver con limpieza) y le envió un mensaje preguntando si hace trabajo de limpieza. Usted no lo contactó ni invitó. Bajo el acuerdo, ¿puede tomar el trabajo?",
+    },
+    options: [
+      { en: "No. Any work with a former Phes client within 12 months is forbidden.", es: "No. Cualquier trabajo con un antiguo cliente de Phes dentro de los 12 meses está prohibido." },
+      { en: "Yes. The inbound-contact carve-out applies: the client contacted you first, without you having approached them or done anything to invite the contact. You may discuss work with them.", es: "Sí. Aplica la exclusión de contacto iniciado por el cliente: el cliente lo contactó primero, sin que usted lo hubiera buscado ni hecho nada para invitar el contacto. Puede discutir el trabajo con él." },
+      { en: "Only if you charge less than Phes.", es: "Solo si cobra menos que Phes." },
+      { en: "Only after consulting an attorney.", es: "Solo después de consultar a un abogado." },
     ],
     correctIndex: 1,
   },

--- a/lib/db/src/schema/lms-signatures.ts
+++ b/lib/db/src/schema/lms-signatures.ts
@@ -515,7 +515,7 @@ export const REQUIRED_PRE_FINAL_SIGNED_DOCS = [
   "drug_alcohol",
   "code_of_conduct",
   "video_photo_release",
-  // PR #7 will add: "non_solicitation"
+  "non_solicitation",
   // PR #8 will add: "social_media"
   // PR #10 will add: "supply_kit"
 ] as const;

--- a/lib/lms-curriculum/src/index.ts
+++ b/lib/lms-curriculum/src/index.ts
@@ -50,6 +50,7 @@ export type ModuleId =
   | "drug-alcohol"
   | "code-of-conduct"
   | "video-photo-release"
+  | "non-solicitation"
   | "acknowledgment";
 
 export type QuizModuleId = Exclude<ModuleId, "acknowledgment">;
@@ -78,6 +79,7 @@ export const MODULE_ORDER: readonly ModuleId[] = [
   "drug-alcohol",
   "code-of-conduct",
   "video-photo-release",
+  "non-solicitation",
   "acknowledgment",
 ] as const;
 
@@ -111,6 +113,15 @@ export const MODULE_ORDER: readonly ModuleId[] = [
  * withdrawal clause, and courtesy preview language. Co-signed by the
  * tenant Phes representative (default-resolved by
  * getTenantOwnerForSignature).
+ *
+ * non-solicitation (Phase 6, PR #7) is also CO-SIGNED. 10-question
+ * comprehension quiz + separate signed agreement at document_type
+ * 'non_solicitation'. References the Illinois Freedom to Work Act
+ * (820 ILCS 90) reasonableness + consideration constraints. Spanish
+ * version is one of the FOUR FLAGGED docs for professional translator
+ * review (pendingTranslationReview: true). 12-month post-separation
+ * limit on soliciting Phes clients; coworkers explicitly carved out
+ * of the agreement; general advertising not deemed solicitation.
  */
 export const QUIZ_MODULE_IDS: readonly QuizModuleId[] = [
   "phes-policies",
@@ -122,6 +133,7 @@ export const QUIZ_MODULE_IDS: readonly QuizModuleId[] = [
   "drug-alcohol",
   "code-of-conduct",
   "video-photo-release",
+  "non-solicitation",
 ] as const;
 
 /** Pass threshold per module (and for the final mixed test). 80%. */
@@ -377,6 +389,25 @@ export const ANSWER_KEY: Readonly<Record<string, number>> = Object.freeze({
   "q-vpr-07-co-signature": 1,
   "q-vpr-08-courtesy-preview": 1,
   "q-vpr-09-active-distribution": 1,
+
+  // ── Module 10: non-solicitation (10, Phase 6 PR #7) ─────────────────────
+  // Phes Non-Solicitation Agreement. Co-signed by the Phes representative.
+  // Constrained by the Illinois Freedom to Work Act (820 ILCS 90): the
+  // restriction must be reasonable, supported by adequate consideration,
+  // and tailored to a legitimate business interest. The agreement only
+  // restricts soliciting Phes CLIENTS (not coworkers, not the general
+  // labor market) for 12 months post-separation. Spanish version is one
+  // of the FOUR FLAGGED docs for professional translator review.
+  "q-ns-01-clients-not-coworkers": 1,
+  "q-ns-02-12-month-duration": 1,
+  "q-ns-03-what-counts-as-solicit": 1,
+  "q-ns-04-general-advertising-ok": 1,
+  "q-ns-05-il-freedom-to-work": 1,
+  "q-ns-06-during-employment-too": 1,
+  "q-ns-07-consideration": 1,
+  "q-ns-08-remedy-injunctive": 1,
+  "q-ns-09-co-signature": 1,
+  "q-ns-10-inbound-clients-exception": 1,
 });
 
 /**
@@ -461,6 +492,13 @@ export const QUESTIONS_BY_MODULE: Readonly<Record<QuizModuleId, readonly string[
       "q-vpr-05-third-party-limits", "q-vpr-06-il-right-of-publicity",
       "q-vpr-07-co-signature", "q-vpr-08-courtesy-preview",
       "q-vpr-09-active-distribution",
+    ],
+    "non-solicitation": [
+      "q-ns-01-clients-not-coworkers", "q-ns-02-12-month-duration",
+      "q-ns-03-what-counts-as-solicit", "q-ns-04-general-advertising-ok",
+      "q-ns-05-il-freedom-to-work", "q-ns-06-during-employment-too",
+      "q-ns-07-consideration", "q-ns-08-remedy-injunctive",
+      "q-ns-09-co-signature", "q-ns-10-inbound-clients-exception",
     ],
   });
 

--- a/lib/training/src/answer-key.ts
+++ b/lib/training/src/answer-key.ts
@@ -188,6 +188,18 @@ export const SERVER_ANSWER_KEY: Readonly<Record<string, number>> = Object.freeze
   "q-vpr-07-co-signature": 1,
   "q-vpr-08-courtesy-preview": 1,
   "q-vpr-09-active-distribution": 1,
+
+  // ── Module 10: non-solicitation (10, Phase 6 PR #7) ────────────────────
+  "q-ns-01-clients-not-coworkers": 1,
+  "q-ns-02-12-month-duration": 1,
+  "q-ns-03-what-counts-as-solicit": 1,
+  "q-ns-04-general-advertising-ok": 1,
+  "q-ns-05-il-freedom-to-work": 1,
+  "q-ns-06-during-employment-too": 1,
+  "q-ns-07-consideration": 1,
+  "q-ns-08-remedy-injunctive": 1,
+  "q-ns-09-co-signature": 1,
+  "q-ns-10-inbound-clients-exception": 1,
 });
 
 /**


### PR DESCRIPTION
## PR #7 of 16 — Phase 6: Non-Solicitation Agreement + Co-Sign

**Second CO-SIGNED legal document.** Adds the Phes Non-Solicitation Agreement as LMS module #10 with a 10-question comprehension quiz + a UETA / E-SIGN binding agreement at `document_type 'non_solicitation'`, co-signed by the Phes representative (tenant owner by default).

**Spanish flagged for professional translator review** — this is one of the four flagged docs (alongside drug_alcohol, commission_consent, wage_deduction_notice). The existing UI banner + PDF watermark fire automatically.

**DO NOT auto-merge.** Review the diff before approving + merging.

## Spec applied

| Spec item | Where it lands |
|-----------|----------------|
| Illinois Freedom to Work Act (820 ILCS 90) compliant | Preamble + section 8; tests enforce citation in both locales |
| 12-month post-separation duration | Section 1; tests enforce "TWELVE MONTHS" verbatim |
| Clients only (coworker carve-out) | Section 3 — explicit "COWORKERS ARE NOT RESTRICTED" |
| Inbound-contact carve-out | Section 5 — former clients may contact YOU |
| General-advertising carve-out | Section 5 — Craigslist / boards / public Facebook are OK |
| No non-compete (free to take other cleaning jobs) | Section 6 — explicit "NO NON-COMPETE" |
| Consideration: training + benefits + 2-year continued employment | Section 7 |
| Severability + blue-pencil | Section 10 |
| Remedies: injunctive + documented damages + attorney fees (NO liquidated damages) | Section 9; tests enforce "does not impose liquidated damages" |
| Phes Representative co-signature required | Section 11 + existing admin Co-sign button picks it up |
| Spanish flagged `pendingTranslationReview: true` | One of the four flagged docs |
| Hard-gate final exam on this doc | REQUIRED_PRE_FINAL_SIGNED_DOCS appended |
| Bypass marks quiz passed, does NOT create signed_document row | Unchanged from PR #4 — `/admin/bypass-module` already enforces this for all standalone signed-doc modules |

## What this PR ships

### A. `non-solicitation` module (Phase 6 quiz)

Slot #10 between `video-photo-release` and `acknowledgment`. Bilingual content covering:
- Restriction scope (clients only) + 12-month duration
- Coworker carve-out (free to recruit Phes coworkers)
- General-advertising and inbound-contact carve-outs
- What counts as solicitation
- IL Freedom to Work Act (820 ILCS 90) reasonableness, consideration, legitimate-interest framework
- Phes Representative co-signature rationale
- Remedies: injunctive relief + documented damages + reasonable attorney fees (no liquidated damages)

**10 quiz questions** (`q-ns-01` through `q-ns-10`), 80% to pass.

### B. `non_solicitation` content registry

13-section bilingual agreement in `lib/lms-signed-documents-content.ts`. Server-authoritative — PDF and version hash bind to the exact bytes. Em-dash-free, en-dash-free.

**Spanish flagged `pendingTranslationReview: true`** — the existing UI banner ("This Spanish translation is under review. The English version is binding until professional translation is approved.") and PDF watermark fire automatically.

### C. Final-exam gate extension

Appends `"non_solicitation"` to `REQUIRED_PRE_FINAL_SIGNED_DOCS`. Final exam now requires drug_alcohol + code_of_conduct + video_photo_release + non_solicitation. Owner / admin / office exempt.

### D. Admin Co-sign UI

No new admin code needed — the `CO_SIGNED_DOCUMENT_TYPES` frontend constant added in PR #6 already includes `non_solicitation`. The Co-sign button + inline affirmation form pick up the new doc automatically.

### E. Schema-layer + drift coverage

- `lib/lms-curriculum/src/index.ts`: ModuleId union, MODULE_ORDER (11 entries now), QUIZ_MODULE_IDS (10 entries), ANSWER_KEY (10 new q-ns-* keys), QUESTIONS_BY_MODULE
- `lib/training/src/answer-key.ts`: mirrors the same 10 keys; drift-sync test enforces parity
- `lib/lms-curriculum-titles.ts`: bilingual title for certificate PDF rendering
- Frontend `humanSignedDocType` already includes `non_solicitation` from prior PRs — locked-final-exam tile + Required-Signed-Acks tile pick it up automatically

## Tests

- **163 / 163 LMS tests pass** (was 150 — 13 new content tests + drift-sync auto-extends + curriculum-shape counts updated)
- Curriculum counts: MODULE_ORDER = 11, QUIZ_MODULE_IDS = 10, ALL_QUESTION_IDS = 154 (40 + 15×5 + 10 + 10 + 9 + 10)
- 13 new non_solicitation content tests covering: registry shape, Spanish `pendingTranslationReview: true` flag, English not flagged, 820 ILCS 90 citation in both locales (with Spanish translation of the act name), 12-month duration verbatim, coworker carve-out section, INBOUND CONTACT carve-out, GENERAL ADVERTISING carve-out, NO NON-COMPETE clause, remedies shape (injunctive + explicit disclaimer of liquidated damages), and EN vs ES hashes differ
- Vite build clean. tsc-libs (CI `tsc-check`) clean.

## Test plan (manual)

**Learner flow:**
- [ ] Log in as `jose.ardila@phes.io` → `/training` → module #10 "Non-Solicitation Agreement" appears after module #9
- [ ] Read content (cover 12-month duration, coworker carve-out, inbound-contact carve-out, NO NON-COMPETE)
- [ ] Take quiz (10 questions, 80% pass)
- [ ] On pass, "Required Signed Acknowledgments" tile lists the unsigned legal docs including non_solicitation
- [ ] Click → SignDocumentView opens with the full English agreement + affirmation checkbox + typed name
- [ ] Toggle to Spanish → see the amber translation-review banner: "This Spanish translation is under review. The English version is binding until professional translation is approved."
- [ ] Sign → returns to Home

**Admin co-sign flow:**
- [ ] As Sal (owner): `/lms/admin` → expand Jose → Signed Acknowledgments panel shows the new non_solicitation entry with the amber "Awaiting Phes representative co-signature" pill + Co-sign button
- [ ] Click Co-sign → inline form → typed name + affirmation → Co-sign
- [ ] Card refreshes; pill flips to green "Co-signed by Phes representative"
- [ ] Download PDF → see English text + employee signature block + co-signature block on the last page

**Negative paths:**
- [ ] Try to submit final exam while non_solicitation is unsigned → 403 with `missing_required_signed_docs` echoed
- [ ] Same flow as owner/admin/office → final exam unlocks (exempt path)
- [ ] Admin bypass on non-solicitation quiz: confirm NO certificate issued + NO signed_document row created; audit log shows `source: "admin_bypass"`
- [ ] Spanish PDF: confirm the translation-review banner renders on page 1

https://claude.ai/code/session_013rJ4N4vgqZWB986x8D6Ahh

---
_Generated by [Claude Code](https://claude.ai/code/session_013rJ4N4vgqZWB986x8D6Ahh)_