### PR TITLE
Regroup global sidebar nav into 7 themed sections

### DIFF
--- a/artifacts/qleno/src/components/layout/app-sidebar.tsx
+++ b/artifacts/qleno/src/components/layout/app-sidebar.tsx
@@ -56,40 +56,50 @@ const NAV_SECTIONS = [
       // MULTI_URL_HIGHLIGHT below.
       { title: "Jobs",      url: "/dispatch",  icon: Briefcase },
       { title: "Customers", url: "/customers", icon: Users },
-      { title: "Accounts",       url: "/accounts",   icon: Building2, roles: ["owner", "admin", "office"] },
-      { title: "Employees",      url: "/employees",  icon: UserCheck },
+      { title: "Accounts",  url: "/accounts",  icon: Building2, roles: ["owner", "admin", "office"] },
+    ],
+  },
+  {
+    label: "Sales",
+    items: [
+      { title: "Leads",  url: "/leads",  icon: UserPlus,   roles: ["owner", "admin", "office"], badge: "needs_contacted" },
+      { title: "Quotes", url: "/quotes", icon: FileTextIcon, roles: ["owner", "admin", "office"] },
+    ],
+  },
+  {
+    label: "Team",
+    items: [
+      { title: "Employees", url: "/employees", icon: UserCheck },
+      { title: "Payroll",   url: "/payroll",   icon: DollarSign, roles: ["owner", "admin"] },
     ],
   },
   {
     label: "Money",
     items: [
       { title: "Invoices", url: "/invoices", icon: FileText },
-      { title: "Payroll",  url: "/payroll",  icon: DollarSign, roles: ["owner", "admin"] },
-      { title: "Quotes",   url: "/quotes",   icon: FileTextIcon, roles: ["owner", "admin", "office"] },
     ],
   },
   {
-    label: "Grow",
+    label: "Insights",
     items: [
-      { title: "Leads",     url: "/leads",             icon: UserPlus,   roles: ["owner", "admin", "office"], badge: "needs_contacted" },
-      { title: "Reports",   url: "/reports",           icon: BarChart2,  roles: ["owner", "admin", "office"] },
-      { title: "Core KPIs", url: "/reports/insights",  icon: TrendingUp, roles: ["owner", "admin", "office"] },
-    ],
-  },
-  {
-    label: "Intelligence",
-    items: [
+      { title: "Reports",        url: "/reports",                icon: BarChart2,     roles: ["owner", "admin", "office"] },
+      { title: "Core KPIs",      url: "/reports/insights",       icon: TrendingUp,    roles: ["owner", "admin", "office"] },
       { title: "Churn Board",    url: "/intelligence/churn",     icon: AlertTriangle, roles: ["owner", "admin"] },
       { title: "Tech Retention", url: "/intelligence/retention", icon: HeartPulse,    roles: ["owner", "admin"] },
     ],
   },
   {
-    label: "Company",
+    label: "Learning",
     items: [
-      { title: "Settings",        url: "/company",         icon: Settings, roles: ["owner", "admin"] },
       { title: "Cleancyclopedia", url: "/cleancyclopedia", icon: BookOpen },
       { title: "Training",        url: "/training",        icon: GraduationCap },
       { title: "Training Admin",  url: "/lms/admin",       icon: GraduationCap, roles: ["owner", "admin", "super_admin", "office"] },
+    ],
+  },
+  {
+    label: "Admin",
+    items: [
+      { title: "Settings", url: "/company", icon: Settings, roles: ["owner", "admin"] },
     ],
   },
 ];


### PR DESCRIPTION
## Summary

Regroup the global sidebar nav from 5 drift-y sections into 7 tight ones:

| Before | After |
|---|---|
| Operations: Dashboard, Jobs, Customers, Accounts, Employees | Operations: Dashboard, Jobs, Customers, Accounts |
| Money: Invoices, Payroll, **Quotes** | Sales: Leads, Quotes |
| Grow: Leads, Reports, Core KPIs | Team: Employees, Payroll |
| Intelligence: Churn Board, Tech Retention | Money: Invoices |
| Company: Settings, Cleancyclopedia, Training, Training Admin | Insights: Reports, Core KPIs, Churn Board, Tech Retention |
| | Learning: Cleancyclopedia, Training, Training Admin |
| | Admin: Settings |

Three real misclassifications fixed:
- Quotes were under Money but they're pre-sale, not revenue.
- Grow and Intelligence both held analytics — Reports + Core KPIs vs Churn + Tech Retention. Same mental model, two headers. Merged into Insights.
- Cleancyclopedia / Training / Training Admin are learning tools, not company admin. Split out.

No URL changes, no role changes, no behavior changes. Same items, regrouped.

## Tradeoff

Money and Admin each have only one item now. More headers, slightly less density. Worth it for the unambiguous mental model — when you add the next thing, the bucket it belongs to is obvious.

## Test plan

- [ ] Open sidebar — 7 group headers in the new order.
- [ ] Confirm Quotes lives under Sales next to Leads.
- [ ] Confirm Employees lives under Team next to Payroll.
- [ ] Confirm Settings is alone under Admin.
- [ ] Active-state highlight still works on each route (no broken `MULTI_URL_HIGHLIGHT` link).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtK2nRynyWpLiHYLuT22Bd)_