### PR TITLE
lms: December cron notification fanout (final sprint PR 5)

### DIFF
--- a/artifacts/api-server/src/lib/lms-annual-cycle-cron.ts
+++ b/artifacts/api-server/src/lib/lms-annual-cycle-cron.ts
@@ -18,7 +18,7 @@
  * nullable so cron-triggered rows show up clearly in audit queries
  * (`WHERE triggered_by_user_id IS NULL` finds them).
  */
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql as drizzleSql } from "drizzle-orm";
 import { db } from "@workspace/db";
 import {
   lmsAnnualAckCyclesTable,
@@ -106,6 +106,7 @@ export async function runAnnualCycleAutoOpen(
       }
 
       let swept = 0;
+      const sweptUserIds = new Set<number>();
       for (const documentType of ANNUAL_DOCUMENT_TYPES) {
         const r = await sweepForDocumentType({
           companyId: company.id,
@@ -114,6 +115,36 @@ export async function runAnnualCycleAutoOpen(
           triggerReason: "annual_cycle",
         });
         swept += r.swept_user_ids.length;
+        for (const uid of r.swept_user_ids) sweptUserIds.add(uid);
+      }
+
+      // PR 5 (final sprint): notification fanout. Two surfaces.
+      //   1. Per-employee: the sweep above inserted lms_pending_re_ack
+      //      rows for every swept user. Each user's /training page
+      //      surfaces a PendingReAckTile that links to the re-sign
+      //      flow. That's the primary actionable channel.
+      //   2. Tenant-level: insert one notifications row keyed by the
+      //      cycle so the office team's notification panel shows the
+      //      event. The existing notifications table is company-scoped
+      //      (no target_user_id), so this is one row per tenant per
+      //      cycle, not per user. Body mentions the swept count so the
+      //      office knows how many employees were notified.
+      // Best-effort: a failure here MUST NOT roll back the cycle
+      // opening or the sweep, both already committed.
+      if (sweptUserIds.size > 0) {
+        try {
+          const title = `Annual training re-acknowledgment opened for ${cycleYear}`;
+          const body = `${sweptUserIds.size} ${sweptUserIds.size === 1 ? "employee" : "employees"} have been added to the ${cycleYear} annual re-acknowledgment cycle. They will see a re-sign tile on their training page. Deadline: December 31.`;
+          await db.execute(
+            drizzleSql`INSERT INTO notifications (company_id, type, title, body, link, meta)
+              VALUES (${company.id}, ${'annual_reack_opened'}, ${title}, ${body}, ${'/lms/admin'}, ${JSON.stringify({ cycle_year: cycleYear, cycle_id: inserted[0].id, swept_count: sweptUserIds.size })}::jsonb)`,
+          );
+        } catch (notifErr) {
+          console.error(
+            `[lms-annual-cycle-cron] notification fanout error company=${company.id}:`,
+            notifErr,
+          );
+        }
       }
 
       results.push({


### PR DESCRIPTION
**Final sprint PR 5** — December cron notification fanout. Existing cron opened the cycle + swept pending re-acks but never wrote to `notifications`. This adds the notification.

## File

| File | Change |
| --- | --- |
| `lib/lms-annual-cycle-cron.ts` | One INSERT into `notifications` per opened cycle, wrapped in try/catch. Surfaces the cron event on the office team's notification panel. |

## Self-audit

| Spec requirement | Status |
| --- | --- |
| Runs Dec 1 at 9 AM CT | ✅ (unchanged from existing cron) |
| Opens cycle for all active tenants | ✅ (unchanged) |
| Sends notification via existing infrastructure | ✅ (this PR — one `notifications` row per opened cycle) |
| Sets cycle deadline at Dec 31 | ✅ (unchanged, default `defaultCycleDeadline()`) |
| Logs cycle opening for audit | ✅ (existing console + notif row + audit trail) |
| Idempotent | ✅ (notification only fires inside the new-cycle branch) |
| Tenant-scoped | ✅ (notification.company_id from the cycle row) |

## Per-user vs tenant notification

The existing `notifications` table is company-scoped (no `target_user_id` column). Adding one would require a schema migration. Per-employee notification surface already exists via the `PendingReAckTile` on `/training` driven by `lms_pending_re_ack` rows from the sweep. This PR adds a single tenant-level notification so the office team's notification panel surfaces the cron event with the swept count.

If you want per-user push/email notifications, that's a follow-up schema migration; out of scope for tonight.

284/284 LMS unit tests pass. Build clean. Will undraft + merge on green CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxGiirnJ3dT4GAzHPNWhrx)_