### PR TITLE
One-click Job Notes translation to Spanish via Claude

### DIFF
--- a/artifacts/api-server/package.json
+++ b/artifacts/api-server/package.json
@@ -13,6 +13,7 @@
     "test:lms": "DATABASE_URL=postgres://stub@stub/stub tsx --test src/tests/lms-*.test.ts"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.71.0",
     "@google-cloud/storage": "^7.19.0",
     "@types/multer": "^2.1.0",
     "@types/pdfkit": "^0.17.5",

--- a/artifacts/api-server/src/routes/index.ts
+++ b/artifacts/api-server/src/routes/index.ts
@@ -82,6 +82,7 @@ import lmsAnnualAckRouter from "./lms-annual-ack.js";
 import lmsSettingsRouter from "./lms-settings.js";
 import lmsAdminAuditRouter from "./lms-admin-audit.js";
 import lmsOnboardingIntakeRouter from "./lms-onboarding-intake.js";
+import translateRouter from "./translate.js";
 
 const router: IRouter = Router();
 
@@ -110,6 +111,9 @@ router.use("/notifications", notificationsRouter);
 router.use("/quotes", quotesRouter);
 router.use("/payments", paymentsRouter);
 router.use("/attachments", attachmentsRouter);
+// [translate-job-notes 2026-05-27] Office-only translation endpoint —
+// Claude API. POST /api/translate {text, target} → {translated}.
+router.use("/translate", translateRouter);
 // [quote-attachments] The routers define full paths internally
 // (`:id/attachments`), so mount them at the resource root.
 router.use("/quotes", quoteAttachmentsRouter);

--- a/artifacts/api-server/src/routes/translate.ts
+++ b/artifacts/api-server/src/routes/translate.ts
@@ -1,0 +1,94 @@
+import { Router } from "express";
+import Anthropic from "@anthropic-ai/sdk";
+import { requireAuth, requireRole } from "../lib/auth.js";
+
+// [translate-job-notes 2026-05-27] Office types Job Notes in English; some
+// Phes techs are more comfortable in Spanish. One-click translation via
+// Claude gives the same text in Spanish that the tech sees alongside the
+// English original. Office-only — customer-facing fields don't route here.
+//
+// Requires ANTHROPIC_API_KEY in Railway env. If missing, we surface a
+// clear error instead of a 500 so the operator knows to set it.
+
+const router = Router();
+
+const MAX_INPUT_CHARS = 5000;
+const SUPPORTED_TARGETS = new Set(["es", "en"]);
+const LANG_NAME: Record<string, string> = { es: "Spanish", en: "English" };
+
+router.post("/", requireAuth, requireRole("owner", "admin", "office"), async (req, res) => {
+  try {
+    const text = typeof req.body?.text === "string" ? req.body.text : "";
+    const target = typeof req.body?.target === "string" ? req.body.target : "es";
+
+    if (!text.trim()) { res.status(400).json({ error: "text required" }); return; }
+    if (text.length > MAX_INPUT_CHARS) {
+      res.status(400).json({ error: `text exceeds ${MAX_INPUT_CHARS} chars` });
+      return;
+    }
+    if (!SUPPORTED_TARGETS.has(target)) {
+      res.status(400).json({ error: `target must be one of: ${[...SUPPORTED_TARGETS].join(", ")}` });
+      return;
+    }
+
+    if (!process.env.ANTHROPIC_API_KEY) {
+      console.warn("[translate] ANTHROPIC_API_KEY not set — translation disabled");
+      res.status(503).json({ error: "Translation is not configured — set ANTHROPIC_API_KEY in Railway" });
+      return;
+    }
+
+    const client = new Anthropic();
+    const targetName = LANG_NAME[target];
+
+    // System prompt keeps the model focused on the narrow task. Avoids the
+    // common failure where the model "answers" the note instead of
+    // translating it (e.g. instructions to the tech turn into the model
+    // doing the work).
+    const system =
+      `You are a translation engine for a residential cleaning company's internal job notes. ` +
+      `Translate the user's text into ${targetName}. Output ONLY the translated text — no quotes, no commentary, no preamble. ` +
+      `Preserve numbers, addresses, names, and codes verbatim. Maintain line breaks and formatting. ` +
+      `Use cleaning-industry vocabulary that a Mexican-Spanish-speaking technician would understand naturally.`;
+
+    const response = await client.messages.create({
+      model: "claude-opus-4-7",
+      max_tokens: 4096,
+      system,
+      messages: [{ role: "user", content: text }],
+    });
+
+    // Concatenate text blocks — there should typically be just one, but
+    // join defensively in case the model emits multiple.
+    const translated = response.content
+      .filter((b): b is Anthropic.TextBlock => b.type === "text")
+      .map(b => b.text)
+      .join("")
+      .trim();
+
+    if (!translated) {
+      res.status(502).json({ error: "Translation returned empty result" });
+      return;
+    }
+
+    res.json({
+      translated,
+      target,
+      input_tokens: response.usage.input_tokens,
+      output_tokens: response.usage.output_tokens,
+    });
+  } catch (e: any) {
+    if (e instanceof Anthropic.AuthenticationError) {
+      console.error("[translate] Auth error:", e.message);
+      res.status(503).json({ error: "Translation auth failed — check ANTHROPIC_API_KEY" });
+      return;
+    }
+    if (e instanceof Anthropic.RateLimitError) {
+      res.status(429).json({ error: "Translation temporarily rate-limited — try again in a moment" });
+      return;
+    }
+    console.error("[translate] Error:", e);
+    res.status(500).json({ error: "Translation failed", message: e?.message });
+  }
+});
+
+export default router;

--- a/artifacts/qleno/src/pages/quote-builder.tsx
+++ b/artifacts/qleno/src/pages/quote-builder.tsx
@@ -45,6 +45,83 @@ function isCounterAddon(name: string): boolean {
   );
 }
 
+// [translate-job-notes 2026-05-27] Inline "Translate to Spanish" button +
+// expandable Spanish display below the Job Notes textarea. Hits
+// /api/translate (Claude API) — server-side, so the API key stays off the
+// client bundle. Hidden when the textarea is empty so the form doesn't
+// scream "translate" at draft-time.
+function JobNotesTranslate({ text }: { text: string }) {
+  const [translated, setTranslated] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Reset the translation if the source text changes after a translation
+  // — stale output is worse than no output.
+  useEffect(() => { setTranslated(null); setError(null); }, [text]);
+
+  if (!text.trim()) return null;
+
+  async function translate() {
+    setLoading(true); setError(null);
+    try {
+      const result = await apiFetch("/api/translate", { method: "POST", body: { text, target: "es" } });
+      setTranslated(String(result?.translated ?? "").trim() || null);
+    } catch (e: any) {
+      setError(e?.message?.includes("503")
+        ? "Translation isn't configured yet — ask an admin to set ANTHROPIC_API_KEY in Railway."
+        : "Translation failed. Try again in a moment.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function copy() {
+    if (!translated) return;
+    try { navigator.clipboard.writeText(translated); } catch { /* ignore */ }
+  }
+
+  return (
+    <div style={{ display: "inline-flex", alignItems: "center", gap: 6, flexWrap: "wrap" }}>
+      <button
+        type="button"
+        onClick={translate}
+        disabled={loading}
+        style={{
+          fontSize: 11, fontWeight: 600, fontFamily: FF,
+          padding: "3px 9px", borderRadius: 6,
+          border: "1px solid #E5E2DC", background: "#FFF", color: "#1A1917",
+          cursor: loading ? "wait" : "pointer", opacity: loading ? 0.6 : 1,
+        }}
+        title="Translate the current Job Notes to Spanish using Claude"
+      >
+        {loading ? "Translating..." : translated ? "Re-translate" : "Translate to Spanish"}
+      </button>
+      {translated && (
+        <button
+          type="button"
+          onClick={copy}
+          style={{ fontSize: 11, fontWeight: 600, fontFamily: FF, padding: "3px 9px", borderRadius: 6, border: "1px solid #E5E2DC", background: "#FFF", color: "#1A1917", cursor: "pointer" }}
+          title="Copy Spanish to clipboard"
+        >
+          Copy
+        </button>
+      )}
+      {(translated || error) && (
+        <div style={{ flexBasis: "100%" }}>
+          {translated && (
+            <div style={{ marginTop: 6, padding: "8px 10px", background: "#F7F6F3", border: "1px solid #E5E2DC", borderRadius: 7, fontSize: 12, color: "#1A1917", fontFamily: FF, whiteSpace: "pre-wrap" }}>
+              {translated}
+            </div>
+          )}
+          {error && (
+            <div style={{ marginTop: 6, fontSize: 11, color: "#DC2626", fontFamily: FF }}>{error}</div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
 async function apiFetch(path: string, opts: { method?: string; body?: any } = {}) {
   const { body, ...rest } = opts;
   const r = await fetch(`${API}${path}`, {
@@ -2153,7 +2230,10 @@ export default function QuoteBuilderPage() {
               {/* Notes section */}
               <div style={{ marginTop: 20, display: "flex", flexDirection: "column", gap: 14 }}>
                 <div>
-                  <div style={{ fontSize: 12, fontWeight: 500, color: "#1A1917", marginBottom: 2, fontFamily: FF }}>Job Notes</div>
+                  <div style={{ display: "flex", alignItems: "baseline", justifyContent: "space-between", marginBottom: 2 }}>
+                    <div style={{ fontSize: 12, fontWeight: 500, color: "#1A1917", fontFamily: FF }}>Job Notes</div>
+                    <JobNotesTranslate text={internalMemo} />
+                  </div>
                   <div style={{ fontSize: 11, color: "#9E9B94", marginBottom: 6, fontFamily: FF }}>Visible to technician.</div>
                   <Textarea value={internalMemo} onChange={e => setInternalMemo(e.target.value)} placeholder="Instructions and notes for the technician..." rows={3} className="mt-1 text-sm" />
                   {pushConfirmed && <p style={{ fontSize: 11, color: "#9E9B94", marginTop: 4, fontFamily: FF }}>✓ Added from call notes.</p>}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,6 +179,9 @@ importers:
 
   artifacts/api-server:
     dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.71.0
+        version: 0.71.2(zod@4.3.6)
       '@google-cloud/storage':
         specifier: ^7.19.0
         version: 7.19.0
@@ -775,6 +778,15 @@ importers:
         version: 4.21.0
 
 packages:
+
+  '@anthropic-ai/sdk@0.71.2':
+    resolution: {integrity: sha512-TGNDEUuEstk/DKu0/TflXAEt+p+p/WhTlFzEnoosvbaDU2LTjm42igSdlL0VijrKpWejtOKxX0b8A7uc+XiSAQ==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -2864,6 +2876,10 @@ packages:
   json-bigint@1.0.0:
     resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
 
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
@@ -3619,6 +3635,9 @@ packages:
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
@@ -3893,6 +3912,12 @@ packages:
         optional: true
 
 snapshots:
+
+  '@anthropic-ai/sdk@0.71.2(zod@4.3.6)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 4.3.6
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -6109,6 +6134,11 @@ snapshots:
     dependencies:
       bignumber.js: 9.3.1
 
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.28.6
+      ts-algebra: 2.0.0
+
   json-schema-traverse@1.0.0: {}
 
   json5@2.2.3: {}
@@ -6844,6 +6874,8 @@ snapshots:
   toidentifier@1.0.1: {}
 
   tr46@0.0.3: {}
+
+  ts-algebra@2.0.0: {}
 
   tsconfck@3.1.6(typescript@5.9.3):
     optionalDependencies:


### PR DESCRIPTION
## Summary

Office types Job Notes in English; many Phes techs are more comfortable in Spanish. Adds a one-click **"Translate to Spanish"** button next to the Job Notes label that calls Claude (Opus 4.7) server-side and renders the Spanish output below the textarea — operator can read it back to the tech or copy it.

### Backend (`artifacts/api-server`)

- New `@anthropic-ai/sdk` dependency.
- `POST /api/translate {text, target}` → `{translated, target, usage}`.
- Office/admin/owner only.
- 5K char input cap, target ∈ `{es, en}`.
- System prompt constrains the model to **translate only** — not respond to or interpret the note. Mexican-Spanish vocabulary preference.
- Auth, rate-limit, and missing-key conditions surface as 503/429 with clear operator-facing messages instead of generic 500s.

### Frontend (`quote-builder.tsx`)

- Inline `JobNotesTranslate` component beside the Job Notes label, hidden while the field is empty.
- Spanish output renders in a read-only block below the textarea with a **Copy** button.
- Source-text change clears stale translation so what's shown always matches the textarea.

## Ops note

⚠️ **`ANTHROPIC_API_KEY` must be set in Railway env before the button works.** Until it is, the endpoint returns a 503 with a clear "ask an admin to set ANTHROPIC_API_KEY" message — no silent failure. Set the key in Railway → Variables, redeploy, done.

## Test plan

- [ ] Set `ANTHROPIC_API_KEY` in Railway → wait for redeploy.
- [ ] Open `/quotes/new`, advance to Add-ons & Notes step.
- [ ] Type English text into Job Notes — "Translate to Spanish" button appears.
- [ ] Click → Spanish translation renders below textarea within ~2s.
- [ ] Copy button copies translated text to clipboard.
- [ ] Edit the English source → translation block clears.
- [ ] If `ANTHROPIC_API_KEY` is unset → button click shows "Translation isn't configured yet" instead of a generic 500.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtK2nRynyWpLiHYLuT22Bd)_