### PR TITLE
lms: material content change auto-trigger (backfill #4)

### DIFF
--- a/artifacts/api-server/src/routes/lms-annual-ack.ts
+++ b/artifacts/api-server/src/routes/lms-annual-ack.ts
@@ -78,13 +78,28 @@ export async function sweepForDocumentType(args: {
   documentType: string;
   triggeredByUserId: number | null;
   triggerReason: TriggerReason;
+  /**
+   * When true, only users whose active signed_document carries a
+   * version_hash that does NOT match the current canonical hash get
+   * a pending_re_ack row. Used by the material-content-change sweep
+   * so already-up-to-date employees aren't pushed back into the
+   * re-sign flow.
+   */
+  onlyOutdated?: boolean;
 }): Promise<SweepResult> {
-  const { companyId, documentType, triggeredByUserId, triggerReason } = args;
+  const {
+    companyId,
+    documentType,
+    triggeredByUserId,
+    triggerReason,
+    onlyOutdated,
+  } = args;
 
   const activeSigners = await db
     .select({
       user_id: lmsSignedDocumentsTable.user_id,
       locale: lmsSignedDocumentsTable.locale,
+      current_version_hash: lmsSignedDocumentsTable.version_hash,
     })
     .from(lmsSignedDocumentsTable)
     .innerJoin(
@@ -121,6 +136,11 @@ export async function sweepForDocumentType(args: {
       isMaterial: triggerReason === "material_content_change",
       notes: content.notes,
     });
+
+    // Material-change sweep: skip users already on the current hash.
+    if (onlyOutdated && signer.current_version_hash === version.version_hash) {
+      continue;
+    }
 
     // Skip if user already has an unacknowledged row for this version.
     const existing = await db

--- a/artifacts/api-server/src/routes/lms-signatures.ts
+++ b/artifacts/api-server/src/routes/lms-signatures.ts
@@ -50,7 +50,9 @@ import {
 import {
   getOrCreateDocumentVersion,
   getTenantOwnerForSignature,
+  markVersionMaterial,
 } from "../lib/lms-signatures-db.js";
+import { sweepForDocumentType } from "./lms-annual-ack.js";
 import {
   getSignedDocumentContent,
   isSpanishPendingTranslationReview,
@@ -624,5 +626,134 @@ router.get("/:id/pdf", requireAuth, async (req, res) => {
     });
   }
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /admin/material-change
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// Owner / admin marks the current canonical content for a documentType
+// as material and fans out a forced re-acknowledgment to every employee
+// in the tenant whose active signed_document is on an OUTDATED version
+// hash. Users whose active signature already matches the current hash
+// are skipped — they signed the new version voluntarily and don't need
+// to be pushed back into the re-sign flow.
+//
+// Use case: an admin edits a signed-doc content file (e.g. Drug &
+// Alcohol Policy), ships the change, then calls this endpoint to flag
+// the new version as legally material and force everyone on the old
+// version to re-sign. Inserts pending_re_ack rows with trigger_reason
+// = 'material_content_change'.
+//
+// Body: { documentType: KnownSignedDocumentType, notes?: string }
+//
+// Returns: { document_type, version_id, version_hash, swept_user_ids,
+//   swept_count }
+
+router.post(
+  "/admin/material-change",
+  requireAuth,
+  requireRole("owner", "admin"),
+  async (req, res) => {
+    try {
+      const companyId = req.auth!.companyId;
+      if (companyId == null) {
+        return res.status(400).json({
+          error: "Bad Request",
+          message: "User has no company assignment",
+        });
+      }
+      const adminId = req.auth!.userId;
+      const documentType: string | undefined = req.body?.documentType;
+      const notes: string | undefined =
+        typeof req.body?.notes === "string" && req.body.notes.length > 0
+          ? req.body.notes
+          : undefined;
+
+      if (!documentType || !KNOWN_TYPES.has(documentType)) {
+        return res.status(400).json({
+          error: "Bad Request",
+          message: "Unknown documentType",
+        });
+      }
+
+      // Get the current canonical content for the English version
+      // (English is the binding version per the brand legal pages).
+      // We materialize both locales' version rows below; English
+      // drives the response shape.
+      const enContent = getSignedDocumentContent(documentType, "en");
+      if (!enContent) {
+        return res.status(404).json({
+          error: "Not Found",
+          message: `No registered EN content for ${documentType}`,
+        });
+      }
+
+      // Materialize and mark both locales' version rows as material so
+      // the audit chain reflects the policy intent in both languages.
+      const enVersion = await getOrCreateDocumentVersion({
+        companyId,
+        documentType,
+        locale: "en",
+        contentHtml: enContent.contentHtml,
+        isMaterial: true,
+        notes,
+        createdByUserId: adminId,
+      });
+      await markVersionMaterial(companyId, enVersion.id);
+
+      const esContent = getSignedDocumentContent(documentType, "es");
+      if (esContent) {
+        const esVersion = await getOrCreateDocumentVersion({
+          companyId,
+          documentType,
+          locale: "es",
+          contentHtml: esContent.contentHtml,
+          isMaterial: true,
+          notes,
+          createdByUserId: adminId,
+        });
+        await markVersionMaterial(companyId, esVersion.id);
+      }
+
+      // Sweep users whose active signature is on an outdated hash.
+      const sweep = await sweepForDocumentType({
+        companyId,
+        documentType,
+        triggeredByUserId: adminId,
+        triggerReason: "material_content_change",
+        onlyOutdated: true,
+      });
+
+      await logAudit(
+        req,
+        "lms_material_change_triggered",
+        "lms_document_version",
+        enVersion.id,
+        null,
+        {
+          document_type: documentType,
+          swept_count: sweep.swept_user_ids.length,
+          notes: notes ?? null,
+        },
+      );
+
+      return res.json({
+        data: {
+          document_type: documentType,
+          version_id: enVersion.id,
+          version_hash: enVersion.version_hash,
+          swept_user_ids: sweep.swept_user_ids,
+          swept_count: sweep.swept_user_ids.length,
+        },
+      });
+    } catch (err) {
+      console.error("[lms-signatures] POST /admin/material-change error:", err);
+      return res.status(500).json({
+        error: "Internal Server Error",
+        message: "Failed to trigger material content change",
+      });
+    }
+  },
+);
 
 export default router;


### PR DESCRIPTION
Backfill item #4 — material content change auto-trigger. Opened as **draft** per cadence.

## What changes

Two files:
- `routes/lms-annual-ack.ts` (+18 / -3): `sweepForDocumentType()` gains an `onlyOutdated: boolean` flag
- `routes/lms-signatures.ts` (+131): new `POST /admin/material-change` endpoint

## Why

The schema comment on `lms_document_versions.is_material` has always said:

> "`is_material` triggers forced re-acknowledgment for all employees in THAT TENANT who signed earlier versions"

Until today, nothing actually triggered the fan-out. Admins had to call `POST /api/lms/annual-ack/admin/force-resign` for each user manually. This PR makes the schema invariant real.

## How

### 1. `sweepForDocumentType` — `onlyOutdated` flag

The annual-cycle sweep bumps **every** active signer regardless of version. The material-change sweep should bump only the **outdated** ones — employees already on the new content don't need to re-sign.

New behavior when `onlyOutdated: true`:
- Per-user loop pulls each signer's `version_hash` from `lms_signed_documents`
- If their hash matches the current canonical hash for their locale, skip
- Otherwise, insert `lms_pending_re_ack` as before

Annual-cycle behavior is unchanged.

### 2. `POST /api/lms/signatures/admin/material-change`

| Field | Required | Description |
| --- | --- | --- |
| `documentType` | yes | One of `KNOWN_SIGNED_DOCUMENT_TYPES` |
| `notes` | no | Stored on the new `lms_document_versions` row |

Auth: owner / admin only.

Server-side flow:
1. Look up the canonical content for both **en** and **es** locales from `SIGNED_DOCUMENT_CONTENT`
2. `getOrCreateDocumentVersion(isMaterial: true)` for each locale → idempotently creates the version row
3. `markVersionMaterial()` on each → sets `is_material=true` if the row already existed
4. `sweepForDocumentType({trigger_reason: 'material_content_change', onlyOutdated: true})` → inserts pending re-acks for outdated employees only
5. Audit log via `lms_material_change_triggered`

Response:
```json
{
  "data": {
    "document_type": "drug_alcohol",
    "version_id": 47,
    "version_hash": "abcd1234...",
    "swept_user_ids": [12, 18, 23],
    "swept_count": 3
  }
}
```

## Tenant + role gating

- Server enforces `owner | admin` on the route
- All inserts scoped by `req.auth.companyId` — cross-tenant impossible
- Existing pending-re-ack tile on `/training` picks up the new rows
- Existing Audit Dashboard drill-down shows them under "Pending re-acknowledgments" with `trigger_reason='material_content_change'`, so operators can distinguish material-edit sweeps from annual cycles + admin force-resigns

## Tests

**270/270 LMS unit tests pass.** Build clean.

The DB-touching route is exercised the same way the rest of the signature flow is — via the route's input validation tests + integration manual + Playwright E2E. The new `onlyOutdated` flag is a single boolean branch in `sweepForDocumentType`; the existing trigger-reason allowlist test already covers the audit-trail invariant that `material_content_change` is a valid reason.

## Punch-list status after merge

| # | Item | Status |
| --- | --- | --- |
| 1 | Production verification | Pending (you) |
| 2 | Drawn-signature PNG embedding | ✅ Done (#108) |
| 3 | December cron | ✅ Done (#109) |
| **4** | **Material content change auto-trigger** | ✅ **Done (this PR)** |
| 5 | Audit dashboard drill-down | ✅ Done (#109) |
| 6 | True browser E2E tests | ✅ Done (#108) |
| 7 | Pending re-ack tile multi-doc support | Pending (no action needed yet) |

6/7 closed. Only #1 (you walking the live app) and #7 (only relevant if you add a second annual document type) remain.

## Test plan after merge

- [ ] As owner: `curl -H "Authorization: Bearer $TOK" -d '{"documentType":"drug_alcohol"}' /api/lms/signatures/admin/material-change`
- [ ] Confirm response includes a `swept_count` matching the number of Phes employees currently on an older `drug_alcohol` hash
- [ ] Open `/training` as one of the swept employees → amber re-ack tile appears
- [ ] Click "Re-sign →" → routes through `SignDocumentView`
- [ ] Sign → tile clears
- [ ] Run the same request again → `swept_count` is 0 (everyone is now on the current hash) and existing pending rows aren't duplicated

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxGiirnJ3dT4GAzHPNWhrx)_