### PR TITLE
fix(lms): preserve passed status on /module/start + lock passed modules in UI

### DIFF
--- a/artifacts/api-server/src/lib/lms-status-pure.ts
+++ b/artifacts/api-server/src/lib/lms-status-pure.ts
@@ -111,6 +111,35 @@ export function isModulePassed(row: {
   return (row.best_score ?? 0) >= PASS_PERCENT;
 }
 
+/**
+ * Decides whether `POST /lms/module/start` is allowed to write
+ * `status: 'in_progress'` into the module_progress row for this
+ * (learner, module).
+ *
+ * Returns true (allowed to set in_progress) when:
+ *   - no row exists yet (fresh insert path), OR
+ *   - the row exists but does NOT satisfy `isModulePassed` (i.e. it's
+ *     genuinely in-progress / failed / not_started)
+ *
+ * Returns false (must omit status from the patch) when the row already
+ * satisfies `isModulePassed`. That guard prevents the Katie-class bug:
+ *   - learner passes a quiz (status='passed', best_score=97, passed_at set)
+ *   - learner later opens the module to review
+ *   - frontend auto-fires `/module/start` on view
+ *   - WITHOUT this guard the upsert clobbers status to 'in_progress',
+ *     which re-enables the quiz UI and lets the learner retake an
+ *     already-passed module — defeating the whole pass concept.
+ *
+ * Pure helper so the regression test can pin the decision matrix
+ * without spinning up a DB. The route handler uses the same predicate.
+ */
+export function canDowngradeToInProgress(
+  existing: { status: string; best_score: number | null } | undefined,
+): boolean {
+  if (!existing) return true;
+  return !isModulePassed(existing);
+}
+
 export function computeStatusFromData(
   input: ComputeStatusInput,
 ): EmployeeFinalStatus {

--- a/artifacts/api-server/src/routes/lms.ts
+++ b/artifacts/api-server/src/routes/lms.ts
@@ -65,6 +65,10 @@ import { requireAuth, requireRole } from "../lib/auth.js";
 import { logAudit } from "../lib/audit.js";
 import { addDays, daysUntil, fireLmsWebhook } from "../lib/lms-helpers.js";
 import { computeEmployeeFinalStatusBatch } from "../lib/lms-status.js";
+import {
+  isModulePassed,
+  canDowngradeToInProgress,
+} from "../lib/lms-status-pure.js";
 import { isEnrollmentTrulyComplete } from "../lib/lms-completion.js";
 import {
   captureRequestMetadata,
@@ -495,12 +499,19 @@ router.post("/module/start", requireAuth, async (req, res) => {
       });
     }
 
+    // Katie-class invariant: viewing a passed module must NOT downgrade
+    // status from 'passed' back to 'in_progress' (which would re-enable the
+    // quiz and let the learner retake an already-passed module). Delegate
+    // the decision to the shared pure helper so the regression test pins
+    // the same predicate the route uses.
+    const existing = progress.find((p) => p.module_id === moduleId);
+    const setInProgress = canDowngradeToInProgress(existing);
     const row = await upsertModuleProgress({
       companyId,
       enrollmentId: enrollment.id,
       moduleId,
       patch: {
-        status: "in_progress",
+        ...(setInProgress ? { status: "in_progress" } : {}),
         started_at: now,
       },
       now,
@@ -1078,13 +1089,23 @@ router.post("/module/acknowledge", requireAuth, async (req, res) => {
       });
     }
 
+    // Maribel-class invariant: if a content-only module is already passed,
+    // preserve the original passed_at timestamp. A second ack (e.g. a learner
+    // reopening the page after passing) should NOT reset the pass date — that
+    // would muddy supersession bookkeeping and audit trails. Status stays
+    // 'passed' either way; this guard just protects the timestamp.
+    const existingAck = progress.find((p) => p.module_id === moduleId);
+    const alreadyPassedAck = existingAck ? isModulePassed(existingAck) : false;
     await upsertModuleProgress({
       companyId,
       enrollmentId: enrollment.id,
       moduleId,
       patch: {
         status: "passed",
-        passed_at: now,
+        passed_at:
+          alreadyPassedAck && existingAck?.passed_at
+            ? existingAck.passed_at
+            : now,
         best_score: 100, // content-only modules count as 100% on ack
       },
       now,

--- a/artifacts/api-server/src/tests/lms-passed-status-clobber.test.ts
+++ b/artifacts/api-server/src/tests/lms-passed-status-clobber.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Regression test for the Katie-class /module/start clobber bug.
+ *
+ * Original bug (2026-05-21 report, learner: Katie):
+ *   - Katie passed Phes Policies quiz (status='passed', best_score=97,
+ *     passed_at='2026-05-20T22:14:55Z', attempts=1).
+ *   - Katie reopened the module the next day to review.
+ *   - Frontend auto-fires `POST /lms/module/start` on view.
+ *   - The route handler unconditionally wrote
+ *     `{ status: 'in_progress', started_at: now }` into the upsert.
+ *   - The defensive SSoT read predicate (`isModulePassed`, which honors
+ *     `best_score >= 80`) still showed her as passed in admin views, but
+ *     the persisted row was clobbered to 'in_progress'.
+ *   - Consequence: the frontend "Resume Quiz" CTA re-opened the quiz UI
+ *     with all answers cleared and let her retake an already-passed
+ *     module. Defeats the whole pass concept.
+ *
+ * Fix: route handler now delegates to `canDowngradeToInProgress` so the
+ * decision is shared with the read path. If the existing row satisfies
+ * `isModulePassed`, the patch OMITS `status` so the upsert preserves the
+ * passed state. If the row is genuinely in-progress / failed / fresh,
+ * the patch includes `status: 'in_progress'` as before.
+ *
+ * Do NOT relax these assertions. If they fail, either the route handler
+ * regressed to unconditional status writes, or the predicate was made
+ * stricter and a Maribel/Katie-pattern row will be silently downgraded.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  canDowngradeToInProgress,
+  isModulePassed,
+} from "../lib/lms-status-pure.js";
+
+describe("canDowngradeToInProgress — /module/start clobber guard", () => {
+  it("returns true when no row exists yet (fresh start)", () => {
+    // First time the learner opens the module — there's no row to
+    // protect. Route handler may write status='in_progress'.
+    assert.equal(
+      canDowngradeToInProgress(undefined),
+      true,
+      "fresh insert path must be allowed to set in_progress",
+    );
+  });
+
+  it("returns true when the row is genuinely in-progress (sub-threshold)", () => {
+    assert.equal(
+      canDowngradeToInProgress({ status: "in_progress", best_score: 60 }),
+      true,
+      "in-progress, score 60 → still allowed to reaffirm in_progress",
+    );
+    assert.equal(
+      canDowngradeToInProgress({ status: "in_progress", best_score: 79 }),
+      true,
+      "one point below threshold → still in-progress",
+    );
+    assert.equal(
+      canDowngradeToInProgress({ status: "not_started", best_score: 0 }),
+      true,
+      "not_started → fresh, allowed",
+    );
+    assert.equal(
+      canDowngradeToInProgress({ status: "failed", best_score: 60 }),
+      true,
+      "failed with sub-threshold score → may resume as in_progress",
+    );
+  });
+
+  it("returns FALSE when status is exactly 'passed' (canonical pass state)", () => {
+    // The clean case — a properly recorded pass. Reopening must not
+    // overwrite this with 'in_progress'.
+    assert.equal(
+      canDowngradeToInProgress({ status: "passed", best_score: 97 }),
+      false,
+      "passed at 97% must not be downgraded by /module/start",
+    );
+    assert.equal(
+      canDowngradeToInProgress({ status: "passed", best_score: 80 }),
+      false,
+      "passed at threshold must not be downgraded",
+    );
+    assert.equal(
+      canDowngradeToInProgress({ status: "passed", best_score: 0 }),
+      false,
+      "grandfather/bypass pass (status=passed, score=0) must not be downgraded",
+    );
+  });
+
+  it("returns FALSE for the Maribel-class lag pattern (status='in_progress' but best_score>=80)", () => {
+    // The defensive predicate covers rows where the recompute migration
+    // hasn't reached the row yet, or an admin retake clobbered status
+    // but the GREATEST() preserved the original best_score. Viewing such
+    // a row must NOT entrench the bad status — it must be left alone so
+    // the recompute can heal it on next cold-start.
+    assert.equal(
+      canDowngradeToInProgress({ status: "in_progress", best_score: 85 }),
+      false,
+      "Maribel pattern: status lagged, best_score didn't — protect it",
+    );
+    assert.equal(
+      canDowngradeToInProgress({ status: "failed", best_score: 100 }),
+      false,
+      "admin retake regressed status to 'failed' but score is 100 → still a pass; do not downgrade",
+    );
+  });
+
+  it("returns FALSE for the exact Katie row pattern from the 2026-05-21 bug report", () => {
+    // Production data state pre-fix:
+    //   id=117, status='in_progress', best_score=97,
+    //   passed_at='2026-05-20T22:14:55Z', attempts=1
+    // She got into this state because she viewed the module after passing.
+    // Even AFTER the fix is shipped, on next cold-start runStatusRecompute
+    // will heal the row to status='passed'. Until then, the route handler
+    // must not deepen the damage by re-writing in_progress on every view.
+    const katieRow = {
+      status: "in_progress",
+      best_score: 97,
+    };
+    assert.equal(
+      isModulePassed(katieRow),
+      true,
+      "Katie row must satisfy the defensive predicate",
+    );
+    assert.equal(
+      canDowngradeToInProgress(katieRow),
+      false,
+      "Katie row must be protected from further /module/start clobbers",
+    );
+  });
+
+  it("agrees with isModulePassed on every case (contract invariant)", () => {
+    // canDowngradeToInProgress = NOT isModulePassed(existing) when existing
+    // is defined. Lock that relationship so a future refactor can't drift
+    // the two predicates.
+    const cases: Array<{ status: string; best_score: number | null }> = [
+      { status: "passed", best_score: 100 },
+      { status: "passed", best_score: 80 },
+      { status: "passed", best_score: 0 },
+      { status: "passed", best_score: null },
+      { status: "in_progress", best_score: 100 },
+      { status: "in_progress", best_score: 80 },
+      { status: "in_progress", best_score: 79 },
+      { status: "in_progress", best_score: 0 },
+      { status: "in_progress", best_score: null },
+      { status: "failed", best_score: 100 },
+      { status: "failed", best_score: 60 },
+      { status: "not_started", best_score: 0 },
+    ];
+    for (const row of cases) {
+      const passed = isModulePassed(row);
+      const canDowngrade = canDowngradeToInProgress(row);
+      assert.equal(
+        canDowngrade,
+        !passed,
+        `contract drift: row=${JSON.stringify(row)} isModulePassed=${passed} canDowngradeToInProgress=${canDowngrade} (expected ${!passed})`,
+      );
+    }
+  });
+});

--- a/artifacts/qleno/src/pages/training.tsx
+++ b/artifacts/qleno/src/pages/training.tsx
@@ -126,6 +126,11 @@ type ModuleProgressRow = {
   status: "not_started" | "in_progress" | "passed" | "failed";
   best_score: number;
   attempts: number;
+  // ISO timestamp set by /quiz/submit when the attempt passed, or by
+  // /module/acknowledge for content-only modules. Optional because
+  // the field is null until a pass is recorded. Used by the
+  // ModuleView completion banner to render "Passed on <date>".
+  passed_at?: string | null;
 };
 
 type LmsState = {
@@ -508,6 +513,23 @@ const T = {
   start_quiz: { en: "Start quiz", es: "Comenzar examen" },
   review_quiz: { en: "Review", es: "Revisar" },
   downloadCert: { en: "Certificate", es: "Certificado" },
+  // Passed-module terminal-state UI (2026-05-21 Katie-class fix).
+  // Passed modules are TERMINAL — no quiz re-entry, no review, no
+  // unlock. The detail screen shows the completion banner + cert
+  // download + a deep-link CTA to the next module.
+  moduleCompleted: { en: "Module completed", es: "Módulo completado" },
+  passedOn: { en: "Passed on", es: "Aprobado el" },
+  bestScoreLabel: { en: "Best score", es: "Mejor puntaje" },
+  continueToNextModule: {
+    en: "Continue to next module",
+    es: "Continuar al siguiente módulo",
+  },
+  allModulesDone: {
+    en: "You've completed every module",
+    es: "Has completado todos los módulos",
+  },
+  returnToTraining: { en: "Return to training", es: "Volver a capacitación" },
+  viewCertificate: { en: "View certificate", es: "Ver certificado" },
 } as const;
 
 function tr(key: keyof typeof T, locale: Locale): string {
@@ -832,39 +854,67 @@ export default function TrainingPage() {
           onDismissRecomputeBanner={dismissRecomputeBanner}
         />
       )}
-      {view.kind === "module" && (
-        <ModuleView
-          module={
-            curriculum.modules.find((m) => m.id === view.moduleId) ??
-            curriculum.modules[0]
-          }
-          locale={locale}
-          isQuizModule={
-            QUIZ_MODULE_IDS.includes(view.moduleId as never)
-          }
-          progress={state.progress.find((p) => p.module_id === view.moduleId) ?? null}
-          isOwner={!!state.is_owner}
-          onBack={() => setView({ kind: "home" })}
-          onTakeQuiz={() => setView({ kind: "quiz", moduleId: view.moduleId })}
-          onAcknowledge={async () => {
-            await lmsApi.acknowledge(token, view.moduleId);
-            await refresh();
-            setView({ kind: "home" });
-          }}
-          onBypass={async () => {
-            await lmsApi.bypassModule(token, view.moduleId);
-            await refresh();
-            setView({ kind: "home" });
-          }}
-          onStart={async () => {
-            try {
-              await lmsApi.startModule(token, view.moduleId);
-            } catch {
-              /* idempotent — ignore conflict */
+      {view.kind === "module" && (() => {
+        // Deep-link target for "Continue to next module" CTA shown on
+        // passed modules. Walks the curriculum in its canonical order
+        // and picks the first downstream module the learner hasn't
+        // passed yet. If every quiz module is passed, returns null so
+        // the CTA falls back to "Return to training" (which still
+        // routes home where the final test + ack tiles live).
+        const currentModuleId = view.moduleId;
+        const orderedIds = curriculum.modules.map((m) => m.id);
+        const startIdx = orderedIds.indexOf(currentModuleId);
+        const nextModuleId =
+          orderedIds
+            .slice(startIdx + 1)
+            .find((id) => !completedIds.includes(id)) ??
+          orderedIds.find(
+            (id) => id !== currentModuleId && !completedIds.includes(id),
+          ) ??
+          null;
+        return (
+          <ModuleView
+            module={
+              curriculum.modules.find((m) => m.id === currentModuleId) ??
+              curriculum.modules[0]
             }
-          }}
-        />
-      )}
+            locale={locale}
+            isQuizModule={
+              QUIZ_MODULE_IDS.includes(currentModuleId as never)
+            }
+            progress={
+              state.progress.find((p) => p.module_id === currentModuleId) ?? null
+            }
+            isOwner={!!state.is_owner}
+            certId={certByModule[currentModuleId]}
+            nextModuleId={nextModuleId}
+            onBack={() => setView({ kind: "home" })}
+            onTakeQuiz={() =>
+              setView({ kind: "quiz", moduleId: currentModuleId })
+            }
+            onAcknowledge={async () => {
+              await lmsApi.acknowledge(token, currentModuleId);
+              await refresh();
+              setView({ kind: "home" });
+            }}
+            onBypass={async () => {
+              await lmsApi.bypassModule(token, currentModuleId);
+              await refresh();
+              setView({ kind: "home" });
+            }}
+            onStart={async () => {
+              try {
+                await lmsApi.startModule(token, currentModuleId);
+              } catch {
+                /* idempotent — ignore conflict */
+              }
+            }}
+            onDownloadCert={(certId) => downloadCertificatePdf(token, certId)}
+            onOpenModule={(id) => setView({ kind: "module", moduleId: id })}
+            onReturnHome={() => setView({ kind: "home" })}
+          />
+        );
+      })()}
       {view.kind === "quiz" && (
         <QuizView
           curriculum={curriculum}
@@ -2420,39 +2470,75 @@ function ModuleView({
   isQuizModule,
   progress,
   isOwner,
+  certId,
+  nextModuleId,
   onBack,
   onTakeQuiz,
   onAcknowledge,
   onBypass,
   onStart,
+  onDownloadCert,
+  onOpenModule,
+  onReturnHome,
 }: {
   module: Module;
   locale: Locale;
   isQuizModule: boolean;
   progress: ModuleProgressRow | null;
   isOwner: boolean;
+  certId?: number;
+  nextModuleId: string | null;
   onBack: () => void;
   onTakeQuiz: () => void;
   onAcknowledge: () => void;
   onBypass: () => void;
   onStart: () => void;
+  onDownloadCert: (certId: number) => Promise<void>;
+  onOpenModule: (moduleId: string) => void;
+  onReturnHome: () => void;
 }) {
   const attempts = progress?.attempts ?? 0;
   const maxAttempts = MAX_MODULE_ATTEMPTS;
   const status = progress?.status ?? "not_started";
-  const atCap = isQuizModule && status !== "passed" && attempts >= maxAttempts;
+  // Katie-class invariant (2026-05-21): a passed module is TERMINAL.
+  // - SSoT predicate matches the backend (`status === 'passed'` OR
+  //   `best_score >= 80`) so a Maribel-pattern row with status lag
+  //   still renders the completion banner instead of the quiz CTA.
+  // - The quiz UI is fully disallowed on passed modules — no Review,
+  //   no Resume, no Retry. The completion banner replaces the bottom
+  //   CTA group.
+  const bestScore = progress?.best_score ?? 0;
+  const isPassed = status === "passed" || bestScore >= 80;
+  const atCap = isQuizModule && !isPassed && attempts >= maxAttempts;
   const quizCta =
-    status === "passed"
-      ? tr("review_quiz", locale)
-      : status === "failed"
+    status === "failed"
       ? tr("retry_quiz", locale)
       : status === "in_progress" && attempts > 0
       ? tr("resume_quiz", locale)
       : tr("start_quiz", locale);
   useEffect(() => {
+    // Katie-class fix: do NOT auto-fire /module/start when the module
+    // is already passed. Even with the backend guard in place, skipping
+    // the call here keeps the network quiet and makes the frontend
+    // contract obvious: passed = terminal, no reopen.
+    if (isPassed) return;
     onStart();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [m.id]);
+  }, [m.id, isPassed]);
+  const passedAtLabel = (() => {
+    const raw = progress?.passed_at;
+    if (!raw) return null;
+    try {
+      const d = new Date(raw);
+      return d.toLocaleDateString(locale === "es" ? "es-US" : "en-US", {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+      });
+    } catch {
+      return null;
+    }
+  })();
   return (
     <div style={{ maxWidth: 720, margin: "0 auto", padding: "20px 18px" }}>
       <BackLink label={tr("back", locale)} onClick={onBack} />
@@ -2487,7 +2573,9 @@ function ModuleView({
         {m.blocks.map((b, i) => (
           <Block key={i} block={b} locale={locale} />
         ))}
-        {isQuizModule && shouldShowLearnerGating(isOwner) ? (
+        {/* Attempt counter strip — hidden on passed modules (no more
+            attempts to track once you've passed). */}
+        {isQuizModule && !isPassed && shouldShowLearnerGating(isOwner) ? (
           <div
             style={{
               marginTop: 18,
@@ -2518,35 +2606,119 @@ function ModuleView({
             </span>
           </div>
         ) : null}
-        <div
-          style={{
-            marginTop: 22,
-            display: "flex",
-            gap: 10,
-            justifyContent: "flex-end",
-            flexWrap: "wrap",
-          }}
-        >
-          {isOwner && status !== "passed" ? (
-            <SecondaryButton onClick={onBypass}>
-              <FastForward size={14} /> {tr("bypassOwner", locale)}
-            </SecondaryButton>
-          ) : null}
-          {isQuizModule ? (
-            <PrimaryButton
-              onClick={onTakeQuiz}
-              disabled={atCap && !isOwner}
+        {isPassed ? (
+          // ─ Passed = terminal completion banner ─
+          // Replaces the quiz CTA group entirely. Shows:
+          //   - "Module completed" + checkmark
+          //   - Best score + passed-on date
+          //   - "View certificate" (when a cert exists)
+          //   - "Continue to next module" (deep-link to first unpassed
+          //     downstream module), or "Return to training" if every
+          //     module is done.
+          // Owner Skip-button stays hidden (status === passed).
+          <div
+            style={{
+              marginTop: 22,
+              background: "#ECFDF5",
+              border: `1px solid #A7F3D0`,
+              borderLeft: `3px solid ${SUCCESS}`,
+              borderRadius: 8,
+              padding: "14px 16px",
+            }}
+          >
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+                color: SUCCESS,
+                fontWeight: 800,
+                fontSize: 14,
+              }}
             >
-              {quizCta}
-              <ChevronRight size={14} style={{ marginLeft: 4 }} />
-            </PrimaryButton>
-          ) : (
-            <PrimaryButton onClick={onAcknowledge}>
-              {tr("acknowledge", locale)}
-              <Check size={14} style={{ marginLeft: 4 }} />
-            </PrimaryButton>
-          )}
-        </div>
+              <CircleCheck size={18} />
+              {tr("moduleCompleted", locale)}
+            </div>
+            <div
+              style={{
+                marginTop: 6,
+                fontSize: 12,
+                color: INK_MUTE,
+                fontWeight: 700,
+              }}
+            >
+              {bestScore > 0
+                ? `${tr("bestScoreLabel", locale)}: ${bestScore}%`
+                : null}
+              {bestScore > 0 && passedAtLabel ? " · " : null}
+              {passedAtLabel
+                ? `${tr("passedOn", locale)} ${passedAtLabel}`
+                : null}
+            </div>
+            <div
+              style={{
+                marginTop: 14,
+                display: "flex",
+                gap: 10,
+                justifyContent: "flex-end",
+                flexWrap: "wrap",
+              }}
+            >
+              {certId ? (
+                <SecondaryButton
+                  onClick={() =>
+                    onDownloadCert(certId).catch((err) =>
+                      console.error("[training] download cert failed:", err),
+                    )
+                  }
+                >
+                  <Download size={14} /> {tr("viewCertificate", locale)}
+                </SecondaryButton>
+              ) : null}
+              {nextModuleId ? (
+                <PrimaryButton onClick={() => onOpenModule(nextModuleId)}>
+                  {tr("continueToNextModule", locale)}
+                  <ChevronRight size={14} style={{ marginLeft: 4 }} />
+                </PrimaryButton>
+              ) : (
+                <PrimaryButton onClick={onReturnHome}>
+                  {tr("returnToTraining", locale)}
+                  <ChevronRight size={14} style={{ marginLeft: 4 }} />
+                </PrimaryButton>
+              )}
+            </div>
+          </div>
+        ) : (
+          <div
+            style={{
+              marginTop: 22,
+              display: "flex",
+              gap: 10,
+              justifyContent: "flex-end",
+              flexWrap: "wrap",
+            }}
+          >
+            {isOwner ? (
+              <SecondaryButton onClick={onBypass}>
+                <FastForward size={14} /> {tr("bypassOwner", locale)}
+              </SecondaryButton>
+            ) : null}
+            {isQuizModule ? (
+              <PrimaryButton
+                onClick={onTakeQuiz}
+                disabled={atCap && !isOwner}
+              >
+                {quizCta}
+                <ChevronRight size={14} style={{ marginLeft: 4 }} />
+              </PrimaryButton>
+            ) : (
+              <PrimaryButton onClick={onAcknowledge}>
+                {tr("acknowledge", locale)}
+                <Check size={14} style={{ marginLeft: 4 }} />
+              </PrimaryButton>
+            )}
+          </div>
+        )}
       </article>
     </div>
   );


### PR DESCRIPTION
## Summary

Bundled fix for the Katie-class bug (2026-05-21 report) where reopening a passed module clobbered its status back to in_progress and let the learner retake an already-passed quiz.

- **Fix A (backend):** /module/start now delegates the in-progress write to a new pure helper canDowngradeToInProgress(existing). If the row satisfies isModulePassed (same predicate the SSoT uses), the patch omits status so passed rows stay passed.
- **Fix A' (backend):** /module/acknowledge preserves the original passed_at when a content-only module is re-acknowledged.
- **Fix B (data):** no new migration needed. Existing runStatusRecompute cold-start matches Katie's row pattern (Phes + non-sandbox + best_score>=80 + status!='passed') and heals it on next deploy.
- **Fix C (regression test):** lms-passed-status-clobber.test.ts pins the new helper + its contract with isModulePassed so a future refactor cannot drift the two predicates.
- **Fix UX (frontend):** passed = TERMINAL. ModuleView skips the auto-fire onStart() for passed modules, replaces the bottom CTA group with a green Module completed banner (best score + passed-on date + View certificate + Continue to next module deep-link, fallback Return to training when every module is done). Quiz UI fully disallowed on passed modules.

## Test plan
- [x] pnpm test:lms — 330/330 LMS tests pass, including the 6 new canDowngradeToInProgress subtests
- [x] tsc --noEmit clean on touched files (3 pre-existing IconKind errors in training.tsx are unrelated; pre-existing lms.ts:1338 last_login_at error is unrelated)
- [ ] After merge + Railway deploy: verify Katie's row 117 normalizes to status='passed' via cold-start runStatusRecompute migration
- [ ] After deploy: node scripts/verify-b1-b6.mjs drift count = 0
- [ ] Smoke: open Katie's passed Phes Policies module, confirm green completion banner shows (no quiz CTA), Continue to next module deep-links correctly

Generated with Claude Code