### PR TITLE
fix(lms): P0 grading drift + handbook completion stamp + bypass cert

### DIFF
--- a/artifacts/api-server/src/routes/lms-handbook.ts
+++ b/artifacts/api-server/src/routes/lms-handbook.ts
@@ -69,6 +69,7 @@ import {
   type SignedAckSummary,
 } from "../lib/lms-handbook-pdf.js";
 import { acknowledgePendingReAcksForSign } from "./lms-annual-ack.js";
+import { isEnrollmentTrulyComplete } from "../lib/lms-completion.js";
 import { logAudit } from "../lib/audit.js";
 
 const router = Router();
@@ -347,11 +348,45 @@ router.post("/sign", requireAuth, async (req, res) => {
       pending_re_acks_settled: acknowledgedCount,
     });
 
+    // 2026-05-19 audit: signing the handbook is the LAST gate in the
+    // completion chain. If the learner had already passed the final
+    // exam + all module quizzes + all 6 pre-final signed docs, then
+    // signing the handbook is what flips the whole enrollment to
+    // 'complete'. Mirror the /quiz/submit pattern (lms.ts:961-970)
+    // so enrollment.completed_at is stamped here too. Without this,
+    // the SSoT computes enrollmentStatus='complete' but the cached
+    // enrollment row stays status='active', completed_at=null — a
+    // read/write divergence the admin dashboard surfaces.
+    let enrollmentCompletedAt: Date | null = null;
+    try {
+      const truth = await isEnrollmentTrulyComplete(companyId, userId);
+      if (truth.complete) {
+        const updated = await db
+          .update(lmsEnrollmentsTable)
+          .set({ status: "completed", completed_at: now, updated_at: now })
+          .where(
+            and(
+              eq(lmsEnrollmentsTable.company_id, companyId),
+              eq(lmsEnrollmentsTable.user_id, userId),
+              // Only update if not already completed (idempotent).
+              eq(lmsEnrollmentsTable.status, "active"),
+            ),
+          )
+          .returning({ completed_at: lmsEnrollmentsTable.completed_at });
+        enrollmentCompletedAt = updated[0]?.completed_at ?? null;
+      }
+    } catch (err) {
+      // Non-fatal: enrollment-completion stamp failure should not
+      // block the signed-document write that already succeeded.
+      console.error("[lms-handbook] enrollment completion stamp failed:", err);
+    }
+
     return res.json({
       data: {
         signed_document_id: signedDocumentId,
         version_hash: version.version_hash,
         signed_at: now,
+        enrollment_completed_at: enrollmentCompletedAt,
       },
     });
   } catch (err) {

--- a/artifacts/api-server/src/routes/lms.ts
+++ b/artifacts/api-server/src/routes/lms.ts
@@ -1703,25 +1703,16 @@ router.post(
         now,
       });
 
-      // Bug-fix sprint #3: bypass now ALSO issues a completion certificate
-      // so the admin dashboard reflects the new pass. Non-fatal — matches
-      // /quiz/submit's try/catch pattern.
-      try {
-        const meta = captureRequestMetadata(req);
-        await issueCertificate({
-          companyId,
-          userId: targetUserId,
-          moduleId,
-          score: 100,
-          passed: true,
-          locale: enrollment.locale === "es" ? "es" : "en",
-          ipAddress: meta.ip_address,
-          deviceInfo: parseMinimalDeviceInfo(meta.user_agent),
-          quizAttemptId: null,
-        });
-      } catch (err) {
-        console.error("[lms] bypass cert issuance failed (non-fatal):", err);
-      }
+      // 2026-05-19 audit: the cert-issuance block that used to live
+      // here was a stale leftover from bug-fix sprint #3. PR #4 reverted
+      // the policy ("bypass does NOT issue a cert"; see the comment at
+      // the audit-log block below) but only updated the comment — the
+      // code kept calling issueCertificate(). Removing it now so the
+      // code matches the policy: bypass marks the quiz passed for
+      // navigation purposes, but does NOT create a completion cert.
+      // A cert represents actual learner action; an admin click does
+      // not. The lms_audit_log row (source='admin_bypass') is the
+      // canonical record of the bypass event.
 
       // Bypassing the final mixed test completes the enrollment ONLY if
       // every other prerequisite is also satisfied. Otherwise we'd

--- a/lib/lms-curriculum/src/index.ts
+++ b/lib/lms-curriculum/src/index.ts
@@ -310,7 +310,7 @@ export const ANSWER_KEY: Readonly<Record<string, number>> = Object.freeze({
   "q-cm-08-hourly-overrun": 1,
   "q-cm-09-commercial-rate": 2,
   "q-cm-10-commercial-early": 1,
-  "q-cm-11-fixit": 1,
+  "q-cm-11-fixit": 0,
   "q-cm-12-quality-probation": 1,
   "q-cm-13-probation-pay": 1,
   "q-cm-14-mileage": 2,
@@ -396,7 +396,7 @@ export const ANSWER_KEY: Readonly<Record<string, number>> = Object.freeze({
   // Workplace Act (820 ILCS 55).
   "q-da-01-no-pre-employment-test": 1,
   "q-da-02-impairment-not-cannabis-use": 1,
-  "q-da-03-impairment-signs": 1,
+  "q-da-03-impairment-signs": 2,
   "q-da-04-reasonable-suspicion-process": 1,
   "q-da-05-post-accident-threshold": 1,
   "q-da-06-prescription-meds": 1,

--- a/lib/training/src/answer-key.ts
+++ b/lib/training/src/answer-key.ts
@@ -75,7 +75,7 @@ export const SERVER_ANSWER_KEY: Readonly<Record<string, number>> = Object.freeze
   "q-cm-08-hourly-overrun": 1,
   "q-cm-09-commercial-rate": 2,
   "q-cm-10-commercial-early": 1,
-  "q-cm-11-fixit": 1,
+  "q-cm-11-fixit": 0,
   "q-cm-12-quality-probation": 1,
   "q-cm-13-probation-pay": 1,
   "q-cm-14-mileage": 2,
@@ -152,7 +152,7 @@ export const SERVER_ANSWER_KEY: Readonly<Record<string, number>> = Object.freeze
   // ── Module 7: drug-alcohol (10, Phase 3 PR #4) ─────────────────────────
   "q-da-01-no-pre-employment-test": 1,
   "q-da-02-impairment-not-cannabis-use": 1,
-  "q-da-03-impairment-signs": 1,
+  "q-da-03-impairment-signs": 2,
   "q-da-04-reasonable-suspicion-process": 1,
   "q-da-05-post-accident-threshold": 1,
   "q-da-06-prescription-meds": 1,


### PR DESCRIPTION
## Summary — four audit fixes, two of them P0 grading errors

The deep audit surfaced **two questions where learners selecting the correct answer were being marked wrong** plus a completion-state inconsistency and a stale code-vs-comment conflict.

| # | Severity | Finding | Fix |
|---|---|---|---|
| A | **P0 grading** | `q-cm-11-fixit` (Compensation Fix-It question) — `curriculum.ts` correctIndex=0, answer keys=1 → learner gets correct answer marked wrong | Answer keys flipped to 0 |
| B | **P0 grading** | `q-da-03-impairment-signs` (Drug & Alcohol) — `curriculum.ts` correctIndex=2, answer keys=1 → "NOT a sign of impairment" question scored against the wrong option | Answer keys flipped to 2 |
| C | **BLOCKER** | `/handbook/sign` doesn't stamp `enrollment.completed_at`. SSoT says complete; cached enrollment row stays active | Call `isEnrollmentTrulyComplete()` + idempotent UPDATE after signed_documents insert |
| D | **MEDIUM** | `/admin/bypass-module` still issues a cert despite PR #4 reverting that policy in comments only | Delete the stale `issueCertificate()` call |

## A — `q-cm-11-fixit` drift origin

I caused this in PR #130 (re-clean policy fix). When I flipped `correctIndex` from 1 → 0 in `curriculum.ts` to make "No additional pay" the correct answer, I didn't update the parallel `SERVER_ANSWER_KEY` or `ANSWER_KEY` (drift-sync file). The frontend showed option 0 with a green check; the backend scored option 1 as right. Learners hit the wrong gate.

## B — `q-da-03-impairment-signs` drift origin

Pre-existing. The question asks "Which is NOT a sign of impairment Phes can act on?" — the only defensible answer is option 2 ("A positive drug test alone") because the handbook policy explicitly says positive drug tests alone are not actionable. `curriculum.ts` correctly has `correctIndex: 2`. Both answer keys had 1 ("bloodshot eyes + cannabis smell") — which IS a sign of impairment, exactly the opposite of what the question asks.

This was masked until now because no one had taken the Drug & Alcohol quiz yet.

## C — handbook completion stamp

Before: signing the handbook wrote the signed-documents row but never closed the `enrollment` cache. After: mirror the `/quiz/submit` pattern — call `isEnrollmentTrulyComplete()` after the signature insert, idempotently set `status='completed'` + `completed_at=now` if true. Non-fatal try/catch so a stamp failure doesn't roll back the successful signature.

## D — bypass cert

`/admin/bypass-module` had a stale `issueCertificate()` block (lines 1700-1724 in main) from "bug-fix sprint #3." PR #4 reverted that policy explicitly in a comment at line 1745 ("bypass does NOT issue a certificate; cert = learner action") but only updated the comment — the code kept creating certs. Deleted the stale block. The `audit_log` row with `source='admin_bypass'` remains the canonical record.

## Verification

- 53 curriculum unit tests pass (drift-sync now passes for q-cm-11 and q-da-03).
- API-server typecheck baseline 767, unchanged.
- After deploy: any learner who failed Compensation or Drug & Alcohol *solely* due to the grading error should retake. The failed attempt rows stay in history; `best_score` carries `GREATEST(old, new)` so the next correct attempt records cleanly.

https://claude.ai/code/session_01AxGiirnJ3dT4GAzHPNWhrx

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxGiirnJ3dT4GAzHPNWhrx)_