### PR TITLE
fix(calc-engine): use per-client hourly_rate as override

### DIFF
--- a/artifacts/api-server/src/routes/jobs.ts
+++ b/artifacts/api-server/src/routes/jobs.ts
@@ -679,6 +679,21 @@ router.get("/:id", requireAuth, async (req, res) => {
     const clientHomeId = primaryHome ? Number(primaryHome.id) : null;
     const clientHomeSqFootage = primaryHome ? primaryHome.sq_footage : null;
 
+    // [PR #63] Surface the per-client hourly rate (from clients.hourly_rate,
+    // backfilled in PR #60) so the edit-job modal can pass it to
+    // /api/pricing/calculate as an override on scope.hourly_rate. Without
+    // this, the engine uses the tenant-wide scope rate (which for Phes's
+    // Standard Clean works out to ~$71.67/hr from MC migration math) —
+    // Nicholas Cooper's modal returns 3 × $71.67 = $215 instead of his
+    // actual 3 × $60 = $180. Per-client variability is the real-world
+    // pricing model; the column was already there, we just weren't using it.
+    const clientRateRows = await db.execute(sql`
+      SELECT hourly_rate FROM clients WHERE id = ${job[0].client_id} LIMIT 1
+    `);
+    const clientHourlyRate = clientRateRows.rows[0]
+      ? (clientRateRows.rows[0] as any).hourly_rate
+      : null;
+
     return res.json({
       ...job[0],
       recurring_schedule_id: jobMeta.recurring_schedule_id ?? null,
@@ -687,6 +702,7 @@ router.get("/:id", requireAuth, async (req, res) => {
       account_id: jobMeta.account_id ?? null,
       client_home_id: clientHomeId,
       client_home_sq_footage: clientHomeSqFootage != null ? Number(clientHomeSqFootage) : null,
+      client_hourly_rate: clientHourlyRate != null ? Number(clientHourlyRate) : null,
       before_photo_count: beforePhotos.length,
       after_photo_count: afterPhotos.length,
       photos: photos.map(p => ({

--- a/artifacts/api-server/src/routes/pricing.ts
+++ b/artifacts/api-server/src/routes/pricing.ts
@@ -525,7 +525,16 @@ export function calcAddonAmount(addon: any, base_price: number, sqft: number | n
 router.post("/calculate", requireAuth, async (req, res) => {
   try {
     const companyId = req.auth!.companyId;
-    const { scope_id, sqft, hours, frequency, addon_ids, discount_code, manual_adjustment, addon_quantities } = req.body;
+    const { scope_id, sqft, hours, frequency, addon_ids, discount_code, manual_adjustment, addon_quantities,
+            // [PR #63] Per-client hourly rate override. When the caller
+            // (edit-job modal) passes a positive number, it wins over the
+            // scope's tenant-wide hourly_rate. Frequency multipliers still
+            // apply on top so a "twice a month" multiplier still works.
+            // Closes the math gap where Phes's Standard Clean scope rate
+            // is ~$71.67/hr (averaged across MC migration data) but
+            // individual clients like Nicholas Cooper are billed at $60/hr.
+            hourly_rate_override,
+    } = req.body;
 
     if (!scope_id) return res.status(400).json({ error: "scope_id is required" });
 
@@ -538,7 +547,14 @@ router.post("/calculate", requireAuth, async (req, res) => {
     const freqs = await db.select().from(pricingFrequenciesTable)
       .where(and(eq(pricingFrequenciesTable.scope_id, scope_id), eq(pricingFrequenciesTable.company_id, companyId)));
     const freqFactor = frequency ? freqs.find(f => f.frequency === frequency) : null;
-    const scope_hourly = parseFloat(String(scope.hourly_rate));
+    // [PR #63] Prefer per-client override when present. Falls back to scope
+    // rate. Both still go through the frequency multiplier path below so
+    // Weekly/Biweekly/etc. discounts continue to apply.
+    const overrideNum = hourly_rate_override != null && hourly_rate_override !== ""
+      ? parseFloat(String(hourly_rate_override))
+      : NaN;
+    const useOverride = !isNaN(overrideNum) && overrideNum > 0;
+    const scope_hourly = useOverride ? overrideNum : parseFloat(String(scope.hourly_rate));
     let hourly_rate: number;
     if (freqFactor?.rate_override != null && freqFactor.rate_override !== "") {
       hourly_rate = parseFloat(String(freqFactor.rate_override));

--- a/artifacts/qleno/src/components/edit-job-modal.tsx
+++ b/artifacts/qleno/src/components/edit-job-modal.tsx
@@ -291,6 +291,14 @@ export default function EditJobModal({
   const [initialPropertySqft, setInitialPropertySqft] = useState<number | null>(null);
   const [primaryHomeId, setPrimaryHomeId] = useState<number | null>(null);
 
+  // [PR #63] Per-client hourly rate. Pulled from GET /api/jobs/:id (which
+  // joins clients.hourly_rate). Passed to /api/pricing/calculate as
+  // `hourly_rate_override` so the engine uses the per-client rate
+  // instead of the tenant-wide scope rate. For Nicholas Cooper this
+  // makes the modal compute 3 hrs × $60 = $180 + parking $15 = $195
+  // instead of 3 hrs × $71.67 (scope rate) = $215.
+  const [clientHourlyRate, setClientHourlyRate] = useState<number | null>(null);
+
   const [baseFee, setBaseFee] = useState<number>(initialBaseFee);
   const [manualRate, setManualRate] = useState(false);
   const [manualOpen, setManualOpen] = useState(false);
@@ -527,6 +535,8 @@ export default function EditJobModal({
         setPropertySqft(sqft);
         setInitialPropertySqft(sqft);
         setPrimaryHomeId(d.client_home_id != null ? Number(d.client_home_id) : null);
+        // [PR #63] Per-client hourly rate from the GET /:id response.
+        setClientHourlyRate(d.client_hourly_rate != null ? Number(d.client_hourly_rate) : null);
 
         // Recurring schedule snapshot.
         const rs = d.recurring_schedule;
@@ -730,6 +740,10 @@ export default function EditJobModal({
             // the "sqft is required for sqft-based scopes" 400 path. null
             // is passed through (engine still runs for hourly scopes).
             sqft: propertySqft,
+            // [PR #63] Per-client hourly rate override. Engine uses this
+            // instead of scope.hourly_rate when provided. Closes the
+            // Nicholas Cooper math gap ($60/hr vs scope ~$71.67/hr).
+            hourly_rate_override: clientHourlyRate,
             frequency,
             addon_ids: Array.from(selectedAddons.keys()),
             addon_quantities: Object.fromEntries(
@@ -748,7 +762,7 @@ export default function EditJobModal({
       }
     }, 250);
     return () => { if (debounceRef.current) clearTimeout(debounceRef.current); };
-  }, [API, token, scopeId, allowedHours, frequency, selectedAddons, manualRate, clientLoaded, isCommercial, hourlyRate, availableAddons, propertySqft]);
+  }, [API, token, scopeId, allowedHours, frequency, selectedAddons, manualRate, clientLoaded, isCommercial, hourlyRate, availableAddons, propertySqft, clientHourlyRate]);
 
   // ── Validation / dirty check ────────────────────────────────────────────
   const dirty = useMemo(() => {

--- a/docs/payroll-compliance-spec.md
+++ b/docs/payroll-compliance-spec.md
@@ -1,0 +1,223 @@
+# Payroll Compliance Monitoring — Feature Spec (Deferred)
+
+**Status:** SAVED FOR LATER — to be implemented AFTER the Nicholas Cooper
+reconciliation work (engine fix + edit-job modal redesign) lands and is
+verified on production.
+
+**Owner:** salmartinez@phes.io
+**Estimate:** 6–8 hours focused work
+**Target sprint:** Post-reconciliation
+
+---
+
+## Why this exists
+
+Phes operates a commission-based pay structure for cleaning technicians.
+Federal and Illinois law require that commission divided by hours worked in
+any workweek meet or exceed the applicable minimum wage. Current Illinois
+minimum wage is $15.00/hour. Phes's internal floor commitment is $20.00/hour.
+
+MaidCentral doesn't surface alerts when a tech's effective hourly rate
+falls below threshold. As Phes migrates to Qleno, this monitoring needs to
+be built in.
+
+## What the feature does
+
+For each pay period, for each technician, Qleno calculates:
+
+```
+Effective Hourly Rate = Total Gross Wages / Total Hours Worked
+```
+
+Where Total Hours Worked = sum of all Job Hours (Clock In to Clock Out)
+within the pay period.
+
+If the effective hourly rate falls below configurable thresholds, Qleno
+displays an alert in the admin dashboard and queues a notification.
+
+## Configurable thresholds (per tenant)
+
+1. **Legal minimum** (default $15.00/hr — IL minimum wage 2025). Below
+   triggers HIGH severity alert.
+2. **Internal floor** (default $20.00/hr — Phes's stated floor). Below
+   triggers MEDIUM severity alert.
+
+Both editable by tenant **owners** (not regular admins) at
+`/admin/settings/payroll-compliance`.
+
+## DB schema additions
+
+**`payroll_compliance_settings`** (one row per tenant):
+- id, company_id, legal_minimum_threshold, internal_floor_threshold,
+  alert_enabled, created_at, updated_at, updated_by_user_id
+
+**`payroll_compliance_alerts`** (one row per alert per tech per period):
+- id, company_id, user_id, pay_period_start, pay_period_end,
+  effective_hourly_rate, threshold_breached (enum:
+  legal_minimum|internal_floor), severity (high|medium), gross_wages,
+  total_hours_worked, alert_status (open|acknowledged|resolved),
+  acknowledged_at, acknowledged_by_user_id, resolution_notes, created_at
+
+## Calculation service
+
+`artifacts/api-server/src/lib/payroll-compliance.ts` →
+`calculatePayrollCompliance(companyId, payPeriodStart, payPeriodEnd)`
+
+- Fetches active techs for the company
+- Computes gross wages + hours per tech
+- Compares vs tenant thresholds
+- Creates alerts for breaches
+- Returns summary: { total_techs, above_all, below_internal,
+  below_legal, alerts_created }
+
+**Edge cases:**
+- Zero hours → skip (no division by zero)
+- Zero wages but positive hours → HIGH severity alert
+- Mid-period start/end → use only active days
+- Tech on Quality Probation at $20/hr flat → normal calc
+
+**Tenant scoping enforced via company_id throughout.**
+
+## Trigger points
+
+1. Manual: Owner clicks "Run Compliance Check" button on dashboard. Runs
+   current open + prior closed period.
+2. Pay period close: auto-runs when a period is closed.
+3. Scheduled: Monday 6:00 AM tenant local time for the prior week, across
+   all tenants with `alert_enabled = true`.
+
+## Admin dashboard sections (`/admin/payroll-compliance`)
+
+1. **Active Alerts** — open alerts; tech name, period, effective rate
+   (color-coded), severity badge, Acknowledge / View Details / Mark
+   Resolved buttons.
+2. **Compliance History** — last 12 months of check runs with summary
+   metrics; click row to drill in.
+3. **Settings Quick View** — current thresholds + link to full settings.
+
+## Alert workflow
+
+- **Created** → appears in dashboard, in-app notification to all `owner`
+  users for the tenant (no email/SMS for V1).
+- **Acknowledged** → status updates, timestamp + user recorded, moves to
+  secondary "Acknowledged but Open" list.
+- **Resolved** → status updates, resolution_notes REQUIRED (e.g., "Topped
+  up via ADP supplemental for $24.50"), removed from active list.
+
+## Settings page (`/admin/settings/payroll-compliance`)
+
+Editable (owner only):
+- legal_minimum_threshold (decimal, > 0)
+- internal_floor_threshold (decimal, > legal_minimum)
+- alert_enabled (toggle)
+
+Display only:
+- Last check timestamp, next scheduled, total alerts last 30 days, link
+  to history.
+
+Save behavior:
+- Audit log entry on every change (old/new value, user, timestamp)
+- Toast on save
+
+## Access control
+
+- `owner` → can edit thresholds, view dashboard, acknowledge, resolve
+- `admin` → can view dashboard, acknowledge, resolve; cannot edit thresholds
+- `technician` → 403 on any access
+- All endpoints enforce tenant scoping via company_id
+
+## API endpoints (`artifacts/api-server/src/routes/payroll-compliance.ts`)
+
+- `GET    /api/payroll-compliance/settings`
+- `PATCH  /api/payroll-compliance/settings` (owner only)
+- `GET    /api/payroll-compliance/alerts` (active)
+- `GET    /api/payroll-compliance/alerts/history` (filterable)
+- `POST   /api/payroll-compliance/alerts/:id/acknowledge`
+- `POST   /api/payroll-compliance/alerts/:id/resolve` (notes required)
+- `POST   /api/payroll-compliance/run-check` (owner only, manual trigger)
+- `GET    /api/payroll-compliance/summary` (dashboard widget)
+
+## Tests required
+
+**Unit (`artifacts/api-server/test/payroll-compliance.test.ts`):**
+- effective rate calc — multiple inputs
+- alert creation logic
+- tenant scoping (no cross-tenant alerts)
+- edge cases (zero hours, zero wages, mid-period)
+- threshold comparison (>= vs >)
+
+**Integration (`artifacts/api-server/test/integration/payroll-compliance-flow.test.ts`):**
+- end-to-end: create tenant, employees, period data, run check, verify
+  alerts
+- cross-tenant isolation
+- acknowledge flow
+- resolution flow (requires notes)
+- settings persistence
+- manual trigger covers current + prior period
+- scheduled trigger respects `alert_enabled`
+
+**Frontend:**
+- dashboard renders alerts
+- acknowledge updates status
+- resolve requires notes
+- settings editable for owner, read-only for admin, 403 for technician
+
+## Docs
+
+`docs/payroll-compliance.md` — see spec for full contents (purpose, how
+it works, configurable thresholds, trigger points, alert workflow, what
+to do when an alert fires, legal context, privacy / tenant isolation).
+
+## Verification checklist (for Sal before merge)
+
+- [ ] Migration creates both tables
+- [ ] Default Phes settings row created ($15 / $20)
+- [ ] Dashboard renders for owner
+- [ ] Manual "Run Compliance Check" button works
+- [ ] Settings page editable by owner only, 403 for non-owner
+- [ ] Acknowledge + Resolve workflows update correctly
+- [ ] Resolution requires non-empty notes
+- [ ] Tenant isolation (test with a second tenant)
+- [ ] All endpoints enforce role + tenant scoping
+- [ ] Audit log entries on settings changes
+- [ ] `docs/payroll-compliance.md` committed
+- [ ] Tests pass in CI
+
+## Branch + PR
+
+- Branch: `feature/qleno-payroll-compliance-monitoring`
+- PR title: `feature: payroll compliance monitoring with configurable minimum wage thresholds`
+- Description: feature overview + legal rationale, summary of components,
+  verification checklist, "multi-tenant SaaS capable" note.
+- Sequential cadence: do not merge until Sal verifies on production.
+
+## OUT OF SCOPE for V1
+
+- ADP / payroll-system integration (alerts are informational; actual
+  payroll adjustments happen outside Qleno)
+- Email or SMS notifications (in-app only V1)
+- Predictive analytics / trend forecasting (point-in-time only)
+- Automatic top-up calculation
+- Multi-state minimum wage per tenant (single threshold per tenant)
+- Historical backfill before deploy
+- MaidCentral compliance data migration
+- Modifying existing LMS modules
+- Handbook / compensation policy changes
+
+## Future enhancements (note in PR description)
+
+- Email / SMS notifications
+- Trend analysis ("Tech X within 5% of legal min for 3 weeks")
+- Auto top-up suggestion ("Top up $X.XX to clear threshold")
+- ADP integration for one-click top-up
+- Per-tech configurable thresholds
+- State-specific defaults (IL $15, CA $16, etc.)
+- Compliance report export for accountant / attorney
+- Mobile push for owners
+
+---
+
+**Order of operations (from Sal):**
+1. ~~Finish Nicholas Cooper reconciliation work (engine fix + modal redesign)~~ — CURRENT SPRINT
+2. LMS audit + MaidCentral module rewrite — separate prompt, Sal will resend
+3. THIS spec — payroll compliance feature


### PR DESCRIPTION
## Summary

Closes the math gap that made Nicholas Cooper's modal compute $215 instead of $195. PR #62 made sqft optional so the engine could run for legacy MC-imported clients, but the engine still used the tenant-wide `pricing_scopes.hourly_rate` — which for Phes's Standard Clean averaged to ~$71.67/hr from MC migration. Per-client variability (Nicholas at $60/hr) was never honored.

The `hourly_rate` column on `clients` was added in PR #60 with a backfill, but nothing was reading it. This PR plumbs it through.

## Changes

1. **`GET /api/jobs/:id`** joins `clients.hourly_rate`, returns it as `client_hourly_rate` in the response (alongside the existing `client_home_sq_footage` from PR #53).

2. **Edit-job modal** reads `client_hourly_rate` from the GET payload, stores in state, passes to `/api/pricing/calculate` as `hourly_rate_override`.

3. **`/api/pricing/calculate`** accepts `hourly_rate_override` — when provided and > 0, uses it instead of `scope.hourly_rate`. Frequency multipliers still apply on top so Weekly/Biweekly/etc. discounts continue to work.

## What this fixes

For Nicholas Cooper:
- `clients.hourly_rate` = $60 (backfilled $180 / 3 = $60 during PR #60)
- Modal opens → sends `hourly_rate_override: 60`
- Engine returns 3 × $60 = $180 base + $15 parking = **$195**. Matches MC.

For every other legacy client, the engine now respects their negotiated rate instead of the averaged scope rate.

## Side effect

Saved `docs/payroll-compliance-spec.md` — the user wants to build a commission-based minimum-wage alert dashboard next sprint (~6–8 hrs). Spec stored so it survives session boundaries.

## Test plan

- [ ] Open Nicholas Cooper's edit-job modal. New total computes to $180 base + $15 parking = $195. (Was $215.)
- [ ] Open a client without `hourly_rate` set (NULL). Engine falls back to `scope.hourly_rate` — no regression.
- [ ] Open a commercial client. Commercial path unchanged (uses `commercial_hourly_rate` directly in the modal, doesn't hit `/pricing/calculate`).
- [ ] Booking widget at `/book/phes-cleaning` — unchanged (doesn't pass `hourly_rate_override`).

## Out of scope

- Edit-job modal redesign to match the customer profile editor (Frequency labels, Service Type filter, day-of-week pills, three-field rate row). That's PR #64, separate.

https://claude.ai/code/session_013jLtBKQ4GvThyvDaoN4V98

---
_Generated by [Claude Code](https://claude.ai/code/session_013jLtBKQ4GvThyvDaoN4V98)_