### PR TITLE
fix(quote-builder): Quick Re-Book never shows or locks a historical price

### DIFF
--- a/artifacts/qleno/src/pages/quote-builder.tsx
+++ b/artifacts/qleno/src/pages/quote-builder.tsx
@@ -231,7 +231,6 @@ export default function QuoteBuilderPage() {
   const [recentServices, setRecentServices] = useState<RecentService[]>([]);
   const [quickBookDismissed, setQuickBookDismissed] = useState(false);
   const [quickBookBanner, setQuickBookBanner] = useState<{ scope: string; date: string } | null>(null);
-  const [quickBookPrice, setQuickBookPrice] = useState<number | null>(null);
   const [hourlyExpanded, setHourlyExpanded] = useState(false);
   const [hourlySubType, setHourlySubType] = useState<string | null>(null);
   const [callNotesOpen, setCallNotesOpen] = useState(false);
@@ -694,10 +693,10 @@ export default function QuoteBuilderPage() {
       pets, dirt_level: dirtLevel,
       addons: cr?.addon_breakdown ?? [],
       discount_code: discountCode || null,
-      base_price: quickBookPrice != null ? String(quickBookPrice) : (cr ? String(cr.base_price) : null),
+      base_price: cr ? String(cr.base_price) : null,
       addons_total: cr ? String(cr.addons_total) : "0",
       discount_amount: cr ? String(cr.discount_amount) : "0",
-      total_price: quickBookPrice != null ? String(quickBookPrice) : (cr ? String(cr.final_total) : null),
+      total_price: cr ? String(cr.final_total) : null,
       estimated_hours: cr ? String(cr.base_hours) : primaryScopeState?.hours ? String(primaryScopeState.hours) : null,
       hourly_rate: cr ? String(cr.hourly_rate) : null,
       notes: notes || null,
@@ -876,7 +875,6 @@ export default function QuoteBuilderPage() {
     setReferralSource("existing_client");
     setQuickBookDismissed(false);
     setQuickBookBanner(null);
-    setQuickBookPrice(null);
     setPreferredTech(null);
     setRecentServices([]);
     // Existing client with an address on file — trust it, skip geocode verification.
@@ -913,7 +911,6 @@ export default function QuoteBuilderPage() {
     setRecentServices([]);
     setQuickBookDismissed(false);
     setQuickBookBanner(null);
-    setQuickBookPrice(null);
     setAddressVerified(null);
     setAddressFormatted("");
     setAddress("");
@@ -932,6 +929,11 @@ export default function QuoteBuilderPage() {
   }
 
   async function handleQuickBook(service: RecentService) {
+    // Quick Re-Book pre-fills scope/frequency/tech from a previous service but
+    // does NOT lock the historical price. Per Sal 2026-05-27: price must always
+    // be calculated fresh from square footage, never pulled from history.
+    // Routes to Property Details (section 2) so the user enters sqft and the
+    // calc engine produces a current price.
     setSelectedScopes([]);
     const matchedScope = scopes.find(s => s.name.toLowerCase().trim() === service.scope.toLowerCase().trim());
     if (matchedScope) {
@@ -939,9 +941,8 @@ export default function QuoteBuilderPage() {
       setFinalScopeId(matchedScope.id);
     }
     if (preferredTech) setSelectedTechId(preferredTech.id);
-    setQuickBookPrice(service.last_price);
     setQuickBookBanner({ scope: service.scope, date: service.last_date });
-    setActiveSection(4);
+    setActiveSection(2);
   }
 
   // ── Highlight-to-push ────────────────────────────────────────────────────
@@ -1642,7 +1643,7 @@ export default function QuoteBuilderPage() {
                 <div style={{ background: "#F7F6F3", border: "1px solid #E5E2DC", borderRadius: 8, padding: "14px 16px", marginBottom: 20 }}>
                   <div style={{ marginBottom: 10 }}>
                     <div style={{ fontSize: 12, fontWeight: 600, color: "#1A1917", fontFamily: FF }}>Quick Re-Book</div>
-                    <div style={{ fontSize: 11, color: "#6B6860", marginTop: 1, fontFamily: FF }}>Re-book a previous service at the same price — skips straight to Review</div>
+                    <div style={{ fontSize: 11, color: "#6B6860", marginTop: 1, fontFamily: FF }}>Pre-fill scope and frequency from a previous service — enter square footage to calculate fresh price</div>
                   </div>
                   <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
                     {recentServices.map((svc, i) => {
@@ -1664,14 +1665,11 @@ export default function QuoteBuilderPage() {
                         >
                           <div style={{ fontSize: 13, fontWeight: 500, color: "#1A1917", fontFamily: FF }}>{svc.scope}</div>
                           <div style={{ fontSize: 11, color: "#6B6860", marginTop: 2, fontFamily: FF }}>Last: {lastDate}</div>
-                          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginTop: 4 }}>
-                            <div style={{ fontSize: 13, fontWeight: 500, color: "#1A1917", fontFamily: FF }}>
-                              ${svc.last_price > 0 ? svc.last_price.toLocaleString("en-US") : "\u2014"}
-                            </div>
-                            {freqLabel && (
+                          {freqLabel && (
+                            <div style={{ display: "flex", justifyContent: "flex-end", marginTop: 4 }}>
                               <span style={{ fontSize: 10, background: "#F0EDE8", color: "#4A4845", borderRadius: 10, padding: "2px 6px", fontFamily: FF }}>{freqLabel}</span>
-                            )}
-                          </div>
+                            </div>
+                          )}
                         </div>
                       );
                     })}


### PR DESCRIPTION
## Summary

Bug: in the Quote Builder, when an existing client (e.g. Sal Martinez) is loaded, the Quick Re-Book panel displays each previous service's historical price as a dollar amount even before square footage has been entered. Sal's principle: **no dollar amount should be visible anywhere in the quote builder until square footage is entered, and prices should always be calculated fresh — never pulled from history.**

## Changes (all in `artifacts/qleno/src/pages/quote-builder.tsx`)

1. **Removed historical price from Quick Re-Book tiles.** The tile now shows scope name, last date, and frequency badge — no dollar amount. Panel description updated to reflect the new behavior.
2. **Removed the price-lock in `handleQuickBook`.** Previously `setQuickBookPrice(service.last_price)` overrode the calc engine's `base_price` and `total_price` in the save payload (lines 615/618). After the fix, both fields always come from the calc engine's fresh computation.
3. **Routed Quick Re-Book click to Property Details (section 2) instead of Review (section 4).** The old flow skipped sqft entry because the price was locked in. Now the user must enter sqft, so the navigation matches.
4. **Cleanup:** deleted the now-dead `quickBookPrice` state, its 2 setter calls in `loadClient` / `clearClient`, and the ternaries that always fell through to the calc engine result anyway.

## Downstream effects

None breaking. The semantic of Quick Re-Book shifts from *"one-click re-book at the historical price"* to *"one-click pre-fill scope/frequency/tech, then enter sqft for a fresh price."* The pre-fill convenience is preserved; the price-lock convenience is gone (which is the desired outcome per Sal — historical prices may be stale relative to current pricing tables or sqft changes).

## Test plan
- [x] `tsc --noEmit` clean on touched lines (2 pre-existing fetch/HeadersInit errors at lines 51 and 431 are unrelated to this change)
- [ ] **Visual verification on prod after Railway deploy:** open Quote Builder, search for an existing client with prior services (Sal Martinez is the easy repro), confirm Quick Re-Book tiles show no dollar amount, click a tile and confirm landing on Property Details (not Review)
- [ ] Confirm the calc engine produces a fresh price once sqft is entered, and Save Quote persists the fresh price (not zero, not the historical value)

Generated with Claude Code