### PR TITLE
fix(lms): owner can walk through quiz without picking answers

### DIFF
--- a/artifacts/qleno/src/pages/training.tsx
+++ b/artifacts/qleno/src/pages/training.tsx
@@ -3010,13 +3010,13 @@ function QuizView({
             {cursor < total - 1 ? (
               <PrimaryButton
                 onClick={() => setCursor((c) => Math.min(total - 1, c + 1))}
-                disabled={answers[cursor] == null}
+                disabled={!isOwner && answers[cursor] == null}
               >
                 {tr("next", locale)} <ChevronRight size={14} />
               </PrimaryButton>
             ) : (
               <PrimaryButton
-                disabled={busy || !allAnswered}
+                disabled={busy || (!isOwner && !allAnswered)}
                 onClick={async () => {
                   // Item 7 (P1 sprint): debounce — `busy` flips
                   // synchronously here, so a second click within the


### PR DESCRIPTION
## Summary

As owner, Sal wanted to click through every question of a module quiz to test the LMS flow — but Next was disabled until he picked an answer, forcing him to either answer each question or use the existing "Skip (Owner)" button (which bypasses the quiz UI entirely).

## Fix

In `QuizView` the Next + Submit buttons now skip their answer gates when `isOwner` is true.

| Button | Before | After |
|---|---|---|
| Next | `disabled={answers[cursor] == null}` | `disabled={!isOwner && answers[cursor] == null}` |
| Submit | `disabled={busy || !allAnswered}` | `disabled={busy || (!isOwner && !allAnswered)}` |

## Scope

**Only `role='owner'` (one per tenant).** Admin, office, and technician roles still get the standard answer-required gating. For Phes, this means only your account benefits; for any future tenant, only their owner.

The existing "Skip (Owner)" instant-pass button is unchanged. Both paths now coexist:
- **Skip (Owner):** instant complete, no quiz UI
- **Start quiz + walk-through (this PR):** owner can click through to verify the question UI / option text / submit flow

## Verification

- Frontend typecheck: 178 errors, baseline unchanged.
- After deploy, you can open any module quiz and tap Next / Submit without picking answers. Submitting unanswered will score 0% and fail (the bypass is for navigation, not scoring), but that's fine for testing the UI flow.

https://claude.ai/code/session_01AxGiirnJ3dT4GAzHPNWhrx

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxGiirnJ3dT4GAzHPNWhrx)_