### PR TITLE
feat(lms): admin self-edit + peer-admin-edit protection

### DIFF
--- a/artifacts/api-server/src/routes/users.ts
+++ b/artifacts/api-server/src/routes/users.ts
@@ -320,6 +320,36 @@ router.get("/:id", requireAuth, async (req, res) => {
 router.put("/:id", requireAuth, requireRole("owner", "admin", "office"), async (req, res) => {
   try {
     const userId = parseInt(req.params.id);
+    const callerRole = req.auth!.role;
+    const callerId = req.auth!.userId;
+
+    // 2026-05-22 (Sal): "Ensure Francisco and Maribel cannot edit any
+    // of their own settings as they are counterparts." Admins are peers
+    // to each other — only the owner sits above them in the chain. So:
+    //   - admin CANNOT edit themselves
+    //   - admin CANNOT edit another admin
+    // Owner / super_admin are unrestricted by this rule (the owner sits
+    // above all admins; super_admin is the Qleno-side bypass).
+    if (callerRole === "admin") {
+      if (userId === callerId) {
+        return res.status(403).json({
+          error: "Forbidden",
+          message: "Admins cannot edit their own user record. Ask the owner.",
+        });
+      }
+      const peer = await db
+        .select({ role: usersTable.role })
+        .from(usersTable)
+        .where(and(eq(usersTable.id, userId), eq(usersTable.company_id, req.auth!.companyId)))
+        .limit(1);
+      if (peer[0]?.role === "admin") {
+        return res.status(403).json({
+          error: "Forbidden",
+          message: "Admins cannot edit another admin's record. Ask the owner.",
+        });
+      }
+    }
+
     const {
       first_name, last_name, role, pay_rate, pay_type, is_active,
       hire_date, phone, skills,
@@ -383,6 +413,31 @@ router.put("/:id", requireAuth, requireRole("owner", "admin", "office"), async (
 router.delete("/:id", requireAuth, requireRole("owner", "admin"), async (req, res) => {
   try {
     const userId = parseInt(req.params.id);
+    const callerRole = req.auth!.role;
+
+    // 2026-05-22 (Sal): admins cannot deactivate themselves OR another
+    // admin (same counterpart rule as PUT / lms-edit). Only the owner
+    // can deactivate an admin.
+    if (callerRole === "admin") {
+      if (userId === req.auth!.userId) {
+        return res.status(403).json({
+          error: "Forbidden",
+          message: "Admins cannot deactivate their own account. Ask the owner.",
+        });
+      }
+      const peer = await db
+        .select({ role: usersTable.role })
+        .from(usersTable)
+        .where(and(eq(usersTable.id, userId), eq(usersTable.company_id, req.auth!.companyId)))
+        .limit(1);
+      if (peer[0]?.role === "admin") {
+        return res.status(403).json({
+          error: "Forbidden",
+          message: "Admins cannot deactivate another admin. Ask the owner.",
+        });
+      }
+    }
+
     await db
       .update(usersTable)
       .set({ is_active: false })
@@ -887,6 +942,23 @@ router.patch(
           error: "Bad Request",
           message: "Cannot edit an owner account via this endpoint",
         });
+      }
+
+      // 2026-05-22 (Sal): admins cannot edit themselves OR another admin
+      // (they are counterparts in the chain — only the owner sits above).
+      if (callerRole === "admin") {
+        if (targetId === req.auth!.userId) {
+          return res.status(403).json({
+            error: "Forbidden",
+            message: "Admins cannot edit their own user record. Ask the owner.",
+          });
+        }
+        if (target[0].role === "admin") {
+          return res.status(403).json({
+            error: "Forbidden",
+            message: "Admins cannot edit another admin's record. Ask the owner.",
+          });
+        }
       }
 
       const patch: {

--- a/artifacts/qleno/src/pages/lms-admin.tsx
+++ b/artifacts/qleno/src/pages/lms-admin.tsx
@@ -954,8 +954,15 @@ function RosterTable({
                     ) : null}
                     {/* Sprint 2026-05-15: owner-default Edit Employee.
                         Admin sees it when admin_edit_employee_allowed
-                        is on. Office never sees it. */}
-                    {canEdit ? (
+                        is on. Office never sees it.
+                        2026-05-22 (Sal): admins cannot edit themselves
+                        or another admin — they are counterparts in the
+                        chain. Owner can edit anyone. */}
+                    {canEdit
+                      && !(
+                        callerRole === "admin"
+                        && (r.user_id === callerUserId || r.role === "admin")
+                      ) ? (
                       <button
                         type="button"
                         onClick={() => onEdit(r)}
@@ -1747,7 +1754,11 @@ function RosterCards({
               >
                 <RotateCcw size={11} /> Reset
               </button>
-              {canEdit ? (
+              {canEdit
+                && !(
+                  callerRole === "admin"
+                  && (r.user_id === callerUserId || r.role === "admin")
+                ) ? (
                 <button
                   type="button"
                   onClick={() => onEdit(r)}


### PR DESCRIPTION
## Why

You said: "Ensure Francisco and Maribel cannot edit any of their own settings as they are counterparts. With the chain of command i am the owner so should have super admin settings."

## Chain of command (codified by this PR)

```
owner (Sal)           ← can edit anyone, including admins
  ↓
admin (Francisco, Maribel)   ← can edit office / techs / team_leads ONLY
  ↓                            cannot edit themselves, cannot edit each other
office
  ↓
technician / team_lead
```

The `super_admin` role in the enum is reserved for Qleno-side cross-tenant staff (per `routes/admin.ts:45`) and stays unrestricted. **You don't need to be elevated to `super_admin`** — owner already has the same effective powers within Phes, and this PR keeps you that way.

## What changed

### Server (three endpoints in `routes/users.ts`)

For each of the three user-mutation endpoints, if `callerRole === 'admin'` AND (`target.id === caller.id` OR `target.role === 'admin'`), respond `403 Forbidden` with a clear message.

| Endpoint | What it does | Protection added |
|---|---|---|
| `PUT /api/users/:id` | Full user update (role, pay, is_active, etc.) | Admin can't self-edit; admin can't edit another admin |
| `PATCH /api/users/:id/lms-edit` | Narrow LMS edit (name, email, role, hire date) | Same |
| `DELETE /api/users/:id` | Soft-delete (sets `is_active=false`) | Admin can't self-deactivate; admin can't deactivate another admin |

Sample 403 body:
```json
{
  "error": "Forbidden",
  "message": "Admins cannot edit their own user record. Ask the owner."
}
```

Owner is exempt from this rule. The pre-existing `if (target.role === 'owner') return 400` guard on `/lms-edit` is preserved (no one can edit the owner via that endpoint).

### Frontend (`lms-admin.tsx` roster)

The **Edit Employee** button is now hidden in the roster when the viewing admin would be editing themselves OR another admin row. Both surfaces:
- Desktop table view (line ~958)
- Mobile cards view (line ~1757)

Server gate remains the source of truth — the UI just doesn't advertise the action when it would 403.

## Verification

- `pnpm exec tsx --test src/tests/lms-curriculum.test.ts src/tests/lms-drift-sync.test.ts src/tests/lms-passed-status-clobber.test.ts` → 63/63 pass
- `tsc --noEmit` → no new errors in modified files (two pre-existing errors in `lms-admin.tsx:793/4778` are unrelated and present on main)

## Test plan

After PR #159 lands (Francisco and Maribel at admin role):

- [ ] Log in as Francisco → open `/lms/admin` → confirm Edit button is **not present** on his own row
- [ ] Log in as Francisco → confirm Edit button is **not present** on Maribel's row
- [ ] Log in as Francisco → confirm Edit button **is** present on a technician's row
- [ ] Log in as Sal (owner) → confirm Edit button **is** present on Francisco's row and Maribel's row
- [ ] Try the raw PATCH from Francisco's session targeting his own user_id → expect 403 with the new message
- [ ] Try PATCH from Francisco targeting Maribel → expect 403

Holding merge per your sequential-cadence convention.

## Note on ordering

This PR builds on the assumption that Francisco and Maribel have role='admin'. Recommend merging in this order:
1. [#159](https://github.com/salmartinez-design/qleno/pull/159) (the role bump) — so they actually get admin
2. **This PR** — so the moment they have admin, the counterpart rule is enforced

Without #159, this PR is still safe (just a no-op for current admins, which is none).

https://claude.ai/code/session_01AxGiirnJ3dT4GAzHPNWhrx

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxGiirnJ3dT4GAzHPNWhrx)_