### PR TITLE
fix(handbook): rewrite Personal Phone Use policy per office practice

### DIFF
--- a/artifacts/qleno/src/lib/training/curriculum.ts
+++ b/artifacts/qleno/src/lib/training/curriculum.ts
@@ -577,10 +577,12 @@ const BASE_MODULES: Module[] = [
       {
         type: "bullets",
         items: [
-          { en: "Personal cell phones kept in your bag or vehicle during a job.", es: "Los teléfonos personales se mantienen en su bolso o vehículo durante un trabajo." },
-          { en: "Phone use during a job is permitted ONLY for the company app (clock-in, check-in, job worksheet) or genuine emergencies.", es: "El uso del teléfono durante un trabajo se permite SOLO para la app de la compañía (Clock In, Check In, hoja de trabajo) o emergencias genuinas." },
-          { en: "Personal calls, texts, and social media wait until break or after the visit.", es: "Llamadas personales, mensajes y redes sociales esperan hasta el descanso o después de la visita." },
-          { en: "To take any non-emergency call, exit the home entirely and notify your teammate.", es: "Para tomar cualquier llamada que no sea emergencia, salga completamente del hogar y notifique a su compañero de equipo." },
+          { en: "Personal cell phones may be carried on you during a job.", es: "Los teléfonos personales pueden llevarse consigo durante un trabajo." },
+          { en: "Music through headphones is allowed during cleaning. Keep the volume respectful and avoid explicit content in client homes.", es: "Se permite escuchar música con audífonos durante la limpieza. Mantenga el volumen respetuoso y evite contenido explícito en hogares de clientes." },
+          { en: "Stay reachable for the office. Office calls and texts may come through during a job and you should respond promptly.", es: "Manténgase disponible para la oficina. Las llamadas y mensajes de la oficina pueden llegar durante un trabajo y debe responder con prontitud." },
+          { en: "Personal phone calls and video calls are NOT allowed during a job, except for genuine emergencies.", es: "Las llamadas personales y videollamadas NO están permitidas durante un trabajo, salvo emergencias genuinas." },
+          { en: "Personal texts and social media wait until break or after the visit.", es: "Mensajes personales y redes sociales esperan hasta el descanso o después de la visita." },
+          { en: "To take a non-emergency call, exit the home entirely and notify your teammate.", es: "Para tomar una llamada que no sea emergencia, salga completamente del hogar y notifique a su compañero de equipo." },
           { en: "Photos and videos of client homes are forbidden, except through the company app for documenting work or damage.", es: "Las fotos y videos de los hogares de los clientes están prohibidos, excepto a través de la app de la compañía para documentar trabajo o daños." },
         ],
       },


### PR DESCRIPTION
## Summary

Rewrites the Module 1 "Personal Phone Use" policy to match how Phes actually operates: phones can be carried, music through headphones is allowed, the office can reach techs mid-job, but personal voice/video calls are still prohibited during a visit.

## Diff at a glance

`curriculum.ts:580-584` — 5 old bullets → 7 new bullets. Spanish parallel updated.

### Before
1. Personal cell phones kept in your bag or vehicle during a job.
2. Phone use during a job is permitted ONLY for the company app or genuine emergencies.
3. Personal calls, texts, and social media wait until break or after the visit.
4. To take any non-emergency call, exit the home entirely and notify your teammate.
5. Photos and videos of client homes are forbidden, except through the company app.

### After
1. Personal cell phones may be carried on you during a job.
2. Music through headphones is allowed during cleaning. Keep the volume respectful and avoid explicit content in client homes.
3. Stay reachable for the office. Office calls and texts may come through during a job and you should respond promptly.
4. Personal phone calls and video calls are NOT allowed during a job, except for genuine emergencies.
5. Personal texts and social media wait until break or after the visit.
6. To take a non-emergency call, exit the home entirely and notify your teammate.
7. Photos and videos of client homes are forbidden, except through the company app for documenting work or damage.

## NLRA Section 7 savings clause

The blue callout immediately below this section ("Nothing in this policy restricts your rights under federal labor law to discuss wages, hours, or working conditions with coworkers or others.") was **left in place**. That clause is a federal-labor-law savings clause — the NLRB scrutinizes phone / social-media / confidentiality policies for "chilling effect" on protected concerted activity, and removing it from a phone-policy section is the exact pattern that draws NLRB challenges. If you ever want to consolidate, there's a longer version in another module at `curriculum.ts:2625` and they could merge.

## Verification

- Frontend typecheck: 178 errors, baseline unchanged.
- No new errors.
- Bundle hash will flip on Railway redeploy, busting any Safari cache.

https://claude.ai/code/session_01AxGiirnJ3dT4GAzHPNWhrx

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxGiirnJ3dT4GAzHPNWhrx)_