### PR TITLE
lms: final comprehensive exam (Phase 13, PR #14 of 16)

### DIFF
--- a/artifacts/api-server/src/routes/lms-handbook.ts
+++ b/artifacts/api-server/src/routes/lms-handbook.ts
@@ -47,7 +47,7 @@ import {
   REQUIRED_PRE_FINAL_SIGNED_DOCS,
   type LmsSignedDocument,
 } from "@workspace/db/schema";
-import { QUIZ_MODULE_IDS } from "@workspace/lms-curriculum";
+import { QUIZ_MODULE_IDS, FINAL_MODULE_ID } from "@workspace/lms-curriculum";
 import { requireAuth, requireRole } from "../lib/auth.js";
 import {
   captureRequestMetadata,
@@ -116,6 +116,13 @@ interface EligibilityResult {
   missing_modules: string[];
   missing_signed_docs: string[];
   passed_modules: string[];
+  /**
+   * Phase 13 (PR #14): the final comprehensive exam is the third gate.
+   * Returns true iff the learner has a passed module_progress row with
+   * module_id === FINAL_MODULE_ID. The final exam itself is wired via
+   * routes/lms.ts /quiz/submit which already accepts the __final id.
+   */
+  final_exam_passed: boolean;
 }
 
 async function checkEligibility(
@@ -130,11 +137,16 @@ async function checkEligibility(
   const missingModules = [...QUIZ_MODULE_IDS].filter(
     (m) => !passedSet.has(m),
   );
+  const finalExamPassed = passedSet.has(FINAL_MODULE_ID);
   return {
-    eligible: missingModules.length === 0 && missingDocs.length === 0,
+    eligible:
+      missingModules.length === 0 &&
+      missingDocs.length === 0 &&
+      finalExamPassed,
     missing_modules: missingModules,
     missing_signed_docs: missingDocs,
     passed_modules: passed,
+    final_exam_passed: finalExamPassed,
   };
 }
 

--- a/artifacts/api-server/src/tests/lms-curriculum.test.ts
+++ b/artifacts/api-server/src/tests/lms-curriculum.test.ts
@@ -87,8 +87,8 @@ describe("LMS curriculum — constants & catalog shape", () => {
     );
   });
 
-  it("FINAL_TEST_SIZE is 50 (per Phes spec, 50 questions sampled from 75-pool)", () => {
-    assert.equal(FINAL_TEST_SIZE, 50);
+  it("FINAL_TEST_SIZE is 30 (Phase 13, PR #14: 30 sampled from the 187-question 13-module pool)", () => {
+    assert.equal(FINAL_TEST_SIZE, 30);
   });
 
   it("phes-policies has 40 questions (cleaning checklist + Deep Clean scope 2026-05-12)", () => {
@@ -412,10 +412,10 @@ describe("sampleFinalQuestionIds", () => {
     };
   }
 
-  it("returns the requested count by default (FINAL_TEST_SIZE = 50)", () => {
+  it("returns the requested count by default (FINAL_TEST_SIZE = 30)", () => {
     const ids = sampleFinalQuestionIds(undefined, seedRng(1));
     assert.equal(ids.length, FINAL_TEST_SIZE);
-    assert.equal(ids.length, 50);
+    assert.equal(ids.length, 30);
   });
 
   it("never exceeds the pool size when count > pool", () => {

--- a/lib/lms-curriculum/src/index.ts
+++ b/lib/lms-curriculum/src/index.ts
@@ -225,7 +225,16 @@ export function shouldShowLearnerGating(isOwner: boolean): boolean {
  * Restructure 2026-05-09: bumped from 15 → 50 to reflect the larger
  * 75-question pool (5 modules × 15 each).
  */
-export const FINAL_TEST_SIZE = 50;
+/**
+ * Phase 13 (PR #14): sampled to 30 from the now-187-question pool. The
+ * user spec calls for 25-30; we pick the upper bound so the test
+ * stretches across more modules (sampler is uniform random across all
+ * QUIZ_MODULE_IDS, so 30 gives a comfortable spread). Previously 50
+ * when the pool was 75; sample-to-pool ratio is now ~16 percent vs the
+ * earlier ~67 percent. The lower density is appropriate for a closing
+ * mixed test, not a re-test of every concept.
+ */
+export const FINAL_TEST_SIZE = 30;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Answer key — mirrors artifacts/qleno/src/lib/training/curriculum.ts.


### PR DESCRIPTION
Phase 13 of 16. Opened as **draft** per your cadence rule.

## What changes

### `FINAL_TEST_SIZE`: 50 → 30
- `lib/lms-curriculum/src/index.ts`. Previously sized for the 75-question pre-restructure pool; at 187 questions across 13 modules a 50-question final is overkill. Your spec said 25-30; we pick the upper bound so the sampler reaches more modules.
- Sample density goes from ~67% to ~16%, which matches "closing mixed test" semantics (not a re-test of every concept).

### Handbook eligibility now requires the final exam
- `routes/lms-handbook.ts`: `checkEligibility()` adds a third gate. Today the gates were: 13 modules passed + 6 standalone acks signed. This PR adds final-exam pass as the third gate.
- Response shape extended:
  ```
  {
    eligible,
    missing_modules,
    missing_signed_docs,
    passed_modules,
    final_exam_passed   // NEW
  }
  ```
  So the frontend sign tile can render the exact reason it's locked.

### Tests
- `lms-curriculum.test.ts`: `FINAL_TEST_SIZE` assertion updated to 30.
- `sampleFinalQuestionIds` default-count assertion: 50 → 30.

## Infrastructure already in place — no new work this PR

- **Final exam itself**: `routes/lms.ts /quiz/submit` already accepts `moduleId === FINAL_MODULE_ID`. Sampler, scoring, attempt cap (4 for final vs 3 for modules), `lms_completion_certificates` row with `module_id='__final'`, and the unlock gate (`isFinalUnlocked`) all exist on main from Phase 2.
- **Frontend final-exam UI**: `training.tsx` already renders the Final Mixed Test card after the last module.
- **Sampling**: uniform random across all `QUIZ_MODULE_IDS`, so every module is represented in expectation.

## Verification

- **202/202 LMS unit tests pass.**
- Production build clean.
- No em dashes in new content.

## Test plan after merge

- [ ] Reload `/training` as a tech who has finished all 13 modules + all 6 signed acks → Final Mixed Test card is unlocked
- [ ] Start the final exam → exactly **30** questions served, sampled across all 13 modules
- [ ] Pass the final → final exam certificate issued; `/api/lms/handbook/eligibility` now returns `eligible: true`
- [ ] Hit `POST /api/lms/handbook/sign` BEFORE passing the final → returns 409 with `final_exam_passed: false`
- [ ] After passing the final, signing the handbook works as in PR #99


---
_Generated by [Claude Code](https://claude.ai/code/session_01AxGiirnJ3dT4GAzHPNWhrx)_