### PR TITLE
fix(lms): owner can click into locked modules to preview content

### DIFF
--- a/artifacts/qleno/src/pages/training.tsx
+++ b/artifacts/qleno/src/pages/training.tsx
@@ -1883,7 +1883,7 @@ function ModuleRow({
     <button
       type="button"
       onClick={effectiveOnClick}
-      disabled={!unlocked || !effectiveOnClick}
+      disabled={(!unlocked && !isOwner) || !effectiveOnClick}
       style={{
         minWidth: 0,
         background: "transparent",
@@ -1891,7 +1891,7 @@ function ModuleRow({
         padding: 0,
         margin: 0,
         textAlign: "left",
-        cursor: unlocked && effectiveOnClick ? "pointer" : "default",
+        cursor: (unlocked || isOwner) && effectiveOnClick ? "pointer" : "default",
         fontFamily: FONT,
         flex: 1,
       }}
@@ -2254,7 +2254,7 @@ function FinalStepCard({
           <button
             type="button"
             onClick={effectiveOnClick}
-            disabled={!unlocked || passed || !effectiveOnClick}
+            disabled={(!unlocked && !isOwner) || passed || !effectiveOnClick}
             style={{
               background: "transparent",
               color: "inherit",


### PR DESCRIPTION
## Summary

Sal report 2026-05-19: as owner he could see module cards on the training dashboard but tapping a non-unlocked one (e.g. Compensation when phes-policies isn't passed yet) did nothing. The "click into module to preview the reader" path appeared dead for owners.

## Root cause

The per-module handler at `training.tsx:1514` correctly applies the owner bypass:

```ts
const handler = isAck
  ? (ackUnlocked || isOwner) ? onOpenAck : undefined
  : (unlocked || isOwner) ? () => onOpenModule(moduleId) : undefined;
```

But the actual `<button>` wrapping the card content (line 1886) was disabled based on `!unlocked` alone — ignoring the owner check:

```ts
disabled={!unlocked || !effectiveOnClick}   // <-- bug
```

HTML disabled buttons don't fire onClick, so the owner-bypass handler never ran. Same bug on `FinalStepCard:2257`.

## Fix

| Line | Before | After |
|---|---|---|
| `1886` (ModuleRow button disabled) | `!unlocked \|\| !effectiveOnClick` | `(!unlocked && !isOwner) \|\| !effectiveOnClick` |
| `1894` (ModuleRow cursor) | `unlocked && effectiveOnClick ? "pointer" : "default"` | `(unlocked \|\| isOwner) && effectiveOnClick ? "pointer" : "default"` |
| `2257` (FinalStepCard button disabled) | `!unlocked \|\| passed \|\| !effectiveOnClick` | `(!unlocked && !isOwner) \|\| passed \|\| !effectiveOnClick` |

Sequential gating for learners (non-owner roles) is unchanged.

## Verification

- Frontend typecheck: 178 errors, baseline unchanged.
- After deploy: tap any module card → opens the reader, regardless of prerequisite order. Same for the Final Mixed Test card.

https://claude.ai/code/session_01AxGiirnJ3dT4GAzHPNWhrx

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxGiirnJ3dT4GAzHPNWhrx)_