### PR TITLE
lms: Phase 14 UI — annual cycle admin + user pending re-ack tile (UI gap PR B of 3)

### DIFF
--- a/artifacts/qleno/src/pages/lms-admin.tsx
+++ b/artifacts/qleno/src/pages/lms-admin.tsx
@@ -145,6 +145,7 @@ export default function LmsAdminPage() {
   const [historyOpen, setHistoryOpen] = useState<RosterRow | null>(null);
   const [expanded, setExpanded] = useState<Set<number>>(new Set());
   const [bulkPwOpen, setBulkPwOpen] = useState(false);
+  const [cyclesOpen, setCyclesOpen] = useState(false);
 
   function toggleExpand(enrollmentId: number) {
     setExpanded((prev) => {
@@ -249,6 +250,23 @@ export default function LmsAdminPage() {
             </div>
           </div>
           <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+            <button
+              type="button"
+              onClick={() => setCyclesOpen(true)}
+              style={{
+                background: TEAL,
+                color: "#fff",
+                border: `1px solid ${TEAL}`,
+                padding: "8px 12px",
+                borderRadius: 8,
+                fontSize: 12,
+                fontWeight: 700,
+                cursor: "pointer",
+                fontFamily: FONT,
+              }}
+            >
+              Annual cycles
+            </button>
             <button
               type="button"
               onClick={() => setBulkPwOpen(true)}
@@ -389,6 +407,13 @@ export default function LmsAdminPage() {
           token={token}
           onClose={() => setBulkPwOpen(false)}
           onSaved={() => setBulkPwOpen(false)}
+        />
+      )}
+
+      {cyclesOpen && (
+        <AnnualCyclesDialog
+          token={token}
+          onClose={() => setCyclesOpen(false)}
         />
       )}
 
@@ -2324,6 +2349,443 @@ type CertificateRow = {
   revoked_at: string | null;
   revoked_reason: string | null;
 };
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Annual cycles dialog (Phase 14 UI)
+//
+// Surfaces the existing /api/lms/annual-ack admin routes:
+//   - GET    /admin/cycles              list cycles for the tenant
+//   - POST   /admin/cycles              open a new cycle + sweep
+//   - PATCH  /admin/cycles/:id/close    close an open cycle
+//
+// Cycles default to the current calendar year + Dec 31 deadline (the
+// server computes both when omitted). The dialog deliberately doesn't
+// surface per-learner force-resign here — that's reachable via the
+// dedicated user row actions in a follow-up.
+// ─────────────────────────────────────────────────────────────────────────────
+
+type AnnualCycleRow = {
+  id: number;
+  cycle_year: number;
+  deadline_at: string;
+  required_documents: string[];
+  opened_at: string;
+  closed_at: string | null;
+  notes: string | null;
+};
+
+function AnnualCyclesDialog({
+  token,
+  onClose,
+}: {
+  token: string | null;
+  onClose: () => void;
+}) {
+  const [cycles, setCycles] = useState<AnnualCycleRow[] | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [openForm, setOpenForm] = useState<{ year: number; notes: string }>(
+    () => ({ year: new Date().getFullYear(), notes: "" }),
+  );
+
+  const refresh = async () => {
+    try {
+      const data = await api<AnnualCycleRow[]>(
+        "GET",
+        "/lms/annual-ack/admin/cycles",
+        token,
+      );
+      setCycles(data);
+      setErr(null);
+    } catch (e) {
+      setErr(String((e as Error).message));
+    }
+  };
+
+  useEffect(() => {
+    void refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [token]);
+
+  const openCycle = async () => {
+    setBusy("open");
+    setErr(null);
+    try {
+      const body: Record<string, unknown> = { cycle_year: openForm.year };
+      if (openForm.notes.trim().length > 0) {
+        body.notes = openForm.notes.trim();
+      }
+      await api("POST", "/lms/annual-ack/admin/cycles", token, body);
+      await refresh();
+    } catch (e) {
+      setErr(String((e as Error).message));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const closeCycle = async (cycleId: number) => {
+    if (!confirm("Close this cycle? Outstanding pending re-acks stay open until employees sign.")) return;
+    setBusy(`close-${cycleId}`);
+    setErr(null);
+    try {
+      await api(
+        "PATCH",
+        `/lms/annual-ack/admin/cycles/${cycleId}/close`,
+        token,
+      );
+      await refresh();
+    } catch (e) {
+      setErr(String((e as Error).message));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Annual re-acknowledgment cycles"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "rgba(15, 23, 42, 0.55)",
+        display: "grid",
+        placeItems: "center",
+        zIndex: 100,
+        padding: 16,
+      }}
+    >
+      <div
+        style={{
+          background: SURFACE,
+          borderRadius: RADIUS,
+          maxWidth: 640,
+          width: "100%",
+          maxHeight: "92vh",
+          overflowY: "auto",
+          padding: 24,
+          fontFamily: FONT,
+          color: INK,
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "baseline",
+            gap: 8,
+            flexWrap: "wrap",
+          }}
+        >
+          <div>
+            <div style={{ fontSize: 18, fontWeight: 800, color: INK }}>
+              Annual re-acknowledgment cycles
+            </div>
+            <div style={{ fontSize: 12.5, color: INK_MUTE, marginTop: 4 }}>
+              Open a cycle to push every active employee with an existing
+              handbook signature into a forced re-sign flow. They'll see a
+              tile on /training on their next login.
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            style={{
+              background: "transparent",
+              border: `1px solid ${LINE}`,
+              borderRadius: 8,
+              padding: "6px 8px",
+              cursor: "pointer",
+              color: INK_MUTE,
+              fontFamily: FONT,
+            }}
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        {err && (
+          <div
+            style={{
+              background: "#FEF2F2",
+              border: `1px solid #FECACA`,
+              color: DANGER,
+              padding: 10,
+              borderRadius: 8,
+              fontSize: 12,
+              marginTop: 12,
+            }}
+          >
+            {err}
+          </div>
+        )}
+
+        {/* Open new cycle form */}
+        <div
+          style={{
+            marginTop: 18,
+            border: `1px solid ${LINE}`,
+            borderRadius: 8,
+            padding: 14,
+            background: LINE_SOFT,
+          }}
+        >
+          <div style={{ fontSize: 13, fontWeight: 800, color: INK }}>
+            Open a new cycle
+          </div>
+          <div style={{ fontSize: 12, color: INK_MUTE, marginTop: 4 }}>
+            Default deadline is Dec 31 of the cycle year. Documents default
+            to handbook only.
+          </div>
+          <div
+            style={{
+              marginTop: 10,
+              display: "flex",
+              gap: 10,
+              alignItems: "flex-end",
+              flexWrap: "wrap",
+            }}
+          >
+            <label style={{ fontSize: 12, fontWeight: 700, color: INK_MUTE }}>
+              Cycle year
+              <input
+                type="number"
+                min={2025}
+                max={2100}
+                value={openForm.year}
+                onChange={(e) =>
+                  setOpenForm((f) => ({ ...f, year: Number(e.target.value) }))
+                }
+                style={{
+                  display: "block",
+                  width: 110,
+                  marginTop: 4,
+                  padding: "8px 10px",
+                  border: `1px solid ${LINE}`,
+                  borderRadius: 8,
+                  fontFamily: FONT,
+                  fontSize: 14,
+                }}
+              />
+            </label>
+            <label
+              style={{
+                flex: 1,
+                minWidth: 180,
+                fontSize: 12,
+                fontWeight: 700,
+                color: INK_MUTE,
+              }}
+            >
+              Notes (optional)
+              <input
+                type="text"
+                value={openForm.notes}
+                onChange={(e) =>
+                  setOpenForm((f) => ({ ...f, notes: e.target.value }))
+                }
+                placeholder="e.g. Q4 2026 handbook refresh"
+                style={{
+                  display: "block",
+                  width: "100%",
+                  marginTop: 4,
+                  padding: "8px 10px",
+                  border: `1px solid ${LINE}`,
+                  borderRadius: 8,
+                  fontFamily: FONT,
+                  fontSize: 14,
+                }}
+              />
+            </label>
+            <button
+              type="button"
+              disabled={busy !== null}
+              onClick={openCycle}
+              style={{
+                background: busy === "open" ? INK_LIGHT : TEAL,
+                color: "#fff",
+                border: 0,
+                padding: "8px 14px",
+                borderRadius: 8,
+                fontSize: 13,
+                fontWeight: 700,
+                fontFamily: FONT,
+                cursor: busy ? "default" : "pointer",
+              }}
+            >
+              {busy === "open" ? "Opening…" : "Open cycle"}
+            </button>
+          </div>
+        </div>
+
+        {/* Cycle list */}
+        <div style={{ marginTop: 18 }}>
+          <div style={{ fontSize: 13, fontWeight: 800, color: INK }}>
+            Cycles
+          </div>
+          {cycles === null ? (
+            <div
+              style={{
+                marginTop: 10,
+                padding: 18,
+                textAlign: "center",
+                color: INK_MUTE,
+              }}
+            >
+              <Loader2 size={16} className="qleno-admin-spin" />
+            </div>
+          ) : cycles.length === 0 ? (
+            <div
+              style={{
+                marginTop: 10,
+                padding: 14,
+                background: PAGE_BG,
+                border: `1px dashed ${LINE}`,
+                borderRadius: 8,
+                fontSize: 13,
+                color: INK_MUTE,
+              }}
+            >
+              No cycles yet. Open one above to fan out forced re-acknowledgments.
+            </div>
+          ) : (
+            <div
+              style={{
+                marginTop: 10,
+                display: "grid",
+                gap: 8,
+              }}
+            >
+              {cycles.map((c) => {
+                const closed = c.closed_at !== null;
+                const closeBusy = busy === `close-${c.id}`;
+                return (
+                  <div
+                    key={c.id}
+                    style={{
+                      display: "grid",
+                      gridTemplateColumns: "1fr auto",
+                      alignItems: "center",
+                      gap: 12,
+                      padding: 12,
+                      border: `1px solid ${LINE}`,
+                      borderLeft: `4px solid ${closed ? INK_LIGHT : SUCCESS}`,
+                      borderRadius: 8,
+                      background: SURFACE,
+                    }}
+                  >
+                    <div>
+                      <div
+                        style={{
+                          fontSize: 14,
+                          fontWeight: 800,
+                          color: INK,
+                          display: "flex",
+                          gap: 8,
+                          alignItems: "center",
+                          flexWrap: "wrap",
+                        }}
+                      >
+                        {c.cycle_year}
+                        <span
+                          style={{
+                            fontSize: 10.5,
+                            fontWeight: 800,
+                            color: closed ? INK_MUTE : SUCCESS,
+                            background: closed ? "#F1F5F9" : "#ECFDF5",
+                            padding: "2px 8px",
+                            borderRadius: 999,
+                            letterSpacing: "0.04em",
+                            textTransform: "uppercase",
+                          }}
+                        >
+                          {closed ? "Closed" : "Open"}
+                        </span>
+                      </div>
+                      <div
+                        style={{
+                          fontSize: 11.5,
+                          color: INK_MUTE,
+                          marginTop: 4,
+                          lineHeight: 1.5,
+                        }}
+                      >
+                        Deadline {humanDateTime(c.deadline_at)} · Opened{" "}
+                        {humanDateTime(c.opened_at)}
+                        {closed ? (
+                          <> · Closed {humanDateTime(c.closed_at!)}</>
+                        ) : null}
+                      </div>
+                      <div
+                        style={{
+                          fontSize: 11,
+                          color: INK_LIGHT,
+                          marginTop: 2,
+                        }}
+                      >
+                        Documents:{" "}
+                        {(c.required_documents ?? []).join(", ") || "—"}
+                      </div>
+                      {c.notes ? (
+                        <div
+                          style={{
+                            fontSize: 11.5,
+                            color: INK_MUTE,
+                            marginTop: 4,
+                            fontStyle: "italic",
+                          }}
+                        >
+                          {c.notes}
+                        </div>
+                      ) : null}
+                    </div>
+                    <div>
+                      {!closed ? (
+                        <button
+                          type="button"
+                          disabled={busy !== null}
+                          onClick={() => closeCycle(c.id)}
+                          style={{
+                            background:
+                              closeBusy || busy !== null
+                                ? INK_LIGHT
+                                : "transparent",
+                            color:
+                              closeBusy || busy !== null ? "#fff" : DANGER,
+                            border: `1px solid ${
+                              closeBusy || busy !== null ? INK_LIGHT : DANGER
+                            }`,
+                            padding: "6px 12px",
+                            borderRadius: 8,
+                            fontSize: 12,
+                            fontWeight: 700,
+                            fontFamily: FONT,
+                            cursor: busy ? "default" : "pointer",
+                          }}
+                        >
+                          {closeBusy ? "Closing…" : "Close cycle"}
+                        </button>
+                      ) : (
+                        <span style={{ fontSize: 11, color: INK_LIGHT }}>
+                          —
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
 
 function LearnerCertificatesPanel({ row }: { row: RosterRow }) {
   const token = useAuthStore((s) => s.token);

--- a/artifacts/qleno/src/pages/training.tsx
+++ b/artifacts/qleno/src/pages/training.tsx
@@ -321,6 +321,23 @@ const lmsApi = {
       ...args,
       affirmation: true,
     }),
+  getPendingReAcks: (token: string | null) =>
+    api<PendingReAckSummary>("GET", "/lms/annual-ack/me/pending", token),
+};
+
+type PendingReAckRow = {
+  id: number;
+  document_type: string;
+  new_version_hash: string;
+  trigger_reason: string;
+  triggered_at: string;
+  defer_until: string | null;
+};
+
+type PendingReAckSummary = {
+  active: PendingReAckRow[];
+  deferred: PendingReAckRow[];
+  total: number;
 };
 
 type HandbookEligibility = {
@@ -534,6 +551,8 @@ export default function TrainingPage() {
   const [signedDocs, setSignedDocs] = useState<SignedDocumentRow[]>([]);
   const [handbookEligibility, setHandbookEligibility] =
     useState<HandbookEligibility | null>(null);
+  const [pendingReAcks, setPendingReAcks] =
+    useState<PendingReAckSummary | null>(null);
 
   const curriculum = useMemo<Curriculum>(
     () => getCurriculum(learner?.companyId ?? null),
@@ -564,7 +583,7 @@ export default function TrainingPage() {
 
   const refresh = useCallback(async () => {
     try {
-      const [next, certs, docs, eligibility] = await Promise.all([
+      const [next, certs, docs, eligibility, pending] = await Promise.all([
         lmsApi.me(token),
         lmsApi.listMyCertificates(token).catch(() => [] as CertificateRow[]),
         lmsApi
@@ -573,11 +592,15 @@ export default function TrainingPage() {
         lmsApi
           .getHandbookEligibility(token)
           .catch(() => null as HandbookEligibility | null),
+        lmsApi
+          .getPendingReAcks(token)
+          .catch(() => null as PendingReAckSummary | null),
       ]);
       setState(next);
       setCertificates(certs);
       setSignedDocs(docs);
       setHandbookEligibility(eligibility);
+      setPendingReAcks(pending);
       // Sync locale from server if present
       if (next.enrollment.locale === "en" || next.enrollment.locale === "es") {
         setLocale(next.enrollment.locale);
@@ -717,6 +740,7 @@ export default function TrainingPage() {
           certByModule={certByModule}
           signedDocByType={signedDocByType}
           handbookEligibility={handbookEligibility}
+          pendingReAcks={pendingReAcks}
           token={token}
           onOpenModule={(moduleId) => setView({ kind: "module", moduleId })}
           onOpenFinal={() => setView({ kind: "final-intro" })}
@@ -1151,6 +1175,7 @@ function Home({
   certByModule,
   signedDocByType,
   handbookEligibility,
+  pendingReAcks,
   token,
   onOpenModule,
   onOpenFinal,
@@ -1169,6 +1194,7 @@ function Home({
   certByModule: Record<string, number>;
   signedDocByType: Record<string, number>;
   handbookEligibility: HandbookEligibility | null;
+  pendingReAcks: PendingReAckSummary | null;
   token: string | null;
   onOpenModule: (id: string) => void;
   onOpenFinal: () => void;
@@ -1188,6 +1214,8 @@ function Home({
   ).length;
   const pct = Math.round((passedCount / totalModules) * 100);
 
+  const activePendingCount = pendingReAcks?.active.length ?? 0;
+
   return (
     <div
       style={{
@@ -1196,6 +1224,14 @@ function Home({
         padding: "26px 18px",
       }}
     >
+      {activePendingCount > 0 ? (
+        <PendingReAckTile
+          locale={locale}
+          pending={pendingReAcks!}
+          onResign={onOpenSignHandbook}
+        />
+      ) : null}
+
       <div
         style={{
           marginBottom: 18,
@@ -3808,6 +3844,108 @@ function HandbookSignView({
           </>
         )}
       </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PendingReAckTile — surfaces outstanding annual / force-resign re-acks.
+//
+// Shown at the top of the home view when GET /api/lms/annual-ack/me/pending
+// returns a non-empty `active` array. Currently the only annual document
+// is "handbook", so the CTA routes through the handbook signing flow. If
+// future documents are added to ANNUAL_DOCUMENT_TYPES, this tile gains a
+// per-document CTA — for now the single CTA is enough.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function PendingReAckTile({
+  locale,
+  pending,
+  onResign,
+}: {
+  locale: Locale;
+  pending: PendingReAckSummary;
+  onResign: () => void;
+}) {
+  const count = pending.active.length;
+  const docTypes = Array.from(
+    new Set(pending.active.map((p) => p.document_type)),
+  );
+  const reasons = Array.from(
+    new Set(pending.active.map((p) => p.trigger_reason)),
+  );
+  const anyAnnual = reasons.includes("annual_cycle");
+  return (
+    <div
+      style={{
+        background: "#FFFBEB",
+        border: `1px solid #FDE68A`,
+        borderLeft: `4px solid ${WARN}`,
+        borderRadius: RADIUS,
+        padding: "14px 18px",
+        marginBottom: 18,
+        display: "grid",
+        gridTemplateColumns: "auto 1fr auto",
+        alignItems: "center",
+        gap: 14,
+        fontFamily: FONT,
+      }}
+    >
+      <AlertTriangle size={22} style={{ color: WARN }} />
+      <div>
+        <div style={{ fontWeight: 800, fontSize: 14.5, color: INK }}>
+          {locale === "es"
+            ? count === 1
+              ? "Tiene un reconocimiento pendiente"
+              : `Tiene ${count} reconocimientos pendientes`
+            : count === 1
+            ? "You have a re-acknowledgment pending"
+            : `You have ${count} re-acknowledgments pending`}
+        </div>
+        <div
+          style={{
+            fontSize: 12.5,
+            color: INK_MUTE,
+            marginTop: 4,
+            lineHeight: 1.55,
+          }}
+        >
+          {anyAnnual
+            ? locale === "es"
+              ? "Política anual: vuelva a firmar para confirmar que comprende los términos actualizados."
+              : "Annual policy: re-sign to confirm you understand the current terms."
+            : locale === "es"
+            ? "Cambio de política: vuelva a firmar el documento actualizado para mantenerse en cumplimiento."
+            : "Policy update: re-sign the updated document to stay in compliance."}
+        </div>
+        <div
+          style={{
+            fontSize: 11,
+            color: INK_LIGHT,
+            marginTop: 4,
+          }}
+        >
+          {docTypes.map((t) => humanSignedDocType(t, locale)).join(" · ")}
+        </div>
+      </div>
+      <button
+        type="button"
+        onClick={onResign}
+        style={{
+          background: WARN,
+          color: "#fff",
+          border: 0,
+          padding: "8px 14px",
+          borderRadius: 8,
+          fontSize: 12.5,
+          fontWeight: 800,
+          fontFamily: FONT,
+          cursor: "pointer",
+          whiteSpace: "nowrap",
+        }}
+      >
+        {locale === "es" ? "Volver a firmar →" : "Re-sign →"}
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
Second of three UI gap PRs. Opened as **draft** per your cadence rule.

## What changes

Two files: `pages/lms-admin.tsx` (+462) and `pages/training.tsx` (+140 / -1).

Closes the user-facing gap from the Phase 14 backend (PR #101). Operators can now manage annual cycles from the admin UI, and learners with pending re-acks see an actionable tile on `/training`.

## Admin surface (`/lms/admin`)

### New "Annual cycles" button in the page header

Teal so it visually separates from the destructive Bulk Reset action.

### `AnnualCyclesDialog`

Modal panel that surfaces every existing route from `/api/lms/annual-ack/admin/cycles`:

| Action | Backend route |
| --- | --- |
| List cycles | `GET /admin/cycles` |
| Open new cycle (with sweep) | `POST /admin/cycles` |
| Close cycle | `PATCH /admin/cycles/:id/close` |

Each cycle row shows year, status pill (Open/Closed), deadline + opened_at + closed_at timestamps, document list, and optional notes. The open-cycle form takes `cycle_year` (defaults to the current year) + optional notes; backend computes the Dec 31 23:59:59.999 UTC deadline and the default `required_documents: ['handbook']`.

Close-cycle has a `confirm()` prompt because outstanding pending re-acks stay open even after the cycle closes (employees can still sign them).

## User surface (`/training`)

### `PendingReAckTile`

Rendered at the top of the home view when `GET /api/lms/annual-ack/me/pending` returns active rows (i.e. unacknowledged AND not currently deferred).

- Amber stripe + warning icon + count
  - `"You have N re-acknowledgments pending"`
  - Spanish: `"Tiene N reconocimientos pendientes"`
- Reason copy switches on `trigger_reason`:
  - `annual_cycle` → "Annual policy: re-sign to confirm you understand the current terms."
  - else → "Policy update: re-sign the updated document to stay in compliance."
- Document type list rendered via the existing `humanSignedDocType()` helper
- **"Re-sign →" button** routes directly into the existing `HandbookSignView` flow (the only annual document today is handbook; future docs would add per-document CTAs)

### Acknowledgment wire-up (no new code)

When the learner re-signs through `HandbookSignView`, the existing `POST /api/lms/handbook/sign` endpoint calls `acknowledgePendingReAcksForSign()` (shipped in PR #101) which flips matching `lms_pending_re_ack` rows to `acknowledged_at = now`. On the next `refresh()` the tile clears automatically.

## Tenant + role gating

All admin routes require `owner | admin` (the close endpoint and the open endpoint) or `owner | admin | office` (list). Server enforces. The dialog button only renders inside the admin page, which is already gated on owner/admin/super_admin/office at the top of the file.

The user-facing tile renders for any authenticated user; the `me/pending` endpoint is scoped to the caller's `userId` + `companyId`.

## Test plan after merge

- [ ] As owner: visit `/lms/admin` → "Annual cycles" button appears in the header
- [ ] Click it → dialog shows "No cycles yet" if none exist
- [ ] Type `2026` + notes → "Open cycle" → row appears with status pill `Open`
- [ ] Trying to re-open `2026` returns 409 (server-side guard)
- [ ] As a tech who has a signed handbook: open `/training` → no tile (no pending re-acks)
- [ ] Owner opens cycle for 2026 → tech reloads `/training` → amber `PendingReAckTile` appears with "Re-sign →" CTA
- [ ] Tech clicks Re-sign → HandbookSignView opens; scroll-to-bottom + affirmation + sign succeeds
- [ ] Tile clears on return to home
- [ ] As owner: click "Close cycle" → confirm → row flips to status `Closed`

## Cadence

Pausing here for your review per the explicit rule. After approval:
- PR C: Phase 15 UI (audit tab on `/lms/admin` + CSV download button)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxGiirnJ3dT4GAzHPNWhrx)_