### PR TITLE
fix(dispatch): label view toggle + honor ?date= URL param

### DIFF
--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -3321,7 +3321,24 @@ export default function JobsPage() {
   const [legendOpen, setLegendOpen] = useState(false);
   const legendBtnRef = useRef<HTMLButtonElement | null>(null);
   const [legendAnchor, setLegendAnchor] = useState<DOMRect | null>(null);
-  const [selectedDate, setSelectedDate] = useState(() => { const d = new Date(); d.setHours(0, 0, 0, 0); return d; });
+  // Read ?date=YYYY-MM-DD on mount so quote-builder's convert-to-job navigation
+  // (which targets the scheduled day) actually lands on that day instead of today.
+  const [selectedDate, setSelectedDate] = useState(() => {
+    const param = new URLSearchParams(window.location.search).get("date");
+    const m = param && /^\d{4}-\d{2}-\d{2}$/.test(param) ? param.match(/^(\d{4})-(\d{2})-(\d{2})$/) : null;
+    if (m) { const d = new Date(parseInt(m[1]), parseInt(m[2]) - 1, parseInt(m[3])); d.setHours(0, 0, 0, 0); return d; }
+    const d = new Date(); d.setHours(0, 0, 0, 0); return d;
+  });
+  // Keep ?date= in sync as the user navigates days — refresh + back-button preserve the view.
+  useEffect(() => {
+    const next = dateKey(selectedDate);
+    const cur = new URLSearchParams(window.location.search).get("date");
+    if (cur !== next) {
+      const url = new URL(window.location.href);
+      url.searchParams.set("date", next);
+      window.history.replaceState(null, "", url.toString());
+    }
+  }, [selectedDate]);
   const [data, setData] = useState<DispatchData | null>(null);
   const [loading, setLoading] = useState(true);
   const [selectedJob, setSelectedJob] = useState<DispatchJob | null>(null);
@@ -4183,8 +4200,8 @@ export default function JobsPage() {
 
               {/* View toggle */}
               <div style={{ display: "flex", border: "1px solid #E5E2DC", borderRadius: 8, overflow: "hidden" }}>
-                <button onClick={() => setDesktopView("timeline")} style={{ padding: "5px 10px", border: "none", cursor: "pointer", backgroundColor: desktopView === "timeline" ? "var(--brand)" : "#FAFAF9", color: desktopView === "timeline" ? "#fff" : "#6B7280", display: "flex" }}><LayoutGrid size={14} /></button>
-                <button onClick={() => setDesktopView("list")} style={{ padding: "5px 10px", border: "none", cursor: "pointer", backgroundColor: desktopView === "list" ? "var(--brand)" : "#FAFAF9", color: desktopView === "list" ? "#fff" : "#6B7280", display: "flex" }}><List size={14} /></button>
+                <button title="Timeline view — techs as rows, time across the top" onClick={() => setDesktopView("timeline")} style={{ padding: "5px 10px", border: "none", cursor: "pointer", backgroundColor: desktopView === "timeline" ? "var(--brand)" : "#FAFAF9", color: desktopView === "timeline" ? "#fff" : "#6B7280", display: "flex", alignItems: "center", gap: 5, fontSize: 12, fontWeight: 600 }}><Calendar size={14} /> Timeline</button>
+                <button title="List view — one card per job, stacked" onClick={() => setDesktopView("list")} style={{ padding: "5px 10px", border: "none", cursor: "pointer", backgroundColor: desktopView === "list" ? "var(--brand)" : "#FAFAF9", color: desktopView === "list" ? "#fff" : "#6B7280", display: "flex", alignItems: "center", gap: 5, fontSize: 12, fontWeight: 600 }}><List size={14} /> List</button>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary

Two dispatch fixes caught in a single session — both manifested as "Save & Convert to Job did nothing" when the operator was actually on the wrong day:

1. **View toggle labels** (`jobs.tsx:4185-4188`) — bare `LayoutGrid` + `List` icons had no labels or tooltips. Added Calendar icon for timeline + "Timeline" / "List" text labels and `title` attributes so the buttons read clearly.

2. **Dispatch ignored `?date=` URL param** (`jobs.tsx:3324`) — `selectedDate` was hard-seeded from `new Date()` on mount. So when `quote-builder.tsx:707` did `navigate('/dispatch?date=2026-05-28')` after converting a quote, the URL bar updated but dispatch rendered today (May 26). The new job was still in the DB on May 28 — just invisible until the operator clicked forward two days. Now reads `?date=YYYY-MM-DD` on mount and `replaceState`s on every `selectedDate` change so refresh + back-button preserve the view.

## Test plan

- [ ] Build a quote at `/quotes/new`, schedule for a future date, hit "Save & Convert to Job" — dispatch should land on that future day with the new job chip visible (not today).
- [ ] On `/dispatch`, change the date via the picker — URL should update to `?date=YYYY-MM-DD`, browser refresh should preserve the day.
- [ ] Hover the view-toggle buttons in the top-right of dispatch — Timeline / List labels should be visible inline + tooltips on hover.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtK2nRynyWpLiHYLuT22Bd)_