### PR TITLE
Drag-and-drop attachments on Quote Call Notes

### DIFF
--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -393,6 +393,27 @@ async function runBookingSchemaGuard(): Promise<void> {
     { label: "recurring_schedules.custom_frequency_weeks",
       stmt: `ALTER TABLE recurring_schedules ADD COLUMN IF NOT EXISTS custom_frequency_weeks INTEGER` },
 
+    // [quote-attachments 2026-05-26] Files attached to a quote's Call
+    // Notes panel — photos clients send, screenshots the office takes,
+    // PDFs. Office-only on the quote screen. After convert-to-job,
+    // assigned techs read them via GET /api/jobs/:id/attachments which
+    // resolves back through quotes.booked_job_id.
+    { label: "CREATE quote_attachments", stmt: `
+      CREATE TABLE IF NOT EXISTS quote_attachments (
+        id           SERIAL PRIMARY KEY,
+        company_id   INTEGER NOT NULL REFERENCES companies(id),
+        quote_id     INTEGER NOT NULL REFERENCES quotes(id) ON DELETE CASCADE,
+        name         TEXT NOT NULL,
+        file_url     TEXT NOT NULL,
+        file_type    TEXT,
+        file_size    INTEGER,
+        uploaded_by  INTEGER REFERENCES users(id),
+        created_at   TIMESTAMP NOT NULL DEFAULT NOW()
+      )
+    ` },
+    { label: "idx_quote_attachments_quote",
+      stmt: `CREATE INDEX IF NOT EXISTS idx_quote_attachments_quote ON quote_attachments(quote_id)` },
+
     // Recurring add-ons junction — parent template for what spawns onto
     // each child job.
     { label: "CREATE recurring_schedule_add_ons", stmt: `

--- a/artifacts/api-server/src/routes/index.ts
+++ b/artifacts/api-server/src/routes/index.ts
@@ -26,6 +26,7 @@ import jobSmsRouter from "./job-sms.js";
 import quotesRouter from "./quotes.js";
 import paymentsRouter from "./payments.js";
 import attachmentsRouter from "./attachments.js";
+import { quoteAttachmentsRouter, jobAttachmentsRouter } from "./quote-attachments.js";
 import propertyGroupsRouter from "./property-groups.js";
 import agreementTemplatesRouter from "./agreement-templates.js";
 import billingRouter from "./billing.js";
@@ -109,6 +110,10 @@ router.use("/notifications", notificationsRouter);
 router.use("/quotes", quotesRouter);
 router.use("/payments", paymentsRouter);
 router.use("/attachments", attachmentsRouter);
+// [quote-attachments] The routers define full paths internally
+// (`:id/attachments`), so mount them at the resource root.
+router.use("/quotes", quoteAttachmentsRouter);
+router.use("/jobs", jobAttachmentsRouter);
 router.use("/property-groups", propertyGroupsRouter);
 router.use("/agreement-templates", agreementTemplatesRouter);
 router.use("/billing", billingRouter);

--- a/artifacts/api-server/src/routes/quote-attachments.ts
+++ b/artifacts/api-server/src/routes/quote-attachments.ts
@@ -1,0 +1,207 @@
+import { Router } from "express";
+import { db } from "@workspace/db";
+import { quoteAttachmentsTable, quotesTable, jobsTable, jobTechniciansTable } from "@workspace/db/schema";
+import { eq, and, desc, count } from "drizzle-orm";
+import { requireAuth, requireRole } from "../lib/auth.js";
+import multer from "multer";
+import path from "path";
+import fs from "fs";
+
+// [quote-attachments 2026-05-26] Drop-zone-driven uploads on the quote
+// builder's Call Notes panel. Mirrors the existing client_attachments
+// pattern (multer disk → /api/uploads/* public). Two routers exported:
+//   - quoteAttachmentsRouter  mounted on /api/quotes        (full CRUD)
+//   - jobAttachmentsRouter    mounted on /api/jobs          (read-only)
+// The job-side route resolves quotes.booked_job_id = :id so techs
+// don't need to know which quote their job came from.
+
+const ALLOWED_MIME = new Set([
+  "image/jpeg", "image/png", "image/heic", "image/heif", "image/webp", "image/gif",
+  "application/pdf",
+]);
+const MAX_FILES_PER_QUOTE = 10;
+const MAX_FILE_BYTES = 10 * 1024 * 1024;
+
+const upload = multer({
+  storage: multer.diskStorage({
+    destination: (_req, _file, cb) => {
+      const dir = "/tmp/uploads";
+      fs.mkdirSync(dir, { recursive: true });
+      cb(null, dir);
+    },
+    filename: (_req, file, cb) => {
+      const ext = path.extname(file.originalname);
+      cb(null, `${Date.now()}-${Math.random().toString(36).slice(2)}${ext}`);
+    },
+  }),
+  limits: { fileSize: MAX_FILE_BYTES },
+  fileFilter: (_req, file, cb) => {
+    if (ALLOWED_MIME.has(file.mimetype)) return cb(null, true);
+    cb(new Error(`Unsupported file type: ${file.mimetype}`));
+  },
+});
+
+// ── /api/quotes/:id/attachments ──────────────────────────────────────────
+export const quoteAttachmentsRouter = Router();
+
+quoteAttachmentsRouter.get("/:id/attachments", requireAuth, async (req, res) => {
+  try {
+    const quoteId = parseInt(req.params.id);
+    if (!quoteId) { res.status(400).json({ error: "quoteId required" }); return; }
+    const rows = await db
+      .select()
+      .from(quoteAttachmentsTable)
+      .where(and(
+        eq(quoteAttachmentsTable.company_id, req.auth!.companyId),
+        eq(quoteAttachmentsTable.quote_id, quoteId),
+      ))
+      .orderBy(desc(quoteAttachmentsTable.created_at));
+    res.json(rows);
+  } catch (e: any) {
+    console.error("List quote attachments error:", e);
+    res.status(500).json({ error: "Internal Server Error", message: e.message });
+  }
+});
+
+quoteAttachmentsRouter.post("/:id/attachments", requireAuth, requireRole("owner", "admin", "office"), upload.single("file"), async (req, res) => {
+  try {
+    const quoteId = parseInt(req.params.id);
+    if (!quoteId) { res.status(400).json({ error: "quoteId required" }); return; }
+    if (!req.file) { res.status(400).json({ error: "file required" }); return; }
+
+    // Verify the quote belongs to this tenant before storing anything.
+    const [quote] = await db.select({ id: quotesTable.id })
+      .from(quotesTable)
+      .where(and(eq(quotesTable.id, quoteId), eq(quotesTable.company_id, req.auth!.companyId)))
+      .limit(1);
+    if (!quote) {
+      try { fs.unlinkSync(req.file.path); } catch { /* ignore */ }
+      res.status(404).json({ error: "Quote not found" });
+      return;
+    }
+
+    // Enforce the 10-file cap per quote.
+    const [{ value: existing }] = await db.select({ value: count() })
+      .from(quoteAttachmentsTable)
+      .where(and(
+        eq(quoteAttachmentsTable.company_id, req.auth!.companyId),
+        eq(quoteAttachmentsTable.quote_id, quoteId),
+      ));
+    if (existing >= MAX_FILES_PER_QUOTE) {
+      try { fs.unlinkSync(req.file.path); } catch { /* ignore */ }
+      res.status(400).json({ error: `Maximum ${MAX_FILES_PER_QUOTE} files per quote` });
+      return;
+    }
+
+    // app.ts mounts express.static on /api/uploads → ../uploads (set as
+    // UPLOADS_DIR). Write there directly so files are served immediately.
+    const uploadsDir = process.env.UPLOADS_DIR ?? path.join(process.cwd(), "uploads");
+    fs.mkdirSync(uploadsDir, { recursive: true });
+    const destPath = path.join(uploadsDir, req.file.filename);
+    fs.renameSync(req.file.path, destPath);
+
+    const bodyName = typeof req.body?.name === "string" ? req.body.name : req.file.originalname;
+    const [attachment] = await db.insert(quoteAttachmentsTable).values({
+      company_id: req.auth!.companyId,
+      quote_id: quoteId,
+      name: bodyName,
+      file_url: `/api/uploads/${req.file.filename}`,
+      file_type: req.file.mimetype,
+      file_size: req.file.size,
+      uploaded_by: req.auth!.userId,
+    }).returning();
+    res.status(201).json(attachment);
+  } catch (e: any) {
+    console.error("Upload quote attachment error:", e);
+    res.status(500).json({ error: "Internal Server Error", message: e.message });
+  }
+});
+
+quoteAttachmentsRouter.delete("/:id/attachments/:fileId", requireAuth, requireRole("owner", "admin", "office"), async (req, res) => {
+  try {
+    const quoteId = parseInt(req.params.id);
+    const fileId = parseInt(req.params.fileId);
+    if (!quoteId || !fileId) { res.status(400).json({ error: "quoteId and fileId required" }); return; }
+
+    const [row] = await db.select()
+      .from(quoteAttachmentsTable)
+      .where(and(
+        eq(quoteAttachmentsTable.id, fileId),
+        eq(quoteAttachmentsTable.quote_id, quoteId),
+        eq(quoteAttachmentsTable.company_id, req.auth!.companyId),
+      ))
+      .limit(1);
+    if (!row) { res.status(404).json({ error: "Attachment not found" }); return; }
+
+    await db.delete(quoteAttachmentsTable).where(eq(quoteAttachmentsTable.id, fileId));
+
+    // Best-effort disk cleanup. Missing file = harmless.
+    if (row.file_url?.startsWith("/api/uploads/")) {
+      const uploadsDir = process.env.UPLOADS_DIR ?? path.join(process.cwd(), "uploads");
+      const diskPath = path.join(uploadsDir, path.basename(row.file_url));
+      try { fs.unlinkSync(diskPath); } catch { /* gone is fine */ }
+    }
+    res.json({ success: true });
+  } catch (e: any) {
+    console.error("Delete quote attachment error:", e);
+    res.status(500).json({ error: "Internal Server Error", message: e.message });
+  }
+});
+
+// ── /api/jobs/:id/attachments ────────────────────────────────────────────
+// Read-only. Resolves quotes.booked_job_id = :id, returns its files.
+// Owners / admins / office see any job; technicians must be assigned to
+// the specific job (primary OR in job_technicians).
+export const jobAttachmentsRouter = Router();
+
+jobAttachmentsRouter.get("/:id/attachments", requireAuth, async (req, res) => {
+  try {
+    const jobId = parseInt(req.params.id);
+    if (!jobId) { res.status(400).json({ error: "jobId required" }); return; }
+
+    const [job] = await db.select({ id: jobsTable.id, assigned_user_id: jobsTable.assigned_user_id })
+      .from(jobsTable)
+      .where(and(eq(jobsTable.id, jobId), eq(jobsTable.company_id, req.auth!.companyId)))
+      .limit(1);
+    if (!job) { res.status(404).json({ error: "Job not found" }); return; }
+
+    const role = req.auth!.role;
+    const userId = req.auth!.userId;
+    if (role === "technician") {
+      const isPrimary = job.assigned_user_id === userId;
+      let isOnCrew = false;
+      if (!isPrimary) {
+        const [match] = await db.select({ id: jobTechniciansTable.id })
+          .from(jobTechniciansTable)
+          .where(and(
+            eq(jobTechniciansTable.job_id, jobId),
+            eq(jobTechniciansTable.user_id, userId),
+          ))
+          .limit(1);
+        isOnCrew = !!match;
+      }
+      if (!isPrimary && !isOnCrew) { res.status(403).json({ error: "Not assigned to this job" }); return; }
+    }
+
+    const [quote] = await db.select({ id: quotesTable.id })
+      .from(quotesTable)
+      .where(and(
+        eq(quotesTable.company_id, req.auth!.companyId),
+        eq(quotesTable.booked_job_id, jobId),
+      ))
+      .limit(1);
+    if (!quote) { res.json([]); return; }
+
+    const rows = await db.select()
+      .from(quoteAttachmentsTable)
+      .where(and(
+        eq(quoteAttachmentsTable.company_id, req.auth!.companyId),
+        eq(quoteAttachmentsTable.quote_id, quote.id),
+      ))
+      .orderBy(desc(quoteAttachmentsTable.created_at));
+    res.json(rows);
+  } catch (e: any) {
+    console.error("List job attachments error:", e);
+    res.status(500).json({ error: "Internal Server Error", message: e.message });
+  }
+});

--- a/artifacts/qleno/src/components/quote-attachments.tsx
+++ b/artifacts/qleno/src/components/quote-attachments.tsx
@@ -1,0 +1,267 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import { Paperclip, X, Loader2, FileText, AlertCircle } from "lucide-react";
+import { getAuthHeaders } from "@/lib/auth";
+
+// Lightweight fetch wrapper — auth header + JSON parse. Mirrors the
+// pattern used throughout the qleno app (each page redefines its own;
+// inlining here keeps this component self-contained).
+async function apiFetch(path: string, opts: RequestInit = {}) {
+  const auth = getAuthHeaders() as Record<string, string>;
+  const headers: Record<string, string> = {
+    ...auth,
+    ...(opts.body ? { "Content-Type": "application/json" } : {}),
+    ...((opts.headers as Record<string, string>) ?? {}),
+  };
+  const body = opts.body && typeof opts.body !== "string" ? JSON.stringify(opts.body) : opts.body;
+  const r = await fetch(path, { ...opts, headers, body });
+  if (!r.ok) throw new Error(`${r.status}`);
+  return r.status === 204 ? null : r.json();
+}
+
+const FF = "'Plus Jakarta Sans', sans-serif";
+const ALLOWED_MIME = new Set([
+  "image/jpeg", "image/png", "image/heic", "image/heif", "image/webp", "image/gif",
+  "application/pdf",
+]);
+const MAX_FILES = 10;
+const MAX_BYTES = 10 * 1024 * 1024;
+
+export type Attachment = {
+  id: number;
+  name: string;
+  file_url: string;
+  file_type: string | null;
+  file_size: number | null;
+  created_at: string;
+};
+
+type Props = {
+  /** Async getter — must return a quote id; if no quote exists yet,
+   *  the caller is expected to create a draft and return its id. The
+   *  attachments component delays the upload until this resolves. */
+  ensureQuoteId: () => Promise<number | null>;
+  /** Read-only mode (e.g., tech viewing on the job side). */
+  readOnly?: boolean;
+  /** Override the GET endpoint — defaults to /api/quotes/:id/attachments,
+   *  but the job view uses /api/jobs/:id/attachments. */
+  endpointOverride?: string;
+  /** Compact mode — smaller thumbs, used inside dense panels. */
+  compact?: boolean;
+};
+
+export function QuoteAttachments({ ensureQuoteId, readOnly, endpointOverride, compact }: Props) {
+  const [attachments, setAttachments] = useState<Attachment[]>([]);
+  const [uploading, setUploading] = useState(false);
+  const [dragOver, setDragOver] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [quoteId, setQuoteId] = useState<number | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Initial load — resolve the quote id, then fetch its attachments.
+  // For brand-new drafts (no quote saved yet) ensureQuoteId may return
+  // null; that's fine, we render the empty drop zone and only mint the
+  // quote when the user actually drops a file.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const id = await ensureQuoteId();
+      if (cancelled) return;
+      setQuoteId(id);
+      if (id != null) await loadList(id);
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  async function loadList(id: number) {
+    try {
+      const url = endpointOverride ?? `/api/quotes/${id}/attachments`;
+      const rows = await apiFetch(url);
+      setAttachments(Array.isArray(rows) ? rows : []);
+    } catch {
+      // Don't blow up the page if the list fetch fails — just leave it empty.
+    }
+  }
+
+  const uploadFiles = useCallback(async (files: FileList | File[]) => {
+    setError(null);
+    const list = Array.from(files);
+    if (list.length === 0) return;
+
+    // Resolve / create quote id before doing anything.
+    const id = quoteId ?? await ensureQuoteId();
+    if (id == null) {
+      setError("Could not create draft quote. Save the quote first, then try again.");
+      return;
+    }
+    setQuoteId(id);
+
+    // Client-side validation — server enforces the same rules but failing
+    // here gives faster feedback and skips wasted bytes on the wire.
+    const filtered: File[] = [];
+    for (const f of list) {
+      if (!ALLOWED_MIME.has(f.type)) {
+        setError(`"${f.name}" is not a supported file type. Use JPG/PNG/HEIC/WEBP/PDF.`);
+        continue;
+      }
+      if (f.size > MAX_BYTES) {
+        setError(`"${f.name}" is over 10 MB.`);
+        continue;
+      }
+      filtered.push(f);
+    }
+    if (attachments.length + filtered.length > MAX_FILES) {
+      setError(`Maximum ${MAX_FILES} files per quote.`);
+      filtered.splice(MAX_FILES - attachments.length);
+    }
+    if (filtered.length === 0) return;
+
+    setUploading(true);
+    for (const file of filtered) {
+      const form = new FormData();
+      form.append("file", file);
+      form.append("name", file.name);
+      try {
+        const res = await fetch(`/api/quotes/${id}/attachments`, {
+          method: "POST",
+          headers: getAuthHeaders() as Record<string, string>,
+          body: form,
+        });
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          setError(body.error || `Upload failed for "${file.name}".`);
+          continue;
+        }
+        const row = await res.json();
+        setAttachments(prev => [row, ...prev]);
+      } catch {
+        setError(`Upload failed for "${file.name}".`);
+      }
+    }
+    setUploading(false);
+  }, [attachments.length, ensureQuoteId, quoteId]);
+
+  async function removeAttachment(id: number) {
+    if (quoteId == null) return;
+    try {
+      await apiFetch(`/api/quotes/${quoteId}/attachments/${id}`, { method: "DELETE" });
+      setAttachments(prev => prev.filter(a => a.id !== id));
+    } catch {
+      setError("Could not delete that file. Refresh and try again.");
+    }
+  }
+
+  function handleDrop(e: React.DragEvent) {
+    e.preventDefault();
+    setDragOver(false);
+    if (readOnly) return;
+    if (e.dataTransfer.files?.length) uploadFiles(e.dataTransfer.files);
+  }
+
+  const thumbSize = compact ? 56 : 72;
+
+  return (
+    <div
+      onDragOver={readOnly ? undefined : e => { e.preventDefault(); setDragOver(true); }}
+      onDragLeave={readOnly ? undefined : () => setDragOver(false)}
+      onDrop={handleDrop}
+      style={{
+        marginTop: 10,
+        padding: dragOver ? 10 : 0,
+        border: dragOver ? "2px dashed #2D9B83" : "2px dashed transparent",
+        borderRadius: 8,
+        background: dragOver ? "#EAF9F4" : "transparent",
+        transition: "background 0.12s, border-color 0.12s, padding 0.12s",
+      }}
+    >
+      {/* Action row */}
+      {!readOnly && (
+        <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap", marginBottom: attachments.length ? 8 : 0 }}>
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={uploading || attachments.length >= MAX_FILES}
+            style={{
+              display: "inline-flex", alignItems: "center", gap: 6,
+              fontSize: 12, fontWeight: 600, fontFamily: FF,
+              padding: "6px 12px", borderRadius: 7,
+              border: "1px solid #E5E2DC", background: "#FFF", color: "#1A1917",
+              cursor: (uploading || attachments.length >= MAX_FILES) ? "not-allowed" : "pointer",
+              opacity: (uploading || attachments.length >= MAX_FILES) ? 0.5 : 1,
+            }}
+          >
+            {uploading ? <Loader2 size={13} className="animate-spin" /> : <Paperclip size={13} />}
+            {uploading ? "Uploading..." : "Attach photo or PDF"}
+          </button>
+          <span style={{ fontSize: 11, color: "#9E9B94", fontFamily: FF }}>
+            or drop files here — {attachments.length}/{MAX_FILES} used
+          </span>
+          <input
+            ref={fileInputRef}
+            type="file"
+            multiple
+            accept="image/jpeg,image/png,image/heic,image/heif,image/webp,image/gif,application/pdf"
+            onChange={e => { if (e.target.files) uploadFiles(e.target.files); e.target.value = ""; }}
+            style={{ display: "none" }}
+          />
+        </div>
+      )}
+
+      {error && (
+        <div style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 11, color: "#DC2626", fontFamily: FF, marginBottom: 8 }}>
+          <AlertCircle size={12} /> {error}
+        </div>
+      )}
+
+      {/* Thumbnail row */}
+      {attachments.length > 0 && (
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+          {attachments.map(a => {
+            const isImage = a.file_type?.startsWith("image/");
+            return (
+              <div
+                key={a.id}
+                style={{
+                  position: "relative",
+                  width: thumbSize, height: thumbSize,
+                  borderRadius: 7, border: "1px solid #E5E2DC", background: "#FAFAF9",
+                  overflow: "hidden",
+                  display: "flex", alignItems: "center", justifyContent: "center",
+                }}
+                title={a.name}
+              >
+                <a href={a.file_url} target="_blank" rel="noopener noreferrer" style={{ display: "block", width: "100%", height: "100%" }}>
+                  {isImage ? (
+                    <img src={a.file_url} alt={a.name} style={{ width: "100%", height: "100%", objectFit: "cover" }} />
+                  ) : (
+                    <div style={{ display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", height: "100%", padding: 4 }}>
+                      <FileText size={20} color="#6B6860" />
+                      <span style={{ fontSize: 9, fontFamily: FF, color: "#6B6860", marginTop: 3, textAlign: "center", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", maxWidth: thumbSize - 8 }}>
+                        {a.name}
+                      </span>
+                    </div>
+                  )}
+                </a>
+                {!readOnly && (
+                  <button
+                    type="button"
+                    onClick={e => { e.stopPropagation(); e.preventDefault(); removeAttachment(a.id); }}
+                    style={{
+                      position: "absolute", top: 3, right: 3,
+                      width: 18, height: 18, borderRadius: "50%",
+                      background: "rgba(0,0,0,0.6)", color: "#FFF",
+                      border: "none", cursor: "pointer",
+                      display: "flex", alignItems: "center", justifyContent: "center",
+                    }}
+                    title="Remove"
+                  >
+                    <X size={11} />
+                  </button>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/artifacts/qleno/src/pages/my-jobs.tsx
+++ b/artifacts/qleno/src/pages/my-jobs.tsx
@@ -8,6 +8,7 @@ import { useEmployeeView } from "@/contexts/employee-view-context";
 import { getJobVisualStatus, STATUS_VISUALS, ensureJobStatusStyles } from "@/lib/job-status";
 import { formatAddress } from "@/lib/format-address";
 import { QlenoMark } from "@/components/brand/QlenoMark";
+import { QuoteAttachments } from "@/components/quote-attachments";
 
 const BASE = import.meta.env.BASE_URL.replace(/\/$/, "");
 
@@ -215,6 +216,36 @@ function DistanceBadge({ jobLat, jobLng, empPos }: {
     }}>
       {parseFloat(miles) < 0.1 ? `${ft} ft` : `${miles} mi`} away — {label}
     </span>
+  );
+}
+
+// [quote-attachments] Tech-facing read-only view of files the office
+// attached on the source quote. Pre-fetches count so the section header
+// only renders when there's actually something to show.
+function OfficeAttachments({ jobId }: { jobId: number }) {
+  const [hasAny, setHasAny] = useState<boolean | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    apiFetch(`/jobs/${jobId}/attachments`)
+      .then(r => r.json())
+      .then((rows: unknown[]) => { if (!cancelled) setHasAny(Array.isArray(rows) && rows.length > 0); })
+      .catch(() => { if (!cancelled) setHasAny(false); });
+    return () => { cancelled = true; };
+  }, [jobId]);
+
+  if (!hasAny) return null;
+  return (
+    <div style={{ marginTop: 12 }}>
+      <p style={{ fontSize: 10, fontWeight: 600, color: "#9E9B94", textTransform: "uppercase", letterSpacing: "0.06em", margin: "0 0 6px" }}>
+        Office Attachments
+      </p>
+      <QuoteAttachments
+        readOnly
+        ensureQuoteId={async () => jobId}
+        endpointOverride={`/api/jobs/${jobId}/attachments`}
+        compact
+      />
+    </div>
   );
 }
 
@@ -481,6 +512,11 @@ function JobCard({ job, empPos, onRefresh, isPreviewMode }: { job: Job; empPos: 
           <p style={{ fontSize: 12, color: "#1A1917", margin: 0 }}>{job.client_notes}</p>
         </div>
       )}
+
+      {/* [quote-attachments] Files the office attached on the source quote.
+          Read-only here — techs see photos/PDFs the client sent or the
+          office screenshotted during the booking call. */}
+      <OfficeAttachments jobId={job.id} />
 
       <PhotoGrid jobId={job.id} type="before" photos={photosBefore} onUploaded={loadPhotos} />
       <PhotoGrid jobId={job.id} type="after" photos={photosAfter} onUploaded={loadPhotos} />

--- a/artifacts/qleno/src/pages/quote-builder.tsx
+++ b/artifacts/qleno/src/pages/quote-builder.tsx
@@ -14,6 +14,7 @@ import {
 import {
   Popover, PopoverContent, PopoverTrigger,
 } from "@/components/ui/popover";
+import { QuoteAttachments } from "@/components/quote-attachments";
 import {
   ArrowLeft, Save, SendHorizonal, ArrowRight, ChevronDown,
   User, Home, Calculator, PlusSquare, AlertCircle, CheckCircle2, Check,
@@ -331,6 +332,22 @@ export default function QuoteBuilderPage() {
       }
     }
   }, [existingQuote, scopes.length]);
+
+  // [quote-attachments] Async resolver passed to the <QuoteAttachments>
+  // component. Returns the working quote id; if no quote exists yet
+  // (brand-new draft, no auto-save fired), mints a draft now so an
+  // attachment can be associated. Subsequent uploads reuse the id.
+  const ensureQuoteId = useCallback(async (): Promise<number | null> => {
+    if (isEdit && id) return parseInt(id);
+    if (autoSavedIdRef.current) return parseInt(autoSavedIdRef.current);
+    try {
+      const result = await apiFetch("/api/quotes", { method: "POST", body: { status: "draft" } });
+      autoSavedIdRef.current = String(result.id);
+      return result.id;
+    } catch {
+      return null;
+    }
+  }, [isEdit, id]);
 
   // ── Call Notes auto-save (10s debounce) ─────────────────────────────────
   useEffect(() => {
@@ -2328,6 +2345,9 @@ export default function QuoteBuilderPage() {
               rows={10}
               style={{ width: "100%", boxSizing: "border-box", resize: "none", border: "1px solid #E5E2DC", borderRadius: 8, padding: "10px 12px", fontSize: 13, lineHeight: "1.6", color: "#1A1917", fontFamily: FF, background: "#FAFAF9", outline: "none" }}
             />
+            {/* [quote-attachments] Drop zone + thumbnail row. Photos and
+                PDFs office uploads stay private to office + assigned techs. */}
+            <QuoteAttachments ensureQuoteId={ensureQuoteId} />
           </div>
 
           {/* Price Preview */}
@@ -2395,7 +2415,7 @@ export default function QuoteBuilderPage() {
                           <div style={{ marginTop: 8, paddingTop: 8, borderTop: "1px dashed #E5E2DC" }}>
                             <div style={{ fontSize: 11, fontWeight: 600, color: "#6B6860", marginBottom: 4, fontFamily: FF }}>Commission ({ratePct}%)</div>
                             <div style={{ fontSize: 12, color: "#6B6860", fontFamily: FF }}>
-                              Pool: ${cs.totalCommission.toFixed(2)}
+                              Tech Pay: ${cs.totalCommission.toFixed(2)}
                             </div>
                             {cs.mode === "unassigned" && (
                               <div style={{ fontSize: 11, color: "#9E9B94", fontFamily: FF, marginTop: 2 }}>Will calculate once techs are assigned</div>

--- a/lib/db/src/schema/index.ts
+++ b/lib/db/src/schema/index.ts
@@ -32,6 +32,7 @@ export * from "./agreement_templates";
 export * from "./form_templates";
 export * from "./form_submissions";
 export * from "./quote_scopes";
+export * from "./quote_attachments";
 export * from "./daily_summaries";
 export * from "./app_audit_log";
 export * from "./payment_links";

--- a/lib/db/src/schema/quote_attachments.ts
+++ b/lib/db/src/schema/quote_attachments.ts
@@ -1,0 +1,27 @@
+import { pgTable, serial, text, integer, timestamp } from "drizzle-orm/pg-core";
+import { createInsertSchema } from "drizzle-zod";
+import { z } from "zod/v4";
+import { companiesTable } from "./companies";
+import { quotesTable } from "./quotes";
+import { usersTable } from "./users";
+
+// [quote-attachments 2026-05-26] Files attached to a quote's Call Notes
+// (client-supplied photos, office screenshots, PDFs). Office-only on the
+// quote screen. When the quote converts to a job, techs assigned to the
+// job can read them via GET /api/jobs/:id/attachments — which resolves
+// back through quotes.booked_job_id. Customers never see these.
+export const quoteAttachmentsTable = pgTable("quote_attachments", {
+  id: serial("id").primaryKey(),
+  company_id: integer("company_id").references(() => companiesTable.id).notNull(),
+  quote_id: integer("quote_id").references(() => quotesTable.id, { onDelete: "cascade" }).notNull(),
+  name: text("name").notNull(),
+  file_url: text("file_url").notNull(),
+  file_type: text("file_type"),
+  file_size: integer("file_size"),
+  uploaded_by: integer("uploaded_by").references(() => usersTable.id),
+  created_at: timestamp("created_at").notNull().defaultNow(),
+});
+
+export const insertQuoteAttachmentSchema = createInsertSchema(quoteAttachmentsTable).omit({ id: true, created_at: true });
+export type InsertQuoteAttachment = z.infer<typeof insertQuoteAttachmentSchema>;
+export type QuoteAttachment = typeof quoteAttachmentsTable.$inferSelect;


### PR DESCRIPTION
## Summary

Office can drag-and-drop client photos / PDFs / screenshots onto the Call Notes card in the quote builder. Files stay private to office + assigned techs — never sent to the customer.

### Frontend
- New `<QuoteAttachments />` component (drop zone + thumbnail row, click to open, X to remove). Reused on both surfaces:
  - **Quote builder Call Notes** — full CRUD for office.
  - **My Jobs job detail** — `readOnly` + `endpointOverride` so techs see the source-quote attachments without an upload UI. Section header only renders when at least one file exists.
- `ensureQuoteId()` helper in the quote builder mints a draft quote on first upload when one doesn't exist yet, so the user can drop a file before typing any notes.
- Rename **"Pool: $X" → "Tech Pay: $X"** in the Price Preview panel so it stops reading like a swimming-pool reference.

### Backend
- New `quote_attachments` table: `(id, company_id, quote_id, name, file_url, file_type, file_size, uploaded_by, created_at)`. Cascades on quote delete. Idempotent CREATE TABLE wired into `phes-data-migration.ts` so existing tenants pick it up on cold-start.
- `/api/quotes/:id/attachments` — GET / POST / DELETE for office (owner/admin/office).
- `/api/jobs/:id/attachments` — read-only. Resolves `quotes.booked_job_id = :id` back to the source quote and returns its files. Tech ACL: must be primary OR in `job_technicians` for that job.
- Multer disk storage with MIME filter (jpg/png/heic/heif/webp/gif/pdf) and 10 MB / 10-file caps, writes into `app.ts`'s existing `UPLOADS_DIR` that's already statically served at `/api/uploads/*`.

## Test plan

- [ ] On `/quotes/new`, type some call notes and drop a photo onto the panel → thumbnail appears, count says 1/10.
- [ ] Drop a PDF → renders as FileText icon with filename pill.
- [ ] Try dropping a `.docx` → rejected client-side with "Unsupported file type."
- [ ] Try dropping 11 files → 10 accepted, error shows for the 11th.
- [ ] Save & Convert the quote to a job, then open the job in My Jobs as the assigned tech → "Office Attachments" section appears with the same files.
- [ ] Confirm the Price Preview now reads "Tech Pay: $X" instead of "Pool: $X".

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtK2nRynyWpLiHYLuT22Bd)_