### PR TITLE
lms: annual re-acknowledgment system (Phase 14, PR #15 of 16)

### DIFF
--- a/artifacts/api-server/src/lib/lms-annual-ack.ts
+++ b/artifacts/api-server/src/lib/lms-annual-ack.ts
@@ -1,0 +1,201 @@
+/**
+ * LMS Annual re-acknowledgment — pure helpers (Phase 14, PR #15 of 16).
+ *
+ * The DB-touching plumbing lives in `routes/lms-annual-ack.ts`. This
+ * module is pure so the unit tests can exercise input validation,
+ * cycle-year math, and trigger-reason allowlists without spinning up
+ * a database.
+ *
+ * Concepts:
+ *   - "Cycle" — one row in `lms_annual_ack_cycles` per tenant per
+ *     calendar year. Default deadline is Dec 31 23:59 UTC of that
+ *     year. Default required_documents is ANNUAL_DOCUMENT_TYPES
+ *     (currently just handbook).
+ *   - "Sweep" — when a cycle is opened, every employee in the tenant
+ *     who has an active signed handbook (or other annual doc) gets a
+ *     row in `lms_pending_re_ack` so the dashboard tile lights up on
+ *     their next login and POST /api/lms/handbook/sign records the
+ *     refreshed signature.
+ *   - "Force resign" — admin manually pushes one user into a re-ack
+ *     flow outside the annual cycle (e.g. a corrected policy that
+ *     only affects a single person).
+ */
+import {
+  ANNUAL_DOCUMENT_TYPES,
+  KNOWN_SIGNED_DOCUMENT_TYPES,
+} from "@workspace/db/schema";
+
+export const ANNUAL_DOCUMENT_TYPE_SET = new Set<string>(
+  ANNUAL_DOCUMENT_TYPES as readonly string[],
+);
+
+const KNOWN_DOCUMENT_TYPE_SET = new Set<string>(
+  KNOWN_SIGNED_DOCUMENT_TYPES as readonly string[],
+);
+
+export const TRIGGER_REASONS = [
+  "annual_cycle",
+  "material_content_change",
+  "admin_force_resign",
+  "policy_correction",
+] as const;
+
+export type TriggerReason = (typeof TRIGGER_REASONS)[number];
+
+const TRIGGER_REASON_SET = new Set<string>(TRIGGER_REASONS);
+
+const MIN_CYCLE_YEAR = 2025;
+const MAX_CYCLE_YEAR = 2100;
+
+/**
+ * Default deadline for a cycle: Dec 31 23:59:59.999 UTC of `cycleYear`.
+ * UTC by design so the deadline is comparable across tenants regardless
+ * of their local time zone. The admin can override per-cycle.
+ */
+export function defaultCycleDeadline(cycleYear: number): Date {
+  return new Date(Date.UTC(cycleYear, 11, 31, 23, 59, 59, 999));
+}
+
+export function isValidCycleYear(input: unknown): input is number {
+  return (
+    typeof input === "number" &&
+    Number.isInteger(input) &&
+    input >= MIN_CYCLE_YEAR &&
+    input <= MAX_CYCLE_YEAR
+  );
+}
+
+export function isValidTriggerReason(input: unknown): input is TriggerReason {
+  return typeof input === "string" && TRIGGER_REASON_SET.has(input);
+}
+
+export function isValidLocale(input: unknown): input is "en" | "es" {
+  return input === "en" || input === "es";
+}
+
+export interface RequiredDocumentsValidation {
+  ok: boolean;
+  documents: string[];
+  invalid: string[];
+  notAnnual: string[];
+}
+
+/**
+ * Validate a caller-supplied required_documents array. Returns
+ * the canonical list (deduped, in input order). Documents must be
+ * (a) in KNOWN_SIGNED_DOCUMENT_TYPES (otherwise `invalid`), and
+ * (b) in ANNUAL_DOCUMENT_TYPES (otherwise `notAnnual`). Empty input
+ * defaults to ANNUAL_DOCUMENT_TYPES so callers can POST `{}` and get
+ * the right thing.
+ */
+export function validateRequiredDocuments(
+  input: unknown,
+): RequiredDocumentsValidation {
+  if (input === undefined || input === null) {
+    return {
+      ok: true,
+      documents: [...ANNUAL_DOCUMENT_TYPES],
+      invalid: [],
+      notAnnual: [],
+    };
+  }
+  if (!Array.isArray(input)) {
+    return { ok: false, documents: [], invalid: [], notAnnual: [] };
+  }
+  if (input.length === 0) {
+    return {
+      ok: true,
+      documents: [...ANNUAL_DOCUMENT_TYPES],
+      invalid: [],
+      notAnnual: [],
+    };
+  }
+  const seen = new Set<string>();
+  const documents: string[] = [];
+  const invalid: string[] = [];
+  const notAnnual: string[] = [];
+  for (const raw of input) {
+    if (typeof raw !== "string") {
+      invalid.push(String(raw));
+      continue;
+    }
+    if (seen.has(raw)) continue;
+    seen.add(raw);
+    if (!KNOWN_DOCUMENT_TYPE_SET.has(raw)) {
+      invalid.push(raw);
+      continue;
+    }
+    if (!ANNUAL_DOCUMENT_TYPE_SET.has(raw)) {
+      notAnnual.push(raw);
+      continue;
+    }
+    documents.push(raw);
+  }
+  return {
+    ok: invalid.length === 0 && notAnnual.length === 0 && documents.length > 0,
+    documents,
+    invalid,
+    notAnnual,
+  };
+}
+
+/**
+ * Parse and validate an ISO timestamp from caller input. Returns null
+ * on invalid input. Empty / undefined returns null too — callers
+ * decide whether to substitute a default.
+ */
+export function parseDeadlineInput(input: unknown): Date | null {
+  if (input === undefined || input === null || input === "") return null;
+  if (typeof input !== "string") return null;
+  const d = new Date(input);
+  if (Number.isNaN(d.getTime())) return null;
+  return d;
+}
+
+/**
+ * Pure: given an array of pending-re-ack rows + the cycle window,
+ * compute summary counts. Used by the admin status endpoint and the
+ * audit dashboard.
+ */
+export interface PendingSummaryInput {
+  acknowledged_at: Date | string | null;
+  defer_until: Date | string | null;
+  triggered_at: Date | string;
+}
+
+export interface PendingSummary {
+  total: number;
+  acknowledged: number;
+  pending: number;
+  deferred: number;
+}
+
+export function summarizePendingReAcks(
+  rows: PendingSummaryInput[],
+  now: Date = new Date(),
+): PendingSummary {
+  const summary: PendingSummary = {
+    total: rows.length,
+    acknowledged: 0,
+    pending: 0,
+    deferred: 0,
+  };
+  const nowMs = now.getTime();
+  for (const r of rows) {
+    if (r.acknowledged_at !== null && r.acknowledged_at !== undefined) {
+      summary.acknowledged += 1;
+      continue;
+    }
+    if (r.defer_until !== null && r.defer_until !== undefined) {
+      const def = r.defer_until instanceof Date
+        ? r.defer_until
+        : new Date(r.defer_until);
+      if (!Number.isNaN(def.getTime()) && def.getTime() > nowMs) {
+        summary.deferred += 1;
+        continue;
+      }
+    }
+    summary.pending += 1;
+  }
+  return summary;
+}

--- a/artifacts/api-server/src/routes/index.ts
+++ b/artifacts/api-server/src/routes/index.ts
@@ -77,6 +77,7 @@ import lmsRouter from "./lms.js";
 import lmsCertificatesRouter from "./lms-certificates.js";
 import lmsSignaturesRouter from "./lms-signatures.js";
 import lmsHandbookRouter from "./lms-handbook.js";
+import lmsAnnualAckRouter from "./lms-annual-ack.js";
 
 const router: IRouter = Router();
 
@@ -158,5 +159,6 @@ router.use("/lms", lmsRouter);
 router.use("/lms/certificates", lmsCertificatesRouter);
 router.use("/lms/signatures", lmsSignaturesRouter);
 router.use("/lms/handbook", lmsHandbookRouter);
+router.use("/lms/annual-ack", lmsAnnualAckRouter);
 
 export default router;

--- a/artifacts/api-server/src/routes/lms-annual-ack.ts
+++ b/artifacts/api-server/src/routes/lms-annual-ack.ts
@@ -1,0 +1,796 @@
+/**
+ * LMS Annual re-acknowledgment — routes (Phase 14, PR #15 of 16).
+ *
+ * Mounted at /api/lms/annual-ack.
+ *
+ * Admin / owner / office endpoints:
+ *   POST   /admin/cycles                    open a cycle and sweep eligible users
+ *   GET    /admin/cycles                    list cycles for the tenant
+ *   GET    /admin/cycles/:id                cycle detail + status counts
+ *   PATCH  /admin/cycles/:id/close          mark a cycle closed
+ *   POST   /admin/force-resign              push a single user into re-ack
+ *   PATCH  /admin/pending/:id/defer         set defer_until on a pending row
+ *
+ * Caller-self endpoints:
+ *   GET    /me/pending                      caller's outstanding re-ack rows
+ *
+ * Tenant isolation: every read + write filters by req.auth.companyId.
+ * Admin endpoints additionally gate on role (owner | admin | office).
+ *
+ * Sweep semantics: when a cycle is opened, the server walks every
+ * non-terminated user in the tenant who has an active signed_document
+ * for each required_documents type and inserts an lms_pending_re_ack
+ * row pointing at the current canonical version (in the locale they
+ * last signed in). Users with no prior handbook signature are skipped
+ * because the original signing flow already gates them.
+ *
+ * Acknowledgment: when POST /api/lms/handbook/sign succeeds it calls
+ * `acknowledgePendingReAcksForSign()` (below, exported) to flip any
+ * matching pending rows to acknowledged_at = now. That keeps Phase 11
+ * and Phase 14 decoupled — the handbook router doesn't need to know
+ * about cycles, just that there might be pending rows to settle.
+ */
+import { Router } from "express";
+import { and, asc, desc, eq, inArray, isNull } from "drizzle-orm";
+import { db } from "@workspace/db";
+import {
+  lmsAnnualAckCyclesTable,
+  lmsPendingReAckTable,
+  lmsSignedDocumentsTable,
+  usersTable,
+} from "@workspace/db/schema";
+import { requireAuth, requireRole } from "../lib/auth.js";
+import { getSignedDocumentContent } from "../lib/lms-signed-documents-content.js";
+import { getOrCreateDocumentVersion } from "../lib/lms-signatures-db.js";
+import {
+  defaultCycleDeadline,
+  isValidCycleYear,
+  isValidTriggerReason,
+  parseDeadlineInput,
+  summarizePendingReAcks,
+  validateRequiredDocuments,
+  type TriggerReason,
+} from "../lib/lms-annual-ack.js";
+import { logAudit } from "../lib/audit.js";
+
+const router = Router();
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers (DB-touching)
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface SweepResult {
+  document_type: string;
+  swept_user_ids: number[];
+}
+
+/**
+ * Sweep every active employee in the tenant who currently has an
+ * active signed_document for the given document_type, and insert a
+ * pending_re_ack row for each. Skips users who already have a
+ * non-acknowledged row for the same (document_type, current version)
+ * so re-running a sweep is idempotent.
+ *
+ * Returns the user IDs that received a NEW pending row this call.
+ */
+async function sweepForDocumentType(args: {
+  companyId: number;
+  documentType: string;
+  triggeredByUserId: number;
+  triggerReason: TriggerReason;
+}): Promise<SweepResult> {
+  const { companyId, documentType, triggeredByUserId, triggerReason } = args;
+
+  const activeSigners = await db
+    .select({
+      user_id: lmsSignedDocumentsTable.user_id,
+      locale: lmsSignedDocumentsTable.locale,
+    })
+    .from(lmsSignedDocumentsTable)
+    .innerJoin(
+      usersTable,
+      eq(lmsSignedDocumentsTable.user_id, usersTable.id),
+    )
+    .where(
+      and(
+        eq(lmsSignedDocumentsTable.company_id, companyId),
+        eq(lmsSignedDocumentsTable.document_type, documentType),
+        eq(lmsSignedDocumentsTable.status, "active"),
+        eq(usersTable.company_id, companyId),
+        isNull(usersTable.termination_date),
+      ),
+    );
+
+  if (activeSigners.length === 0) {
+    return { document_type: documentType, swept_user_ids: [] };
+  }
+
+  const sweptIds: number[] = [];
+  const now = new Date();
+
+  for (const signer of activeSigners) {
+    const locale = signer.locale === "es" ? "es" : "en";
+    const content = getSignedDocumentContent(documentType, locale);
+    if (!content) continue;
+
+    const version = await getOrCreateDocumentVersion({
+      companyId,
+      documentType,
+      locale,
+      contentHtml: content.contentHtml,
+      isMaterial: triggerReason === "material_content_change",
+      notes: content.notes,
+    });
+
+    // Skip if user already has an unacknowledged row for this version.
+    const existing = await db
+      .select({ id: lmsPendingReAckTable.id })
+      .from(lmsPendingReAckTable)
+      .where(
+        and(
+          eq(lmsPendingReAckTable.company_id, companyId),
+          eq(lmsPendingReAckTable.user_id, signer.user_id),
+          eq(lmsPendingReAckTable.document_type, documentType),
+          eq(lmsPendingReAckTable.new_version_id, version.id),
+          isNull(lmsPendingReAckTable.acknowledged_at),
+        ),
+      )
+      .limit(1);
+    if (existing[0]) continue;
+
+    await db.insert(lmsPendingReAckTable).values({
+      company_id: companyId,
+      user_id: signer.user_id,
+      document_type: documentType,
+      new_version_id: version.id,
+      new_version_hash: version.version_hash,
+      trigger_reason: triggerReason,
+      triggered_at: now,
+      triggered_by_user_id: triggeredByUserId,
+    });
+    sweptIds.push(signer.user_id);
+  }
+
+  return { document_type: documentType, swept_user_ids: sweptIds };
+}
+
+/**
+ * Called by routes/lms-handbook.ts POST /sign after a successful sign.
+ * Flips every unacknowledged pending row for this user+document_type
+ * to acknowledged_at=now, pointing to the freshly inserted
+ * signed_document row.
+ *
+ * Tenant-scoped (caller must pass companyId derived from req.auth).
+ * Returns the number of rows updated for audit.
+ */
+export async function acknowledgePendingReAcksForSign(args: {
+  companyId: number;
+  userId: number;
+  documentType: string;
+  signedDocumentId: number;
+  now?: Date;
+}): Promise<number> {
+  const now = args.now ?? new Date();
+  const updated = await db
+    .update(lmsPendingReAckTable)
+    .set({
+      acknowledged_at: now,
+      acknowledged_signed_document_id: args.signedDocumentId,
+      updated_at: now,
+    })
+    .where(
+      and(
+        eq(lmsPendingReAckTable.company_id, args.companyId),
+        eq(lmsPendingReAckTable.user_id, args.userId),
+        eq(lmsPendingReAckTable.document_type, args.documentType),
+        isNull(lmsPendingReAckTable.acknowledged_at),
+      ),
+    )
+    .returning({ id: lmsPendingReAckTable.id });
+  return updated.length;
+}
+
+/**
+ * Find the currently open cycle for a tenant. "Open" = closed_at IS
+ * NULL. Returns the most recent cycle when more than one is open
+ * (shouldn't happen in practice — uniqueIndex enforces one per year).
+ */
+export async function findOpenCycle(
+  companyId: number,
+): Promise<{ id: number; cycle_year: number } | null> {
+  const rows = await db
+    .select({
+      id: lmsAnnualAckCyclesTable.id,
+      cycle_year: lmsAnnualAckCyclesTable.cycle_year,
+    })
+    .from(lmsAnnualAckCyclesTable)
+    .where(
+      and(
+        eq(lmsAnnualAckCyclesTable.company_id, companyId),
+        isNull(lmsAnnualAckCyclesTable.closed_at),
+      ),
+    )
+    .orderBy(desc(lmsAnnualAckCyclesTable.cycle_year))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /admin/cycles — open a cycle and sweep eligible users
+// ─────────────────────────────────────────────────────────────────────────────
+
+router.post(
+  "/admin/cycles",
+  requireAuth,
+  requireRole("owner", "admin"),
+  async (req, res) => {
+    try {
+      const companyId = req.auth!.companyId;
+      if (companyId == null) {
+        return res.status(400).json({
+          error: "Bad Request",
+          message: "User has no company assignment",
+        });
+      }
+      const adminId = req.auth!.userId;
+      const body = req.body ?? {};
+
+      if (!isValidCycleYear(body.cycle_year)) {
+        return res.status(400).json({
+          error: "Bad Request",
+          message: "cycle_year must be an integer between 2025 and 2100",
+        });
+      }
+      const cycleYear: number = body.cycle_year;
+
+      const docs = validateRequiredDocuments(body.required_documents);
+      if (!docs.ok) {
+        return res.status(400).json({
+          error: "Bad Request",
+          message:
+            "required_documents must be a non-empty array of known annual document types",
+          data: { invalid: docs.invalid, not_annual: docs.notAnnual },
+        });
+      }
+
+      const deadlineFromBody = parseDeadlineInput(body.deadline_at);
+      if (
+        body.deadline_at !== undefined &&
+        body.deadline_at !== null &&
+        body.deadline_at !== "" &&
+        deadlineFromBody === null
+      ) {
+        return res.status(400).json({
+          error: "Bad Request",
+          message: "deadline_at must be a valid ISO timestamp",
+        });
+      }
+      const deadlineAt = deadlineFromBody ?? defaultCycleDeadline(cycleYear);
+
+      const notes =
+        typeof body.notes === "string" && body.notes.length > 0
+          ? body.notes
+          : null;
+
+      // Reject if a cycle already exists for this (company, year).
+      const existing = await db
+        .select({
+          id: lmsAnnualAckCyclesTable.id,
+          closed_at: lmsAnnualAckCyclesTable.closed_at,
+        })
+        .from(lmsAnnualAckCyclesTable)
+        .where(
+          and(
+            eq(lmsAnnualAckCyclesTable.company_id, companyId),
+            eq(lmsAnnualAckCyclesTable.cycle_year, cycleYear),
+          ),
+        )
+        .limit(1);
+      if (existing[0]) {
+        return res.status(409).json({
+          error: "Conflict",
+          message: `A cycle for ${cycleYear} already exists`,
+          data: existing[0],
+        });
+      }
+
+      const inserted = await db
+        .insert(lmsAnnualAckCyclesTable)
+        .values({
+          company_id: companyId,
+          cycle_year: cycleYear,
+          deadline_at: deadlineAt,
+          required_documents: docs.documents,
+          notes,
+        })
+        .returning();
+      const cycle = inserted[0]!;
+
+      // Sweep each required document type. Collect totals for the
+      // response so the dashboard tile shows immediate confirmation.
+      const sweeps: SweepResult[] = [];
+      for (const documentType of docs.documents) {
+        const result = await sweepForDocumentType({
+          companyId,
+          documentType,
+          triggeredByUserId: adminId,
+          triggerReason: "annual_cycle",
+        });
+        sweeps.push(result);
+      }
+
+      const total_swept = sweeps.reduce(
+        (sum, r) => sum + r.swept_user_ids.length,
+        0,
+      );
+
+      await logAudit(
+        req,
+        "lms_annual_cycle_opened",
+        "lms_annual_ack_cycle",
+        cycle.id,
+        null,
+        { cycle_year: cycleYear, total_swept, sweeps },
+      );
+
+      return res.json({
+        data: {
+          cycle,
+          sweeps,
+          total_swept,
+        },
+      });
+    } catch (err) {
+      console.error("[lms-annual-ack] POST /admin/cycles error:", err);
+      return res.status(500).json({
+        error: "Internal Server Error",
+        message: "Failed to open annual cycle",
+      });
+    }
+  },
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /admin/cycles — list cycles for the tenant
+// ─────────────────────────────────────────────────────────────────────────────
+
+router.get(
+  "/admin/cycles",
+  requireAuth,
+  requireRole("owner", "admin", "office"),
+  async (req, res) => {
+    try {
+      const companyId = req.auth!.companyId;
+      if (companyId == null) {
+        return res.status(400).json({
+          error: "Bad Request",
+          message: "User has no company assignment",
+        });
+      }
+      const rows = await db
+        .select()
+        .from(lmsAnnualAckCyclesTable)
+        .where(eq(lmsAnnualAckCyclesTable.company_id, companyId))
+        .orderBy(desc(lmsAnnualAckCyclesTable.cycle_year));
+      return res.json({ data: rows });
+    } catch (err) {
+      console.error("[lms-annual-ack] GET /admin/cycles error:", err);
+      return res.status(500).json({
+        error: "Internal Server Error",
+        message: "Failed to load cycles",
+      });
+    }
+  },
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /admin/cycles/:id — cycle detail + status counts
+// ─────────────────────────────────────────────────────────────────────────────
+
+router.get(
+  "/admin/cycles/:id",
+  requireAuth,
+  requireRole("owner", "admin", "office"),
+  async (req, res) => {
+    try {
+      const companyId = req.auth!.companyId;
+      if (companyId == null) {
+        return res.status(400).json({
+          error: "Bad Request",
+          message: "User has no company assignment",
+        });
+      }
+      const id = Number(req.params.id);
+      if (!Number.isFinite(id) || id <= 0) {
+        return res
+          .status(400)
+          .json({ error: "Bad Request", message: "Invalid id" });
+      }
+      const cycleRows = await db
+        .select()
+        .from(lmsAnnualAckCyclesTable)
+        .where(
+          and(
+            eq(lmsAnnualAckCyclesTable.company_id, companyId),
+            eq(lmsAnnualAckCyclesTable.id, id),
+          ),
+        )
+        .limit(1);
+      const cycle = cycleRows[0];
+      if (!cycle) {
+        return res.status(404).json({
+          error: "Not Found",
+          message: "Cycle not found",
+        });
+      }
+
+      const required: string[] = Array.isArray(cycle.required_documents)
+        ? (cycle.required_documents as string[])
+        : [];
+
+      // Pending re-ack rows triggered during this cycle's window.
+      const windowStart = cycle.opened_at;
+      const windowEnd = cycle.closed_at ?? new Date();
+      const rows = required.length
+        ? await db
+            .select({
+              id: lmsPendingReAckTable.id,
+              user_id: lmsPendingReAckTable.user_id,
+              document_type: lmsPendingReAckTable.document_type,
+              triggered_at: lmsPendingReAckTable.triggered_at,
+              acknowledged_at: lmsPendingReAckTable.acknowledged_at,
+              defer_until: lmsPendingReAckTable.defer_until,
+              trigger_reason: lmsPendingReAckTable.trigger_reason,
+            })
+            .from(lmsPendingReAckTable)
+            .where(
+              and(
+                eq(lmsPendingReAckTable.company_id, companyId),
+                inArray(lmsPendingReAckTable.document_type, required),
+                eq(lmsPendingReAckTable.trigger_reason, "annual_cycle"),
+              ),
+            )
+        : [];
+
+      // Filter to the cycle window in-memory. Drizzle doesn't have
+      // a "between" helper for tz-aware timestamps that pairs cleanly
+      // with `inArray`; rows count is small (one per employee per
+      // required doc) so this is cheap.
+      const wsMs = (windowStart as Date).getTime();
+      const weMs = (windowEnd as Date).getTime();
+      const inWindow = rows.filter((r) => {
+        const ts = (r.triggered_at as Date).getTime();
+        return ts >= wsMs && ts <= weMs;
+      });
+
+      const summary = summarizePendingReAcks(inWindow);
+
+      return res.json({
+        data: {
+          cycle,
+          summary,
+          pending: inWindow,
+        },
+      });
+    } catch (err) {
+      console.error("[lms-annual-ack] GET /admin/cycles/:id error:", err);
+      return res.status(500).json({
+        error: "Internal Server Error",
+        message: "Failed to load cycle detail",
+      });
+    }
+  },
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PATCH /admin/cycles/:id/close — mark a cycle closed
+// ─────────────────────────────────────────────────────────────────────────────
+
+router.patch(
+  "/admin/cycles/:id/close",
+  requireAuth,
+  requireRole("owner", "admin"),
+  async (req, res) => {
+    try {
+      const companyId = req.auth!.companyId;
+      if (companyId == null) {
+        return res.status(400).json({
+          error: "Bad Request",
+          message: "User has no company assignment",
+        });
+      }
+      const id = Number(req.params.id);
+      if (!Number.isFinite(id) || id <= 0) {
+        return res
+          .status(400)
+          .json({ error: "Bad Request", message: "Invalid id" });
+      }
+      const now = new Date();
+      const updated = await db
+        .update(lmsAnnualAckCyclesTable)
+        .set({ closed_at: now })
+        .where(
+          and(
+            eq(lmsAnnualAckCyclesTable.company_id, companyId),
+            eq(lmsAnnualAckCyclesTable.id, id),
+            isNull(lmsAnnualAckCyclesTable.closed_at),
+          ),
+        )
+        .returning();
+      if (!updated[0]) {
+        return res.status(404).json({
+          error: "Not Found",
+          message: "Cycle not found or already closed",
+        });
+      }
+      await logAudit(
+        req,
+        "lms_annual_cycle_closed",
+        "lms_annual_ack_cycle",
+        id,
+      );
+      return res.json({ data: updated[0] });
+    } catch (err) {
+      console.error("[lms-annual-ack] PATCH close error:", err);
+      return res.status(500).json({
+        error: "Internal Server Error",
+        message: "Failed to close cycle",
+      });
+    }
+  },
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /admin/force-resign — push a single user into re-ack
+// ─────────────────────────────────────────────────────────────────────────────
+
+router.post(
+  "/admin/force-resign",
+  requireAuth,
+  requireRole("owner", "admin"),
+  async (req, res) => {
+    try {
+      const companyId = req.auth!.companyId;
+      if (companyId == null) {
+        return res.status(400).json({
+          error: "Bad Request",
+          message: "User has no company assignment",
+        });
+      }
+      const adminId = req.auth!.userId;
+      const body = req.body ?? {};
+
+      const targetUserId = Number(body.user_id);
+      if (!Number.isFinite(targetUserId) || targetUserId <= 0) {
+        return res.status(400).json({
+          error: "Bad Request",
+          message: "user_id is required",
+        });
+      }
+      const documentType: unknown = body.document_type;
+      if (typeof documentType !== "string" || documentType.length === 0) {
+        return res.status(400).json({
+          error: "Bad Request",
+          message: "document_type is required",
+        });
+      }
+      const reason: unknown = body.trigger_reason ?? "admin_force_resign";
+      if (!isValidTriggerReason(reason)) {
+        return res.status(400).json({
+          error: "Bad Request",
+          message: `trigger_reason must be one of admin_force_resign, policy_correction, material_content_change, annual_cycle`,
+        });
+      }
+
+      // Tenant gate the target.
+      const targetUser = await db
+        .select({ id: usersTable.id })
+        .from(usersTable)
+        .where(
+          and(
+            eq(usersTable.id, targetUserId),
+            eq(usersTable.company_id, companyId),
+          ),
+        )
+        .limit(1);
+      if (!targetUser[0]) {
+        return res.status(404).json({
+          error: "Not Found",
+          message: "User not found in this tenant",
+        });
+      }
+
+      // Pick the locale of their last signed handbook if any, else en.
+      const lastSigned = await db
+        .select({ locale: lmsSignedDocumentsTable.locale })
+        .from(lmsSignedDocumentsTable)
+        .where(
+          and(
+            eq(lmsSignedDocumentsTable.company_id, companyId),
+            eq(lmsSignedDocumentsTable.user_id, targetUserId),
+            eq(lmsSignedDocumentsTable.document_type, documentType),
+          ),
+        )
+        .orderBy(desc(lmsSignedDocumentsTable.signed_at))
+        .limit(1);
+      const locale =
+        lastSigned[0]?.locale === "es" ? "es" : "en";
+
+      const content = getSignedDocumentContent(documentType, locale);
+      if (!content) {
+        return res.status(400).json({
+          error: "Bad Request",
+          message: `No canonical content registered for ${documentType}/${locale}`,
+        });
+      }
+
+      const version = await getOrCreateDocumentVersion({
+        companyId,
+        documentType,
+        locale,
+        contentHtml: content.contentHtml,
+        isMaterial: reason === "material_content_change",
+        notes: content.notes,
+      });
+
+      const inserted = await db
+        .insert(lmsPendingReAckTable)
+        .values({
+          company_id: companyId,
+          user_id: targetUserId,
+          document_type: documentType,
+          new_version_id: version.id,
+          new_version_hash: version.version_hash,
+          trigger_reason: reason,
+          triggered_by_user_id: adminId,
+        })
+        .returning();
+
+      await logAudit(
+        req,
+        "lms_force_resign",
+        "lms_pending_re_ack",
+        inserted[0]!.id,
+        null,
+        { document_type: documentType, target_user_id: targetUserId, reason },
+      );
+
+      return res.json({ data: inserted[0] });
+    } catch (err) {
+      console.error("[lms-annual-ack] POST /admin/force-resign error:", err);
+      return res.status(500).json({
+        error: "Internal Server Error",
+        message: "Failed to force re-sign",
+      });
+    }
+  },
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PATCH /admin/pending/:id/defer — set defer_until on a pending row
+// ─────────────────────────────────────────────────────────────────────────────
+
+router.patch(
+  "/admin/pending/:id/defer",
+  requireAuth,
+  requireRole("owner", "admin"),
+  async (req, res) => {
+    try {
+      const companyId = req.auth!.companyId;
+      if (companyId == null) {
+        return res.status(400).json({
+          error: "Bad Request",
+          message: "User has no company assignment",
+        });
+      }
+      const id = Number(req.params.id);
+      if (!Number.isFinite(id) || id <= 0) {
+        return res
+          .status(400)
+          .json({ error: "Bad Request", message: "Invalid id" });
+      }
+      const deferUntil = parseDeadlineInput(req.body?.defer_until);
+      if (deferUntil === null) {
+        return res.status(400).json({
+          error: "Bad Request",
+          message: "defer_until must be a valid ISO timestamp",
+        });
+      }
+      const updated = await db
+        .update(lmsPendingReAckTable)
+        .set({ defer_until: deferUntil, updated_at: new Date() })
+        .where(
+          and(
+            eq(lmsPendingReAckTable.company_id, companyId),
+            eq(lmsPendingReAckTable.id, id),
+            isNull(lmsPendingReAckTable.acknowledged_at),
+          ),
+        )
+        .returning();
+      if (!updated[0]) {
+        return res.status(404).json({
+          error: "Not Found",
+          message: "Pending re-ack row not found or already acknowledged",
+        });
+      }
+      await logAudit(
+        req,
+        "lms_pending_re_ack_deferred",
+        "lms_pending_re_ack",
+        id,
+        null,
+        { defer_until: deferUntil.toISOString() },
+      );
+      return res.json({ data: updated[0] });
+    } catch (err) {
+      console.error("[lms-annual-ack] PATCH defer error:", err);
+      return res.status(500).json({
+        error: "Internal Server Error",
+        message: "Failed to set defer_until",
+      });
+    }
+  },
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /me/pending — caller's outstanding re-ack rows
+// ─────────────────────────────────────────────────────────────────────────────
+
+router.get("/me/pending", requireAuth, async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    if (companyId == null) {
+      return res.status(400).json({
+        error: "Bad Request",
+        message: "User has no company assignment",
+      });
+    }
+    const userId = req.auth!.userId;
+    const rows = await db
+      .select({
+        id: lmsPendingReAckTable.id,
+        document_type: lmsPendingReAckTable.document_type,
+        new_version_hash: lmsPendingReAckTable.new_version_hash,
+        trigger_reason: lmsPendingReAckTable.trigger_reason,
+        triggered_at: lmsPendingReAckTable.triggered_at,
+        defer_until: lmsPendingReAckTable.defer_until,
+      })
+      .from(lmsPendingReAckTable)
+      .where(
+        and(
+          eq(lmsPendingReAckTable.company_id, companyId),
+          eq(lmsPendingReAckTable.user_id, userId),
+          isNull(lmsPendingReAckTable.acknowledged_at),
+        ),
+      )
+      .orderBy(asc(lmsPendingReAckTable.triggered_at));
+
+    const now = new Date();
+    const active = rows.filter((r) => {
+      if (!r.defer_until) return true;
+      const def = r.defer_until as Date;
+      return def.getTime() <= now.getTime();
+    });
+    const deferred = rows.filter((r) => {
+      if (!r.defer_until) return false;
+      const def = r.defer_until as Date;
+      return def.getTime() > now.getTime();
+    });
+
+    return res.json({
+      data: {
+        active,
+        deferred,
+        total: rows.length,
+      },
+    });
+  } catch (err) {
+    console.error("[lms-annual-ack] GET /me/pending error:", err);
+    return res.status(500).json({
+      error: "Internal Server Error",
+      message: "Failed to load pending re-acks",
+    });
+  }
+});
+
+export default router;

--- a/artifacts/api-server/src/routes/lms-handbook.ts
+++ b/artifacts/api-server/src/routes/lms-handbook.ts
@@ -68,6 +68,7 @@ import {
   generateComprehensiveHandbookPdf,
   type SignedAckSummary,
 } from "../lib/lms-handbook-pdf.js";
+import { acknowledgePendingReAcksForSign } from "./lms-annual-ack.js";
 import { logAudit } from "../lib/audit.js";
 
 const router = Router();
@@ -322,7 +323,21 @@ router.post("/sign", requireAuth, async (req, res) => {
         version_hash: version.version_hash,
       },
     });
-    await logAudit(req, "lms_handbook_signed", "lms_signed_document", signedDocumentId);
+
+    // Settle any outstanding annual / forced re-ack rows for this user
+    // and document. Tenant-scoped; runs even when no cycle is active
+    // because admin force-resign rows live outside cycles.
+    const acknowledgedCount = await acknowledgePendingReAcksForSign({
+      companyId,
+      userId,
+      documentType: HANDBOOK_DOCUMENT_TYPE,
+      signedDocumentId,
+      now,
+    });
+
+    await logAudit(req, "lms_handbook_signed", "lms_signed_document", signedDocumentId, null, {
+      pending_re_acks_settled: acknowledgedCount,
+    });
 
     return res.json({
       data: {

--- a/artifacts/api-server/src/tests/lms-annual-ack.test.ts
+++ b/artifacts/api-server/src/tests/lms-annual-ack.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Annual re-acknowledgment helpers — unit tests (Phase 14, PR #15).
+ *
+ * Covers the pure helpers in `lib/lms-annual-ack.ts`. The DB-touching
+ * route handlers are exercised via integration testing on a live
+ * Postgres; that path is gated by Express + JWT + Supabase RLS and
+ * intentionally not mocked here (same pattern as lms-handbook.test.ts).
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  ANNUAL_DOCUMENT_TYPE_SET,
+  TRIGGER_REASONS,
+  defaultCycleDeadline,
+  isValidCycleYear,
+  isValidLocale,
+  isValidTriggerReason,
+  parseDeadlineInput,
+  summarizePendingReAcks,
+  validateRequiredDocuments,
+} from "../lib/lms-annual-ack.js";
+import { ANNUAL_DOCUMENT_TYPES } from "@workspace/db/schema";
+
+describe("defaultCycleDeadline", () => {
+  it("returns Dec 31 23:59:59.999 UTC for the cycle year", () => {
+    const d = defaultCycleDeadline(2026);
+    assert.equal(d.getUTCFullYear(), 2026);
+    assert.equal(d.getUTCMonth(), 11);
+    assert.equal(d.getUTCDate(), 31);
+    assert.equal(d.getUTCHours(), 23);
+    assert.equal(d.getUTCMinutes(), 59);
+    assert.equal(d.getUTCSeconds(), 59);
+    assert.equal(d.getUTCMilliseconds(), 999);
+  });
+
+  it("crosses year correctly (returns 2027-12-31, not 2028-01-01)", () => {
+    const d = defaultCycleDeadline(2027);
+    assert.equal(d.getUTCFullYear(), 2027);
+    assert.equal(d.toISOString().slice(0, 10), "2027-12-31");
+  });
+});
+
+describe("isValidCycleYear", () => {
+  it("accepts integers in [2025, 2100]", () => {
+    assert.equal(isValidCycleYear(2025), true);
+    assert.equal(isValidCycleYear(2026), true);
+    assert.equal(isValidCycleYear(2100), true);
+  });
+  it("rejects out-of-range values", () => {
+    assert.equal(isValidCycleYear(2024), false);
+    assert.equal(isValidCycleYear(2101), false);
+  });
+  it("rejects non-integers", () => {
+    assert.equal(isValidCycleYear(2026.5), false);
+    assert.equal(isValidCycleYear("2026"), false);
+    assert.equal(isValidCycleYear(null), false);
+    assert.equal(isValidCycleYear(undefined), false);
+  });
+});
+
+describe("isValidTriggerReason", () => {
+  it("accepts every TRIGGER_REASONS member", () => {
+    for (const r of TRIGGER_REASONS) {
+      assert.equal(isValidTriggerReason(r), true);
+    }
+  });
+  it("rejects unknown reasons", () => {
+    assert.equal(isValidTriggerReason("rebrand"), false);
+    assert.equal(isValidTriggerReason(""), false);
+    assert.equal(isValidTriggerReason(null), false);
+  });
+});
+
+describe("isValidLocale", () => {
+  it("accepts en/es", () => {
+    assert.equal(isValidLocale("en"), true);
+    assert.equal(isValidLocale("es"), true);
+  });
+  it("rejects everything else", () => {
+    assert.equal(isValidLocale("EN"), false);
+    assert.equal(isValidLocale("fr"), false);
+    assert.equal(isValidLocale(null), false);
+  });
+});
+
+describe("parseDeadlineInput", () => {
+  it("parses a valid ISO timestamp", () => {
+    const d = parseDeadlineInput("2026-12-31T23:59:59Z");
+    assert.ok(d instanceof Date);
+    assert.equal(d!.toISOString(), "2026-12-31T23:59:59.000Z");
+  });
+  it("returns null for invalid strings", () => {
+    assert.equal(parseDeadlineInput("not a date"), null);
+    assert.equal(parseDeadlineInput(""), null);
+  });
+  it("returns null for non-strings", () => {
+    assert.equal(parseDeadlineInput(123), null);
+    assert.equal(parseDeadlineInput(null), null);
+    assert.equal(parseDeadlineInput(undefined), null);
+  });
+});
+
+describe("validateRequiredDocuments", () => {
+  it("defaults to ANNUAL_DOCUMENT_TYPES when input is undefined", () => {
+    const v = validateRequiredDocuments(undefined);
+    assert.equal(v.ok, true);
+    assert.deepEqual(v.documents, [...ANNUAL_DOCUMENT_TYPES]);
+  });
+
+  it("defaults to ANNUAL_DOCUMENT_TYPES when input is an empty array", () => {
+    const v = validateRequiredDocuments([]);
+    assert.equal(v.ok, true);
+    assert.deepEqual(v.documents, [...ANNUAL_DOCUMENT_TYPES]);
+  });
+
+  it("accepts the canonical list", () => {
+    const v = validateRequiredDocuments(["handbook"]);
+    assert.equal(v.ok, true);
+    assert.deepEqual(v.documents, ["handbook"]);
+  });
+
+  it("rejects unknown document types via `invalid`", () => {
+    const v = validateRequiredDocuments(["handbook", "definitely_made_up"]);
+    assert.equal(v.ok, false);
+    assert.deepEqual(v.invalid, ["definitely_made_up"]);
+  });
+
+  it("rejects known-but-non-annual docs via `notAnnual`", () => {
+    const v = validateRequiredDocuments(["handbook", "supply_kit"]);
+    assert.equal(v.ok, false);
+    assert.deepEqual(v.notAnnual, ["supply_kit"]);
+  });
+
+  it("dedupes input", () => {
+    const v = validateRequiredDocuments(["handbook", "handbook"]);
+    assert.equal(v.ok, true);
+    assert.deepEqual(v.documents, ["handbook"]);
+  });
+
+  it("rejects non-array input", () => {
+    const v = validateRequiredDocuments("handbook");
+    assert.equal(v.ok, false);
+  });
+
+  it("rejects non-string entries", () => {
+    const v = validateRequiredDocuments([42]);
+    assert.equal(v.ok, false);
+  });
+});
+
+describe("ANNUAL_DOCUMENT_TYPE_SET", () => {
+  it("includes handbook", () => {
+    assert.equal(ANNUAL_DOCUMENT_TYPE_SET.has("handbook"), true);
+  });
+
+  it("does NOT include one-time docs", () => {
+    assert.equal(ANNUAL_DOCUMENT_TYPE_SET.has("non_solicitation"), false);
+    assert.equal(ANNUAL_DOCUMENT_TYPE_SET.has("supply_kit"), false);
+    assert.equal(ANNUAL_DOCUMENT_TYPE_SET.has("video_photo_release"), false);
+  });
+});
+
+describe("summarizePendingReAcks", () => {
+  const now = new Date("2026-05-13T12:00:00Z");
+  const past = new Date("2026-04-01T00:00:00Z").toISOString();
+  const future = new Date("2026-12-31T00:00:00Z").toISOString();
+  const beforeNow = new Date("2026-05-01T00:00:00Z").toISOString();
+
+  it("returns all-zero counts for an empty array", () => {
+    const s = summarizePendingReAcks([], now);
+    assert.deepEqual(s, { total: 0, acknowledged: 0, pending: 0, deferred: 0 });
+  });
+
+  it("counts acknowledged rows separately", () => {
+    const s = summarizePendingReAcks(
+      [
+        { acknowledged_at: now, defer_until: null, triggered_at: past },
+        { acknowledged_at: null, defer_until: null, triggered_at: past },
+      ],
+      now,
+    );
+    assert.equal(s.acknowledged, 1);
+    assert.equal(s.pending, 1);
+    assert.equal(s.deferred, 0);
+    assert.equal(s.total, 2);
+  });
+
+  it("counts a future defer_until as deferred (not pending)", () => {
+    const s = summarizePendingReAcks(
+      [
+        {
+          acknowledged_at: null,
+          defer_until: future,
+          triggered_at: past,
+        },
+      ],
+      now,
+    );
+    assert.equal(s.deferred, 1);
+    assert.equal(s.pending, 0);
+  });
+
+  it("counts a past defer_until as pending (deferral has expired)", () => {
+    const s = summarizePendingReAcks(
+      [
+        {
+          acknowledged_at: null,
+          defer_until: beforeNow,
+          triggered_at: past,
+        },
+      ],
+      now,
+    );
+    assert.equal(s.pending, 1);
+    assert.equal(s.deferred, 0);
+  });
+
+  it("acknowledged beats deferred (acknowledged wins regardless of defer_until)", () => {
+    const s = summarizePendingReAcks(
+      [
+        {
+          acknowledged_at: now,
+          defer_until: future,
+          triggered_at: past,
+        },
+      ],
+      now,
+    );
+    assert.equal(s.acknowledged, 1);
+    assert.equal(s.deferred, 0);
+    assert.equal(s.pending, 0);
+  });
+});
+
+describe("TRIGGER_REASONS", () => {
+  it("includes the four expected reasons", () => {
+    const set = new Set<string>(TRIGGER_REASONS);
+    assert.ok(set.has("annual_cycle"));
+    assert.ok(set.has("material_content_change"));
+    assert.ok(set.has("admin_force_resign"));
+    assert.ok(set.has("policy_correction"));
+    assert.equal(set.size, 4);
+  });
+});


### PR DESCRIPTION
Phase 14 of 16. Opened as **draft** per your cadence rule.

## What changes

### New router `/api/lms/annual-ack`

| Method | Path | Auth |
| --- | --- | --- |
| POST | `/admin/cycles` | owner, admin |
| GET | `/admin/cycles` | owner, admin, office |
| GET | `/admin/cycles/:id` | owner, admin, office |
| PATCH | `/admin/cycles/:id/close` | owner, admin |
| POST | `/admin/force-resign` | owner, admin |
| PATCH | `/admin/pending/:id/defer` | owner, admin |
| GET | `/me/pending` | any authed user |

### Sweep semantics

Opening a cycle inserts an `lms_pending_re_ack` row for every non-terminated employee in the tenant who has an active signed_document for each `required_documents` type. Each row points at the **current canonical version** in the locale the employee last signed in. Re-running the sweep is idempotent (skips users that already have an unacknowledged row for that version).

### Acknowledgment wiring

`POST /api/lms/handbook/sign` now calls `acknowledgePendingReAcksForSign()` after the new signed_document is inserted, so any open `annual_cycle` or `admin_force_resign` rows for that (user, document_type) flip to `acknowledged_at = now` with `acknowledged_signed_document_id` pointing at the new signature. Phase 11 stays decoupled from cycle bookkeeping.

### Defaults

- `cycle_year` validated to [2025, 2100]
- `required_documents` defaults to `ANNUAL_DOCUMENT_TYPES` (currently `['handbook']`) when caller omits it
- `deadline_at` defaults to Dec 31 23:59:59.999 UTC of `cycle_year`
- `trigger_reason` allowed values: `annual_cycle`, `material_content_change`, `admin_force_resign`, `policy_correction`

## Tables already exist

`lms_annual_ack_cycles` and `lms_pending_re_ack` were defined in `lib/db/src/schema/lms-signatures.ts` and provisioned by `phes-data-migration.ts` lines 868-905. This PR adds routes + helpers only — no migration changes.

## Tests

**230/230 LMS unit tests pass** (was 202; 28 new tests). Build clean.

New test file `tests/lms-annual-ack.test.ts` covers:
- `defaultCycleDeadline` returns Dec 31 23:59:59.999 UTC
- `isValidCycleYear` accepts [2025, 2100], rejects non-integers
- `validateRequiredDocuments` defaults to `ANNUAL_DOCUMENT_TYPES`, rejects unknown types, rejects known-but-non-annual docs (e.g. supply_kit), dedupes
- `parseDeadlineInput` parses ISO strings, returns null on garbage
- `summarizePendingReAcks` counts acknowledged / pending / deferred correctly (future defer_until = deferred, past defer_until = pending, acknowledged beats deferred)
- `TRIGGER_REASONS` allowlist integrity
- `ANNUAL_DOCUMENT_TYPE_SET` excludes one-time docs (non_solicit, supply_kit, video_photo)

## Test plan after merge

- [ ] As owner: `POST /api/lms/annual-ack/admin/cycles` with `{cycle_year: 2026}` → returns cycle row, sweeps every active employee with a signed handbook
- [ ] As that employee: `GET /api/lms/annual-ack/me/pending` → returns the new pending row
- [ ] Employee signs handbook via existing `/api/lms/handbook/sign` → `me/pending` now empty, dashboard tile clears
- [ ] Owner: `GET /api/lms/annual-ack/admin/cycles/:id` → summary shows `acknowledged: 1`
- [ ] Owner: `POST /api/lms/annual-ack/admin/force-resign` for a specific user (single-user policy correction)
- [ ] Owner: re-open same year → returns 409 Conflict

## Phase 15 hook

`GET /admin/cycles/:id` already returns `{cycle, summary, pending}` which the Phase 15 audit dashboard will consume directly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxGiirnJ3dT4GAzHPNWhrx)_