### PR TITLE
fix(lms): unblock learners on missing question ids + fix Resume vs Start button

### DIFF
--- a/artifacts/qleno/src/pages/training.tsx
+++ b/artifacts/qleno/src/pages/training.tsx
@@ -1825,7 +1825,7 @@ function ModuleRow({
       ? tr("review_quiz", locale)
       : status === "failed"
       ? tr("retry_quiz", locale)
-      : status === "in_progress"
+      : status === "in_progress" && attempts > 0
       ? tr("resume_quiz", locale)
       : isQuizModule
       ? tr("start_quiz", locale)
@@ -2399,7 +2399,7 @@ function ModuleView({
       ? tr("review_quiz", locale)
       : status === "failed"
       ? tr("retry_quiz", locale)
-      : status === "in_progress"
+      : status === "in_progress" && attempts > 0
       ? tr("resume_quiz", locale)
       : tr("start_quiz", locale);
   useEffect(() => {
@@ -2720,18 +2720,50 @@ function QuizView({
   // Load (or initialize) the quiz state from server.
   useEffect(() => {
     let cancelled = false;
+    // Defensive filter (Sal report 2026-05-19): the curriculum's
+    // QUESTIONS_BY_MODULE list (and SERVER_ANSWER_KEY) currently
+    // reference question ids whose text is missing from the bundled
+    // curriculum.quiz bank. Without this filter, the quiz advances to
+    // an unresolvable id and renders "Question not found." Drop any
+    // id we can't resolve, preserve parallel answers, then proceed.
+    const validIdSet = new Set(curriculum.quiz.map((q) => q.id));
+    const filterIds = (
+      ids: string[],
+      ans: (number | null)[] = [],
+    ): { ids: string[]; answers: (number | null)[] } => {
+      const outIds: string[] = [];
+      const outAns: (number | null)[] = [];
+      ids.forEach((qid, i) => {
+        if (validIdSet.has(qid)) {
+          outIds.push(qid);
+          outAns.push(ans[i] ?? null);
+        } else {
+          console.warn(
+            `[quiz] dropping unresolvable question id "${qid}" (module=${moduleId})`,
+          );
+        }
+      });
+      return { ids: outIds, answers: outAns };
+    };
+
     (async () => {
       try {
         const existing = await lmsApi.getQuizState(token, moduleId);
         if (cancelled) return;
         if (existing) {
           // Resume.
-          setQuestionIds(
+          const filtered = filterIds(
             existing.meta?.question_ids ??
               fixedQuestionIds(curriculum, moduleId),
+            existing.answers ?? [],
           );
-          setAnswers(existing.answers ?? []);
-          setCursor(existing.current_question_index ?? 0);
+          setQuestionIds(filtered.ids);
+          setAnswers(filtered.answers);
+          // Clamp cursor to the new (possibly shorter) list.
+          const savedCursor = existing.current_question_index ?? 0;
+          setCursor(
+            Math.min(savedCursor, Math.max(0, filtered.ids.length - 1)),
+          );
           setResumeReady(true);
           return;
         }
@@ -2748,8 +2780,9 @@ function QuizView({
         } else {
           qids = fixedQuestionIds(curriculum, moduleId);
         }
-        setQuestionIds(qids);
-        setAnswers(new Array(qids.length).fill(null));
+        const filtered = filterIds(qids);
+        setQuestionIds(filtered.ids);
+        setAnswers(new Array(filtered.ids.length).fill(null));
         setCursor(0);
         setResumeReady(true);
       } catch (e) {


### PR DESCRIPTION
## URGENT — Learner block + UX fix

Two issues found while Sal was running the LMS himself.

### Issue 1 — Mid-quiz "Question not found." (BLOCKER)

Sal was mid-quiz on phes-policies. After the shoe-covers question, the next prompt rendered *"Question not found."* and trapped him.

**Root cause:** bundle inconsistency. `lib/lms-curriculum/src/index.ts` references **57** `q-pp-*` ids in `QUESTIONS_BY_MODULE.phes-policies` + `SERVER_ANSWER_KEY`, but `artifacts/qleno/src/lib/training/curriculum.ts` only defines **40** of them. 17 ids are referenced-but-undefined, including `q-pp-14-phone-use` (the one Sal hit). Every learner sampled into one of those slots gets the same break.

**Defensive fix (this PR):** `training.tsx` QuizView `useEffect` now filters `questionIds` against `curriculum.quiz` at load time. Unresolvable ids are dropped (with `console.warn` for ops), parallel `answers` trimmed, cursor clamped. Quiz length shrinks for affected learners but they can complete instead of being trapped.

**Follow-up required (not this PR):** reconcile `QUESTIONS_BY_MODULE` + `SERVER_ANSWER_KEY` against `curriculum.quiz`. Either re-author the 17 missing questions or strip the dangling references. The list of missing ids is in the `console.warn` output once this is deployed.

### Issue 2 — "Resume quiz" shown before quiz started (UX)

Quiz card said *"Resume quiz"* before the learner had attempted any question. Cause: `status='in_progress'` is set by `/lms/module/start` (reader open) AND by quiz attempts. Button text checked `status` alone, so opening the reader flipped Start → Resume even with `attempts=0`.

**Fix:** condition for Resume now also requires `attempts > 0`. Two CTA sites in `training.tsx` (lines ~1828 and ~2402) updated to match.

### Verification

- Frontend typecheck: 178 errors, baseline unchanged.
- After deploy, the failing slot is dropped silently; Sal completes the quiz.
- The 17 dangling ids surface as `[quiz] dropping unresolvable question id "X"` warnings in browser console, which gives ops the list to reconcile.

https://claude.ai/code/session_01AxGiirnJ3dT4GAzHPNWhrx

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxGiirnJ3dT4GAzHPNWhrx)_