### PR TITLE
content(lms): allowed-hours deep dive + q-cm-16 + mileage rate to $0.725

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -304,6 +304,16 @@
 4. Smart tech availability check (fires after date selected in Review)
 5. UI cleanup: inline address verification, collapsible call notes
 6. Recurring job timezone bug fix (parseDate local vs UTC)
+7. **Payroll detail view (day-by-day) — Qleno roadmap.** Sal's reference
+   is the MaidCentral PayrollSummaryIndividual screen: each day
+   expandable, showing per-day tips / Daily Hours / Daily Pay ($X/hr
+   effective). Per-customer table with Customer · Fee · Position · Pay
+   type · **Actual / Allowed hours** · Pay. Job Hours total + Drive &
+   Office Hours total. Allowed hours is the load-bearing field — techs
+   need to see budget vs actual to grasp the efficiency math taught in
+   the Compensation module's "Allowed Hours" section. Today Qleno's
+   payroll screens don't surface allowed-hours per day. Spec needed,
+   then frontend + API work. Flagged 2026-05-20.
 
 ## Dev Workflow
 - Edit locally in Claude Code

--- a/artifacts/api-server/src/routes/compliance-settings.ts
+++ b/artifacts/api-server/src/routes/compliance-settings.ts
@@ -33,7 +33,7 @@ router.patch("/", requireAuth, async (req, res) => {
         ${b.plawa_enabled ?? true}, ${b.plawa_annual_hours ?? 40},
         ${b.pto_enabled ?? true}, ${b.pto_year1_credit ?? 40}, ${b.pto_max_cap ?? 80},
         ${b.pto_payout_on_separation ?? true}, ${b.holiday_pay_enabled ?? true}, ${b.holiday_pay_hours ?? 8},
-        ${b.mileage_reimbursement_enabled ?? true}, ${b.mileage_rate ?? 0.70},
+        ${b.mileage_reimbursement_enabled ?? true}, ${b.mileage_rate ?? 0.725},
         ${b.quality_probation_enabled ?? true}, ${b.re_clean_workflow_enabled ?? true},
         ${b.insubordination_reclassification_enabled ?? true},
         ${b.scorecard_enabled ?? true}, ${b.scorecard_floor_pct ?? 95.00},

--- a/artifacts/api-server/src/routes/mileage-requests.ts
+++ b/artifacts/api-server/src/routes/mileage-requests.ts
@@ -64,7 +64,7 @@ router.post("/", requireAuth, async (req, res) => {
       .from(companiesTable)
       .where(eq(companiesTable.id, companyId))
       .limit(1);
-    const rate = parseFloat(company?.mileage_rate || "0.7000");
+    const rate = parseFloat(company?.mileage_rate || "0.7250");
     const milesNum = parseFloat(miles);
     const reimbursement = (milesNum * rate).toFixed(2);
 

--- a/artifacts/api-server/src/routes/payroll-settings.ts
+++ b/artifacts/api-server/src/routes/payroll-settings.ts
@@ -52,7 +52,7 @@ router.patch("/", requireAuth, async (req, res) => {
         ${quality_probation_threshold_complaints ?? 2},
         ${quality_probation_window_days ?? 30},
         ${quality_probation_pay_rate ?? 20},
-        ${mileage_rate ?? 0.70},
+        ${mileage_rate ?? 0.725},
         NOW()
       )
       ON CONFLICT (company_id) DO UPDATE SET

--- a/artifacts/api-server/src/tests/lms-curriculum.test.ts
+++ b/artifacts/api-server/src/tests/lms-curriculum.test.ts
@@ -120,7 +120,7 @@ describe("LMS curriculum — constants & catalog shape", () => {
       "social-media": 10,
       "phes-401k": 10,
       "supply-kit": 10,
-      compensation: 15,
+      compensation: 16,
       "cleaning-best-practices": 15,
       maidcentral: 15,
       "products-tools": 15,
@@ -135,8 +135,8 @@ describe("LMS curriculum — constants & catalog shape", () => {
     }
   });
 
-  it("ALL_QUESTION_IDS is 187 total (40 + 15*5 + 10 + 10 + 9 + 13 + 10 + 10 + 10)", () => {
-    assert.equal(ALL_QUESTION_IDS.length, 187);
+  it("ALL_QUESTION_IDS is 188 total (40 + 16 + 15*4 + 10 + 10 + 9 + 13 + 10 + 10 + 10)", () => {
+    assert.equal(ALL_QUESTION_IDS.length, 188);
   });
 
   it("ANSWER_KEY has exactly the keys enumerated by ALL_QUESTION_IDS", () => {
@@ -246,9 +246,9 @@ describe("scoreQuiz", () => {
   });
 
   it("passes at exactly the 80% boundary on a 15-question quiz (12/15 = 80%)", () => {
-    // Use compensation (15) — phes-policies is now 23 after the 2026-05-11
-    // handbook reconciliation, so it no longer hits the 12/15 boundary.
-    const qids: string[] = [...QUESTIONS_BY_MODULE["compensation"]];
+    // Use cleaning-best-practices (15) — compensation went 15→16 in the
+    // 2026-05-20 allowed-hours sprint, so it no longer hits the 12/15 boundary.
+    const qids: string[] = [...QUESTIONS_BY_MODULE["cleaning-best-practices"]];
     const answers: number[] = qids.map((q: string, i: number) =>
       i < 12 ? ANSWER_KEY[q] : (ANSWER_KEY[q] + 1) % 3,
     );
@@ -258,7 +258,7 @@ describe("scoreQuiz", () => {
   });
 
   it("fails below 80% (11/15 = 73%)", () => {
-    const qids: string[] = [...QUESTIONS_BY_MODULE["compensation"]];
+    const qids: string[] = [...QUESTIONS_BY_MODULE["cleaning-best-practices"]];
     const answers: number[] = qids.map((q: string, i: number) =>
       i < 11 ? ANSWER_KEY[q] : (ANSWER_KEY[q] + 1) % 3,
     );

--- a/artifacts/qleno/src/lib/training/curriculum.ts
+++ b/artifacts/qleno/src/lib/training/curriculum.ts
@@ -915,7 +915,7 @@ const BASE_MODULES: Module[] = [
         items: [
           { en: "Reimbursed for travel BETWEEN one client location and a second client location on the same workday.", es: "Se reembolsa el viaje ENTRE una ubicación de cliente y una segunda ubicación de cliente en el mismo día laboral." },
           { en: "Home-to-first-job and last-job-to-home mileage is NOT reimbursable.", es: "El millaje de casa al primer trabajo y del último trabajo a casa NO es reembolsable." },
-          { en: "Reimbursed at the IRS standard mileage rate in effect at the time of travel.", es: "Se reembolsa a la tarifa estándar de millaje del IRS vigente al momento del viaje." },
+          { en: "Reimbursed at $0.725 per mile (Phes's current rate, at or above the IRS standard mileage rate in effect at the time of travel).", es: "Se reembolsa a $0.725 por milla (la tarifa actual de Phes, al nivel o por encima de la tarifa estándar de millaje del IRS vigente al momento del viaje)." },
           { en: "Must be submitted through the Phes app within the same calendar month incurred. Include date, client names, total miles.", es: "Debe enviarse por la app de Phes dentro del mismo mes calendario en que se incurrió. Incluya fecha, nombres de clientes, total de millas." },
           { en: "Late or incomplete submissions may be denied. Mileage reimbursement is NOT considered wages.", es: "Las solicitudes tardías o incompletas pueden ser denegadas. El reembolso de millaje NO se considera salario." },
         ],
@@ -1161,6 +1161,43 @@ const BASE_MODULES: Module[] = [
         ],
       },
 
+      { type: "h", text: { en: "Allowed Hours: How They Work and How to Maximize Your Pay", es: "Horas Asignadas: Cómo Funcionan y Cómo Maximizar Su Pago" } },
+      {
+        type: "p",
+        text: {
+          en: "Every Phes job has an allowed hours number — the time Phes budgets for that visit, based on the home, the service type, and historical performance data. Allowed hours are the budget. Your commission is paid on the job total, NOT on the time you take. That means: if you finish faster than the allowed hours without compromising quality, your effective hourly rate goes UP.",
+          es: "Cada trabajo de Phes tiene un número de horas asignadas — el tiempo que Phes presupuesta para esa visita, según el hogar, el tipo de servicio y datos históricos de desempeño. Las horas asignadas son el presupuesto. Su comisión se paga sobre el total del trabajo, NO sobre el tiempo que tarda. Eso significa: si termina más rápido que las horas asignadas sin comprometer la calidad, su tarifa efectiva por hora SUBE.",
+        },
+      },
+      {
+        type: "p",
+        text: {
+          en: "Example: a 4-hour Move-Out clean billed at $80/hour = $320 job total. Your 32% commission = $102.40. That's a fixed amount tied to the JOB, not to how long it takes you.",
+          es: "Ejemplo: una limpieza de Mudanza de 4 horas facturada a $80/hora = $320 total del trabajo. Su 32% de comisión = $102.40. Esa es una cantidad fija ligada al TRABAJO, no a cuánto tarda.",
+        },
+      },
+      {
+        type: "table",
+        head: {
+          en: ["If you finish in…", "Your pay", "Your effective $/hr"],
+          es: ["Si termina en…", "Su pago", "Su tarifa efectiva $/hr"],
+        },
+        rows: [
+          { en: ["4.0 hours (the full allowed time)", "$102.40", "$25.60/hr"], es: ["4.0 horas (todo el tiempo asignado)", "$102.40", "$25.60/hr"] },
+          { en: ["3.5 hours", "$102.40", "$29.26/hr"], es: ["3.5 horas", "$102.40", "$29.26/hr"] },
+          { en: ["3.2 hours", "$102.40", "$32.00/hr"], es: ["3.2 horas", "$102.40", "$32.00/hr"] },
+          { en: ["2.5 hours", "$102.40", "$40.96/hr"], es: ["2.5 horas", "$102.40", "$40.96/hr"] },
+        ],
+      },
+      {
+        type: "callout",
+        tone: "warning",
+        text: {
+          en: "Speed does NOT replace quality. The 24-hour Quality Verification window means your commission is contingent until the client either confirms satisfaction OR 24 hours pass with no complaint. If you rush and the client calls back unhappy: you return for the Fix-It re-clean within 24 hours and full commission stays earned, plus a 3-hour minimum on the re-clean visit. If you refuse a valid re-clean without lawful reason: commission is NOT earned. The job defaults to $18.00 per hour for on-site time. That's significantly LESS than $25.60/hr, never mind the $40.96/hr you would have made on a fast clean done right. Bottom line: a fast clean done well = more $/hr. A fast clean done badly = $18/hr fallback if you refuse the fix. The math only works when quality holds.",
+          es: "La rapidez NO reemplaza la calidad. La ventana de Verificación de Calidad de 24 horas significa que su comisión es contingente hasta que el cliente confirme satisfacción O pasen 24 horas sin queja. Si se apura y el cliente llama inconforme: regresa a la re-limpieza Fix-It dentro de 24 horas y la comisión completa se mantiene ganada, más un mínimo de 3 horas en la visita de re-limpieza. Si rechaza una re-limpieza válida sin razón legal: la comisión NO se gana. El trabajo se rige por la tarifa por hora en sitio de $18.00. Eso es significativamente MENOS que $25.60/hr, mucho menos los $40.96/hr que habría ganado con una limpieza rápida bien hecha. Conclusión: una limpieza rápida bien hecha = más $/hr. Una limpieza rápida mal hecha = $18/hr de respaldo si rechaza arreglarla. La matemática solo funciona cuando la calidad se mantiene.",
+        },
+      },
+
       { type: "h", text: { en: "Hourly Time Blocks", es: "Bloques de Tiempo por Hora" } },
       {
         type: "p",
@@ -1217,8 +1254,8 @@ const BASE_MODULES: Module[] = [
       {
         type: "p",
         text: {
-          en: "Phes reimburses mileage between client homes (not your commute from home to first job, or last job to home). Submit mileage requests through the system; the office reviews and approves. The current rate is $0.70 per mile.",
-          es: "Phes reembolsa el millaje entre hogares de clientes (no su trayecto desde casa al primer trabajo, ni del último trabajo a casa). Envíe solicitudes de millaje a través del sistema; la oficina revisa y aprueba. La tarifa actual es $0.70 por milla.",
+          en: "Phes reimburses mileage between client homes (not your commute from home to first job, or last job to home). Submit mileage requests through the system; the office reviews and approves. The current rate is $0.725 per mile.",
+          es: "Phes reembolsa el millaje entre hogares de clientes (no su trayecto desde casa al primer trabajo, ni del último trabajo a casa). Envíe solicitudes de millaje a través del sistema; la oficina revisa y aprueba. La tarifa actual es $0.725 por milla.",
         },
       },
 
@@ -3858,6 +3895,21 @@ const BASE_QUIZ: QuizQuestion[] = [
       { en: "Biweekly, every other Friday", es: "Quincenal, cada dos viernes" },
       { en: "Monthly on the 1st", es: "Mensual el día 1" },
       { en: "Same-day cash at the end of each shift", es: "Efectivo el mismo día al final de cada turno" },
+    ],
+    correctIndex: 1,
+  },
+  {
+    id: "q-cm-16-allowed-hours-math",
+    moduleId: "compensation",
+    prompt: {
+      en: "You're solo on a 4-hour Move-Out clean billed at $80/hour ($320 total). You finish in 3.2 hours with no quality issues. How much do you earn?",
+      es: "Trabaja solo en una limpieza de Mudanza de 4 horas facturada a $80/hora ($320 total). Termina en 3.2 horas sin problemas de calidad. ¿Cuánto gana?",
+    },
+    options: [
+      { en: "$64.00 (32% of 3.2 hours × $80/hr — your actual time).", es: "$64.00 (32% de 3.2 horas × $80/hr — su tiempo real)." },
+      { en: "$102.40 (32% of the $320 job total — commission is on the job, not the time). That's $32/hr effective. The 0.8-hour difference is yours to keep as long as quality holds.", es: "$102.40 (32% del total de $320 del trabajo — la comisión es sobre el trabajo, no sobre el tiempo). Eso es $32/hr efectivos. La diferencia de 0.8 horas es suya mientras la calidad se mantenga." },
+      { en: "$80.00 (4 × $20 default hourly).", es: "$80.00 (4 × $20 por hora por defecto)." },
+      { en: "$57.60 (18% commission for fast work).", es: "$57.60 (18% de comisión por trabajo rápido)." },
     ],
     correctIndex: 1,
   },

--- a/lib/db/src/schema/companies.ts
+++ b/lib/db/src/schema/companies.ts
@@ -55,7 +55,7 @@ export const companiesTable = pgTable("companies", {
   auto_charge_on_invoice: boolean("auto_charge_on_invoice").notNull().default(false),
   annual_revenue_goal: integer("annual_revenue_goal"),
   payment_terms_days: integer("payment_terms_days").notNull().default(0),
-  mileage_rate: numeric("mileage_rate", { precision: 6, scale: 4 }).notNull().default("0.7000"),
+  mileage_rate: numeric("mileage_rate", { precision: 6, scale: 4 }).notNull().default("0.7250"),
   phone: text("phone"),
   email: text("email"),
   address: text("address"),

--- a/lib/lms-curriculum/src/index.ts
+++ b/lib/lms-curriculum/src/index.ts
@@ -320,6 +320,7 @@ export const ANSWER_KEY: Readonly<Record<string, number>> = Object.freeze({
   "q-cm-13-probation-pay": 1,
   "q-cm-14-mileage": 2,
   "q-cm-15-payroll-cycle": 1,
+  "q-cm-16-allowed-hours-math": 1,
 
   // ── Module 3: cleaning-best-practices (15) ───────────────────────────────
   "q-cb-01-room-flow": 1,
@@ -565,6 +566,7 @@ export const QUESTIONS_BY_MODULE: Readonly<Record<QuizModuleId, readonly string[
       "q-cm-07-clock-in-difference", "q-cm-08-hourly-overrun", "q-cm-09-commercial-rate",
       "q-cm-10-commercial-early", "q-cm-11-fixit", "q-cm-12-quality-probation",
       "q-cm-13-probation-pay", "q-cm-14-mileage", "q-cm-15-payroll-cycle",
+      "q-cm-16-allowed-hours-math",
     ],
     "cleaning-best-practices": [
       "q-cb-01-room-flow", "q-cb-02-room-order", "q-cb-03-direction",

--- a/lib/training/src/answer-key.ts
+++ b/lib/training/src/answer-key.ts
@@ -85,6 +85,7 @@ export const SERVER_ANSWER_KEY: Readonly<Record<string, number>> = Object.freeze
   "q-cm-13-probation-pay": 1,
   "q-cm-14-mileage": 2,
   "q-cm-15-payroll-cycle": 1,
+  "q-cm-16-allowed-hours-math": 1,
 
   // ── Module 3: cleaning-best-practices ────────────────────────────────────
   "q-cb-01-room-flow": 1,


### PR DESCRIPTION
## What

Three things bundled:

1. **Allowed-hours deep dive in the Compensation module.** New subsection explaining how commission is paid on the JOB TOTAL not the time, with a worked Move-Out example (4 hr allowed × $80/hr × 32% = $102.40, becomes $32/hr effective if finished in 3.2 hr). Quality-non-negotiable callout explains the Fix-It / $18/hr fallback for rushed-then-refused-reclean scenarios.

2. **New quiz question `q-cm-16-allowed-hours-math`** testing the central concept (compensation pool went 15 → 16 questions).

3. **Mileage rate fixed to $0.725/mile** across all 6 code locations (schema default, runtime fallback, two settings endpoints, both handbook references). Production DB row UPDATED out-of-band as part of PR prep. Phes pays slightly above the 2025 IRS standard of $0.70.

## Files changed

- `curriculum.ts` — allowed-hours subsection (paragraphs + table + callout), q-cm-16 question, mileage rate $0.70 → $0.725 in handbook §7 + Compensation section
- `lib/db/src/schema/companies.ts` — schema default 0.7000 → 0.7250
- `routes/mileage-requests.ts` — runtime fallback 0.7000 → 0.7250
- `routes/compliance-settings.ts` — default 0.70 → 0.725
- `routes/payroll-settings.ts` — default 0.70 → 0.725
- `lib/lms-curriculum/src/index.ts` — q-cm-16 added to answer-key + pool
- `lib/training/src/answer-key.ts` — q-cm-16 added
- `tests/lms-curriculum.test.ts` — compensation count 15→16, ALL_QUESTION_IDS 187→188, 80% boundary tests switched to cleaning-best-practices (still 15)
- `CLAUDE.md` — Pending Next Sessions item 7 documenting Qleno payroll detail view roadmap

## Production DB note

The code change alone does not retro-update existing rows. `companies.mileage_rate` for Phes (id=1) was directly UPDATED 0.7000 → 0.7250 during PR prep (verified BEFORE/AFTER in the same script). All other tenant rows unaffected.

## Verification

- `pnpm run test:lms`: 324/324 pass
- tsx import: phes-policies 40 questions, compensation 16 questions, all 13 modules load cleanly
- Production DB row updated and verified

## Out of scope

- Qleno payroll detail view (day-by-day, MaidCentral-style) — flagged in CLAUDE.md as roadmap item 7, separate spec + frontend work needed.
- IL employment attorney review of the $18/hr Fix-It fallback language (already flagged in PR #149's LEGAL-REVIEW-PENDING comments).