### PR TITLE
Trim Hourly add-on list to 6 items + zero time-impact

### DIFF
--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -3382,6 +3382,13 @@ export async function runPhesDataMigration(): Promise<void> {
   // before insert, safe to re-run.
   await runTop10AddonsAndBundleMigration();
 
+  // [hourly-addon-cleanup 2026-05-27] After the audit, Hourly scopes
+  // should expose exactly 6 add-ons (Oven/Refrigerator/Cabinets/
+  // Windows/Basement/Parking) with ZERO time impact (clients are
+  // already billed by clock-time). Removes Baseboards + the +15%
+  // markup from Hourly, renames the "Time Add" suffix, zeros time.
+  await runHourlyAddonCleanupMigration();
+
   // Run employee-specific migrations
   await runAleCuervoMigration();
 
@@ -3410,6 +3417,82 @@ export async function runPhesDataMigration(): Promise<void> {
 // Idempotent: checks pricing_addons.name uniqueness per company before
 // inserting. Existing rows are not touched (no UPDATE pass — operators
 // may have already customized the price/time after first seed).
+// [hourly-addon-cleanup 2026-05-27] Bring Hourly scopes (Hourly Deep
+// Clean + Hourly Standard Cleaning) in line with Sal's post-audit
+// spec: exactly 6 add-ons (Oven, Refrigerator, Kitchen Cabinets,
+// Windows, Basement, Parking Fee) with ZERO time impact — clients are
+// already paying for clock-time, so a time-add would double-count.
+// Also strips Baseboards (added in MC parity PR) and the +15% Second
+// Appointment markup which don't belong on the Hourly add-on list.
+// Idempotent — UPDATEs converge to the same end-state regardless of
+// starting state.
+async function runHourlyAddonCleanupMigration() {
+  try {
+    const scopeResult = await db.execute(sql`
+      SELECT id, name FROM pricing_scopes WHERE company_id = ${PHES} AND is_active = true
+    `);
+    const scopeMap: Record<string, number> = {};
+    for (const row of (scopeResult as any).rows ?? []) {
+      scopeMap[row.name] = parseInt(row.id);
+    }
+    const HD = scopeMap["Hourly Deep Clean"];
+    const HS = scopeMap["Hourly Standard Cleaning"];
+    if (!HD && !HS) {
+      console.log("[hourly-addon-cleanup] No active hourly scopes — skipping.");
+      return;
+    }
+
+    // 1) Zero out time_add_minutes on every Hourly variant, drop the
+    //    "— Time Add" suffix from the name, mirror price = 0 / time = 0.
+    //    Match on the "(Hourly" substring to catch both naming styles.
+    await db.execute(sql`
+      UPDATE pricing_addons
+      SET time_add_minutes = 0,
+          price_value = 0,
+          price_type = 'time_only',
+          name = regexp_replace(name, '\\s*[—-]\\s*Time Add', '', 'gi')
+      WHERE company_id = ${PHES}
+        AND (name ILIKE '%(Hourly%' OR name ILIKE '%Hourly — Time Add%')
+    `);
+
+    // 2) Strip Baseboards from Hourly scope_ids. The MC parity migration
+    //    put Baseboards on all 8 scopes; Hourly drops it per audit.
+    const flatScopes = [
+      scopeMap["Deep Clean"],
+      scopeMap["Move In / Move Out"],
+      scopeMap["One-Time Standard Clean"],
+      scopeMap["Recurring Cleaning"],
+      scopeMap["Commercial Cleaning"],
+      scopeMap["PPM Turnover"],
+    ].filter(Boolean);
+    if (flatScopes.length > 0) {
+      const flatScopesJson = JSON.stringify(flatScopes);
+      const flatFirst = flatScopes[0];
+      await db.execute(sql`
+        UPDATE pricing_addons
+        SET scope_ids = ${flatScopesJson},
+            scope_id = ${flatFirst}
+        WHERE company_id = ${PHES}
+          AND name = 'Baseboards'
+      `);
+    }
+
+    // 3) Deactivate the "+15% markup" Second Appointment row on HS.
+    //    The discount version (-15%) stays — only the markup is wrong
+    //    for the new Hourly add-on layout.
+    await db.execute(sql`
+      UPDATE pricing_addons
+      SET is_active = false
+      WHERE company_id = ${PHES}
+        AND name = 'Second Appointment — +15% (markup)'
+    `);
+
+    console.log("[hourly-addon-cleanup] Hourly add-on list aligned (6 items, zero-time).");
+  } catch (err) {
+    console.error("[hourly-addon-cleanup] Migration error (non-fatal):", err);
+  }
+}
+
 async function runTop10AddonsAndBundleMigration() {
   try {
     const scopeResult = await db.execute(sql`


### PR DESCRIPTION
## Summary

Audit feedback: the Hourly Standard Cleaning and Hourly Deep Clean add-on lists carried artifacts that didn't match Sal's spec — extra rows + a time-add that double-counts billable time.

Three fixes in one idempotent migration (`runHourlyAddonCleanupMigration`):

1. **Zero time + drop misleading suffix on Hourly variants** — Oven/Refrigerator/Cabinets/Windows/Basement Hourly rows had `time_add_minutes=45`. Clients on hourly billing already pay for clock-time, so a time-add doubles the charge. Set time_add_minutes=0, price_value=0, price_type='time_only', and strip the `" — Time Add"` suffix from the displayed name.

2. **Remove Baseboards from Hourly scopes** — the MC parity migration put Baseboards on all 8 scopes. Hourly should expose the 6 standard add-ons only. Strip HD + HS from Baseboards' `scope_ids` (Baseboards stays on the 6 flat-rate scopes).

3. **Deactivate "+15% markup" Second Appointment on HS** — doesn't belong on Hourly. The matching `-15%` Second Appointment Discount on flat-rate scopes stays untouched.

After cold-start the Hourly add-on list will be exactly: **Oven, Refrigerator, Kitchen Cabinets, Windows, Basement, Parking Fee**. All zero-time, Parking the only one carrying a $ ($20 flat).

## Parking Fee editability + Job Notes translation

Both flagged for follow-up:
- **Parking Fee editable per-quote** — waiting on UX preference (Price Adjustments field vs inline edit vs both).
- **Translate Job Notes → Spanish via Claude API** — confirmed, will be next PR after this lands.

## Test plan

- [ ] Wait for Railway redeploy + cold-start.
- [ ] Build an Hourly Standard quote — add-on list shows exactly 6 rows, all with "No additional charge" except Parking ($20).
- [ ] Increment Oven (or any other) on Hourly — total dollar AND Est. hours stay unchanged.
- [ ] Build a Deep Clean quote — Baseboards still appears ($30 / 45 min). Confirm Hourly cleanup didn't accidentally strip it from flat-rate scopes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtK2nRynyWpLiHYLuT22Bd)_