### PR TITLE
lms: Phase 9 supply kit responsibility module + signed ack (PR #10 of 16)

### DIFF
--- a/artifacts/api-server/src/lib/lms-curriculum-titles.ts
+++ b/artifacts/api-server/src/lib/lms-curriculum-titles.ts
@@ -72,6 +72,10 @@ const MODULE_TITLES: Record<string, BilingualTitle> = {
     en: "Phes 401(k) Retirement Plan",
     es: "Plan de Jubilación 401(k) de Phes",
   },
+  "supply-kit": {
+    en: "Supply Kit Responsibility",
+    es: "Responsabilidad del Kit de Suministros",
+  },
   acknowledgment: {
     en: "Onboarding Acknowledgment",
     es: "Confirmación de Incorporación",

--- a/artifacts/api-server/src/lib/lms-signed-documents-content.ts
+++ b/artifacts/api-server/src/lib/lms-signed-documents-content.ts
@@ -657,6 +657,121 @@ const SOCIAL_MEDIA_ES: SignedDocumentLocaleContent = {
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
+// supply_kit (Phase 9, PR #10)
+//
+// One-sided employee acknowledgment (NOT co-signed). Establishes
+// responsibility for Phes-provided cleaning supplies, uniform, keys,
+// and assigned hardware. Reasonable wear is on Phes; negligent damage
+// may be billed. CRITICAL: does NOT pre-authorize automatic payroll
+// deductions. Illinois Wage Payment and Collection Act (820 ILCS 115)
+// requires contemporaneous written authorization for any specific
+// deduction; this agreement explains that and reserves Phes's right
+// to seek reimbursement through other lawful channels.
+//
+// NOT in the four flagged docs for human translator review.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const SUPPLY_KIT_EN: SignedDocumentLocaleContent = {
+  title: "Supply Kit Responsibility Acknowledgment",
+  contentHtml: [
+    "PHES CLEANING SERVICES",
+    "SUPPLY KIT RESPONSIBILITY ACKNOWLEDGMENT",
+    "Effective Date: January 1, 2026",
+    "",
+    "By signing this acknowledgment, I confirm that I have read and understand the Phes Supply Kit Responsibility Policy contained in the 2026 Phes Employee Handbook and the Supply Kit training module. I commit to the following terms as a condition of my employment with Phes Cleaning Services:",
+    "",
+    "1. PHES PROPERTY.",
+    "Every item Phes issues to me as part of my supply kit is the property of Phes Cleaning Services and is loaned to me for the duration of my employment. This includes the cleaning caddy, color-coded microfiber cloths, mop and bucket, any assigned vacuum, step stool, Phes-branded refillable chemical bottles and their contents, Phes-branded uniform (shirt, apron, name badge), shoe covers, any assigned Phes phone or tablet, and any client keys, key cards, or alarm-code cards I am issued.",
+    "",
+    "2. REASONABLE CARE.",
+    "I will exercise reasonable care of the supply kit. I will use the kit only for Phes work, store it safely, and not lend, sell, or transfer any item to anyone outside Phes.",
+    "",
+    "3. REASONABLE WEAR VERSUS NEGLIGENT DAMAGE.",
+    "I understand that REASONABLE WEAR AND TEAR from using the kit as intended (microfiber fraying, belt wear, uniform fading, mop heads needing replacement) is absorbed by Phes at no cost to me. NEGLIGENT DAMAGE OR LOSS (leaving equipment in the rain, lending the Phes phone, losing a client key while running personal errands, accident in a Phes vehicle off the clock) is different and may result in Phes billing me for replacement.",
+    "",
+    "4. PROMPT REPORTING.",
+    "If anything in my kit is damaged, lost, or stops working, I will report it to the office BEFORE my next shift. I understand that Phes can resolve almost any honestly reported issue and that covering up damage or loss is itself a violation of this Agreement and of the Code of Conduct.",
+    "",
+    "5. LOST CLIENT KEY OR ACCESS CARD.",
+    "If I lose a client's key, key card, or alarm-code card, I will call the office IMMEDIATELY rather than waiting until the end of my shift. Phes will arrange a rekey or code change with the client and pay for it. The lost key itself is not grounds for discipline; covering it up or delaying the report is.",
+    "",
+    "6. NO PERSONAL USE.",
+    "I will not use Phes supplies, equipment, vehicle, or uniform for personal work (cleaning my own home or a friend's home, side-gig work, or any other non-Phes purpose). I will not lend Phes property to anyone, including coworkers off the clock.",
+    "",
+    "7. NO MODIFICATIONS.",
+    "I will not modify or alter Phes equipment. I will not buy substitute cleaning chemicals on my own initiative. If a Phes-issued item is not working, I will ask the office for a replacement rather than swapping in something I obtained myself.",
+    "",
+    "8. UNIFORM CARE.",
+    "I will wash the Phes uniform shirt and apron after each shift. I will not alter the uniform with paint, embroidery, or unofficial patches. If I need a religious or medical accommodation related to the uniform, I will request it through the office accommodation process.",
+    "",
+    "9. RETURN OF PHES PROPERTY AT SEPARATION.",
+    "On or before my last day of employment with Phes (voluntary or involuntary), I will return ALL Phes property to the office: caddy, vacuum, supplies in their Phes-branded bottles, any Phes phone or tablet, all client keys and access cards, the uniform shirt and apron, and any other Phes-issued item. Phes will inspect the returned items and apply the reasonable-wear-versus-negligent-damage standard described in Section 3.",
+    "",
+    "10. ILLINOIS WAGE PAYMENT AND COLLECTION ACT (NO AUTOMATIC PAYROLL DEDUCTION).",
+    "I understand that signing this Agreement does NOT pre-authorize Phes to take any deduction from my paycheck for damaged or unreturned property. Under the Illinois Wage Payment and Collection Act, 820 ILCS 115, any specific deduction from my wages requires a separate written authorization signed by me AT THE TIME OF THE DEDUCTION, for that specific deduction. If Phes determines that a damaged or unreturned item must be replaced and that the cost may be billed to me, Phes will notify me in writing with the documented cost. If I agree to repayment, Phes and I will sign a separate written authorization before any amount is taken from my paycheck. If I do not agree to repayment, Phes may seek reimbursement through other lawful channels but will not unilaterally deduct from my paycheck.",
+    "",
+    "11. AT-WILL EMPLOYMENT.",
+    "Nothing in this acknowledgment alters my at-will employment status with Phes. Phes may terminate my employment at any time, with or without cause or notice, for any lawful reason.",
+    "",
+    "12. ELECTRONIC SIGNATURE CONSENT.",
+    "I consent to sign this acknowledgment electronically. I understand that my electronic signature has the same legal effect as a handwritten signature, in accordance with the federal Electronic Signatures in Global and National Commerce Act (E-SIGN) and the Illinois Uniform Electronic Transactions Act (UETA).",
+    "",
+    "By typing or drawing my signature below and clicking the I Agree button, I affirm that I have read, understood, and accept this Supply Kit Responsibility Acknowledgment.",
+  ].join("\n"),
+  notes: "Phase 9 PR #10 — Phes supply-kit responsibility acknowledgment. IL Wage Payment and Collection Act compliant (no automatic payroll deduction pre-authorization).",
+};
+
+const SUPPLY_KIT_ES: SignedDocumentLocaleContent = {
+  title: "Reconocimiento de Responsabilidad del Kit de Suministros",
+  contentHtml: [
+    "PHES CLEANING SERVICES",
+    "RECONOCIMIENTO DE RESPONSABILIDAD DEL KIT DE SUMINISTROS",
+    "Fecha Efectiva: 1 de enero de 2026",
+    "",
+    "Al firmar este reconocimiento, confirmo que he leído y entiendo la Política de Responsabilidad del Kit de Suministros de Phes contenida en el Manual del Empleado de Phes 2026 y en el módulo de capacitación del Kit de Suministros. Me comprometo a los siguientes términos como condición de mi empleo con Phes Cleaning Services:",
+    "",
+    "1. PROPIEDAD DE PHES.",
+    "Cada artículo que Phes me entrega como parte de mi kit de suministros es propiedad de Phes Cleaning Services y se me presta durante el tiempo de mi empleo. Esto incluye el caddy de limpieza, paños de microfibra codificados por color, trapeador y cubeta, cualquier aspiradora asignada, banquito, botellas recargables con marca de Phes y su contenido, uniforme con marca de Phes (camisa, delantal, gafete), cubre-zapatos, cualquier teléfono o tableta de Phes asignado, y cualquier llave, tarjeta de acceso o tarjeta de código de alarma del cliente que se me entregue.",
+    "",
+    "2. CUIDADO RAZONABLE.",
+    "Ejerceré el cuidado razonable del kit de suministros. Usaré el kit solo para trabajo de Phes, lo almacenaré con seguridad y no prestaré, venderé ni transferiré ningún artículo a nadie fuera de Phes.",
+    "",
+    "3. DESGASTE RAZONABLE FRENTE A DAÑO POR NEGLIGENCIA.",
+    "Entiendo que el DESGASTE Y USO RAZONABLE por usar el kit como se pretende (microfibras que se deshilachan, desgaste de bandas, uniforme que se desvanece, cabezas de trapeador que necesitan reemplazo) lo absorbe Phes sin costo para mí. El DAÑO POR NEGLIGENCIA O LA PÉRDIDA (dejar equipo en la lluvia, prestar el teléfono de Phes, perder la llave de un cliente mientras hago mandados personales, accidente en un vehículo de Phes fuera del horario) es distinto y puede resultar en que Phes me facture el reemplazo.",
+    "",
+    "4. REPORTE PRONTO.",
+    "Si algo en mi kit se daña, se pierde o deja de funcionar, lo reportaré a la oficina ANTES de mi siguiente turno. Entiendo que Phes puede resolver casi cualquier asunto reportado honestamente y que ocultar daños o pérdidas es en sí una violación de este Acuerdo y del Código de Conducta.",
+    "",
+    "5. LLAVE O TARJETA DE ACCESO DE CLIENTE PERDIDA.",
+    "Si pierdo la llave de un cliente, una tarjeta de acceso o una tarjeta de código de alarma, llamaré INMEDIATAMENTE a la oficina en lugar de esperar al final de mi turno. Phes coordinará un cambio de cerradura o de código con el cliente y lo pagará. La llave perdida en sí no es motivo de disciplina; ocultarlo o retrasar el reporte sí lo es.",
+    "",
+    "6. SIN USO PERSONAL.",
+    "No usaré los suministros, el equipo, el vehículo ni el uniforme de Phes para trabajo personal (limpiar mi propia casa o la casa de un amigo, trabajo paralelo o cualquier otro propósito no relacionado con Phes). No prestaré la propiedad de Phes a nadie, incluyendo compañeros fuera del turno.",
+    "",
+    "7. SIN MODIFICACIONES.",
+    "No modificaré ni alteraré el equipo de Phes. No compraré productos químicos de limpieza sustitutos por mi propia iniciativa. Si un artículo emitido por Phes no funciona, pediré a la oficina un reemplazo en lugar de cambiarlo por algo que yo haya obtenido.",
+    "",
+    "8. CUIDADO DEL UNIFORME.",
+    "Lavaré la camisa y el delantal del uniforme de Phes después de cada turno. No alteraré el uniforme con pintura, bordado ni parches no oficiales. Si necesito una acomodación religiosa o médica relacionada con el uniforme, la solicitaré a través del proceso de acomodación de la oficina.",
+    "",
+    "9. DEVOLUCIÓN DE LA PROPIEDAD DE PHES AL SEPARARSE.",
+    "En o antes de mi último día de empleo con Phes (voluntario o involuntario), devolveré TODA la propiedad de Phes a la oficina: caddy, aspiradora, suministros en sus botellas con marca de Phes, cualquier teléfono o tableta de Phes, todas las llaves y tarjetas de acceso de clientes, la camisa y el delantal del uniforme, y cualquier otro artículo emitido por Phes. Phes inspeccionará los artículos devueltos y aplicará el estándar de desgaste razonable frente a daño por negligencia descrito en la Sección 3.",
+    "",
+    "10. LEY DE PAGO DE SALARIOS Y RECOLECCIÓN DE ILLINOIS (SIN DEDUCCIÓN AUTOMÁTICA DE NÓMINA).",
+    "Entiendo que firmar este Acuerdo NO pre-autoriza a Phes a tomar ninguna deducción de mi pago por propiedad dañada o no devuelta. Bajo la Ley de Pago de Salarios y Recolección de Illinois, 820 ILCS 115, cualquier deducción específica de mis salarios requiere una autorización escrita separada firmada por mí AL MOMENTO DE LA DEDUCCIÓN, para esa deducción específica. Si Phes determina que un artículo dañado o no devuelto debe ser reemplazado y que el costo se me puede facturar, Phes me notificará por escrito con el costo documentado. Si acepto el pago, Phes y yo firmaremos una autorización escrita separada antes de que se tome cualquier monto de mi pago. Si no acepto el pago, Phes puede buscar el reembolso a través de otras vías legales, pero no deducirá unilateralmente de mi pago.",
+    "",
+    "11. EMPLEO A VOLUNTAD.",
+    "Nada en este reconocimiento altera mi estatus de empleo a voluntad con Phes. Phes puede terminar mi empleo en cualquier momento, con o sin causa o aviso, por cualquier razón legal.",
+    "",
+    "12. CONSENTIMIENTO DE FIRMA ELECTRÓNICA.",
+    "Doy mi consentimiento para firmar este reconocimiento electrónicamente. Entiendo que mi firma electrónica tiene el mismo efecto legal que una firma manuscrita, conforme a la Ley federal de Firmas Electrónicas en el Comercio Global y Nacional (E-SIGN) y a la Ley Uniforme de Transacciones Electrónicas de Illinois (UETA).",
+    "",
+    "Al escribir o dibujar mi firma a continuación y hacer clic en el botón Acepto, afirmo que he leído, entendido y aceptado este Reconocimiento de Responsabilidad del Kit de Suministros.",
+  ].join("\n"),
+  notes: "Phase 9 PR #10 — Phes supply-kit responsibility, Spanish version. Not in the four flagged docs.",
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Registry
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -681,7 +796,12 @@ export const SIGNED_DOCUMENT_CONTENT: SignedDocumentRegistry = {
     en: SOCIAL_MEDIA_EN,
     es: SOCIAL_MEDIA_ES,
   },
-  // PR #10 will add: supply_kit. Same shape, same conventions.
+  supply_kit: {
+    en: SUPPLY_KIT_EN,
+    es: SUPPLY_KIT_ES,
+  },
+  // All standalone signed-doc registry entries land in PR #10 (this PR).
+  // PR #13 will add: handbook (final comprehensive signed handbook PDF).
 };
 
 /**

--- a/artifacts/api-server/src/tests/lms-curriculum.test.ts
+++ b/artifacts/api-server/src/tests/lms-curriculum.test.ts
@@ -33,7 +33,7 @@ import {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("LMS curriculum — constants & catalog shape", () => {
-  it("MODULE_ORDER has all 13 modules in expected sequence (phes-401k added 2026-05-13 Phase 8)", () => {
+  it("MODULE_ORDER has all 14 modules in expected sequence (supply-kit added 2026-05-13 Phase 9)", () => {
     assert.deepEqual([...MODULE_ORDER], [
       "phes-policies",
       "compensation",
@@ -47,11 +47,12 @@ describe("LMS curriculum — constants & catalog shape", () => {
       "non-solicitation",
       "social-media",
       "phes-401k",
+      "supply-kit",
       "acknowledgment",
     ]);
   });
 
-  it("QUIZ_MODULE_IDS contains exactly the 12 quiz modules (no acknowledgment)", () => {
+  it("QUIZ_MODULE_IDS contains exactly the 13 quiz modules (no acknowledgment)", () => {
     assert.deepEqual([...QUIZ_MODULE_IDS], [
       "phes-policies",
       "compensation",
@@ -65,6 +66,7 @@ describe("LMS curriculum — constants & catalog shape", () => {
       "non-solicitation",
       "social-media",
       "phes-401k",
+      "supply-kit",
     ]);
   });
 
@@ -107,6 +109,7 @@ describe("LMS curriculum — constants & catalog shape", () => {
     //   q-ns-13 trade-secret-vs-Section-7)
     // social-media: 10 (Phase 7 spec, NLRA Section 7 + carve-out comprehension)
     // phes-401k: 10 (Phase 8 spec, 401(k) plan-features comprehension)
+    // supply-kit: 10 (Phase 9 spec, IL Wage Payment + responsibility)
     // all others: 15 (per original Phes spec)
     const expected: Record<string, number> = {
       "phes-policies": 40,
@@ -116,6 +119,7 @@ describe("LMS curriculum — constants & catalog shape", () => {
       "non-solicitation": 13,
       "social-media": 10,
       "phes-401k": 10,
+      "supply-kit": 10,
       compensation: 15,
       "cleaning-best-practices": 15,
       maidcentral: 15,
@@ -131,8 +135,8 @@ describe("LMS curriculum — constants & catalog shape", () => {
     }
   });
 
-  it("ALL_QUESTION_IDS is 177 total (40 + 15*5 + 10 + 10 + 9 + 13 + 10 + 10)", () => {
-    assert.equal(ALL_QUESTION_IDS.length, 177);
+  it("ALL_QUESTION_IDS is 187 total (40 + 15*5 + 10 + 10 + 9 + 13 + 10 + 10 + 10)", () => {
+    assert.equal(ALL_QUESTION_IDS.length, 187);
   });
 
   it("ANSWER_KEY has exactly the keys enumerated by ALL_QUESTION_IDS", () => {

--- a/artifacts/api-server/src/tests/lms-signed-documents.test.ts
+++ b/artifacts/api-server/src/tests/lms-signed-documents.test.ts
@@ -55,6 +55,12 @@ describe("SIGNED_DOCUMENT_CONTENT registry", () => {
     assert.ok(SIGNED_DOCUMENT_CONTENT.social_media!.es);
   });
 
+  it("includes supply_kit (Phase 9 PR #10)", () => {
+    assert.ok(SIGNED_DOCUMENT_CONTENT.supply_kit);
+    assert.ok(SIGNED_DOCUMENT_CONTENT.supply_kit!.en);
+    assert.ok(SIGNED_DOCUMENT_CONTENT.supply_kit!.es);
+  });
+
   it("every registered document has BOTH en and es entries", () => {
     for (const [type, entry] of Object.entries(SIGNED_DOCUMENT_CONTENT)) {
       assert.ok(entry?.en?.contentHtml, `${type}: missing en.contentHtml`);
@@ -166,6 +172,99 @@ describe("listRegisteredDocumentTypes", () => {
 
   it("includes social_media after PR #8", () => {
     assert.ok(listRegisteredDocumentTypes().includes("social_media"));
+  });
+
+  it("includes supply_kit after PR #10", () => {
+    assert.ok(listRegisteredDocumentTypes().includes("supply_kit"));
+  });
+});
+
+describe("supply_kit content shape (PR #10 spec checks)", () => {
+  it("English entry is NOT flagged pendingTranslationReview", () => {
+    assert.equal(
+      SIGNED_DOCUMENT_CONTENT.supply_kit!.en.pendingTranslationReview ?? false,
+      false,
+    );
+  });
+
+  it("Spanish entry is NOT flagged pendingTranslationReview (not one of the four flagged docs)", () => {
+    assert.equal(
+      SIGNED_DOCUMENT_CONTENT.supply_kit!.es.pendingTranslationReview ?? false,
+      false,
+    );
+    assert.equal(isSpanishPendingTranslationReview("supply_kit"), false);
+  });
+
+  it("English Section 10 cites the Illinois Wage Payment and Collection Act (820 ILCS 115) and explicitly says signing does NOT pre-authorize automatic deductions", () => {
+    const en = SIGNED_DOCUMENT_CONTENT.supply_kit!.en.contentHtml;
+    assert.ok(
+      en.includes("Illinois Wage Payment and Collection Act"),
+      "English must reference the Illinois Wage Payment and Collection Act",
+    );
+    assert.ok(
+      en.includes("820 ILCS 115"),
+      "English must include the 820 ILCS 115 citation",
+    );
+    assert.ok(
+      en.includes("does NOT pre-authorize"),
+      "English must explicitly state signing does NOT pre-authorize automatic payroll deductions",
+    );
+    assert.ok(
+      en.includes("separate written authorization"),
+      "English must reference the required separate written authorization at time of any specific deduction",
+    );
+  });
+
+  it("Spanish Section 10 cites 820 ILCS 115 with Spanish act name and explains no automatic deduction", () => {
+    const es = SIGNED_DOCUMENT_CONTENT.supply_kit!.es.contentHtml;
+    assert.ok(
+      es.includes("Ley de Pago de Salarios y Recolección de Illinois"),
+      "Spanish must reference the IL Wage Payment and Collection Act translation",
+    );
+    assert.ok(
+      es.includes("820 ILCS 115"),
+      "Spanish must include the 820 ILCS 115 citation",
+    );
+    assert.ok(
+      es.includes("NO pre-autoriza"),
+      "Spanish must explicitly state signing does NOT pre-authorize deductions",
+    );
+  });
+
+  it("English content distinguishes reasonable wear from negligent damage", () => {
+    const en = SIGNED_DOCUMENT_CONTENT.supply_kit!.en.contentHtml;
+    assert.ok(
+      en.includes("REASONABLE WEAR AND TEAR"),
+      "English must call out reasonable wear and tear",
+    );
+    assert.ok(
+      en.includes("NEGLIGENT DAMAGE"),
+      "English must call out negligent damage",
+    );
+  });
+
+  it("English content requires return of ALL Phes property at separation", () => {
+    const en = SIGNED_DOCUMENT_CONTENT.supply_kit!.en.contentHtml;
+    assert.ok(
+      en.includes("return ALL Phes property"),
+      "English must require return of ALL Phes property at separation",
+    );
+  });
+
+  it("English content prohibits personal use of Phes supplies/equipment/vehicle/uniform", () => {
+    const en = SIGNED_DOCUMENT_CONTENT.supply_kit!.en.contentHtml;
+    assert.ok(
+      en.includes("NO PERSONAL USE"),
+      "English must include the no-personal-use section header",
+    );
+  });
+
+  it("English and Spanish content hash to DIFFERENT version hashes (legally distinct)", () => {
+    const en = SIGNED_DOCUMENT_CONTENT.supply_kit!.en.contentHtml;
+    const es = SIGNED_DOCUMENT_CONTENT.supply_kit!.es.contentHtml;
+    const hEn = hashContent(en, "en");
+    const hEs = hashContent(es, "es");
+    assert.notEqual(hEn, hEs);
   });
 });
 

--- a/artifacts/qleno/src/lib/training/curriculum.ts
+++ b/artifacts/qleno/src/lib/training/curriculum.ts
@@ -5499,7 +5499,7 @@ const BASE_QUIZ: QuizQuestion[] = [
       es: "Sus paños de microfibra se deshilachan después de varios meses de uso regular. ¿Es responsable del costo de reemplazo?",
     },
     options: [
-      { en: "Yes — anything that wears out is on you.", es: "Sí — cualquier cosa que se desgaste es responsabilidad suya." },
+      { en: "Yes, anything that wears out is on you.", es: "Sí, cualquier cosa que se desgaste es responsabilidad suya." },
       { en: "No. Reasonable wear and tear from using equipment as intended is absorbed by Phes. Negligent damage or loss is different.", es: "No. El desgaste razonable por usar el equipo como se pretende es absorbido por Phes. El daño por negligencia o la pérdida es distinto." },
       { en: "Only if a client complains.", es: "Solo si un cliente se queja." },
       { en: "Only if you have been at Phes less than one year.", es: "Solo si lleva menos de un año en Phes." },

--- a/artifacts/qleno/src/lib/training/curriculum.ts
+++ b/artifacts/qleno/src/lib/training/curriculum.ts
@@ -2799,6 +2799,188 @@ const BASE_MODULES: Module[] = [
       },
     ],
   },
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // 13. SUPPLY KIT RESPONSIBILITY (Phase 9, PR #10)
+  // ═══════════════════════════════════════════════════════════════════════════
+  //
+  // One-sided employee acknowledgment (NOT co-signed). Establishes
+  // responsibility for Phes-provided cleaning supplies, uniform, keys,
+  // alarm codes, and any assigned hardware. Distinguishes reasonable
+  // wear-and-tear (Phes absorbs) from negligent damage or loss
+  // (employee may be billed). Critically: does NOT pre-authorize
+  // automatic payroll deductions — Illinois Wage Payment and Collection
+  // Act (820 ILCS 115) requires contemporaneous written authorization
+  // for any specific deduction, so the agreement reserves Phes's right
+  // to seek reimbursement and explains the IL deduction-authorization
+  // requirement.
+  {
+    id: "supply-kit",
+    number: 13,
+    iconKind: "spray",
+    title: {
+      en: "Supply Kit Responsibility",
+      es: "Responsabilidad del Kit de Suministros",
+    },
+    subtitle: {
+      en: "What Phes gives you to do the job, how to care for it, and what happens if something is lost or damaged through negligence.",
+      es: "Lo que Phes le entrega para hacer el trabajo, cómo cuidarlo, y qué pasa si algo se pierde o daña por negligencia.",
+    },
+    estimatedMinutes: 8,
+    blocks: [
+      {
+        type: "callout",
+        tone: "info",
+        text: {
+          en: "Why this module matters. Phes provides the tools you need to do the job. The supply kit is Phes property loaned to you while you are employed. The agreement is short and practical: take reasonable care of the kit, report damage or loss promptly, return everything at separation. Normal wear is on Phes, not on you. Negligent damage or unreported loss may result in you being billed for replacement.",
+          es: "Por qué importa este módulo. Phes provee las herramientas que necesita para hacer el trabajo. El kit de suministros es propiedad de Phes prestada a usted mientras esté empleado. El acuerdo es corto y práctico: cuide razonablemente el kit, reporte daños o pérdidas a tiempo, devuelva todo al separarse. El desgaste normal está a cargo de Phes, no de usted. Los daños por negligencia o la pérdida no reportada pueden resultar en que se le facture el reemplazo.",
+        },
+      },
+
+      { type: "h", text: { en: "What Is in the Supply Kit", es: "Qué Está en el Kit de Suministros" } },
+      {
+        type: "p",
+        text: {
+          en: "The exact contents of your kit are listed on the Kit Inventory Sheet you receive on your first day. A typical Phes kit includes:",
+          es: "El contenido exacto de su kit está listado en la Hoja de Inventario del Kit que recibe el primer día. Un kit típico de Phes incluye:",
+        },
+      },
+      {
+        type: "bullets",
+        items: [
+          { en: "Cleaning caddy, color-coded microfiber cloths, mop and bucket, vacuum (or vacuum allocation if assigned to a team vehicle), step stool.", es: "Caddy de limpieza, paños de microfibra codificados por color, trapeador y cubeta, aspiradora (o asignación de aspiradora si está asignado a un vehículo de equipo), banquito." },
+          { en: "Cleaning chemicals issued in their Phes-branded refillable bottles. Refills come from the office stock room.", es: "Productos químicos de limpieza entregados en sus botellas recargables con marca de Phes. Las recargas vienen del cuarto de suministros de la oficina." },
+          { en: "Phes-branded uniform (shirt, apron, name badge) and shoe covers.", es: "Uniforme con marca de Phes (camisa, delantal, gafete) y cubre-zapatos." },
+          { en: "Phes phone or tablet (if assigned for MaidCentral / Qleno access), keys, key cards, or alarm-code cards for recurring-visit clients.", es: "Teléfono o tableta de Phes (si se le asigna para acceso a MaidCentral / Qleno), llaves, tarjetas de acceso o tarjetas de códigos de alarma para clientes recurrentes." },
+        ],
+      },
+
+      { type: "h", text: { en: "What Is Phes Property and What Is Yours", es: "Qué es Propiedad de Phes y Qué es Suyo" } },
+      {
+        type: "p",
+        text: {
+          en: "Everything in the kit is PHES PROPERTY. It is loaned to you for the duration of your employment. You do not own any of it. What you DO own:",
+          es: "Todo en el kit es PROPIEDAD DE PHES. Se le presta durante el tiempo de su empleo. Usted no es dueño de nada de eso. Lo que SÍ le pertenece:",
+        },
+      },
+      {
+        type: "bullets",
+        items: [
+          { en: "Tips from clients are yours (recorded on the Worksheet per the handbook).", es: "Las propinas de clientes son suyas (registradas en la Hoja de Trabajo según el manual)." },
+          { en: "Personal items you bring (your phone, your water bottle, your own car).", es: "Artículos personales que traiga (su teléfono, su botella de agua, su propio auto)." },
+          { en: "Your general knowledge, skill, and experience.", es: "Su conocimiento general, habilidad y experiencia." },
+        ],
+      },
+
+      { type: "h", text: { en: "Reasonable Wear vs Negligent Damage", es: "Desgaste Razonable vs Daño por Negligencia" } },
+      {
+        type: "p",
+        text: {
+          en: "Phes absorbs REASONABLE WEAR AND TEAR that comes from using equipment as intended. Examples:",
+          es: "Phes absorbe el DESGASTE Y USO RAZONABLE que viene de usar el equipo como se pretende. Ejemplos:",
+        },
+      },
+      {
+        type: "bullets",
+        items: [
+          { en: "Microfiber cloths fraying after months of use.", es: "Paños de microfibra que se deshilachan después de meses de uso." },
+          { en: "A vacuum belt wearing out from normal cleaning.", es: "Una banda de aspiradora que se desgasta por limpieza normal." },
+          { en: "Uniform fading from regular washing.", es: "Uniforme que se desvanece por el lavado regular." },
+          { en: "A mop head needing replacement after extended use.", es: "Una cabeza de trapeador que necesita reemplazo después de uso prolongado." },
+        ],
+      },
+      {
+        type: "p",
+        text: {
+          en: "NEGLIGENT DAMAGE or LOSS is different. Examples:",
+          es: "El DAÑO POR NEGLIGENCIA o la PÉRDIDA es distinto. Ejemplos:",
+        },
+      },
+      {
+        type: "bullets",
+        items: [
+          { en: "Leaving the vacuum in the rain in a client driveway, ruining it.", es: "Dejar la aspiradora en la lluvia en la entrada de un cliente, arruinándola." },
+          { en: "Loaning the Phes phone to a friend and it not coming back.", es: "Prestar el teléfono de Phes a un amigo y que no regrese." },
+          { en: "Losing a client's house key because it was off your keyring while you ran personal errands.", es: "Perder la llave de la casa de un cliente porque no estaba en su llavero mientras hacía mandados personales." },
+          { en: "Using a Phes vehicle off the clock for personal trips and getting into an accident.", es: "Usar un vehículo de Phes fuera del horario para viajes personales y tener un accidente." },
+        ],
+      },
+
+      { type: "h", text: { en: "Report Damage or Loss Promptly", es: "Reporte Daños o Pérdidas con Prontitud" } },
+      {
+        type: "callout",
+        tone: "warning",
+        text: {
+          en: "If something in your kit is damaged, lost, or stops working, report it to the office BEFORE your next shift. The single biggest difference between a covered incident and a billed incident is whether you reported it. Phes can almost always resolve an honestly reported issue. Phes cannot resolve a hidden one.",
+          es: "Si algo en su kit se daña, se pierde o deja de funcionar, repórtelo a la oficina ANTES de su siguiente turno. La mayor diferencia entre un incidente cubierto y un incidente facturado es si lo reportó. Phes casi siempre puede resolver un asunto reportado honestamente. Phes no puede resolver uno oculto.",
+        },
+      },
+
+      { type: "h", text: { en: "Lost Client Key or Alarm Code", es: "Llave del Cliente o Código de Alarma Perdido" } },
+      {
+        type: "p",
+        text: {
+          en: "If you lose a client's key, key card, or alarm-code card, call the office IMMEDIATELY (not at the end of your shift, not the next day). The office will arrange a rekey or code change with the client. Phes pays for the rekey. The lost-key itself is not grounds for discipline; covering it up or delaying the report is.",
+          es: "Si pierde la llave de un cliente, una tarjeta de acceso o una tarjeta de código de alarma, llame a la oficina INMEDIATAMENTE (no al final del turno, no al día siguiente). La oficina coordinará un cambio de cerradura o de código con el cliente. Phes paga el cambio de cerradura. La llave perdida en sí no es motivo de disciplina; ocultarlo o retrasar el reporte sí lo es.",
+        },
+      },
+
+      { type: "h", text: { en: "No Personal Use, No Modifications", es: "Sin Uso Personal, Sin Modificaciones" } },
+      {
+        type: "bullets",
+        items: [
+          { en: "Do not use Phes supplies or equipment for personal cleaning at your own home or at a friend's home.", es: "No use suministros ni equipo de Phes para limpieza personal en su propia casa o en la casa de un amigo." },
+          { en: "Do not lend the Phes phone, tablet, vehicle, or keys to anyone, including coworkers off the clock.", es: "No preste el teléfono, tableta, vehículo o llaves de Phes a nadie, incluyendo compañeros fuera de turno." },
+          { en: "Do not modify or alter the equipment. If something is not working, get the office to issue a replacement.", es: "No modifique ni altere el equipo. Si algo no funciona, pida a la oficina que entregue un reemplazo." },
+          { en: "Do not buy substitute chemicals on your own initiative. Phes uses specific products for safety and consistency. Refills come from the office.", es: "No compre productos químicos sustitutos por su cuenta. Phes usa productos específicos por seguridad y consistencia. Las recargas vienen de la oficina." },
+        ],
+      },
+
+      { type: "h", text: { en: "Uniform Care", es: "Cuidado del Uniforme" } },
+      {
+        type: "p",
+        text: {
+          en: "Wash the uniform shirt and apron after each shift. Replace a torn uniform by asking the office (replacement is free for normal wear). Do not alter the uniform with paint, embroidery, or unofficial patches. If you have a religious or medical accommodation request related to the uniform, ask the office for the accommodation conversation.",
+          es: "Lave la camisa y el delantal del uniforme después de cada turno. Reemplace un uniforme roto pidiéndoselo a la oficina (el reemplazo es gratis por desgaste normal). No altere el uniforme con pintura, bordado ni parches no oficiales. Si tiene una solicitud de acomodación religiosa o médica relacionada con el uniforme, pida a la oficina la conversación de acomodación.",
+        },
+      },
+
+      { type: "h", text: { en: "Replacement and the Illinois Wage Payment and Collection Act", es: "Reemplazo y la Ley de Pago de Salarios y Recolección de Illinois" } },
+      {
+        type: "p",
+        text: {
+          en: "If something is damaged through negligence or unreported loss and Phes needs to bill you for replacement, here is how it works. Phes determines a replacement cost based on the documented item value. Phes notifies you in writing. If you agree to repayment, Phes and you SIGN A SEPARATE WRITTEN AUTHORIZATION (at that time, for that specific deduction) before any amount is taken from your paycheck. This is required by the Illinois Wage Payment and Collection Act, 820 ILCS 115, which prohibits employers from taking ANY deduction from wages without contemporaneous written authorization. Signing this Supply Kit Agreement does NOT pre-authorize automatic future deductions.",
+          es: "Si algo se daña por negligencia o se pierde sin reportar y Phes necesita facturarle un reemplazo, así funciona. Phes determina un costo de reemplazo basado en el valor documentado del artículo. Phes le notifica por escrito. Si acepta el pago, Phes y usted FIRMAN UNA AUTORIZACIÓN ESCRITA SEPARADA (en ese momento, para esa deducción específica) antes de que se tome cualquier monto de su pago. Esto es requerido por la Ley de Pago de Salarios y Recolección de Illinois, 820 ILCS 115, que prohíbe a los empleadores tomar CUALQUIER deducción del salario sin autorización escrita contemporánea. Firmar este Acuerdo del Kit de Suministros NO pre-autoriza deducciones futuras automáticas.",
+        },
+      },
+      {
+        type: "callout",
+        tone: "info",
+        text: {
+          en: "If you do not agree to repayment, Phes may seek reimbursement through other lawful channels but will not unilaterally deduct from your paycheck. This protects you under Illinois law.",
+          es: "Si no acepta el pago, Phes puede buscar el reembolso a través de otras vías legales, pero no deducirá unilateralmente de su pago. Esto le protege bajo la ley de Illinois.",
+        },
+      },
+
+      { type: "h", text: { en: "Return at Separation", es: "Devolución al Separarse" } },
+      {
+        type: "p",
+        text: {
+          en: "On or before your last day with Phes (voluntary or involuntary), you will return ALL Phes property to the office: caddy, vacuum, supplies in their Phes-branded bottles, Phes phone or tablet, all client keys and access cards, the uniform shirt and apron, and any other Phes-issued item. Phes will inspect the returned items and apply the reasonable-wear vs negligent-damage standard described above. Failure to return Phes property may result in Phes seeking reimbursement at replacement cost, subject to the same Illinois Wage Payment and Collection Act limits on payroll deductions.",
+          es: "En o antes de su último día con Phes (voluntario o involuntario), devolverá TODA la propiedad de Phes a la oficina: el caddy, la aspiradora, los suministros en sus botellas con marca de Phes, el teléfono o tableta de Phes, todas las llaves y tarjetas de acceso de clientes, la camisa y el delantal del uniforme, y cualquier otro artículo emitido por Phes. Phes inspeccionará los artículos devueltos y aplicará el estándar de desgaste razonable vs daño por negligencia descrito arriba. No devolver la propiedad de Phes puede resultar en que Phes busque el reembolso al costo de reemplazo, sujeto a los mismos límites de la Ley de Pago de Salarios y Recolección de Illinois sobre deducciones de nómina.",
+        },
+      },
+
+      {
+        type: "callout",
+        tone: "info",
+        text: {
+          en: "After this quiz: you will sign a separate Supply Kit Responsibility Acknowledgment that records your commitment. It is a one-sided acknowledgment (not co-signed). You can re-download the signed PDF anytime from your training page. The signature confirms that you understand the kit is Phes property, that you will report damage and loss, and that you understand any specific payroll deduction would require a separate written authorization at the time of the deduction.",
+          es: "Después de este examen: firmará un Reconocimiento de Responsabilidad del Kit de Suministros por separado que registra su compromiso. Es un reconocimiento unilateral (no co-firmado). Puede volver a descargar el PDF firmado en cualquier momento desde su página de capacitación. La firma confirma que entiende que el kit es propiedad de Phes, que reportará daños y pérdidas, y que entiende que cualquier deducción de nómina específica requeriría una autorización escrita separada al momento de la deducción.",
+        },
+      },
+    ],
+  },
 ];
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -5287,6 +5469,160 @@ const BASE_QUIZ: QuizQuestion[] = [
       { en: "Yes. Opt out anytime through My.ADP.com, the ADP Mobile Solutions App, or the Voice-Response System. You can re-enroll later whenever you want.", es: "Sí. Cancele en cualquier momento a través de My.ADP.com, la aplicación ADP Mobile Solutions o el sistema de respuesta por voz. Puede volver a inscribirse después cuando quiera." },
       { en: "Only during the first month after auto-enrollment.", es: "Solo durante el primer mes después de la inscripción automática." },
       { en: "Only if you are under age 21.", es: "Solo si tiene menos de 21 años." },
+    ],
+    correctIndex: 1,
+  },
+
+  // ═════════════════════════════════════════════════════════════════════════════
+  // Module 13: SUPPLY KIT RESPONSIBILITY (10 questions, Phase 9 PR #10)
+  // ═════════════════════════════════════════════════════════════════════════════
+  {
+    id: "q-sk-01-property-of-phes",
+    moduleId: "supply-kit",
+    prompt: {
+      en: "Who owns the items in your Phes supply kit (caddy, vacuum, chemicals in Phes-branded bottles, uniform, keys, Phes phone)?",
+      es: "¿Quién es dueño de los artículos de su kit de suministros de Phes (caddy, aspiradora, productos en botellas con marca de Phes, uniforme, llaves, teléfono de Phes)?",
+    },
+    options: [
+      { en: "You own them once you start using them.", es: "Usted los posee una vez que empiece a usarlos." },
+      { en: "Phes owns all of it. The kit is loaned to you for the duration of your employment.", es: "Phes es dueña de todo. El kit se le presta durante el tiempo de su empleo." },
+      { en: "You and Phes own them jointly.", es: "Usted y Phes son propietarios conjuntos." },
+      { en: "Whoever is assigned the route owns them.", es: "Quien tenga asignada la ruta los posee." },
+    ],
+    correctIndex: 1,
+  },
+  {
+    id: "q-sk-02-reasonable-wear-vs-negligence",
+    moduleId: "supply-kit",
+    prompt: {
+      en: "Your microfiber cloths are fraying after several months of regular use. Are you responsible for replacement cost?",
+      es: "Sus paños de microfibra se deshilachan después de varios meses de uso regular. ¿Es responsable del costo de reemplazo?",
+    },
+    options: [
+      { en: "Yes — anything that wears out is on you.", es: "Sí — cualquier cosa que se desgaste es responsabilidad suya." },
+      { en: "No. Reasonable wear and tear from using equipment as intended is absorbed by Phes. Negligent damage or loss is different.", es: "No. El desgaste razonable por usar el equipo como se pretende es absorbido por Phes. El daño por negligencia o la pérdida es distinto." },
+      { en: "Only if a client complains.", es: "Solo si un cliente se queja." },
+      { en: "Only if you have been at Phes less than one year.", es: "Solo si lleva menos de un año en Phes." },
+    ],
+    correctIndex: 1,
+  },
+  {
+    id: "q-sk-03-report-damage-promptly",
+    moduleId: "supply-kit",
+    prompt: {
+      en: "You knock over the vacuum and crack the housing during a shift. What does the agreement ask you to do?",
+      es: "Tira la aspiradora y rompe la carcasa durante un turno. ¿Qué le pide el acuerdo que haga?",
+    },
+    options: [
+      { en: "Try to hide the damage and hope it isn't noticed.", es: "Tratar de ocultar el daño y esperar que no se note." },
+      { en: "Report the damage to the office BEFORE your next shift. Phes can almost always resolve an honestly reported issue. Phes cannot resolve a hidden one.", es: "Reportar el daño a la oficina ANTES de su siguiente turno. Phes casi siempre puede resolver un asunto reportado honestamente. Phes no puede resolver uno oculto." },
+      { en: "Take a photo and post it on Instagram.", es: "Tomar una foto y publicarla en Instagram." },
+      { en: "Buy a replacement out of pocket and swap it in.", es: "Comprar un reemplazo de su bolsillo y cambiarlo." },
+    ],
+    correctIndex: 1,
+  },
+  {
+    id: "q-sk-04-lost-key-procedure",
+    moduleId: "supply-kit",
+    prompt: {
+      en: "You realize during a shift that you have misplaced a client's house key. What does the agreement require?",
+      es: "Se da cuenta durante un turno de que perdió la llave de la casa de un cliente. ¿Qué requiere el acuerdo?",
+    },
+    options: [
+      { en: "Wait until your shift ends, then mention it to the office.", es: "Esperar hasta que termine su turno, luego mencionárselo a la oficina." },
+      { en: "Call the office IMMEDIATELY. Phes arranges a rekey or code change with the client and pays for it. The lost key itself is not grounds for discipline; covering it up or delaying the report is.", es: "Llamar a la oficina INMEDIATAMENTE. Phes coordina un cambio de cerradura o de código con el cliente y lo paga. La llave perdida en sí no es motivo de disciplina; ocultarlo o retrasar el reporte sí lo es." },
+      { en: "Have your spouse return the key on their way home.", es: "Que su cónyuge devuelva la llave de camino a casa." },
+      { en: "Make a copy and continue using the spare.", es: "Hacer una copia y seguir usando el repuesto." },
+    ],
+    correctIndex: 1,
+  },
+  {
+    id: "q-sk-05-return-at-separation",
+    moduleId: "supply-kit",
+    prompt: {
+      en: "It's your last day at Phes. The office wants the caddy, supplies, Phes phone, uniform, and client keys back. Is this in the agreement?",
+      es: "Es su último día en Phes. La oficina quiere de vuelta el caddy, suministros, teléfono de Phes, uniforme y llaves de clientes. ¿Está esto en el acuerdo?",
+    },
+    options: [
+      { en: "No. After your last day the kit is yours to keep.", es: "No. Después de su último día el kit es suyo para quedárselo." },
+      { en: "Yes. On or before your last day, you return ALL Phes property to the office. Phes inspects the returned items and applies the reasonable-wear vs negligent-damage standard.", es: "Sí. En o antes de su último día, devuelve TODA la propiedad de Phes a la oficina. Phes inspecciona los artículos devueltos y aplica el estándar de desgaste razonable vs daño por negligencia." },
+      { en: "Only if you are fired, not if you quit.", es: "Solo si lo despiden, no si renuncia." },
+      { en: "Only the keys; the rest is yours.", es: "Solo las llaves; el resto es suyo." },
+    ],
+    correctIndex: 1,
+  },
+  {
+    id: "q-sk-06-no-automatic-deduction",
+    moduleId: "supply-kit",
+    prompt: {
+      en: "By signing the Supply Kit Agreement, are you pre-authorizing Phes to deduct money from your paycheck automatically for future damage or loss?",
+      es: "Al firmar el Acuerdo del Kit de Suministros, ¿está pre-autorizando a Phes a deducir dinero de su pago automáticamente por daños o pérdidas futuros?",
+    },
+    options: [
+      { en: "Yes. The signature gives Phes blanket authority for future deductions.", es: "Sí. La firma le da a Phes autoridad general para futuras deducciones." },
+      { en: "No. Under the Illinois Wage Payment and Collection Act (820 ILCS 115), any specific deduction requires a separate written authorization at the time of the deduction. Phes will notify you in writing first and a separate authorization must be signed before any amount is taken from your paycheck.", es: "No. Bajo la Ley de Pago de Salarios y Recolección de Illinois (820 ILCS 115), cualquier deducción específica requiere una autorización escrita separada al momento de la deducción. Phes le notificará por escrito primero y se debe firmar una autorización separada antes de que se tome cualquier monto de su pago." },
+      { en: "Only if the damage is over $500.", es: "Solo si el daño es mayor a $500." },
+      { en: "Only if you have been at Phes less than 90 days.", es: "Solo si lleva menos de 90 días en Phes." },
+    ],
+    correctIndex: 1,
+  },
+  {
+    id: "q-sk-07-no-personal-use",
+    moduleId: "supply-kit",
+    prompt: {
+      en: "You finish a Phes job early. Can you bring the Phes vacuum and supplies home to clean your own apartment before returning to the office?",
+      es: "Termina un trabajo de Phes temprano. ¿Puede llevar la aspiradora y los suministros de Phes a casa para limpiar su propio apartamento antes de volver a la oficina?",
+    },
+    options: [
+      { en: "Yes, since you finished early.", es: "Sí, ya que terminó temprano." },
+      { en: "No. Phes supplies and equipment are for Phes work only. You may not use them for personal cleaning or lend them to anyone outside Phes.", es: "No. Los suministros y el equipo de Phes son solo para trabajo de Phes. No puede usarlos para limpieza personal ni prestarlos a nadie fuera de Phes." },
+      { en: "Yes, but only the chemicals, not the vacuum.", es: "Sí, pero solo los productos, no la aspiradora." },
+      { en: "Only if your apartment is on the route.", es: "Solo si su apartamento está en la ruta." },
+    ],
+    correctIndex: 1,
+  },
+  {
+    id: "q-sk-08-no-modifications",
+    moduleId: "supply-kit",
+    prompt: {
+      en: "You think you could improve the cleaning chemistry by mixing your own substitute. Can you swap the Phes-issued chemicals for products you buy yourself?",
+      es: "Cree que podría mejorar la química de limpieza mezclando su propio sustituto. ¿Puede cambiar los productos químicos emitidos por Phes por productos que usted mismo compre?",
+    },
+    options: [
+      { en: "Yes, as long as it cleans better.", es: "Sí, mientras limpie mejor." },
+      { en: "No. Phes uses specific products for safety and consistency. Do not buy substitutes; do not modify or alter equipment. If something is not working, get the office to issue a replacement.", es: "No. Phes usa productos específicos por seguridad y consistencia. No compre sustitutos; no modifique ni altere el equipo. Si algo no funciona, pida a la oficina que entregue un reemplazo." },
+      { en: "Only if the substitute is the same brand.", es: "Solo si el sustituto es de la misma marca." },
+      { en: "Only with client approval.", es: "Solo con aprobación del cliente." },
+    ],
+    correctIndex: 1,
+  },
+  {
+    id: "q-sk-09-uniform-care",
+    moduleId: "supply-kit",
+    prompt: {
+      en: "You want to add an embroidered name patch to your Phes apron because it looks nicer. Can you do that?",
+      es: "Quiere agregar un parche bordado con su nombre al delantal de Phes porque se ve mejor. ¿Puede hacerlo?",
+    },
+    options: [
+      { en: "Yes, personalization is encouraged.", es: "Sí, se anima la personalización." },
+      { en: "No. Do not alter the uniform with paint, embroidery, or unofficial patches. If you need accommodation related to the uniform (religious, medical), ask the office.", es: "No. No altere el uniforme con pintura, bordado ni parches no oficiales. Si necesita acomodación relacionada con el uniforme (religiosa, médica), pídala a la oficina." },
+      { en: "Only if the patch is small.", es: "Solo si el parche es pequeño." },
+      { en: "Only on the apron, not the shirt.", es: "Solo en el delantal, no en la camisa." },
+    ],
+    correctIndex: 1,
+  },
+  {
+    id: "q-sk-10-replacement-process",
+    moduleId: "supply-kit",
+    prompt: {
+      en: "Phes determines that a damaged item must be replaced and you may be billed. What happens next under the Illinois Wage Payment and Collection Act?",
+      es: "Phes determina que un artículo dañado debe ser reemplazado y se le puede facturar. ¿Qué pasa después bajo la Ley de Pago de Salarios y Recolección de Illinois?",
+    },
+    options: [
+      { en: "Phes deducts the cost from your next paycheck automatically.", es: "Phes deduce el costo de su próximo pago automáticamente." },
+      { en: "Phes notifies you in writing with the documented cost. If you agree to repayment, Phes and you sign a separate written authorization for that specific deduction. If you do not agree, Phes may seek reimbursement through other lawful channels but will not unilaterally deduct from your paycheck.", es: "Phes le notifica por escrito con el costo documentado. Si acepta el pago, Phes y usted firman una autorización escrita separada para esa deducción específica. Si no acepta, Phes puede buscar el reembolso a través de otras vías legales, pero no deducirá unilateralmente de su pago." },
+      { en: "Phes withholds your tips until the cost is paid.", es: "Phes retiene sus propinas hasta que se pague el costo." },
+      { en: "The office files a small-claims case against you immediately.", es: "La oficina presenta una demanda en corte de reclamos menores contra usted inmediatamente." },
     ],
     correctIndex: 1,
   },

--- a/lib/db/src/schema/lms-signatures.ts
+++ b/lib/db/src/schema/lms-signatures.ts
@@ -517,7 +517,7 @@ export const REQUIRED_PRE_FINAL_SIGNED_DOCS = [
   "video_photo_release",
   "non_solicitation",
   "social_media",
-  // PR #10 will add: "supply_kit"
+  "supply_kit",
 ] as const;
 
 export type RequiredPreFinalSignedDoc =

--- a/lib/lms-curriculum/src/index.ts
+++ b/lib/lms-curriculum/src/index.ts
@@ -53,6 +53,7 @@ export type ModuleId =
   | "non-solicitation"
   | "social-media"
   | "phes-401k"
+  | "supply-kit"
   | "acknowledgment";
 
 export type QuizModuleId = Exclude<ModuleId, "acknowledgment">;
@@ -84,6 +85,7 @@ export const MODULE_ORDER: readonly ModuleId[] = [
   "non-solicitation",
   "social-media",
   "phes-401k",
+  "supply-kit",
   "acknowledgment",
 ] as const;
 
@@ -148,6 +150,18 @@ export const MODULE_ORDER: readonly ModuleId[] = [
  * Safe Harbor match, profit-sharing vesting schedule, catch-up
  * contributions (50+ and 60-63 super catch-up), enrollment paths,
  * and the 10% early-withdrawal penalty.
+ *
+ * supply-kit (Phase 9, PR #10) is the last standalone signed-doc
+ * module. 10-question comprehension quiz + separate signed
+ * acknowledgment at document_type 'supply_kit'. Establishes the
+ * employee's responsibility for Phes-provided cleaning supplies,
+ * uniform, keys, and any assigned hardware. Distinguishes
+ * reasonable wear (Phes absorbs) from negligent damage (employee
+ * may be billed). Does NOT pre-authorize automatic payroll
+ * deductions — the Illinois Wage Payment and Collection Act
+ * (820 ILCS 115) requires contemporaneous written authorization
+ * for any specific deduction, so the agreement reserves Phes's
+ * right to seek reimbursement and references that requirement.
  */
 export const QUIZ_MODULE_IDS: readonly QuizModuleId[] = [
   "phes-policies",
@@ -162,6 +176,7 @@ export const QUIZ_MODULE_IDS: readonly QuizModuleId[] = [
   "non-solicitation",
   "social-media",
   "phes-401k",
+  "supply-kit",
 ] as const;
 
 /** Pass threshold per module (and for the final mixed test). 80%. */
@@ -480,6 +495,25 @@ export const ANSWER_KEY: Readonly<Record<string, number>> = Object.freeze({
   "q-401-08-early-withdrawal-penalty": 1,
   "q-401-09-beneficiary-importance": 1,
   "q-401-10-opt-out-paths": 1,
+
+  // ── Module 13: supply-kit (10, Phase 9 PR #10) ──────────────────────────
+  // Phes Supply Kit Responsibility Agreement. NOT co-signed. Establishes
+  // employee responsibility for Phes-provided supplies, uniform, keys,
+  // and assigned hardware. Distinguishes reasonable wear (Phes absorbs)
+  // from negligent damage (employee may be billed). Does NOT
+  // pre-authorize payroll deductions; references IL Wage Payment and
+  // Collection Act (820 ILCS 115) which requires contemporaneous written
+  // authorization for any specific deduction.
+  "q-sk-01-property-of-phes": 1,
+  "q-sk-02-reasonable-wear-vs-negligence": 1,
+  "q-sk-03-report-damage-promptly": 1,
+  "q-sk-04-lost-key-procedure": 1,
+  "q-sk-05-return-at-separation": 1,
+  "q-sk-06-no-automatic-deduction": 1,
+  "q-sk-07-no-personal-use": 1,
+  "q-sk-08-no-modifications": 1,
+  "q-sk-09-uniform-care": 1,
+  "q-sk-10-replacement-process": 1,
 });
 
 /**
@@ -588,6 +622,13 @@ export const QUESTIONS_BY_MODULE: Readonly<Record<QuizModuleId, readonly string[
       "q-401-05-vesting-immediate", "q-401-06-enrollment-paths",
       "q-401-07-catch-up-50-plus", "q-401-08-early-withdrawal-penalty",
       "q-401-09-beneficiary-importance", "q-401-10-opt-out-paths",
+    ],
+    "supply-kit": [
+      "q-sk-01-property-of-phes", "q-sk-02-reasonable-wear-vs-negligence",
+      "q-sk-03-report-damage-promptly", "q-sk-04-lost-key-procedure",
+      "q-sk-05-return-at-separation", "q-sk-06-no-automatic-deduction",
+      "q-sk-07-no-personal-use", "q-sk-08-no-modifications",
+      "q-sk-09-uniform-care", "q-sk-10-replacement-process",
     ],
   });
 

--- a/lib/training/src/answer-key.ts
+++ b/lib/training/src/answer-key.ts
@@ -228,6 +228,18 @@ export const SERVER_ANSWER_KEY: Readonly<Record<string, number>> = Object.freeze
   "q-401-08-early-withdrawal-penalty": 1,
   "q-401-09-beneficiary-importance": 1,
   "q-401-10-opt-out-paths": 1,
+
+  // ── Module 13: supply-kit (10, Phase 9 PR #10) ─────────────────────────
+  "q-sk-01-property-of-phes": 1,
+  "q-sk-02-reasonable-wear-vs-negligence": 1,
+  "q-sk-03-report-damage-promptly": 1,
+  "q-sk-04-lost-key-procedure": 1,
+  "q-sk-05-return-at-separation": 1,
+  "q-sk-06-no-automatic-deduction": 1,
+  "q-sk-07-no-personal-use": 1,
+  "q-sk-08-no-modifications": 1,
+  "q-sk-09-uniform-care": 1,
+  "q-sk-10-replacement-process": 1,
 });
 
 /**


### PR DESCRIPTION
## PR #10 of 16 — Phase 9: Supply Kit Responsibility Module + Signed Acknowledgment

Last of the standalone signed-doc series. Adds the Phes Supply Kit Responsibility Acknowledgment as LMS module #13 with 10-question quiz + UETA/E-SIGN binding acknowledgment at `document_type 'supply_kit'`. Not co-signed.

After this PR merges, the hard-gate list is complete: drug_alcohol + code_of_conduct + video_photo_release + non_solicitation + social_media + supply_kit.

**DO NOT auto-merge.** Review before approving.

## Key design choice: IL Wage Payment and Collection Act compliance

The agreement does NOT pre-authorize automatic payroll deductions for damaged or unreturned property. IL Wage Payment and Collection Act (820 ILCS 115) requires contemporaneous written authorization for any specific deduction. Section 10 explains this in plain English/Spanish.

## What ships

- `supply-kit` module (slot #13), 12-section bilingual content covering: Phes property, reasonable care, wear vs negligence (with concrete examples both sides), prompt reporting, lost-key procedure, no personal use, no modifications, uniform care, separation return, IL Wage Payment Act, at-will, E-SIGN consent
- 10 quiz questions `q-sk-01` through `q-sk-10`
- `supply_kit` bilingual content registry entry (not flagged for translator review)
- `supply_kit` appended to `REQUIRED_PRE_FINAL_SIGNED_DOCS`
- Drift-mirrored answer key
- Bilingual cert title
- Frontend `humanSignedDocType` already covers it from prior PRs

## Tests

- 194/194 LMS tests pass (was 184)
- MODULE_ORDER = 14, QUIZ_MODULE_IDS = 13, ALL_QUESTION_IDS = 187
- 9 new supply_kit content tests: registry shape, no pendingTranslationReview, 820 ILCS 115 citation in both locales, "does NOT pre-authorize" language, wear vs negligence, return-of-all-Phes-property, no-personal-use, hash divergence
- tsc-libs + Vite build clean

https://claude.ai/code/session_013rJ4N4vgqZWB986x8D6Ahh

---
_Generated by [Claude Code](https://claude.ai/code/session_013rJ4N4vgqZWB986x8D6Ahh)_