### PR TITLE
fix(lms): q-pp-25-sick-no-balance wrong answer key + bucket-cascade myth

### DIFF
--- a/artifacts/qleno/src/lib/training/curriculum.ts
+++ b/artifacts/qleno/src/lib/training/curriculum.ts
@@ -3389,11 +3389,11 @@ const BASE_QUIZ: QuizQuestion[] = [
     },
     options: [
       { en: "Phes covers the absence with the next leave bucket in order. PTO comes next, then Unpaid Personal Leave. It is NOT unexcused unless all three buckets are exhausted or you no-call/no-showed.", es: "Phes cubre la ausencia con la siguiente cubeta en orden. Sigue PTO, luego Licencia Personal No Pagada. NO es injustificada a menos que las tres cubetas estén agotadas o haya sido un no llamó / no se presentó." },
-      { en: "Unexcused — once PLAWA is gone, every sick call counts toward discipline.", es: "Injustificada — una vez agotado el PLAWA, cada llamada por enfermedad cuenta hacia la disciplina." },
+      { en: "Unexcused — both PTO and Unpaid Personal Leave require 7 days advance notice and cannot cover a same-day call-off. Once PLAWA is exhausted, a same-day sick call counts toward the discipline scale, UNLESS the absence is protected by law (FMLA, ADA, workers comp, pregnancy, jury duty, bereavement, VESSA, lactation, etc. — see Section 4).", es: "Injustificada — tanto el PTO como la Licencia Personal No Pagada requieren 7 días de aviso anticipado y no pueden cubrir una llamada el mismo día. Una vez agotado el PLAWA, una llamada por enfermedad el mismo día cuenta hacia la escala de disciplina, A MENOS QUE la ausencia esté protegida por la ley (FMLA, ADA, compensación al trabajador, embarazo, servicio de jurado, duelo, VESSA, lactancia, etc. — vea la Sección 4)." },
       { en: "PTO is automatically deducted, but if PTO is also gone you're unexcused.", es: "Se deduce PTO automáticamente, pero si el PTO también está agotado, queda como injustificada." },
       { en: "Phes terminates immediately for going over PLAWA.", es: "Phes termina inmediatamente por exceder el PLAWA." },
     ],
-    correctIndex: 0,
+    correctIndex: 1,
   },
   {
     id: "q-pp-26-unpaid-personal",

--- a/lib/lms-curriculum/src/index.ts
+++ b/lib/lms-curriculum/src/index.ts
@@ -284,7 +284,7 @@ export const ANSWER_KEY: Readonly<Record<string, number>> = Object.freeze({
   "q-pp-21-pto-cap": 1,
   "q-pp-22-separation-payout": 1,
   "q-pp-23-holiday-90day": 1,
-  "q-pp-25-sick-no-balance": 0,
+  "q-pp-25-sick-no-balance": 1,
   "q-pp-26-unpaid-personal": 1,
   "q-pp-27-bucket-order": 1,
   "q-pp-28-unexcused-definition": 1,

--- a/lib/training/src/answer-key.ts
+++ b/lib/training/src/answer-key.ts
@@ -49,7 +49,7 @@ export const SERVER_ANSWER_KEY: Readonly<Record<string, number>> = Object.freeze
   "q-pp-21-pto-cap": 1,
   "q-pp-22-separation-payout": 1,
   "q-pp-23-holiday-90day": 1,
-  "q-pp-25-sick-no-balance": 0,
+  "q-pp-25-sick-no-balance": 1,
   "q-pp-26-unpaid-personal": 1,
   "q-pp-27-bucket-order": 1,
   "q-pp-28-unexcused-definition": 1,


### PR DESCRIPTION
## The bug

The quiz question `q-pp-25-sick-no-balance` had `correctIndex=0` pointing at the 'cascade to PTO, then Unpaid Personal Leave' answer. That answer contradicts the handbook's own rules:

- **PTO requires 7 days advance notice** (Section 4 PTO bullet 3)
- **Unpaid Personal Leave requires 7 days advance notice AND is explicitly 'for PLANNED absences only. Not for same-day call-offs'** (Section 4 Unpaid Personal Leave bullet 5)

So neither bucket can cover a same-day sick call. After PLAWA is exhausted, a same-day sick call is unexcused unless the absence is otherwise protected by law.

## Changes

- Flips `correctIndex: 0 → 1` in all three answer-key locations
- Rewrites option B (the new correct answer) to spell out the rule **and** the protected-by-law carve-outs (FMLA, ADA, workers comp, pregnancy, jury duty, bereavement, VESSA, lactation — see Section 4)

## Out of scope (follow-up PR coming)

- 14 other contradictions in the bucket-cascade family (q-pp-11/27/28/31/34 prompts + handbook Section 4 callouts + q-pp-32 ES phantom 4th bucket + q-pp-18 bereavement scope drift)
- 5 ghost question IDs (q-pp-14/17/24/30/39) registered without authored content
- Adding FMLA to the protected-absences list
- QuizView branded header (Phes prominent, Qleno secondary)

All of the above will ship in PR #131 once each new question + reworded paragraph is reviewed by Sal.

## Verification

- `pnpm run test:lms`: 324/324 pass (no existing test exercises this specific answer-key entry; safe at the test layer)
- **No real employee has taken the phes-policies quiz yet.** Sal was testing under Katie's name (user_id=459) and will reset her enrollment after this lands, so the wrong-answer-key did not affect any active learner's record.