### PR TITLE
Top-10 add-on catalog + Oven+Refrigerator bundle + Lucide icons

### DIFF
--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -3377,6 +3377,11 @@ export async function runPhesDataMigration(): Promise<void> {
   // an explicit UPDATE pass).
   await runBaseboardsWindowsParityMigration();
 
+  // [top10-addons 2026-05-27] Seed the top-10 tenant-add-on catalog +
+  // the Oven+Refrigerator bundle for Phes. Idempotent — checks by name
+  // before insert, safe to re-run.
+  await runTop10AddonsAndBundleMigration();
+
   // Run employee-specific migrations
   await runAleCuervoMigration();
 
@@ -3397,6 +3402,161 @@ export async function runPhesDataMigration(): Promise<void> {
 //   2. Windows (inside panes) — Standard / Recurring goes 12% → 15%.
 // Idempotent — UPDATEs converge to the same row regardless of starting
 // state, so safe to re-run on every cold start.
+// [top10-addons 2026-05-27] Seed 10 common tenant-add-on options as
+// INACTIVE for Phes so the office can flip them on per-job from the
+// Pricing & Scopes settings page. Also seeds the Oven+Refrigerator
+// combo bundle as ACTIVE (per Sal — most-requested combo).
+//
+// Idempotent: checks pricing_addons.name uniqueness per company before
+// inserting. Existing rows are not touched (no UPDATE pass — operators
+// may have already customized the price/time after first seed).
+async function runTop10AddonsAndBundleMigration() {
+  try {
+    const scopeResult = await db.execute(sql`
+      SELECT id, name FROM pricing_scopes WHERE company_id = ${PHES} AND is_active = true
+    `);
+    const scopeMap: Record<string, number> = {};
+    for (const row of (scopeResult as any).rows ?? []) {
+      scopeMap[row.name] = parseInt(row.id);
+    }
+    const D = scopeMap["Deep Clean"];
+    const MIO = scopeMap["Move In / Move Out"];
+    const S = scopeMap["One-Time Standard Clean"];
+    const R = scopeMap["Recurring Cleaning"];
+    const HD = scopeMap["Hourly Deep Clean"];
+    const HS = scopeMap["Hourly Standard Cleaning"];
+
+    const flatScopes = [D, MIO, S, R].filter(Boolean);
+    const hourlyScopes = [HD, HS].filter(Boolean);
+
+    if (flatScopes.length === 0) {
+      console.log("[top10-addons] No active residential scopes — skipping.");
+      return;
+    }
+
+    // Top-10 catalog. Sort orders 200+ to keep them after existing
+    // add-ons. show_office=true so they appear in Pricing & Scopes
+    // settings; is_active=false so they DON'T appear on quote screens
+    // until Sal flips them on per add-on.
+    const top10: Array<{
+      name: string;
+      price_type: string; price_value: number;
+      time_minutes: number;
+      sort_order: number;
+    }> = [
+      { name: "Laundry (wash + dry + fold)", price_type: "flat", price_value: 30, time_minutes: 60, sort_order: 200 },
+      { name: "Make Beds",                   price_type: "flat", price_value: 10, time_minutes: 10, sort_order: 210 },
+      { name: "Inside Window Tracks",        price_type: "flat", price_value: 20, time_minutes: 30, sort_order: 220 },
+      { name: "Pet Hair / Pet Cleanup",      price_type: "flat", price_value: 25, time_minutes: 30, sort_order: 230 },
+      { name: "Wash Dishes",                 price_type: "flat", price_value: 20, time_minutes: 30, sort_order: 240 },
+      { name: "Patio / Balcony Sweep",       price_type: "flat", price_value: 25, time_minutes: 30, sort_order: 250 },
+      { name: "Inside Microwave",            price_type: "flat", price_value: 15, time_minutes: 15, sort_order: 260 },
+      { name: "Ceiling Fan Dusting",         price_type: "flat", price_value:  5, time_minutes: 15, sort_order: 270 },
+      { name: "Blinds Detail Clean",         price_type: "flat", price_value:  5, time_minutes:  5, sort_order: 280 },
+      { name: "Garage Sweep",                price_type: "flat", price_value: 40, time_minutes: 60, sort_order: 290 },
+    ];
+
+    for (const a of top10) {
+      // Idempotency: skip if a row with this name already exists for Phes.
+      const existing = await db.execute(sql`
+        SELECT id FROM pricing_addons
+         WHERE company_id = ${PHES} AND lower(name) = lower(${a.name}) LIMIT 1
+      `);
+      if (((existing as any).rows ?? []).length > 0) continue;
+
+      const scopeIdsJson = JSON.stringify(flatScopes);
+      const firstScopeId = flatScopes[0];
+      await db.execute(sql`
+        INSERT INTO pricing_addons
+          (company_id, scope_id, name, addon_type, scope_ids,
+           price_type, price_value, time_add_minutes, time_unit,
+           is_itemized, show_office, show_online, show_portal,
+           is_active, sort_order)
+        VALUES
+          (${PHES}, ${firstScopeId}, ${a.name}, 'cleaning_extras', ${scopeIdsJson},
+           ${a.price_type}, ${a.price_value}, ${a.time_minutes}, 'each',
+           true, true, false, false,
+           false, ${a.sort_order})
+      `);
+
+      // Hourly variants — $0 time-only mirror, also inactive by default.
+      if (hourlyScopes.length > 0) {
+        const hourlyName = `${a.name} (Hourly — Time Add)`;
+        const hourlyExists = await db.execute(sql`
+          SELECT id FROM pricing_addons
+           WHERE company_id = ${PHES} AND lower(name) = lower(${hourlyName}) LIMIT 1
+        `);
+        if (((hourlyExists as any).rows ?? []).length === 0) {
+          const hourlyScopeJson = JSON.stringify(hourlyScopes);
+          await db.execute(sql`
+            INSERT INTO pricing_addons
+              (company_id, scope_id, name, addon_type, scope_ids,
+               price_type, price_value, time_add_minutes, time_unit,
+               is_itemized, show_office, show_online, show_portal,
+               is_active, sort_order)
+            VALUES
+              (${PHES}, ${hourlyScopes[0]}, ${hourlyName}, 'cleaning_extras', ${hourlyScopeJson},
+               'time_only', 0, ${a.time_minutes}, 'each',
+               false, true, false, false,
+               false, ${a.sort_order + 1})
+          `);
+        }
+      }
+    }
+    console.log("[top10-addons] Catalog seeded (inactive).");
+
+    // ── Oven + Refrigerator combo bundle (ACTIVE) ─────────────────────
+    // Pulls the canonical Oven Cleaning + Refrigerator Cleaning add-ons
+    // by name. $15 off when both are on the quote. Bundle stays disabled
+    // automatically if either constituent add-on is inactive.
+    const bundleName = "Oven + Refrigerator Combo";
+    const bundleExists = await db.execute(sql`
+      SELECT id FROM addon_bundles
+       WHERE company_id = ${PHES} AND lower(name) = lower(${bundleName}) LIMIT 1
+    `);
+    if (((bundleExists as any).rows ?? []).length > 0) {
+      console.log("[top10-addons] Bundle already present — skipping.");
+      return;
+    }
+
+    const ovenRow = await db.execute(sql`
+      SELECT id FROM pricing_addons
+       WHERE company_id = ${PHES} AND name = 'Oven Cleaning' LIMIT 1
+    `);
+    const fridgeRow = await db.execute(sql`
+      SELECT id FROM pricing_addons
+       WHERE company_id = ${PHES} AND name = 'Refrigerator Cleaning' LIMIT 1
+    `);
+    const ovenId = ((ovenRow as any).rows ?? [])[0]?.id;
+    const fridgeId = ((fridgeRow as any).rows ?? [])[0]?.id;
+    if (!ovenId || !fridgeId) {
+      console.warn("[top10-addons] Oven or Refrigerator add-on missing — bundle skipped.");
+      return;
+    }
+
+    const bundleInsert = await db.execute(sql`
+      INSERT INTO addon_bundles (company_id, name, description, discount_type, discount_value, active)
+      VALUES (${PHES}, ${bundleName}, 'Save $15 when both Oven and Refrigerator cleaning are added.',
+              'flat_total', 15, true)
+      RETURNING id
+    `);
+    const bundleId = ((bundleInsert as any).rows ?? [])[0]?.id;
+    if (!bundleId) {
+      console.warn("[top10-addons] Bundle insert returned no id — items not linked.");
+      return;
+    }
+    await db.execute(sql`
+      INSERT INTO addon_bundle_items (bundle_id, addon_id) VALUES (${bundleId}, ${ovenId})
+    `);
+    await db.execute(sql`
+      INSERT INTO addon_bundle_items (bundle_id, addon_id) VALUES (${bundleId}, ${fridgeId})
+    `);
+    console.log("[top10-addons] Oven + Refrigerator Combo bundle seeded (active).");
+  } catch (err) {
+    console.error("[top10-addons] Migration error (non-fatal):", err);
+  }
+}
+
 async function runBaseboardsWindowsParityMigration() {
   try {
     const scopeResult = await db.execute(sql`

--- a/artifacts/qleno/src/lib/addon-icons.tsx
+++ b/artifacts/qleno/src/lib/addon-icons.tsx
@@ -1,0 +1,65 @@
+import * as React from "react";
+import {
+  ChefHat,
+  Refrigerator,
+  Archive,
+  RectangleHorizontal,
+  Layers,
+  Car,
+  Sliders,
+  Shirt,
+  BedDouble,
+  Frame,
+  PawPrint,
+  UtensilsCrossed,
+  TreePine,
+  Microwave,
+  Fan,
+  Blinds,
+  Warehouse,
+  Tag,
+  type LucideIcon,
+} from "lucide-react";
+
+// [addon-icons 2026-05-27] Name-based lucide icon lookup for add-on rows
+// in the quote builder and the pricing-settings page. Patterns are
+// matched case-insensitively in declaration order — first hit wins, so
+// list more specific patterns before generic ones.
+//
+// New tenant-custom add-ons fall back to the generic Tag icon. If we
+// ever ship per-addon icon configuration (column on pricing_addons),
+// route the explicit choice through here and use this map only as the
+// default. Keep the map readable — one row per add-on family.
+const ICON_RULES: Array<{ pattern: RegExp; icon: LucideIcon }> = [
+  { pattern: /\boven\b/i,                       icon: ChefHat },
+  { pattern: /\brefrigerator\b|\bfridge\b/i,    icon: Refrigerator },
+  { pattern: /\bcabinet/i,                      icon: Archive },
+  { pattern: /\bwindow tracks?\b/i,             icon: Frame },
+  { pattern: /\bwindow/i,                       icon: RectangleHorizontal },
+  { pattern: /\bbaseboard/i,                    icon: RectangleHorizontal },
+  { pattern: /\bbasement/i,                     icon: Layers },
+  { pattern: /\bparking/i,                      icon: Car },
+  { pattern: /manual adjustment|adjustment/i,   icon: Sliders },
+  { pattern: /\blaundry|wash.*fold\b/i,         icon: Shirt },
+  { pattern: /\bmake beds?\b|\bbed making\b/i,  icon: BedDouble },
+  { pattern: /\bpet (hair|cleanup|dander)\b/i,  icon: PawPrint },
+  { pattern: /\bwash dishes|\bdish(es)?\b/i,    icon: UtensilsCrossed },
+  { pattern: /\bpatio|\bbalcony/i,              icon: TreePine },
+  { pattern: /\bmicrowave/i,                    icon: Microwave },
+  { pattern: /\bceiling fan|\bfan dusting\b/i,  icon: Fan },
+  { pattern: /\bblinds?\b/i,                    icon: Blinds },
+  { pattern: /\bgarage/i,                       icon: Warehouse },
+];
+
+export function getAddonIcon(name: string): LucideIcon {
+  for (const rule of ICON_RULES) {
+    if (rule.pattern.test(name)) return rule.icon;
+  }
+  return Tag;
+}
+
+/** Convenience renderer — keeps call sites short. */
+export function AddonIcon({ name, size = 14, color = "#6B6860" }: { name: string; size?: number; color?: string }) {
+  const Icon = getAddonIcon(name);
+  return <Icon size={size} color={color} />;
+}

--- a/artifacts/qleno/src/pages/company/addons-tab.tsx
+++ b/artifacts/qleno/src/pages/company/addons-tab.tsx
@@ -3,6 +3,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { getAuthHeaders } from "@/lib/auth";
 import { useToast } from "@/hooks/use-toast";
 import { Plus, Save, X, Check, ToggleLeft, ToggleRight, Trash2, Edit2 } from "lucide-react";
+import { AddonIcon } from "@/lib/addon-icons";
 
 const API = import.meta.env.BASE_URL.replace(/\/$/, "");
 
@@ -391,7 +392,12 @@ export function AddonsTab() {
                     <td style={{ ...td, fontWeight: 500 }}>
                       {isEditing
                         ? <input style={{ ...inputStyle, width: 180 }} value={String(editRow.name ?? "")} onChange={e => setEditRow(p => ({ ...p, name: e.target.value }))} />
-                        : addon.name}
+                        : (
+                          <span style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
+                            <AddonIcon name={addon.name} size={14} />
+                            {addon.name}
+                          </span>
+                        )}
                     </td>
                     <td style={td}>
                       {isEditing

--- a/artifacts/qleno/src/pages/quote-builder.tsx
+++ b/artifacts/qleno/src/pages/quote-builder.tsx
@@ -23,6 +23,7 @@ import {
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { calculateCommissionSplit } from "@/lib/commission";
+import { AddonIcon } from "@/lib/addon-icons";
 
 const API = import.meta.env.BASE_URL.replace(/\/$/, "");
 const FF = "'Plus Jakarta Sans', sans-serif";
@@ -2084,7 +2085,10 @@ export default function QuoteBuilderPage() {
                                 ) : (
                                   <Checkbox checked={isSel} onCheckedChange={checked => updateScopeAddon(targetScope.scope_id, addon.id, Boolean(checked))} />
                                 )}
-                                <span style={{ flex: 1, fontSize: 12, color: "#1A1917", fontFamily: FF }}>{addon.name}</span>
+                                <span style={{ flex: 1, fontSize: 12, color: "#1A1917", fontFamily: FF, display: "flex", alignItems: "center", gap: 6 }}>
+                                  <AddonIcon name={addon.name} size={13} />
+                                  {addon.name}
+                                </span>
                                 <span style={{ fontSize: 11, color: fromCalc && fromCalc.amount < 0 ? "#DC2626" : "#9E9B94", flexShrink: 0, fontFamily: FF }}>{priceText}</span>
                               </div>
                             );


### PR DESCRIPTION
## Summary

Three coordinated changes from the pricing audit:

### 1. Top-10 add-on catalog (inactive by default)

Seeds 10 common cleaning add-ons for Phes:

| Name | Price | Time |
|---|---|---|
| Laundry (wash + dry + fold) | $30 | 60 min |
| Make Beds | $10 | 10 min |
| Inside Window Tracks | $20 | 30 min |
| Pet Hair / Pet Cleanup | $25 | 30 min |
| Wash Dishes | $20 | 30 min |
| Patio / Balcony Sweep | $25 | 30 min |
| Inside Microwave | $15 | 15 min |
| Ceiling Fan Dusting | $5 | 15 min |
| Blinds Detail Clean | $5 | 5 min |
| Garage Sweep | $40 | 60 min |

Each scoped to Deep Clean, Move In/Out, One-Time Standard, Recurring + a $0 time-only hourly variant. **All inactive by default** — they appear in Company → Pricing & Scopes → Add-ons where you flip them on individually. They don't show on quote screens until flipped active.

### 2. Oven + Refrigerator Combo bundle (active)

Seeds a "$15 off when both selected" bundle using the existing `addon_bundles` + `addon_bundle_items` tables. The pricing/calc endpoint already honors active bundles, so no API change needed. Bundle auto-no-ops if either component add-on is inactive.

### 3. Lucide icons on every add-on row

New helper `lib/addon-icons.tsx` maps name patterns to Lucide icons:
- Oven → `ChefHat`, Refrigerator → `Refrigerator`, Kitchen Cabinets → `Archive`
- Windows → `RectangleHorizontal`, Basement → `Layers`, Parking → `Car`
- Laundry → `Shirt`, Make Beds → `BedDouble`, Pet Hair → `PawPrint`
- Dishes → `UtensilsCrossed`, Patio → `TreePine`, Microwave → `Microwave`
- Ceiling Fan → `Fan`, Blinds → `Blinds`, Garage → `Warehouse`

Falls back to a generic `Tag` icon for tenant-custom add-ons. Renders in:
- Quote builder add-on rows (left of the name)
- Company Settings → Pricing & Scopes → Add-ons table

## Idempotency

Migration checks `pricing_addons.name` and `addon_bundles.name` per company before insert. Safe to re-run on every cold-start. Existing add-ons are untouched so any office-customized price/time stays.

## Test plan

- [ ] Wait for Railway redeploy + cold-start.
- [ ] `/company` → Pricing & Scopes → Add-ons: confirm 10 new rows appear, all inactive (greyed). Icons render next to each name.
- [ ] Flip "Laundry" to active — appears in the quote builder add-on list with a shirt icon next to it.
- [ ] On a new quote with both Oven (qty 1) and Refrigerator (qty 1) checked, confirm a "$15.00" line shows under "Oven + Refrigerator Combo" in the bundle breakdown.
- [ ] On a new quote with just Oven checked, the bundle does NOT apply.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtK2nRynyWpLiHYLuT22Bd)_