### PR TITLE
lms: non-solicitation amendment (Phase 6.5, follow-up to PR #7)

### DIFF
--- a/artifacts/api-server/src/lib/lms-signed-documents-content.ts
+++ b/artifacts/api-server/src/lib/lms-signed-documents-content.ts
@@ -457,7 +457,7 @@ const NON_SOLICITATION_EN: SignedDocumentLocaleContent = {
     "Phes provides the following consideration in exchange for my acceptance of this Agreement: paid training, regular scheduled shifts, paid time off accruing under the Illinois Paid Leave for All Workers Act, holiday pay, and the other benefits described in the Compensation module of the Phes Employee Handbook. Continued employment past two years also constitutes adequate consideration under Illinois law.",
     "",
     "8. REASONABLE SCOPE.",
-    "I acknowledge that the twelve-month duration, the clients-only scope, the inbound-contact carve-out, and the absence of any geographic territory restriction collectively make this Agreement reasonable and necessary to protect Phes's legitimate business interest in client relationships, consistent with the Illinois Freedom to Work Act.",
+    "I expressly acknowledge that the twelve-month duration, the clients-only scope, the inbound-contact carve-out, and the absence of any geographic territory restriction collectively make this Agreement reasonable and necessary to protect Phes's legitimate business interests in client relationships and confidential information, and that the consideration described in section 7 is adequate, consistent with the Illinois Freedom to Work Act.",
     "",
     "9. REMEDIES.",
     "If Phes believes I have violated this Agreement, Phes may seek injunctive relief (a court order requiring me to stop the prohibited conduct) and may recover documented damages and reasonable attorney fees, as permitted by Illinois law. Phes does not impose liquidated damages or penalty clauses under this Agreement.",
@@ -468,15 +468,27 @@ const NON_SOLICITATION_EN: SignedDocumentLocaleContent = {
     "11. PHES REPRESENTATIVE CO-SIGNATURE.",
     "This Agreement is a two-way commitment. I agree to the twelve-month client non-solicit; Phes commits to the consideration described in section 7. The signed instrument is co-signed by the Phes representative. The co-signature appears on the final PDF after my signature.",
     "",
-    "12. AT-WILL EMPLOYMENT.",
+    "12. PROHIBITION ON DIRECT PAYMENTS FROM CLIENTS.",
+    "During my employment with Phes, I will not accept payment, supply reimbursements, or any other monetary or in-kind compensation directly from a Phes Client for cleaning work that should be billed through Phes. Customary cash tips offered by a client and noted on the Worksheet are not direct payments and remain permitted under the tipping rules described in the Phes Employee Handbook. All scheduled cleaning work performed for a Phes Client during my employment is to be booked through the office and billed by Phes. This Section 12 is in addition to, and does not replace, the conflict-of-interest rules in the Code of Conduct or the post-employment client non-solicitation in Section 1.",
+    "",
+    "13. CONFIDENTIAL TRADE SECRETS (INDEFINITE DURATION).",
+    "During my employment with Phes and indefinitely thereafter, I will not disclose, use, or transmit to any person or entity outside Phes any Phes trade secret. Trade secret under this Agreement means information that meets the definition of a trade secret under the Illinois Trade Secrets Act (765 ILCS 1065) and that I learned, accessed, or developed because of my employment with Phes, including: (a) the Phes client list and any associated client contact information; (b) Phes pricing structures, pricing rules, and quote formulas; (c) internal cleaning procedures, checklists, and quality-control practices documented by Phes as proprietary; (d) vendor and supplier relationships and the pricing terms negotiated with them; (e) route information and internal operational schedules; (f) internal software (including the Qleno platform) and non-public business strategy, financial projections, or planning information disclosed to me as part of my employment. This Section 13 does not restrict my general knowledge, skill, or experience acquired during my employment, my right under federal Section 7 of the National Labor Relations Act to discuss my own pay, hours, schedule, or working conditions, or any other federally protected activity.",
+    "",
+    "14. AT-WILL EMPLOYMENT.",
     "Nothing in this Agreement alters my at-will employment status with Phes. Phes may terminate my employment at any time, with or without cause or notice, for any lawful reason. My obligations under this Agreement survive termination of employment.",
     "",
-    "13. ELECTRONIC SIGNATURE CONSENT.",
+    "15. ELECTRONIC SIGNATURE CONSENT.",
     "I consent to sign this Agreement electronically. I understand that my electronic signature has the same legal effect as a handwritten signature, in accordance with the federal Electronic Signatures in Global and National Commerce Act (E-SIGN) and the Illinois Uniform Electronic Transactions Act (UETA).",
     "",
     "By typing or drawing my signature below and clicking the I Agree button, I affirm that I have read, understood, and accept this Non-Solicitation Agreement.",
   ].join("\n"),
-  notes: "Phase 6 PR #7 — Phes non-solicitation agreement. 12 months, clients only, IL Freedom to Work Act compliant.",
+  notes:
+    "Phase 6 PR #7 — Phes non-solicitation agreement. 12 months, " +
+    "clients only, IL Freedom to Work Act compliant. Phase 6.5 amendment: " +
+    "added Section 12 direct-payment prohibition, Section 13 indefinite " +
+    "trade-secret confidentiality (scoped to IL Trade Secrets Act + NLRA " +
+    "Section 7 carve-out), and strengthened Section 8 reasonableness " +
+    "acknowledgment.",
 };
 
 const NON_SOLICITATION_ES: SignedDocumentLocaleContent = {
@@ -511,7 +523,7 @@ const NON_SOLICITATION_ES: SignedDocumentLocaleContent = {
     "Phes provee la siguiente consideración a cambio de mi aceptación de este Acuerdo: capacitación pagada, turnos programados regulares, tiempo libre pagado que se acumula bajo la Ley de Licencia Pagada para Todos los Trabajadores de Illinois, pago por feriados y los demás beneficios descritos en el módulo de Compensación del Manual del Empleado de Phes. El empleo continuo por más de dos años también constituye consideración adecuada bajo la ley de Illinois.",
     "",
     "8. ALCANCE RAZONABLE.",
-    "Reconozco que la duración de doce meses, el alcance limitado a clientes, la exclusión de contacto iniciado por el cliente y la ausencia de cualquier restricción de territorio geográfico hacen, en conjunto, que este Acuerdo sea razonable y necesario para proteger el interés comercial legítimo de Phes en las relaciones con los clientes, consistente con la Ley de Libertad para Trabajar de Illinois.",
+    "Reconozco expresamente que la duración de doce meses, el alcance limitado a clientes, la exclusión de contacto iniciado por el cliente y la ausencia de cualquier restricción de territorio geográfico hacen, en conjunto, que este Acuerdo sea razonable y necesario para proteger los intereses comerciales legítimos de Phes en las relaciones con los clientes y en la información confidencial, y que la consideración descrita en la sección 7 es adecuada, consistente con la Ley de Libertad para Trabajar de Illinois.",
     "",
     "9. REMEDIOS.",
     "Si Phes cree que he violado este Acuerdo, Phes puede buscar alivio por orden judicial (una orden de la corte que me exija detener la conducta prohibida) y puede recuperar daños documentados y honorarios razonables de abogado, según lo permita la ley de Illinois. Phes no impone daños liquidados ni cláusulas de penalización bajo este Acuerdo.",
@@ -522,10 +534,16 @@ const NON_SOLICITATION_ES: SignedDocumentLocaleContent = {
     "11. CO-FIRMA DEL REPRESENTANTE DE PHES.",
     "Este Acuerdo es un compromiso de dos vías. Yo acepto la no solicitación de clientes de doce meses; Phes se compromete con la consideración descrita en la sección 7. El instrumento firmado es co-firmado por el representante de Phes. La co-firma aparece en el PDF final después de mi firma.",
     "",
-    "12. EMPLEO A VOLUNTAD.",
+    "12. PROHIBICIÓN DE PAGOS DIRECTOS DE CLIENTES.",
+    "Durante mi empleo con Phes, no aceptaré pago, reembolsos de suministros ni ninguna otra compensación monetaria o en especie directamente de un Cliente de Phes por trabajo de limpieza que deba facturarse a través de Phes. Las propinas en efectivo de costumbre que un cliente ofrezca y que se anoten en la Hoja de Trabajo no son pagos directos y siguen permitidas bajo las reglas de propinas descritas en el Manual del Empleado de Phes. Todo trabajo de limpieza programado realizado para un Cliente de Phes durante mi empleo debe reservarse a través de la oficina y ser facturado por Phes. Esta Sección 12 es adicional a, y no reemplaza, las reglas de conflicto de interés del Código de Conducta ni la no solicitación de clientes posterior al empleo en la Sección 1.",
+    "",
+    "13. SECRETOS COMERCIALES CONFIDENCIALES (DURACIÓN INDEFINIDA).",
+    "Durante mi empleo con Phes y de manera indefinida después, no divulgaré, usaré ni transmitiré a ninguna persona o entidad fuera de Phes ningún secreto comercial de Phes. Secreto comercial bajo este Acuerdo significa información que cumple la definición de secreto comercial bajo la Ley de Secretos Comerciales de Illinois (765 ILCS 1065) y que aprendí, accedí o desarrollé debido a mi empleo con Phes, incluyendo: (a) la lista de clientes de Phes y cualquier información de contacto del cliente asociada; (b) las estructuras de precios, reglas de precios y fórmulas de cotización de Phes; (c) procedimientos internos de limpieza, listas de verificación y prácticas de control de calidad documentadas por Phes como propietarias; (d) las relaciones con proveedores y los términos de precios negociados con ellos; (e) información de rutas y horarios operativos internos; (f) software interno (incluyendo la plataforma Qleno) e información no pública de estrategia comercial, proyecciones financieras o planeación que se me haya divulgado como parte de mi empleo. Esta Sección 13 no restringe mi conocimiento general, habilidad o experiencia adquiridos durante mi empleo, ni mi derecho bajo la Sección 7 federal de la Ley Nacional de Relaciones Laborales a discutir mi propio pago, horas, horario o condiciones laborales, ni ninguna otra actividad federalmente protegida.",
+    "",
+    "14. EMPLEO A VOLUNTAD.",
     "Nada en este Acuerdo altera mi estatus de empleo a voluntad con Phes. Phes puede terminar mi empleo en cualquier momento, con o sin causa o aviso, por cualquier razón legal. Mis obligaciones bajo este Acuerdo sobreviven a la terminación del empleo.",
     "",
-    "13. CONSENTIMIENTO DE FIRMA ELECTRÓNICA.",
+    "15. CONSENTIMIENTO DE FIRMA ELECTRÓNICA.",
     "Doy mi consentimiento para firmar este Acuerdo electrónicamente. Entiendo que mi firma electrónica tiene el mismo efecto legal que una firma manuscrita, conforme a la Ley federal de Firmas Electrónicas en el Comercio Global y Nacional (E-SIGN) y a la Ley Uniforme de Transacciones Electrónicas de Illinois (UETA).",
     "",
     "Al escribir o dibujar mi firma a continuación y hacer clic en el botón Acepto, afirmo que he leído, entendido y aceptado este Acuerdo de No Solicitación.",

--- a/artifacts/api-server/src/tests/lms-curriculum.test.ts
+++ b/artifacts/api-server/src/tests/lms-curriculum.test.ts
@@ -102,7 +102,9 @@ describe("LMS curriculum — constants & catalog shape", () => {
     // drug-alcohol: 10 (Phase 3 spec, legally-important concepts only)
     // code-of-conduct: 10 (Phase 4 spec, behavior-comprehension)
     // video-photo-release: 9 (Phase 5 spec, release-rights comprehension)
-    // non-solicitation: 10 (Phase 6 spec, agreement-scope comprehension)
+    // non-solicitation: 13 (Phase 6 spec + Phase 6.5 amendment: original
+    //   10 + q-ns-11 direct-payment + q-ns-12 trade-secret +
+    //   q-ns-13 trade-secret-vs-Section-7)
     // social-media: 10 (Phase 7 spec, NLRA Section 7 + carve-out comprehension)
     // phes-401k: 10 (Phase 8 spec, 401(k) plan-features comprehension)
     // all others: 15 (per original Phes spec)
@@ -111,7 +113,7 @@ describe("LMS curriculum — constants & catalog shape", () => {
       "drug-alcohol": 10,
       "code-of-conduct": 10,
       "video-photo-release": 9,
-      "non-solicitation": 10,
+      "non-solicitation": 13,
       "social-media": 10,
       "phes-401k": 10,
       compensation: 15,
@@ -129,8 +131,8 @@ describe("LMS curriculum — constants & catalog shape", () => {
     }
   });
 
-  it("ALL_QUESTION_IDS is 174 total (40 + 15*5 + 10 + 10 + 9 + 10 + 10 + 10)", () => {
-    assert.equal(ALL_QUESTION_IDS.length, 174);
+  it("ALL_QUESTION_IDS is 177 total (40 + 15*5 + 10 + 10 + 9 + 13 + 10 + 10)", () => {
+    assert.equal(ALL_QUESTION_IDS.length, 177);
   });
 
   it("ANSWER_KEY has exactly the keys enumerated by ALL_QUESTION_IDS", () => {

--- a/artifacts/api-server/src/tests/lms-signed-documents.test.ts
+++ b/artifacts/api-server/src/tests/lms-signed-documents.test.ts
@@ -375,6 +375,124 @@ describe("non_solicitation content shape (PR #7 spec checks)", () => {
   });
 });
 
+// Phase 6.5 amendment: trade-secret confidentiality + direct-payment ban +
+// strengthened reasonableness acknowledgment. Coworker non-solicit and
+// liquidated damages remain INTENTIONALLY OMITTED per IL Freedom to Work
+// Act enforceability concerns.
+describe("non_solicitation Phase 6.5 amendment (post-PR #7)", () => {
+  it("English Section 12 prohibits direct payments from clients with explicit tip carve-out", () => {
+    const en = SIGNED_DOCUMENT_CONTENT.non_solicitation!.en.contentHtml;
+    assert.ok(
+      en.includes("PROHIBITION ON DIRECT PAYMENTS FROM CLIENTS"),
+      "English must include the direct-payment-prohibition section header",
+    );
+    assert.ok(
+      en.includes("Customary cash tips offered by a client and noted on the Worksheet are not direct payments"),
+      "English must carve out customary cash tips from the direct-payment prohibition",
+    );
+  });
+
+  it("Spanish Section 12 prohibits direct payments from clients with explicit tip carve-out", () => {
+    const es = SIGNED_DOCUMENT_CONTENT.non_solicitation!.es.contentHtml;
+    assert.ok(
+      es.includes("PROHIBICIÓN DE PAGOS DIRECTOS DE CLIENTES"),
+      "Spanish must include the direct-payment-prohibition section header",
+    );
+    assert.ok(
+      es.includes("Las propinas en efectivo de costumbre"),
+      "Spanish must carve out customary cash tips from the direct-payment prohibition",
+    );
+  });
+
+  it("English Section 13 establishes indefinite trade-secret confidentiality scoped to the Illinois Trade Secrets Act (765 ILCS 1065)", () => {
+    const en = SIGNED_DOCUMENT_CONTENT.non_solicitation!.en.contentHtml;
+    assert.ok(
+      en.includes("CONFIDENTIAL TRADE SECRETS (INDEFINITE DURATION)"),
+      "English must include the trade-secret confidentiality section header",
+    );
+    assert.ok(
+      en.includes("Illinois Trade Secrets Act (765 ILCS 1065)"),
+      "English must reference the Illinois Trade Secrets Act with the 765 ILCS 1065 citation",
+    );
+    assert.ok(
+      en.includes("the Phes client list"),
+      "English must enumerate the Phes client list as a trade secret",
+    );
+    assert.ok(
+      en.includes("pricing structures, pricing rules, and quote formulas"),
+      "English must enumerate pricing rules + quote formulas as a trade secret",
+    );
+  });
+
+  it("Spanish Section 13 establishes indefinite trade-secret confidentiality scoped to the Illinois Trade Secrets Act", () => {
+    const es = SIGNED_DOCUMENT_CONTENT.non_solicitation!.es.contentHtml;
+    assert.ok(
+      es.includes("SECRETOS COMERCIALES CONFIDENCIALES (DURACIÓN INDEFINIDA)"),
+      "Spanish must include the trade-secret confidentiality section header",
+    );
+    assert.ok(
+      es.includes("Ley de Secretos Comerciales de Illinois (765 ILCS 1065)"),
+      "Spanish must reference the IL Trade Secrets Act translation with the 765 ILCS 1065 citation",
+    );
+  });
+
+  it("English Section 13 carves out general knowledge and NLRA Section 7 protected concerted activity", () => {
+    const en = SIGNED_DOCUMENT_CONTENT.non_solicitation!.en.contentHtml;
+    assert.ok(
+      en.includes("does not restrict my general knowledge, skill, or experience"),
+      "English must preserve the general-knowledge carve-out",
+    );
+    assert.ok(
+      en.includes("Section 7 of the National Labor Relations Act"),
+      "English must preserve the NLRA Section 7 carve-out so wage / working-condition discussion stays protected",
+    );
+  });
+
+  it("Spanish Section 13 carves out NLRA Section 7 protected activity", () => {
+    const es = SIGNED_DOCUMENT_CONTENT.non_solicitation!.es.contentHtml;
+    assert.ok(
+      es.includes("Sección 7 federal de la Ley Nacional de Relaciones Laborales"),
+      "Spanish must preserve the NLRA Section 7 carve-out",
+    );
+  });
+
+  it("English Section 8 contains the strengthened express reasonableness acknowledgment", () => {
+    const en = SIGNED_DOCUMENT_CONTENT.non_solicitation!.en.contentHtml;
+    assert.ok(
+      en.includes("I expressly acknowledge"),
+      "English Section 8 must include the express reasonableness acknowledgment",
+    );
+    assert.ok(
+      en.includes("the consideration described in section 7 is adequate"),
+      "English Section 8 must include the explicit consideration-adequacy acknowledgment",
+    );
+  });
+
+  it("Spanish Section 8 contains the strengthened express reasonableness acknowledgment", () => {
+    const es = SIGNED_DOCUMENT_CONTENT.non_solicitation!.es.contentHtml;
+    assert.ok(
+      es.includes("Reconozco expresamente"),
+      "Spanish Section 8 must include the express reasonableness acknowledgment",
+    );
+  });
+
+  it("Amendment INTENTIONALLY OMITS coworker non-solicitation (IL Freedom to Work Act enforceability concern)", () => {
+    const en = SIGNED_DOCUMENT_CONTENT.non_solicitation!.en.contentHtml;
+    assert.ok(
+      en.includes("COWORKERS ARE NOT RESTRICTED"),
+      "English must preserve the coworker carve-out; adding a coworker non-solicit for hourly workers risks blue-penciling the whole agreement under IL Freedom to Work Act",
+    );
+  });
+
+  it("Amendment INTENTIONALLY OMITS liquidated damages (IL courts disfavor in hourly-worker non-solicits)", () => {
+    const en = SIGNED_DOCUMENT_CONTENT.non_solicitation!.en.contentHtml;
+    assert.ok(
+      en.includes("does not impose liquidated damages"),
+      "English must preserve the explicit liquidated-damages disclaimer; IL courts routinely strike these as penalty clauses",
+    );
+  });
+});
+
 describe("video_photo_release content shape (PR #6 spec checks)", () => {
   it("English entry is NOT flagged pendingTranslationReview (not in the four flagged docs)", () => {
     assert.equal(

--- a/artifacts/qleno/src/lib/training/curriculum.ts
+++ b/artifacts/qleno/src/lib/training/curriculum.ts
@@ -2358,6 +2358,60 @@ const BASE_MODULES: Module[] = [
         },
       },
 
+      { type: "h", text: { en: "No Direct Payments From Clients", es: "Sin Pagos Directos de Clientes" } },
+      {
+        type: "p",
+        text: {
+          en: "While you are employed at Phes, you will not accept payment, supply reimbursements, or any other monetary or in-kind compensation directly from a Phes client for cleaning work that should be billed through Phes. Customary cash tips offered by a client are not direct payments; record the tip on the Worksheet as described in the Phes Employee Handbook.",
+          es: "Mientras esté empleado en Phes, no aceptará pago, reembolsos de suministros ni ninguna otra compensación monetaria o en especie directamente de un cliente de Phes por trabajo de limpieza que deba facturarse a través de Phes. Las propinas en efectivo de costumbre que un cliente ofrezca no son pagos directos; registre la propina en la Hoja de Trabajo como se describe en el Manual del Empleado de Phes.",
+        },
+      },
+      {
+        type: "bullets",
+        items: [
+          { en: "If a client tries to pay you directly for the scheduled Phes job, decline and explain that all work is billed through the office.", es: "Si un cliente intenta pagarle directamente por el trabajo programado de Phes, rechácelo y explíquele que todo el trabajo se factura a través de la oficina." },
+          { en: "If a client asks for additional services outside the scheduled job, refer them to the office. The office books and bills the extra work through Phes.", es: "Si un cliente pide servicios adicionales fuera del trabajo programado, refiéralo a la oficina. La oficina reserva y factura el trabajo adicional a través de Phes." },
+          { en: "Accepting a direct payment is a separate violation: it breaks both the conflict-of-interest rule in the Code of Conduct and the Non-Solicitation Agreement.", es: "Aceptar un pago directo es una violación separada: rompe tanto la regla de conflicto de interés del Código de Conducta como el Acuerdo de No Solicitación." },
+        ],
+      },
+
+      { type: "h", text: { en: "Confidential Trade Secrets (Indefinite)", es: "Secretos Comerciales Confidenciales (Indefinido)" } },
+      {
+        type: "p",
+        text: {
+          en: "Some Phes information you learn on the job is a TRADE SECRET. The agreement asks you not to disclose, use, or transmit that information to anyone outside Phes, both during your employment and indefinitely after you leave. This obligation is governed by the Illinois Trade Secrets Act (765 ILCS 1065) and is scoped narrowly to information that meets that statute's definition of a trade secret. Examples:",
+          es: "Parte de la información de Phes que aprende en el trabajo es un SECRETO COMERCIAL. El acuerdo le pide no divulgar, usar ni transmitir esa información a nadie fuera de Phes, tanto durante su empleo como indefinidamente después de irse. Esta obligación se rige por la Ley de Secretos Comerciales de Illinois (765 ILCS 1065) y tiene un alcance estrecho a la información que cumple la definición de secreto comercial bajo esa ley. Ejemplos:",
+        },
+      },
+      {
+        type: "bullets",
+        items: [
+          { en: "The Phes client list and any associated client contact information.", es: "La lista de clientes de Phes y cualquier información de contacto del cliente asociada." },
+          { en: "Phes pricing structures, pricing rules, and quote formulas.", es: "Las estructuras de precios, reglas de precios y fórmulas de cotización de Phes." },
+          { en: "Internal cleaning procedures, checklists, and quality-control practices documented as proprietary.", es: "Procedimientos internos de limpieza, listas de verificación y prácticas de control de calidad documentadas como propietarias." },
+          { en: "Vendor and supplier relationships and the pricing terms negotiated with vendors.", es: "Las relaciones con proveedores y los términos de precios negociados con ellos." },
+          { en: "Route information and internal operational schedules.", es: "Información de rutas y horarios operativos internos." },
+          { en: "The Qleno platform's non-public features, internal business strategy, and financial projections disclosed to you because of your job.", es: "Las funciones no públicas de la plataforma Qleno, la estrategia comercial interna y las proyecciones financieras que se le hayan divulgado por su trabajo." },
+        ],
+      },
+      {
+        type: "callout",
+        tone: "info",
+        text: {
+          en: "Importantly: this confidentiality obligation does NOT restrict your general knowledge, skill, or experience acquired during your employment, and it does NOT restrict your federally protected Section 7 right under the National Labor Relations Act to discuss your own pay, hours, schedule, or working conditions. It is narrowly aimed at Phes trade secrets, not at general experience or protected concerted activity.",
+          es: "Importante: esta obligación de confidencialidad NO restringe su conocimiento general, habilidad o experiencia adquiridos durante su empleo, y NO restringe su derecho federalmente protegido bajo la Sección 7 de la Ley Nacional de Relaciones Laborales a discutir su propio pago, horas, horario o condiciones laborales. Apunta de forma estrecha a los secretos comerciales de Phes, no a la experiencia general ni a la actividad concertada protegida.",
+        },
+      },
+
+      { type: "h", text: { en: "Express Reasonableness Acknowledgment", es: "Reconocimiento Expreso de Razonabilidad" } },
+      {
+        type: "p",
+        text: {
+          en: "By signing the agreement, you expressly acknowledge that the twelve-month duration, the clients-only scope, the inbound-contact carve-out, and the absence of any geographic territory restriction together make the agreement reasonable and necessary to protect Phes's legitimate business interests in client relationships and confidential information, and that the consideration Phes provides (paid training, scheduled shifts, paid time off, holiday pay, and the benefits described in the Compensation module) is adequate.",
+          es: "Al firmar el acuerdo, usted reconoce expresamente que la duración de doce meses, el alcance limitado a clientes, la exclusión de contacto iniciado por el cliente y la ausencia de cualquier restricción de territorio geográfico hacen, en conjunto, que el acuerdo sea razonable y necesario para proteger los intereses comerciales legítimos de Phes en las relaciones con los clientes y en la información confidencial, y que la consideración que Phes provee (capacitación pagada, turnos programados, tiempo libre pagado, pago por feriados y los beneficios descritos en el módulo de Compensación) es adecuada.",
+        },
+      },
+
       {
         type: "callout",
         tone: "info",
@@ -4880,6 +4934,51 @@ const BASE_QUIZ: QuizQuestion[] = [
       { en: "Yes. The inbound-contact carve-out applies: the client contacted you first, without you having approached them or done anything to invite the contact. You may discuss work with them.", es: "Sí. Aplica la exclusión de contacto iniciado por el cliente: el cliente lo contactó primero, sin que usted lo hubiera buscado ni hecho nada para invitar el contacto. Puede discutir el trabajo con él." },
       { en: "Only if you charge less than Phes.", es: "Solo si cobra menos que Phes." },
       { en: "Only after consulting an attorney.", es: "Solo después de consultar a un abogado." },
+    ],
+    correctIndex: 1,
+  },
+  {
+    id: "q-ns-11-direct-payment-prohibition",
+    moduleId: "non-solicitation",
+    prompt: {
+      en: "At the end of a scheduled Phes job, a happy client offers to pay you $50 in cash directly so the office \"doesn't take a cut.\" What does the Non-Solicitation Agreement require you to do?",
+      es: "Al final de un trabajo programado de Phes, un cliente satisfecho le ofrece pagarle $50 en efectivo directamente para que la oficina \"no se quede con un porcentaje.\" ¿Qué requiere el Acuerdo de No Solicitación que haga?",
+    },
+    options: [
+      { en: "Accept it because the office didn't book this part.", es: "Aceptarlo porque la oficina no reservó esta parte." },
+      { en: "Decline the direct payment. All scheduled cleaning work for a Phes client must be booked through the office and billed by Phes. Customary cash tips noted on the Worksheet are still allowed; substituting a direct payment for billed work is not.", es: "Rechazar el pago directo. Todo trabajo de limpieza programado para un cliente de Phes debe reservarse a través de la oficina y ser facturado por Phes. Las propinas en efectivo de costumbre anotadas en la Hoja de Trabajo siguen permitidas; sustituir un pago directo por trabajo facturado no lo está." },
+      { en: "Accept it if you split it with the office afterward.", es: "Aceptarlo si lo comparte con la oficina después." },
+      { en: "Accept it only on Fridays.", es: "Aceptarlo solo los viernes." },
+    ],
+    correctIndex: 1,
+  },
+  {
+    id: "q-ns-12-trade-secret-confidentiality",
+    moduleId: "non-solicitation",
+    prompt: {
+      en: "Two years after leaving Phes, you publish a blog post that lists Phes's specific pricing rules and quote formulas that you learned on the job. Is this a violation of the agreement?",
+      es: "Dos años después de irse de Phes, publica un artículo de blog que enumera las reglas de precios y fórmulas de cotización específicas de Phes que aprendió en el trabajo. ¿Esto es una violación del acuerdo?",
+    },
+    options: [
+      { en: "No, because you no longer work at Phes.", es: "No, porque ya no trabaja en Phes." },
+      { en: "Yes. Phes pricing structures, pricing rules, and quote formulas are trade secrets under the Illinois Trade Secrets Act (765 ILCS 1065). The confidentiality obligation under Section 13 runs indefinitely and applies to disclosure outside Phes.", es: "Sí. Las estructuras de precios, reglas de precios y fórmulas de cotización de Phes son secretos comerciales bajo la Ley de Secretos Comerciales de Illinois (765 ILCS 1065). La obligación de confidencialidad bajo la Sección 13 corre indefinidamente y aplica a la divulgación fuera de Phes." },
+      { en: "Only if the blog post names a specific client.", es: "Solo si el artículo nombra a un cliente específico." },
+      { en: "Only if Phes paid for the blog hosting.", es: "Solo si Phes pagó el alojamiento del blog." },
+    ],
+    correctIndex: 1,
+  },
+  {
+    id: "q-ns-13-trade-secret-vs-section-7",
+    moduleId: "non-solicitation",
+    prompt: {
+      en: "After leaving Phes, you tweet about how much Phes pays cleaning techs and tag two former coworkers asking what they thought of the pay. The post does not mention any client list, pricing rules, or internal procedures. Is this a violation of the indefinite confidentiality obligation?",
+      es: "Después de irse de Phes, tuitea sobre cuánto paga Phes a los técnicos de limpieza y etiqueta a dos antiguos compañeros preguntando qué pensaban del pago. La publicación no menciona ninguna lista de clientes, reglas de precios ni procedimientos internos. ¿Es una violación de la obligación de confidencialidad indefinida?",
+    },
+    options: [
+      { en: "Yes. Anything about Phes is confidential forever.", es: "Sí. Cualquier cosa sobre Phes es confidencial para siempre." },
+      { en: "No. The confidentiality clause is scoped to trade secrets under the Illinois Trade Secrets Act and does NOT restrict discussion of your own pay, hours, schedule, or working conditions, which is separately protected under Section 7 of the National Labor Relations Act.", es: "No. La cláusula de confidencialidad tiene un alcance limitado a los secretos comerciales bajo la Ley de Secretos Comerciales de Illinois y NO restringe la discusión de su propio pago, horas, horario o condiciones laborales, lo cual está separadamente protegido bajo la Sección 7 de la Ley Nacional de Relaciones Laborales." },
+      { en: "Yes, because you tagged coworkers.", es: "Sí, porque etiquetó a compañeros." },
+      { en: "Only if a current Phes employee likes the post.", es: "Solo si un empleado actual de Phes le da like." },
     ],
     correctIndex: 1,
   },

--- a/lib/lms-curriculum/src/index.ts
+++ b/lib/lms-curriculum/src/index.ts
@@ -436,6 +436,12 @@ export const ANSWER_KEY: Readonly<Record<string, number>> = Object.freeze({
   "q-ns-08-remedy-injunctive": 1,
   "q-ns-09-co-signature": 1,
   "q-ns-10-inbound-clients-exception": 1,
+  // Phase 6.5 amendment (post-PR #7): added q-ns-11/12/13 to verify
+  // comprehension of the new direct-payment prohibition (Section 12)
+  // and trade-secret confidentiality (Section 13).
+  "q-ns-11-direct-payment-prohibition": 1,
+  "q-ns-12-trade-secret-confidentiality": 1,
+  "q-ns-13-trade-secret-vs-section-7": 1,
 
   // ── Module 11: social-media (10, Phase 7 PR #8) ─────────────────────────
   // Phes Social Media Policy. NOT co-signed. Critical NLRA Section 7
@@ -565,6 +571,9 @@ export const QUESTIONS_BY_MODULE: Readonly<Record<QuizModuleId, readonly string[
       "q-ns-05-il-freedom-to-work", "q-ns-06-during-employment-too",
       "q-ns-07-consideration", "q-ns-08-remedy-injunctive",
       "q-ns-09-co-signature", "q-ns-10-inbound-clients-exception",
+      "q-ns-11-direct-payment-prohibition",
+      "q-ns-12-trade-secret-confidentiality",
+      "q-ns-13-trade-secret-vs-section-7",
     ],
     "social-media": [
       "q-sm-01-client-confidentiality", "q-sm-02-nlra-section-7",

--- a/lib/training/src/answer-key.ts
+++ b/lib/training/src/answer-key.ts
@@ -200,6 +200,10 @@ export const SERVER_ANSWER_KEY: Readonly<Record<string, number>> = Object.freeze
   "q-ns-08-remedy-injunctive": 1,
   "q-ns-09-co-signature": 1,
   "q-ns-10-inbound-clients-exception": 1,
+  // Phase 6.5 amendment — added q-ns-11/12/13.
+  "q-ns-11-direct-payment-prohibition": 1,
+  "q-ns-12-trade-secret-confidentiality": 1,
+  "q-ns-13-trade-secret-vs-section-7": 1,
 
   // ── Module 11: social-media (10, Phase 7 PR #8) ────────────────────────
   "q-sm-01-client-confidentiality": 1,


### PR DESCRIPTION
## Phase 6.5: Non-Solicitation Amendment (follow-up to PR #7 / #93)

Amends the merged Phes Non-Solicitation Agreement with **three additions that strengthen the agreement without putting Illinois enforceability at risk**. This is a small, surgical follow-up — not a rewrite of PR #93.

**DO NOT auto-merge.** Non-solicitation is one of the four legally-weighted documents — review carefully before approving.

## Why this is an amendment, not a rewrite

A stronger version was discussed that would have added:
1. 12-month coworker non-solicitation
2. $5,000 liquidated damages per violation

Both were **rejected** on Illinois enforceability grounds:

| Rejected item | Illinois risk |
|---------------|---------------|
| Coworker non-solicit | Illinois Freedom to Work Act (820 ILCS 90) makes coworker non-solicits for low-wage hourly workers vulnerable to being struck down. Risk: blue-penciling the **entire** agreement. |
| $5,000 liquidated damages | IL courts **routinely strike** liquidated-damages clauses in hourly-employee non-solicits as unenforceable penalty provisions. |

This amendment therefore adds only the items that don't create enforceability risk.

## What this PR ships

### A. Three new + one strengthened section in `non_solicitation` signed agreement (EN + ES)

| Section | Change | Risk profile |
|---------|--------|--------------|
| **§8 Reasonable Scope** | Strengthened from a bare acknowledgment to **"I expressly acknowledge"** that 12-month duration + clients-only scope + inbound-contact carve-out + no geographic restriction + adequacy of §7 consideration are all reasonable | Defensive — gives Phes an in-document admission to point at if reasonableness is later challenged |
| **§12 Prohibition on Direct Payments from Clients** | New. Employee will not accept direct payments (cash, supply reimbursement, in-kind compensation) from a Phes client for cleaning work that should be billed through Phes. **Customary cash tips noted on the Worksheet remain permitted** | Low — operational rule, consistent with existing Code of Conduct conflict-of-interest |
| **§13 Confidential Trade Secrets (Indefinite Duration)** | New. Indefinite obligation scoped narrowly to the **Illinois Trade Secrets Act (765 ILCS 1065)** definition. Trade secrets enumerated: client list + contact info, pricing structures + quote formulas, internal procedures, vendor pricing, route information, Qleno non-public features | Low — IL Trade Secrets Act expressly permits indefinite trade-secret protection. **Critical carve-outs included** for (a) employee's general knowledge/skill/experience, and (b) NLRA Section 7 right to discuss pay/hours/working conditions |
| §14 At-Will Employment | Renumbered from §12 | None |
| §15 Electronic Signature Consent | Renumbered from §13 | None |

Cross-reference in §11 still references "§7 consideration" — unchanged.

### B. What this PR INTENTIONALLY does NOT change

- **Coworker non-solicit**: still explicitly carved OUT in §3 (`COWORKERS ARE NOT RESTRICTED`). Test enforces this.
- **Liquidated damages**: still explicitly disclaimed in §9 (`Phes does not impose liquidated damages or penalty clauses`). Test enforces this.
- **12-month duration**: unchanged.
- **Phes Representative co-signature**: unchanged. Admin Co-sign UI picks up new version automatically.
- **Spanish `pendingTranslationReview`**: still `true` (one of the four flagged docs for human translator review).
- **Hard-gate behavior**: unchanged. `/quiz/submit` for `FINAL_MODULE_ID` still rejects when `non_solicitation` is unsigned.

### C. Version registry behavior

The amended `contentHtml` hashes to a new `version_hash`. The existing `getOrCreateDocumentVersion` helper auto-registers the new `lms_document_versions` row the next time anyone signs. Employees who signed v1 keep their v1 signature (still legally valid for what it covered); new signers sign v2. No `is_material` flag is set, so no forced re-acknowledgment sweep fires — the amendment is treated as additive content. If you want forced re-acknowledgment of v1 signers (relevant once Jose is enrolled but hasn't signed yet, or for any employees who may have signed during testing), let me know and I can mark v2 material.

### D. Curriculum module body

Three new sections rendered to learners BEFORE the signing step:
- "No Direct Payments From Clients"
- "Confidential Trade Secrets (Indefinite)" — with the NLRA Section 7 carve-out called out as a green-tone callout
- "Express Reasonableness Acknowledgment"

### E. Quiz coverage

Three new questions (`q-ns-11`, `q-ns-12`, `q-ns-13`):
- **q-ns-11-direct-payment-prohibition**: scenario at end of a Phes shift; tip-vs-direct-payment distinction
- **q-ns-12-trade-secret-confidentiality**: 2-years-post-leaving blog post enumerating pricing rules; tests that trade-secret obligation runs indefinitely under 765 ILCS 1065
- **q-ns-13-trade-secret-vs-section-7**: ensures employees understand the confidentiality clause does NOT restrict pay/hours/working-condition discussion protected by NLRA Section 7

## Test counts

- `ALL_QUESTION_IDS`: 174 → **177** (40 + 15×5 + 10 + 10 + 9 + 13 + 10 + 10)
- `non-solicitation` module: 10 → **13 questions**
- LMS tests: 174 → **184** (10 new content tests)

New content tests assert: each new section header present in EN and ES, 765 ILCS 1065 citation in both locales (with Spanish translation of the act name), 29 U.S.C. NLRA Section 7 carve-out preserved in Section 13, general-knowledge carve-out preserved, strengthened §8 wording present in both locales, and **explicit regression checks that the coworker non-solicit and liquidated-damages disclaimer are preserved** (so this amendment doesn't accidentally undo the IL-Freedom-to-Work-Act-compliant design).

Vite build clean. tsc-libs (CI `tsc-check`) clean.

## Test plan (manual)

**Learner flow:**
- [ ] Log in as `jose.ardila@phes.io` → `/training` → module #10 "Non-Solicitation Agreement" → read content; verify the new sections render: "No Direct Payments From Clients", "Confidential Trade Secrets (Indefinite)" (with green callout for NLRA Section 7 / general-knowledge carve-outs), "Express Reasonableness Acknowledgment"
- [ ] Take quiz (13 questions now, 80% pass)
- [ ] If not yet signed: SignDocumentView opens with the amended 15-section English text. Toggle to Spanish → translation-review banner still renders (Spanish still flagged)
- [ ] Sign → returns to Home; `lms_document_versions` should contain a NEW row at the amended hash for `(company_id, 'non_solicitation', 'en')` and `(company_id, 'non_solicitation', 'es')`

**Admin co-sign flow:**
- [ ] As Sal (owner): `/lms/admin` → expand Jose → Co-sign the new signed_document row → PDF renders with 15 sections + employee signature + co-signature block

**Negative paths:**
- [ ] Final exam still gated on non_solicitation signature (unchanged)
- [ ] Admin bypass on non-solicitation quiz: no certificate, no signed_document row, audit log shows `source: "admin_bypass"` (unchanged)

https://claude.ai/code/session_013rJ4N4vgqZWB986x8D6Ahh

---
_Generated by [Claude Code](https://claude.ai/code/session_013rJ4N4vgqZWB986x8D6Ahh)_