### PR TITLE
lms: pre-onboarding sprint Section B (P1) — quiz cap, debounce, bypass settings, settings page (Items 6-9; Item 10 deferred)

### DIFF
--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -667,6 +667,21 @@ async function runBookingSchemaGuard(): Promise<void> {
     { label: "users.archived_at",
       stmt: `ALTER TABLE users ADD COLUMN IF NOT EXISTS archived_at TIMESTAMPTZ` },
 
+    // Items 8 + 9 (P1 sprint, 2026-05-14): per-tenant LMS settings.
+    // Single row per company. First inhabitant: admin_bypass_allowed
+    // (default false). Future settings join the same row.
+    { label: "CREATE lms_settings", stmt: `
+      CREATE TABLE IF NOT EXISTS lms_settings (
+        id                    SERIAL PRIMARY KEY,
+        company_id            INTEGER NOT NULL REFERENCES companies(id),
+        admin_bypass_allowed  BOOLEAN NOT NULL DEFAULT FALSE,
+        created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        updated_at            TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      )
+    ` },
+    { label: "lms_settings_company_uq",
+      stmt: `CREATE UNIQUE INDEX IF NOT EXISTS lms_settings_company_uq ON lms_settings(company_id)` },
+
     { label: "CREATE lms_module_progress", stmt: `
       CREATE TABLE IF NOT EXISTS lms_module_progress (
         id               SERIAL PRIMARY KEY,

--- a/artifacts/api-server/src/routes/index.ts
+++ b/artifacts/api-server/src/routes/index.ts
@@ -78,6 +78,7 @@ import lmsCertificatesRouter from "./lms-certificates.js";
 import lmsSignaturesRouter from "./lms-signatures.js";
 import lmsHandbookRouter from "./lms-handbook.js";
 import lmsAnnualAckRouter from "./lms-annual-ack.js";
+import lmsSettingsRouter from "./lms-settings.js";
 import lmsAdminAuditRouter from "./lms-admin-audit.js";
 
 const router: IRouter = Router();
@@ -161,6 +162,7 @@ router.use("/lms/certificates", lmsCertificatesRouter);
 router.use("/lms/signatures", lmsSignaturesRouter);
 router.use("/lms/handbook", lmsHandbookRouter);
 router.use("/lms/annual-ack", lmsAnnualAckRouter);
+router.use("/lms-settings", lmsSettingsRouter);
 router.use("/lms/admin-audit", lmsAdminAuditRouter);
 
 export default router;

--- a/artifacts/api-server/src/routes/lms-settings.ts
+++ b/artifacts/api-server/src/routes/lms-settings.ts
@@ -1,0 +1,130 @@
+/**
+ * LMS per-tenant settings (Items 8 + 9, P1 sprint 2026-05-14).
+ *
+ * Mounted at /api/lms-settings. Owner-only writes; owner / admin can
+ * read (admin needs to know what they can/cannot do, even if they
+ * can't change the toggle).
+ *
+ *   GET  /              fetch current settings (auto-creates default row)
+ *   PATCH /            update toggles (owner-only)
+ */
+import { Router } from "express";
+import { eq } from "drizzle-orm";
+import { db } from "@workspace/db";
+import {
+  lmsSettingsTable,
+  type LmsSettings,
+} from "@workspace/db/schema";
+import { requireAuth, requireRole } from "../lib/auth.js";
+import { logAudit } from "../lib/audit.js";
+
+const router = Router();
+
+async function getOrCreateSettings(companyId: number): Promise<LmsSettings> {
+  const existing = await db
+    .select()
+    .from(lmsSettingsTable)
+    .where(eq(lmsSettingsTable.company_id, companyId))
+    .limit(1);
+  if (existing[0]) return existing[0];
+
+  const inserted = await db
+    .insert(lmsSettingsTable)
+    .values({ company_id: companyId, admin_bypass_allowed: false })
+    .onConflictDoNothing({ target: lmsSettingsTable.company_id })
+    .returning();
+  if (inserted[0]) return inserted[0];
+
+  // Race: another caller created the row between our SELECT + INSERT.
+  const after = await db
+    .select()
+    .from(lmsSettingsTable)
+    .where(eq(lmsSettingsTable.company_id, companyId))
+    .limit(1);
+  if (!after[0]) {
+    throw new Error("Failed to create or fetch lms_settings row");
+  }
+  return after[0];
+}
+
+router.get(
+  "/",
+  requireAuth,
+  requireRole("owner", "admin"),
+  async (req, res) => {
+    try {
+      const companyId = req.auth!.companyId;
+      if (companyId == null) {
+        return res.status(400).json({
+          error: "Bad Request",
+          message: "User has no company assignment",
+        });
+      }
+      const settings = await getOrCreateSettings(companyId);
+      return res.json({ data: settings });
+    } catch (err) {
+      console.error("[lms-settings] GET / error:", err);
+      return res.status(500).json({
+        error: "Internal Server Error",
+        message: "Failed to load LMS settings",
+      });
+    }
+  },
+);
+
+router.patch(
+  "/",
+  requireAuth,
+  requireRole("owner"),
+  async (req, res) => {
+    try {
+      const companyId = req.auth!.companyId;
+      if (companyId == null) {
+        return res.status(400).json({
+          error: "Bad Request",
+          message: "User has no company assignment",
+        });
+      }
+      const existing = await getOrCreateSettings(companyId);
+
+      const patch: Partial<{ admin_bypass_allowed: boolean }> = {};
+      if (typeof req.body?.admin_bypass_allowed === "boolean") {
+        patch.admin_bypass_allowed = req.body.admin_bypass_allowed;
+      }
+      if (Object.keys(patch).length === 0) {
+        return res.status(400).json({
+          error: "Bad Request",
+          message: "No valid setting provided",
+        });
+      }
+
+      const now = new Date();
+      const updated = await db
+        .update(lmsSettingsTable)
+        .set({ ...patch, updated_at: now })
+        .where(eq(lmsSettingsTable.company_id, companyId))
+        .returning();
+
+      await logAudit(
+        req,
+        "lms_settings.update",
+        "lms_settings",
+        existing.id,
+        {
+          admin_bypass_allowed: existing.admin_bypass_allowed,
+        },
+        patch,
+      );
+
+      return res.json({ data: updated[0] });
+    } catch (err) {
+      console.error("[lms-settings] PATCH / error:", err);
+      return res.status(500).json({
+        error: "Internal Server Error",
+        message: "Failed to update LMS settings",
+      });
+    }
+  },
+);
+
+export default router;

--- a/artifacts/api-server/src/routes/lms.ts
+++ b/artifacts/api-server/src/routes/lms.ts
@@ -38,6 +38,7 @@ import {
   lmsModuleProgressTable,
   lmsQuizStateTable,
   lmsQuizAttemptsTable,
+  lmsSettingsTable,
   usersTable,
   type LmsEnrollment,
   type LmsModuleProgress,
@@ -90,6 +91,47 @@ const MAX_EXTEND_DAYS = 90;
 const QUIZ_MODULE_SET = new Set<string>(QUIZ_MODULE_IDS);
 /** Set of every legitimate module id, including the final-test pseudo-id. */
 const KNOWN_MODULE_IDS = new Set<string>([...MODULE_ORDER, FINAL_MODULE_ID]);
+
+// Item 7 (P1 sprint 2026-05-14): in-memory idempotency cache for
+// /quiz/submit. Frontend generates a UUID when the quiz starts and
+// sends it on submit; if the same key arrives twice within the
+// window, the second call returns the cached response of the first
+// instead of inserting a duplicate attempt. This kills the
+// double-click / slow-network ghost-attempt problem (Sal's audit
+// found 11 attempts at the same timestamp on Compensation for one
+// tech). 60-second window; per-(user_id, idempotency_key) keyed.
+const QUIZ_IDEMPOTENCY_TTL_MS = 60_000;
+interface CachedQuizResponse {
+  body: unknown;
+  expires_at: number;
+}
+const quizIdempotencyCache = new Map<string, CachedQuizResponse>();
+function rememberQuizResponse(
+  userId: number,
+  key: string,
+  body: unknown,
+): void {
+  // Evict expired entries opportunistically. Map is small (one entry
+  // per active quiz submission across all users, ~seconds) so a full
+  // sweep is cheap.
+  const now = Date.now();
+  for (const [k, v] of quizIdempotencyCache.entries()) {
+    if (v.expires_at <= now) quizIdempotencyCache.delete(k);
+  }
+  quizIdempotencyCache.set(`${userId}:${key}`, {
+    body,
+    expires_at: now + QUIZ_IDEMPOTENCY_TTL_MS,
+  });
+}
+function recallQuizResponse(userId: number, key: string): unknown | null {
+  const hit = quizIdempotencyCache.get(`${userId}:${key}`);
+  if (!hit) return null;
+  if (hit.expires_at <= Date.now()) {
+    quizIdempotencyCache.delete(`${userId}:${key}`);
+    return null;
+  }
+  return hit.body;
+}
 
 function isQuizModuleId(id: string): boolean {
   return QUIZ_MODULE_SET.has(id);
@@ -595,6 +637,22 @@ router.post("/quiz/submit", requireAuth, async (req, res) => {
     const clientQuestionIds: string[] | undefined = Array.isArray(req.body?.questionIds)
       ? req.body.questionIds
       : undefined;
+    // Item 7 (P1 sprint): client-supplied UUID generated when the
+    // quiz attempt started. If the same key arrives twice within the
+    // 60-second window, return the cached response from the first
+    // call instead of inserting a duplicate attempt. Old clients that
+    // don't send the field skip the dedupe; this is forward-compatible.
+    const idempotencyKey: string | undefined =
+      typeof req.body?.idempotency_key === "string" &&
+      req.body.idempotency_key.length > 0
+        ? req.body.idempotency_key
+        : undefined;
+    if (idempotencyKey) {
+      const cached = recallQuizResponse(userId, idempotencyKey);
+      if (cached) {
+        return res.json(cached);
+      }
+    }
 
     if (typeof moduleId !== "string" || !KNOWN_MODULE_IDS.has(moduleId)) {
       return res
@@ -694,18 +752,37 @@ router.post("/quiz/submit", requireAuth, async (req, res) => {
       req.auth!.role === "owner" ||
       req.auth!.role === "admin" ||
       req.auth!.role === "office";
+    // Item 6 (P1 sprint): re-read attempts directly from the DB
+    // immediately before the cap check. Pre-fix, we read from the
+    // `progress` array loaded above which became stale under racing
+    // double-clicks (Sal's audit found 21 attempts on Compensation
+    // for a tech where the cap was supposedly 3). The freshest
+    // attempts count comes from a count of lms_quiz_attempts rows
+    // for this enrollment + module; using that as the gate means a
+    // racing concurrent submit with the same idempotency_key gets
+    // dedup'd above (Item 7), and a different key still races but
+    // at least sees the most recent count.
+    const liveAttemptsRows = await db
+      .select({ id: lmsQuizAttemptsTable.id })
+      .from(lmsQuizAttemptsTable)
+      .where(
+        and(
+          eq(lmsQuizAttemptsTable.enrollment_id, enrollment.id),
+          eq(lmsQuizAttemptsTable.module_id, moduleId),
+        ),
+      );
+    const liveAttemptsCount = liveAttemptsRows.length;
     const existing = progress.find((p) => p.module_id === moduleId);
-    const attemptsSoFar = existing?.attempts ?? 0;
     const alreadyPassed = existing?.status === "passed";
     const maxAttempts = maxAttemptsFor(moduleId);
-    if (!canBypassCap && !alreadyPassed && attemptsSoFar >= maxAttempts) {
+    if (!canBypassCap && !alreadyPassed && liveAttemptsCount >= maxAttempts) {
       return res.status(403).json({
         error: "Forbidden",
         message:
           moduleId === FINAL_MODULE_ID
             ? `You've used all ${maxAttempts} final-exam attempts. Ask your admin to extend or bypass.`
-            : `You've used all ${maxAttempts} attempts on this module. Ask your admin to extend or bypass.`,
-        attempts_used: attemptsSoFar,
+            : `You've used all ${maxAttempts} attempts on this module. Contact your admin to reset this module.`,
+        attempts_used: liveAttemptsCount,
         max_attempts: maxAttempts,
       });
     }
@@ -835,8 +912,8 @@ router.post("/quiz/submit", requireAuth, async (req, res) => {
       { module_id: moduleId, score: result.score },
     );
 
-    const attemptsAfter = attemptsSoFar + 1;
-    return res.json({
+    const attemptsAfter = liveAttemptsCount + 1;
+    const responseBody = {
       data: {
         score: result.score,
         passed: result.passed,
@@ -851,7 +928,14 @@ router.post("/quiz/submit", requireAuth, async (req, res) => {
         attempts_remaining: Math.max(0, maxAttempts - attemptsAfter),
         certificate_id: issuedCertId,
       },
-    });
+    };
+    // Item 7: cache the response under the idempotency key so a
+    // duplicate POST within 60s returns the same body instead of
+    // racing into a second insert.
+    if (idempotencyKey) {
+      rememberQuizResponse(userId, idempotencyKey, responseBody);
+    }
+    return res.json(responseBody);
   } catch (err) {
     console.error("[lms] /quiz/submit error:", err);
     return res
@@ -1116,6 +1200,18 @@ router.get(
           .json({ error: "Bad Request", message: "User has no company assignment" });
       }
 
+      // Item 8 (P1 sprint): roster reads admin_bypass_allowed so the
+      // frontend can hide the Bypass button when admin is the caller
+      // and the setting is off. (Backend still enforces the gate.)
+      const settingsRow = await db
+        .select({
+          admin_bypass_allowed: lmsSettingsTable.admin_bypass_allowed,
+        })
+        .from(lmsSettingsTable)
+        .where(eq(lmsSettingsTable.company_id, companyId))
+        .limit(1);
+      const adminBypassAllowed = settingsRow[0]?.admin_bypass_allowed ?? false;
+
       const enrollments = await db
         .select({
           id: lmsEnrollmentsTable.id,
@@ -1239,7 +1335,10 @@ router.get(
         };
       });
 
-      return res.json({ data: rows });
+      return res.json({
+        data: rows,
+        meta: { admin_bypass_allowed: adminBypassAllowed },
+      });
     } catch (err) {
       console.error("[lms] /admin/learners error:", err);
       return res
@@ -1456,6 +1555,28 @@ router.post(
         return res
           .status(400)
           .json({ error: "Bad Request", message: "User has no company assignment" });
+      }
+      // Item 8 (P1 sprint 2026-05-14): owners always allowed; admins +
+      // office only allowed when lms_settings.admin_bypass_allowed=true
+      // for this tenant. Default false because misclick risk on a long
+      // roster is real and bypass mutates the "Passed" record.
+      const callerRole = req.auth!.role;
+      if (callerRole !== "owner") {
+        const settings = await db
+          .select({
+            admin_bypass_allowed: lmsSettingsTable.admin_bypass_allowed,
+          })
+          .from(lmsSettingsTable)
+          .where(eq(lmsSettingsTable.company_id, companyId))
+          .limit(1);
+        const allowed = settings[0]?.admin_bypass_allowed ?? false;
+        if (!allowed) {
+          return res.status(403).json({
+            error: "Forbidden",
+            message:
+              "Module bypass is owner-only. Ask the owner to enable admin bypass under LMS settings.",
+          });
+        }
       }
       const moduleId: string | undefined = req.body?.moduleId;
       if (typeof moduleId !== "string" || !KNOWN_MODULE_IDS.has(moduleId)) {

--- a/artifacts/api-server/src/tests/lms-curriculum.test.ts
+++ b/artifacts/api-server/src/tests/lms-curriculum.test.ts
@@ -454,17 +454,20 @@ describe("sampleFinalQuestionIds", () => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("max attempt constants", () => {
-  it("MAX_MODULE_ATTEMPTS is 3 per spec (phes 2026-05-11)", () => {
-    assert.equal(MAX_MODULE_ATTEMPTS, 3);
+  it("MAX_MODULE_ATTEMPTS is 4 (phes pre-onboarding sprint 2026-05-14)", () => {
+    // Item 6 (P1 sprint 2026-05-14): bumped from 3 → 4 after Sal's
+    // audit found 21 attempts on Compensation for one tech (server
+    // wasn't enforcing the cap). Final exam stays at 4 for parity.
+    assert.equal(MAX_MODULE_ATTEMPTS, 4);
   });
 
   it("MAX_FINAL_ATTEMPTS is 4 per spec (phes 2026-05-11)", () => {
     assert.equal(MAX_FINAL_ATTEMPTS, 4);
   });
 
-  it("maxAttemptsFor returns 3 for every per-module quiz id", () => {
+  it("maxAttemptsFor returns 4 for every per-module quiz id", () => {
     for (const m of QUIZ_MODULE_IDS) {
-      assert.equal(maxAttemptsFor(m), 3, `expected 3 for ${m}`);
+      assert.equal(maxAttemptsFor(m), 4, `expected 4 for ${m}`);
     }
   });
 
@@ -472,11 +475,11 @@ describe("max attempt constants", () => {
     assert.equal(maxAttemptsFor(FINAL_MODULE_ID), 4);
   });
 
-  it("maxAttemptsFor returns 3 for the acknowledgment module (no quiz, but symmetric)", () => {
+  it("maxAttemptsFor returns 4 for the acknowledgment module (no quiz, but symmetric)", () => {
     // Acknowledgment is content-only; cap doesn't apply in /quiz/submit
-    // (different endpoint), but the helper still classifies it under the
-    // default 3-attempt bucket.
-    assert.equal(maxAttemptsFor("acknowledgment"), 3);
+    // (different endpoint), but the helper still classifies it under
+    // the default 4-attempt bucket.
+    assert.equal(maxAttemptsFor("acknowledgment"), 4);
   });
 });
 

--- a/artifacts/qleno/src/App.tsx
+++ b/artifacts/qleno/src/App.tsx
@@ -78,7 +78,8 @@ const AdminBilling        = lazy(() => import("@/pages/admin/billing"));
 const AdminCleancyclopedia= lazy(() => import("@/pages/admin/cleancyclopedia"));
 const NotificationsPage   = lazy(() => import("@/pages/notifications"));
 const TrainingPage        = lazy(() => import("@/pages/training"));
-const LmsAdminPage        = lazy(() => import("@/pages/lms-admin"));
+const LmsAdminPage         = lazy(() => import("@/pages/lms-admin"));
+const LmsAdminSettingsPage = lazy(() => import("@/pages/lms-admin-settings"));
 const NotFound            = lazy(() => import("@/pages/not-found"));
 
 // [job-card-redesign] Dev-only visual test page — gated by PROD env.
@@ -187,6 +188,7 @@ function Router() {
         <Route path="/notifications" component={NotificationsPage} />
 
         <Route path="/training" component={TrainingPage} />
+        <Route path="/lms/admin/settings" component={LmsAdminSettingsPage} />
         <Route path="/lms/admin" component={LmsAdminPage} />
         <Route path="/lms" component={TrainingPage} />
 

--- a/artifacts/qleno/src/pages/lms-admin-settings.tsx
+++ b/artifacts/qleno/src/pages/lms-admin-settings.tsx
@@ -1,0 +1,367 @@
+/**
+ * /lms/admin/settings — owner-only LMS configuration page
+ * (Item 9, P1 sprint 2026-05-14).
+ *
+ * Today's inhabitant: admin_bypass_allowed (Item 8). Future inhabitants
+ * (deadline window, passing threshold, attempt cap, reminder cadence,
+ * notification triggers, bilingual toggle per module, LMS-specific
+ * branding) belong here too — keep the page general so adding a
+ * setting doesn't require a new route.
+ *
+ * Owner-only: admin role gets a 403 access-denied panel. The backend
+ * route also enforces requireRole("owner") on PATCH /api/lms-settings.
+ */
+import { useEffect, useMemo, useState } from "react";
+import { useAuthStore } from "@/lib/auth";
+import { useLocation } from "wouter";
+import { ChevronLeft, X, Loader2 } from "lucide-react";
+
+const NAVY = "#0A2342";
+const TEAL = "#0096B3";
+const INK = "#0F172A";
+const INK_MUTE = "#475569";
+const INK_LIGHT = "#94A3B8";
+const PAGE_BG = "#F8FAFC";
+const SURFACE = "#FFFFFF";
+const LINE = "#E2E8F0";
+const SUCCESS = "#0F766E";
+const DANGER = "#B91C1C";
+const FONT = "'Plus Jakarta Sans', sans-serif";
+const RADIUS = 10;
+
+const API_BASE = (import.meta.env.BASE_URL || "/").replace(/\/$/, "") + "/api";
+
+interface AuthPayload {
+  role?: string;
+}
+
+function readRoleFromToken(token: string | null): AuthPayload | null {
+  if (!token) return null;
+  try {
+    const parts = token.split(".");
+    if (parts.length < 2) return null;
+    return JSON.parse(atob(parts[1])) as AuthPayload;
+  } catch {
+    return null;
+  }
+}
+
+interface LmsSettings {
+  id: number;
+  company_id: number;
+  admin_bypass_allowed: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+async function api<T>(
+  method: "GET" | "PATCH",
+  path: string,
+  token: string | null,
+  body?: unknown,
+): Promise<T> {
+  const res = await fetch(`${API_BASE}${path}`, {
+    method,
+    headers: {
+      ...(token ? { authorization: `Bearer ${token}` } : {}),
+      "content-type": "application/json",
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`${method} ${path} → ${res.status}: ${text}`);
+  }
+  const json = await res.json();
+  return json.data as T;
+}
+
+export default function LmsAdminSettingsPage() {
+  const token = useAuthStore((s) => s.token);
+  const auth = useMemo(() => readRoleFromToken(token), [token]);
+  const isOwner = auth?.role === "owner";
+  const [, setLocation] = useLocation();
+  const [settings, setSettings] = useState<LmsSettings | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [savedAt, setSavedAt] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!isOwner) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const data = await api<LmsSettings>("GET", "/lms-settings", token);
+        if (!cancelled) setSettings(data);
+      } catch (e) {
+        if (!cancelled) setErr(String((e as Error).message));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [isOwner, token]);
+
+  async function patchSetting(patch: Partial<LmsSettings>) {
+    setBusy(true);
+    setErr(null);
+    try {
+      const data = await api<LmsSettings>(
+        "PATCH",
+        "/lms-settings",
+        token,
+        patch,
+      );
+      setSettings(data);
+      setSavedAt(Date.now());
+    } catch (e) {
+      setErr(String((e as Error).message));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (!isOwner) {
+    return (
+      <Shell>
+        <div
+          style={{
+            maxWidth: 480,
+            margin: "60px auto",
+            background: SURFACE,
+            border: `1px solid ${LINE}`,
+            borderRadius: RADIUS,
+            padding: 28,
+            textAlign: "center",
+          }}
+        >
+          <X size={36} style={{ color: DANGER }} />
+          <div
+            style={{
+              fontWeight: 800,
+              fontSize: 18,
+              color: INK,
+              marginTop: 8,
+            }}
+          >
+            Owner only
+          </div>
+          <div style={{ fontSize: 13, color: INK_MUTE, marginTop: 4 }}>
+            LMS settings are restricted to the tenant owner. Contact Sal
+            if you need a setting changed.
+          </div>
+        </div>
+      </Shell>
+    );
+  }
+
+  return (
+    <Shell>
+      <div style={{ maxWidth: 720, margin: "20px auto", padding: "0 16px" }}>
+        <button
+          type="button"
+          onClick={() => setLocation("/lms/admin")}
+          style={{
+            background: "transparent",
+            border: 0,
+            color: NAVY,
+            fontSize: 13,
+            fontWeight: 700,
+            cursor: "pointer",
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 4,
+            fontFamily: FONT,
+          }}
+        >
+          <ChevronLeft size={14} /> Back to roster
+        </button>
+        <div style={{ marginTop: 14 }}>
+          <div
+            style={{
+              fontWeight: 800,
+              fontSize: 22,
+              letterSpacing: "-0.015em",
+              color: INK,
+            }}
+          >
+            LMS Settings
+          </div>
+          <div style={{ fontSize: 13, color: INK_MUTE, marginTop: 4 }}>
+            Per-tenant configuration for the Learning Management System.
+            Owner-only changes; admins can read but not write.
+          </div>
+        </div>
+
+        {err && (
+          <div
+            style={{
+              marginTop: 14,
+              background: "#FEF2F2",
+              border: `1px solid #FECACA`,
+              color: DANGER,
+              padding: 10,
+              borderRadius: 8,
+              fontSize: 12,
+              fontWeight: 700,
+            }}
+          >
+            {err}
+          </div>
+        )}
+
+        {settings === null && !err ? (
+          <div
+            style={{
+              marginTop: 30,
+              padding: 30,
+              textAlign: "center",
+              color: INK_MUTE,
+            }}
+          >
+            <Loader2 size={20} className="qleno-spin" />
+          </div>
+        ) : settings ? (
+          <div
+            style={{
+              marginTop: 18,
+              background: SURFACE,
+              border: `1px solid ${LINE}`,
+              borderRadius: RADIUS,
+              padding: 0,
+              fontFamily: FONT,
+            }}
+          >
+            <SettingRow
+              title="Allow administrators to bypass modules"
+              description="When OFF (default), only the owner sees the Bypass button on the per-employee admin row. When ON, both owner AND admin role see it. Same type-to-confirm guard regardless of role. Office role NEVER sees it. The backend enforces this gate too — flipping the toggle off immediately revokes admin bypass."
+              checked={settings.admin_bypass_allowed}
+              onChange={(v) => patchSetting({ admin_bypass_allowed: v })}
+              disabled={busy}
+            />
+          </div>
+        ) : null}
+
+        {savedAt ? (
+          <div
+            style={{
+              marginTop: 14,
+              fontSize: 12,
+              color: SUCCESS,
+              fontWeight: 700,
+            }}
+          >
+            Saved.
+          </div>
+        ) : null}
+
+        <div
+          style={{
+            marginTop: 28,
+            fontSize: 11,
+            color: INK_LIGHT,
+            lineHeight: 1.55,
+          }}
+        >
+          Future settings will live on this page: deadline window,
+          passing threshold, per-module attempt cap, reminder cadence,
+          notification triggers, bilingual toggle per module, LMS-
+          specific branding.
+        </div>
+      </div>
+      <style>{`
+        @keyframes qleno-spin { to { transform: rotate(360deg); } }
+        .qleno-spin { animation: qleno-spin 1s linear infinite; }
+      `}</style>
+    </Shell>
+  );
+}
+
+function SettingRow({
+  title,
+  description,
+  checked,
+  onChange,
+  disabled,
+}: {
+  title: string;
+  description: string;
+  checked: boolean;
+  onChange: (next: boolean) => void;
+  disabled: boolean;
+}) {
+  return (
+    <div
+      style={{
+        padding: "16px 18px",
+        display: "grid",
+        gridTemplateColumns: "1fr auto",
+        gap: 16,
+        alignItems: "flex-start",
+        borderBottom: `1px solid ${LINE}`,
+      }}
+    >
+      <div>
+        <div style={{ fontWeight: 700, fontSize: 14, color: INK }}>{title}</div>
+        <div
+          style={{
+            fontSize: 12,
+            color: INK_MUTE,
+            marginTop: 4,
+            lineHeight: 1.55,
+          }}
+        >
+          {description}
+        </div>
+      </div>
+      <button
+        type="button"
+        onClick={() => onChange(!checked)}
+        disabled={disabled}
+        aria-pressed={checked}
+        style={{
+          background: checked ? TEAL : "#CBD5E1",
+          color: "#fff",
+          border: 0,
+          padding: "0",
+          width: 56,
+          height: 30,
+          borderRadius: 999,
+          cursor: disabled ? "default" : "pointer",
+          position: "relative",
+          opacity: disabled ? 0.6 : 1,
+          fontFamily: FONT,
+          flexShrink: 0,
+        }}
+      >
+        <span
+          style={{
+            position: "absolute",
+            top: 3,
+            left: checked ? 28 : 3,
+            width: 24,
+            height: 24,
+            background: "#fff",
+            borderRadius: 999,
+            transition: "left 120ms ease",
+          }}
+        />
+      </button>
+    </div>
+  );
+}
+
+function Shell({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        background: PAGE_BG,
+        fontFamily: FONT,
+        color: INK,
+      }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/artifacts/qleno/src/pages/lms-admin.tsx
+++ b/artifacts/qleno/src/pages/lms-admin.tsx
@@ -11,6 +11,7 @@
  * Visual style matches training.tsx (Plus Jakarta Sans, NAVY/TEAL palette).
  */
 import { Fragment, useEffect, useMemo, useState } from "react";
+import { useLocation } from "wouter";
 import { useAuthStore } from "@/lib/auth";
 import { QlenoLogo } from "@/components/brand/QlenoLogo";
 import {
@@ -133,6 +134,7 @@ function useViewportIsMobile(): boolean {
 
 export default function LmsAdminPage() {
   const token = useAuthStore((s) => s.token);
+  const [, setLocation] = useLocation();
   const auth = useMemo(() => readRoleFromToken(token), [token]);
   const isAuthorized =
     auth?.role === "owner" ||
@@ -141,6 +143,11 @@ export default function LmsAdminPage() {
     auth?.role === "office";
   const isMobile = useViewportIsMobile();
   const [rows, setRows] = useState<RosterRow[] | null>(null);
+  // Item 8 (P1 sprint): owner-only bypass by default. Frontend reads
+  // the per-tenant `admin_bypass_allowed` flag from /api/lms-settings
+  // and passes it to ModuleAttemptsGrid so the Bypass button is
+  // hidden for admins when the toggle is off. Backend enforces too.
+  const [adminBypassAllowed, setAdminBypassAllowed] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
   const [extendOpen, setExtendOpen] = useState<RosterRow | null>(null);
   const [resetOpen, setResetOpen] = useState<RosterRow | null>(null);
@@ -169,6 +176,19 @@ export default function LmsAdminPage() {
     try {
       const data = await api<RosterRow[]>("GET", "/lms/admin/learners", token);
       setRows(data);
+      // Settings fetch is fire-and-forget for the roster path. If the
+      // GET fails (admin without read perm, network blip), we leave
+      // adminBypassAllowed=false (the safe default).
+      try {
+        const settings = await api<{ admin_bypass_allowed: boolean }>(
+          "GET",
+          "/lms-settings",
+          token,
+        );
+        setAdminBypassAllowed(!!settings.admin_bypass_allowed);
+      } catch {
+        setAdminBypassAllowed(false);
+      }
       setError(null);
     } catch (e) {
       setError(String((e as Error).message));
@@ -310,6 +330,26 @@ export default function LmsAdminPage() {
             >
               Bulk reset password
             </button>
+            {/* Item 9 (P1 sprint): owner-only Settings page entry. */}
+            {auth?.role === "owner" ? (
+              <button
+                type="button"
+                onClick={() => setLocation("/lms/admin/settings")}
+                style={{
+                  background: "transparent",
+                  color: NAVY,
+                  border: `1px solid ${LINE}`,
+                  padding: "8px 12px",
+                  borderRadius: 8,
+                  fontSize: 12,
+                  fontWeight: 700,
+                  cursor: "pointer",
+                  fontFamily: FONT,
+                }}
+              >
+                Settings
+              </button>
+            ) : null}
             <button
               type="button"
               onClick={refresh}
@@ -384,6 +424,7 @@ export default function LmsAdminPage() {
             onArchive={setArchiveOpen}
             onResetDeadline={setResetDeadlineOpen}
             callerRole={auth?.role ?? null}
+            adminBypassAllowed={adminBypassAllowed}
           />
         ) : (
           <RosterTable
@@ -397,6 +438,7 @@ export default function LmsAdminPage() {
             onArchive={setArchiveOpen}
             onResetDeadline={setResetDeadlineOpen}
             callerRole={auth?.role ?? null}
+            adminBypassAllowed={adminBypassAllowed}
           />
         )}
       </div>
@@ -553,6 +595,7 @@ function RosterTable({
   onArchive,
   onResetDeadline,
   callerRole,
+  adminBypassAllowed,
 }: {
   rows: RosterRow[];
   expanded: Set<number>;
@@ -564,6 +607,7 @@ function RosterTable({
   onArchive: (r: RosterRow) => void;
   onResetDeadline: (r: RosterRow) => void;
   callerRole: string | null;
+  adminBypassAllowed: boolean;
 }) {
   return (
     <div
@@ -799,7 +843,7 @@ function RosterTable({
                       borderBottom: `1px solid ${LINE_SOFT}`,
                     }}
                   >
-                    <ModuleAttemptsGrid row={r} onBypass={onBypass} />
+                    <ModuleAttemptsGrid row={r} onBypass={onBypass} callerRole={callerRole} adminBypassAllowed={adminBypassAllowed} />
                     <LearnerCertificatesPanel row={r} />
                     <LearnerSignedDocumentsPanel row={r} />
                   </td>
@@ -817,10 +861,25 @@ function RosterTable({
 function ModuleAttemptsGrid({
   row,
   onBypass,
+  callerRole,
+  adminBypassAllowed,
 }: {
   row: RosterRow;
   onBypass: (userId: number, moduleId: string) => Promise<void>;
+  callerRole: string | null;
+  adminBypassAllowed: boolean;
 }) {
+  // Item 8 (P1 sprint): bypass visibility gate.
+  //   - Owner always sees Bypass.
+  //   - Admin only sees when admin_bypass_allowed setting is true.
+  //   - Office NEVER sees Bypass (was a backend-only path before).
+  const canSeeBypass =
+    callerRole === "owner" ||
+    (callerRole === "admin" && adminBypassAllowed);
+  // Type-to-confirm dialog state. The clicked moduleId is the
+  // expected confirm string — caller types the module name to
+  // enable the destructive button.
+  const [pendingBypass, setPendingBypass] = useState<string | null>(null);
   // Item 2 (P0 sprint): canonical denominator. We list the 13 quiz
   // modules + the Final Mixed Test as a separate trailing card. The
   // older content-only "acknowledgment" entry from MODULE_ORDER is
@@ -897,15 +956,18 @@ function ModuleAttemptsGrid({
                     : `${attempts}/${max} attempts${atCap ? " · at cap" : ""}`}
                 </div>
               </div>
-              {!passed ? (
+              {!passed && canSeeBypass ? (
                 <button
                   type="button"
-                  onClick={() => onBypass(row.user_id, moduleId)}
+                  onClick={() => setPendingBypass(moduleId)}
                   title="Bypass — mark as passed"
                   style={{
-                    background: NAVY,
-                    color: "#fff",
-                    border: 0,
+                    // Item 8 (P1 sprint): red ghost. Misclick risk on
+                    // a long roster is real; this is destructive
+                    // (mutates the "Passed" record on a learner).
+                    background: "transparent",
+                    color: DANGER,
+                    border: `1px solid ${DANGER}`,
                     padding: "5px 8px",
                     borderRadius: 6,
                     fontSize: 11,
@@ -925,6 +987,178 @@ function ModuleAttemptsGrid({
           );
         })}
       </div>
+      {pendingBypass !== null ? (
+        <BypassConfirmDialog
+          moduleId={pendingBypass}
+          onClose={() => setPendingBypass(null)}
+          onConfirm={async () => {
+            await onBypass(row.user_id, pendingBypass);
+            setPendingBypass(null);
+          }}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// BypassConfirmDialog (Item 8, P1 sprint 2026-05-14)
+//
+// Type-to-confirm gate before mutating a learner's module_progress
+// record to status='passed'. Owner / admin (when allowed) types the
+// uppercase module name to enable the destructive button. Mirrors
+// the Reset Enrollment dialog pattern.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function BypassConfirmDialog({
+  moduleId,
+  onClose,
+  onConfirm,
+}: {
+  moduleId: string;
+  onClose: () => void;
+  onConfirm: () => Promise<void>;
+}) {
+  const expected = humanModule(moduleId).toUpperCase();
+  const [confirm, setConfirm] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const valid = confirm.trim().toUpperCase() === expected;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Bypass module"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "rgba(15, 23, 42, 0.55)",
+        display: "grid",
+        placeItems: "center",
+        zIndex: 100,
+        padding: 16,
+      }}
+    >
+      <div
+        style={{
+          background: SURFACE,
+          borderRadius: RADIUS,
+          maxWidth: 460,
+          width: "100%",
+          padding: 24,
+          fontFamily: FONT,
+          color: INK,
+        }}
+      >
+        <div style={{ fontSize: 16, fontWeight: 800, color: INK }}>
+          Bypass {humanModule(moduleId)}
+        </div>
+        <div
+          style={{
+            fontSize: 12.5,
+            color: INK_MUTE,
+            marginTop: 6,
+            lineHeight: 1.55,
+          }}
+        >
+          Marks this module as PASSED for the learner without them
+          taking the quiz. Issues a completion certificate. The action
+          is logged with your name + role for legal. Only use when you
+          have a clear reason (technical error, accommodation,
+          documented prior credit).
+        </div>
+        <label
+          style={{
+            display: "block",
+            marginTop: 14,
+            fontSize: 12,
+            fontWeight: 700,
+            color: INK_MUTE,
+            textTransform: "uppercase",
+            letterSpacing: "0.06em",
+          }}
+        >
+          Type the module name to confirm: <strong>{expected}</strong>
+        </label>
+        <input
+          type="text"
+          value={confirm}
+          onChange={(e) => setConfirm(e.target.value)}
+          placeholder={expected}
+          disabled={busy}
+          style={{
+            width: "100%",
+            marginTop: 6,
+            padding: "10px 12px",
+            border: `1px solid ${LINE}`,
+            borderRadius: 8,
+            fontSize: 14,
+            fontFamily: FONT,
+          }}
+        />
+        {err && (
+          <div style={{ color: DANGER, fontSize: 12, marginTop: 8 }}>{err}</div>
+        )}
+        <div
+          style={{
+            marginTop: 18,
+            display: "flex",
+            gap: 8,
+            justifyContent: "flex-end",
+          }}
+        >
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={busy}
+            style={{
+              background: "transparent",
+              color: INK_MUTE,
+              border: `1px solid ${LINE}`,
+              padding: "8px 14px",
+              borderRadius: 8,
+              fontSize: 13,
+              fontWeight: 700,
+              cursor: "pointer",
+              fontFamily: FONT,
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            disabled={!valid || busy}
+            onClick={async () => {
+              setBusy(true);
+              setErr(null);
+              try {
+                await onConfirm();
+              } catch (e) {
+                setErr(String((e as Error).message));
+              } finally {
+                setBusy(false);
+              }
+            }}
+            style={{
+              background: !valid || busy ? INK_LIGHT : DANGER,
+              color: "#fff",
+              border: 0,
+              padding: "8px 14px",
+              borderRadius: 8,
+              fontSize: 13,
+              fontWeight: 700,
+              fontFamily: FONT,
+              cursor: !valid || busy ? "default" : "pointer",
+            }}
+          >
+            {busy ? "Bypassing…" : "Bypass module"}
+          </button>
+        </div>
+      </div>
     </div>
   );
 }
@@ -940,6 +1174,7 @@ function RosterCards({
   onArchive,
   onResetDeadline,
   callerRole,
+  adminBypassAllowed,
 }: {
   rows: RosterRow[];
   expanded: Set<number>;
@@ -951,6 +1186,7 @@ function RosterCards({
   onArchive: (r: RosterRow) => void;
   onResetDeadline: (r: RosterRow) => void;
   callerRole: string | null;
+  adminBypassAllowed: boolean;
 }) {
   return (
     <div style={{ display: "grid", gap: 10 }} data-testid="roster-cards">
@@ -1113,7 +1349,7 @@ function RosterCards({
           </div>
           {expanded.has(r.enrollment_id) ? (
             <div style={{ marginTop: 6 }}>
-              <ModuleAttemptsGrid row={r} onBypass={onBypass} />
+              <ModuleAttemptsGrid row={r} onBypass={onBypass} callerRole={callerRole} adminBypassAllowed={adminBypassAllowed} />
               <LearnerCertificatesPanel row={r} />
               <LearnerSignedDocumentsPanel row={r} />
             </div>

--- a/artifacts/qleno/src/pages/training.tsx
+++ b/artifacts/qleno/src/pages/training.tsx
@@ -239,11 +239,20 @@ const lmsApi = {
     moduleId: string,
     answers: (number | null)[],
     questionIds?: string[],
+    // Item 7 (P1 sprint 2026-05-14): client-generated UUID. Sent on
+    // every submit; server dedupes a duplicate POST within 60s by
+    // returning the cached response of the first call. Pre-fix, a
+    // double-click or slow network created ghost attempts (Sal's
+    // audit found 11 0% submissions all timestamped 10:24 AM for
+    // one tech). Required field; if unset the server falls back to
+    // the racing behavior, so always pass a fresh value per attempt.
+    idempotencyKey?: string,
   ) =>
     api<SubmitResult>("POST", "/lms/quiz/submit", token, {
       moduleId,
       answers,
       questionIds,
+      idempotency_key: idempotencyKey,
     }),
   acknowledge: (
     token: string | null,
@@ -2678,6 +2687,18 @@ function QuizView({
   const [busy, setBusy] = useState(false);
   const [result, setResult] = useState<SubmitResult | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // Item 7 (P1 sprint): per-attempt UUID for server-side deduplication
+  // of double-click / slow-network ghost submits. Generated when the
+  // QuizView mounts; reset whenever moduleId changes (a new attempt =
+  // a new key). Stable across re-renders so a bouncing button doesn't
+  // generate multiple keys.
+  const idempotencyKeyRef = useRef<string>("");
+  if (!idempotencyKeyRef.current) {
+    idempotencyKeyRef.current =
+      typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+        ? crypto.randomUUID()
+        : `att-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  }
 
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -2948,6 +2969,13 @@ function QuizView({
               <PrimaryButton
                 disabled={busy || !allAnswered}
                 onClick={async () => {
+                  // Item 7 (P1 sprint): debounce — `busy` flips
+                  // synchronously here, so a second click within the
+                  // same render frame is ignored by the disabled
+                  // guard above. The idempotency_key acts as a
+                  // backstop when the click + network race lands
+                  // multiple POSTs at the server in the same tick.
+                  if (busy) return;
                   setBusy(true);
                   try {
                     const r = await lmsApi.submitQuiz(
@@ -2955,6 +2983,7 @@ function QuizView({
                       moduleId,
                       answers,
                       questionIds,
+                      idempotencyKeyRef.current,
                     );
                     setResult(r);
                   } catch (e) {

--- a/lib/db/src/schema/index.ts
+++ b/lib/db/src/schema/index.ts
@@ -94,3 +94,4 @@ export * from "./lms";
 // signed_documents, document_versions, signature_events,
 // completion_certificates, annual_ack_cycles, pending_re_ack.
 export * from "./lms-signatures";
+export * from "./lms-settings";

--- a/lib/db/src/schema/lms-settings.ts
+++ b/lib/db/src/schema/lms-settings.ts
@@ -1,0 +1,51 @@
+/**
+ * LMS per-tenant settings (Items 8 + 9, P1 sprint 2026-05-14).
+ *
+ * Single row per tenant, keyed by company_id. The first inhabitant
+ * is `admin_bypass_allowed` (default false). Future inhabitants
+ * (deadline window, passing threshold, attempt cap, reminder
+ * cadence, notification triggers, bilingual toggle per module,
+ * LMS-specific branding) live here too — keep the table general so
+ * adding a column doesn't require a new table per setting.
+ */
+import {
+  pgTable,
+  serial,
+  integer,
+  boolean,
+  timestamp,
+  uniqueIndex,
+} from "drizzle-orm/pg-core";
+import { companiesTable } from "./companies";
+
+export const lmsSettingsTable = pgTable(
+  "lms_settings",
+  {
+    id: serial("id").primaryKey(),
+    company_id: integer("company_id")
+      .notNull()
+      .references(() => companiesTable.id),
+    /**
+     * Item 8 (P1 sprint): owners always see Bypass buttons in the
+     * /lms/admin per-employee drawer. Admins only see them when the
+     * owner explicitly enables this setting via /lms/admin/settings.
+     * Default false because misclick risk on a long roster is real
+     * and bypass is a destructive write that mutates the "Passed"
+     * record on a learner.
+     */
+    admin_bypass_allowed: boolean("admin_bypass_allowed")
+      .notNull()
+      .default(false),
+    created_at: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updated_at: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => ({
+    uq_company: uniqueIndex("lms_settings_company_uq").on(t.company_id),
+  }),
+);
+
+export type LmsSettings = typeof lmsSettingsTable.$inferSelect;

--- a/lib/lms-curriculum/src/index.ts
+++ b/lib/lms-curriculum/src/index.ts
@@ -188,7 +188,13 @@ export const QUIZ_PASS_THRESHOLD = 0.8;
  * exempt from this gate via `/lms/admin/bypass-module`. Admins can also
  * extend the deadline or bypass on behalf of a learner from /lms/admin.
  */
-export const MAX_MODULE_ATTEMPTS = 3;
+// Item 6 (P0/P1 sprint 2026-05-14): per-module cap raised from 3 → 4
+// after Sal's audit found 21 attempts on Compensation for one tech
+// (server wasn't enforcing the cap; UI showed "3/3 at cap" but the
+// /quiz/submit handler accepted submissions anyway). Final exam cap
+// stays at 4 for parity. Server-side enforcement now lives in
+// /quiz/submit guarded by maxAttemptsFor().
+export const MAX_MODULE_ATTEMPTS = 4;
 export const MAX_FINAL_ATTEMPTS = 4;
 
 /** Max attempts allowed for a given module id (module or `__final`). */


### PR DESCRIPTION
**Pre-onboarding sprint, Section B (P1)** — Items 6, 7, 8, 9 from today's audit. Item 10 (Employee Journey consolidated page) deferred to a follow-up. Opened as draft; will undraft + merge once CI clears.

## Items shipped

| # | Item | Files |
| --- | --- | --- |
| 6 | Quiz attempt cap raised to 4 + server re-reads from `lms_quiz_attempts` before the gate | `lib/lms-curriculum/src/index.ts`, `routes/lms.ts` |
| 7 | Submit-button debounce + server-side `idempotency_key` (60s in-memory cache) | `routes/lms.ts`, `pages/training.tsx` |
| 8 | Bypass owner-only by default, red-ghost restyle, type-the-module-name confirm, `admin_bypass_allowed` setting gates admin role | `routes/lms.ts`, `pages/lms-admin.tsx` |
| 9 | NEW LMS Settings page at `/lms/admin/settings` (owner-only) + `lms_settings` table | `lib/db/src/schema/lms-settings.ts`, `phes-data-migration.ts`, `routes/lms-settings.ts`, `routes/index.ts`, `pages/lms-admin-settings.tsx`, `App.tsx`, `pages/lms-admin.tsx` |

## Schema changes (idempotent, applied via existing cold-start runner)

- `lms_settings` table — single row per `company_id`, first column `admin_bypass_allowed BOOLEAN DEFAULT FALSE`. Unique index on `company_id`.

## Deferred — Item 10 Journey page

Item 10 ships a **new** `/lms/admin/employee/<id>/journey` page consolidating modules timeline + signed docs + cert history + admin actions for one employee. Substantial standalone surface; deferring to a follow-up PR so this Section B can deploy ahead of tomorrow morning's onboarding without a giant blast radius. Existing dialogs (Extend, Reset, History, Reset Deadline, Archive) remain functional in the meantime — operators have all the same data, just spread across multiple dialogs instead of a single page.

## Tests

**284/284 LMS unit tests pass** (3 attempt-cap tests updated 3→4). Build clean.

## Test plan after deploy

1. As tech: take a quiz. Submit → confirm one attempt recorded. Click Submit AGAIN immediately during the spinner → confirm only one attempt was recorded (idempotency_key dedup).
2. As tech who has used 4 attempts on a module: submit a 5th → server returns 403 with "Contact your admin to reset this module."
3. As owner: visit `/lms/admin` → confirm new "Settings" button in the header. Click → opens `/lms/admin/settings`. Toggle "Allow administrators to bypass modules" ON → "Saved." appears.
4. As admin (a non-owner with admin role): visit `/lms/admin/settings` → confirm 403 access-denied panel. Visit `/lms/admin` → confirm Bypass buttons now visible (because owner enabled).
5. As admin: try to bypass → confirm BypassConfirmDialog opens, requires typing the uppercase module name to enable Bypass button. Confirm bypass succeeds + audit log records caller role + module + timestamp.
6. As owner: turn the setting back OFF. As admin: confirm Bypass buttons disappear AND backend rejects with 403 "Module bypass is owner-only."

## Cadence

Per Sal's "don't wait, push" override for this sprint, will undraft + squash-merge once CI clears.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxGiirnJ3dT4GAzHPNWhrx)_