### PR TITLE
hotfix: unlock gate honors best_score &gt;= 80 (Maribel block)

### DIFF
--- a/artifacts/api-server/src/routes/lms.ts
+++ b/artifacts/api-server/src/routes/lms.ts
@@ -212,9 +212,25 @@ async function loadProgress(enrollmentId: number): Promise<LmsModuleProgress[]> 
     .where(eq(lmsModuleProgressTable.enrollment_id, enrollmentId));
 }
 
-/** Module ids that have status='passed'. */
+/**
+ * Module ids the learner has effectively passed.
+ *
+ * Hotfix 2026-05-17 (Maribel Castillo report): the read path (SSoT
+ * in lib/lms-status.ts) treats `best_score >= 80` as passed regardless
+ * of the stored `status` field. The write-path lock check has to honor
+ * the SAME rule, otherwise the frontend shows a module unlocked
+ * (because the SSoT-backed roster says the prereq is passed) while
+ * `POST /lms/quiz/submit` rejects with 403 "locked". The status
+ * recompute migration normalizes legacy rows; this helper closes the
+ * window for any row that lands in a weird state going forward.
+ */
 function completedModuleIds(progress: readonly LmsModuleProgress[]): string[] {
-  return progress.filter((p) => p.status === "passed").map((p) => p.module_id);
+  const passPercent = Math.round(QUIZ_PASS_THRESHOLD * 100);
+  return progress
+    .filter(
+      (p) => p.status === "passed" || (p.best_score ?? 0) >= passPercent,
+    )
+    .map((p) => p.module_id);
 }
 
 /**


### PR DESCRIPTION
## URGENT — Maribel onboarding block

Maribel Castillo got `403 Module "compensation" is locked` twice when submitting Compensation, again on Sexual Harassment. Final Mixed Test won't start.

## Root cause

PR #125 wired the **read path** (Roster, Audit Dashboard, Employee Journey) through the SSoT, which applies a defensive rule: `module_progress.best_score >= 80` ⇒ PASSED regardless of stored `status`. The **write path** (the unlock gate inside `POST /lms/quiz/submit`, `/module/start`, `/quiz/state`, `/quiz/seed`) still reads strict `status='passed'` via `completedModuleIds()`.

When a learner's prereq row has `best_score >= 80` but `status` hasn't synced (which is exactly the state the recompute migration exists to fix), the frontend renders the next module unlocked (SSoT said so) while the backend rejects the submit (strict status said locked). The recompute migration runs on cold start — any row landing in that state *between* deploys (or written after the migration ran) hit the gap. Maribel is the first victim.

## Fix

`completedModuleIds()` at `routes/lms.ts:216` now applies the same defensive rule:

```ts
function completedModuleIds(progress: readonly LmsModuleProgress[]): string[] {
  const passPercent = Math.round(QUIZ_PASS_THRESHOLD * 100);
  return progress
    .filter((p) => p.status === "passed" || (p.best_score ?? 0) >= passPercent)
    .map((p) => p.module_id);
}
```

One helper, six call sites — read path and write path are now consistent. Status recompute migration still runs on every cold start to keep persisted data in sync; this helper closes the live window the migration's once-per-boot cadence can't.

## Verification

- 19 SSoT unit tests still pass.
- Typecheck baseline unchanged (767 errors, all pre-existing).
- After deploy, Maribel resubmits the Compensation quiz — should succeed. Final Mixed Test card should unlock once she clears the remaining required modules.

## Risk

Minimal. The change makes the unlock gate **more permissive** in exactly the direction the SSoT already reports passed. If a learner has `best_score >= 80` on a module, they have demonstrably passed it — no scenario where the prior strict gate produced a "correct" 403.

https://claude.ai/code/session_01AxGiirnJ3dT4GAzHPNWhrx

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxGiirnJ3dT4GAzHPNWhrx)_