### PR TITLE
fix(lms): training header gets Qleno-home + Admin nav links

### DIFF
--- a/artifacts/qleno/src/pages/training.tsx
+++ b/artifacts/qleno/src/pages/training.tsx
@@ -1032,6 +1032,7 @@ function Header({
   isOwner?: boolean;
 }) {
   const isMobile = useIsMobile();
+  const [, setLocation] = useLocation();
   return (
     <header
       style={{
@@ -1053,7 +1054,24 @@ function Header({
           minWidth: 0,
         }}
       >
-        <QlenoLogo size={isMobile ? "md" : "lg"} theme="light" layout="horizontal" />
+        {/* Sal report 2026-05-19: from /training there was no way back
+            to the main Qleno app. Wrapping the logo in a clickable
+            ghosts the standard "logo = home" convention. */}
+        <button
+          type="button"
+          onClick={() => setLocation("/")}
+          aria-label={locale === "es" ? "Volver a Qleno" : "Back to Qleno"}
+          style={{
+            background: "transparent",
+            border: 0,
+            padding: 0,
+            cursor: "pointer",
+            display: "inline-flex",
+            alignItems: "center",
+          }}
+        >
+          <QlenoLogo size={isMobile ? "md" : "lg"} theme="light" layout="horizontal" />
+        </button>
         <div
           style={{
             height: isMobile ? 26 : 36,
@@ -1117,6 +1135,30 @@ function Header({
       >
         {daysRemaining != null && shouldShowLearnerGating(isOwner) && (
           <DeadlineBadge days={daysRemaining} locale={locale} />
+        )}
+        {/* Sal report 2026-05-19: from /training, owners had no nav
+            link to /lms/admin. Adding here so the LMS dashboard is one
+            tap away while testing. Owner-only — admin/office staff
+            still navigate via URL bar (out of scope for this fix). */}
+        {isOwner && (
+          <button
+            type="button"
+            onClick={() => setLocation("/lms/admin")}
+            style={{
+              background: "transparent",
+              border: `1px solid ${LINE}`,
+              borderRadius: 999,
+              padding: isMobile ? "6px 10px" : "6px 14px",
+              cursor: "pointer",
+              fontSize: 12,
+              fontWeight: 700,
+              color: INK,
+              fontFamily: "inherit",
+              letterSpacing: "0.02em",
+            }}
+          >
+            {locale === "es" ? "Admin" : "Admin"}
+          </button>
         )}
         <LocaleToggle locale={locale} setLocale={setLocale} compact={isMobile} />
       </div>


### PR DESCRIPTION
## Summary

Sal report 2026-05-19: from the `/training` page (LMS home) there was no nav back to the main Qleno app, and no link to the LMS admin. Owner gets trapped on the training surface.

## Changes

Two additions to the training `Header` component:

1. **Qleno logo is now a clickable home link.** Wrapped in a button that routes to `/`. Visible to everyone — every learner can leave training and go back to the main app. Standard "logo = home" UX convention.

2. **Owner-only "Admin" pill between deadline badge and locale toggle.** Routes to `/lms/admin`. Scoped to `role='owner'` only, matching the same scoping decision from the prior quiz-walkthrough PR.

## Layout after change

```
[Qleno logo →home]  | Phes Onboarding & Training        [Deadline] [Admin] [EN|ES]
```

Mobile lays out vertically per existing `isMobile` checks.

## Verification

- Frontend typecheck: 178 errors, baseline unchanged.
- After deploy:
  - Tap Qleno logo → main app dashboard
  - Tap Admin pill (owner only) → `/lms/admin`

https://claude.ai/code/session_01AxGiirnJ3dT4GAzHPNWhrx

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxGiirnJ3dT4GAzHPNWhrx)_