### PR TITLE
lms: Phes Policies content + quiz updates (10 edits, 5 modify, 4 add, 4 remove — MINOR)

### DIFF
--- a/artifacts/qleno/src/lib/training/curriculum.ts
+++ b/artifacts/qleno/src/lib/training/curriculum.ts
@@ -3128,7 +3128,7 @@ const BASE_QUIZ: QuizQuestion[] = [
   {
     id: "q-pp-11-unexcused-fourth",
     moduleId: "phes-policies",
-    prompt: { en: "An absence becomes 'unexcused' only when (a) you no-call/no-show OR (b) all four leave buckets (PLAWA, PTO, Unpaid Personal Leave, Unpaid Absence Allowance) are exhausted. Once an absence IS unexcused, what happens at the 4th occurrence?", es: "Una ausencia se considera 'injustificada' solo cuando (a) no llama / no se presenta, O (b) las cuatro cubetas (PLAWA, PTO, Licencia Personal No Pagada, Tolerancia de Ausencia No Pagada) están agotadas. Una vez que una ausencia ES injustificada, ¿qué sucede en la 4ª ocurrencia?" },
+    prompt: { en: "An absence becomes 'unexcused' only when (a) you no-call/no-show OR (b) all three leave buckets (PLAWA, PTO, Unpaid Personal Leave) are exhausted. Once an absence IS unexcused, what happens at the 4th occurrence?", es: "Una ausencia se considera 'injustificada' solo cuando (a) no llama / no se presenta, O (b) las tres cubetas de licencia (PLAWA, PTO, Licencia Personal No Pagada) están agotadas. Una vez que una ausencia ES injustificada, ¿qué sucede en la 4ª ocurrencia?" },
     options: [
       { en: "Coaching conversation", es: "Conversación de orientación" },
       { en: "Written warning", es: "Advertencia por escrito" },
@@ -3158,18 +3158,6 @@ const BASE_QUIZ: QuizQuestion[] = [
       { en: "Walk in carefully without covers — just don't track dirt", es: "Entrar con cuidado sin cubrezapatos" },
       { en: "Don't enter — get fresh covers from your vehicle, or call office for a teammate to bring some", es: "No entrar — buscar cubrezapatos en el vehículo, o llamar a la oficina" },
       { en: "Ask the client if they mind", es: "Preguntar al cliente si le importa" },
-    ],
-    correctIndex: 2,
-  },
-  {
-    id: "q-pp-14-phone-use",
-    moduleId: "phes-policies",
-    prompt: { en: "Mid-clean, your sister texts you about dinner plans. When do you respond?", es: "Durante la limpieza, su hermana le envía mensaje sobre la cena. ¿Cuándo responde?" },
-    options: [
-      { en: "Right away — it'll only take a second", es: "Ahora mismo — solo toma un segundo" },
-      { en: "Step into the bathroom for privacy and respond", es: "Entrar al baño por privacidad y responder" },
-      { en: "After the visit or during your break — personal phones are not allowed during a job", es: "Después de la visita o en su descanso — los teléfonos personales no se permiten durante un trabajo" },
-      { en: "Ask your partner to respond for you", es: "Pedirle a su compañero que responda por usted" },
     ],
     correctIndex: 2,
   },
@@ -3204,21 +3192,6 @@ const BASE_QUIZ: QuizQuestion[] = [
     correctIndex: 1,
   },
   {
-    id: "q-pp-17-office-exception",
-    moduleId: "phes-policies",
-    prompt: {
-      en: "You open today's job in the app and see a note from the office: 'Mrs. Johnson is a loyal client — please make the master bed today as a one-time courtesy.' Are you allowed to make the bed?",
-      es: "Abre el trabajo de hoy en la app y ve una nota de la oficina: 'La Sra. Johnson es cliente leal — por favor tienda la cama principal hoy como cortesía única.' ¿Puede tender la cama?",
-    },
-    options: [
-      { en: "No — standard guidelines never bend.", es: "No — las guías estándar nunca cambian." },
-      { en: "Yes — the office grants exceptions, and they communicate them via app notes or a direct message. Follow the note.", es: "Sí — la oficina otorga excepciones, y las comunica por notas en la app o mensaje directo. Siga la nota." },
-      { en: "Only if Mrs. Johnson asks me personally.", es: "Solo si la Sra. Johnson me pide en persona." },
-      { en: "Yes, but only if I call the office first to double-check.", es: "Sí, pero solo si llamo a la oficina primero para confirmar." },
-    ],
-    correctIndex: 1,
-  },
-  {
     id: "q-pp-18-bereavement",
     moduleId: "phes-policies",
     prompt: {
@@ -3227,7 +3200,7 @@ const BASE_QUIZ: QuizQuestion[] = [
     },
     options: [
       { en: "Up to 3 unpaid days off — use PLAWA to get paid.", es: "Hasta 3 días no pagados — use PLAWA para recibir pago." },
-      { en: "Up to 3 paid days at your regular rate (immediate family: spouse, child, parent, sibling).", es: "Hasta 3 días pagados a su tarifa regular (familia inmediata: cónyuge, hijo/a, padre/madre, hermano/a)." },
+      { en: "Up to 3 paid scheduled workdays at your regular rate, for immediate family (spouse, child, parent, or sibling).", es: "Hasta 3 días laborales programados pagados a su tarifa regular, para familia inmediata (cónyuge, hijo/a, padre/madre o hermano/a)." },
       { en: "Up to 5 paid days plus travel time.", es: "Hasta 5 días pagados más tiempo de viaje." },
       { en: "Phes does not offer bereavement leave.", es: "Phes no ofrece licencia por duelo." },
     ],
@@ -3309,17 +3282,17 @@ const BASE_QUIZ: QuizQuestion[] = [
     correctIndex: 1,
   },
   {
-    id: "q-pp-24-sick-doc",
+    id: "q-pp-24-plawa-foreseeable",
     moduleId: "phes-policies",
     prompt: {
-      en: "You're out with the flu for 4 consecutive workdays and use PLAWA. Does Phes require a doctor's note?",
-      es: "Está fuera con gripe por 4 días laborales consecutivos y usa PLAWA. ¿Phes requiere una nota médica?",
+      en: "You catch the flu and are out for 5 consecutive workdays. Each day, you give the 20-minute grace call. Since it is more than 4 consecutive PLAWA days, do you need advance approval?",
+      es: "Le da gripe y está fuera 5 días laborales consecutivos. Cada día da la llamada de gracia de 20 minutos. Como son más de 4 días consecutivos de PLAWA, ¿necesita aprobación previa?",
     },
     options: [
-      { en: "Yes — Phes requires a note for any absence of 3 days or more.", es: "Sí — Phes requiere una nota para cualquier ausencia de 3 días o más." },
-      { en: "No — Phes never requires a reason or a doctor's note to use PLAWA, regardless of how long the absence is. Phes policy is stricter than Illinois law on this point: we choose not to require documentation.", es: "No — Phes nunca exige una razón ni nota médica para usar PLAWA, sin importar la duración de la ausencia. La política de Phes es más estricta que la ley de Illinois en este punto: elegimos no exigir documentación." },
-      { en: "Only if the client complained about your absence.", es: "Solo si el cliente se quejó de su ausencia." },
-      { en: "Yes — flu absences specifically require a note.", es: "Sí — las ausencias por gripe específicamente requieren una nota." },
+      { en: "Yes. Any PLAWA absence over 4 days requires advance approval without exception.", es: "Sí. Cualquier ausencia de PLAWA mayor a 4 días requiere aprobación previa sin excepción." },
+      { en: "No. Advance approval only applies to FORESEEABLE absences (scheduled procedure, planned retreat, known appointment series). Sudden illness like the flu is unforeseeable. Just give the grace call each day. If you are sick a week with the flu and call each day, that is fine.", es: "No. La aprobación previa solo aplica a ausencias PREVISIBLES (procedimiento programado, retiro planeado, serie de citas conocida). Una enfermedad súbita como la gripe es imprevisible. Solo dé la llamada de gracia cada día. Si está enfermo una semana con gripe y llama cada día, está bien." },
+      { en: "Yes. You must submit a doctor's note before returning.", es: "Sí. Debe entregar una nota médica antes de regresar." },
+      { en: "No. PLAWA covers up to 3 days only. After day 3 the absence becomes unexcused.", es: "No. PLAWA cubre solo hasta 3 días. Después del día 3 la ausencia es injustificada." },
     ],
     correctIndex: 1,
   },
@@ -3331,7 +3304,7 @@ const BASE_QUIZ: QuizQuestion[] = [
       es: "Ha usado las 40 horas de su PLAWA en este Año de Beneficios. Despierta enfermo y llama para faltar (con la llamada de gracia de 20 minutos). ¿Cómo se clasifica esta ausencia?",
     },
     options: [
-      { en: "Phes covers the absence with the next leave bucket in order — PTO, then Unpaid Personal Leave, then Unpaid Absence Allowance. It is NOT unexcused unless all four buckets are exhausted or you no-call/no-showed.", es: "Phes cubre la ausencia con la siguiente cubeta en orden — PTO, luego Licencia Personal No Pagada, luego Tolerancia de Ausencia No Pagada. NO es injustificada a menos que las cuatro cubetas estén agotadas o haya sido un no llamó / no se presentó." },
+      { en: "Phes covers the absence with the next leave bucket in order. PTO comes next, then Unpaid Personal Leave. It is NOT unexcused unless all three buckets are exhausted or you no-call/no-showed.", es: "Phes cubre la ausencia con la siguiente cubeta en orden. Sigue PTO, luego Licencia Personal No Pagada. NO es injustificada a menos que las tres cubetas estén agotadas o haya sido un no llamó / no se presentó." },
       { en: "Unexcused — once PLAWA is gone, every sick call counts toward discipline.", es: "Injustificada — una vez agotado el PLAWA, cada llamada por enfermedad cuenta hacia la disciplina." },
       { en: "PTO is automatically deducted, but if PTO is also gone you're unexcused.", es: "Se deduce PTO automáticamente, pero si el PTO también está agotado, queda como injustificada." },
       { en: "Phes terminates immediately for going over PLAWA.", es: "Phes termina inmediatamente por exceder el PLAWA." },
@@ -3347,7 +3320,7 @@ const BASE_QUIZ: QuizQuestion[] = [
     },
     options: [
       { en: "None — you're out of leave, the day will be unexcused.", es: "Ninguna — está sin licencia, el día será injustificado." },
-      { en: "Unpaid Personal Leave (bucket #3 of 4): up to 40 hours / 5 days per year, available from day one, requires 7 days advance notice, same first-come-first-serve and max-2-off approval rules as PTO.", es: "Licencia Personal No Pagada (cubeta #3 de 4): hasta 40 horas / 5 días por año, disponible desde el primer día, requiere 7 días de aviso anticipado, mismas reglas de aprobación que el PTO (primero en llegar, máximo 2 libres)." },
+      { en: "Unpaid Personal Leave (bucket #3 of 3): up to 40 hours / 5 days per year, available from day one, requires 7 days advance notice, same first-come-first-serve and max-2-off approval rules as PTO.", es: "Licencia Personal No Pagada (cubeta #3 de 3): hasta 40 horas / 5 días por año, disponible desde el primer día, requiere 7 días de aviso anticipado, mismas reglas de aprobación que el PTO (primero en llegar, máximo 2 libres)." },
       { en: "Borrow PTO from a coworker.", es: "Pídale prestado PTO a un compañero." },
       { en: "Auto-promotion to overtime hours to cover the missed time.", es: "Promoción automática a horas extra para cubrir el tiempo perdido." },
     ],
@@ -3397,21 +3370,6 @@ const BASE_QUIZ: QuizQuestion[] = [
       { en: "Yes, but only for sick calls on weekends.", es: "Sí, pero solo para llamadas por enfermedad en fines de semana." },
     ],
     correctIndex: 1,
-  },
-  {
-    id: "q-pp-30-plawa-no-discipline",
-    moduleId: "phes-policies",
-    prompt: {
-      en: "You use 16 hours of PLAWA over the course of the year — every one with the proper 20-minute grace call. Can Phes count any of those absences toward the discipline scale?",
-      es: "Usa 16 horas de PLAWA durante el año — cada una con la llamada de gracia de 20 minutos. ¿Puede Phes contar alguna de esas ausencias hacia la escala de disciplina?",
-    },
-    options: [
-      { en: "No — using PLAWA with proper notice can NEVER count toward discipline. By law, it is protected leave; by Phes policy, we go even further: no reason needed, no note needed, no penalty.", es: "No — usar PLAWA con aviso apropiado NUNCA puede contar hacia la disciplina. Por ley, es licencia protegida; por política de Phes, vamos más lejos: sin razón requerida, sin nota, sin penalización." },
-      { en: "Yes — 16 hours in a year is excessive and triggers a written warning.", es: "Sí — 16 horas en un año es excesivo y activa una advertencia por escrito." },
-      { en: "Only if more than 2 absences land on a Monday or Friday.", es: "Solo si más de 2 ausencias caen en lunes o viernes." },
-      { en: "Yes, after the 3rd PLAWA day.", es: "Sí, después del 3er día de PLAWA." },
-    ],
-    correctIndex: 0,
   },
   {
     id: "q-pp-31-plawa-default",
@@ -3534,21 +3492,6 @@ const BASE_QUIZ: QuizQuestion[] = [
     correctIndex: 1,
   },
   {
-    id: "q-pp-39-trash-bag-limit",
-    moduleId: "phes-policies",
-    prompt: {
-      en: "You arrive at a job and the household has 8 full trash bags. What's the rule?",
-      es: "Llega a un trabajo y el hogar tiene 8 bolsas de basura llenas. ¿Cuál es la regla?",
-    },
-    options: [
-      { en: "Take them all — the client is paying for service.", es: "Llévelas todas — el cliente está pagando." },
-      { en: "Maximum 5 bags per visit. Take the first 5, document the rest with a note in the app, and call the office. We do not haul extra.", es: "Máximo 5 bolsas por visita. Tome las primeras 5, documente el resto con nota en la app, y llame a la oficina. No llevamos extra." },
-      { en: "Refuse to take any — let the client deal with it.", es: "Rehúse llevarse alguna — que el cliente se encargue." },
-      { en: "Take whatever fits in your car.", es: "Tome lo que quepa en su carro." },
-    ],
-    correctIndex: 1,
-  },
-  {
     id: "q-pp-40-no-price-discussion",
     moduleId: "phes-policies",
     prompt: {
@@ -3560,6 +3503,66 @@ const BASE_QUIZ: QuizQuestion[] = [
       { en: "Politely say 'I'll have the office reach out to discuss pricing,' then call the office team. Pricing is 100% the office's job — never negotiate, never accept cash discounts, never quote prices.", es: "Diga cortésmente 'la oficina los contactará para hablar del precio,' luego llame a el equipo de la oficina. El precio es 100% trabajo de la oficina — nunca negocie, nunca acepte descuentos en efectivo, nunca cotice." },
       { en: "Tell them Phes doesn't do discounts and finish the job in silence.", es: "Dígale que Phes no hace descuentos y termine el trabajo en silencio." },
       { en: "Quote a discount yourself to keep them happy.", es: "Cotice un descuento usted mismo para mantenerlos contentos." },
+    ],
+    correctIndex: 1,
+  },
+  {
+    id: "q-pp-41-lifting-limit",
+    moduleId: "phes-policies",
+    prompt: {
+      en: "Phes employees never lift items over what weight alone?",
+      es: "Los empleados de Phes nunca levantan artículos solos por encima de qué peso?",
+    },
+    options: [
+      { en: "10 lbs. Anything heavier needs office approval.", es: "10 libras. Cualquier cosa más pesada requiere aprobación de la oficina." },
+      { en: "25 lbs. This includes furniture, large appliances, and packed boxes. Clean around heavy items. If a job requires moving something over 25 lbs, call the office. The rule protects you from injury and protects Phes from workers' compensation claims.", es: "25 libras. Esto incluye muebles, electrodomésticos grandes y cajas empacadas. Limpie alrededor de los artículos pesados. Si un trabajo requiere mover algo de más de 25 libras, llame a la oficina. La regla lo protege de lesiones y protege a Phes de reclamos de compensación al trabajador." },
+      { en: "50 lbs. Anything heavier requires a partner.", es: "50 libras. Cualquier cosa más pesada requiere un compañero." },
+      { en: "There is no weight limit if you lift with proper form.", es: "No hay límite de peso si levanta con la postura correcta." },
+    ],
+    correctIndex: 1,
+  },
+  {
+    id: "q-pp-42-w2-tip-reporting",
+    moduleId: "phes-policies",
+    prompt: {
+      en: "How are tips reported for tax purposes?",
+      es: "¿Cómo se reportan las propinas para fines fiscales?",
+    },
+    options: [
+      { en: "Cash tips are reported on your W-2 by Phes; booking-system tips you self-report.", es: "Las propinas en efectivo las reporta Phes en su W-2; las propinas del sistema de reservas las reporta usted mismo." },
+      { en: "All tips are tax-free.", es: "Todas las propinas están libres de impuestos." },
+      { en: "Tips received through the booking system are reported as wages on your W-2 (Phes reports them). Cash tips are yours to keep and are self-reported by you to the IRS.", es: "Las propinas recibidas a través del sistema de reservas se reportan como salarios en su W-2 (Phes las reporta). Las propinas en efectivo son suyas y usted mismo las reporta al IRS." },
+      { en: "Phes reports both cash and booking-system tips on your W-2.", es: "Phes reporta tanto las propinas en efectivo como las del sistema de reservas en su W-2." },
+    ],
+    correctIndex: 2,
+  },
+  {
+    id: "q-pp-43-abandonment-window",
+    moduleId: "phes-policies",
+    prompt: {
+      en: "You missed your shift today without calling and you wake up the next morning. What is the rule about when to contact the office to avoid job abandonment?",
+      es: "Faltó a su turno hoy sin llamar y se despierta a la mañana siguiente. ¿Cuál es la regla para contactar a la oficina y evitar el abandono del empleo?",
+    },
+    options: [
+      { en: "The office will call you. Wait until they reach out.", es: "La oficina lo llamará. Espere hasta que se comuniquen con usted." },
+      { en: "Two windows apply. First, call the office BEFORE the 20-minute grace window ends on the day of the shift. If you missed that, you still have 24 hours after the missed shift to make contact. Failing both windows is JOB ABANDONMENT and results in immediate termination effective the date of the missed shift. The 24-hour window gives you a chance to explain genuine incapacity (medical emergency, accident, hospitalization).", es: "Aplican dos ventanas. Primero, llame a la oficina ANTES de que termine la ventana de gracia de 20 minutos el día del turno. Si la perdió, todavía tiene 24 horas después del turno perdido para hacer contacto. Fallar ambas ventanas es ABANDONO DEL EMPLEO y resulta en terminación inmediata efectiva en la fecha del turno perdido. La ventana de 24 horas le da la oportunidad de explicar una incapacidad genuina (emergencia médica, accidente, hospitalización)." },
+      { en: "You have 72 hours after the missed shift to explain.", es: "Tiene 72 horas después del turno perdido para explicar." },
+      { en: "Missing a shift without calling first is always automatic termination with no second chance.", es: "Perder un turno sin llamar siempre es terminación automática sin segunda oportunidad." },
+    ],
+    correctIndex: 1,
+  },
+  {
+    id: "q-pp-44-move-in-empty-home",
+    moduleId: "phes-policies",
+    prompt: {
+      en: "You arrive at a Move-In / Move-Out clean and the home is still fully furnished with belongings throughout. What do you do?",
+      es: "Llega a una limpieza de Mudanza y la casa todavía está completamente amueblada con pertenencias por todas partes. ¿Qué hace?",
+    },
+    options: [
+      { en: "Start cleaning around the furniture. Move-In / Move-Out is the same as a Deep Clean.", es: "Empiece a limpiar alrededor de los muebles. Una Mudanza es igual a una Limpieza Profunda." },
+      { en: "STOP and call the office BEFORE starting. Move-In / Move-Out cleans assume an empty home. Scope and pricing change when there is furniture in the way. Do not begin a Move-In / Move-Out clean in a non-empty space without office approval.", es: "DETÉNGASE y llame a la oficina ANTES de empezar. Las limpiezas de Mudanza asumen una casa vacía. El alcance y el precio cambian cuando hay muebles en medio. No empiece una limpieza de Mudanza en un espacio no vacío sin aprobación de la oficina." },
+      { en: "Ask the client to move everything out, then start cleaning.", es: "Pídale al cliente que saque todo, luego empiece a limpiar." },
+      { en: "Charge the client extra on the spot and proceed.", es: "Cobre al cliente extra en sitio y proceda." },
     ],
     correctIndex: 1,
   },

--- a/artifacts/qleno/src/lib/training/curriculum.ts
+++ b/artifacts/qleno/src/lib/training/curriculum.ts
@@ -276,7 +276,8 @@ const BASE_MODULES: Module[] = [
 
       { type: "h", text: { en: "Job Abandonment", es: "Abandono del Empleo" } },
       {
-        type: "p",
+        type: "callout",
+        tone: "warning",
         text: {
           en: "Failure to contact the office BEFORE the end of the 20-minute grace window on a scheduled shift, AND failure to make contact within 24 hours after the missed shift, constitutes JOB ABANDONMENT and results in immediate termination effective the date of the missed shift. The 24-hour post-shift contact window provides the employee an opportunity to explain genuine incapacity (medical emergency, accident, hospitalization). Documentation of genuine incapacity may result in reinstatement at office discretion.",
           es: "No contactar a la oficina ANTES del fin de la ventana de gracia de 20 minutos en un turno programado, Y no establecer contacto dentro de las 24 horas posteriores al turno perdido, constituye ABANDONO DEL EMPLEO y resulta en terminación inmediata efectiva en la fecha del turno perdido. La ventana de contacto de 24 horas después del turno brinda al empleado una oportunidad de explicar una incapacidad genuina (emergencia médica, accidente, hospitalización). La documentación de una incapacidad genuina puede resultar en reincorporación a discreción de la oficina.",
@@ -330,7 +331,7 @@ const BASE_MODULES: Module[] = [
           { en: "Notice: the 20-minute grace call only. No advance approval required.", es: "Aviso: solo la llamada de gracia de 20 minutos. No se requiere aprobación previa." },
           { en: "Cannot be denied for business needs. PLAWA is protected leave.", es: "No se puede negar por necesidades del negocio. PLAWA es licencia protegida." },
           { en: "PLAWA is AUTOMATIC when you have hours and give the grace call. You do not need to specifically request 'sick time' or give a reason. PLAWA covers you by default.", es: "PLAWA es AUTOMÁTICA cuando tiene horas y da la llamada de gracia. No necesita solicitar específicamente 'tiempo por enfermedad' ni dar una razón. PLAWA lo cubre por defecto." },
-          { en: "4 or more CONSECUTIVE PLAWA days requires advance approval if the absence is foreseeable.", es: "4 o más días consecutivos de PLAWA requieren aprobación previa si la ausencia es previsible." },
+          { en: "4 or more CONSECUTIVE PLAWA days requires advance approval if the absence is foreseeable. 'Foreseeable' means planned in advance: a scheduled medical procedure, a planned mental health retreat, or a known appointment series. Unforeseeable absences (sudden illness like the flu, family emergency, accident) do NOT require advance approval. Just give the grace call each day. If you are sick for a week with the flu and call each day, that is fine.", es: "4 o más días consecutivos de PLAWA requieren aprobación previa si la ausencia es previsible. 'Previsible' significa planeado con anticipación: un procedimiento médico programado, un retiro de salud mental planeado, o una serie de citas conocida. Las ausencias imprevisibles (enfermedad súbita como la gripe, emergencia familiar, accidente) NO requieren aprobación previa. Solo dé la llamada de gracia cada día. Si está enfermo una semana con la gripe y llama cada día, está bien." },
           { en: "If you run out of PLAWA: the office cascades to PTO (if eligible), then Unpaid Personal Leave (if approved in advance).", es: "Si se queda sin PLAWA: la oficina pasa a PTO (si es elegible), luego a Licencia Personal No Pagada (si se aprueba con anticipación)." },
           { en: "No retaliation for lawful PLAWA use. Phes cannot discipline, demote, fire, or penalize you for using PLAWA legally.", es: "Sin represalias por el uso legal de PLAWA. Phes no puede disciplinar, degradar, despedir ni penalizar por usar PLAWA legalmente." },
         ],
@@ -392,7 +393,7 @@ const BASE_MODULES: Module[] = [
           { en: "Workplace injury / workers' compensation absences.", es: "Ausencias por lesión laboral o compensación al trabajador." },
           { en: "Pregnancy-related medical needs or appointments.", es: "Necesidades o citas médicas relacionadas con el embarazo." },
           { en: "Lactation breaks.", es: "Pausas de lactancia." },
-          { en: "Bereavement (immediate family: spouse, child, parent, sibling).", es: "Duelo (familia inmediata: cónyuge, hijo/a, padre/madre, hermano/a)." },
+          { en: "Bereavement for immediate family, spouse, child, parent, or sibling (up to 3 paid scheduled workdays).", es: "Duelo por familia inmediata, cónyuge, hijo/a, padre/madre o hermano/a (hasta 3 días laborales programados pagados)." },
           { en: "Military leave and family military leave.", es: "Licencia militar y licencia militar familiar." },
           { en: "Court appearances as a crime victim, or for proceedings related to domestic violence, sexual violence, or other qualifying crimes (VESSA).", es: "Comparecencias judiciales como víctima de delito, o para procedimientos relacionados con violencia doméstica, violencia sexual u otros delitos calificantes (VESSA)." },
           { en: "Disability-related absences covered by reasonable accommodation.", es: "Ausencias relacionadas con discapacidad cubiertas por acomodación razonable." },
@@ -523,7 +524,7 @@ const BASE_MODULES: Module[] = [
           { en: "Closed-toe athletic shoes (solid black or solid white). No sandals. No Crocs. No open backs.", es: "Calzado deportivo cerrado (negro sólido o blanco sólido). Sin sandalias. Sin Crocs. Sin parte trasera abierta." },
           { en: "Shoe covers mandatory inside all client homes from the threshold. Change between homes. Never reuse.", es: "Cubrezapatos obligatorios dentro de todos los hogares de clientes desde el umbral. Cambielos entre hogares. Nunca los reutilice." },
           { en: "Hair tied back if shoulder-length or longer.", es: "Cabello recogido si llega al hombro o más largo." },
-          { en: "Jewelry minimal. No large rings or bracelets that scratch surfaces.", es: "Joyería mínima. Sin anillos ni pulseras grandes que rayen superficies." },
+          { en: "Jewelry should be minimal and safe for cleaning work. Specifically: no rings with raised stones, no dangling bracelets, no long necklaces, no large earrings. Small studs, plain wedding bands, and small chain necklaces tucked under your shirt are acceptable. The standard: nothing that can scratch surfaces or catch on equipment, fabric, or fixtures.", es: "La joyería debe ser mínima y segura para el trabajo de limpieza. Específicamente: sin anillos con piedras elevadas, sin pulseras colgantes, sin collares largos, sin aretes grandes. Aretes pequeños tipo poste, anillos de matrimonio sencillos y cadenas pequeñas guardadas dentro de la camisa son aceptables. El estándar: nada que pueda rayar superficies o engancharse con equipo, tela o accesorios." },
         ],
       },
       {
@@ -584,17 +585,15 @@ const BASE_MODULES: Module[] = [
       {
         type: "bullets",
         items: [
-          { en: "Bodily fluids (blood, vomit, urine, feces). Decline politely. The office can refer a biohazard service.", es: "Fluidos corporales (sangre, vómito, orina, heces). Rechácelo cortésmente. La oficina puede referir un servicio de biohazard." },
+          { en: "Bodily fluids and biohazards (blood, vomit, urine, feces, hoarding situations, infestations). Decline politely. The office can refer a biohazard service.", es: "Fluidos corporales y riesgos biológicos (sangre, vómito, orina, heces, situaciones de acumulación, infestaciones). Rechácelo cortésmente. La oficina puede referir un servicio de biohazard." },
           { en: "Inside the oven, refrigerator, or freezer (default scope). The office can add it; call.", es: "Dentro del horno, refrigerador o congelador (alcance estándar). La oficina lo puede agregar; llame." },
-          { en: "Pet waste, including litter boxes.", es: "Desechos de mascotas, incluyendo cajas de arena." },
+          { en: "Pet waste, including litter boxes and animal waste.", es: "Desechos de mascotas, incluyendo cajas de arena y desechos animales." },
           { en: "Cash transactions on site. All payment goes through the office.", es: "Transacciones en efectivo en sitio. Todo pago pasa por la oficina." },
           { en: "Climbing higher than the company-issued step stool. Never stand on furniture.", es: "Subir más alto que el banquito de la compañía. Nunca se pare en muebles." },
           { en: "Wash dishes.", es: "Lavar platos." },
           { en: "Make beds.", es: "Tender camas." },
           { en: "Move heavy furniture. We clean around it. Anything over 25 lbs we do not lift or relocate.", es: "Mover muebles pesados. Limpiamos alrededor. Nada que pese más de 25 lb se levanta o se mueve." },
           { en: "Clean window tracks.", es: "Limpiar rieles de ventanas." },
-          { en: "Carpet steam cleaning.", es: "Limpieza de alfombras a vapor." },
-          { en: "Biohazards, animal waste, hoarding situations, or infestations.", es: "Riesgos biológicos, desechos animales, situaciones de acumulación o infestaciones." },
           { en: "Outdoor cleaning, fireplaces, running errands.", es: "Limpieza al aire libre, chimeneas, recados." },
         ],
       },
@@ -641,8 +640,8 @@ const BASE_MODULES: Module[] = [
         type: "callout",
         tone: "warning",
         text: {
-          en: "Move-In / Move-Out cleans ASSUME the space is empty. If you arrive and the home is still furnished or has belongings throughout, call the office BEFORE starting. The scope and pricing change when there is furniture in the way.",
-          es: "Las limpiezas de Mudanza ASUMEN que el espacio está vacío. Si llega y la casa aún tiene muebles o pertenencias por todas partes, llame a la oficina ANTES de empezar. El alcance y el precio cambian cuando hay muebles en medio.",
+          en: "Important: Move-In / Move-Out cleans assume an empty home. If you arrive and the space is furnished or has belongings still in place, STOP. Call the office before starting. Scope and pricing change when there is furniture in the way. Do not begin a Move-In / Move-Out clean in a non-empty space without office approval.",
+          es: "Importante: las limpiezas de Mudanza asumen una casa vacía. Si llega y el espacio está amueblado o tiene pertenencias todavía en su lugar, DETÉNGASE. Llame a la oficina antes de empezar. El alcance y el precio cambian cuando hay muebles en medio. No empiece una limpieza de Mudanza en un espacio no vacío sin aprobación de la oficina.",
         },
       },
 
@@ -682,8 +681,8 @@ const BASE_MODULES: Module[] = [
         type: "callout",
         tone: "warning",
         text: {
-          en: "Pricing conversations are 100% the office's job. If a client tries to negotiate, asks for a discount, offers cash for an unscheduled service, or tries to renegotiate the service fee in front of you, politely say 'I will have the office reach out to discuss pricing' and call the office. Clients who try to negotiate outside pricing with techs risk losing service. Protect yourself: stay out of money conversations.",
-          es: "Las conversaciones sobre precios son 100% trabajo de la oficina. Si un cliente intenta negociar, pide descuento, ofrece efectivo por un servicio no agendado o intenta renegociar la tarifa frente a usted, diga cortésmente 'la oficina los contactará para discutir el precio' y llame a la oficina. Los clientes que intentan negociar fuera del precio con los técnicos arriesgan perder el servicio. Protéjase: manténgase fuera de conversaciones de dinero.",
+          en: "Pricing conversations are 100% the office's job. If a client tries to negotiate, asks for a discount, offers cash for an unscheduled service, or tries to renegotiate the service fee in front of you, politely say 'I will have the office reach out to discuss pricing' and call the office. If a client attempts to negotiate pricing with you, the office will follow up with them directly. Do not let it pull you into the conversation. Protect yourself: stay out of money conversations.",
+          es: "Las conversaciones sobre precios son 100% trabajo de la oficina. Si un cliente intenta negociar, pide descuento, ofrece efectivo por un servicio no agendado o intenta renegociar la tarifa frente a usted, diga cortésmente 'la oficina los contactará para discutir el precio' y llame a la oficina. Si un cliente intenta negociar el precio con usted, la oficina dará seguimiento directamente. No deje que la conversación lo arrastre. Protéjase: manténgase fuera de conversaciones de dinero.",
         },
       },
 
@@ -803,6 +802,16 @@ const BASE_MODULES: Module[] = [
         ],
       },
 
+      { type: "h", text: { en: "Lifting Limits", es: "Límites de Levantamiento" } },
+      {
+        type: "callout",
+        tone: "warning",
+        text: {
+          en: "Phes employees never lift items over 25 lbs alone. This includes furniture, large appliances, packed boxes, or anything else requiring two-person handling. Clean around heavy items. Do not attempt to move them. If a job requires moving something over 25 lbs, call the office. This rule protects you from injury and protects Phes from workers' compensation claims.",
+          es: "Los empleados de Phes nunca levantan artículos de más de 25 libras solos. Esto incluye muebles, electrodomésticos grandes, cajas empacadas o cualquier cosa que requiera dos personas. Limpie alrededor de los artículos pesados. No intente moverlos. Si un trabajo requiere mover algo de más de 25 libras, llame a la oficina. Esta regla lo protege de lesiones y protege a Phes de reclamos de compensación al trabajador.",
+        },
+      },
+
       { type: "h", text: { en: "Uniform Issuance", es: "Entrega de Uniformes" } },
       {
         type: "bullets",
@@ -887,6 +896,7 @@ const BASE_MODULES: Module[] = [
           { en: "Tips are 100% the employee's.", es: "Las propinas son 100% del empleado." },
           { en: "Cash tips: keep them.", es: "Propinas en efectivo: quédeselas." },
           { en: "Tips through the booking system are paid on the next paycheck.", es: "Las propinas a través del sistema de reservas se pagan en el siguiente cheque." },
+          { en: "Tips received through the booking system are reported as wages on your W-2.", es: "Las propinas recibidas a través del sistema de reservas se reportan como salarios en su W-2." },
           { en: "No kickback is owed to anyone.", es: "No se debe ningún porcentaje a nadie." },
           { en: "Tax responsibility: employees are responsible for reporting cash tips for tax purposes per IRS rules. Tips paid through the booking system are reported on your paycheck.", es: "Responsabilidad fiscal: los empleados son responsables de reportar las propinas en efectivo para fines fiscales conforme a las reglas del IRS. Las propinas pagadas a través del sistema de reservas se reportan en su cheque." },
         ],


### PR DESCRIPTION
Content-only edits to the `phes-policies` training module body + matched quiz updates. No schema changes, no new modules, no new tables. **Marked MINOR — defers re-ack to next December cycle.**

Opened as **draft** per your cadence rule.

## What changes

Two commits on one branch, single file: `artifacts/qleno/src/lib/training/curriculum.ts`.

### Commit 1: 10 content edits to Phes Policies & Procedures body

| # | Section | Edit |
| --- | --- | --- |
| 1 | 4 — Protected Absences | Bereavement bullet now reads "for immediate family, spouse, child, parent, or sibling (up to 3 paid scheduled workdays)" to match the dedicated Bereavement Leave subsection. |
| 2 | 6 — Never Discuss Price | Punitive "clients who try to negotiate risk losing service" sentence replaced with neutral framing: "the office will follow up with them directly. Do not let it pull you into the conversation." |
| 3 | 6 — Move-In/Move-Out | Empty-home warning prepended with "Important:" and strengthened to "STOP. Call the office before starting. Do not begin a Move-In / Move-Out clean in a non-empty space without office approval." |
| 4 | 7 — Equipment | NEW **Lifting Limits** warning callout inserted between Company-Provided Equipment and Uniform Issuance. "Phes employees never lift items over 25 lbs alone." |
| 5 | 6 — What Phes Does NOT Do | `Carpet steam cleaning` line REMOVED. Was not part of the original spec. |
| 6 | 6 — What Phes Does NOT Do | "Bodily fluids" + standalone "Biohazards, animal waste, hoarding situations, infestations" entries merged into one. "Pet waste, including litter boxes" expanded to include "and animal waste." Third redundant entry removed. |
| 7 | 3 — Job Abandonment | Paragraph wrapped in `tone: "warning"` callout for visual prominence. Content unchanged. |
| 8 | 4 — PLAWA | "4 or more consecutive PLAWA days" bullet expanded with foreseeable vs. unforeseeable examples and the "if you are sick for a week with the flu and call each day, that is fine" exception. |
| 9 | 5 — Dress Code | Jewelry guidance tightened with specific prohibitions (raised stones, dangling bracelets, long necklaces, large earrings) and what is acceptable (small studs, plain wedding bands, tucked small chain necklaces). |
| 10 | 8 — Tipping | NEW bullet: "Tips received through the booking system are reported as wages on your W-2." Required disclosure under IRS Section 6053. |

### Commit 2: Quiz alignment — 5 modify, 4 add, 4 remove (net 40)

If the content changes, the quiz has to match. Otherwise employees can pass on outdated material.

#### Modified (5)

| Question | Why |
| --- | --- |
| **Q11** (unexcused-fourth) | Prompt referenced "four leave buckets" including the deprecated "Unpaid Absence Allowance". Updated to three buckets (PLAWA, PTO, Unpaid Personal Leave). |
| **Q18** (bereavement) | Correct-answer option now uses "3 paid scheduled workdays" matching Edit 1. |
| **Q24** (renamed `q-pp-24-plawa-foreseeable`) | Re-purposed from "does Phes require a doctor's note?" to a focused test of the new foreseeable / unforeseeable PLAWA distinction. Five-day flu scenario matches the example in Edit 8. |
| **Q25** (sick-no-balance) | Correct-answer option's "next bucket is PTO, then Unpaid Personal Leave, then Unpaid Absence Allowance" / "four buckets" language updated to three buckets. |
| **Q26** (unpaid-personal) | "bucket #3 of 4" → "bucket #3 of 3". |

#### Added (4 new)

| Question | Tests |
| --- | --- |
| **Q41** (lifting-limit) | Direct test of the 25-lb policy from Edit 4. When to lift vs. when to call the office, with OSHA + workers' comp framing. |
| **Q42** (w2-tip-reporting) | Tests Edit 10. Distinguishes cash tips (employee self-reports to IRS) from booking-system tips (Phes reports on the W-2). |
| **Q43** (abandonment-window) | Tests the two-window job abandonment rule. Validates understanding of BOTH the during-shift 20-minute call AND the post-shift 24-hour grace window from Edit 7. |
| **Q44** (move-in-empty-home) | Tests Edit 3. Employee must STOP and call the office before starting a Move-In / Move-Out clean in a furnished space. |

#### Removed (4 lowest-priority)

| Question | Why |
| --- | --- |
| **Q14** (phone-use sister-text) | Operational scenario. Phone-use policy is reinforced by Q15 (photos) and general professional-conduct flow. |
| **Q17** (office-exception courtesy note) | Narrow edge case. The off-scope flow is already tested by Q3 (oven add-on) and Q16 (dishes + bed-making). |
| **Q30** (plawa-no-discipline) | Overlaps Q29 (PLAWA cannot be denied for business needs) and Q33 (PLAWA reason not required). PLAWA-protection principle is redundantly covered. |
| **Q39** (trash-bag-limit) | Single operational rule (5-bag cap), easy to look up and not legally loaded. |

#### Quiz integrity

- Total phes-policies question count: **40** (unchanged)
- 80% pass threshold preserved
- Every new question has one clearly correct answer and three clearly incorrect distractors (no trick questions, no two-correct options)
- Spanish translations applied to every modification and addition

## Illinois compliance verification

| Edit | Illinois reference |
| --- | --- |
| 1 (bereavement) | Voluntarily exceeds Illinois Family Bereavement Leave Act floor — Phes is under 50 employees so the law only requires unpaid leave. Phes pays. |
| 4 (lifting limit) | Aligns with OSHA general duty clause; strengthens Phes Workers' Compensation Act defense |
| 8 (foreseeable) | Consistent with PLAWA (820 ILCS 192). Makes Phes policy MORE generous than the law requires for unforeseeable absences. |
| 10 (W-2 tips) | Required disclosure under IRS Section 6053 |
| 2, 3, 5, 6, 7, 9 | No legal substance changed — editorial and operational only |

## Version handling

**MINOR bump.** None of these edits change employee rights, obligations, or compensation. They are clarifications, consistency fixes, visual emphasis, and quiz alignment only.

- No forced re-acknowledgment triggered. Existing signed handbooks remain valid through the current annual cycle.
- The phes-policies module content hash changes naturally next time a learner completes the module (captured per certificate via `curriculum_version_hash`).
- The signed legal handbook (`lms_signed_documents.document_type='handbook'`) is a SEPARATE registry entry and is unchanged.
- Captured in the next December annual cycle sweep via the Phase 14 routes shipped in PR #101.

## Style adherence

- No em dashes (`—`), no en dashes (`–`), no hyphens used as sentence separators in any NEW content (10 content edits + 4 new quiz questions + 5 modified options)
- Pre-existing em dashes in untouched question options are out of scope for this content-alignment PR
- Compound hyphens (Move-In / Move-Out, on-site, two-person) are preserved unchanged

## Test plan after merge

- [ ] Open `/training` as a tech and visit Phes Policies & Procedures
- [ ] Verify all 10 content edits render correctly in EN and ES
- [ ] Take the quiz: 40 questions sampled, randomly ordered
- [ ] Confirm Q41 (lifting), Q42 (W-2), Q43 (abandonment window), Q44 (Move-In empty home) appear in rotation
- [ ] Confirm Q14, Q17, Q30, Q39 no longer appear
- [ ] Confirm modified Q11, Q18, Q24, Q25, Q26 carry the updated language
- [ ] Switch locale to Español and verify all changes render in Spanish

## Cadence

Pausing here for your review per the explicit rule. Do not auto-merge.

This PR is parallel to the open Phase 14 UI PR (#105) and does not depend on it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxGiirnJ3dT4GAzHPNWhrx)_