### PR TITLE
fix(lms): phantom-user-cleanup migration referenced nonexistent audit_log.user_id

### DIFF
--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -1881,7 +1881,14 @@ async function runPhantomUserCleanup(): Promise<void> {
     await db.execute(
       sql`DELETE FROM lms_enrollments WHERE user_id = ${id}`,
     );
-    await db.execute(sql`DELETE FROM audit_log WHERE user_id = ${id}`);
+    // audit_log has admin_user_id + target_user_id (no user_id column). The
+    // original WHERE user_id = $id query threw `column "user_id" does not
+    // exist`, which the outer try/catch swallowed as non-fatal — meaning the
+    // DELETE FROM users below never ran. Phantom users 447/448 survived
+    // every boot until this fix landed.
+    await db.execute(
+      sql`DELETE FROM audit_log WHERE admin_user_id = ${id} OR target_user_id = ${id}`,
+    );
 
     await db.execute(sql`DELETE FROM users WHERE id = ${id}`);
     deleted.push(id);


### PR DESCRIPTION
Unblocks B4 + B6c from the LMS admin-view-consistency sprint.

audit_log has admin_user_id + target_user_id columns. The previous DELETE referenced a user_id column that doesn't exist, threw, was caught as non-fatal by the outer try/catch in runPhesDataMigration, and aborted before the DELETE FROM users line. Phantom users 447 (crosstenant@evil.test) and 448 (AUDIT_CLEANUP / PLEASE_DELETE) survived every boot since the sprint shipped.

This fix swaps the WHERE clause to admin_user_id OR target_user_id so the DELETE actually runs. Migration stays idempotent on re-run.

Verified locally against Railway prod DB: post-deploy boot will log [phantom-user-cleanup] deleted_user_ids=[447,448] blocked=[] not_found=[].