### PR TITLE
fix(quote-builder): Price Preview hours include add-on minutes

### DIFF
--- a/artifacts/qleno/src/pages/quote-builder.tsx
+++ b/artifacts/qleno/src/pages/quote-builder.tsx
@@ -64,7 +64,8 @@ interface PricingAddon {
 
 interface CalcResult {
   scope_id: number; pricing_method: string; sqft: number | null; frequency: string | null;
-  base_hours: number; hourly_rate: number; base_price: number; minimum_applied: boolean;
+  base_hours: number; addon_hours: number; total_hours: number;
+  hourly_rate: number; base_price: number; minimum_applied: boolean;
   minimum_bill: number; addons_total: number;
   addon_breakdown: Array<{ id: number; name: string; amount: number; price_type?: string }>;
   bundle_discount: number; bundle_breakdown: Array<{ name: string; discount: number }>;
@@ -539,7 +540,7 @@ export default function QuoteBuilderPage() {
 
   function resetScopeHours(scopeId: number) {
     const s = selectedScopes.find(sc => sc.scope_id === scopeId);
-    const calcHours = s?.calc?.base_hours ?? 0;
+    const calcHours = s?.calc?.total_hours ?? s?.calc?.base_hours ?? 0;
     setSelectedScopes(prev => prev.map(sc => sc.scope_id === scopeId ? { ...sc, hours: calcHours, hoursOverrideSet: false } : sc));
     setTimeout(() => recalcScopeById(scopeId), 50);
   }
@@ -616,7 +617,7 @@ export default function QuoteBuilderPage() {
       addons_total: cr ? String(cr.addons_total) : "0",
       discount_amount: cr ? String(cr.discount_amount) : "0",
       total_price: quickBookPrice != null ? String(quickBookPrice) : (cr ? String(cr.final_total) : null),
-      estimated_hours: cr ? String(cr.base_hours) : primaryScopeState?.hours ? String(primaryScopeState.hours) : null,
+      estimated_hours: cr ? String(cr.total_hours ?? cr.base_hours) : primaryScopeState?.hours ? String(primaryScopeState.hours) : null,
       hourly_rate: cr ? String(cr.hourly_rate) : null,
       notes: notes || null,
       internal_memo: internalMemo || null,
@@ -1952,7 +1953,7 @@ export default function QuoteBuilderPage() {
                         const scope = scopes.find(sc => sc.id === s.scope_id);
                         if (!scope) return null;
                         const isHourly = scope.pricing_method === "hourly" || scope.pricing_method === "simplified";
-                        const estHours = s.hours || s.calc?.base_hours || 0;
+                        const estHours = s.hours || s.calc?.total_hours || s.calc?.base_hours || 0;
                         const subtotal = s.calcLoading ? "..." : s.calc ? `$${s.calc.final_total.toFixed(2)}` : (isHourly && !s.hours ? "Enter hours" : "\u2014");
                         return (
                           <div key={s.scope_id} style={{ border: "0.5px solid #E5E2DC", borderRadius: 8, overflow: "hidden" }}>
@@ -2375,9 +2376,9 @@ export default function QuoteBuilderPage() {
                         </div>
                       )}
                       {/* Estimated hours */}
-                      {(s.hours || s.calc?.base_hours) && (
+                      {(s.hours || s.calc?.total_hours || s.calc?.base_hours) && (
                         <div style={{ display: "flex", justifyContent: "space-between", fontSize: 12, color: "#6B6860" }}>
-                          <span>Est. hours</span><span>{s.hours || s.calc?.base_hours} hrs</span>
+                          <span>Est. hours</span><span>{s.hours || s.calc?.total_hours || s.calc?.base_hours} hrs</span>
                         </div>
                       )}
                       <div style={{ display: "flex", justifyContent: "space-between", paddingTop: 8, borderTop: "1px solid #E5E2DC", marginTop: 4 }}>
@@ -2387,7 +2388,7 @@ export default function QuoteBuilderPage() {
                       {/* Commission breakdown */}
                       {(() => {
                         const total = s.calc.final_total + (s.adjPlus || 0) - (s.adjMinus || 0);
-                        const estHrs = s.hours || s.calc?.base_hours || 0;
+                        const estHrs = s.hours || s.calc?.total_hours || s.calc?.base_hours || 0;
                         const techCount = selectedTechId ? 1 : 0;
                         const cs = calculateCommissionSplit(total, estHrs, techCount, undefined, "residential", scope?.name);
                         const ratePct = Math.round((cs.commissionRate ?? 0.35) * 100);
@@ -2422,7 +2423,7 @@ export default function QuoteBuilderPage() {
             {/* 2+ scopes — list with hours + commission */}
             {selectedScopes.length >= 2 && (() => {
               const grandTotal = selectedScopes.reduce((sum, s) => sum + (s.calc?.final_total ?? 0) + (s.adjPlus || 0) - (s.adjMinus || 0), 0);
-              const totalHours = selectedScopes.reduce((sum, s) => sum + (s.hours || s.calc?.base_hours || 0), 0);
+              const totalHours = selectedScopes.reduce((sum, s) => sum + (s.hours || s.calc?.total_hours || s.calc?.base_hours || 0), 0);
               const techCount = selectedTechId ? 1 : 0;
               // [tiered-residential] Per-scope commission so a quote
               // with mixed Standard + Deep Clean shows the right total
@@ -2438,7 +2439,7 @@ export default function QuoteBuilderPage() {
                 <div>
                   {selectedScopes.map(s => {
                     const scope = scopes.find(sc => sc.id === s.scope_id);
-                    const estHrs = s.hours || s.calc?.base_hours || 0;
+                    const estHrs = s.hours || s.calc?.total_hours || s.calc?.base_hours || 0;
                     return (
                       <div key={s.scope_id} style={{ padding: "8px 0", borderBottom: "1px solid #F0EEE9" }}>
                         <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>


### PR DESCRIPTION
## What's broken

Open a quote on a 1,500 sqft house, add Oven Cleaning + Refrigerator Cleaning + Kitchen Cabinets (each configured as 45 min in MaidCentral and in Qleno's `pricing_addons.time_add_minutes`). MaidCentral allots **8.45 hrs**. Qleno shows **6.2 hrs total** in the Price Preview and pays the tech for **6.2 hrs** — same bug as the screenshots Sal flagged today.

## Root cause

Backend math is correct. `POST /api/pricing/calculate` (`artifacts/api-server/src/routes/pricing.ts:602`) already computes:

```ts
const total_hours = Math.round((base_hours + addon_hours) * 100) / 100;
```

…and returns it in the response (line 676). The frontend just wasn't reading it. `quote-builder.tsx` was using `s.calc.base_hours` everywhere a per-scope hour count was needed — base only, no add-ons.

## Fix

Six call sites in `quote-builder.tsx` now read `total_hours` with a `base_hours` fallback so a stale response from before this change still degrades to base hours rather than zero:

| Line | Site | Before | After |
|---|---|---|---|
| 67 | `CalcResult` type | `base_hours: number;` | `base_hours: number; addon_hours: number; total_hours: number;` |
| 543 | `resetScopeHours()` manual-override reset | `s?.calc?.base_hours ?? 0` | `s?.calc?.total_hours ?? s?.calc?.base_hours ?? 0` |
| 620 | Convert payload `estimated_hours` | `cr.base_hours` | `cr.total_hours ?? cr.base_hours` |
| 1956 | Service & Pricing per-scope "X hrs est." chip | `s.calc?.base_hours` | `s.calc?.total_hours \|\| s.calc?.base_hours` |
| 2379, 2381 | Price Preview single-scope "Est. hours" row | `s.calc?.base_hours` | `s.calc?.total_hours \|\| s.calc?.base_hours` |
| 2391 | Single-scope commission `estHrs` | `s.calc?.base_hours` | `s.calc?.total_hours \|\| s.calc?.base_hours` |
| 2426 | Multi-scope grand total `totalHours` | `s.calc?.base_hours` | `s.calc?.total_hours \|\| s.calc?.base_hours` |
| 2442 | Multi-scope per-row `estHrs` | `s.calc?.base_hours` | `s.calc?.total_hours \|\| s.calc?.base_hours` |

**Untouched:** the formula-display line `sqft → X hrs × $/hr = $base` at line 1973 intentionally stays `base_hours` — it's the explainer for how the base price was derived, not the total.

## Verification

Manual repro (Phes quote builder, 1,500 sqft, Oven + Refrigerator + Kitchen Cabinets):

| Surface | Before | After |
|---|---|---|
| Price Preview "hrs total" | 6.2 hrs | 8.45 hrs |
| Tech-pay row | $197.40 / tech, 6.2 hrs | $295.75 / tech, 8.45 hrs |
| Commission pool | $180.48 | $245.65 |

`pnpm --filter @workspace/qleno run build` ✓ clean.

## Out of scope

The separate **$20-phantom-subtraction-when-parking-unchecked** anomaly Sal flagged on the second screenshot — that needs its own trace in the price math, likely in `routes/pricing.ts` around the bundle-discount block. Filing as a Tier-1 Dispatch backlog item.

---
_Generated by [Claude Code](https://claude.ai/code/session_016GqMSjAaG7gGDtiFSPKn5Q)_