### PR TITLE
feat(lms): per-question quiz review on pass and fail + post-pass retake

### DIFF
--- a/artifacts/api-server/src/routes/lms.ts
+++ b/artifacts/api-server/src/routes/lms.ts
@@ -830,23 +830,16 @@ router.post("/quiz/submit", requireAuth, async (req, res) => {
       );
     const liveAttemptsCount = liveAttemptsRows.length;
     const existing = progress.find((p) => p.module_id === moduleId);
-    const alreadyPassed = existing?.status === "passed";
-    // Item 11 (onboarding-readiness sprint 2026-05-15): once passed,
-    // the quiz is locked. Prevents the Pass → Fail → Pass overwrite
-    // that surfaced in Jose's audit. Owner / admin retains the
-    // existing bypass-module path for legitimate overrides; this gate
-    // only fires for the learner-driven re-attempt path.
-    if (alreadyPassed && !canBypassCap) {
-      return res.status(403).json({
-        error: "Forbidden",
-        message:
-          "This module is already passed. Ask your admin to reset the module if you want to retake it.",
-        attempts_used: liveAttemptsCount,
-        already_passed: true,
-      });
-    }
+    // 2026-05-22: learner-requested review-and-retake flow. Once passed,
+    // the module is no longer locked — learners may retake for learning
+    // value. The Pass → Fail → Pass overwrite that surfaced in Jose's
+    // audit (Item 11, 2026-05-15) is now prevented by the stayPassed +
+    // best_score logic below: once a learner has passed, status stays
+    // 'passed' and best_score never goes down, regardless of how the
+    // subsequent attempt scored. Retakes still count toward the
+    // maxAttempts cap.
     const maxAttempts = maxAttemptsFor(moduleId);
-    if (!canBypassCap && !alreadyPassed && liveAttemptsCount >= maxAttempts) {
+    if (!canBypassCap && liveAttemptsCount >= maxAttempts) {
       return res.status(403).json({
         error: "Forbidden",
         message:

--- a/artifacts/qleno/src/pages/training.tsx
+++ b/artifacts/qleno/src/pages/training.tsx
@@ -3057,27 +3057,34 @@ function QuizView({
     // 2026-05-19 (Pattern 2 — corporate compliance standard): build the
     // "questions you missed" breakdown for the fail screen. Shows the
     // prompt + the learner's selection but NOT the correct answer.
-    // Preserves assessment integrity across retries. Final Mixed Test
-    // omits perQuestion on purpose (question-bank leakage prevention),
-    // so the breakdown is empty in that case.
-    const wrongQuestions: Array<{
+    // 2026-05-22: per Sal, both pass AND fail show the full per-question
+    // review — every prompt, what the learner selected, what was correct,
+    // and a green/red indicator. Final Mixed Test still omits perQuestion
+    // (question-bank leakage prevention), so the breakdown is empty for
+    // the final.
+    const perQuestionReview: Array<{
       index: number;
       prompt: string;
       selected: string | null;
+      correct: string | null;
+      isCorrect: boolean;
     }> = [];
-    if (!result.passed && result.perQuestion) {
+    if (result.perQuestion) {
       result.perQuestion.forEach((ok, i) => {
-        if (ok) return;
         const q = questions[i];
         if (!q) return;
         const selectedIdx = answers[i];
-        wrongQuestions.push({
+        perQuestionReview.push({
           index: i + 1,
           prompt: q.prompt[locale],
           selected:
             selectedIdx != null && q.options[selectedIdx]
               ? q.options[selectedIdx][locale]
               : null,
+          correct: q.options[q.correctIndex]
+            ? q.options[q.correctIndex][locale]
+            : null,
+          isCorrect: ok,
         });
       });
     }
@@ -3089,8 +3096,16 @@ function QuizView({
         maxAttempts={result.max_attempts ?? maxAttempts}
         passThreshold={PASS_THRESHOLD_PCT}
         isOwner={isOwner}
-        wrongQuestions={wrongQuestions}
+        perQuestionReview={perQuestionReview}
         onBackHome={onCancel}
+        onRetake={() => {
+          // Reset client-side state for a fresh attempt. The server
+          // no longer blocks retake-after-pass; stayPassed + best_score
+          // GREATEST() preserve the pass record on lower-scoring retakes.
+          setAnswers(new Array(questionIds.length).fill(null));
+          setCursor(0);
+          setResult(null);
+        }}
         onContinue={async () => {
           if (result.passed) {
             await onPassed();
@@ -3399,8 +3414,9 @@ function ResultView({
   maxAttempts,
   passThreshold,
   isOwner,
-  wrongQuestions,
+  perQuestionReview,
   onContinue,
+  onRetake,
   onBackHome,
 }: {
   locale: Locale;
@@ -3410,18 +3426,21 @@ function ResultView({
   passThreshold: number;
   isOwner: boolean;
   /**
-   * 2026-05-19 (Pattern 2): on a failed per-module quiz, the list of
-   * questions the learner missed. Each entry shows the prompt + the
-   * learner's selected option, NOT the correct answer. This preserves
-   * assessment integrity across retake attempts. Empty for the Final
-   * Mixed Test (which omits perQuestion on purpose).
+   * 2026-05-22 (Sal): the full per-question review — every question
+   * with prompt, learner's selection, the correct option, and a
+   * green/red indicator. Shown on BOTH pass and fail so employees can
+   * learn from what they got right and wrong. Final Mixed Test omits
+   * perQuestion on purpose so this is empty for the final.
    */
-  wrongQuestions?: Array<{
+  perQuestionReview?: Array<{
     index: number;
     prompt: string;
     selected: string | null;
+    correct: string | null;
+    isCorrect: boolean;
   }>;
   onContinue: () => void;
+  onRetake: () => void;
   onBackHome: () => void | Promise<void>;
 }) {
   const { passed, score } = result;
@@ -3432,7 +3451,7 @@ function ResultView({
   return (
     <div
       style={{
-        maxWidth: !passed && wrongQuestions && wrongQuestions.length > 0 ? 600 : 480,
+        maxWidth: perQuestionReview && perQuestionReview.length > 0 ? 640 : 480,
         margin: "60px auto",
         padding: 18,
       }}
@@ -3473,11 +3492,12 @@ function ResultView({
                 }/${maxAttempts} ${tr("attemptsUsed", locale)})`}
           </div>
         ) : null}
-        {/* Pattern 2 (corporate compliance standard): on fail, surface
-            the prompts the learner missed + their selection so they
-            know what to re-read. Correct answer is NOT shown — keeps
-            the assessment honest across retries. */}
-        {!passed && wrongQuestions && wrongQuestions.length > 0 ? (
+        {/* 2026-05-22 (Sal): full per-question review — green for correct,
+            red for wrong, learner's selection shown, correct answer
+            revealed for wrong ones so the learner knows what they should
+            have picked. Shown on BOTH pass and fail. Final test still
+            hides this because perQuestion is omitted there on purpose. */}
+        {perQuestionReview && perQuestionReview.length > 0 ? (
           <div
             style={{
               marginTop: 18,
@@ -3496,9 +3516,13 @@ function ResultView({
                 marginBottom: 10,
               }}
             >
-              {locale === "es"
-                ? `Preguntas que necesita revisar (${wrongQuestions.length})`
-                : `Questions to review (${wrongQuestions.length})`}
+              {(() => {
+                const correctCount = perQuestionReview.filter((r) => r.isCorrect).length;
+                const total = perQuestionReview.length;
+                return locale === "es"
+                  ? `Revisión por pregunta (${correctCount} de ${total} correctas)`
+                  : `Question-by-question review (${correctCount} of ${total} correct)`;
+              })()}
             </div>
             <ul
               style={{
@@ -3510,49 +3534,63 @@ function ResultView({
                 gap: 12,
               }}
             >
-              {wrongQuestions.map((wq) => (
+              {perQuestionReview.map((r) => (
                 <li
-                  key={wq.index}
+                  key={r.index}
                   style={{
                     fontSize: 12.5,
                     color: INK,
                     lineHeight: 1.45,
+                    paddingLeft: 22,
+                    position: "relative",
                   }}
                 >
+                  <span
+                    style={{
+                      position: "absolute",
+                      left: 0,
+                      top: 1,
+                      color: r.isCorrect ? SUCCESS : DANGER,
+                      fontWeight: 800,
+                    }}
+                    aria-hidden="true"
+                  >
+                    {r.isCorrect ? "✓" : "✗"}
+                  </span>
                   <div style={{ fontWeight: 700, marginBottom: 3 }}>
-                    {locale === "es" ? "Pregunta" : "Question"} {wq.index}.{" "}
-                    {wq.prompt}
+                    {locale === "es" ? "Pregunta" : "Question"} {r.index}.{" "}
+                    {r.prompt}
                   </div>
-                  {wq.selected != null ? (
+                  {r.selected != null ? (
                     <div
                       style={{
-                        color: DANGER,
+                        color: r.isCorrect ? SUCCESS : DANGER,
                         fontSize: 12,
                       }}
                     >
                       {locale === "es" ? "Su respuesta: " : "Your answer: "}
-                      {wq.selected}
+                      {r.selected}
                     </div>
                   ) : (
                     <div style={{ color: INK_MUTE, fontSize: 12, fontStyle: "italic" }}>
                       {locale === "es" ? "Sin respuesta seleccionada" : "No answer selected"}
                     </div>
                   )}
+                  {!r.isCorrect && r.correct != null ? (
+                    <div
+                      style={{
+                        color: SUCCESS,
+                        fontSize: 12,
+                        marginTop: 2,
+                      }}
+                    >
+                      {locale === "es" ? "Respuesta correcta: " : "Correct answer: "}
+                      {r.correct}
+                    </div>
+                  ) : null}
                 </li>
               ))}
             </ul>
-            <div
-              style={{
-                marginTop: 12,
-                fontSize: 11.5,
-                color: INK_MUTE,
-                fontStyle: "italic",
-              }}
-            >
-              {locale === "es"
-                ? "Revise la sección correspondiente del módulo antes de volver a intentarlo."
-                : "Review the relevant section of the module before retrying."}
-            </div>
           </div>
         ) : null}
         <div
@@ -3564,17 +3602,22 @@ function ResultView({
             flexWrap: "wrap",
           }}
         >
-          {/* Sal report 2026-05-19: previously the fail screen had only
-              "Try again" — no way to leave the quiz without retrying.
-              Now we always show a secondary "Back to home" alongside the
-              primary CTA, except on pass (Continue navigates forward
-              naturally). */}
-          {!passed ? (
+          {/* 2026-05-22 (Sal): retake is always offered, on pass and on
+              fail. On pass the primary CTA stays "Next" (continue to the
+              next module); on fail the primary stays "Try again" when
+              retries remain. The "Back to home" secondary is also kept
+              everywhere except after a no-retries-left fail. */}
+          {!passed && !noMoreRetries ? (
             <SecondaryButton onClick={() => { void onBackHome(); }}>
               {tr("back", locale)}
             </SecondaryButton>
           ) : null}
-          <PrimaryButton onClick={onContinue}>
+          {passed && attemptsRemaining > 0 ? (
+            <SecondaryButton onClick={onRetake}>
+              {tr("retry", locale)}
+            </SecondaryButton>
+          ) : null}
+          <PrimaryButton onClick={passed ? onContinue : onContinue}>
             {passed
               ? tr("next", locale)
               : noMoreRetries


### PR DESCRIPTION
## Why

You asked: "regardless of pass or fail, I would like the employees to see what questions they got correct and what questions they got wrong then being prompt to retake the test again I am OK with that. Please also add this to all of the modules."

Before this PR:
- On a **passed** quiz, the learner saw only the score + Next button. No breakdown.
- On a **failed** quiz, they saw a "Questions to review" list with their selections — but NOT the correct answers (an earlier "assessment integrity" guardrail).
- Retake was **blocked** once a module was passed (server returned 403 with "Ask your admin to reset the module").

## What changed

### Result screen — full per-question review on pass + fail

Every question now shows in the post-quiz review:
- The prompt
- The learner's selected option (green text if correct, red if wrong)
- A ✓ or ✗ indicator
- **For wrong questions:** the correct answer is now revealed (so they know what they should have picked). For correct questions the correct answer isn't repeated.
- Header counter: "Question-by-question review (X of Y correct)"

Applies to all 13 module quizzes. The Final Mixed Test still omits per-question results on purpose (question-bank leakage prevention).

### Retake button — always available

- **On pass:** a secondary "Try again" button appears alongside the primary "Next" CTA, as long as `attemptsRemaining > 0`.
- **On fail with retries left:** unchanged ("Back to home" secondary + "Try again" primary).
- **On fail with no retries:** unchanged ("Back to home").

### Server gate removed

`POST /lms/quiz/submit` previously returned 403 if `existing.status === 'passed'`. That gate is removed.

**Safety:** the Pass → Fail → Pass overwrite concern from Jose's audit (Item 11, 2026-05-15) is still prevented — `stayPassed` (lms.ts:894) and `best_score` GREATEST() (helper at line 266 per existing comment) already protect the canonical pass record. A retake that scores lower than the original pass:
- keeps the row's `status` = `passed` (via `passedNow || stayPassed`)
- keeps `best_score` at the higher original value
- does NOT overwrite `passed_at` (only stamped on the first pass)

So learners can practice freely without risking their pass.

Retakes still count against the `maxAttempts` cap.

## Verification

- `pnpm exec tsx --test src/tests/lms-curriculum.test.ts src/tests/lms-drift-sync.test.ts src/tests/lms-passed-status-clobber.test.ts` → 63/63 pass
- `tsc --noEmit` → no new errors in modified files
- Manual smoke: pending production deployment

## Test plan (after deploy)

- [ ] Retake a passed module — confirm Retake button appears alongside Next
- [ ] Submit a worse retake on a previously-passed module — confirm `status` stays passed and `best_score` doesn't drop
- [ ] Fail a module — confirm the review now shows correct answers for the questions you missed (was hidden before)
- [ ] Spot-check Spanish strings on the review rows
- [ ] Verify Final Mixed Test still hides per-question review (intentional)

## Open question

The previous `lms-passed-status-clobber` test verifies the `stayPassed` invariant under owner retake. I did not add a new test for the learner-retake path because the same invariant covers it (the path is identical once you get past the removed 403 gate). Happy to add an explicit test if you want a belt-and-suspenders signal.

Holding merge — let me know after you verify on production.

https://claude.ai/code/session_01AxGiirnJ3dT4GAzHPNWhrx

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxGiirnJ3dT4GAzHPNWhrx)_