### PR TITLE
feat(lms): admin-view role promotions — Francisco + Maribel + discoverability

### DIFF
--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -2075,6 +2075,79 @@ async function runPhantomUserCleanup(): Promise<void> {
   );
 }
 
+/**
+ * 2026-05-22 (Sal): "we need to enable Francisco and Maribel to also have
+ * admin view." Bumps both to role='admin' on Phes (company_id=1). Idempotent:
+ * only acts when current role is 'technician' or 'team_lead'; never touches
+ * owners or accounts already at admin/office/super_admin. Match is by
+ * first+last name (case-insensitive), scoped to Phes, excluding the owner row.
+ *
+ * The general affordance ("a setting for everyone to enable admin view")
+ * already exists in the LMS Admin → Edit Employee dialog (role dropdown
+ * includes technician / team_lead / admin / office). This migration is the
+ * one-time grant for Francisco and Maribel so they have access immediately
+ * after this commit deploys; future promotions go through the dialog.
+ */
+const PHES_ADMIN_PROMOTIONS_2026_05_22: ReadonlyArray<{ first: string; last: string }> = [
+  { first: "Francisco", last: "Estevez" },
+  { first: "Maribel", last: "Castillo" },
+];
+
+async function runPhesAdminPromotions(): Promise<void> {
+  const PHES = 1;
+  const promoted: number[] = [];
+  const alreadyAdmin: number[] = [];
+  const ownerSkipped: number[] = [];
+  const otherRoleSkipped: Array<{ id: number; role: string }> = [];
+  const notFound: string[] = [];
+
+  for (const entry of PHES_ADMIN_PROMOTIONS_2026_05_22) {
+    const label = `${entry.first} ${entry.last}`;
+    const rows = await db.execute<{ id: number; role: string }>(sql`
+      SELECT id, role FROM users
+      WHERE company_id = ${PHES}
+        AND LOWER(first_name) = LOWER(${entry.first})
+        AND LOWER(last_name) = LOWER(${entry.last})
+      ORDER BY id ASC
+      LIMIT 1
+    `);
+    const row = ((rows as any).rows ?? rows)[0] as { id: number; role: string } | undefined;
+
+    if (!row) {
+      notFound.push(label);
+      continue;
+    }
+
+    if (row.role === "owner") {
+      ownerSkipped.push(row.id);
+      continue;
+    }
+    if (row.role === "admin") {
+      alreadyAdmin.push(row.id);
+      continue;
+    }
+    if (row.role !== "technician" && row.role !== "team_lead") {
+      otherRoleSkipped.push({ id: row.id, role: row.role });
+      continue;
+    }
+
+    await db.execute(sql`
+      UPDATE users
+      SET role = 'admin'
+      WHERE id = ${row.id} AND company_id = ${PHES}
+    `);
+    promoted.push(row.id);
+  }
+
+  console.log(
+    `[phes-migration] admin-promotions — promoted=${promoted.length} (${promoted.join(",") || "none"})`
+      + ` already-admin=${alreadyAdmin.length}`
+      + ` owner-skipped=${ownerSkipped.length}`
+      + ` other-role-skipped=${otherRoleSkipped.length}`
+      + ` not-found=${notFound.length}${notFound.length ? ` [${notFound.join("; ")}]` : ""}`,
+  );
+}
+
 export async function runPhesDataMigration(): Promise<void> {
   await runBookingSchemaGuard();
 
@@ -2124,6 +2197,12 @@ export async function runPhesDataMigration(): Promise<void> {
     await runPhantomUserCleanup();
   } catch (err: any) {
     console.warn("[phes-migration] phantom-user-cleanup — non-fatal:", err?.message ?? err);
+  }
+
+  try {
+    await runPhesAdminPromotions();
+  } catch (err: any) {
+    console.warn("[phes-migration] admin-promotions — non-fatal:", err?.message ?? err);
   }
 
   try {

--- a/artifacts/qleno/src/pages/lms-admin.tsx
+++ b/artifacts/qleno/src/pages/lms-admin.tsx
@@ -4059,6 +4059,18 @@ function EditEmployeeDialog({
                   <option value="admin">{T.roleAdmin}</option>
                   <option value="office">{T.roleOffice}</option>
                 </select>
+                <div
+                  style={{
+                    marginTop: 6,
+                    fontSize: 11.5,
+                    color: "#5b5851",
+                    lineHeight: 1.4,
+                  }}
+                >
+                  {lang === "es"
+                    ? "Administrador y Oficina pueden ver el panel /lms/admin. Técnico y Líder de equipo solo ven su propio entrenamiento."
+                    : "Admin and Office can see the /lms/admin dashboard. Technician and Team Lead see only their own training."}
+                </div>
               </Field>
               <Field label={T.hireDate}>
                 <input


### PR DESCRIPTION
## Why

You said: "we need to enable Francisco and Maribel to also have admin view. I need a setting for everyone to enable admin view. In the case for example someone gets promoted or we have a hierarchy change."

## TL;DR

The self-service control already exists — the LMS Admin → **Edit Employee** dialog has a role dropdown with `technician / team_lead / admin / office`. Promoting anyone to `admin` grants them `/lms/admin` access. This PR does two things:

1. **One-time migration** — bumps Francisco Estevez and Maribel Castillo to `admin` immediately on next deploy.
2. **Discoverability fix** — adds a one-liner hint under the Role select so future promotions are obvious.

## Detail

### 1. Migration

New `runPhesAdminPromotions()` in `phes-data-migration.ts`. Runs on every cold-start (idempotent).

| Input | Outcome |
|---|---|
| User with `role='technician'` or `role='team_lead'` matching the name list | UPDATE to `role='admin'` |
| User already at `admin` | Skip silently |
| Owner row | Skip silently (cannot demote owner via this path) |
| Any other role (`office`, `super_admin`) | Skip and log |
| Name not found in Phes tenant | Log so you can fix the data drift |

Promotion list:
```ts
{ first: "Francisco", last: "Estevez" }
{ first: "Maribel",   last: "Castillo" }
```

(I sourced Maribel's last name from `seed.ts:601` — `info@phes.io → maribel@phes.io` migration where `first_name = 'Maribel' AND last_name = 'Castillo'`. If she's filed under a different last name in the live DB, the migration will log "not-found" and you can let me know.)

### 2. Discoverability

Small caption added under the Role dropdown in the Edit Employee dialog:

> Admin and Office can see the /lms/admin dashboard. Technician and Team Lead see only their own training.

(Spanish version included.) Once you (or any owner) opens an employee row, the role selector now tells you exactly what each role unlocks. Future promotions = one click, no code.

## Existing infrastructure (no change needed)

- `PATCH /api/users/:id/lms-edit` already accepts and persists `role` changes (`users.ts:932-940`), gated to `requireRole('owner', 'admin')` with the `admin_edit_employee_allowed` setting controlling whether non-owner admins can wield it.
- `users.role` enum already includes all six roles (`owner`, `admin`, `office`, `technician`, `team_lead`, `super_admin`).
- `/lms/admin` page is gated server-side via `requireRole('owner', 'admin')` (plus `office` on a few read-only endpoints).

## Verification

- `pnpm exec tsx --test src/tests/lms-curriculum.test.ts src/tests/lms-drift-sync.test.ts src/tests/lms-passed-status-clobber.test.ts` → 63/63 pass
- Migration is idempotent (only acts when current role is `technician` / `team_lead`)

## Test plan

- [ ] Deploy and observe migration log line `[phes-migration] admin-promotions — promoted=N (...)`
- [ ] Log in as Francisco — verify `/lms/admin` route loads
- [ ] Log in as Maribel — verify `/lms/admin` route loads
- [ ] Open Edit Employee on a random tech — confirm role caption renders in EN + ES
- [ ] Promote a third employee via the dropdown to test the self-service path end-to-end

Held draft per your sequential-cadence convention — let me know when you've verified on production and I'll merge.

https://claude.ai/code/session_01AxGiirnJ3dT4GAzHPNWhrx

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxGiirnJ3dT4GAzHPNWhrx)_