### PR TITLE
fix(lms-admin): make Qleno logo a clickable home link

### DIFF
--- a/artifacts/qleno/src/pages/lms-admin.tsx
+++ b/artifacts/qleno/src/pages/lms-admin.tsx
@@ -599,6 +599,7 @@ export default function LmsAdminPage() {
 }
 
 function Shell({ children }: { children: React.ReactNode }) {
+  const [, setLocation] = useLocation();
   return (
     <div
       style={{
@@ -624,7 +625,25 @@ function Shell({ children }: { children: React.ReactNode }) {
             gap: 12,
           }}
         >
-          <QlenoLogo size="md" theme="light" layout="horizontal" />
+          {/* Sal report 2026-05-20: from /lms/admin there was no path
+              back to the main Qleno app. Wrapping the logo in a
+              clickable mirrors the same fix shipped on /training in
+              PR #135 — "logo = home" UX convention. */}
+          <button
+            type="button"
+            onClick={() => setLocation("/")}
+            aria-label="Back to Qleno"
+            style={{
+              background: "transparent",
+              border: 0,
+              padding: 0,
+              cursor: "pointer",
+              display: "inline-flex",
+              alignItems: "center",
+            }}
+          >
+            <QlenoLogo size="md" theme="light" layout="horizontal" />
+          </button>
           <div
             style={{
               height: 22,


### PR DESCRIPTION
## Summary

Sal report 2026-05-20: from `/lms/admin` there was no path back to the main Qleno app. PR #135 fixed the same issue on the learner `/training` page; the admin Shell header is a separate component and didn't get the treatment.

## Change

`lms-admin.tsx` Shell component (the header used by every admin page):
- Hook `setLocation` from existing `useLocation` import
- Wrap `<QlenoLogo />` in a `<button>` that routes to `"/"`
- Mirrors the `/training` fix from PR #135 exactly: same UX, same aria-label, transparent borderless styling

## Verification

- Frontend typecheck: 178 errors, baseline unchanged
- After deploy: tap the Qleno logo top-left of any `/lms/admin*` page → main app dashboard

## Pending in parallel

PR #143 (restore archived employees + last_login_at) is mid-CI as of this PR being opened. No file overlap; both can merge in either order.

https://claude.ai/code/session_01AxGiirnJ3dT4GAzHPNWhrx

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxGiirnJ3dT4GAzHPNWhrx)_