### PR TITLE
feat(lms): per-module reset action for owner+admin

### DIFF
--- a/artifacts/api-server/src/routes/lms.ts
+++ b/artifacts/api-server/src/routes/lms.ts
@@ -1914,6 +1914,146 @@ router.post(
 );
 
 // ─────────────────────────────────────────────────────────────────────────────
+// POST /admin/reset-module — Owner+Admin only (2026-05-20 feature)
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// Body: { userId, moduleId }
+//
+// Scoped reset: wipes JUST the named module for the named learner.
+// Deletes the lms_module_progress row, all lms_quiz_attempts rows, and
+// the lms_quiz_state autosave row for the (enrollment, moduleId) pair.
+// Other modules + the enrollment itself + the deadline + certs from
+// other modules are NOT touched. Certs for THIS module are also kept
+// (consistent with the bypass policy — certs represent historical
+// learner action; a fresh reset doesn't revoke prior earned certs).
+//
+// Use case: admin/owner notices a specific module is broken or a
+// learner needs to redo just one piece. /admin/reset is too aggressive
+// for that.
+
+router.post(
+  "/admin/reset-module",
+  requireAuth,
+  requireRole("owner", "admin"),
+  async (req, res) => {
+    try {
+      const companyId = req.auth!.companyId;
+      if (companyId == null) {
+        return res
+          .status(400)
+          .json({ error: "Bad Request", message: "User has no company assignment" });
+      }
+      const targetUserId = Number(req.body?.userId);
+      const moduleId = String(req.body?.moduleId ?? "").trim();
+
+      if (!Number.isFinite(targetUserId) || targetUserId <= 0) {
+        return res
+          .status(400)
+          .json({ error: "Bad Request", message: "userId is required" });
+      }
+      if (!moduleId) {
+        return res
+          .status(400)
+          .json({ error: "Bad Request", message: "moduleId is required" });
+      }
+      // Validate moduleId against the curriculum so a typo can't quietly
+      // succeed against a non-existent module.
+      const validIds = new Set<string>([
+        ...(QUIZ_MODULE_IDS as readonly string[]),
+        FINAL_MODULE_ID,
+        "acknowledgment",
+      ]);
+      if (!validIds.has(moduleId)) {
+        return res
+          .status(400)
+          .json({ error: "Bad Request", message: `Unknown moduleId: ${moduleId}` });
+      }
+
+      // Tenant gate.
+      const targetUser = await db
+        .select({ company_id: usersTable.company_id })
+        .from(usersTable)
+        .where(eq(usersTable.id, targetUserId))
+        .limit(1);
+      if (!targetUser[0] || targetUser[0].company_id !== companyId) {
+        return res
+          .status(404)
+          .json({ error: "Not Found", message: "User not found in tenant" });
+      }
+
+      const existing = await db
+        .select()
+        .from(lmsEnrollmentsTable)
+        .where(
+          and(
+            eq(lmsEnrollmentsTable.company_id, companyId),
+            eq(lmsEnrollmentsTable.user_id, targetUserId),
+          ),
+        )
+        .limit(1);
+      if (!existing[0]) {
+        return res
+          .status(404)
+          .json({ error: "Not Found", message: "No enrollment to reset" });
+      }
+      const enrollmentId = existing[0].id;
+
+      // Delete the per-module rows. All three tables key on
+      // (enrollment_id, module_id) so the scope stays strictly local.
+      const progressDel = await db
+        .delete(lmsModuleProgressTable)
+        .where(
+          and(
+            eq(lmsModuleProgressTable.enrollment_id, enrollmentId),
+            eq(lmsModuleProgressTable.module_id, moduleId),
+          ),
+        );
+      const stateDel = await db
+        .delete(lmsQuizStateTable)
+        .where(
+          and(
+            eq(lmsQuizStateTable.enrollment_id, enrollmentId),
+            eq(lmsQuizStateTable.module_id, moduleId),
+          ),
+        );
+      const attemptsDel = await db
+        .delete(lmsQuizAttemptsTable)
+        .where(
+          and(
+            eq(lmsQuizAttemptsTable.enrollment_id, enrollmentId),
+            eq(lmsQuizAttemptsTable.module_id, moduleId),
+          ),
+        );
+
+      await logAudit(
+        req,
+        "lms.admin.module_reset",
+        "lms_enrollment",
+        enrollmentId,
+        null,
+        {
+          target_user_id: targetUserId,
+          module_id: moduleId,
+          progress_rows_deleted: (progressDel as any).rowCount ?? null,
+          state_rows_deleted: (stateDel as any).rowCount ?? null,
+          attempt_rows_deleted: (attemptsDel as any).rowCount ?? null,
+        },
+      );
+
+      return res.json({ data: { ok: true, module_id: moduleId } });
+    } catch (err) {
+      console.error("[lms] /admin/reset-module error:", err);
+      return res
+        .status(500)
+        .json({
+          error: "Internal Server Error",
+          message: "Failed to reset module",
+        });
+    }
+  },
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
 // GET /admin/learners/:userId/attempts — Owner+Admin only
 // ─────────────────────────────────────────────────────────────────────────────
 //

--- a/artifacts/qleno/src/pages/lms-admin.tsx
+++ b/artifacts/qleno/src/pages/lms-admin.tsx
@@ -220,6 +220,19 @@ export default function LmsAdminPage() {
     }
   }
 
+  // 2026-05-20: per-module reset. Mirrors bypassFor's shape so the
+  // grid's prop wiring is symmetric. Wipes module_progress, all
+  // quiz_attempts, and the autosave for the ONE module. Other modules
+  // + the enrollment + certs are untouched.
+  async function resetModuleFor(userId: number, moduleId: string) {
+    try {
+      await api("POST", "/lms/admin/reset-module", token, { userId, moduleId });
+      await refresh();
+    } catch (e) {
+      setError(String((e as Error).message));
+    }
+  }
+
   useEffect(() => {
     if (!isAuthorized) return;
     void refresh();
@@ -459,6 +472,7 @@ export default function LmsAdminPage() {
             onReset={setResetOpen}
             onHistory={setHistoryOpen}
             onBypass={bypassFor}
+            onResetModule={resetModuleFor}
             onArchive={setArchiveOpen}
             onResetDeadline={setResetDeadlineOpen}
             onEdit={setEditEmpOpen}
@@ -476,6 +490,7 @@ export default function LmsAdminPage() {
             onReset={setResetOpen}
             onHistory={setHistoryOpen}
             onBypass={bypassFor}
+            onResetModule={resetModuleFor}
             onArchive={setArchiveOpen}
             onResetDeadline={setResetDeadlineOpen}
             onEdit={setEditEmpOpen}
@@ -678,6 +693,7 @@ function RosterTable({
   onReset,
   onHistory,
   onBypass,
+  onResetModule,
   onArchive,
   onResetDeadline,
   onEdit,
@@ -693,6 +709,7 @@ function RosterTable({
   onReset: (r: RosterRow) => void;
   onHistory: (r: RosterRow) => void;
   onBypass: (userId: number, moduleId: string) => Promise<void>;
+  onResetModule: (userId: number, moduleId: string) => Promise<void>;
   onArchive: (r: RosterRow) => void;
   onResetDeadline: (r: RosterRow) => void;
   onEdit: (r: RosterRow) => void;
@@ -999,7 +1016,7 @@ function RosterTable({
                       borderBottom: `1px solid ${LINE_SOFT}`,
                     }}
                   >
-                    <ModuleAttemptsGrid row={r} onBypass={onBypass} callerRole={callerRole} adminBypassAllowed={adminBypassAllowed} />
+                    <ModuleAttemptsGrid row={r} onBypass={onBypass} onResetModule={onResetModule} callerRole={callerRole} adminBypassAllowed={adminBypassAllowed} />
                     <LearnerCertificatesPanel row={r} />
                     <LearnerSignedDocumentsPanel row={r} />
                   </td>
@@ -1017,11 +1034,13 @@ function RosterTable({
 function ModuleAttemptsGrid({
   row,
   onBypass,
+  onResetModule,
   callerRole,
   adminBypassAllowed,
 }: {
   row: RosterRow;
   onBypass: (userId: number, moduleId: string) => Promise<void>;
+  onResetModule: (userId: number, moduleId: string) => Promise<void>;
   callerRole: string | null;
   adminBypassAllowed: boolean;
 }) {
@@ -1036,6 +1055,12 @@ function ModuleAttemptsGrid({
   // expected confirm string — caller types the module name to
   // enable the destructive button.
   const [pendingBypass, setPendingBypass] = useState<string | null>(null);
+  // 2026-05-20: per-module reset. Wipes module_progress + quiz_attempts
+  // + autosave for the named module only. Owner+admin only (same gate
+  // as bypass — both are destructive admin actions). Visible whenever
+  // the module has been touched (status != not_started OR attempts > 0).
+  const [pendingResetModule, setPendingResetModule] = useState<string | null>(null);
+  const canSeeReset = callerRole === "owner" || callerRole === "admin";
   // Item 2 (P0 sprint): canonical denominator. We list the 13 quiz
   // modules + the Final Mixed Test as a separate trailing card. The
   // older content-only "acknowledgment" entry from MODULE_ORDER is
@@ -1139,6 +1164,34 @@ function ModuleAttemptsGrid({
                   <FastForward size={11} /> Bypass
                 </button>
               ) : null}
+              {/* 2026-05-20: per-module Reset. Shown when the module
+                  has been touched (so there's something to wipe) and
+                  the caller is owner/admin. Wipes module_progress +
+                  quiz_attempts + autosave for THIS module only. */}
+              {canSeeReset && (status !== "not_started" || attempts > 0) ? (
+                <button
+                  type="button"
+                  onClick={() => setPendingResetModule(moduleId)}
+                  title="Reset this module (wipes progress, attempts, autosave)"
+                  style={{
+                    background: "transparent",
+                    color: INK_MUTE,
+                    border: `1px solid ${LINE}`,
+                    padding: "5px 8px",
+                    borderRadius: 6,
+                    fontSize: 11,
+                    fontWeight: 800,
+                    cursor: "pointer",
+                    fontFamily: FONT,
+                    display: "inline-flex",
+                    alignItems: "center",
+                    gap: 4,
+                    flexShrink: 0,
+                  }}
+                >
+                  <RotateCcw size={11} /> Reset
+                </button>
+              ) : null}
             </div>
           );
         })}
@@ -1153,6 +1206,199 @@ function ModuleAttemptsGrid({
           }}
         />
       ) : null}
+      {pendingResetModule !== null ? (
+        <ModuleResetConfirmDialog
+          moduleId={pendingResetModule}
+          onClose={() => setPendingResetModule(null)}
+          onConfirm={async () => {
+            await onResetModule(row.user_id, pendingResetModule);
+            setPendingResetModule(null);
+          }}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ModuleResetConfirmDialog (2026-05-20)
+//
+// Type-RESET-to-confirm gate before wiping a single module's progress,
+// attempts, and autosave for the targeted learner. Mirrors the Bypass
+// dialog pattern. Owner+admin only.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function ModuleResetConfirmDialog({
+  moduleId,
+  onClose,
+  onConfirm,
+}: {
+  moduleId: string;
+  onClose: () => void;
+  onConfirm: () => Promise<void>;
+}) {
+  const expected = "RESET";
+  const [confirm, setConfirm] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const valid = confirm.trim().toUpperCase() === expected;
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Reset module"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "rgba(15, 23, 42, 0.55)",
+        display: "grid",
+        placeItems: "center",
+        zIndex: 100,
+        padding: 16,
+      }}
+    >
+      <div
+        style={{
+          background: SURFACE,
+          borderRadius: RADIUS,
+          maxWidth: 460,
+          width: "100%",
+          padding: 24,
+          fontFamily: FONT,
+          color: INK,
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            fontSize: 16,
+            fontWeight: 800,
+            color: INK,
+          }}
+        >
+          <AlertTriangle size={16} style={{ color: DANGER }} /> Reset {humanModule(moduleId)}
+        </div>
+        <div
+          style={{
+            fontSize: 12.5,
+            color: INK_MUTE,
+            marginTop: 6,
+            lineHeight: 1.55,
+          }}
+        >
+          Wipes the learner's progress on JUST this module: module status,
+          best score, attempt count, quiz autosave, and the immutable
+          attempt history rows. Other modules + the enrollment + the
+          deadline + any earned certificates are NOT touched.
+        </div>
+        <label
+          style={{
+            display: "block",
+            fontSize: 11,
+            fontWeight: 800,
+            color: INK_MUTE,
+            textTransform: "uppercase",
+            letterSpacing: "0.04em",
+            marginTop: 16,
+            marginBottom: 6,
+          }}
+        >
+          Type RESET to confirm
+        </label>
+        <input
+          type="text"
+          value={confirm}
+          onChange={(e) => setConfirm(e.target.value)}
+          placeholder="RESET"
+          autoFocus
+          style={{
+            width: "100%",
+            padding: "8px 10px",
+            border: `1px solid ${LINE}`,
+            borderRadius: 6,
+            fontSize: 13,
+            fontFamily: FONT,
+            color: INK,
+            outline: "none",
+            boxSizing: "border-box",
+          }}
+        />
+        {err ? (
+          <div
+            style={{
+              marginTop: 10,
+              fontSize: 12,
+              color: DANGER,
+              fontWeight: 700,
+            }}
+          >
+            {err}
+          </div>
+        ) : null}
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "flex-end",
+            gap: 8,
+            marginTop: 18,
+          }}
+        >
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={busy}
+            style={{
+              background: "transparent",
+              border: `1px solid ${LINE}`,
+              color: INK,
+              padding: "8px 14px",
+              borderRadius: 6,
+              fontSize: 13,
+              fontWeight: 700,
+              cursor: busy ? "default" : "pointer",
+              fontFamily: FONT,
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            disabled={!valid || busy}
+            onClick={async () => {
+              setBusy(true);
+              setErr(null);
+              try {
+                await onConfirm();
+              } catch (e) {
+                setErr(String((e as Error).message));
+                setBusy(false);
+              }
+            }}
+            style={{
+              background: valid && !busy ? DANGER : INK_MUTE,
+              border: 0,
+              color: "#fff",
+              padding: "8px 14px",
+              borderRadius: 6,
+              fontSize: 13,
+              fontWeight: 800,
+              cursor: valid && !busy ? "pointer" : "default",
+              fontFamily: FONT,
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 6,
+              opacity: valid && !busy ? 1 : 0.7,
+            }}
+          >
+            <RotateCcw size={12} /> {busy ? "Resetting…" : "Reset module"}
+          </button>
+        </div>
+      </div>
     </div>
   );
 }
@@ -1327,6 +1573,7 @@ function RosterCards({
   onReset,
   onHistory,
   onBypass,
+  onResetModule,
   onArchive,
   onResetDeadline,
   onEdit,
@@ -1342,6 +1589,7 @@ function RosterCards({
   onReset: (r: RosterRow) => void;
   onHistory: (r: RosterRow) => void;
   onBypass: (userId: number, moduleId: string) => Promise<void>;
+  onResetModule: (userId: number, moduleId: string) => Promise<void>;
   onArchive: (r: RosterRow) => void;
   onResetDeadline: (r: RosterRow) => void;
   onEdit: (r: RosterRow) => void;
@@ -1539,7 +1787,7 @@ function RosterCards({
           </div>
           {expanded.has(r.enrollment_id) ? (
             <div style={{ marginTop: 6 }}>
-              <ModuleAttemptsGrid row={r} onBypass={onBypass} callerRole={callerRole} adminBypassAllowed={adminBypassAllowed} />
+              <ModuleAttemptsGrid row={r} onBypass={onBypass} onResetModule={onResetModule} callerRole={callerRole} adminBypassAllowed={adminBypassAllowed} />
               <LearnerCertificatesPanel row={r} />
               <LearnerSignedDocumentsPanel row={r} />
             </div>


### PR DESCRIPTION
## Summary

Per-module reset. The existing `/admin/reset` wipes the entire enrollment — too aggressive when only ONE module needs to be redone. Sal: "modules 1 and 2 are fine but module 3 has an issue and only that one should reset."

## Backend

`POST /api/lms/admin/reset-module` — Owner+Admin only.
- Body: `{ userId, moduleId }`
- Tenant-gated
- Validates `moduleId` against `QUIZ_MODULE_IDS + FINAL_MODULE_ID + 'acknowledgment'` so a typo can't quietly succeed
- Deletes `lms_module_progress` row, `lms_quiz_state` autosave row, and all `lms_quiz_attempts` rows — for the `(enrollment, moduleId)` pair only
- Audit logged as `lms.admin.module_reset` with per-table row counts

**Not touched:** other modules, the enrollment itself, the deadline, any certs (consistent with the bypass policy: certs represent historical learner action).

## Frontend

`ModuleAttemptsGrid` (per-module card grid inside the admin drawer):
- Each module card now shows a small "Reset" button next to "Bypass" when:
  - caller is owner or admin
  - module has been touched (`status != 'not_started'` OR `attempts > 0`)
- Click opens `ModuleResetConfirmDialog` — type-RESET-to-confirm pattern, mirrors the existing enrollment-level Reset dialog
- `resetModuleFor()` page-level handler POSTs to `/api/lms/admin/reset-module` and refreshes the roster
- `onResetModule` prop plumbed through Roster + grid (mirrors `onBypass`; both desktop and mobile invocations updated)

## Verification

- Typecheck baselines: frontend 178, api-server 767 — both unchanged
- After deploy: in the admin drawer, expand any employee → each module card with prior progress shows `[Reset]` next to `[Bypass]` → click → type RESET → confirm → that module wipes; others stay

https://claude.ai/code/session_01AxGiirnJ3dT4GAzHPNWhrx

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxGiirnJ3dT4GAzHPNWhrx)_