### PR TITLE
Restore Maps autocomplete in quote builder + clean 1-tech wording

### DIFF
--- a/artifacts/qleno/src/pages/quote-builder.tsx
+++ b/artifacts/qleno/src/pages/quote-builder.tsx
@@ -180,6 +180,9 @@ export default function QuoteBuilderPage() {
   const [inputMounted, setInputMounted] = useState(false);
   const [addressVerified, setAddressVerified] = useState<boolean | null>(null);
   const [addressFormatted, setAddressFormatted] = useState("");
+  // [maps-runtime-fallback] Cache the resolved Maps key so the geocode
+  // helper (separate REST call) doesn't need to know how it was sourced.
+  const mapsKeyRef = useRef<string>("");
   const [callNoteTooltip, setCallNoteTooltip] = useState<{ x: number; y: number; text: string } | null>(null);
   const [pushConfirmed, setPushConfirmed] = useState(false);
 
@@ -379,8 +382,11 @@ export default function QuoteBuilderPage() {
   }, [sqft]);
 
   // ── Load Google Maps Places API ──────────────────────────────────────────
+  // [maps-runtime-fallback 2026-05-26] Same pattern as jobs.tsx — fetch the
+  // key from /api/config/google-maps-key first so we stay resilient when
+  // the Railway build didn't inject VITE_GOOGLE_MAPS_API_KEY. Falls back
+  // to the build-time var if the server endpoint is unreachable.
   useEffect(() => {
-    const key = (import.meta as any).env?.VITE_GOOGLE_MAPS_API_KEY ?? "";
     if ((window as any).google?.maps?.places) { setMapsReady(true); return; }
     const scriptId = "gmap-places-script";
     if (document.getElementById(scriptId)) {
@@ -388,14 +394,34 @@ export default function QuoteBuilderPage() {
       if (existing) { existing.addEventListener("load", () => setMapsReady(true)); }
       return;
     }
-    if (!key) return;
-    const s = document.createElement("script");
-    s.id = scriptId;
-    s.src = `https://maps.googleapis.com/maps/api/js?key=${key}&libraries=places`;
-    s.async = true;
-    s.defer = true;
-    s.onload = () => setMapsReady(true);
-    document.head.appendChild(s);
+
+    let cancelled = false;
+    (async () => {
+      let key = "";
+      try {
+        const r = await fetch(`${API}/api/config/google-maps-key`, { headers: getAuthHeaders() });
+        if (r.ok) {
+          const body = await r.json().catch(() => ({}));
+          key = String(body?.key ?? "");
+        }
+      } catch { /* fall through to build-time fallback */ }
+      if (!key) key = (import.meta as any).env?.VITE_GOOGLE_MAPS_API_KEY ?? "";
+      if (cancelled || !key) return;
+      mapsKeyRef.current = key;
+
+      // Re-check whether another instance already injected the script
+      // while we were awaiting the fetch.
+      if ((window as any).google?.maps?.places) { setMapsReady(true); return; }
+      if (document.getElementById(scriptId)) return;
+      const s = document.createElement("script");
+      s.id = scriptId;
+      s.src = `https://maps.googleapis.com/maps/api/js?key=${key}&libraries=places`;
+      s.async = true;
+      s.defer = true;
+      s.onload = () => { if (!cancelled) setMapsReady(true); };
+      document.head.appendChild(s);
+    })();
+    return () => { cancelled = true; };
   }, []);
 
   // ── Wire autocomplete after Maps ready + input mounted ──────────────────
@@ -428,7 +454,7 @@ export default function QuoteBuilderPage() {
 
   // ── Geocode helper for client-loaded addresses ───────────────────────────
   async function geocodeVerify(addressStr: string) {
-    const key = (import.meta as any).env?.VITE_GOOGLE_MAPS_API_KEY ?? "";
+    const key = mapsKeyRef.current || (import.meta as any).env?.VITE_GOOGLE_MAPS_API_KEY || "";
     if (!key || !addressStr.trim()) { setAddressVerified(false); return; }
     try {
       const r = await fetch(
@@ -2422,8 +2448,11 @@ export default function QuoteBuilderPage() {
                             )}
                             {cs.mode === "equal" && cs.perTech.length > 0 && (
                               <div style={{ fontSize: 11, color: "#6B6860", fontFamily: FF, marginTop: 2 }}>
-                                ${cs.totalCommission.toFixed(2)} / {techCount} tech = ${cs.perTech[0].commission.toFixed(2)} each
-                                {estHrs > 0 && ` | ${cs.perTech[0].hours} hrs each`}
+                                {techCount === 1 ? (
+                                  <>${cs.perTech[0].commission.toFixed(2)}{estHrs > 0 && ` · ${cs.perTech[0].hours} hrs`}</>
+                                ) : (
+                                  <>${cs.totalCommission.toFixed(2)} ÷ {techCount} techs = ${cs.perTech[0].commission.toFixed(2)} each{estHrs > 0 && ` · ${cs.perTech[0].hours} hrs each`}</>
+                                )}
                               </div>
                             )}
                           </div>
@@ -2482,7 +2511,11 @@ export default function QuoteBuilderPage() {
                     <div style={{ fontSize: 11, fontWeight: 600, color: "#6B6860", marginBottom: 2, fontFamily: FF }}>Commission (blended): ${csTotalCommission.toFixed(2)}</div>
                     {cs.mode === "unassigned" && <div style={{ fontSize: 11, color: "#9E9B94", fontFamily: FF }}>Will calculate once techs are assigned</div>}
                     {cs.mode === "equal" && cs.perTech.length > 0 && (
-                      <div style={{ fontSize: 11, color: "#6B6860", fontFamily: FF }}>${cs.perTech[0].commission.toFixed(2)} / tech | {cs.perTech[0].hours} hrs / tech</div>
+                      <div style={{ fontSize: 11, color: "#6B6860", fontFamily: FF }}>
+                        {techCount === 1
+                          ? <>${cs.perTech[0].commission.toFixed(2)} · {cs.perTech[0].hours} hrs</>
+                          : <>${cs.perTech[0].commission.toFixed(2)} / tech · {cs.perTech[0].hours} hrs / tech</>}
+                      </div>
                     )}
                   </div>
                   <div style={{ fontSize: 12, color: "#9E9B94", marginTop: 10, textAlign: "center", fontFamily: FF }}>


### PR DESCRIPTION
## Summary

Two unrelated fixes that surfaced together in the Service Address / Price Preview area of the quote builder:

### 1. Address autocomplete + verification stopped working

`quote-builder.tsx` only read the build-time `VITE_GOOGLE_MAPS_API_KEY`. When Railway didn't inject it on a build, the script tag never loaded and the Places Autocomplete never wired — typing in Service Address went silent, no verification banner, no zip auto-population. Dispatch (`jobs.tsx`) kept working because it already has a runtime fallback.

Port the same fallback into the quote builder: fetch the key from `/api/config/google-maps-key` first, fall through to the build-time var if the server endpoint is unreachable. Cache the resolved key in a `mapsKeyRef` so the separate `geocodeVerify` REST call uses the same source.

### 2. 1-tech wording cleanup

With 1 tech assigned the Price Preview rendered:

```
$158.72 / 1 tech = $158.72 each | 6.2 hrs each
```

Redundant division and "each" wording. Now reads:

```
$158.72 · 6.2 hrs           (1 tech)
$158.72 ÷ 2 techs = $79.36 each · 3.1 hrs each   (2+ techs)
```

Same cleanup applied to the multi-scope grand-total panel.

## Test plan

- [ ] Open `/quotes/new` — start typing a Service Address — Google autocomplete dropdown should appear after 2-3 characters.
- [ ] Pick a suggestion — address field populates, zip auto-fills, verification banner appears.
- [ ] On a single Deep Clean scope with 1 tech selected, Price Preview reads "$X · Y hrs" (no "/1 tech =").
- [ ] Assign 2 techs to the same quote — reads "$X ÷ 2 techs = $Y each · Z hrs each".

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtK2nRynyWpLiHYLuT22Bd)_