### PR TITLE
fix: LMS Phes admin-view consistency + Jose reconcile + phantom cleanup

### DIFF
--- a/artifacts/api-server/src/lib/lms-status-pure.ts
+++ b/artifacts/api-server/src/lib/lms-status-pure.ts
@@ -1,0 +1,209 @@
+/**
+ * LMS employee final status — pure computation layer.
+ *
+ * Separated from `lms-status.ts` so unit tests can exercise the
+ * compute logic without spinning up Postgres. The DB-fronted wrappers
+ * (`computeEmployeeFinalStatus`, `computeEmployeeFinalStatusBatch`)
+ * live next door and re-export `computeStatusFromData` from here.
+ */
+import { REQUIRED_PRE_FINAL_SIGNED_DOCS } from "@workspace/db/schema";
+import {
+  FINAL_MODULE_ID,
+  QUIZ_MODULE_IDS,
+  QUIZ_PASS_THRESHOLD,
+  MAX_FINAL_ATTEMPTS,
+} from "@workspace/lms-curriculum";
+import { computeCompliance, type ComplianceFlags } from "./lms-admin-audit.js";
+
+const PASS_PERCENT = Math.round(QUIZ_PASS_THRESHOLD * 100);
+const QUIZ_MODULE_SET = new Set<string>(QUIZ_MODULE_IDS as readonly string[]);
+const REQUIRED_DOC_SET = new Set<string>(
+  REQUIRED_PRE_FINAL_SIGNED_DOCS as readonly string[],
+);
+
+export type FinalExamStatus =
+  | "not_started"
+  | "in_progress"
+  | "passed"
+  | "failed";
+
+export type EnrollmentStatus =
+  | "not_started"
+  | "in_progress"
+  | "complete"
+  | "overdue"
+  | "sandbox";
+
+export interface EmployeeFinalStatus {
+  userId: number;
+  companyId: number;
+  modulesPassed: number;
+  modulesTotal: number;
+  passedModuleIds: string[];
+  signedDocumentsCompleted: number;
+  signedDocumentsTotal: number;
+  signedDocumentTypes: string[];
+  finalExamStatus: FinalExamStatus;
+  finalExamBestScore: number | null;
+  finalExamAttempts: number;
+  handbookSigned: boolean;
+  handbookSignedAt: Date | null;
+  enrollmentStatus: EnrollmentStatus;
+  currentModuleId: string | null;
+  daysRemaining: number | null;
+  lastActivityAt: Date | null;
+  pendingReAcks: number;
+  isSandbox: boolean;
+  compliance: ComplianceFlags;
+  computedAt: Date;
+}
+
+export interface ComputeStatusInput {
+  userId: number;
+  companyId: number;
+  isSandbox: boolean;
+  enrollment: {
+    deadline_at: Date | string | null;
+    last_activity_at: Date | string | null;
+  } | null;
+  progress: Array<{
+    module_id: string;
+    status: string;
+    best_score: number | null;
+    attempts: number;
+  }>;
+  signedDocumentTypes: string[];
+  handbookSignedAt: Date | null;
+  finalAttemptsCount: number;
+  pendingReAcks: number;
+  now?: Date;
+}
+
+export function computeStatusFromData(
+  input: ComputeStatusInput,
+): EmployeeFinalStatus {
+  const now = input.now ?? new Date();
+
+  const passedModuleIds: string[] = [];
+  let finalBestScore: number | null = null;
+  for (const p of input.progress) {
+    if (p.module_id === FINAL_MODULE_ID) {
+      finalBestScore = p.best_score ?? 0;
+      continue;
+    }
+    if (!QUIZ_MODULE_SET.has(p.module_id)) continue;
+    const score = p.best_score ?? 0;
+    if (score >= PASS_PERCENT || p.status === "passed") {
+      passedModuleIds.push(p.module_id);
+    }
+  }
+  const modulesPassed = passedModuleIds.length;
+  const modulesTotal = QUIZ_MODULE_IDS.length;
+
+  const signedDocSet = new Set(
+    input.signedDocumentTypes.filter((t) => REQUIRED_DOC_SET.has(t)),
+  );
+  const signedDocumentsCompleted = signedDocSet.size;
+  const signedDocumentsTotal = REQUIRED_PRE_FINAL_SIGNED_DOCS.length;
+
+  const handbookSigned = input.handbookSignedAt !== null;
+
+  const finalExamBestScore = finalBestScore;
+  const finalExamAttempts = Math.max(0, input.finalAttemptsCount | 0);
+  let finalExamStatus: FinalExamStatus;
+  if ((finalExamBestScore ?? 0) >= PASS_PERCENT) {
+    finalExamStatus = "passed";
+  } else if (finalExamAttempts >= MAX_FINAL_ATTEMPTS) {
+    finalExamStatus = "failed";
+  } else if (finalExamAttempts > 0) {
+    finalExamStatus = "in_progress";
+  } else {
+    finalExamStatus = "not_started";
+  }
+
+  const passedForCompliance =
+    finalExamStatus === "passed"
+      ? [...passedModuleIds, FINAL_MODULE_ID]
+      : passedModuleIds;
+  const compliance = computeCompliance({
+    passed_module_ids: passedForCompliance,
+    signed_document_types: input.signedDocumentTypes,
+    handbook_signed: handbookSigned,
+    pending_re_ack_count: input.pendingReAcks,
+    deadline_at: input.enrollment?.deadline_at ?? null,
+    now,
+  });
+
+  const passedSet = new Set(passedModuleIds);
+  let currentModuleId: string | null = null;
+  for (const m of QUIZ_MODULE_IDS) {
+    if (!passedSet.has(m)) {
+      currentModuleId = m;
+      break;
+    }
+  }
+  if (currentModuleId === null && finalExamStatus !== "passed") {
+    currentModuleId = FINAL_MODULE_ID;
+  }
+
+  let daysRemaining: number | null = null;
+  if (input.enrollment?.deadline_at) {
+    const dl =
+      input.enrollment.deadline_at instanceof Date
+        ? input.enrollment.deadline_at
+        : new Date(input.enrollment.deadline_at);
+    if (!Number.isNaN(dl.getTime())) {
+      const ms = dl.getTime() - now.getTime();
+      daysRemaining = Math.ceil(ms / (24 * 60 * 60 * 1000));
+    }
+  }
+
+  let enrollmentStatus: EnrollmentStatus;
+  if (input.isSandbox) {
+    enrollmentStatus = "sandbox";
+  } else if (compliance.overall === "complete") {
+    enrollmentStatus = "complete";
+  } else if (compliance.overall === "overdue") {
+    enrollmentStatus = "overdue";
+  } else if (
+    modulesPassed > 0 ||
+    finalExamAttempts > 0 ||
+    signedDocumentsCompleted > 0 ||
+    handbookSigned
+  ) {
+    enrollmentStatus = "in_progress";
+  } else {
+    enrollmentStatus = "not_started";
+  }
+
+  const lastActivityAt =
+    input.enrollment?.last_activity_at instanceof Date
+      ? input.enrollment.last_activity_at
+      : input.enrollment?.last_activity_at
+      ? new Date(input.enrollment.last_activity_at)
+      : null;
+
+  return {
+    userId: input.userId,
+    companyId: input.companyId,
+    modulesPassed,
+    modulesTotal,
+    passedModuleIds,
+    signedDocumentsCompleted,
+    signedDocumentsTotal,
+    signedDocumentTypes: input.signedDocumentTypes,
+    finalExamStatus,
+    finalExamBestScore,
+    finalExamAttempts,
+    handbookSigned,
+    handbookSignedAt: input.handbookSignedAt,
+    enrollmentStatus,
+    currentModuleId,
+    daysRemaining,
+    lastActivityAt,
+    pendingReAcks: input.pendingReAcks,
+    isSandbox: input.isSandbox,
+    compliance,
+    computedAt: now,
+  };
+}

--- a/artifacts/api-server/src/lib/lms-status.ts
+++ b/artifacts/api-server/src/lib/lms-status.ts
@@ -1,0 +1,219 @@
+/**
+ * LMS employee final status — single source of truth (DB layer).
+ *
+ * Phes admin-view-consistency sprint (2026-05-15). Before this module
+ * existed, three admin views (Roster, Audit Dashboard, Employee
+ * Journey) each rolled their own pass-counting and final-exam state
+ * logic. Jose Ardila's record disagreed across all three: 5/13 on
+ * Roster, 6/13 on Audit Dashboard, 7/13 on Employee Journey — same
+ * underlying data, three answers.
+ *
+ * Pure compute lives in `lms-status-pure.ts` so unit tests can
+ * exercise it without Postgres. This file is the DB-fronted wrapper
+ * the route handlers call.
+ *
+ * Defensive read rule for the Final Mixed Test (and every module):
+ * if `lms_module_progress.best_score >= 80`, the SSoT reports the
+ * module as PASSED regardless of the stored `status` field. This
+ * closes the Jose bug (best_score=100, status='in_progress'). The
+ * status recompute migration normalizes the persisted data; this
+ * defensive rule is the belt to that suspenders.
+ */
+import { and, eq, inArray, isNull } from "drizzle-orm";
+import { db } from "@workspace/db";
+import {
+  lmsEnrollmentsTable,
+  lmsModuleProgressTable,
+  lmsPendingReAckTable,
+  lmsQuizAttemptsTable,
+  lmsSignedDocumentsTable,
+  usersTable,
+  type LmsModuleProgress,
+} from "@workspace/db/schema";
+import { FINAL_MODULE_ID } from "@workspace/lms-curriculum";
+import {
+  computeStatusFromData,
+  type EmployeeFinalStatus,
+} from "./lms-status-pure.js";
+
+export {
+  computeStatusFromData,
+  type EmployeeFinalStatus,
+  type EnrollmentStatus,
+  type FinalExamStatus,
+  type ComputeStatusInput,
+} from "./lms-status-pure.js";
+
+const HANDBOOK_DOCUMENT_TYPE = "handbook" as const;
+
+/**
+ * Batched DB-fronted variant. Loads every record for `userIds` in
+ * one round-trip per table, then computes the SSoT shape for each.
+ * Tenant-scoped via companyId — cross-tenant userIds are silently
+ * dropped (the SELECT for users filters them out).
+ */
+export async function computeEmployeeFinalStatusBatch(
+  userIds: number[],
+  companyId: number,
+): Promise<Map<number, EmployeeFinalStatus>> {
+  const out = new Map<number, EmployeeFinalStatus>();
+  if (userIds.length === 0) return out;
+  const now = new Date();
+
+  const users = await db
+    .select({
+      id: usersTable.id,
+      is_sandbox: usersTable.is_sandbox,
+    })
+    .from(usersTable)
+    .where(
+      and(
+        eq(usersTable.company_id, companyId),
+        inArray(usersTable.id, userIds),
+      ),
+    );
+  if (users.length === 0) return out;
+  const scopedUserIds = users.map((u) => u.id);
+
+  const enrollments = await db
+    .select({
+      user_id: lmsEnrollmentsTable.user_id,
+      id: lmsEnrollmentsTable.id,
+      deadline_at: lmsEnrollmentsTable.deadline_at,
+      last_activity_at: lmsEnrollmentsTable.last_activity_at,
+    })
+    .from(lmsEnrollmentsTable)
+    .where(
+      and(
+        eq(lmsEnrollmentsTable.company_id, companyId),
+        inArray(lmsEnrollmentsTable.user_id, scopedUserIds),
+      ),
+    );
+  const enrollmentByUser = new Map<number, (typeof enrollments)[number]>();
+  for (const e of enrollments) enrollmentByUser.set(e.user_id, e);
+  const enrollmentIds = enrollments.map((e) => e.id);
+  const userByEnrollment = new Map<number, number>();
+  for (const e of enrollments) userByEnrollment.set(e.id, e.user_id);
+
+  const progressRows: Pick<
+    LmsModuleProgress,
+    "enrollment_id" | "module_id" | "status" | "best_score" | "attempts"
+  >[] = enrollmentIds.length
+    ? await db
+        .select({
+          enrollment_id: lmsModuleProgressTable.enrollment_id,
+          module_id: lmsModuleProgressTable.module_id,
+          status: lmsModuleProgressTable.status,
+          best_score: lmsModuleProgressTable.best_score,
+          attempts: lmsModuleProgressTable.attempts,
+        })
+        .from(lmsModuleProgressTable)
+        .where(inArray(lmsModuleProgressTable.enrollment_id, enrollmentIds))
+    : [];
+  const progressByUser = new Map<number, typeof progressRows>();
+  for (const p of progressRows) {
+    const uid = userByEnrollment.get(p.enrollment_id);
+    if (uid === undefined) continue;
+    const arr = progressByUser.get(uid) ?? [];
+    arr.push(p);
+    progressByUser.set(uid, arr);
+  }
+
+  const signedDocs = await db
+    .select({
+      user_id: lmsSignedDocumentsTable.user_id,
+      document_type: lmsSignedDocumentsTable.document_type,
+      signed_at: lmsSignedDocumentsTable.signed_at,
+    })
+    .from(lmsSignedDocumentsTable)
+    .where(
+      and(
+        eq(lmsSignedDocumentsTable.company_id, companyId),
+        eq(lmsSignedDocumentsTable.status, "active"),
+        inArray(lmsSignedDocumentsTable.user_id, scopedUserIds),
+      ),
+    );
+  const signedByUser = new Map<number, string[]>();
+  const handbookSignedAtByUser = new Map<number, Date>();
+  for (const d of signedDocs) {
+    const arr = signedByUser.get(d.user_id) ?? [];
+    arr.push(d.document_type);
+    signedByUser.set(d.user_id, arr);
+    if (d.document_type === HANDBOOK_DOCUMENT_TYPE && d.signed_at) {
+      handbookSignedAtByUser.set(d.user_id, d.signed_at as Date);
+    }
+  }
+
+  const pendingRows = await db
+    .select({
+      user_id: lmsPendingReAckTable.user_id,
+    })
+    .from(lmsPendingReAckTable)
+    .where(
+      and(
+        eq(lmsPendingReAckTable.company_id, companyId),
+        isNull(lmsPendingReAckTable.acknowledged_at),
+        inArray(lmsPendingReAckTable.user_id, scopedUserIds),
+      ),
+    );
+  const pendingByUser = new Map<number, number>();
+  for (const r of pendingRows) {
+    pendingByUser.set(r.user_id, (pendingByUser.get(r.user_id) ?? 0) + 1);
+  }
+
+  const finalAttemptsRows = enrollmentIds.length
+    ? await db
+        .select({
+          enrollment_id: lmsQuizAttemptsTable.enrollment_id,
+        })
+        .from(lmsQuizAttemptsTable)
+        .where(
+          and(
+            eq(lmsQuizAttemptsTable.company_id, companyId),
+            eq(lmsQuizAttemptsTable.module_id, FINAL_MODULE_ID),
+            eq(lmsQuizAttemptsTable.superseded, false),
+            inArray(lmsQuizAttemptsTable.enrollment_id, enrollmentIds),
+          ),
+        )
+    : [];
+  const finalAttemptsByUser = new Map<number, number>();
+  for (const r of finalAttemptsRows) {
+    const uid = userByEnrollment.get(r.enrollment_id);
+    if (uid === undefined) continue;
+    finalAttemptsByUser.set(uid, (finalAttemptsByUser.get(uid) ?? 0) + 1);
+  }
+
+  for (const u of users) {
+    const enrollment = enrollmentByUser.get(u.id);
+    out.set(
+      u.id,
+      computeStatusFromData({
+        userId: u.id,
+        companyId,
+        isSandbox: !!u.is_sandbox,
+        enrollment: enrollment
+          ? {
+              deadline_at: enrollment.deadline_at,
+              last_activity_at: enrollment.last_activity_at,
+            }
+          : null,
+        progress: progressByUser.get(u.id) ?? [],
+        signedDocumentTypes: signedByUser.get(u.id) ?? [],
+        handbookSignedAt: handbookSignedAtByUser.get(u.id) ?? null,
+        finalAttemptsCount: finalAttemptsByUser.get(u.id) ?? 0,
+        pendingReAcks: pendingByUser.get(u.id) ?? 0,
+        now,
+      }),
+    );
+  }
+
+  return out;
+}
+
+export async function computeEmployeeFinalStatus(
+  userId: number,
+  companyId: number,
+): Promise<EmployeeFinalStatus | null> {
+  const batch = await computeEmployeeFinalStatusBatch([userId], companyId);
+  return batch.get(userId) ?? null;
+}

--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -56,6 +56,12 @@ async function runBookingSchemaGuard(): Promise<void> {
     // never auto-reset again — even on subsequent deploys.
     { label: "users.password_reset_to_chicago23_at", stmt: "ALTER TABLE users ADD COLUMN IF NOT EXISTS password_reset_to_chicago23_at TIMESTAMPTZ" },
     { label: "users.is_sandbox", stmt: "ALTER TABLE users ADD COLUMN IF NOT EXISTS is_sandbox BOOLEAN NOT NULL DEFAULT FALSE" },
+    // Phes admin-view-consistency sprint (2026-05-15). Supersession
+    // columns on lms_quiz_attempts. Backfilled by runSupersessionBackfill
+    // for legacy Phes data that predates the per-module cap.
+    { label: "lms_quiz_attempts.superseded", stmt: "ALTER TABLE lms_quiz_attempts ADD COLUMN IF NOT EXISTS superseded BOOLEAN NOT NULL DEFAULT FALSE" },
+    { label: "lms_quiz_attempts.superseded_reason", stmt: "ALTER TABLE lms_quiz_attempts ADD COLUMN IF NOT EXISTS superseded_reason TEXT" },
+    { label: "lms_quiz_attempts.superseded_at", stmt: "ALTER TABLE lms_quiz_attempts ADD COLUMN IF NOT EXISTS superseded_at TIMESTAMPTZ" },
     { label: "companies.default_residential_pay_type", stmt: "ALTER TABLE companies ADD COLUMN IF NOT EXISTS default_residential_pay_type TEXT DEFAULT 'commission'" },
     { label: "companies.default_residential_pay_rate", stmt: "ALTER TABLE companies ADD COLUMN IF NOT EXISTS default_residential_pay_rate NUMERIC(8,4) DEFAULT 0.35" },
     { label: "companies.default_commercial_pay_type",  stmt: "ALTER TABLE companies ADD COLUMN IF NOT EXISTS default_commercial_pay_type  TEXT DEFAULT 'hourly'" },
@@ -1665,6 +1671,228 @@ async function runSandboxAccountRepurpose(): Promise<void> {
   );
 }
 
+/**
+ * Phes admin-view-consistency sprint (2026-05-15) — Item 2.
+ *
+ * Marks legacy quiz attempts beyond the cap as superseded. For each
+ * (user_id, module_id) pair in Phes, keep the 4 most recent attempts
+ * (ORDER BY attempted_at DESC) active and flag the remainder as
+ * superseded with reason 'exceeded_cap_legacy_backfill'.
+ *
+ * Idempotent — guards on WHERE superseded=false so a re-run is a no-op.
+ *
+ * Also recomputes lms_module_progress.attempts to the non-superseded
+ * count, so the admin roster's per-row "attempts" column shows the
+ * correct cap-relative value instead of the raw historical count.
+ *
+ * Phes only (company_id=1). Other tenants are out of scope until the
+ * 2nd-tenant readiness sprint.
+ */
+const PHES_COMPANY_ID = 1;
+
+async function runSupersessionBackfill(): Promise<void> {
+  const cap = 4;
+  const candidates = await db.execute<{
+    enrollment_id: number;
+    module_id: string;
+    user_id: number;
+    total: number;
+  }>(sql`
+    SELECT
+      qa.enrollment_id,
+      qa.module_id,
+      e.user_id,
+      COUNT(*)::int AS total
+    FROM lms_quiz_attempts qa
+    INNER JOIN lms_enrollments e ON e.id = qa.enrollment_id
+    WHERE qa.company_id = ${PHES_COMPANY_ID}
+      AND qa.superseded = FALSE
+    GROUP BY qa.enrollment_id, qa.module_id, e.user_id
+    HAVING COUNT(*) > ${cap}
+  `);
+  const rows = ((candidates as any).rows ?? candidates) as Array<{
+    enrollment_id: number;
+    module_id: string;
+    user_id: number;
+    total: number;
+  }>;
+
+  if (rows.length === 0) {
+    console.log("[supersession-backfill] tenant=1 users=0 attempts_superseded=0");
+    return;
+  }
+
+  let totalSuperseded = 0;
+  const touchedUsers = new Set<number>();
+  for (const row of rows) {
+    const result = await db.execute(sql`
+      UPDATE lms_quiz_attempts
+      SET
+        superseded = TRUE,
+        superseded_reason = 'exceeded_cap_legacy_backfill',
+        superseded_at = NOW()
+      WHERE id IN (
+        SELECT id FROM lms_quiz_attempts
+        WHERE enrollment_id = ${row.enrollment_id}
+          AND module_id = ${row.module_id}
+          AND superseded = FALSE
+        ORDER BY attempted_at DESC
+        OFFSET ${cap}
+      )
+    `);
+    const n = (result as any).rowCount ?? 0;
+    totalSuperseded += n;
+    if (n > 0) touchedUsers.add(row.user_id);
+  }
+
+  // Sync lms_module_progress.attempts to the non-superseded count so
+  // the admin roster's "X/Y attempts" cell respects the cap.
+  if (totalSuperseded > 0) {
+    await db.execute(sql`
+      UPDATE lms_module_progress mp
+      SET attempts = sub.live_count
+      FROM (
+        SELECT
+          qa.enrollment_id,
+          qa.module_id,
+          COUNT(*)::int AS live_count
+        FROM lms_quiz_attempts qa
+        WHERE qa.company_id = ${PHES_COMPANY_ID}
+          AND qa.superseded = FALSE
+        GROUP BY qa.enrollment_id, qa.module_id
+      ) sub
+      WHERE mp.enrollment_id = sub.enrollment_id
+        AND mp.module_id = sub.module_id
+        AND mp.company_id = ${PHES_COMPANY_ID}
+    `);
+  }
+
+  console.log(
+    `[supersession-backfill] tenant=${PHES_COMPANY_ID} users=${touchedUsers.size} attempts_superseded=${totalSuperseded}`,
+  );
+}
+
+/**
+ * Phes admin-view-consistency sprint (2026-05-15) — Item 3.
+ *
+ * Normalizes lms_module_progress rows where best_score >= 80 but
+ * status != 'passed'. The Final Mixed Test bug surfaced this: Jose's
+ * row had best_score=100 with status='in_progress'. The defensive
+ * rule in the SSoT covers the read path; this migration corrects the
+ * persisted data so downstream queries (and any cache layers) see
+ * the right value too.
+ *
+ * Idempotent — WHERE clause filters out rows already at 'passed'.
+ * Phes only (company_id=1).
+ */
+async function runStatusRecompute(): Promise<void> {
+  const result = await db.execute(sql`
+    UPDATE lms_module_progress
+    SET
+      status = 'passed',
+      passed_at = COALESCE(passed_at, NOW())
+    WHERE company_id = ${PHES_COMPANY_ID}
+      AND best_score >= 80
+      AND status != 'passed'
+  `);
+  const n = (result as any).rowCount ?? 0;
+  console.log(`[status-recompute] tenant=${PHES_COMPANY_ID} rows_updated=${n}`);
+}
+
+/**
+ * Phes admin-view-consistency sprint (2026-05-15) — Item 4.
+ *
+ * Hard-deletes the two phantom users Dispatch found in the audit:
+ *   - 447: crosstenant@evil.test, company_id=1, active. Origin unknown
+ *          (not from Dispatch's fixture work).
+ *   - 448: pwn@x.test (renamed by audit cleanup to AUDIT_CLEANUP/
+ *          PLEASE_DELETE), is_active=false.
+ *
+ * Guard: if either user has any active signed_document with a real
+ * signature, SKIP that user and log a warning. Legal trail can't be
+ * deleted. Dispatch reported neither user advanced past sign-up, so
+ * we expect zero blocked rows.
+ *
+ * Cascade order: children first, then users. Cascading FKs handle
+ * most of it, but we delete explicitly so the row counts are auditable.
+ */
+const PHANTOM_USER_IDS = [447, 448] as const;
+
+async function runPhantomUserCleanup(): Promise<void> {
+  const deleted: number[] = [];
+  const blocked: number[] = [];
+  const notFound: number[] = [];
+
+  for (const id of PHANTOM_USER_IDS) {
+    const userRows = await db.execute<{
+      id: number;
+      email: string;
+      company_id: number | null;
+    }>(sql`
+      SELECT id, email, company_id FROM users WHERE id = ${id}
+    `);
+    const row = ((userRows as any).rows ?? userRows)[0];
+    if (!row) {
+      notFound.push(id);
+      continue;
+    }
+    if (row.company_id !== PHES_COMPANY_ID) {
+      // Not Phes — out of scope. Don't touch.
+      blocked.push(id);
+      continue;
+    }
+
+    const signedRows = await db.execute<{ count: number }>(sql`
+      SELECT COUNT(*)::int AS count FROM lms_signed_documents
+      WHERE user_id = ${id} AND status = 'active'
+    `);
+    const signedCount =
+      ((signedRows as any).rows ?? signedRows)[0]?.count ?? 0;
+    if (signedCount > 0) {
+      console.warn(
+        `[phantom-user-cleanup] user_id=${id} skipped — ${signedCount} active signed_document(s); legal trail preserved`,
+      );
+      blocked.push(id);
+      continue;
+    }
+
+    // Children first.
+    await db.execute(
+      sql`DELETE FROM lms_quiz_attempts WHERE enrollment_id IN (SELECT id FROM lms_enrollments WHERE user_id = ${id})`,
+    );
+    await db.execute(
+      sql`DELETE FROM lms_quiz_state WHERE enrollment_id IN (SELECT id FROM lms_enrollments WHERE user_id = ${id})`,
+    );
+    await db.execute(
+      sql`DELETE FROM lms_module_progress WHERE enrollment_id IN (SELECT id FROM lms_enrollments WHERE user_id = ${id})`,
+    );
+    await db.execute(
+      sql`DELETE FROM lms_completion_certificates WHERE user_id = ${id}`,
+    );
+    await db.execute(
+      sql`DELETE FROM lms_pending_re_ack WHERE user_id = ${id}`,
+    );
+    await db.execute(
+      sql`DELETE FROM lms_signature_events WHERE user_id = ${id}`,
+    );
+    await db.execute(
+      sql`DELETE FROM lms_signed_documents WHERE user_id = ${id}`,
+    );
+    await db.execute(
+      sql`DELETE FROM lms_enrollments WHERE user_id = ${id}`,
+    );
+    await db.execute(sql`DELETE FROM audit_log WHERE user_id = ${id}`);
+
+    await db.execute(sql`DELETE FROM users WHERE id = ${id}`);
+    deleted.push(id);
+  }
+
+  console.log(
+    `[phantom-user-cleanup] deleted_user_ids=${JSON.stringify(deleted)} ` +
+      `blocked=${JSON.stringify(blocked)} not_found=${JSON.stringify(notFound)}`,
+  );
+}
+
 export async function runPhesDataMigration(): Promise<void> {
   await runBookingSchemaGuard();
 
@@ -1684,6 +1912,24 @@ export async function runPhesDataMigration(): Promise<void> {
     await runSandboxAccountRepurpose();
   } catch (err: any) {
     console.warn("[phes-migration] sandbox-repurpose — non-fatal:", err?.message ?? err);
+  }
+
+  try {
+    await runSupersessionBackfill();
+  } catch (err: any) {
+    console.warn("[phes-migration] supersession-backfill — non-fatal:", err?.message ?? err);
+  }
+
+  try {
+    await runStatusRecompute();
+  } catch (err: any) {
+    console.warn("[phes-migration] status-recompute — non-fatal:", err?.message ?? err);
+  }
+
+  try {
+    await runPhantomUserCleanup();
+  } catch (err: any) {
+    console.warn("[phes-migration] phantom-user-cleanup — non-fatal:", err?.message ?? err);
   }
 
   try {

--- a/artifacts/api-server/src/routes/lms-admin-audit.ts
+++ b/artifacts/api-server/src/routes/lms-admin-audit.ts
@@ -46,6 +46,10 @@ import {
   type ComplianceFlags,
   type AuditCsvRowInput,
 } from "../lib/lms-admin-audit.js";
+import {
+  computeEmployeeFinalStatus,
+  computeEmployeeFinalStatusBatch,
+} from "../lib/lms-status.js";
 import { logAudit } from "../lib/audit.js";
 
 const router = Router();
@@ -198,15 +202,24 @@ async function loadAuditRoster(
     pendingByUser.set(p.user_id, arr);
   }
 
+  // Phes admin-view-consistency sprint (2026-05-15): the audit
+  // dashboard's per-row pass set + compliance flags now come from the
+  // SSoT. The roster's own SELECTs above are kept (they feed the
+  // per-row metadata the dashboard renders), but the COUNT-style
+  // fields are sourced from the same `computeEmployeeFinalStatusBatch`
+  // call the roster endpoint uses, so the two views can't disagree.
+  const ssotByUser = await computeEmployeeFinalStatusBatch(userIds, companyId);
+
   // 5. Assemble rows + compute compliance.
   const rows: AuditRosterRow[] = users.map((u) => {
     const enrollment = enrollmentByUser.get(u.id) ?? null;
-    const passed = passedByUser.get(u.id) ?? [];
     const signed = signedByUser.get(u.id) ?? [];
     const pending = pendingByUser.get(u.id) ?? [];
     const handbookAt = handbookSignedAtByUser.get(u.id) ?? null;
     const finalAt = finalPassedAtByUser.get(u.id) ?? null;
-    const compliance = computeCompliance({
+    const ssot = ssotByUser.get(u.id);
+    const passed = ssot?.passedModuleIds ?? passedByUser.get(u.id) ?? [];
+    const compliance = ssot?.compliance ?? computeCompliance({
       passed_module_ids: passed,
       signed_document_types: signed,
       handbook_signed: handbookAt !== null,
@@ -464,24 +477,17 @@ router.get(
         )
         .orderBy(desc(lmsPendingReAckTable.triggered_at));
 
-      const passedModuleIds = progress
-        .filter((p) => p.status === "passed")
-        .map((p) => p.module_id);
-      const activeSignedTypes = signedDocs
-        .filter((d) => d.status === "active")
-        .map((d) => d.document_type);
-      const handbookRow = signedDocs.find(
-        (d) => d.document_type === HANDBOOK_DOCUMENT_TYPE && d.status === "active",
-      );
-      const finalProgress = progress.find(
-        (p) => p.module_id === FINAL_MODULE_ID && p.status === "passed",
-      );
-      const openPending = pending.filter((p) => p.acknowledged_at === null);
-      const compliance = computeCompliance({
-        passed_module_ids: passedModuleIds,
-        signed_document_types: activeSignedTypes,
-        handbook_signed: !!handbookRow,
-        pending_re_ack_count: openPending.length,
+      // Phes admin-view-consistency sprint (2026-05-15): the per-learner
+      // detail page now reads its derived fields (passed module set,
+      // compliance flags, final-exam state) from the SSoT instead of
+      // re-deriving them inline. Without this, Roster + Audit Dashboard
+      // + Employee Journey diverged on Jose's record.
+      const ssot = await computeEmployeeFinalStatus(targetUserId, companyId);
+      const compliance = ssot?.compliance ?? computeCompliance({
+        passed_module_ids: [],
+        signed_document_types: [],
+        handbook_signed: false,
+        pending_re_ack_count: 0,
         deadline_at: enrollment?.deadline_at ?? null,
       });
 
@@ -503,6 +509,7 @@ router.get(
           certificates,
           pending_re_acks: pending,
           compliance,
+          status: ssot,
         },
       });
     } catch (err) {

--- a/artifacts/api-server/src/routes/lms.ts
+++ b/artifacts/api-server/src/routes/lms.ts
@@ -64,6 +64,7 @@ import { SERVER_ANSWER_KEY } from "@workspace/training";
 import { requireAuth, requireRole } from "../lib/auth.js";
 import { logAudit } from "../lib/audit.js";
 import { addDays, daysUntil, fireLmsWebhook } from "../lib/lms-helpers.js";
+import { computeEmployeeFinalStatusBatch } from "../lib/lms-status.js";
 import { isEnrollmentTrulyComplete } from "../lib/lms-completion.js";
 import {
   captureRequestMetadata,
@@ -779,6 +780,11 @@ router.post("/quiz/submit", requireAuth, async (req, res) => {
         and(
           eq(lmsQuizAttemptsTable.enrollment_id, enrollment.id),
           eq(lmsQuizAttemptsTable.module_id, moduleId),
+          // Phes admin-view-consistency sprint (2026-05-15): legacy
+          // attempts beyond the cap are flagged superseded by the
+          // backfill migration so cap math now respects only the
+          // attempts that actually count.
+          eq(lmsQuizAttemptsTable.superseded, false),
         ),
       );
     const liveAttemptsCount = liveAttemptsRows.length;
@@ -1292,40 +1298,26 @@ router.get(
       }
 
       const now = new Date();
-      // Item 3 (onboarding-readiness sprint 2026-05-15): canonical
-      // denominator is the 13 QUIZ_MODULE_IDS, NOT MODULE_ORDER (14,
-      // which still includes the content-only acknowledgment slot).
-      // The final mixed test and the final handbook are separate
-      // gates and are NOT in this percentage.
-      const totalModules = QUIZ_MODULE_IDS.length;
-      const QUIZ_SET = new Set<string>(QUIZ_MODULE_IDS as readonly string[]);
+      // Phes admin-view-consistency sprint (2026-05-15): roster reads
+      // its aggregate fields (passed_count, progress_pct, current_module,
+      // final_exam_passed, handbook_signed) from the SSoT instead of
+      // rolling its own filter. The per-module `modules` map still comes
+      // from raw module_progress so the admin UI can render the per-row
+      // "2/4 attempts" cells without a second round trip.
+      const ssotByUser = await computeEmployeeFinalStatusBatch(
+        enrollments.map((e) => e.user_id),
+        companyId,
+      );
 
       const rows = enrollments.map((e) => {
         const progress = progressByEnrollment.get(e.id) ?? [];
-        // Count only QUIZ_MODULE_IDS toward the percentage. The final
-        // mixed test is a SEPARATE gate (without this filter a learner
-        // who passed all 13 modules + the final test reported 14/13).
-        const passedCount = progress.filter(
-          (p) => p.status === "passed" && QUIZ_SET.has(p.module_id),
-        ).length;
+        const ssot = ssotByUser.get(e.user_id);
+        const passedCount = ssot?.modulesPassed ?? 0;
+        const totalModules = ssot?.modulesTotal ?? QUIZ_MODULE_IDS.length;
         const passedRatio = totalModules > 0 ? passedCount / totalModules : 0;
-        const completed = progress
-          .filter((p) => p.status === "passed")
-          .map((p) => p.module_id);
-
-        let currentModule: string | null = null;
-        for (const m of MODULE_ORDER) {
-          if (!completed.includes(m)) {
-            currentModule = m;
-            break;
-          }
-        }
-        if (currentModule === null && isFinalUnlocked(completed)) {
-          currentModule = FINAL_MODULE_ID;
-        }
 
         // Per-module attempt + status snapshot keyed by module_id so the
-        // admin UI can render "2/3 attempts" or "passed" without an extra
+        // admin UI can render "2/4 attempts" or "passed" without an extra
         // round trip. Includes `__final` if the learner has touched it.
         const modules: Record<
           string,
@@ -1349,7 +1341,9 @@ router.get(
           progress_pct: Math.round(passedRatio * 100),
           passed_count: passedCount,
           total_modules: totalModules,
-          current_module: currentModule,
+          current_module: ssot?.currentModuleId ?? null,
+          final_exam_passed: ssot?.finalExamStatus === "passed",
+          handbook_signed: ssot?.handbookSigned ?? false,
           // Item 4 (P0 sprint): when deadline_started_at is null, the
           // countdown hasn't started yet. Surface days_remaining as
           // null so the frontend renders "Not yet started" instead of

--- a/artifacts/api-server/src/tests/lms-status.test.ts
+++ b/artifacts/api-server/src/tests/lms-status.test.ts
@@ -1,0 +1,304 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { computeStatusFromData } from "../lib/lms-status-pure.js";
+import {
+  QUIZ_MODULE_IDS,
+  FINAL_MODULE_ID,
+} from "@workspace/lms-curriculum";
+import { REQUIRED_PRE_FINAL_SIGNED_DOCS } from "@workspace/db/schema";
+
+const ALL_PASSED_PROGRESS = QUIZ_MODULE_IDS.map((m) => ({
+  module_id: m,
+  status: "passed" as const,
+  best_score: 90,
+  attempts: 1,
+}));
+
+const ALL_DOCS_SIGNED = [...REQUIRED_PRE_FINAL_SIGNED_DOCS];
+
+const baseInput = () => ({
+  userId: 100,
+  companyId: 1,
+  isSandbox: false,
+  enrollment: {
+    deadline_at: new Date("2026-12-31T00:00:00Z"),
+    last_activity_at: new Date("2026-05-14T12:00:00Z"),
+  },
+  progress: [] as any[],
+  signedDocumentTypes: [] as string[],
+  handbookSignedAt: null as Date | null,
+  finalAttemptsCount: 0,
+  pendingReAcks: 0,
+  now: new Date("2026-05-15T12:00:00Z"),
+});
+
+describe("computeStatusFromData (Phes admin-view-consistency sprint 2026-05-15)", () => {
+  it("counts modulesPassed from best_score >= 80 even when status != 'passed'", () => {
+    const input = baseInput();
+    // Jose case: best_score=100, status='in_progress' — should still
+    // count as passed. The SSoT defensive rule fires regardless of
+    // whether the recompute migration has run yet.
+    input.progress = [
+      {
+        module_id: QUIZ_MODULE_IDS[0],
+        status: "in_progress",
+        best_score: 100,
+        attempts: 3,
+      },
+      {
+        module_id: QUIZ_MODULE_IDS[1],
+        status: "passed",
+        best_score: 85,
+        attempts: 1,
+      },
+    ];
+    const result = computeStatusFromData(input);
+    assert.equal(result.modulesPassed, 2);
+    assert.ok(result.passedModuleIds.includes(QUIZ_MODULE_IDS[0]));
+    assert.ok(result.passedModuleIds.includes(QUIZ_MODULE_IDS[1]));
+  });
+
+  it("does NOT count modules with best_score below threshold", () => {
+    const input = baseInput();
+    input.progress = [
+      {
+        module_id: QUIZ_MODULE_IDS[0],
+        status: "in_progress",
+        best_score: 75,
+        attempts: 2,
+      },
+    ];
+    const result = computeStatusFromData(input);
+    assert.equal(result.modulesPassed, 0);
+  });
+
+  it("resolves Final Mixed Test to 'passed' when best_score >= 80 (Jose bug)", () => {
+    const input = baseInput();
+    input.progress = [
+      {
+        module_id: FINAL_MODULE_ID,
+        status: "in_progress",
+        best_score: 100,
+        attempts: 1,
+      },
+    ];
+    input.finalAttemptsCount = 1;
+    const result = computeStatusFromData(input);
+    assert.equal(result.finalExamStatus, "passed");
+    assert.equal(result.finalExamBestScore, 100);
+  });
+
+  it("resolves Final Mixed Test to 'failed' after 4 attempts with no pass", () => {
+    const input = baseInput();
+    input.progress = [
+      {
+        module_id: FINAL_MODULE_ID,
+        status: "in_progress",
+        best_score: 70,
+        attempts: 4,
+      },
+    ];
+    input.finalAttemptsCount = 4;
+    const result = computeStatusFromData(input);
+    assert.equal(result.finalExamStatus, "failed");
+  });
+
+  it("resolves Final Mixed Test to 'in_progress' when 0 < attempts < cap and no pass", () => {
+    const input = baseInput();
+    input.progress = [
+      {
+        module_id: FINAL_MODULE_ID,
+        status: "in_progress",
+        best_score: 65,
+        attempts: 2,
+      },
+    ];
+    input.finalAttemptsCount = 2;
+    const result = computeStatusFromData(input);
+    assert.equal(result.finalExamStatus, "in_progress");
+  });
+
+  it("resolves Final Mixed Test to 'not_started' when attempts is 0", () => {
+    const input = baseInput();
+    const result = computeStatusFromData(input);
+    assert.equal(result.finalExamStatus, "not_started");
+  });
+
+  it("returns enrollmentStatus='sandbox' for sandbox accounts and excludes their progress from the aggregate label", () => {
+    const input = baseInput();
+    input.isSandbox = true;
+    input.progress = ALL_PASSED_PROGRESS;
+    input.signedDocumentTypes = ALL_DOCS_SIGNED;
+    input.handbookSignedAt = new Date();
+    const result = computeStatusFromData(input);
+    assert.equal(result.enrollmentStatus, "sandbox");
+    assert.equal(result.isSandbox, true);
+  });
+
+  it("returns enrollmentStatus='complete' only when all four gates are met", () => {
+    const input = baseInput();
+    input.progress = [
+      ...ALL_PASSED_PROGRESS,
+      {
+        module_id: FINAL_MODULE_ID,
+        status: "passed",
+        best_score: 90,
+        attempts: 1,
+      },
+    ];
+    input.signedDocumentTypes = [...ALL_DOCS_SIGNED, "handbook"];
+    input.handbookSignedAt = new Date("2026-05-14T10:00:00Z");
+    input.finalAttemptsCount = 1;
+    const result = computeStatusFromData(input);
+    assert.equal(result.enrollmentStatus, "complete");
+    assert.equal(result.modulesPassed, QUIZ_MODULE_IDS.length);
+    assert.equal(result.signedDocumentsCompleted, REQUIRED_PRE_FINAL_SIGNED_DOCS.length);
+    assert.equal(result.finalExamStatus, "passed");
+    assert.equal(result.handbookSigned, true);
+  });
+
+  it("misses 'complete' if any one gate fails (handbook not signed)", () => {
+    const input = baseInput();
+    input.progress = [
+      ...ALL_PASSED_PROGRESS,
+      {
+        module_id: FINAL_MODULE_ID,
+        status: "passed",
+        best_score: 90,
+        attempts: 1,
+      },
+    ];
+    input.signedDocumentTypes = ALL_DOCS_SIGNED; // no handbook
+    input.finalAttemptsCount = 1;
+    const result = computeStatusFromData(input);
+    assert.notEqual(result.enrollmentStatus, "complete");
+    assert.equal(result.handbookSigned, false);
+  });
+
+  it("counts signed documents correctly (6 required pre-final)", () => {
+    const input = baseInput();
+    input.signedDocumentTypes = ["drug_alcohol", "code_of_conduct"];
+    const result = computeStatusFromData(input);
+    assert.equal(result.signedDocumentsCompleted, 2);
+    assert.equal(result.signedDocumentsTotal, REQUIRED_PRE_FINAL_SIGNED_DOCS.length);
+    assert.equal(result.signedDocumentsTotal, 6);
+  });
+
+  it("picks the first un-passed module as currentModuleId", () => {
+    const input = baseInput();
+    input.progress = [
+      {
+        module_id: QUIZ_MODULE_IDS[0],
+        status: "passed",
+        best_score: 90,
+        attempts: 1,
+      },
+      {
+        module_id: QUIZ_MODULE_IDS[1],
+        status: "passed",
+        best_score: 85,
+        attempts: 1,
+      },
+    ];
+    const result = computeStatusFromData(input);
+    assert.equal(result.currentModuleId, QUIZ_MODULE_IDS[2]);
+  });
+
+  it("points currentModuleId at FINAL_MODULE_ID when all 13 are passed but final isn't", () => {
+    const input = baseInput();
+    input.progress = ALL_PASSED_PROGRESS;
+    const result = computeStatusFromData(input);
+    assert.equal(result.currentModuleId, FINAL_MODULE_ID);
+  });
+
+  it("returns null currentModuleId when everything is done", () => {
+    const input = baseInput();
+    input.progress = [
+      ...ALL_PASSED_PROGRESS,
+      {
+        module_id: FINAL_MODULE_ID,
+        status: "passed",
+        best_score: 90,
+        attempts: 1,
+      },
+    ];
+    input.finalAttemptsCount = 1;
+    const result = computeStatusFromData(input);
+    assert.equal(result.currentModuleId, null);
+  });
+
+  it("computes daysRemaining off enrollment.deadline_at", () => {
+    const input = baseInput();
+    input.enrollment = {
+      deadline_at: new Date("2026-05-25T12:00:00Z"),
+      last_activity_at: null,
+    };
+    input.now = new Date("2026-05-15T12:00:00Z");
+    const result = computeStatusFromData(input);
+    assert.equal(result.daysRemaining, 10);
+  });
+
+  it("returns negative daysRemaining when overdue", () => {
+    const input = baseInput();
+    input.enrollment = {
+      deadline_at: new Date("2026-05-10T12:00:00Z"),
+      last_activity_at: null,
+    };
+    input.now = new Date("2026-05-15T12:00:00Z");
+    const result = computeStatusFromData(input);
+    assert.ok((result.daysRemaining ?? 0) < 0);
+  });
+
+  it("returns daysRemaining=null when no deadline is set", () => {
+    const input = baseInput();
+    input.enrollment = {
+      deadline_at: null,
+      last_activity_at: null,
+    };
+    const result = computeStatusFromData(input);
+    assert.equal(result.daysRemaining, null);
+  });
+
+  it("populates pendingReAcks from the input", () => {
+    const input = baseInput();
+    input.pendingReAcks = 3;
+    const result = computeStatusFromData(input);
+    assert.equal(result.pendingReAcks, 3);
+  });
+
+  it("exposes compliance.overall consistent with enrollmentStatus", () => {
+    const input = baseInput();
+    input.progress = [
+      ...ALL_PASSED_PROGRESS,
+      {
+        module_id: FINAL_MODULE_ID,
+        status: "passed",
+        best_score: 95,
+        attempts: 1,
+      },
+    ];
+    input.signedDocumentTypes = ALL_DOCS_SIGNED;
+    input.handbookSignedAt = new Date();
+    input.finalAttemptsCount = 1;
+    const result = computeStatusFromData(input);
+    assert.equal(result.compliance.overall, "complete");
+    assert.equal(result.enrollmentStatus, "complete");
+  });
+
+  it("does not count FINAL_MODULE_ID toward modulesPassed (separate gate)", () => {
+    const input = baseInput();
+    input.progress = [
+      {
+        module_id: FINAL_MODULE_ID,
+        status: "passed",
+        best_score: 100,
+        attempts: 1,
+      },
+    ];
+    input.finalAttemptsCount = 1;
+    const result = computeStatusFromData(input);
+    assert.equal(result.modulesPassed, 0);
+    assert.equal(result.modulesTotal, QUIZ_MODULE_IDS.length);
+    assert.equal(result.finalExamStatus, "passed");
+  });
+});

--- a/lib/db/src/schema/lms.ts
+++ b/lib/db/src/schema/lms.ts
@@ -261,6 +261,18 @@ export const lmsQuizAttemptsTable = pgTable(
     attempted_at: timestamp("attempted_at", { withTimezone: true })
       .notNull()
       .defaultNow(),
+    /**
+     * Phes admin-view-consistency sprint (2026-05-15). When true, the
+     * attempt is excluded from the visible-attempts count + the
+     * non-superseded best-score recomputation. Set by the supersession
+     * backfill migration on legacy rows that predate the per-module
+     * attempt cap, and by future cap-enforcement on write if the cap
+     * ever changes mid-flight. Immutable history is preserved (no
+     * DELETE), but cap math now respects it.
+     */
+    superseded: boolean("superseded").notNull().default(false),
+    superseded_reason: text("superseded_reason"),
+    superseded_at: timestamp("superseded_at", { withTimezone: true }),
   },
   (t) => ({
     idx_enrollment_module_attempted: index(


### PR DESCRIPTION
## Summary

Phes-only sprint, autonomous. Builds the SSoT primitives the original PR 1 spec assumed existed, then wires them in. Items 1-4 shipped per spec.

## What changed

### Item 1 — `computeEmployeeFinalStatus` is the read path
- **New:** `lib/lms-status-pure.ts` — pure compute layer, unit-testable.
- **New:** `lib/lms-status.ts` — DB-fronted batch wrapper.
- **Wired into:** Roster (`GET /api/lms/admin/learners`), Audit Dashboard `/summary` (`loadAuditRoster`), Audit Dashboard `/learner/:userId`. Employee Journey page inherits from the audit endpoint.
- **Defensive rule:** if `module_progress.best_score >= 80`, the module reports as PASSED regardless of the stored `status`. Closes Jose's Final Mixed Test bug (best_score=100, status='in_progress') at the read path; the recompute migration fixes the persisted data alongside.

### Item 2 — Supersession backfill
- **Schema:** `lms_quiz_attempts.superseded BOOLEAN`, `superseded_reason TEXT`, `superseded_at TIMESTAMPTZ`. Drizzle + idempotent `ALTER TABLE`.
- **`runSupersessionBackfill` (Phes only):** for each `(user_id, module_id)`, keep 4 most-recent attempts active, flag remainder as superseded with reason `exceeded_cap_legacy_backfill`. Recomputes `lms_module_progress.attempts` to the non-superseded count.
- **Cap-check:** `/quiz/submit`'s `liveAttemptsRows` SELECT now filters `superseded = false`.

### Item 3 — Status recompute
- **`runStatusRecompute` (Phes only):** `UPDATE lms_module_progress SET status='passed', passed_at = COALESCE(passed_at, NOW()) WHERE best_score >= 80 AND status != 'passed'`.

### Item 4 — Phantom users
- **`runPhantomUserCleanup`:** hard-deletes users 447 + 448 with cascading rows in FK-safe order. Guard: if any active signed_documents exist, skips and warns. (Dispatch reported neither user advanced past sign-up, so 0 expected blocks.)

## Tests

19 unit tests on the pure SSoT, all passing. Coverage:
- Module pass via `best_score` (Jose case)
- Final exam state machine (4 transitions + defensive ≥80 rule)
- Sandbox account → `enrollmentStatus='sandbox'`
- `enrollmentStatus='complete'` requires all four gates
- 6-doc signed-doc counting
- `currentModuleId` picks first un-passed, falls through to FINAL when 13 done
- `daysRemaining` math (positive, negative, null deadline)
- `FINAL_MODULE_ID` excluded from `modulesPassed`
- `compliance.overall` stays consistent with `enrollmentStatus`

Pre-existing typecheck baseline unchanged. Pre-existing `bundle-discount.test.ts` infra failure fails on main too (unrelated to this PR).

## Verification (Section B, run after Railway deploy)

Boot log should show:
```
[supersession-backfill] tenant=1 users=N attempts_superseded=M
[status-recompute] tenant=1 rows_updated=M
[phantom-user-cleanup] deleted_user_ids=[447,448] blocked=[] not_found=[]
```

Then spot-checks against production:
- **B1** — Roster, Audit Dashboard, and Employee Journey all show identical `passed_count` for Jose.
- **B2** — Jose's Compensation attempts: `superseded=false` count = 4, `superseded=true` count = 17.
- **B3** — Jose's Final Mixed Test: if `best_score >= 80`, `status='passed'`.
- **B4** — `users` where `id IN (447, 448)`: 0 rows.
- **B5** — Every Phes employee's `passed_count` in roster equals the SSoT compute.
- **B6** — Re-running migrations produces 0 updates (idempotent).

I cannot run B1-B6 against production from the sandbox (no live API/DB). Posting deploy SHAs + asking for spot-check confirmation after Railway settles.

## Not in scope (next sprint)

PII leak via `/api/users` to technicians, JWT in localStorage, catch-all JSON 404, `POST /api/users` rate limit + audit log, em-dash cleanup, audit dashboard route deep-link.

https://claude.ai/code/session_01AxGiirnJ3dT4GAzHPNWhrx

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxGiirnJ3dT4GAzHPNWhrx)_