### PR TITLE
Scroll-to-top on section change + include add-on time in Est. hours

### DIFF
--- a/artifacts/qleno/src/pages/quote-builder.tsx
+++ b/artifacts/qleno/src/pages/quote-builder.tsx
@@ -118,6 +118,17 @@ export default function QuoteBuilderPage() {
   const [activeSection, setActiveSection] = useState(0);
   const [saving, setSaving] = useState(false);
 
+  // [scroll-on-step 2026-05-27] Snap viewport to top whenever the user
+  // advances or backs up a section. Without this the page keeps its
+  // prior scroll position — the new section's "Next" button sat in view
+  // while the section header was off-screen above, so it looked like the
+  // form had jumped to its bottom. Mobile already did this inline at the
+  // step-button onClick; mirroring it here covers every entry point
+  // (top-tab clicks, programmatic setActiveSection on convert, etc.).
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  }, [activeSection]);
+
   // ── Section 0: Customer Info ─────────────────────────────────────────────
   const [selectedClientId, setSelectedClientId] = useState<number | null>(null);
   const [clientSearch, setClientSearch] = useState("");

--- a/artifacts/qleno/src/pages/quote-builder.tsx
+++ b/artifacts/qleno/src/pages/quote-builder.tsx
@@ -65,7 +65,8 @@ interface PricingAddon {
 
 interface CalcResult {
   scope_id: number; pricing_method: string; sqft: number | null; frequency: string | null;
-  base_hours: number; hourly_rate: number; base_price: number; minimum_applied: boolean;
+  base_hours: number; addon_hours?: number; total_hours?: number;
+  hourly_rate: number; base_price: number; minimum_applied: boolean;
   minimum_bill: number; addons_total: number;
   addon_breakdown: Array<{ id: number; name: string; amount: number; price_type?: string }>;
   bundle_discount: number; bundle_breakdown: Array<{ name: string; discount: number }>;
@@ -2431,10 +2432,12 @@ export default function QuoteBuilderPage() {
                           <span>−{s.adjMinusReason || "Adjustment"}</span><span>-${s.adjMinus.toFixed(2)}</span>
                         </div>
                       )}
-                      {/* Estimated hours */}
-                      {(s.hours || s.calc?.base_hours) && (
+                      {/* Estimated hours — total_hours from the backend already includes
+                          add-on time-adds (Oven +45 min, etc). Falls back to base_hours
+                          when the calc hasn't returned yet. */}
+                      {(s.hours || s.calc?.total_hours || s.calc?.base_hours) && (
                         <div style={{ display: "flex", justifyContent: "space-between", fontSize: 12, color: "#6B6860" }}>
-                          <span>Est. hours</span><span>{s.hours || s.calc?.base_hours} hrs</span>
+                          <span>Est. hours</span><span>{s.calc?.total_hours ?? s.hours ?? s.calc?.base_hours} hrs</span>
                         </div>
                       )}
                       <div style={{ display: "flex", justifyContent: "space-between", paddingTop: 8, borderTop: "1px solid #E5E2DC", marginTop: 4 }}>
@@ -2444,7 +2447,10 @@ export default function QuoteBuilderPage() {
                       {/* Commission breakdown */}
                       {(() => {
                         const total = s.calc.final_total + (s.adjPlus || 0) - (s.adjMinus || 0);
-                        const estHrs = s.hours || s.calc?.base_hours || 0;
+                        // [addon-time 2026-05-27] Use total_hours so commission-per-tech
+                        // hours reflect add-on time (e.g. Oven +45 min) just like the
+                        // Est. hours line above.
+                        const estHrs = s.calc?.total_hours ?? s.hours ?? s.calc?.base_hours ?? 0;
                         const techCount = selectedTechId ? 1 : 0;
                         const cs = calculateCommissionSplit(total, estHrs, techCount, undefined, "residential", scope?.name);
                         const ratePct = Math.round((cs.commissionRate ?? 0.35) * 100);
@@ -2482,7 +2488,10 @@ export default function QuoteBuilderPage() {
             {/* 2+ scopes — list with hours + commission */}
             {selectedScopes.length >= 2 && (() => {
               const grandTotal = selectedScopes.reduce((sum, s) => sum + (s.calc?.final_total ?? 0) + (s.adjPlus || 0) - (s.adjMinus || 0), 0);
-              const totalHours = selectedScopes.reduce((sum, s) => sum + (s.hours || s.calc?.base_hours || 0), 0);
+              // [addon-time 2026-05-27] Sum total_hours so add-on time-adds roll up
+              // into the multi-scope grand total (was summing base_hours and dropping
+              // Oven/Refrigerator/etc. minutes).
+              const totalHours = selectedScopes.reduce((sum, s) => sum + (s.calc?.total_hours ?? s.hours ?? s.calc?.base_hours ?? 0), 0);
               const techCount = selectedTechId ? 1 : 0;
               // [tiered-residential] Per-scope commission so a quote
               // with mixed Standard + Deep Clean shows the right total
@@ -2498,7 +2507,7 @@ export default function QuoteBuilderPage() {
                 <div>
                   {selectedScopes.map(s => {
                     const scope = scopes.find(sc => sc.id === s.scope_id);
-                    const estHrs = s.hours || s.calc?.base_hours || 0;
+                    const estHrs = s.calc?.total_hours ?? s.hours ?? s.calc?.base_hours ?? 0;
                     return (
                       <div key={s.scope_id} style={{ padding: "8px 0", borderBottom: "1px solid #F0EEE9" }}>
                         <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>


### PR DESCRIPTION
## Summary

Two unrelated quote-builder bugs shipped together since they were both surfaced in the same testing session:

### 1. Section navigation didn't scroll to top

After hitting "Next" on a step, the new section rendered but the viewport stayed where it was — so the user saw the bottom of the new section with the header off-screen above. Mobile already inlined `window.scrollTo` on its step-button onClick; desktop didn't. Moved it into a `useEffect` keyed on `activeSection` so every entry point (Next/Back, top-tab clicks, programmatic `setActiveSection(4)` on convert) gets the same snap-to-top behavior. Smooth scroll so it doesn't feel jarring.

### 2. Add-on time wasn't reflected in Est. hours

Backend already returns `total_hours = base_hours + addon_hours` (`pricing.ts:715`). Frontend Price Preview was reading `base_hours` only, so when the office checked Oven Cleaning (`time_add_minutes=45`), the dollar amount jumped +$50 but Est. hours stayed at the tier baseline (e.g. 7.6 hrs for 2000 sqft Deep Clean instead of 8.35).

Fix four display sites — all default to `total_hours`, fall back to `hours`/`base_hours` for the brief render before the calc returns:

- Single-scope "Est. hours" line in the Price Preview
- Single-scope commission-per-tech hours math
- Multi-scope grand-total "X hrs total"
- Multi-scope per-line "Est. X hrs" subtitle

Also widens the `CalcResult` TypeScript interface to include `addon_hours` and `total_hours` (already populated by the backend, just untyped on the frontend).

## Test plan

- [ ] Build a quote, advance past Customer Info → page scrolls back to top.
- [ ] On Property Details with a sqft entered, add an Oven (qty 1) — Est. hours rises by 0.75 (45 min).
- [ ] Multi-scope quote (Deep Clean + Recurring) — grand total "X hrs total" reflects all add-on time.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtK2nRynyWpLiHYLuT22Bd)_