### PR TITLE
lms: pre-onboarding sprint Section C — Item 11 verify, Item 12 last_activity, Item 13 polish

### DIFF
--- a/artifacts/api-server/src/routes/lms.ts
+++ b/artifacts/api-server/src/routes/lms.ts
@@ -181,9 +181,17 @@ async function getOrCreateEnrollment(
 }
 
 /**
- * Stamp `last_activity_at` for an enrollment. Called on every progress
- * write (start, autosave, submit, acknowledge) so the admin roster shows
- * a useful "last activity" timestamp.
+ * Stamp `last_activity_at` for an enrollment.
+ *
+ * Item 12 (P1 sprint 2026-05-14): the admin "Last activity" column
+ * needs to mean "is this person actually working through the LMS",
+ * not "did they crack the reader open and bounce". Pre-fix, every
+ * /module/start (reader open), /quiz/state PUT (autosave),
+ * /module/acknowledge, /grandfather, and /admin/bypass-module call
+ * stamped this — so Jose's roster card showed his last activity as
+ * Sexual Harassment 10:55 AM even though he had ZERO attempts on
+ * that module. Now ONLY /quiz/submit calls this helper. Every other
+ * caller of touchEnrollment was removed.
  */
 async function touchEnrollment(enrollmentId: number, now: Date = new Date()): Promise<void> {
   await db
@@ -466,7 +474,8 @@ router.post("/module/start", requireAuth, async (req, res) => {
       },
       now,
     });
-    await touchEnrollment(enrollment.id, now);
+    // Item 12 (P1 sprint): /module/start is a reader open, not a
+    // quiz attempt. Do NOT stamp last_activity_at here.
     return res.json({ data: row });
   } catch (err) {
     console.error("[lms] /module/start error:", err);
@@ -595,7 +604,8 @@ router.post("/quiz/state", requireAuth, async (req, res) => {
       })
       .returning();
 
-    await touchEnrollment(enrollment.id, now);
+    // Item 12 (P1 sprint): /quiz/state autosave is mid-attempt
+    // typing, not a submit. Do NOT stamp last_activity_at here.
     return res.json({ data: inserted[0] });
   } catch (err) {
     console.error("[lms] POST /quiz/state error:", err);
@@ -1020,7 +1030,8 @@ router.post("/module/acknowledge", requireAuth, async (req, res) => {
         .where(eq(lmsEnrollmentsTable.id, enrollment.id));
     }
 
-    await touchEnrollment(enrollment.id, now);
+    // Item 12 (P1 sprint): /module/acknowledge is a content-only
+    // signature, not a quiz submit. Do NOT stamp last_activity_at.
 
     // Phase 12: issue a completion certificate for content-only modules
     // (e.g. qleno-app, acknowledgment). No score because there's no quiz.
@@ -1160,7 +1171,10 @@ router.post("/grandfather", requireAuth, async (req, res) => {
       });
     }
 
-    await touchEnrollment(enrollment.id, now);
+    // Item 12 (P1 sprint): /grandfather is a one-time legacy data
+    // import, not employee activity. Do NOT stamp last_activity_at —
+    // a freshly grandfathered employee should still show "Not yet
+    // started" until they actually submit a quiz.
     await logAudit(
       req,
       "lms.grandfather",
@@ -1667,7 +1681,8 @@ router.post(
           ),
         );
 
-      await touchEnrollment(enrollment.id, now);
+      // Item 12 (P1 sprint): /admin/bypass-module is an admin action,
+      // not employee activity. Do NOT stamp last_activity_at.
 
       // PR #4 policy decision: bypass marks the quiz passed for
       // navigation purposes but does NOT issue a completion certificate

--- a/artifacts/qleno/src/pages/lms-admin.tsx
+++ b/artifacts/qleno/src/pages/lms-admin.tsx
@@ -1527,9 +1527,34 @@ function ProgressDot({ pct }: { pct: number }) {
   );
 }
 
+// Item 13c (P1 sprint 2026-05-14): canonical display titles per
+// module id. Pre-fix, the helper just split-on-dash + capitalized,
+// which produced "Il Sexual Harassment" for `il-sexual-harassment`
+// instead of the proper "Illinois Sexual Harassment Prevention".
+// Audit any future module name changes against this map.
+const MODULE_DISPLAY_TITLES: Record<string, string> = {
+  "phes-policies": "Phes Policies & Procedures",
+  "compensation": "Compensation",
+  "cleaning-best-practices": "Cleaning Best Practices",
+  "maidcentral": "MaidCentral",
+  "products-tools": "Products & Tools",
+  "il-sexual-harassment": "Illinois Sexual Harassment Prevention",
+  "drug-alcohol": "Drug & Alcohol",
+  "code-of-conduct": "Code of Conduct",
+  "video-photo-release": "Video & Photo Release",
+  "non-solicitation": "Non-Solicitation",
+  "social-media": "Social Media",
+  "phes-401k": "Phes 401(k)",
+  "supply-kit": "Supply Kit Responsibility",
+  "__final": "Final Mixed Test",
+  "__handbook": "Comprehensive Handbook",
+  "acknowledgment": "Acknowledgment",
+};
+
 function humanModule(id: string | null): string {
   if (!id) return "—";
-  if (id === "__final") return "Final mixed test";
+  if (MODULE_DISPLAY_TITLES[id]) return MODULE_DISPLAY_TITLES[id];
+  // Fallback: split-on-dash + Title Case for unknown ids.
   return id
     .split("-")
     .map((w) => w[0]?.toUpperCase() + w.slice(1))
@@ -1976,7 +2001,12 @@ type AttemptRow = {
 };
 
 function humanModuleLabel(id: string): string {
-  if (id === "__final") return "Final mixed test";
+  // Item 13c (P1 sprint): delegate to the canonical humanModule
+  // helper so attempt-history headers don't show "Il Sexual
+  // Harassment" while the rest of the dashboard shows the proper
+  // "Illinois Sexual Harassment Prevention".
+  if (MODULE_DISPLAY_TITLES[id]) return MODULE_DISPLAY_TITLES[id];
+  if (id === "__final") return "Final Mixed Test";
   return id
     .split("-")
     .map((w) => w[0]?.toUpperCase() + w.slice(1))
@@ -4024,6 +4054,12 @@ const ThStyle: React.CSSProperties = {
   textTransform: "uppercase",
   letterSpacing: "0.06em",
   borderBottom: `1px solid ${LINE}`,
+  // Item 13a (P1 sprint 2026-05-14): the audit dashboard MODULES /
+  // FINAL columns truncated to "FINAI" on narrow desktops because
+  // there was no min-width and the text-transform widened the
+  // letters. Force whole-word display + a sane minimum width.
+  whiteSpace: "nowrap",
+  minWidth: 80,
 };
 
 const TdStyle: React.CSSProperties = {


### PR DESCRIPTION
**Pre-onboarding sprint, Section C** — Items 11, 12, 13. Final PR in the sprint. Opened as draft; will undraft + merge once CI clears.

## Items shipped

| # | Item | Files |
| --- | --- | --- |
| 11 | Sign Handbook + Final Test gates verified — no code change needed | (investigation only) |
| 12 | `last_activity_at` strict quiz-only — removed from 5 non-quiz call sites | `routes/lms.ts` |
| 13a | Audit dashboard MODULES/FINAL header truncation fixed | `pages/lms-admin.tsx` (`ThStyle`) |
| 13b | "1 days" → "1 day" pluralization | already shipped in Section A (PR #114) |
| 13c | Module name normalization (`il-sexual-harassment` → "Illinois Sexual Harassment Prevention") | `pages/lms-admin.tsx` (new `MODULE_DISPLAY_TITLES` map) |

## Item 11 finding (investigation result)

| Surface | Behavior | Verdict |
| --- | --- | --- |
| Sign Handbook button (training.tsx:3543) | `disabled={!eligible && !isOwner}` | Correct — owners exempt for testing, non-owners gated |
| Final Mixed Test card (training.tsx:1599) | `fullyUnlocked = finalUnlocked && (isOwner || missingSignedDocs.length === 0)` | Correct — same pattern |
| `POST /api/lms/handbook/sign` | Re-checks eligibility; returns 409 if not eligible | Correct (Phase 11) |
| `POST /api/lms/quiz/start` for FINAL | Re-checks unlocked + missing signed docs | Correct (PR #4) |

Sal's "owner could click Sign Handbook with prereqs unmet" observation matches by-design owner bypass — not a gap. PR #112 (which I incorrectly reported as merged earlier today, then merged for real before starting Section A) was the **DoneView** fix, not a gate fix. Both gates were correct before that PR and remain correct.

## Item 12 (last_activity strict quiz-only)

Removed `touchEnrollment` from these endpoints:
- `/module/start` (reader open)
- `/quiz/state PUT` (autosave during attempt)
- `/module/acknowledge` (content-only signature)
- `/grandfather` (one-time legacy import)
- `/admin/bypass-module` (admin action)

Kept on: `/quiz/submit` only. The roster's "Last activity" column now means "is this person actually working" — which was Sal's stated intent. Jose's previously-misleading "Sexual Harassment 10:55 AM" with zero attempts on that module is no longer reproducible going forward.

## Tests + build

**284/284 LMS unit tests pass.** Build clean.

## Test plan after deploy

1. As tech: open a module reader without taking the quiz. Reload `/lms/admin` → confirm last_activity stays where it was (does NOT update from the reader open).
2. As tech: take + submit a quiz. Reload `/lms/admin` → confirm last_activity updates to the submit timestamp.
3. As owner: open `/lms/admin` audit dashboard on a 1366px desktop → confirm "FINAL" header renders fully (no truncation).
4. As owner: open the per-employee row "Show modules" → confirm any `il-sexual-harassment` reference reads "Illinois Sexual Harassment Prevention".
5. As owner: open AttemptHistoryDialog → confirm same normalization (header reads the canonical title, not the slug-cased version).

## Sprint summary

| Section | PR | Status |
| --- | --- | --- |
| A (P0) | #114 | merged |
| B (P1, Items 6-9) | #115 | merged |
| C (Items 11-13) | this PR | open |
| **Item 10 (Journey page)** | not yet PR'd | deferred |

After this merges, the only remaining audit item from today's prompt is the Employee Journey consolidated page (Item 10). Sal's MC-cross-reference (Item 3 archival of specific users) also remains pending — the infra shipped in Section A; the actual archive of Alma/Ana/Diana/etc. is gated on Sal pulling MC roster.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxGiirnJ3dT4GAzHPNWhrx)_