### PR TITLE
fix: disambiguate mileage reimbursement quiz questions in Compensation module

### DIFF
--- a/artifacts/api-server/src/tests/lms-curriculum.test.ts
+++ b/artifacts/api-server/src/tests/lms-curriculum.test.ts
@@ -101,7 +101,7 @@ describe("LMS curriculum — constants & catalog shape", () => {
 
   it("each non-policies module has its specified question count", () => {
     // phes-policies: 41 (40 baseline + parking 2026-05-22)
-    // compensation: 17 (16 baseline + training-redo-paid 2026-05-22)
+    // compensation: 18 (17 + fix-it-mileage 2026-05-22)
     // drug-alcohol: 10 (Phase 3 spec, legally-important concepts only)
     // code-of-conduct: 10 (Phase 4 spec, behavior-comprehension)
     // video-photo-release: 9 (Phase 5 spec, release-rights comprehension)
@@ -119,7 +119,7 @@ describe("LMS curriculum — constants & catalog shape", () => {
       "social-media": 10,
       "phes-401k": 10,
       "supply-kit": 10,
-      compensation: 17,
+      compensation: 18,
       "cleaning-best-practices": 15,
       maidcentral: 15,
       "products-tools": 15,
@@ -134,8 +134,8 @@ describe("LMS curriculum — constants & catalog shape", () => {
     }
   });
 
-  it("ALL_QUESTION_IDS is 190 total (41 + 17 + 15*4 + 10 + 10 + 9 + 13 + 10 + 10 + 10)", () => {
-    assert.equal(ALL_QUESTION_IDS.length, 190);
+  it("ALL_QUESTION_IDS is 191 total (41 + 18 + 15*4 + 10 + 10 + 9 + 13 + 10 + 10 + 10)", () => {
+    assert.equal(ALL_QUESTION_IDS.length, 191);
   });
 
   it("ANSWER_KEY has exactly the keys enumerated by ALL_QUESTION_IDS", () => {
@@ -274,10 +274,10 @@ describe("scoreQuiz", () => {
   });
 
   it("respects a custom threshold (lower bar passes more)", () => {
-    const qids: string[] = [...QUESTIONS_BY_MODULE["compensation"]]; // 17 questions
-    // 9 correct of 17 = 53%
+    const qids: string[] = [...QUESTIONS_BY_MODULE["compensation"]]; // 18 questions
+    // 10 correct of 18 = 56%
     const answers: number[] = qids.map((q: string, i: number) =>
-      i < 9 ? ANSWER_KEY[q] : 99,
+      i < 10 ? ANSWER_KEY[q] : 99,
     );
     const fail = scoreQuiz(answers, qids); // default 0.80
     const pass = scoreQuiz(answers, qids, 0.5); // 50% threshold

--- a/artifacts/qleno/src/lib/training/curriculum.ts
+++ b/artifacts/qleno/src/lib/training/curriculum.ts
@@ -3960,14 +3960,17 @@ const BASE_QUIZ: QuizQuestion[] = [
   {
     id: "q-cm-14-mileage",
     moduleId: "compensation",
-    prompt: { en: "Which of these is NOT covered by mileage reimbursement?", es: "¿Cuál de estos NO está cubierto por el reembolso de millaje?" },
+    prompt: {
+      en: "Which of the following drives IS reimbursed by Phes under the current mileage policy?",
+      es: "¿Cuál de los siguientes manejos SÍ es reembolsado por Phes bajo la política actual de millaje?",
+    },
     options: [
-      { en: "Driving from Client A's home to Client B's home", es: "Manejar de la casa del Cliente A a la del B" },
-      { en: "Driving back to the office mid-day to swap supplies", es: "Manejar a la oficina a media-tarde para cambiar suministros" },
-      { en: "Driving from your home to your first job of the day (commute)", es: "Manejar de su casa al primer trabajo del día (trayecto)" },
-      { en: "Driving to a Fix-It call", es: "Manejar a una llamada Fix-It" },
+      { en: "Driving from Client A's home directly to Client B's home on the same workday.", es: "Manejar de la casa del Cliente A directamente a la casa del Cliente B el mismo día laboral." },
+      { en: "Driving from your personal home to your first scheduled job of the day in the morning.", es: "Manejar de su casa personal a su primer trabajo programado del día en la mañana." },
+      { en: "Driving from your last scheduled job of the day back to your own personal home address.", es: "Manejar de su último trabajo programado del día de regreso a su propia casa personal." },
+      { en: "Driving to the Phes office to pick up supplies before your first scheduled client job.", es: "Manejar a la oficina de Phes a recoger suministros antes de su primer trabajo programado." },
     ],
-    correctIndex: 2,
+    correctIndex: 0,
   },
   {
     id: "q-cm-15-payroll-cycle",
@@ -4055,6 +4058,21 @@ const BASE_QUIZ: QuizQuestion[] = [
       { en: "You are charged a flat $50 deduction from next paycheck for the callback visit.", es: "Se le cobra una deducción fija de $50 de su próximo pago por la visita de regreso." },
     ],
     correctIndex: 1,
+  },
+  {
+    id: "q-cm-21-fix-it-mileage",
+    moduleId: "compensation",
+    prompt: {
+      en: "You finish a job at Client A's home and then drive directly to Client B's home for a scheduled Fix-It call. Is the mileage reimbursable?",
+      es: "Termina un trabajo en la casa del Cliente A y luego maneja directamente a la casa del Cliente B para una llamada Fix-It programada. ¿Es reembolsable el millaje?",
+    },
+    options: [
+      { en: "Yes. The drive from Client A's home to Client B's home is between two client locations on the same workday, so it qualifies for mileage reimbursement at $0.725 per mile.", es: "Sí. El manejo de la casa del Cliente A a la del Cliente B es entre dos ubicaciones de clientes el mismo día laboral, así que califica para reembolso de millaje a $0.725 por milla." },
+      { en: "No. Fix-It re-clean visits are never reimbursable for mileage no matter where the original job was located or when the visit got scheduled by the office.", es: "No. Las visitas Fix-It de re-limpieza nunca son reembolsables por millaje sin importar dónde estuviera el trabajo original o cuándo la oficina programó la visita." },
+      { en: "Yes, but only at half of the standard mileage rate because Fix-It calls fall under a separate Quality Verification compensation category at Phes.", es: "Sí, pero solo a la mitad de la tarifa estándar de millaje porque las llamadas Fix-It caen en una categoría separada de Verificación de Calidad en Phes." },
+      { en: "No. Phes mileage reimbursement only covers original scheduled visits, not Fix-It re-clean visits, which are part of the original commission already earned on that job.", es: "No. El reembolso de millaje de Phes solo cubre las visitas programadas originales, no las visitas Fix-It de re-limpieza, que son parte de la comisión original ya ganada." },
+    ],
+    correctIndex: 0,
   },
 
   // ═════════════════════════════════════════════════════════════════════════════

--- a/lib/lms-curriculum/src/index.ts
+++ b/lib/lms-curriculum/src/index.ts
@@ -320,13 +320,14 @@ export const ANSWER_KEY: Readonly<Record<string, number>> = Object.freeze({
   "q-cm-11-fixit": 0,
   "q-cm-12-quality-probation": 1,
   "q-cm-13-probation-pay": 1,
-  "q-cm-14-mileage": 2,
+  "q-cm-14-mileage": 0,
   "q-cm-15-payroll-cycle": 0,
   "q-cm-16-allowed-hours-math": 1,
   "q-cm-17-recovery-tech-three-hour": 1,
   "q-cm-18-valid-quality-complaint": 1,
   "q-cm-19-refused-reclean-eighteen": 1,
   "q-cm-20-training-redo-paid": 1,
+  "q-cm-21-fix-it-mileage": 0,
 
   // ── Module 3: cleaning-best-practices (15) ───────────────────────────────
   "q-cb-01-room-flow": 1,
@@ -579,6 +580,8 @@ export const QUESTIONS_BY_MODULE: Readonly<Record<QuizModuleId, readonly string[
       "q-cm-19-refused-reclean-eighteen",
       // Training-period paid-redo window (2026-05-22)
       "q-cm-20-training-redo-paid",
+      // Mileage disambiguation + Fix-It mileage (2026-05-22)
+      "q-cm-21-fix-it-mileage",
     ],
     "cleaning-best-practices": [
       "q-cb-01-room-flow", "q-cb-02-room-order", "q-cb-03-direction",

--- a/lib/training/src/answer-key.ts
+++ b/lib/training/src/answer-key.ts
@@ -82,13 +82,14 @@ export const SERVER_ANSWER_KEY: Readonly<Record<string, number>> = Object.freeze
   "q-cm-11-fixit": 0,
   "q-cm-12-quality-probation": 1,
   "q-cm-13-probation-pay": 1,
-  "q-cm-14-mileage": 2,
+  "q-cm-14-mileage": 0,
   "q-cm-15-payroll-cycle": 0,
   "q-cm-16-allowed-hours-math": 1,
   "q-cm-17-recovery-tech-three-hour": 1,
   "q-cm-18-valid-quality-complaint": 1,
   "q-cm-19-refused-reclean-eighteen": 1,
   "q-cm-20-training-redo-paid": 1,
+  "q-cm-21-fix-it-mileage": 0,
 
   // ── Module 3: cleaning-best-practices ────────────────────────────────────
   "q-cb-01-room-flow": 1,


### PR DESCRIPTION
## Why

`q-cm-14-mileage` asked which drive is NOT covered by mileage reimbursement and had two distractors that both qualify as not reimbursed under current policy:
- "Driving back to the office mid-day to swap supplies" — detour to office is not reimbursed
- "Driving from your home to your first job of the day (commute)" — commute is not reimbursed

Either was a defensible answer, so the question had no single correct response.

## What changed

### `q-cm-14-mileage` — inverted

**Before:**
> Which of these is NOT covered by mileage reimbursement?
> 0. Driving from Client A's home to Client B's home
> 1. Driving back to the office mid-day to swap supplies
> 2. **Driving from your home to your first job of the day (commute)** ← correct
> 3. Driving to a Fix-It call

**After:**
> Which of the following drives IS reimbursed by Phes under the current mileage policy?
> 0. **Driving from Client A's home directly to Client B's home on the same workday.** ← correct
> 1. Driving from your personal home to your first scheduled job of the day in the morning.
> 2. Driving from your last scheduled job of the day back to your own personal home address.
> 3. Driving to the Phes office to pick up supplies before your first scheduled client job.

Single correct answer; three clearly non-reimbursable distractors. correctIndex changed from 2 → 0; both answer keys updated.

### `q-cm-21-fix-it-mileage` — new

> You finish a job at Client A's home and then drive directly to Client B's home for a scheduled Fix-It call. Is the mileage reimbursable?
> 0. **Yes. The drive from Client A's home to Client B's home is between two client locations on the same workday, so it qualifies for mileage reimbursement at $0.725 per mile.** ← correct
> 1. No. Fix-It re-clean visits are never reimbursable for mileage no matter where the original job was located or when the visit got scheduled by the office.
> 2. Yes, but only at half of the standard mileage rate because Fix-It calls fall under a separate Quality Verification compensation category at Phes.
> 3. No. Phes mileage reimbursement only covers original scheduled visits, not Fix-It re-clean visits, which are part of the original commission already earned on that job.

Tests that the client-to-client rule applies regardless of whether the destination is an original visit or a Fix-It re-clean.

### ⚠️ Count discrepancy — needs your call

Spec says Module 2 should be exactly 15 questions ("if this brings the total above 15, drop the lowest-value existing question"). Reality:

| Version | Count | Source |
|---|---|---|
| Pre-2026-05-21 | 15 | Original spec |
| Post-2026-05-21 alignment | 16 | Dropped q-cm-04/06/10 (legal-fragile); added q-cm-17/18/19 (legal hardening) |
| Post-PR #156 | 17 | Added q-cm-20-training-redo-paid (your 3-week paid-redo policy) |
| **This PR** | **18** | + q-cm-21-fix-it-mileage |

To hit 15 I'd need to delete 3 existing questions. Each of the existing 17 covers a distinct policy point — none feels obviously "lowest value" to me. **I did not drop anything.** Tell me which 3 to drop (or whether to keep at 18) and I'll push a follow-up commit.

If forced to recommend, my candidates would be:
1. `q-cm-05-comm-split-200` — 50/50 equal-split math; somewhat redundant with `q-cm-07-clock-in-difference` which covers the more nuanced proportional split
2. `q-cm-16-allowed-hours-math` — 32% of $320 math drill; the rule is already covered by `q-cm-03-deep-clean-rate`
3. `q-cm-11-fixit` — original-tech re-clean unpaid; partially overlaps with `q-cm-17-recovery-tech-three-hour` and `q-cm-19-refused-reclean-eighteen`

But all three are defensible as standalone questions. Your call.

## Verification

- `pnpm exec tsx --test src/tests/lms-curriculum.test.ts src/tests/lms-drift-sync.test.ts` → 57/57 pass (drift-sync clean; compensation count 17 → 18; `ALL_QUESTION_IDS` 190 → 191)
- Length audit: 0 biased questions across all 13 modules

## Test plan

- [ ] Take Module 2 quiz on production
- [ ] Verify `q-cm-14-mileage` grades correct answer as the client-to-client option
- [ ] Verify `q-cm-21-fix-it-mileage` grades correct answer as the Yes-reimbursed option
- [ ] Spot-check Spanish rendering on both
- [ ] Decide count target: keep at 18 or specify which 3 to drop

Holding merge per your sequential-cadence instruction — will not merge until you verify on production.

https://claude.ai/code/session_01AxGiirnJ3dT4GAzHPNWhrx

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxGiirnJ3dT4GAzHPNWhrx)_