### PR TITLE
fix(lms): add Back to home button on quiz fail screen

### DIFF
--- a/artifacts/qleno/src/pages/training.tsx
+++ b/artifacts/qleno/src/pages/training.tsx
@@ -2843,6 +2843,7 @@ function QuizView({
         maxAttempts={result.max_attempts ?? maxAttempts}
         passThreshold={PASS_THRESHOLD_PCT}
         isOwner={isOwner}
+        onBackHome={onCancel}
         onContinue={async () => {
           if (result.passed) {
             await onPassed();
@@ -3083,6 +3084,7 @@ function ResultView({
   passThreshold,
   isOwner,
   onContinue,
+  onBackHome,
 }: {
   locale: Locale;
   result: SubmitResult;
@@ -3091,6 +3093,7 @@ function ResultView({
   passThreshold: number;
   isOwner: boolean;
   onContinue: () => void;
+  onBackHome: () => void | Promise<void>;
 }) {
   const { passed, score } = result;
   // Owners are never "out of attempts" — the server bypasses the cap
@@ -3135,7 +3138,25 @@ function ResultView({
                 }/${maxAttempts} ${tr("attemptsUsed", locale)})`}
           </div>
         ) : null}
-        <div style={{ marginTop: 18 }}>
+        <div
+          style={{
+            marginTop: 18,
+            display: "flex",
+            gap: 10,
+            justifyContent: "center",
+            flexWrap: "wrap",
+          }}
+        >
+          {/* Sal report 2026-05-19: previously the fail screen had only
+              "Try again" — no way to leave the quiz without retrying.
+              Now we always show a secondary "Back to home" alongside the
+              primary CTA, except on pass (Continue navigates forward
+              naturally). */}
+          {!passed ? (
+            <SecondaryButton onClick={() => { void onBackHome(); }}>
+              {tr("back", locale)}
+            </SecondaryButton>
+          ) : null}
           <PrimaryButton onClick={onContinue}>
             {passed
               ? tr("next", locale)


### PR DESCRIPTION
## Summary

Sal report 2026-05-19: failing a quiz with retries remaining showed **only** "Try again" — no way to leave the quiz without retrying. The learner gets trapped on the failed-result screen with no escape.

## Fix

`ResultView` now accepts an `onBackHome` prop and renders a secondary "Back" button alongside the primary CTA whenever the learner has not passed. Wired to QuizView's existing `onCancel` callback — same handler the in-quiz `BackLink` uses, so navigation is consistent.

### Layout after this change

| State | Buttons |
|---|---|
| Failed + retries remaining | `[Back]` `[Try again]` |
| Failed + no retries | `[Back]` `[Back]` (primary already said "back") |
| Passed | `[Continue]` (single button, no escape needed) |

## Note on Sal's second issue

> "once you go back to question 1 you can't go to main screen you're stuck here"

Inside the quiz (after clicking Try again), the question screen DOES have a page-level `BackLink` at the top calling `onCancel` (line 2888 in training.tsx). That should already navigate home. If it doesn't on mobile, that's a separate bug — would need a console trace to diagnose. For now this PR fixes the more critical issue (fail screen has no exit at all).

## Verification

- Frontend typecheck: 178 errors, baseline unchanged.
- After deploy, on Sal's next failed attempt he'll see `[Back] [Try again]` and can exit cleanly.

https://claude.ai/code/session_01AxGiirnJ3dT4GAzHPNWhrx

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxGiirnJ3dT4GAzHPNWhrx)_