### PR TITLE
fix(lms): idempotent resync of module_progress.attempts against quiz_attempts

### DIFF
--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -1891,6 +1891,56 @@ async function runSupersessionBackfill(): Promise<void> {
 }
 
 /**
+ * 2026-05-20 audit follow-up: idempotent resync of
+ * lms_module_progress.attempts against the non-superseded
+ * lms_quiz_attempts count. The original supersession-backfill above
+ * has its own resync, but that one only fires when this run's
+ * backfill touched something (`totalSuperseded > 0`). If supersession
+ * was already done in a prior boot but the resync missed any rows,
+ * the drift persists.
+ *
+ * This function runs on every boot and only UPDATEs rows where the
+ * stored `attempts` actually differs from the live count — so a
+ * tenant in steady state is a no-op. Phes only.
+ */
+async function runModuleProgressAttemptsResync(): Promise<void> {
+  const result = await db.execute(sql`
+    UPDATE lms_module_progress mp
+    SET attempts = COALESCE(sub.live_count, 0)
+    FROM (
+      SELECT
+        e.id AS enrollment_id,
+        mp_inner.module_id,
+        COALESCE(
+          (
+            SELECT COUNT(*)::int
+            FROM lms_quiz_attempts qa
+            WHERE qa.enrollment_id = e.id
+              AND qa.module_id = mp_inner.module_id
+              AND qa.superseded = FALSE
+          ),
+          0
+        ) AS live_count
+      FROM lms_module_progress mp_inner
+      INNER JOIN lms_enrollments e ON e.id = mp_inner.enrollment_id
+      INNER JOIN users u ON u.id = e.user_id
+      WHERE mp_inner.company_id = ${PHES_COMPANY_ID}
+        AND u.is_sandbox = FALSE
+    ) sub
+    WHERE mp.enrollment_id = sub.enrollment_id
+      AND mp.module_id = sub.module_id
+      AND mp.company_id = ${PHES_COMPANY_ID}
+      AND mp.attempts != sub.live_count
+  `);
+  const n = (result as any).rowCount ?? 0;
+  if (n > 0) {
+    console.log(
+      `[module-progress-attempts-resync] tenant=${PHES_COMPANY_ID} rows_updated=${n}`,
+    );
+  }
+}
+
+/**
  * Phes admin-view-consistency sprint (2026-05-15) — Item 3.
  *
  * Normalizes lms_module_progress rows where best_score >= 80 but
@@ -2056,6 +2106,12 @@ export async function runPhesDataMigration(): Promise<void> {
     await runSupersessionBackfill();
   } catch (err: any) {
     console.warn("[phes-migration] supersession-backfill — non-fatal:", err?.message ?? err);
+  }
+
+  try {
+    await runModuleProgressAttemptsResync();
+  } catch (err: any) {
+    console.warn("[phes-migration] module-progress-attempts-resync — non-fatal:", err?.message ?? err);
   }
 
   try {


### PR DESCRIPTION
## Summary

Audit follow-up. PR #125's supersession backfill had an embedded resync of `lms_module_progress.attempts` ↔ `COUNT(non-superseded quiz_attempts)`, but it was gated on `totalSuperseded > 0` — only fired when THIS boot's backfill actually touched something. If supersession ran in a prior boot, or partially synced, the drift could persist on subsequent boots.

## What Sal hit today

Perceived divergence: Katie's attempt count appearing different between her learner view and the admin roster. After audit, that specific case was a metric-naming confusion (`0/13 modules-passed` vs `1/4 attempts`). But the **underlying possibility of `module_progress.attempts` drifting from the cap-checked count** is real for any user with legacy attempts that pre-date the supersession backfill (e.g. Jose's 21-attempt Compensation history).

## Fix

New `runModuleProgressAttemptsResync()` in `phes-data-migration.ts`:
- Runs unconditionally on every cold start
- Only writes rows where stored `attempts` actually differs from live non-superseded count (`mp.attempts != sub.live_count` predicate)
- Steady-state tenant: no-op, no log line emitted
- Drifted tenant: heals; row count logged
- Phes only (`company_id=1`); sandbox excluded
- Wired right after `runSupersessionBackfill` in `runPhesDataMigration`

## Verification

- api-server typecheck baseline: 767 errors, unchanged
- Boot log to look for after Railway deploy:
  ```
  [module-progress-attempts-resync] tenant=1 rows_updated=N
  ```
  If `N > 0`, drift was real and is now healed. If no line emitted, tenant was already in sync.

https://claude.ai/code/session_01AxGiirnJ3dT4GAzHPNWhrx

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxGiirnJ3dT4GAzHPNWhrx)_