### PR TITLE
feat: clock-entry delete + admin force-delete + job rate mods

### DIFF
--- a/artifacts/api-server/scripts/_julie_mitros_fix.ts
+++ b/artifacts/api-server/scripts/_julie_mitros_fix.ts
@@ -1,0 +1,72 @@
+/**
+ * One-shot fix for Julie Mitros (clients.id=74).
+ *
+ * MC source of truth: 818 S 6th Ave, La Grange, IL 60526. Zone:
+ * La Grange/Hodgkins/Berwyn (id=13).
+ *
+ * Our record was left in a half-fixed state: jobs.address_* was patched
+ * (correctly) but clients.address/city/zip were stale (city was
+ * "North Chicago", zip was "60088") because the previous auto-pick
+ * routed the edit to job level when clients.address was NULL.
+ *
+ * Idempotent. CASE guards so re-running is a no op once correct.
+ */
+import { db, pool } from "@workspace/db";
+import { sql } from "drizzle-orm";
+import { geocodeAddress } from "../src/lib/geocode.js";
+
+const COMPANY_ID = 1;
+const CLIENT_ID = 74;
+const REAL_ADDRESS = "818 S 6th Ave";
+const REAL_CITY = "La Grange";
+const REAL_STATE = "IL";
+const REAL_ZIP = "60525";
+
+(async () => {
+  console.log("─── BEFORE ───");
+  const before = await db.execute(sql`
+    SELECT id, first_name, last_name, address, city, state, zip, lat, lng, zone_id,
+           (SELECT name FROM service_zones WHERE id = clients.zone_id) AS zone_name
+    FROM clients WHERE id = ${CLIENT_ID} AND company_id = ${COMPANY_ID}
+  `);
+  console.table(before.rows);
+
+  const fullAddress = `${REAL_ADDRESS}, ${REAL_CITY}, ${REAL_STATE} ${REAL_ZIP}`;
+  console.log(`\nGeocoding: ${fullAddress}`);
+  const coords = await geocodeAddress(fullAddress);
+  if (!coords) console.warn("  geocode returned null — proceeding without lat/lng");
+  else console.log(`  → lat=${coords.lat} lng=${coords.lng}`);
+
+  const zoneRow = await db.execute(sql`
+    SELECT id FROM service_zones
+    WHERE company_id = ${COMPANY_ID}
+      AND is_active = true
+      AND ${REAL_ZIP} = ANY(zip_codes)
+    LIMIT 1
+  `);
+  const zoneId = zoneRow.rows.length ? (zoneRow.rows[0] as any).id : null;
+  console.log(`  zone_id for zip ${REAL_ZIP}: ${zoneId}`);
+
+  await db.execute(sql`
+    UPDATE clients SET
+      address = ${REAL_ADDRESS},
+      city    = ${REAL_CITY},
+      state   = ${REAL_STATE},
+      zip     = ${REAL_ZIP},
+      lat     = COALESCE(${coords?.lat?.toString() ?? null}, lat),
+      lng     = COALESCE(${coords?.lng?.toString() ?? null}, lng),
+      zone_id = ${zoneId}
+    WHERE id = ${CLIENT_ID} AND company_id = ${COMPANY_ID}
+  `);
+  console.log("  → clients row patched");
+
+  console.log("\n─── AFTER ───");
+  const after = await db.execute(sql`
+    SELECT id, first_name, last_name, address, city, state, zip, lat, lng, zone_id,
+           (SELECT name FROM service_zones WHERE id = clients.zone_id) AS zone_name
+    FROM clients WHERE id = ${CLIENT_ID} AND company_id = ${COMPANY_ID}
+  `);
+  console.table(after.rows);
+
+  await pool.end();
+})();

--- a/artifacts/api-server/scripts/_norma_apr28_audit.ts
+++ b/artifacts/api-server/scripts/_norma_apr28_audit.ts
@@ -1,0 +1,72 @@
+import { db, pool } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+(async () => {
+  console.log("=== Norma Puga's user record ===");
+  const norma = await db.execute(sql`
+    SELECT id, first_name, last_name, role, branch_id, is_active
+    FROM users
+    WHERE company_id = 1
+      AND lower(first_name) = 'norma'
+      AND lower(last_name) IN ('puga', 'guerrero puga', 'guerrero-puga')
+  `);
+  console.table(norma.rows);
+
+  const normaIds = (norma.rows as any[]).map(r => r.id);
+  console.log(`Norma user_ids: ${normaIds.join(', ')}`);
+
+  console.log("\n=== Norma's jobs scheduled for 2026-04-28 ===");
+  const jobs = await db.execute(sql`
+    SELECT j.id, j.scheduled_date, j.scheduled_time, j.allowed_hours,
+           j.service_type, j.status, j.frequency,
+           j.client_id, j.assigned_user_id, j.zone_id, j.base_fee,
+           j.address_street, j.address_zip, j.recurring_schedule_id,
+           c.first_name, c.last_name, c.zip AS client_zip,
+           sz.name AS zone_name, sz.color AS zone_color
+    FROM jobs j
+    LEFT JOIN clients c ON c.id = j.client_id
+    LEFT JOIN service_zones sz ON sz.id = j.zone_id
+    WHERE j.company_id = 1
+      AND j.scheduled_date = '2026-04-28'
+      AND j.assigned_user_id = 32
+    ORDER BY j.scheduled_time
+  `);
+  console.table(jobs.rows);
+
+  console.log("\n=== Julie Mitros client record (post-fix?) ===");
+  const julie = await db.execute(sql`
+    SELECT id, first_name, last_name, address, city, state, zip, lat, lng, zone_id,
+           (SELECT name FROM service_zones WHERE id = clients.zone_id) AS zone_name
+    FROM clients
+    WHERE company_id = 1 AND lower(first_name) LIKE '%julie%' AND lower(last_name) LIKE '%mitros%'
+  `);
+  console.table(julie.rows);
+
+  console.log("\n=== Robert Stortz client record ===");
+  const robert = await db.execute(sql`
+    SELECT id, first_name, last_name, address, city, state, zip, lat, lng, zone_id,
+           (SELECT name FROM service_zones WHERE id = clients.zone_id) AS zone_name
+    FROM clients
+    WHERE company_id = 1 AND lower(first_name) LIKE '%robert%' AND lower(last_name) LIKE '%stortz%'
+  `);
+  console.table(robert.rows);
+
+  console.log("\n=== Audit log entries from the last 24h ===");
+  const audit = await db.execute(sql`
+    SELECT id, performed_at, performed_by, action, target_type, target_id,
+           old_value::text AS ov, new_value::text AS nv
+    FROM app_audit_log
+    WHERE company_id = 1
+      AND performed_at > now() - interval '24 hours'
+      AND (action LIKE '%ADDRESS%' OR action LIKE '%TECH%' OR action = 'UPDATE')
+    ORDER BY performed_at DESC
+    LIMIT 10
+  `);
+  for (const r of audit.rows as any[]) {
+    console.log(`  ${r.performed_at} ${r.action} ${r.target_type}#${r.target_id} by user ${r.performed_by}`);
+  }
+
+  // Skipping job_audit_log query — schema drift on created_at column.
+
+  await pool.end();
+})();

--- a/artifacts/api-server/scripts/_pegah_fix.ts
+++ b/artifacts/api-server/scripts/_pegah_fix.ts
@@ -1,0 +1,137 @@
+/**
+ * One-shot fix for Pegah Abbasian (clients.id=125) and the
+ * Westmont/Lombard/Elmhurst zone.
+ *
+ * Source of truth: MaidCentral record (Job ID 61563726) shows:
+ *   address: 28262 Diehl Road
+ *   city:    Warrenville
+ *   state:   IL
+ *   zip:     60555
+ *   zone:    Westmont|Lombard|Elmhurst
+ *
+ * Our import wrote the street number "28262" into clients.zip, leaving city
+ * and zip wrong. Plus our Westmont/Lombard/Elmhurst zone does not include
+ * 60555 in its zip_codes[] array (MC does). Fix both, idempotent.
+ *
+ * Steps:
+ *   1. Add 60555 to service_zones.zip_codes for Westmont/Lombard/Elmhurst
+ *      (idempotent: array_append only if missing).
+ *   2. Patch clients.id=125: city='Warrenville', zip='60555' (only when
+ *      currently null/wrong), geocode lat/lng via the existing helper.
+ *   3. Resolve clients.zone_id from the now-correct zip.
+ *   4. Print before/after for verification.
+ */
+import { db, pool } from "@workspace/db";
+import { sql } from "drizzle-orm";
+import { geocodeAddress } from "../src/lib/geocode.js";
+
+const COMPANY_ID = 1;
+const PEGAH_CLIENT_ID = 125;
+const ZONE_NAME = "Westmont/Lombard/Elmhurst";
+const NEW_ZIP = "60555";
+const REAL_CITY = "Warrenville";
+const REAL_STATE = "IL";
+const REAL_ADDRESS = "28262 Diehl Road";
+
+(async () => {
+  console.log("─── BEFORE ───");
+  const beforeClient = await db.execute(sql`
+    SELECT id, first_name, last_name, address, city, state, zip, lat, lng, zone_id
+    FROM clients WHERE id = ${PEGAH_CLIENT_ID} AND company_id = ${COMPANY_ID}
+  `);
+  console.table(beforeClient.rows);
+
+  const beforeZone = await db.execute(sql`
+    SELECT id, name, color, zip_codes FROM service_zones
+    WHERE company_id = ${COMPANY_ID} AND name = ${ZONE_NAME}
+  `);
+  if (!beforeZone.rows.length) {
+    console.error(`ABORT: zone "${ZONE_NAME}" not found for company ${COMPANY_ID}`);
+    await pool.end();
+    process.exit(1);
+  }
+  const zoneRow = beforeZone.rows[0] as any;
+  console.log(`Zone "${ZONE_NAME}" (id=${zoneRow.id}, color=${zoneRow.color})`);
+  console.log(`  zip_codes before: ${(zoneRow.zip_codes ?? []).join(", ")}`);
+
+  // ── 1. Extend the zone to include 60555 (idempotent) ──────────────────────
+  if ((zoneRow.zip_codes ?? []).includes(NEW_ZIP)) {
+    console.log(`  zip_codes already contains ${NEW_ZIP} — skipping`);
+  } else {
+    await db.execute(sql`
+      UPDATE service_zones
+      SET zip_codes = array_append(zip_codes, ${NEW_ZIP})
+      WHERE id = ${zoneRow.id} AND NOT (${NEW_ZIP} = ANY(zip_codes))
+    `);
+    console.log(`  → appended ${NEW_ZIP}`);
+  }
+
+  // ── 2. Geocode the real address ────────────────────────────────────────────
+  const fullAddress = `${REAL_ADDRESS}, ${REAL_CITY}, ${REAL_STATE} ${NEW_ZIP}`;
+  console.log(`\nGeocoding: ${fullAddress}`);
+  const coords = await geocodeAddress(fullAddress);
+  if (!coords) {
+    console.warn("  geocode returned null — proceeding without lat/lng");
+  } else {
+    console.log(`  → lat=${coords.lat} lng=${coords.lng}`);
+  }
+
+  // ── 3. Patch Pegah's client record ─────────────────────────────────────────
+  // Use CASE guards so re-running is idempotent and we never overwrite manual
+  // corrections that may have already happened in the UI.
+  const before = beforeClient.rows[0] as any;
+  const cityNeedsFix = !before.city || before.city.trim() === "";
+  const zipNeedsFix = !before.zip || before.zip === "28262" || before.zip !== NEW_ZIP;
+  const stateNeedsFix = !before.state || before.state.trim() === "";
+
+  if (cityNeedsFix || zipNeedsFix || stateNeedsFix || (coords && (!before.lat || !before.lng))) {
+    await db.execute(sql`
+      UPDATE clients SET
+        city  = CASE WHEN city IS NULL OR city = '' THEN ${REAL_CITY} ELSE city END,
+        state = CASE WHEN state IS NULL OR state = '' THEN ${REAL_STATE} ELSE state END,
+        zip   = CASE WHEN zip IS NULL OR zip = '' OR zip = '28262' THEN ${NEW_ZIP} ELSE zip END,
+        lat   = CASE WHEN lat IS NULL AND ${coords?.lat ?? null}::numeric IS NOT NULL THEN ${coords?.lat ?? null}::numeric ELSE lat END,
+        lng   = CASE WHEN lng IS NULL AND ${coords?.lng ?? null}::numeric IS NOT NULL THEN ${coords?.lng ?? null}::numeric ELSE lng END
+      WHERE id = ${PEGAH_CLIENT_ID} AND company_id = ${COMPANY_ID}
+    `);
+    console.log("  → clients row patched");
+  } else {
+    console.log("  clients row already correct — skipping");
+  }
+
+  // ── 4. Resolve and persist zone_id ─────────────────────────────────────────
+  const zoneMatch = await db.execute(sql`
+    SELECT id FROM service_zones
+    WHERE company_id = ${COMPANY_ID}
+      AND is_active = true
+      AND ${NEW_ZIP} = ANY(zip_codes)
+    LIMIT 1
+  `);
+  if (zoneMatch.rows.length) {
+    const newZoneId = (zoneMatch.rows[0] as any).id;
+    await db.execute(sql`
+      UPDATE clients SET zone_id = ${newZoneId}
+      WHERE id = ${PEGAH_CLIENT_ID} AND company_id = ${COMPANY_ID}
+    `);
+    console.log(`  → clients.zone_id = ${newZoneId}`);
+  } else {
+    console.warn(`  no zone found containing zip ${NEW_ZIP} — zone_id unchanged`);
+  }
+
+  console.log("\n─── AFTER ───");
+  const after = await db.execute(sql`
+    SELECT c.id, c.first_name, c.last_name, c.address, c.city, c.state, c.zip,
+           c.lat, c.lng, c.zone_id, sz.name AS zone_name, sz.color AS zone_color
+    FROM clients c
+    LEFT JOIN service_zones sz ON sz.id = c.zone_id
+    WHERE c.id = ${PEGAH_CLIENT_ID} AND c.company_id = ${COMPANY_ID}
+  `);
+  console.table(after.rows);
+
+  const afterZone = await db.execute(sql`
+    SELECT zip_codes FROM service_zones WHERE id = ${zoneRow.id}
+  `);
+  console.log(`Zone "${ZONE_NAME}" zip_codes after: ${(afterZone.rows[0] as any).zip_codes.join(", ")}`);
+
+  await pool.end();
+})();

--- a/artifacts/api-server/scripts/_pegah_zone_audit.ts
+++ b/artifacts/api-server/scripts/_pegah_zone_audit.ts
@@ -1,0 +1,59 @@
+import { db, pool } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+(async () => {
+  console.log("=== Pegah Abbasian client record ===");
+  const client = await db.execute(sql`
+    SELECT id, first_name, last_name, address, city, state, zip, zone_id, lat, lng
+    FROM clients
+    WHERE company_id = 1 AND lower(first_name) LIKE '%pegah%'
+  `);
+  console.table(client.rows);
+
+  console.log("\n=== Pegah's most recent job(s) ===");
+  const jobs = await db.execute(sql`
+    SELECT j.id, j.scheduled_date, j.scheduled_time, j.service_type, j.status,
+           j.address_street, j.address_city, j.address_state, j.address_zip, j.zone_id,
+           c.first_name, c.last_name, c.zip AS client_zip
+    FROM jobs j
+    LEFT JOIN clients c ON c.id = j.client_id
+    WHERE j.company_id = 1
+      AND lower(c.first_name) LIKE '%pegah%'
+    ORDER BY j.scheduled_date DESC
+    LIMIT 5
+  `);
+  console.table(jobs.rows);
+
+  console.log("\n=== Service zones (zip arrays) ===");
+  const zones = await db.execute(sql`
+    SELECT id, name, color, is_active, zip_codes
+    FROM service_zones
+    WHERE company_id = 1
+    ORDER BY name
+  `);
+  for (const z of zones.rows as any[]) {
+    console.log(`  ${z.name} (${z.color}) [active=${z.is_active}]: ${(z.zip_codes ?? []).slice(0, 20).join(', ')}${(z.zip_codes ?? []).length > 20 ? '...' : ''}`);
+  }
+
+  console.log("\n=== Zip lookup: which zone (if any) covers Pegah's zip? ===");
+  const c = client.rows[0] as any;
+  if (c?.zip) {
+    const match = await db.execute(sql`
+      SELECT id, name, color, zip_codes
+      FROM service_zones
+      WHERE company_id = 1
+        AND is_active = true
+        AND ${c.zip} = ANY(zip_codes)
+    `);
+    console.log(`  Pegah's zip: ${c.zip}`);
+    if (match.rows.length === 0) {
+      console.log(`  → NO ZONE COVERS THIS ZIP`);
+    } else {
+      console.log(`  → matched zone: ${(match.rows[0] as any).name} (${(match.rows[0] as any).color})`);
+    }
+  } else {
+    console.log("  → Pegah's clients.zip is NULL");
+  }
+
+  await pool.end();
+})();

--- a/artifacts/api-server/scripts/_phes_slug.ts
+++ b/artifacts/api-server/scripts/_phes_slug.ts
@@ -1,0 +1,7 @@
+import { db, pool } from "@workspace/db";
+import { sql } from "drizzle-orm";
+(async () => {
+  const r = await db.execute(sql`SELECT id, name, slug FROM companies WHERE id = 1`);
+  console.table(r.rows);
+  await pool.end();
+})();

--- a/artifacts/api-server/scripts/_users_branch_id_fix.ts
+++ b/artifacts/api-server/scripts/_users_branch_id_fix.ts
@@ -1,0 +1,64 @@
+/**
+ * Live DB drift repair: users.branch_id column.
+ *
+ * Drizzle schema (lib/db/src/schema/users.ts) declares users.branch_id but
+ * the live database is missing the column. The just-deployed
+ * GET /api/users/techs-with-status?branch_id=N query references it and
+ * fails with a 500, leaving the dispatch drawer's tech dropdown empty in
+ * production.
+ *
+ * Idempotent: ADD COLUMN IF NOT EXISTS. Adds the FK to branches(id) since
+ * that matches the schema declaration.
+ */
+import { db, pool } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+(async () => {
+  console.log("=== before ===");
+  const before = await db.execute(sql`
+    SELECT column_name, data_type FROM information_schema.columns
+    WHERE table_schema='public' AND table_name='users' AND column_name='branch_id'
+  `);
+  console.log(before.rows.length ? "branch_id present" : "branch_id MISSING");
+
+  console.log("\n=== ALTER TABLE ===");
+  await db.execute(sql`
+    ALTER TABLE users ADD COLUMN IF NOT EXISTS branch_id INTEGER
+  `);
+  // Foreign key constraint, skipped if already present.
+  await db.execute(sql`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1 FROM information_schema.table_constraints
+        WHERE constraint_schema='public'
+          AND table_name='users'
+          AND constraint_name='users_branch_id_fkey'
+      ) THEN
+        ALTER TABLE users
+          ADD CONSTRAINT users_branch_id_fkey
+          FOREIGN KEY (branch_id) REFERENCES branches(id);
+      END IF;
+    END $$;
+  `);
+  console.log("ALTER applied");
+
+  console.log("\n=== after ===");
+  const after = await db.execute(sql`
+    SELECT column_name, data_type, is_nullable FROM information_schema.columns
+    WHERE table_schema='public' AND table_name='users' AND column_name='branch_id'
+  `);
+  console.table(after.rows);
+
+  console.log("\n=== row stats ===");
+  const stats = await db.execute(sql`
+    SELECT
+      COUNT(*)::int AS total,
+      COUNT(branch_id)::int AS with_branch,
+      (COUNT(*) - COUNT(branch_id))::int AS null_branch
+    FROM users
+  `);
+  console.table(stats.rows);
+
+  await pool.end();
+})();

--- a/artifacts/api-server/scripts/aa_geocode_zips.ts
+++ b/artifacts/api-server/scripts/aa_geocode_zips.ts
@@ -1,0 +1,175 @@
+/**
+ * AA — Backfill clients.zip via Google Maps Geocoding API for PHES clients
+ * with NULL zip who have a street address on file (either clients.address
+ * or the most recent jobs.address_street for that client).
+ *
+ * Strategy:
+ *   1. Pull PHES clients with zip IS NULL AND has some street address.
+ *   2. Geocode via Maps API with "Chicago, IL" region bias.
+ *   3. Extract postal_code from address_components.
+ *   4. If found, UPDATE clients.zip (and city/state if missing).
+ *   5. Single transaction at the end with rowcount gate.
+ *
+ * Designed to be safe for re-runs — WHERE zip IS NULL prevents overwriting
+ * any existing values.
+ */
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+const API_KEY = process.env.GOOGLE_MAPS_API_KEY;
+if (!API_KEY) {
+  console.error("GOOGLE_MAPS_API_KEY not set in env");
+  process.exit(1);
+}
+
+type GeocodeResult = {
+  postal_code?: string;
+  city?: string;
+  state?: string;
+};
+
+async function geocode(streetAddr: string): Promise<GeocodeResult | null> {
+  // Bias toward Chicagoland since PHES service area is there.
+  const q = encodeURIComponent(streetAddr.trim() + ", Chicago, IL");
+  const url = `https://maps.googleapis.com/maps/api/geocode/json?address=${q}&region=us&key=${API_KEY}`;
+  try {
+    const r = await fetch(url);
+    if (!r.ok) return null;
+    const json = await r.json() as any;
+    if (json.status !== "OK" || !Array.isArray(json.results) || json.results.length === 0) return null;
+    const comps = json.results[0].address_components as Array<{ long_name: string; short_name: string; types: string[] }>;
+    const result: GeocodeResult = {};
+    for (const c of comps) {
+      if (c.types.includes("postal_code")) result.postal_code = c.short_name;
+      if (c.types.includes("locality")) result.city = c.long_name;
+      if (c.types.includes("administrative_area_level_1")) result.state = c.short_name;
+    }
+    return result.postal_code ? result : null;
+  } catch (e) {
+    console.error(`geocode error for "${streetAddr}":`, e);
+    return null;
+  }
+}
+
+async function main() {
+  console.log("=== AA — Geocode zip backfill (Google Maps) ===\n");
+
+  // Pull candidates: PHES clients with NULL zip who appear in upcoming jobs
+  // AND have some street address available (prefer clients.address, fall
+  // back to most recent jobs.address_street).
+  const candidates = await db.execute(sql`
+    SELECT
+      c.id,
+      c.first_name || ' ' || c.last_name AS name,
+      COALESCE(
+        NULLIF(TRIM(c.address), ''),
+        (SELECT j.address_street FROM jobs j
+          WHERE j.client_id = c.id AND j.company_id = 1
+            AND TRIM(COALESCE(j.address_street,'')) != ''
+          ORDER BY j.created_at DESC LIMIT 1)
+      ) AS resolved_address,
+      c.city AS current_city,
+      c.state AS current_state
+    FROM clients c
+    WHERE c.company_id = 1
+      AND (c.zip IS NULL OR TRIM(c.zip) = '')
+      AND EXISTS (
+        SELECT 1 FROM jobs j
+         WHERE j.client_id = c.id AND j.company_id = 1
+           AND j.scheduled_date >= '2026-04-01'
+      )
+    ORDER BY c.id
+  `);
+
+  const list = (candidates.rows as any[]).filter(c => c.resolved_address);
+  console.log(`Candidates: ${list.length} PHES clients with NULL zip + upcoming jobs + an address`);
+
+  const backfills: Array<{
+    id: number;
+    name: string;
+    address: string;
+    zip: string;
+    city: string | null;
+    state: string | null;
+  }> = [];
+
+  for (const c of list) {
+    process.stdout.write(`  [${c.id}] ${c.name.slice(0, 40).padEnd(40)} "${c.resolved_address.slice(0, 40)}" → `);
+    const g = await geocode(c.resolved_address);
+    if (!g?.postal_code) {
+      console.log("NO ZIP FOUND");
+      continue;
+    }
+    console.log(`${g.postal_code}  (${g.city ?? "?"}, ${g.state ?? "?"})`);
+    backfills.push({
+      id: c.id,
+      name: c.name,
+      address: c.resolved_address,
+      zip: g.postal_code,
+      city: c.current_city ? null : (g.city ?? null),   // only set if currently null
+      state: c.current_state ? null : (g.state ?? null),
+    });
+    // Small delay to stay friendly with Google's rate limits
+    await new Promise(r => setTimeout(r, 60));
+  }
+
+  console.log(`\nFound zips for ${backfills.length} / ${list.length} clients.`);
+
+  if (backfills.length === 0) {
+    console.log("Nothing to UPDATE. Exiting.");
+    process.exit(0);
+  }
+
+  // --- Transaction ---
+  console.log("\n=== UPDATE transaction ===");
+  await db.execute(sql`BEGIN`);
+  try {
+    let updated = 0;
+    for (const b of backfills) {
+      const res = await db.execute(sql`
+        UPDATE clients
+           SET zip = ${b.zip},
+               city = COALESCE(city, ${b.city}),
+               state = COALESCE(state, ${b.state})
+         WHERE id = ${b.id}
+           AND company_id = 1
+           AND (zip IS NULL OR TRIM(zip) = '')
+      `);
+      updated += res.rowCount ?? 0;
+    }
+    console.log(`UPDATE rowcount: ${updated} / ${backfills.length} expected`);
+    if (updated !== backfills.length) {
+      throw new Error(`rowcount mismatch: got ${updated}, expected ${backfills.length}`);
+    }
+    await db.execute(sql`COMMIT`);
+    console.log("--- COMMIT OK ---");
+  } catch (err) {
+    await db.execute(sql`ROLLBACK`);
+    console.error("--- ROLLBACK ---");
+    console.error(err);
+    process.exit(1);
+  }
+
+  // Post-verify: which Apr 23 clients now have resolvable zones?
+  console.log("\n=== Apr 23 post-verify ===");
+  const post = await db.execute(sql`
+    SELECT DISTINCT
+      c.id,
+      c.first_name || ' ' || c.last_name AS name,
+      c.zip,
+      (SELECT z.name FROM service_zones z
+         WHERE z.company_id = 1 AND z.is_active = true
+           AND c.zip = ANY(z.zip_codes) LIMIT 1) AS derived_zone,
+      (SELECT z.color FROM service_zones z
+         WHERE z.company_id = 1 AND z.is_active = true
+           AND c.zip = ANY(z.zip_codes) LIMIT 1) AS derived_color
+    FROM jobs j
+    LEFT JOIN clients c ON c.id = j.client_id
+    WHERE j.company_id = 1 AND j.scheduled_date = '2026-04-23'
+    ORDER BY c.id
+  `);
+  console.table(post.rows);
+
+  process.exit(0);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/aa_nominatim_backfill.ts
+++ b/artifacts/api-server/scripts/aa_nominatim_backfill.ts
@@ -1,0 +1,159 @@
+/**
+ * AA — Backfill clients.zip via OpenStreetMap Nominatim for PHES clients
+ * with NULL zip who have a street address. (The configured
+ * GOOGLE_MAPS_API_KEY is a browser key with HTTP-referer restrictions
+ * and can't be used for server-side Geocoding API calls.)
+ *
+ * Rate limit: Nominatim is 1 req/sec max per their usage policy. We pace
+ * at ~1.2s between calls. Sets User-Agent per their requirement.
+ */
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+const UA = "qleno-dispatch-backfill/1.0 (sal@phes.io)";
+
+type GeocodeResult = {
+  postal_code?: string;
+  city?: string;
+  state?: string;
+};
+
+async function geocode(streetAddr: string): Promise<GeocodeResult | null> {
+  const q = encodeURIComponent(streetAddr.trim() + ", Chicago, IL");
+  const url = `https://nominatim.openstreetmap.org/search?q=${q}&format=json&addressdetails=1&limit=1&countrycodes=us`;
+  try {
+    const r = await fetch(url, { headers: { "User-Agent": UA } });
+    if (!r.ok) return null;
+    const arr = await r.json() as any[];
+    if (!Array.isArray(arr) || arr.length === 0) return null;
+    const a = arr[0].address || {};
+    if (!a.postcode) return null;
+    return {
+      postal_code: String(a.postcode).slice(0, 5), // only US 5-digit
+      city: a.city || a.town || a.village || a.suburb || null,
+      state: a.state ? (a["ISO3166-2-lvl4"] ? String(a["ISO3166-2-lvl4"]).replace("US-", "") : null) : null,
+    };
+  } catch (e) {
+    console.error(`geocode error for "${streetAddr}":`, e);
+    return null;
+  }
+}
+
+async function main() {
+  console.log("=== AA — Nominatim zip backfill ===\n");
+
+  const candidates = await db.execute(sql`
+    SELECT
+      c.id,
+      c.first_name || ' ' || c.last_name AS name,
+      COALESCE(
+        NULLIF(TRIM(c.address), ''),
+        (SELECT j.address_street FROM jobs j
+          WHERE j.client_id = c.id AND j.company_id = 1
+            AND TRIM(COALESCE(j.address_street,'')) != ''
+          ORDER BY j.created_at DESC LIMIT 1)
+      ) AS resolved_address,
+      c.city AS current_city,
+      c.state AS current_state
+    FROM clients c
+    WHERE c.company_id = 1
+      AND (c.zip IS NULL OR TRIM(c.zip) = '')
+      AND EXISTS (
+        SELECT 1 FROM jobs j
+         WHERE j.client_id = c.id AND j.company_id = 1
+           AND j.scheduled_date >= '2026-04-01'
+      )
+    ORDER BY c.id
+  `);
+
+  const list = (candidates.rows as any[]).filter(c => c.resolved_address);
+  console.log(`Candidates: ${list.length} PHES clients\n`);
+
+  const backfills: Array<{
+    id: number;
+    name: string;
+    address: string;
+    zip: string;
+    city: string | null;
+    state: string | null;
+  }> = [];
+
+  for (let i = 0; i < list.length; i++) {
+    const c = list[i];
+    process.stdout.write(`  [${i + 1}/${list.length}] [${c.id}] ${String(c.name).slice(0, 35).padEnd(35)} "${String(c.resolved_address).slice(0, 35)}" → `);
+    const g = await geocode(c.resolved_address);
+    if (!g?.postal_code) {
+      console.log("NO ZIP");
+      await new Promise(r => setTimeout(r, 1200));
+      continue;
+    }
+    console.log(`${g.postal_code}  ${g.city ?? ""} ${g.state ?? ""}`);
+    backfills.push({
+      id: c.id,
+      name: c.name,
+      address: c.resolved_address,
+      zip: g.postal_code,
+      city: c.current_city ? null : (g.city ?? null),
+      state: c.current_state ? null : (g.state ?? null),
+    });
+    await new Promise(r => setTimeout(r, 1200)); // Nominatim rate limit
+  }
+
+  console.log(`\nGeocode found zips for ${backfills.length} / ${list.length} clients.\n`);
+  if (backfills.length === 0) {
+    console.log("Nothing to UPDATE. Exiting.");
+    process.exit(0);
+  }
+
+  // Transaction
+  console.log("=== UPDATE transaction ===");
+  await db.execute(sql`BEGIN`);
+  try {
+    let updated = 0;
+    for (const b of backfills) {
+      const res = await db.execute(sql`
+        UPDATE clients
+           SET zip = ${b.zip},
+               city = COALESCE(city, ${b.city}),
+               state = COALESCE(state, ${b.state})
+         WHERE id = ${b.id}
+           AND company_id = 1
+           AND (zip IS NULL OR TRIM(zip) = '')
+      `);
+      updated += res.rowCount ?? 0;
+    }
+    console.log(`UPDATE rowcount: ${updated} (expected ${backfills.length})`);
+    if (updated !== backfills.length) {
+      throw new Error(`rowcount mismatch: got ${updated}, expected ${backfills.length}`);
+    }
+    await db.execute(sql`COMMIT`);
+    console.log("--- COMMIT OK ---");
+  } catch (err) {
+    await db.execute(sql`ROLLBACK`);
+    console.error("--- ROLLBACK ---");
+    throw err;
+  }
+
+  // Verify Apr 23 coverage
+  console.log("\n=== Apr 23 post-verify ===");
+  const post = await db.execute(sql`
+    SELECT DISTINCT
+      c.id,
+      c.first_name || ' ' || c.last_name AS name,
+      c.zip,
+      (SELECT z.name FROM service_zones z
+         WHERE z.company_id = 1 AND z.is_active = true
+           AND c.zip = ANY(z.zip_codes) LIMIT 1) AS zone_name,
+      (SELECT z.color FROM service_zones z
+         WHERE z.company_id = 1 AND z.is_active = true
+           AND c.zip = ANY(z.zip_codes) LIMIT 1) AS zone_color
+    FROM jobs j
+    LEFT JOIN clients c ON c.id = j.client_id
+    WHERE j.company_id = 1 AND j.scheduled_date = '2026-04-23'
+    ORDER BY c.id
+  `);
+  console.table(post.rows);
+
+  process.exit(0);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/ac_manual_zip_fix.ts
+++ b/artifacts/api-server/scripts/ac_manual_zip_fix.ts
@@ -1,0 +1,135 @@
+/**
+ * AC — Manual zip backfill for the 6 PHES clients Nominatim failed on.
+ * Uses Sal's confidence list. Executes UPDATE in a transaction and then
+ * VERIFIES each row resolves to an active service_zone. If ANY of the 6
+ * does NOT resolve to a zone (null zone_name), ROLLBACK and report — no
+ * partial commits.
+ *
+ * Manual list (from _commit_AA.md next-steps):
+ *   46, 61  Kristofer/Kriztofer Bz  → 60457  (Hickory Hills)
+ *   49      Michael Baffoe          → 60455  (Bridgeview, near Oak Lawn)
+ *   86      Jalinia Logan           → 60707  (Elmwood Park area)
+ *   110     John Piscopo            → 60707  (Elmwood Park)
+ *   1052    Danni Varenhorst        → 60608  (Chicago, S Halsted)
+ */
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+type Backfill = { id: number; zip: string; note: string };
+const BACKFILLS: Backfill[] = [
+  { id: 46,   zip: "60457", note: "Kristofer Bz / Hickory Hills" },
+  { id: 61,   zip: "60457", note: "Kriztofer Bz / Hickory Hills" },
+  { id: 49,   zip: "60455", note: "Michael Baffoe / Bridgeview" },
+  { id: 86,   zip: "60707", note: "Jalinia Logan / Elmwood Park" },
+  { id: 110,  zip: "60707", note: "John Piscopo / Elmwood Park" },
+  { id: 1052, zip: "60608", note: "Danni Varenhorst / Chicago S Halsted" },
+];
+
+async function main() {
+  console.log("=== AC — Manual zip backfill ===\n");
+
+  // Pre-flight: confirm each target zip resolves to an active zone.
+  // (Do this BEFORE touching rows so we fail fast if a zip is unmapped.)
+  console.log("--- Pre-flight: zone resolution for proposed zips ---");
+  const zipsToCheck = Array.from(new Set(BACKFILLS.map(b => b.zip)));
+  const zipZoneRows = await db.execute(sql`
+    SELECT z.zip AS zip, sz.name, sz.color
+      FROM (VALUES ${sql.raw(zipsToCheck.map(z => `('${z}')`).join(","))}) AS z(zip)
+      LEFT JOIN service_zones sz
+        ON sz.company_id = 1 AND sz.is_active = true AND sz.zip_codes @> ARRAY[z.zip]
+  `);
+  console.table(zipZoneRows.rows);
+
+  const unmappedZips = (zipZoneRows.rows as any[]).filter(r => !r.name).map(r => r.zip);
+  if (unmappedZips.length > 0) {
+    console.error(`\n✗ Zips with no matching service_zones row: ${unmappedZips.join(", ")}`);
+    console.error("Aborting — fix zones before running backfill.");
+    process.exit(1);
+  }
+  console.log("✓ All proposed zips resolve to active service_zones.\n");
+
+  // Snapshot current state (for audit).
+  console.log("--- Pre-update state ---");
+  const ids = BACKFILLS.map(b => b.id);
+  const pre = await db.execute(sql`
+    SELECT id, first_name || ' ' || last_name AS name, zip, city, state
+      FROM clients
+     WHERE company_id = 1 AND id IN (${sql.raw(ids.join(","))})
+     ORDER BY id
+  `);
+  console.table(pre.rows);
+
+  // Run the UPDATE in a single transaction.
+  console.log("--- UPDATE transaction ---");
+  await db.execute(sql`BEGIN`);
+  try {
+    let rowsUpdated = 0;
+    for (const b of BACKFILLS) {
+      const res = await db.execute(sql`
+        UPDATE clients
+           SET zip = ${b.zip}
+         WHERE id = ${b.id}
+           AND company_id = 1
+      `);
+      const n = res.rowCount ?? 0;
+      console.log(`  UPDATE id=${b.id} zip=${b.zip}  (${b.note})  → rowcount ${n}`);
+      rowsUpdated += n;
+    }
+    console.log(`Total UPDATE rowcount: ${rowsUpdated} (expected ${BACKFILLS.length})`);
+    if (rowsUpdated !== BACKFILLS.length) {
+      throw new Error(`rowcount mismatch: got ${rowsUpdated}, expected ${BACKFILLS.length}`);
+    }
+
+    // Verify EACH row now resolves to a zone. If any fails → ROLLBACK.
+    console.log("\n--- In-transaction zone verification ---");
+    const verify = await db.execute(sql`
+      SELECT c.id, c.first_name || ' ' || c.last_name AS name, c.zip,
+             (SELECT name  FROM service_zones sz
+               WHERE sz.company_id = 1 AND sz.is_active = true
+                 AND sz.zip_codes @> ARRAY[c.zip] LIMIT 1) AS zone_name,
+             (SELECT color FROM service_zones sz
+               WHERE sz.company_id = 1 AND sz.is_active = true
+                 AND sz.zip_codes @> ARRAY[c.zip] LIMIT 1) AS zone_color
+        FROM clients c
+       WHERE c.company_id = 1 AND c.id IN (${sql.raw(ids.join(","))})
+       ORDER BY c.id
+    `);
+    console.table(verify.rows);
+
+    const unresolved = (verify.rows as any[]).filter(r => !r.zone_name || !r.zone_color);
+    if (unresolved.length > 0) {
+      console.error(`\n✗ ${unresolved.length} row(s) did not resolve to a zone post-UPDATE:`);
+      for (const r of unresolved) console.error(`   id=${r.id} ${r.name} zip=${r.zip}`);
+      throw new Error("partial resolution — aborting before commit");
+    }
+
+    await db.execute(sql`COMMIT`);
+    console.log("\n--- COMMIT OK — all 6 rows resolved to zones ---");
+  } catch (err) {
+    await db.execute(sql`ROLLBACK`);
+    console.error("\n--- ROLLBACK ---");
+    console.error(err);
+    process.exit(1);
+  }
+
+  // Final post-commit snapshot for Apr 23 dispatch
+  console.log("\n=== Apr 23 post-verify (all 14 dispatch clients) ===");
+  const post = await db.execute(sql`
+    SELECT DISTINCT c.id, c.first_name || ' ' || c.last_name AS name, c.zip,
+           (SELECT name  FROM service_zones sz
+             WHERE sz.company_id = 1 AND sz.is_active = true
+               AND sz.zip_codes @> ARRAY[c.zip] LIMIT 1) AS zone_name,
+           (SELECT color FROM service_zones sz
+             WHERE sz.company_id = 1 AND sz.is_active = true
+               AND sz.zip_codes @> ARRAY[c.zip] LIMIT 1) AS zone_color
+      FROM jobs j LEFT JOIN clients c ON c.id = j.client_id
+     WHERE j.company_id = 1 AND j.scheduled_date = '2026-04-23'
+     ORDER BY c.id
+  `);
+  console.table(post.rows);
+  const apr23Null = (post.rows as any[]).filter(r => !r.zone_name).length;
+  console.log(`\nApr 23 cards without zone_color: ${apr23Null} / ${post.rows.length}`);
+
+  process.exit(0);
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/ad_client_homes_probe.ts
+++ b/artifacts/api-server/scripts/ad_client_homes_probe.ts
@@ -1,0 +1,52 @@
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+async function main() {
+  console.log("=== client_homes schema + Shannon rows ===\n");
+  const cols = await db.execute(sql`
+    SELECT column_name, data_type, is_nullable
+      FROM information_schema.columns
+     WHERE table_schema = 'public' AND table_name = 'client_homes'
+     ORDER BY ordinal_position
+  `);
+  console.table(cols.rows);
+
+  console.log("\n=== client_homes rows for Shannon (client_id=77) ===");
+  const rows = await db.execute(sql`SELECT * FROM client_homes WHERE client_id = 77`);
+  console.table(rows.rows);
+
+  console.log("\n=== client_homes total coverage (how widely is it populated?) ===");
+  const stats = await db.execute(sql`
+    SELECT COUNT(*)::int AS total_rows,
+           COUNT(DISTINCT client_id)::int AS distinct_clients
+      FROM client_homes
+  `);
+  console.table(stats.rows);
+
+  console.log("\n=== jobs.address_* usage across PHES (is the jobs-level address the real source of truth?) ===");
+  const jobAddrCoverage = await db.execute(sql`
+    SELECT
+      COUNT(*)::int AS total_jobs,
+      COUNT(*) FILTER (WHERE address_street IS NOT NULL AND TRIM(address_street) != '')::int AS with_address_street,
+      COUNT(*) FILTER (WHERE address_zip IS NOT NULL    AND TRIM(address_zip) != '')::int    AS with_address_zip,
+      COUNT(*) FILTER (WHERE address_city IS NOT NULL   AND TRIM(address_city) != '')::int   AS with_address_city
+    FROM jobs WHERE company_id = 1
+  `);
+  console.table(jobAddrCoverage.rows);
+
+  // Does the dispatch endpoint already pull j.address_street? Probing 5 random Apr 23 rows to see:
+  console.log("\n=== Sample Apr 23 jobs: do they have their own address_street (job-level) vs client address? ===");
+  const sample = await db.execute(sql`
+    SELECT j.id, c.first_name || ' ' || c.last_name AS client,
+           LEFT(COALESCE(j.address_street, ''), 35) AS job_addr,
+           LEFT(COALESCE(c.address, ''), 35)       AS client_addr,
+           (TRIM(COALESCE(j.address_street,'')) != TRIM(COALESCE(c.address,''))) AS addrs_differ
+      FROM jobs j JOIN clients c ON c.id = j.client_id
+     WHERE j.company_id = 1 AND j.scheduled_date = '2026-04-23'
+     ORDER BY c.id
+  `);
+  console.table(sample.rows);
+
+  process.exit(0);
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/ad_shannon_audit.ts
+++ b/artifacts/api-server/scripts/ad_shannon_audit.ts
@@ -1,0 +1,140 @@
+/**
+ * AD — Read-only audit of Shannon Heidloff's client record + Apr 23 job.
+ * No writes. Reports on:
+ *   1. Shannon's client row(s)
+ *   2. Whether schema supports multi-address per client (separate table? column on job?)
+ *   3. Today's job — which address is it using?
+ *   4. Historical jobs — any different addresses in use?
+ */
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+async function main() {
+  console.log("=== AD — Shannon Heidloff read-only audit ===\n");
+
+  // 1. Shannon's client row(s)
+  console.log("--- 1. clients row(s) matching Shannon / Heidloff ---");
+  const client = await db.execute(sql`
+    SELECT id, first_name, last_name, phone, email, address, city, state, zip, is_active,
+           LEFT(COALESCE(notes, ''), 200) AS notes_preview
+      FROM clients
+     WHERE company_id = 1
+       AND (first_name ILIKE 'shannon%' OR last_name ILIKE 'heidloff%')
+     ORDER BY id
+  `);
+  console.table(client.rows);
+
+  // 2. Address-related tables in the schema
+  console.log("\n--- 2a. All schema tables with 'address' in the name ---");
+  const addrTables = await db.execute(sql`
+    SELECT table_schema, table_name
+      FROM information_schema.tables
+     WHERE table_schema IN ('public')
+       AND (table_name ILIKE '%address%' OR table_name ILIKE '%location%')
+     ORDER BY table_name
+  `);
+  console.table(addrTables.rows);
+
+  // 2b. Any table with a client_id FK that could be a multi-address store?
+  console.log("\n--- 2b. Tables with a client_id column (possible multi-address stores) ---");
+  const clientFkTables = await db.execute(sql`
+    SELECT table_schema, table_name, column_name
+      FROM information_schema.columns
+     WHERE table_schema = 'public'
+       AND column_name = 'client_id'
+     ORDER BY table_name
+  `);
+  console.table(clientFkTables.rows);
+
+  // 3. clients table structure — all columns (so we see what address-like fields exist)
+  console.log("\n--- 3. clients table columns ---");
+  const clientCols = await db.execute(sql`
+    SELECT column_name, data_type, is_nullable
+      FROM information_schema.columns
+     WHERE table_schema = 'public' AND table_name = 'clients'
+     ORDER BY ordinal_position
+  `);
+  console.table(clientCols.rows);
+
+  // 4. jobs table columns with "address" in the name (overrides?)
+  console.log("\n--- 4. jobs columns with 'address' in the name ---");
+  const jobAddrCols = await db.execute(sql`
+    SELECT column_name, data_type, is_nullable
+      FROM information_schema.columns
+     WHERE table_schema = 'public' AND table_name = 'jobs'
+       AND column_name ILIKE '%address%'
+     ORDER BY ordinal_position
+  `);
+  console.table(jobAddrCols.rows);
+
+  // 5. Shannon's Apr 23 job — which address is it using?
+  console.log("\n--- 5. Shannon's Apr 23 job: address state ---");
+  const apr23Job = await db.execute(sql`
+    SELECT j.id AS job_id, j.mc_job_id, j.scheduled_date, j.scheduled_time,
+           j.address_street, j.address_city, j.address_state, j.address_zip,
+           c.id AS client_id,
+           c.first_name || ' ' || c.last_name AS client_name,
+           c.address AS client_address,
+           c.city    AS client_city,
+           c.state   AS client_state,
+           c.zip     AS client_zip
+      FROM jobs j
+      JOIN clients c ON c.id = j.client_id
+     WHERE c.company_id = 1
+       AND (c.first_name ILIKE 'shannon%' OR c.last_name ILIKE 'heidloff%')
+       AND j.scheduled_date = '2026-04-23'
+     ORDER BY j.scheduled_time
+  `);
+  console.table(apr23Job.rows);
+
+  // 6. Historical — all Shannon jobs, address-per-job
+  console.log("\n--- 6. Shannon's job history — distinct addresses used ---");
+  const history = await db.execute(sql`
+    SELECT j.scheduled_date, j.scheduled_time,
+           j.address_street, j.address_city, j.address_zip,
+           j.mc_job_id, j.status
+      FROM jobs j
+      JOIN clients c ON c.id = j.client_id
+     WHERE c.company_id = 1
+       AND (c.first_name ILIKE 'shannon%' OR c.last_name ILIKE 'heidloff%')
+     ORDER BY j.scheduled_date DESC, j.scheduled_time DESC
+     LIMIT 25
+  `);
+  console.table(history.rows);
+
+  // 7. Distinct addresses across all Shannon's jobs — frequency count
+  console.log("\n--- 7. Distinct addresses across Shannon's jobs (with counts) ---");
+  const distinct = await db.execute(sql`
+    SELECT TRIM(COALESCE(j.address_street, '')) AS street,
+           TRIM(COALESCE(j.address_city, ''))   AS city,
+           TRIM(COALESCE(j.address_zip, ''))    AS zip,
+           COUNT(*)::int AS n_jobs,
+           MIN(j.scheduled_date) AS first_seen,
+           MAX(j.scheduled_date) AS last_seen
+      FROM jobs j
+      JOIN clients c ON c.id = j.client_id
+     WHERE c.company_id = 1
+       AND (c.first_name ILIKE 'shannon%' OR c.last_name ILIKE 'heidloff%')
+     GROUP BY 1, 2, 3
+     ORDER BY n_jobs DESC
+  `);
+  console.table(distinct.rows);
+
+  // 8. Is there a mc_dispatch_staging row that shows what MC exported for this job?
+  console.log("\n--- 8. MC staging row for Shannon's Apr 23 job (source-of-truth address) ---");
+  const staging = await db.execute(sql`
+    SELECT mcs.mc_job_id, mcs.scheduled_date,
+           LEFT(COALESCE(mcs.address, ''), 80) AS mc_address,
+           mcs.customer_name
+      FROM jobs j
+      JOIN clients c ON c.id = j.client_id
+      LEFT JOIN mc_dispatch_staging mcs ON mcs.mc_job_id::bigint = j.mc_job_id
+     WHERE c.company_id = 1
+       AND (c.first_name ILIKE 'shannon%' OR c.last_name ILIKE 'heidloff%')
+       AND j.scheduled_date = '2026-04-23'
+  `);
+  console.table(staging.rows);
+
+  process.exit(0);
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/ad_shannon_job_fix.ts
+++ b/artifacts/api-server/scripts/ad_shannon_job_fix.ts
@@ -1,0 +1,92 @@
+/**
+ * AD — Backfill jobs.address_city / address_state / address_zip for Shannon
+ * Heidloff's Apr 23 one-off at 1111 Whitfield Rd, Northbrook IL 60062.
+ *
+ * Gate: target row MUST match (id=4231 AND mc_job_id=62088584 AND
+ * scheduled_date=2026-04-23 AND street LIKE '%Whitfield%'). If not →
+ * ROLLBACK and abort. Single-row UPDATE, wrapped in a transaction.
+ */
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+async function main() {
+  console.log("=== AD — Shannon job 4231 address backfill (Northbrook IL 60062) ===\n");
+
+  // Dry-run: confirm the target row state pre-update.
+  console.log("--- Pre-update state ---");
+  const pre = await db.execute(sql`
+    SELECT id, mc_job_id, scheduled_date, scheduled_time,
+           address_street, address_city, address_state, address_zip
+      FROM jobs
+     WHERE id = 4231 AND company_id = 1
+  `);
+  console.table(pre.rows);
+
+  const row = (pre.rows as any[])[0];
+  if (!row) {
+    console.error("✗ No row found for job id 4231. Aborting.");
+    process.exit(1);
+  }
+  if (String(row.mc_job_id) !== "62088584") {
+    console.error(`✗ mc_job_id mismatch: expected 62088584, got ${row.mc_job_id}. Aborting.`);
+    process.exit(1);
+  }
+  if (row.scheduled_date !== "2026-04-23") {
+    console.error(`✗ scheduled_date mismatch: expected 2026-04-23, got ${row.scheduled_date}. Aborting.`);
+    process.exit(1);
+  }
+  if (!row.address_street || !/whitfield/i.test(row.address_street)) {
+    console.error(`✗ address_street doesn't look like a Whitfield address: "${row.address_street}". Aborting.`);
+    process.exit(1);
+  }
+  console.log("✓ Target row verified (id=4231, mc_job_id=62088584, Apr 23, Whitfield street).\n");
+
+  // Transaction
+  console.log("--- UPDATE transaction ---");
+  await db.execute(sql`BEGIN`);
+  try {
+    const res = await db.execute(sql`
+      UPDATE jobs
+         SET address_city  = 'Northbrook',
+             address_state = 'IL',
+             address_zip   = '60062'
+       WHERE id = 4231
+         AND company_id = 1
+         AND mc_job_id = 62088584
+    `);
+    const n = res.rowCount ?? 0;
+    console.log(`UPDATE rowcount: ${n} (expected 1)`);
+    if (n !== 1) throw new Error(`rowcount mismatch: got ${n}, expected 1`);
+
+    // In-transaction verify
+    const check = await db.execute(sql`
+      SELECT id, address_street, address_city, address_state, address_zip
+        FROM jobs WHERE id = 4231
+    `);
+    console.log("In-transaction post-state:");
+    console.table(check.rows);
+    const r = (check.rows as any[])[0];
+    if (r.address_city !== "Northbrook" || r.address_state !== "IL" || r.address_zip !== "60062") {
+      throw new Error(`post-UPDATE state wrong: ${JSON.stringify(r)}`);
+    }
+
+    await db.execute(sql`COMMIT`);
+    console.log("\n--- COMMIT OK ---");
+  } catch (err) {
+    await db.execute(sql`ROLLBACK`);
+    console.error("\n--- ROLLBACK ---");
+    console.error(err);
+    process.exit(1);
+  }
+
+  console.log("\n=== Post-commit state ===");
+  const post = await db.execute(sql`
+    SELECT id, mc_job_id, scheduled_date, scheduled_time,
+           address_street, address_city, address_state, address_zip
+      FROM jobs WHERE id = 4231
+  `);
+  console.table(post.rows);
+
+  process.exit(0);
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/ae_add_north_shore_zone.ts
+++ b/artifacts/api-server/scripts/ae_add_north_shore_zone.ts
@@ -1,0 +1,131 @@
+/**
+ * AE — Add PHES "North Shore" service_zone. Data-only write.
+ *
+ * Spec divergences already reviewed with Sal:
+ *   - column is `zip_codes` (not `zips`)
+ *   - service_zones has no `branch_id`; uses `location text` ('oak_lawn' | 'schaumburg')
+ *   - no UNIQUE (company_id, name) constraint → WHERE NOT EXISTS guard instead of ON CONFLICT
+ *   - no `updated_at` column; `created_at` is NOT NULL
+ *
+ * Idempotent: re-running with the row already in place returns rowcount 0
+ * (NOT EXISTS blocks) — transaction still commits (no-op). Rowcount gate
+ * enforces "expect 1 on first run, 0 on re-run".
+ */
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+const NAME = "North Shore";
+const COLOR = "#00B8A9";
+const ZIPS = ["60062","60025","60026","60091","60093","60015","60035"];
+const LOCATION = "oak_lawn";
+const SORT_ORDER = 19;
+
+async function main() {
+  console.log("=== AE — Add service_zone 'North Shore' ===\n");
+
+  // Pre-check
+  console.log("--- Pre-write: does 'North Shore' already exist? ---");
+  const pre = await db.execute(sql`
+    SELECT id, name, color, zip_codes, location, sort_order
+      FROM service_zones WHERE company_id = 1 AND name = ${NAME}
+  `);
+  console.table(pre.rows);
+  const alreadyExists = (pre.rows as any[]).length > 0;
+  if (alreadyExists) {
+    console.log("⚠ Row exists — INSERT will no-op (expected rowcount 0).");
+  } else {
+    console.log("✓ Clean insert path.");
+  }
+
+  // Transaction
+  console.log("\n--- INSERT transaction ---");
+  await db.execute(sql`BEGIN`);
+  try {
+    const zipLit = sql.raw(`ARRAY[${ZIPS.map(z => `'${z}'`).join(",")}]::text[]`);
+    const res = await db.execute(sql`
+      INSERT INTO service_zones
+        (company_id, name, color, zip_codes, location, is_active, sort_order, created_at)
+      SELECT 1,
+             ${NAME},
+             ${COLOR},
+             ${zipLit},
+             ${LOCATION},
+             true,
+             ${SORT_ORDER},
+             NOW()
+       WHERE NOT EXISTS (
+         SELECT 1 FROM service_zones WHERE company_id = 1 AND name = ${NAME}
+       )
+      RETURNING id, name, color, zip_codes, location, is_active, sort_order, created_at
+    `);
+    const n = res.rowCount ?? 0;
+    console.log(`INSERT rowcount: ${n} (expected ${alreadyExists ? 0 : 1})`);
+    if (n !== (alreadyExists ? 0 : 1)) {
+      throw new Error(`rowcount mismatch: got ${n}, expected ${alreadyExists ? 0 : 1}`);
+    }
+    if (n === 1) {
+      console.log("Inserted row:");
+      console.table(res.rows);
+    }
+
+    await db.execute(sql`COMMIT`);
+    console.log("\n--- COMMIT OK ---");
+  } catch (err) {
+    await db.execute(sql`ROLLBACK`);
+    console.error("\n--- ROLLBACK ---");
+    console.error(err);
+    process.exit(1);
+  }
+
+  // Post-commit verification — zone resolves + Shannon's job picks it up.
+  console.log("\n=== Post-commit verification ===");
+
+  console.log("\n1. North Shore zone present + contains 60062:");
+  const zoneRow = await db.execute(sql`
+    SELECT id, name, color, zip_codes, location, is_active
+      FROM service_zones
+     WHERE company_id = 1 AND '60062' = ANY(zip_codes)
+  `);
+  console.table(zoneRow.rows);
+
+  console.log("\n2. Shannon's Apr 23 job resolves to North Shore via job-level zip:");
+  const shannon = await db.execute(sql`
+    SELECT j.id, j.scheduled_date, j.scheduled_time,
+           j.address_street, j.address_zip,
+           c.zip AS client_zip,
+           COALESCE(NULLIF(j.address_zip, ''), c.zip) AS resolved_zip,
+           (SELECT name  FROM service_zones sz
+              WHERE sz.company_id = 1 AND sz.is_active = true
+                AND COALESCE(NULLIF(j.address_zip, ''), c.zip) = ANY(sz.zip_codes) LIMIT 1) AS zone_name,
+           (SELECT color FROM service_zones sz
+              WHERE sz.company_id = 1 AND sz.is_active = true
+                AND COALESCE(NULLIF(j.address_zip, ''), c.zip) = ANY(sz.zip_codes) LIMIT 1) AS zone_color
+      FROM jobs j JOIN clients c ON c.id = j.client_id
+     WHERE j.id = 4231
+  `);
+  console.table(shannon.rows);
+
+  const s = (shannon.rows as any[])[0];
+  const pass = s?.resolved_zip === "60062" && s?.zone_name === "North Shore" && s?.zone_color === "#00B8A9";
+  console.log(`\nExpected: resolved_zip=60062, zone_name='North Shore', zone_color='#00B8A9'`);
+  console.log(pass ? "✓ PASS" : "✗ FAIL — see row above.");
+
+  console.log("\n3. Apr 23 dispatch snapshot (all 14 cards, with zone resolution):");
+  const apr23 = await db.execute(sql`
+    SELECT c.id AS client_id, c.first_name || ' ' || c.last_name AS name,
+           COALESCE(NULLIF(j.address_zip, ''), c.zip) AS resolved_zip,
+           (SELECT name FROM service_zones sz
+              WHERE sz.company_id = 1 AND sz.is_active = true
+                AND COALESCE(NULLIF(j.address_zip, ''), c.zip) = ANY(sz.zip_codes) LIMIT 1) AS zone_name,
+           (SELECT color FROM service_zones sz
+              WHERE sz.company_id = 1 AND sz.is_active = true
+                AND COALESCE(NULLIF(j.address_zip, ''), c.zip) = ANY(sz.zip_codes) LIMIT 1) AS zone_color
+      FROM jobs j LEFT JOIN clients c ON c.id = j.client_id
+     WHERE j.company_id = 1 AND j.scheduled_date = '2026-04-23'
+     ORDER BY c.id
+  `);
+  console.table(apr23.rows);
+
+  process.exit(pass ? 0 : 1);
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/ae_zip_overlap_probe.ts
+++ b/artifacts/api-server/scripts/ae_zip_overlap_probe.ts
@@ -1,0 +1,22 @@
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+async function main() {
+  const r = await db.execute(sql`
+    SELECT name, zip_codes,
+           array_length(zip_codes, 1) AS n,
+           ARRAY(SELECT unnest(zip_codes) INTERSECT
+                 SELECT unnest(ARRAY['60062','60025','60026','60091','60093','60015','60035'])) AS overlap_with_proposed
+      FROM service_zones
+     WHERE company_id = 1
+       AND (zip_codes && ARRAY['60062','60025','60026','60091','60093','60015','60035']
+            OR name IN ('North Shore','Chicago North Residential Zone'))
+  `);
+  for (const row of r.rows as any[]) {
+    console.log(`\n${row.name} (${row.n} zips)`);
+    console.log(`  zip_codes: [${(row.zip_codes as string[]).join(", ")}]`);
+    console.log(`  overlap with proposed North Shore zips: [${(row.overlap_with_proposed as string[]).join(", ")}]`);
+  }
+  process.exit(0);
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/ae_zones_audit.ts
+++ b/artifacts/api-server/scripts/ae_zones_audit.ts
@@ -1,0 +1,139 @@
+/**
+ * AE — Read-only audit of service_zones before adding "North Shore".
+ * No writes. Reports: column names, PHES zones, color collisions vs
+ * #00B8A9, Oak Lawn branch id, zip-coverage conflicts (60062 etc.
+ * shouldn't already belong to another zone).
+ */
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+const PROPOSED_NAME = "North Shore";
+const PROPOSED_COLOR = "#00B8A9";
+const PROPOSED_ZIPS = ["60062","60025","60026","60091","60093","60015","60035"];
+
+async function main() {
+  console.log("=== AE — service_zones audit (pre-write, read-only) ===\n");
+
+  // 1. service_zones column schema — SPEC says `zips` but prior code uses `zip_codes`
+  console.log("--- 1. service_zones columns ---");
+  const cols = await db.execute(sql`
+    SELECT column_name, data_type, is_nullable
+      FROM information_schema.columns
+     WHERE table_schema = 'public' AND table_name = 'service_zones'
+     ORDER BY ordinal_position
+  `);
+  console.table(cols.rows);
+
+  // 2. Unique constraint on (company_id, name)? Needed for ON CONFLICT
+  console.log("\n--- 2. service_zones unique constraints ---");
+  const cons = await db.execute(sql`
+    SELECT tc.constraint_name, tc.constraint_type,
+           string_agg(kcu.column_name, ', ' ORDER BY kcu.ordinal_position) AS columns
+      FROM information_schema.table_constraints tc
+      JOIN information_schema.key_column_usage kcu
+        ON tc.constraint_name = kcu.constraint_name
+     WHERE tc.table_schema = 'public' AND tc.table_name = 'service_zones'
+       AND tc.constraint_type IN ('PRIMARY KEY', 'UNIQUE')
+     GROUP BY tc.constraint_name, tc.constraint_type
+     ORDER BY tc.constraint_type
+  `);
+  console.table(cons.rows);
+
+  // 3. All PHES zones (no branch_id column — location text field instead)
+  console.log("\n--- 3. PHES service_zones (company_id=1) ---");
+  const zones = await db.execute(sql`
+    SELECT id, name, color, zip_codes, location, is_active, sort_order, created_at
+      FROM service_zones
+     WHERE company_id = 1
+     ORDER BY sort_order, name
+  `);
+  console.table(zones.rows);
+
+  // 4. Color collision check
+  console.log(`\n--- 4. Color collision vs proposed ${PROPOSED_COLOR} ---`);
+  const collide = await db.execute(sql`
+    SELECT id, name, color
+      FROM service_zones
+     WHERE company_id = 1 AND UPPER(color) = UPPER(${PROPOSED_COLOR})
+  `);
+  if ((collide.rows as any[]).length === 0) {
+    console.log(`✓ No existing PHES zone uses ${PROPOSED_COLOR}.`);
+  } else {
+    console.error(`✗ Color collision:`);
+    console.table(collide.rows);
+  }
+
+  // 5. Zip-coverage conflict — proposed zips already in another zone?
+  console.log(`\n--- 5. Proposed zip coverage — any already owned by another zone? ---`);
+  const zipLit = sql.raw(`ARRAY[${PROPOSED_ZIPS.map(z => `'${z}'`).join(",")}]::text[]`);
+  const zipConflict = await db.execute(sql`
+    SELECT z.id, z.name, z.color, z.zip_codes,
+           ARRAY(SELECT unnest(${zipLit}) INTERSECT SELECT unnest(z.zip_codes)) AS overlap
+      FROM service_zones z
+     WHERE z.company_id = 1
+       AND z.zip_codes && ${zipLit}
+  `);
+  if ((zipConflict.rows as any[]).length === 0) {
+    console.log(`✓ None of ${PROPOSED_ZIPS.join(", ")} overlap with existing zones.`);
+  } else {
+    console.log(`⚠ Zip overlap(s):`);
+    console.table(zipConflict.rows);
+  }
+
+  // 6. Branches (for reference — service_zones doesn't actually have a branch FK)
+  console.log("\n--- 6. PHES branches (not linked to service_zones but reporting for completeness) ---");
+  const branches = await db.execute(sql`
+    SELECT id, name, is_active FROM branches WHERE company_id = 1 ORDER BY id
+  `);
+  console.table(branches.rows);
+
+  // 6b. Distinct location values used across existing zones
+  console.log("\n--- 6b. Distinct `location` values currently used on service_zones ---");
+  const locs = await db.execute(sql`
+    SELECT location, COUNT(*)::int AS n
+      FROM service_zones WHERE company_id = 1
+     GROUP BY location ORDER BY n DESC
+  `);
+  console.table(locs.rows);
+
+  // 7. Existing zone with name "North Shore" (would be target of ON CONFLICT — BUT
+  //    no unique on (company_id, name) exists per constraint scan, so ON CONFLICT
+  //    (company_id, name) WILL FAIL. Plain INSERT + pre-check path needed.)
+  console.log("\n--- 7. Existing 'North Shore' row? ---");
+  const existing = await db.execute(sql`
+    SELECT id, name, color, zip_codes, location, is_active
+      FROM service_zones
+     WHERE company_id = 1 AND name = ${PROPOSED_NAME}
+  `);
+  if ((existing.rows as any[]).length === 0) {
+    console.log("✓ No existing 'North Shore' row — INSERT path will fire.");
+  } else {
+    console.table(existing.rows);
+  }
+
+  // 8. Which clients are currently at the proposed zips? (impact scan)
+  console.log("\n--- 8. PHES clients at proposed zips (zone will start coloring their cards) ---");
+  const affected = await db.execute(sql`
+    SELECT c.id, c.first_name || ' ' || c.last_name AS name, c.zip, c.is_active
+      FROM clients c
+     WHERE c.company_id = 1 AND c.zip = ANY(${zipLit})
+     ORDER BY c.zip, c.id
+  `);
+  console.log(`  ${affected.rows.length} client(s) at proposed zips:`);
+  console.table(affected.rows);
+
+  // 9. Same scan at the job level — any upcoming jobs whose address_zip is in the proposed list?
+  console.log("\n--- 9. Upcoming jobs with jobs.address_zip in proposed set ---");
+  const affectedJobs = await db.execute(sql`
+    SELECT j.id, j.scheduled_date, j.scheduled_time, j.address_street, j.address_zip,
+           c.first_name || ' ' || c.last_name AS client
+      FROM jobs j JOIN clients c ON c.id = j.client_id
+     WHERE j.company_id = 1 AND j.address_zip = ANY(${zipLit})
+       AND j.scheduled_date >= CURRENT_DATE
+     ORDER BY j.scheduled_date, j.scheduled_time
+  `);
+  console.table(affectedJobs.rows);
+
+  process.exit(0);
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/af_apply_jobs_cols.ts
+++ b/artifacts/api-server/scripts/af_apply_jobs_cols.ts
@@ -1,0 +1,18 @@
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+async function main() {
+  console.log("=== AF — Add jobs.actual_end_time / locked_at / completed_by_user_id ===\n");
+  await db.execute(sql`ALTER TABLE jobs ADD COLUMN IF NOT EXISTS actual_end_time      TIMESTAMP`);
+  await db.execute(sql`ALTER TABLE jobs ADD COLUMN IF NOT EXISTS locked_at            TIMESTAMP`);
+  await db.execute(sql`ALTER TABLE jobs ADD COLUMN IF NOT EXISTS completed_by_user_id INTEGER`);
+
+  const cols = await db.execute(sql`
+    SELECT column_name, data_type, is_nullable FROM information_schema.columns
+     WHERE table_schema='public' AND table_name='jobs'
+       AND column_name IN ('actual_end_time','locked_at','completed_by_user_id')
+  `);
+  console.table(cols.rows);
+  process.exit(0);
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/af_jim_pre_complete.ts
+++ b/artifacts/api-server/scripts/af_jim_pre_complete.ts
@@ -1,0 +1,16 @@
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+async function main() {
+  const r = await db.execute(sql`
+    SELECT j.id, j.status, j.actual_end_time, j.locked_at, j.completed_by_user_id,
+           j.completion_pdf_url, j.completion_pdf_sent_at,
+           c.first_name || ' ' || c.last_name AS client
+      FROM jobs j LEFT JOIN clients c ON c.id = j.client_id
+     WHERE j.company_id = 1 AND j.scheduled_date = '2026-04-23'
+       AND (c.first_name ILIKE 'jim%' OR c.last_name ILIKE 'schultz%')
+  `);
+  console.table(r.rows);
+  process.exit(0);
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/af_jim_verify.ts
+++ b/artifacts/api-server/scripts/af_jim_verify.ts
@@ -1,0 +1,70 @@
+/**
+ * AF — Post-click verify for Jim Schultz's Apr 23 job (id=3695).
+ * Run AFTER hitting "Mark Complete" → "Yes, complete" in the drawer.
+ * Reports status transition, AF column writes, PDF generation, invoice
+ * creation, and QB queue state.
+ */
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+async function main() {
+  console.log("=== AF — Jim Schultz (job 3695) post-complete verify ===\n");
+
+  console.log("--- 1. Jobs row ---");
+  const job = await db.execute(sql`
+    SELECT id, status,
+           actual_end_time, locked_at, completed_by_user_id,
+           completion_pdf_url IS NOT NULL AS has_pdf,
+           completion_pdf_sent_at,
+           billed_hours, billed_amount
+      FROM jobs WHERE id = 3695
+  `);
+  console.table(job.rows);
+
+  const row = (job.rows as any[])[0];
+  const pass = row?.status === "complete"
+            && row?.actual_end_time !== null
+            && row?.locked_at !== null
+            && row?.completed_by_user_id !== null;
+  console.log(pass ? "\n✓ AF column writes PASS" : "\n✗ AF column writes FAIL (see row above)");
+
+  console.log("\n--- 2. Who completed it (via completed_by_user_id → users) ---");
+  const who = await db.execute(sql`
+    SELECT u.id, u.first_name, u.last_name, u.email, u.role
+      FROM jobs j JOIN users u ON u.id = j.completed_by_user_id
+     WHERE j.id = 3695
+  `);
+  console.table(who.rows);
+
+  console.log("\n--- 3. Invoice created from this job ---");
+  const inv = await db.execute(sql`
+    SELECT id, status, total, payment_terms, due_date, created_at
+      FROM invoices WHERE job_id = 3695 AND company_id = 1
+     ORDER BY created_at DESC
+  `);
+  if (inv.rows.length === 0) console.log("(no invoice row — invoice_error path hit)");
+  else console.table(inv.rows);
+
+  console.log("\n--- 4. QB sync queue (should be empty for PHES — qb_connected=false) ---");
+  const q = await db.execute(sql`
+    SELECT id, entity_type, entity_id, status, attempts, LEFT(COALESCE(last_error,''), 60) AS last_error, created_at
+      FROM qb_sync_queue
+     WHERE company_id = 1 AND entity_type = 'invoice'
+     ORDER BY created_at DESC LIMIT 5
+  `);
+  if (q.rows.length === 0) console.log("(empty — expected; syncInvoice() no-op'd on null token)");
+  else console.table(q.rows);
+
+  console.log("\n--- 5. Drawer-read surface via /api/dispatch fields ---");
+  // These are the fields the drawer uses to render locked state post-click.
+  const drawer = await db.execute(sql`
+    SELECT j.locked_at, j.actual_end_time, j.completed_by_user_id, j.status,
+           (j.locked_at IS NOT NULL OR j.status IN ('complete','cancelled')) AS is_locked_per_drawer,
+           to_char(j.actual_end_time AT TIME ZONE 'America/Chicago', 'Mon DD, HH:MI AM') AS completed_at_label
+      FROM jobs j WHERE j.id = 3695
+  `);
+  console.table(drawer.rows);
+
+  process.exit(pass ? 0 : 1);
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/af_qb_queue_full_probe.ts
+++ b/artifacts/api-server/scripts/af_qb_queue_full_probe.ts
@@ -1,0 +1,38 @@
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+async function main() {
+  console.log("=== qb_sync_queue: entire table, any entity_type ===");
+  const all = await db.execute(sql`
+    SELECT id, company_id, entity_type, entity_id, status, attempts, created_at, updated_at,
+           LEFT(COALESCE(last_error,''), 80) AS last_error
+      FROM qb_sync_queue
+     ORDER BY created_at DESC
+     LIMIT 20
+  `);
+  if (all.rows.length === 0) console.log("(empty — no rows ever queued)");
+  else console.table(all.rows);
+
+  console.log("\n=== PHES company QB connection state ===");
+  const co = await db.execute(sql`
+    SELECT id, name,
+           qb_connected, qb_realm_id,
+           (qb_access_token IS NOT NULL) AS has_access_token,
+           (qb_refresh_token IS NOT NULL) AS has_refresh_token
+      FROM companies
+     WHERE id = 1
+  `);
+  console.table(co.rows);
+
+  console.log("\n=== Any complete jobs on Apr 23? ===");
+  const done = await db.execute(sql`
+    SELECT id, client_id, status, actual_end_time, locked_at, completed_by_user_id
+      FROM jobs
+     WHERE company_id = 1 AND scheduled_date = '2026-04-23' AND status = 'complete'
+  `);
+  if (done.rows.length === 0) console.log("(none complete yet — Mark Complete hasn't been clicked post-AF)");
+  else console.table(done.rows);
+
+  process.exit(0);
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/af_qb_queue_probe.ts
+++ b/artifacts/api-server/scripts/af_qb_queue_probe.ts
@@ -1,0 +1,16 @@
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+async function main() {
+  const r = await db.execute(sql`
+    SELECT id, company_id, entity_type, entity_id, status, attempts, created_at
+      FROM qb_sync_queue
+     WHERE entity_type = 'invoice'
+     ORDER BY created_at DESC
+     LIMIT 5
+  `);
+  if (r.rows.length === 0) console.log("(no rows)");
+  else console.table(r.rows);
+  process.exit(0);
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/af_schema_probe.ts
+++ b/artifacts/api-server/scripts/af_schema_probe.ts
@@ -1,0 +1,52 @@
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+async function main() {
+  console.log("=== jobs columns (db truth) ===");
+  const jc = await db.execute(sql`
+    SELECT column_name, data_type, is_nullable
+      FROM information_schema.columns
+     WHERE table_schema='public' AND table_name='jobs'
+       AND (column_name ILIKE '%complet%' OR column_name ILIKE '%end%'
+            OR column_name ILIKE '%lock%' OR column_name ILIKE '%finish%')
+     ORDER BY ordinal_position
+  `);
+  console.table(jc.rows);
+
+  console.log("\n=== Tables that look QB/queue related ===");
+  const t = await db.execute(sql`
+    SELECT table_name FROM information_schema.tables
+     WHERE table_schema='public'
+       AND (table_name ILIKE '%qb%' OR table_name ILIKE '%quickbooks%'
+            OR table_name ILIKE '%sync%' OR table_name ILIKE '%queue%')
+     ORDER BY table_name
+  `);
+  console.table(t.rows);
+
+  console.log("\n=== qb_tokens columns ===");
+  const qt = await db.execute(sql`
+    SELECT column_name, data_type FROM information_schema.columns
+     WHERE table_schema='public' AND table_name='qb_tokens'
+     ORDER BY ordinal_position
+  `);
+  console.table(qt.rows);
+
+  console.log("\n=== job_technicians columns ===");
+  const jt = await db.execute(sql`
+    SELECT column_name, data_type, is_nullable FROM information_schema.columns
+     WHERE table_schema='public' AND table_name='job_technicians'
+     ORDER BY ordinal_position
+  `);
+  console.table(jt.rows);
+
+  console.log("\n=== timeclock_entries (clock-in probe) ===");
+  const te = await db.execute(sql`
+    SELECT table_name FROM information_schema.tables
+     WHERE table_schema='public' AND (table_name ILIKE '%clock%' OR table_name ILIKE '%time%')
+     ORDER BY table_name
+  `);
+  console.table(te.rows);
+
+  process.exit(0);
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/ai14_apply.ts
+++ b/artifacts/api-server/scripts/ai14_apply.ts
@@ -1,0 +1,196 @@
+/**
+ * AI.14 Apply — Arianna Goose (CL-0026 / clients.id=26)
+ *
+ * Confirmations from operator:
+ *  1. State/zip use CASE WHEN known-bad-value pattern (state='IL', zip='14813').
+ *  2. UPDATE recurring_schedules id=14 (Wed) and id=15 (Sat) in place. No INSERT.
+ *  3. Backfill 43 rows / $6,880 expected net new in job_history.
+ *  4. Notes tag '[manual_ai14 2026-04-28]'.
+ *  5. Flat $160 — no retroactive pricing engine run.
+ *
+ * All steps wrapped in a single transaction. Idempotent — safe to re-run.
+ */
+import { db, pool } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+const COMPANY_ID = 1;
+const CLIENT_ID  = 26;
+const ROSA_ID    = 36;
+const TAG        = "[manual_ai14 2026-04-28]";
+const WED_ANCHOR = "2025-01-08";
+const SAT_ANCHOR = "2025-01-04";
+const WINDOW_END = "2026-04-25";
+
+async function main() {
+  // Final guard: per-tenant flag must still be off before we touch schedules.
+  const flag = await db.execute(sql`
+    SELECT recurring_engine_enabled FROM companies WHERE id = ${COMPANY_ID}
+  `);
+  const enabled = (flag.rows[0] as any)?.recurring_engine_enabled;
+  if (enabled !== false) {
+    throw new Error(
+      `ABORT: companies.recurring_engine_enabled for id=${COMPANY_ID} is ${enabled}, expected false`
+    );
+  }
+  console.log(`[guard] recurring_engine_enabled=false for company ${COMPANY_ID}  OK`);
+
+  await db.execute(sql`BEGIN`);
+  try {
+    // ── Step 1: Patch client row ─────────────────────────────────────────────
+    const clientUpd = await db.execute(sql`
+      UPDATE clients
+         SET city  = COALESCE(city,  'Dyer'),
+             state = CASE WHEN state IS NULL OR state = 'IL'    THEN 'IN'    ELSE state END,
+             zip   = CASE WHEN zip   IS NULL OR zip   = '14813' THEN '46311' ELSE zip   END,
+             address = COALESCE(address, '14813 West 101st Avenue'),
+             client_type = 'commercial'
+       WHERE id = ${CLIENT_ID} AND company_id = ${COMPANY_ID}
+       RETURNING id, address, city, state, zip, client_type, first_name, last_name, email, phone
+    `);
+    console.log("[step1] client patched:");
+    console.table(clientUpd.rows);
+
+    // ── Step 2: UPDATE existing recurring_schedules in place ────────────────
+    const wedSched = await db.execute(sql`
+      UPDATE recurring_schedules
+         SET day_of_week      = COALESCE(day_of_week, 'wednesday'),
+             start_date       = LEAST(start_date, ${WED_ANCHOR}::date),
+             duration_minutes = COALESCE(duration_minutes, 180)
+       WHERE id = 14 AND customer_id = ${CLIENT_ID} AND company_id = ${COMPANY_ID}
+       RETURNING id, day_of_week, start_date, duration_minutes, base_fee, assigned_employee_id, service_type, is_active
+    `);
+    const satSched = await db.execute(sql`
+      UPDATE recurring_schedules
+         SET day_of_week      = COALESCE(day_of_week, 'saturday'),
+             start_date       = LEAST(start_date, ${SAT_ANCHOR}::date),
+             duration_minutes = COALESCE(duration_minutes, 180)
+       WHERE id = 15 AND customer_id = ${CLIENT_ID} AND company_id = ${COMPANY_ID}
+       RETURNING id, day_of_week, start_date, duration_minutes, base_fee, assigned_employee_id, service_type, is_active
+    `);
+    console.log("[step2] schedules updated:");
+    console.table([...(wedSched.rows as any[]), ...(satSched.rows as any[])]);
+
+    // ── Step 3: Backfill job_history (idempotent NOT EXISTS dedup by date) ──
+    // We insert from a generated series; rows where (customer_id, job_date)
+    // already exists are skipped. Re-running this script is a no-op.
+    const wedIns = await db.execute(sql`
+      INSERT INTO job_history (company_id, customer_id, job_date, revenue, service_type, technician, notes)
+      SELECT ${COMPANY_ID},
+             ${CLIENT_ID},
+             gs::date,
+             160.00,
+             'Commercial Cleaning',
+             'Rosa Gallegos',
+             ${TAG}
+        FROM generate_series(${WED_ANCHOR}::date, ${WINDOW_END}::date, interval '7 days') AS gs
+       WHERE NOT EXISTS (
+               SELECT 1 FROM job_history jh
+                WHERE jh.customer_id = ${CLIENT_ID}
+                  AND jh.company_id  = ${COMPANY_ID}
+                  AND jh.job_date    = gs::date
+             )
+      RETURNING job_date::text AS d
+    `);
+
+    const satIns = await db.execute(sql`
+      INSERT INTO job_history (company_id, customer_id, job_date, revenue, service_type, technician, notes)
+      SELECT ${COMPANY_ID},
+             ${CLIENT_ID},
+             gs::date,
+             160.00,
+             'Commercial Cleaning',
+             'Rosa Gallegos',
+             ${TAG}
+        FROM generate_series(${SAT_ANCHOR}::date, ${WINDOW_END}::date, interval '7 days') AS gs
+       WHERE NOT EXISTS (
+               SELECT 1 FROM job_history jh
+                WHERE jh.customer_id = ${CLIENT_ID}
+                  AND jh.company_id  = ${COMPANY_ID}
+                  AND jh.job_date    = gs::date
+             )
+      RETURNING job_date::text AS d
+    `);
+
+    const wedDates = (wedIns.rows as any[]).map(r => r.d).sort();
+    const satDates = (satIns.rows as any[]).map(r => r.d).sort();
+    console.log(`[step3] wed inserted: ${wedDates.length} -> ${JSON.stringify(wedDates)}`);
+    console.log(`[step3] sat inserted: ${satDates.length}`);
+    console.log(`         first 5: ${JSON.stringify(satDates.slice(0, 5))}`);
+    console.log(`         last  5: ${JSON.stringify(satDates.slice(-5))}`);
+
+    const insertedTotal = wedDates.length + satDates.length;
+    if (insertedTotal !== 43) {
+      console.warn(
+        `[warn] inserted ${insertedTotal} rows; dry-run projected 43. ` +
+        `If this is a fresh run, this is a problem. If it's a re-run after a partial apply, expect 0.`
+      );
+    }
+
+    await db.execute(sql`COMMIT`);
+    console.log("[tx] COMMIT");
+  } catch (e) {
+    await db.execute(sql`ROLLBACK`);
+    console.error("[tx] ROLLBACK", e);
+    process.exit(1);
+  }
+
+  // ── Step 4: Verification queries (printed after commit) ──────────────────
+  console.log("\n========== STEP 4: VERIFICATION ==========\n");
+
+  console.log("V1) clients id=26 (CL-0026):");
+  const v1 = await db.execute(sql`
+    SELECT id, first_name, last_name, address, city, state, zip,
+           client_type, branch_id, is_active
+    FROM clients WHERE id = ${CLIENT_ID} AND company_id = ${COMPANY_ID}
+  `);
+  console.table(v1.rows);
+
+  console.log("\nV2) recurring_schedules for customer_id=26:");
+  const v2 = await db.execute(sql`
+    SELECT id, frequency, day_of_week, start_date, duration_minutes,
+           base_fee, assigned_employee_id, service_type, is_active
+    FROM recurring_schedules
+    WHERE customer_id = ${CLIENT_ID} AND company_id = ${COMPANY_ID}
+    ORDER BY id
+  `);
+  console.table(v2.rows);
+  console.log(`   row count: ${v2.rows.length} (expected 2)`);
+
+  console.log("\nV3) job_history rows tagged [manual_ai14]:");
+  const v3 = await db.execute(sql`
+    SELECT count(*)::int AS rows,
+           COALESCE(SUM(revenue), 0)::numeric AS revenue,
+           MIN(job_date)::text AS first_date,
+           MAX(job_date)::text AS last_date
+    FROM job_history
+    WHERE customer_id = ${CLIENT_ID} AND company_id = ${COMPANY_ID}
+      AND notes LIKE '%manual_ai14%'
+  `);
+  console.table(v3.rows);
+
+  console.log("\nV4) job_history total for customer_id=26 (all sources):");
+  const v4 = await db.execute(sql`
+    SELECT count(*)::int AS rows,
+           COALESCE(SUM(revenue), 0)::numeric AS revenue,
+           MIN(job_date)::text AS first_date,
+           MAX(job_date)::text AS last_date
+    FROM job_history
+    WHERE customer_id = ${CLIENT_ID} AND company_id = ${COMPANY_ID}
+  `);
+  console.table(v4.rows);
+
+  console.log("\nV5) coverage breakdown by year (sanity check):");
+  const v5 = await db.execute(sql`
+    SELECT EXTRACT(YEAR FROM job_date)::int AS yr,
+           count(*)::int AS rows,
+           COALESCE(SUM(revenue), 0)::numeric AS revenue
+    FROM job_history
+    WHERE customer_id = ${CLIENT_ID} AND company_id = ${COMPANY_ID}
+    GROUP BY 1 ORDER BY 1
+  `);
+  console.table(v5.rows);
+
+  await pool.end();
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/ai14_dryrun.ts
+++ b/artifacts/api-server/scripts/ai14_dryrun.ts
@@ -1,0 +1,84 @@
+/**
+ * AI.14 Dry-Run — Arianna Goose (CL-0026 / clients.id=26) backfill audit
+ * READ-ONLY. No INSERT/UPDATE/DELETE.
+ */
+import { db, pool } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+const COMPANY_ID = 1; // PHES
+const CLIENT_ID = 26; // CL-0026 → Arianna Goose
+const WINDOW_END = "2026-04-25"; // last Saturday before 2026-04-28
+const WED_ANCHOR = "2025-01-08";
+const SAT_ANCHOR = "2025-01-04";
+
+async function main() {
+  const existing = await db.execute(sql`
+    SELECT job_date::text AS d, revenue::text AS rev,
+           service_type, technician, notes
+    FROM job_history
+    WHERE customer_id = ${CLIENT_ID} AND company_id = ${COMPANY_ID}
+    ORDER BY job_date
+  `);
+  const existingByDate = new Map<string, any>();
+  for (const r of existing.rows as any[]) existingByDate.set(r.d, r);
+
+  const ai14Tagged = (existing.rows as any[]).filter(r =>
+    typeof r.notes === "string" && r.notes.toLowerCase().includes("manual_ai14")
+  );
+
+  const wedDates = await db.execute(sql`
+    SELECT generate_series(${WED_ANCHOR}::date, ${WINDOW_END}::date, interval '7 days')::date::text AS d
+  `);
+  const satDates = await db.execute(sql`
+    SELECT generate_series(${SAT_ANCHOR}::date, ${WINDOW_END}::date, interval '7 days')::date::text AS d
+  `);
+
+  const wedAll = (wedDates.rows as any[]).map(r => r.d);
+  const satAll = (satDates.rows as any[]).map(r => r.d);
+
+  const wedExists = wedAll.filter(d => existingByDate.has(d));
+  const satExists = satAll.filter(d => existingByDate.has(d));
+  const wedAdd = wedAll.filter(d => !existingByDate.has(d));
+  const satAdd = satAll.filter(d => !existingByDate.has(d));
+
+  const targetSet = new Set([...wedAll, ...satAll]);
+  const offCadence = (existing.rows as any[])
+    .filter(r => !targetSet.has(r.d))
+    .map(r => ({ d: r.d, rev: r.rev, svc: r.service_type, notes: (r.notes ?? "").slice(0, 60) }));
+
+  const head = (a: string[]) => a.slice(0, 5);
+  const tail = (a: string[]) => a.slice(-5);
+
+  console.log("─────────── AI.14 BACKFILL DELTA ───────────");
+  console.log("Existing job_history rows for CL-0026:", existing.rows.length);
+  console.log("Rows already tagged [manual_ai14]:    ", ai14Tagged.length);
+  console.log("");
+  console.log("WED series (anchor 2025-01-08, weekly through 2026-04-22):");
+  console.log("  total occurrences:    ", wedAll.length);
+  console.log("  already in history:   ", wedExists.length);
+  console.log("  WOULD INSERT:         ", wedAdd.length);
+  console.log("  first 5 to insert:    ", head(wedAdd));
+  console.log("  last  5 to insert:    ", tail(wedAdd));
+  console.log("");
+  console.log("SAT series (anchor 2025-01-04, weekly through 2026-04-25):");
+  console.log("  total occurrences:    ", satAll.length);
+  console.log("  already in history:   ", satExists.length);
+  console.log("  WOULD INSERT:         ", satAdd.length);
+  console.log("  first 5 to insert:    ", head(satAdd));
+  console.log("  last  5 to insert:    ", tail(satAdd));
+  console.log("");
+  console.log("Existing dates NOT on Wed-08 or Sat-04 cadence (will be left alone):");
+  console.log("  count:                ", offCadence.length);
+  console.table(offCadence.slice(0, 30));
+  console.log("");
+  const projected = (wedAdd.length + satAdd.length) * 160;
+  console.log("PROJECTED RESULT IF APPLIED:");
+  console.log("  rows added:           ", wedAdd.length + satAdd.length);
+  console.log("  $ added:              $" + projected.toFixed(2));
+  console.log("  ending row count:     ", existing.rows.length + wedAdd.length + satAdd.length);
+  console.log("  ending revenue:       $" + (15230 + projected).toFixed(2));
+
+  await pool.end();
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/apply-rate-mods.ts
+++ b/artifacts/api-server/scripts/apply-rate-mods.ts
@@ -1,0 +1,200 @@
+/**
+ * One-shot: apply job_rate_mods schema + backfill the specific April adjustments
+ * Sal called out, then recompute billed_amount on the affected jobs.
+ *
+ * Run:
+ *   cd artifacts/api-server
+ *   ./node_modules/.bin/tsx --env-file=../../.env scripts/apply-rate-mods.ts [--dry-run]
+ */
+import { pool, db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+const DRY_RUN = process.argv.includes("--dry-run");
+
+type Backfill = {
+  client_first: string;
+  client_last: string;
+  scheduled_date?: string;          // optional pin to a specific date
+  month?: { from: string; to: string }; // or anywhere in this window
+  mod_type: "time" | "flat";
+  minutes?: number;
+  amount: number;
+  reason: string;
+};
+
+const BACKFILL: Backfill[] = [
+  // Chris Schultz April: +30 min → +$30
+  { client_first: "Chris", client_last: "Schultz",
+    month: { from: "2026-04-01", to: "2026-04-30" },
+    mod_type: "time", minutes: 30, amount: 30, reason: "Extra time on site" },
+  // Jim Schultz April: +30 min → +$27.50
+  { client_first: "Jim", client_last: "Schultz",
+    month: { from: "2026-04-01", to: "2026-04-30" },
+    mod_type: "time", minutes: 30, amount: 27.5, reason: "Extra time on site" },
+  // Daniel Walter April: +2 hrs → +$100
+  { client_first: "Daniel", client_last: "Walter",
+    month: { from: "2026-04-01", to: "2026-04-30" },
+    mod_type: "time", minutes: 120, amount: 100, reason: "Additional 2 hours" },
+  // Jaira Estrada Apr 20: flat +$20 parking, flat -$50 adjustment
+  { client_first: "Jaira", client_last: "Estrada", scheduled_date: "2026-04-20",
+    mod_type: "flat", amount: 20, reason: "Parking" },
+  { client_first: "Jaira", client_last: "Estrada", scheduled_date: "2026-04-20",
+    mod_type: "flat", amount: -50, reason: "Adjustment" },
+  // Jaira Estrada Apr 21
+  { client_first: "Jaira", client_last: "Estrada", scheduled_date: "2026-04-21",
+    mod_type: "flat", amount: 20, reason: "Parking" },
+  { client_first: "Jaira", client_last: "Estrada", scheduled_date: "2026-04-21",
+    mod_type: "flat", amount: -50, reason: "Adjustment" },
+  // Jaira Estrada Apr 24
+  { client_first: "Jaira", client_last: "Estrada", scheduled_date: "2026-04-24",
+    mod_type: "flat", amount: 20, reason: "Parking" },
+  { client_first: "Jaira", client_last: "Estrada", scheduled_date: "2026-04-24",
+    mod_type: "flat", amount: -50, reason: "Adjustment" },
+  // Jaira Estrada Apr 28: parking only
+  { client_first: "Jaira", client_last: "Estrada", scheduled_date: "2026-04-28",
+    mod_type: "flat", amount: 20, reason: "Parking" },
+];
+
+async function ensureSchema(): Promise<void> {
+  console.log("[schema] CREATE TABLE IF NOT EXISTS job_rate_mods");
+  await db.execute(sql.raw(`
+    CREATE TABLE IF NOT EXISTS job_rate_mods (
+      id          SERIAL PRIMARY KEY,
+      company_id  INT NOT NULL REFERENCES companies(id),
+      job_id      INT NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
+      mod_type    TEXT NOT NULL CHECK (mod_type IN ('time', 'flat')),
+      minutes     INT,
+      amount      NUMERIC(10,2) NOT NULL,
+      reason      TEXT NOT NULL,
+      created_by  INT REFERENCES users(id),
+      created_at  TIMESTAMP NOT NULL DEFAULT NOW()
+    )
+  `));
+  await db.execute(sql.raw(
+    `CREATE INDEX IF NOT EXISTS idx_job_rate_mods_job ON job_rate_mods(company_id, job_id)`
+  ));
+}
+
+async function findJobs(b: Backfill): Promise<number[]> {
+  const conditions: string[] = [
+    `c.first_name ILIKE $1`,
+    `c.last_name ILIKE $2`,
+  ];
+  const params: any[] = [b.client_first, b.client_last];
+  if (b.scheduled_date) {
+    conditions.push(`j.scheduled_date = $${params.length + 1}::date`);
+    params.push(b.scheduled_date);
+  } else if (b.month) {
+    conditions.push(
+      `j.scheduled_date BETWEEN $${params.length + 1}::date AND $${params.length + 2}::date`
+    );
+    params.push(b.month.from, b.month.to);
+  }
+  const queryText = `
+    SELECT j.id
+    FROM jobs j
+    JOIN clients c ON c.id = j.client_id
+    WHERE ${conditions.join(" AND ")}
+    ORDER BY j.scheduled_date ASC
+  `;
+  const result = await pool.query(queryText, params);
+  return result.rows.map((r: any) => Number(r.id));
+}
+
+async function jobAlreadyHasMod(jobId: number, b: Backfill): Promise<boolean> {
+  const result = await pool.query(
+    `SELECT 1 FROM job_rate_mods
+     WHERE job_id = $1 AND mod_type = $2 AND amount = $3 AND reason = $4
+     LIMIT 1`,
+    [jobId, b.mod_type, b.amount.toFixed(2), b.reason]
+  );
+  return result.rows.length > 0;
+}
+
+async function getCompanyId(jobId: number): Promise<number> {
+  const r = await pool.query(`SELECT company_id FROM jobs WHERE id = $1`, [jobId]);
+  return Number(r.rows[0].company_id);
+}
+
+async function recomputeBilledAmount(jobId: number, companyId: number): Promise<{ base: number; mods: number; billed: number }> {
+  const j = await pool.query(`SELECT base_fee FROM jobs WHERE id = $1`, [jobId]);
+  const base = parseFloat(j.rows[0].base_fee || "0");
+  const m = await pool.query(
+    `SELECT COALESCE(SUM(amount), 0)::numeric AS total
+     FROM job_rate_mods WHERE job_id = $1 AND company_id = $2`,
+    [jobId, companyId]
+  );
+  const modsTotal = parseFloat(m.rows[0].total || "0");
+  const billed = base + modsTotal;
+  if (!DRY_RUN) {
+    await pool.query(
+      `UPDATE jobs SET billed_amount = $1 WHERE id = $2 AND company_id = $3`,
+      [billed.toFixed(2), jobId, companyId]
+    );
+  }
+  return { base, mods: modsTotal, billed };
+}
+
+async function main(): Promise<void> {
+  console.log(DRY_RUN ? "[DRY RUN — no writes]" : "[LIVE — writing to DB]");
+  // Schema creation is idempotent (IF NOT EXISTS); run it even on dry-run
+  // so the dup-check query below has a table to read.
+  await ensureSchema();
+
+  const touchedJobs = new Set<number>();
+  const touchedJobMeta = new Map<number, number>(); // jobId → companyId
+
+  for (const b of BACKFILL) {
+    const jobs = await findJobs(b);
+    const tag = `${b.client_first} ${b.client_last} ${b.scheduled_date ?? b.month?.from + ".." + b.month?.to}`;
+    if (jobs.length === 0) {
+      console.warn(`  ⚠ no jobs matched: ${tag}`);
+      continue;
+    }
+    if (b.scheduled_date && jobs.length > 1) {
+      console.warn(`  ⚠ ${jobs.length} jobs matched for date-pinned mod: ${tag} — using all`);
+    }
+    if (b.month && jobs.length > 1) {
+      // For month-window backfills, the spec says "April job" (singular) — only
+      // apply to the first job if multiple matched.
+      console.warn(`  ⚠ ${jobs.length} jobs matched for month window — using FIRST only: ${tag}`);
+      jobs.length = 1;
+    }
+    for (const jobId of jobs) {
+      const companyId = await getCompanyId(jobId);
+      touchedJobMeta.set(jobId, companyId);
+      if (await jobAlreadyHasMod(jobId, b)) {
+        console.log(`  ↻ skip (already exists): job ${jobId} ${b.mod_type} ${b.amount} "${b.reason}"`);
+        touchedJobs.add(jobId);
+        continue;
+      }
+      console.log(
+        `  + job ${jobId}: ${b.mod_type}${b.minutes !== undefined ? " " + b.minutes + "min" : ""} ${b.amount >= 0 ? "+" : ""}$${b.amount} (${b.reason})`
+      );
+      if (!DRY_RUN) {
+        await pool.query(
+          `INSERT INTO job_rate_mods (company_id, job_id, mod_type, minutes, amount, reason)
+           VALUES ($1, $2, $3, $4, $5, $6)`,
+          [companyId, jobId, b.mod_type, b.mod_type === "time" ? b.minutes ?? null : null,
+           b.amount.toFixed(2), b.reason]
+        );
+      }
+      touchedJobs.add(jobId);
+    }
+  }
+
+  console.log(`\n[recompute] ${touchedJobs.size} affected job(s)`);
+  for (const jobId of touchedJobs) {
+    const companyId = touchedJobMeta.get(jobId)!;
+    const { base, mods, billed } = await recomputeBilledAmount(jobId, companyId);
+    console.log(`  job ${jobId}: base $${base.toFixed(2)} + mods $${mods.toFixed(2)} = billed $${billed.toFixed(2)}`);
+  }
+
+  await pool.end();
+  console.log(DRY_RUN ? "\n[DRY RUN complete — no rows changed]" : "\n[DONE]");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/artifacts/api-server/scripts/apr23_source_split.ts
+++ b/artifacts/api-server/scripts/apr23_source_split.ts
@@ -1,0 +1,19 @@
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+async function main() {
+  const r = await db.execute(sql`
+    SELECT
+      CASE WHEN mc_job_id IS NULL THEN 'NO_MC_ID (engine/manual)' ELSE 'MC_IMPORTED' END AS source,
+      COUNT(*)::int AS job_count,
+      SUM(base_fee::numeric)::numeric(14,2) AS revenue,
+      SUM(allowed_hours::numeric)::numeric(14,2) AS hours
+    FROM jobs
+    WHERE company_id = 1
+      AND scheduled_date = '2026-04-23'
+    GROUP BY 1
+  `);
+  console.table(r.rows);
+  process.exit(0);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/apr23_time_audit.ts
+++ b/artifacts/api-server/scripts/apr23_time_audit.ts
@@ -1,0 +1,99 @@
+/**
+ * Schema notes for Sal's time audit:
+ *   - jobs.scheduled_time is TEXT (not TIME), so EXTRACT won't work directly.
+ *     Using string inspection + conditional cast.
+ *   - mc_dispatch_staging has no raw_data JSONB; parsed fields only.
+ *     Using scheduled_raw (original MC string) + scheduled_time_start/end.
+ */
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+async function main() {
+  // 1. Raw scheduled_time values, all 14 Apr 23 jobs
+  console.log("=== 1. Apr 23 jobs — raw scheduled_time values ===");
+  const q1 = await db.execute(sql`
+    SELECT
+      j.id,
+      j.mc_job_id,
+      c.first_name || ' ' || c.last_name AS client_name,
+      j.scheduled_time,
+      pg_typeof(j.scheduled_time)::text AS time_type,
+      LENGTH(j.scheduled_time) AS time_len,
+      j.scheduled_date::text AS scheduled_date,
+      j.allowed_hours::text AS allowed_hours
+    FROM jobs j
+    LEFT JOIN clients c ON c.id = j.client_id
+    WHERE j.company_id = 1 AND j.scheduled_date = '2026-04-23'
+    ORDER BY
+      CASE WHEN j.scheduled_time ~ '^\\d{1,2}:\\d{2}(:\\d{2})?$'
+           THEN j.scheduled_time::time
+           ELSE NULL
+      END NULLS LAST,
+      j.scheduled_time,
+      j.id
+  `);
+  console.table(q1.rows);
+
+  // 2. City Light Church (should be 1:30 PM per MC). mc_job_id=48581765
+  console.log("\n=== 2. City Light Church (mc_job_id=48581765) ===");
+  const q2 = await db.execute(sql`
+    SELECT
+      id, mc_job_id, scheduled_time,
+      pg_typeof(scheduled_time)::text AS time_type,
+      LENGTH(scheduled_time) AS time_len
+    FROM jobs
+    WHERE company_id = 1 AND scheduled_date = '2026-04-23'
+      AND mc_job_id = 48581765
+  `);
+  console.table(q2.rows);
+
+  // 3. Shannon Heidloff (MC shows 1:30 PM). mc_job_id=62088584
+  console.log("\n=== 3. Shannon Heidloff (mc_job_id=62088584) ===");
+  const q3 = await db.execute(sql`
+    SELECT
+      id, mc_job_id, scheduled_time,
+      pg_typeof(scheduled_time)::text AS time_type,
+      LENGTH(scheduled_time) AS time_len
+    FROM jobs
+    WHERE company_id = 1 AND scheduled_date = '2026-04-23'
+      AND mc_job_id = 62088584
+  `);
+  console.table(q3.rows);
+
+  // 4. Cross-reference against mc_dispatch_staging
+  console.log("\n=== 4. mc_dispatch_staging — what MC actually sent ===");
+  const q4 = await db.execute(sql`
+    SELECT
+      mc_job_id,
+      customer_name,
+      scheduled_raw,
+      scheduled_date::text AS staging_date,
+      scheduled_time_start,
+      scheduled_time_end
+    FROM mc_dispatch_staging
+    WHERE mc_job_id IN (48581765, 62088584, 60606153, 62002679)
+    ORDER BY mc_job_id
+  `);
+  console.table(q4.rows);
+
+  // 5. Bonus: all 14 jobs cross-ref staging → jobs to see where the time got scrambled
+  console.log("\n=== 5. Full Apr 23 side-by-side (staging vs jobs) ===");
+  const q5 = await db.execute(sql`
+    SELECT
+      j.id AS job_id,
+      j.mc_job_id,
+      LEFT(mcs.customer_name, 30) AS mc_customer,
+      mcs.scheduled_time_start AS staging_time,
+      j.scheduled_time AS jobs_time,
+      (mcs.scheduled_time_start = j.scheduled_time) AS exact_match,
+      LEFT(mcs.scheduled_raw, 45) AS mc_scheduled_raw
+    FROM jobs j
+    LEFT JOIN mc_dispatch_staging mcs ON mcs.mc_job_id = j.mc_job_id
+    WHERE j.company_id = 1 AND j.scheduled_date = '2026-04-23'
+    ORDER BY mcs.scheduled_time_start NULLS LAST, j.id
+  `);
+  console.table(q5.rows);
+
+  process.exit(0);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/apr23_verify.ts
+++ b/artifacts/api-server/scripts/apr23_verify.ts
@@ -1,0 +1,95 @@
+/**
+ * Apr 23 post-cleanup verification.
+ * Note: jobs table has no `scope` column — using `service_type` as the
+ * closest equivalent. (Column confirmed absent via A.1 schema probe.)
+ */
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+async function main() {
+  // 1. Confirm 2081 is gone
+  console.log("=== 1. Job 2081 presence check ===");
+  const q1 = await db.execute(sql`
+    SELECT id, mc_job_id, client_id, scheduled_date::text AS scheduled_date,
+           scheduled_time, base_fee::text AS base_fee, status::text AS status
+      FROM jobs WHERE id = 2081
+  `);
+  console.log(`rowcount: ${q1.rowCount} (expect 0)`);
+  console.table(q1.rows);
+
+  // 2. Full Apr 23 roster, dispatch order. No `scope` column — using service_type.
+  console.log("\n=== 2. Full Apr 23 roster (by scheduled_time) ===");
+  const q2 = await db.execute(sql`
+    SELECT
+      j.id,
+      j.mc_job_id,
+      j.scheduled_time,
+      j.base_fee::text AS base_fee,
+      j.allowed_hours::text AS allowed_hours,
+      j.status::text AS status,
+      COALESCE(c.first_name || ' ' || c.last_name, '(no client)') AS client_name,
+      j.service_type::text AS service_type,
+      ARRAY(
+        SELECT u.first_name || ' ' || u.last_name
+          FROM job_technicians jt
+          JOIN users u ON u.id = jt.user_id
+         WHERE jt.job_id = j.id
+         ORDER BY jt.is_primary DESC, jt.id
+      ) AS techs
+    FROM jobs j
+    LEFT JOIN clients c ON c.id = j.client_id
+    WHERE j.company_id = 1 AND j.scheduled_date = '2026-04-23'
+    ORDER BY j.scheduled_time NULLS LAST, j.id
+  `);
+  console.log(`rowcount: ${q2.rowCount} (expect 14)`);
+  console.table(q2.rows);
+
+  // 3. Any Apr 23 job with 11h duration or $845 fee that isn't 2081?
+  console.log("\n=== 3. Any Apr 23 job with 11h duration OR $840-$850 fee? ===");
+  const q3 = await db.execute(sql`
+    SELECT j.id, j.mc_job_id, j.client_id,
+           COALESCE(c.first_name || ' ' || c.last_name, '(no client)') AS client_name,
+           j.scheduled_time, j.base_fee::text AS base_fee,
+           j.allowed_hours::text AS allowed_hours,
+           j.status::text AS status
+      FROM jobs j
+      LEFT JOIN clients c ON c.id = j.client_id
+     WHERE j.company_id = 1 AND j.scheduled_date = '2026-04-23'
+       AND (j.allowed_hours::numeric = 11 OR j.base_fee::numeric BETWEEN 840 AND 850)
+  `);
+  console.log(`rowcount: ${q3.rowCount} (expect 0 — 2081 was the only $845 / 10.5h candidate)`);
+  console.table(q3.rows);
+
+  // 4. Any Apr 23 job assigned to Alejandra Cuervo (via assigned_user_id OR job_technicians)?
+  console.log("\n=== 4. Any Apr 23 job assigned to Alejandra Cuervo? ===");
+  const q4 = await db.execute(sql`
+    SELECT j.id, j.mc_job_id, j.scheduled_time,
+           j.base_fee::text AS base_fee,
+           j.allowed_hours::text AS allowed_hours,
+           c.first_name || ' ' || c.last_name AS client_name,
+           'via_tech_table' AS via
+      FROM jobs j
+      JOIN job_technicians jt ON jt.job_id = j.id
+      JOIN users u ON u.id = jt.user_id
+      LEFT JOIN clients c ON c.id = j.client_id
+     WHERE j.company_id = 1 AND j.scheduled_date = '2026-04-23'
+       AND (u.first_name ILIKE 'alejandra%' OR u.last_name ILIKE 'cuervo%')
+    UNION ALL
+    SELECT j.id, j.mc_job_id, j.scheduled_time,
+           j.base_fee::text AS base_fee,
+           j.allowed_hours::text AS allowed_hours,
+           c.first_name || ' ' || c.last_name AS client_name,
+           'via_assigned_user_id' AS via
+      FROM jobs j
+      JOIN users u ON u.id = j.assigned_user_id
+      LEFT JOIN clients c ON c.id = j.client_id
+     WHERE j.company_id = 1 AND j.scheduled_date = '2026-04-23'
+       AND (u.first_name ILIKE 'alejandra%' OR u.last_name ILIKE 'cuervo%')
+    ORDER BY id, via
+  `);
+  console.log(`rowcount: ${q4.rowCount}`);
+  console.table(q4.rows);
+
+  process.exit(0);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/biz_hours_probe.ts
+++ b/artifacts/api-server/scripts/biz_hours_probe.ts
@@ -1,0 +1,25 @@
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+async function main() {
+  // 1. Find any business-hours-shaped columns on companies
+  console.log("=== companies columns (business/hours/dispatch) ===");
+  const cols = await db.execute(sql`
+    SELECT column_name, data_type, is_nullable
+      FROM information_schema.columns
+     WHERE table_name = 'companies' AND table_schema = 'public'
+       AND (column_name LIKE '%hour%' OR column_name LIKE '%business%'
+            OR column_name LIKE '%schedule%' OR column_name LIKE '%day%'
+            OR column_name LIKE '%dispatch%')
+     ORDER BY ordinal_position
+  `);
+  console.table(cols.rows);
+
+  // 2. Full PHES company row — see what's actually populated
+  console.log("\n=== PHES company row (company_id=1) ===");
+  const phes = await db.execute(sql`SELECT * FROM companies WHERE id = 1`);
+  console.log(phes.rows);
+
+  process.exit(0);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/hover_audit.ts
+++ b/artifacts/api-server/scripts/hover_audit.ts
@@ -1,0 +1,265 @@
+/**
+ * Phase A — hover card data-availability audit. READ-ONLY.
+ */
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+async function main() {
+  // ========== A.2 — job_history last_service per upcoming job's customer ==========
+  console.log("=== A.2 — Last service per client (5 sample customers) ===");
+  const a2 = await db.execute(sql`
+    SELECT customer_id,
+           MAX(job_date)::text AS last_service_date,
+           COUNT(*)::int AS history_rows
+      FROM job_history
+     WHERE company_id = 1
+       AND customer_id IN (
+         SELECT DISTINCT client_id
+           FROM jobs
+          WHERE company_id = 1 AND scheduled_date >= '2026-04-22'
+            AND client_id IS NOT NULL
+          LIMIT 5
+       )
+     GROUP BY customer_id
+     ORDER BY last_service_date DESC
+  `);
+  console.table(a2.rows);
+
+  // Full coverage — how many upcoming-job clients have job_history entries
+  console.log("\n=== A.2b — Coverage of last-service lookup for upcoming jobs ===");
+  const a2b = await db.execute(sql`
+    WITH upcoming AS (
+      SELECT DISTINCT client_id
+        FROM jobs
+       WHERE company_id = 1
+         AND scheduled_date >= '2026-04-22'
+         AND client_id IS NOT NULL
+    )
+    SELECT
+      COUNT(*)::int AS total_upcoming_clients,
+      COUNT(*) FILTER (WHERE EXISTS (
+        SELECT 1 FROM job_history jh
+         WHERE jh.company_id=1 AND jh.customer_id = u.client_id
+      ))::int AS with_history,
+      COUNT(*) FILTER (WHERE NOT EXISTS (
+        SELECT 1 FROM job_history jh
+         WHERE jh.company_id=1 AND jh.customer_id = u.client_id
+      ))::int AS no_history
+    FROM upcoming u
+  `);
+  console.table(a2b.rows);
+
+  // ========== A.3 — Entry instruction / notes fields ==========
+  console.log("\n=== A.3 — clients: note/access/instruction-like columns ===");
+  const a3cols = await db.execute(sql`
+    SELECT column_name, data_type
+      FROM information_schema.columns
+     WHERE table_name = 'clients' AND table_schema = 'public'
+       AND (column_name LIKE '%note%' OR column_name LIKE '%memo%'
+            OR column_name LIKE '%instruction%' OR column_name LIKE '%entry%'
+            OR column_name LIKE '%access%' OR column_name LIKE '%lockbox%'
+            OR column_name LIKE '%alarm%' OR column_name LIKE '%pet%')
+     ORDER BY ordinal_position
+  `);
+  console.table(a3cols.rows);
+
+  console.log("\n=== A.3b — jobs: note-like columns ===");
+  const a3jobs = await db.execute(sql`
+    SELECT column_name, data_type
+      FROM information_schema.columns
+     WHERE table_name = 'jobs' AND table_schema = 'public'
+       AND (column_name LIKE '%note%' OR column_name LIKE '%memo%')
+     ORDER BY ordinal_position
+  `);
+  console.table(a3jobs.rows);
+
+  console.log("\n=== A.3c — clients.notes + home_access_notes population ===");
+  const a3pop = await db.execute(sql`
+    SELECT
+      COUNT(*)::int AS total,
+      COUNT(*) FILTER (WHERE notes IS NOT NULL AND TRIM(notes) != '')::int AS with_notes,
+      COUNT(*) FILTER (WHERE home_access_notes IS NOT NULL AND TRIM(home_access_notes) != '')::int AS with_home_access,
+      COUNT(*) FILTER (WHERE alarm_code IS NOT NULL AND TRIM(alarm_code) != '')::int AS with_alarm,
+      COUNT(*) FILTER (WHERE pets IS NOT NULL AND TRIM(pets) != '')::int AS with_pets
+    FROM clients WHERE company_id = 1
+  `);
+  console.table(a3pop.rows);
+
+  console.log("\n=== A.3d — clients with non-empty home_access_notes (sample 8) ===");
+  const a3sample = await db.execute(sql`
+    SELECT id,
+           first_name || ' ' || last_name AS name,
+           LEFT(home_access_notes, 120) AS home_access_preview,
+           LEFT(COALESCE(notes,''), 60) AS notes_preview,
+           LEFT(COALESCE(alarm_code,''), 20) AS alarm,
+           LEFT(COALESCE(pets,''), 30) AS pets
+      FROM clients
+     WHERE company_id = 1
+       AND (home_access_notes IS NOT NULL AND TRIM(home_access_notes) != '')
+     LIMIT 8
+  `);
+  console.table(a3sample.rows);
+
+  console.log("\n=== A.3e — jobs.notes / jobs.office_notes population for upcoming jobs ===");
+  const a3jobsPop = await db.execute(sql`
+    SELECT
+      COUNT(*)::int AS total_upcoming,
+      COUNT(*) FILTER (WHERE notes IS NOT NULL AND TRIM(notes) != '')::int AS with_notes,
+      COUNT(*) FILTER (WHERE office_notes IS NOT NULL AND TRIM(office_notes) != '')::int AS with_office_notes
+    FROM jobs
+    WHERE company_id = 1 AND scheduled_date >= '2026-04-22'
+  `);
+  console.table(a3jobsPop.rows);
+
+  // ========== A.4 — Payment method fields ==========
+  console.log("\n=== A.4 — clients: payment/card/stripe columns ===");
+  const a4cols = await db.execute(sql`
+    SELECT column_name, data_type
+      FROM information_schema.columns
+     WHERE table_name = 'clients' AND table_schema = 'public'
+       AND (column_name LIKE '%payment%' OR column_name LIKE '%stripe%'
+            OR column_name LIKE '%square%' OR column_name LIKE '%card%'
+            OR column_name LIKE '%billing%')
+     ORDER BY ordinal_position
+  `);
+  console.table(a4cols.rows);
+
+  console.log("\n=== A.4b — payment_source distribution ===");
+  const a4src = await db.execute(sql`
+    SELECT COALESCE(payment_source, '(null)') AS payment_source,
+           COUNT(*)::int AS n
+      FROM clients WHERE company_id = 1
+     GROUP BY payment_source ORDER BY n DESC
+  `);
+  console.table(a4src.rows);
+
+  console.log("\n=== A.4c — payment_method distribution ===");
+  const a4m = await db.execute(sql`
+    SELECT COALESCE(payment_method, '(null)') AS payment_method,
+           COUNT(*)::int AS n
+      FROM clients WHERE company_id = 1
+     GROUP BY payment_method ORDER BY n DESC
+  `);
+  console.table(a4m.rows);
+
+  console.log("\n=== A.4d — auto_charge / stripe_payment_method_id coverage ===");
+  const a4auto = await db.execute(sql`
+    SELECT
+      COUNT(*)::int AS total,
+      COUNT(*) FILTER (WHERE auto_charge = true)::int AS auto_charge_on,
+      COUNT(*) FILTER (WHERE stripe_payment_method_id IS NOT NULL)::int AS stripe_pm_set,
+      COUNT(*) FILTER (WHERE default_card_last_4 IS NOT NULL)::int AS card_last4_set,
+      COUNT(*) FILTER (WHERE card_brand IS NOT NULL)::int AS card_brand_set
+    FROM clients WHERE company_id = 1
+  `);
+  console.table(a4auto.rows);
+
+  // ========== A.5 — Zone colors ==========
+  console.log("\n=== A.5 — Zone colors + client counts ===");
+  const a5 = await db.execute(sql`
+    SELECT z.id, z.name, z.color,
+           COUNT(DISTINCT c.id)::int AS clients_in_zone
+      FROM service_zones z
+      LEFT JOIN clients c ON c.zone_id = z.id AND c.company_id = 1
+     WHERE z.company_id = 1
+     GROUP BY z.id, z.name, z.color
+     ORDER BY clients_in_zone DESC
+     LIMIT 20
+  `);
+  console.table(a5.rows);
+
+  console.log("\n=== A.5b — service_zones schema (show branch linkage if any) ===");
+  const a5schema = await db.execute(sql`
+    SELECT column_name, data_type, is_nullable
+      FROM information_schema.columns
+     WHERE table_name = 'service_zones' AND table_schema = 'public'
+     ORDER BY ordinal_position
+  `);
+  console.table(a5schema.rows);
+
+  // ========== A.6 — Branch determination ==========
+  console.log("\n=== A.6 — jobs.branch_id + branches table ===");
+  const a6jobs = await db.execute(sql`
+    SELECT
+      COUNT(*)::int AS total,
+      COUNT(*) FILTER (WHERE branch_id IS NOT NULL)::int AS with_branch_id,
+      COUNT(*) FILTER (WHERE branch IS NOT NULL AND TRIM(branch) != '')::int AS with_branch_text
+    FROM jobs WHERE company_id = 1
+  `);
+  console.log("jobs branch coverage:");
+  console.table(a6jobs.rows);
+
+  const a6branches = await db.execute(sql`
+    SELECT table_name FROM information_schema.tables
+     WHERE table_schema = 'public' AND table_name LIKE '%branch%'
+  `);
+  console.log("\nbranch-related tables:");
+  console.table(a6branches.rows);
+
+  const a6schema = await db.execute(sql`
+    SELECT column_name, data_type
+      FROM information_schema.columns
+     WHERE table_schema = 'public' AND table_name = 'branches'
+     ORDER BY ordinal_position
+  `);
+  if ((a6schema.rowCount ?? 0) > 0) {
+    console.log("\nbranches table schema:");
+    console.table(a6schema.rows);
+
+    const a6list = await db.execute(sql`
+      SELECT * FROM branches WHERE company_id = 1 ORDER BY id LIMIT 10
+    `);
+    console.log("\nbranches for PHES:");
+    console.table(a6list.rows);
+  }
+
+  // ========== A.7 — Clock tables ==========
+  console.log("\n=== A.7 — clock/geofence tables ===");
+  const a7tables = await db.execute(sql`
+    SELECT table_name FROM information_schema.tables
+     WHERE table_schema = 'public'
+       AND (table_name LIKE '%clock%' OR table_name LIKE '%geofence%' OR table_name LIKE '%timeclock%')
+     ORDER BY table_name
+  `);
+  console.table(a7tables.rows);
+
+  console.log("\n=== A.7b — timeclock schema ===");
+  const a7schema = await db.execute(sql`
+    SELECT column_name, data_type, is_nullable
+      FROM information_schema.columns
+     WHERE table_schema = 'public' AND table_name = 'timeclock'
+     ORDER BY ordinal_position
+  `);
+  console.table(a7schema.rows);
+
+  console.log("\n=== A.7c — Sample clock entries for recent jobs ===");
+  const a7sample = await db.execute(sql`
+    SELECT tc.id, tc.job_id, tc.user_id,
+           tc.clock_in_at::text AS clock_in_at,
+           tc.clock_out_at::text AS clock_out_at,
+           tc.distance_from_job_ft::text AS distance_ft,
+           tc.flagged
+      FROM timeclock tc
+      JOIN jobs j ON j.id = tc.job_id
+     WHERE j.company_id = 1
+       AND j.scheduled_date >= '2026-04-15'
+     ORDER BY tc.id DESC
+     LIMIT 10
+  `);
+  console.table(a7sample.rows);
+
+  console.log("\n=== A.7d — Count of clock entries per status of MC-imported jobs ===");
+  const a7coverage = await db.execute(sql`
+    SELECT j.status::text,
+           COUNT(*) FILTER (WHERE EXISTS (SELECT 1 FROM timeclock t WHERE t.job_id = j.id))::int AS jobs_with_clock,
+           COUNT(*)::int AS total_jobs
+      FROM jobs j
+     WHERE j.company_id = 1 AND j.mc_job_id IS NOT NULL
+     GROUP BY j.status
+     ORDER BY total_jobs DESC
+  `);
+  console.table(a7coverage.rows);
+
+  process.exit(0);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/hover_audit_2.ts
+++ b/artifacts/api-server/scripts/hover_audit_2.ts
@@ -1,0 +1,82 @@
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+async function main() {
+  // Sample jobs.notes content to see if it's the MC import tag or real content
+  console.log("=== jobs.notes sample for upcoming jobs ===");
+  const notesSample = await db.execute(sql`
+    SELECT id, mc_job_id, LEFT(COALESCE(notes,''), 120) AS notes_preview,
+           CASE
+             WHEN notes LIKE '%mc_import_phase4%' THEN 'mc_import_tag'
+             WHEN notes IS NULL OR TRIM(notes) = '' THEN 'empty'
+             ELSE 'real_content'
+           END AS kind
+      FROM jobs
+     WHERE company_id = 1 AND scheduled_date >= '2026-04-22'
+     ORDER BY id
+     LIMIT 15
+  `);
+  console.table(notesSample.rows);
+
+  // Categorize upcoming job notes by kind
+  const notesKind = await db.execute(sql`
+    SELECT
+      CASE
+        WHEN notes IS NULL OR TRIM(notes) = '' THEN 'empty'
+        WHEN notes LIKE '%mc_import_phase4%' AND LENGTH(notes) < 80 THEN 'mc_import_tag_only'
+        WHEN notes LIKE '%mc_import_phase4%' THEN 'mc_import_tag_plus_content'
+        ELSE 'real_content'
+      END AS kind,
+      COUNT(*)::int AS n
+    FROM jobs
+    WHERE company_id = 1 AND scheduled_date >= '2026-04-22'
+    GROUP BY kind
+    ORDER BY n DESC
+  `);
+  console.log("\nUpcoming jobs notes categorization:");
+  console.table(notesKind.rows);
+
+  // Sample a job row with all hover-card-relevant fields
+  console.log("\n=== Full row sample (first upcoming PHES job) ===");
+  const full = await db.execute(sql`
+    SELECT j.id, j.mc_job_id, j.client_id, j.scheduled_date::text AS scheduled_date,
+           j.scheduled_time, j.base_fee::text AS base_fee, j.status,
+           j.assigned_user_id, j.estimated_hours::text AS estimated_hours,
+           j.actual_hours::text AS actual_hours, j.allowed_hours::text AS allowed_hours,
+           j.address_street, j.zone_id, j.branch_id,
+           LEFT(COALESCE(j.notes,''), 100) AS notes,
+           c.first_name || ' ' || c.last_name AS client_name,
+           c.phone AS client_phone,
+           c.address AS client_address,
+           c.city, c.zip,
+           c.zone_id AS client_zone_id,
+           z.name AS zone_name,
+           z.color AS zone_color,
+           b.name AS branch_name
+      FROM jobs j
+      LEFT JOIN clients c ON c.id = j.client_id
+      LEFT JOIN service_zones z ON z.id = j.zone_id
+      LEFT JOIN branches b ON b.id = j.branch_id
+     WHERE j.company_id = 1 AND j.scheduled_date >= '2026-04-22'
+     ORDER BY j.scheduled_date, j.id
+     LIMIT 3
+  `);
+  console.log(full.rows);
+
+  // zone_id coverage on jobs
+  console.log("\n=== jobs.zone_id vs clients.zone_id coverage ===");
+  const zoneCov = await db.execute(sql`
+    SELECT
+      COUNT(*)::int AS total_jobs,
+      COUNT(*) FILTER (WHERE j.zone_id IS NOT NULL)::int AS jobs_with_zone,
+      COUNT(*) FILTER (WHERE c.zone_id IS NOT NULL)::int AS clients_with_zone,
+      COUNT(*) FILTER (WHERE j.zone_id IS NULL AND c.zone_id IS NOT NULL)::int AS client_zone_but_no_job_zone
+    FROM jobs j
+    LEFT JOIN clients c ON c.id = j.client_id
+    WHERE j.company_id = 1 AND j.scheduled_date >= '2026-04-22'
+  `);
+  console.table(zoneCov.rows);
+
+  process.exit(0);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/j2_create_unique_index.ts
+++ b/artifacts/api-server/scripts/j2_create_unique_index.ts
@@ -1,0 +1,67 @@
+/**
+ * J2 — CREATE UNIQUE INDEX CONCURRENTLY on jobs to prevent dedupe-race dupes.
+ *
+ * Uses a partial index so manual one-off jobs (recurring_schedule_id IS NULL)
+ * are not constrained — only auto-generated recurring jobs must be unique on
+ * (company_id, recurring_schedule_id, scheduled_date).
+ *
+ * CONCURRENTLY cannot run inside a transaction; we run it at session level.
+ */
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+async function main() {
+  console.log("=== J2 — create partial unique index ===\n");
+
+  // Check if index already exists (idempotent)
+  const existing = await db.execute(sql`
+    SELECT indexname
+      FROM pg_indexes
+     WHERE schemaname = 'public'
+       AND tablename = 'jobs'
+       AND indexname = 'jobs_recurring_dedupe_idx'
+  `);
+  if ((existing.rowCount ?? 0) > 0) {
+    console.log("Index already exists. Skipping.");
+    process.exit(0);
+  }
+
+  // Final safety check: no dup tuples
+  const dupes = await db.execute(sql`
+    SELECT company_id, recurring_schedule_id, scheduled_date, COUNT(*)::int AS n
+      FROM jobs
+     WHERE recurring_schedule_id IS NOT NULL
+     GROUP BY company_id, recurring_schedule_id, scheduled_date
+    HAVING COUNT(*) > 1
+  `);
+  const dupCount = dupes.rowCount ?? 0;
+  if (dupCount > 0) {
+    console.log(`!! ${dupCount} dup tuples remain. Aborting index creation.`);
+    console.log(dupes.rows);
+    process.exit(1);
+  }
+  console.log("Pre-flight: zero dup tuples. Safe to create unique index.");
+
+  console.log("\nCreating index (CONCURRENTLY, may take a few seconds)...");
+  await db.execute(sql`
+    CREATE UNIQUE INDEX CONCURRENTLY jobs_recurring_dedupe_idx
+        ON jobs (company_id, recurring_schedule_id, scheduled_date)
+     WHERE recurring_schedule_id IS NOT NULL
+  `);
+  console.log("Index created.");
+
+  // Verify
+  const after = await db.execute(sql`
+    SELECT indexname, indexdef
+      FROM pg_indexes
+     WHERE schemaname = 'public'
+       AND tablename = 'jobs'
+       AND indexname = 'jobs_recurring_dedupe_idx'
+  `);
+  console.log("\nPost-verify:");
+  console.log(after.rows);
+
+  process.exit(0);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/j4_investigate_apr20.ts
+++ b/artifacts/api-server/scripts/j4_investigate_apr20.ts
@@ -1,0 +1,81 @@
+/**
+ * J4 investigation — reconcile 79 vs 56 Apr-20 $0 phantom count.
+ * READ-ONLY.
+ */
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+async function main() {
+  // All Apr-20 recurring rows grouped by schedule with base_fee
+  const byScheduleAll = await db.execute(sql`
+    SELECT recurring_schedule_id,
+           COUNT(*)::int AS n,
+           COUNT(*) FILTER (WHERE base_fee IS NULL OR base_fee::numeric = 0)::int AS zero_n,
+           MIN(created_at) AS first_created,
+           MAX(created_at) AS last_created
+      FROM jobs
+     WHERE company_id = 1
+       AND recurring_schedule_id IS NOT NULL
+       AND scheduled_date = '2026-04-20'
+     GROUP BY recurring_schedule_id
+     ORDER BY recurring_schedule_id
+  `);
+  console.log("Apr-20 recurring rows by schedule:");
+  console.table(byScheduleAll.rows);
+
+  // Sum totals
+  const totals = await db.execute(sql`
+    SELECT COUNT(*) FILTER (WHERE base_fee IS NULL OR base_fee::numeric = 0)::int AS zero_n,
+           COUNT(*)::int AS total_n
+      FROM jobs
+     WHERE company_id = 1
+       AND recurring_schedule_id IS NOT NULL
+       AND scheduled_date = '2026-04-20'
+  `);
+  console.log("\nApr-20 recurring totals:", totals.rows);
+
+  // Count by created_at window
+  const byWindow = await db.execute(sql`
+    SELECT DATE_TRUNC('hour', created_at) AS hour_bucket,
+           COUNT(*)::int AS n
+      FROM jobs
+     WHERE company_id = 1
+       AND recurring_schedule_id IS NOT NULL
+       AND scheduled_date = '2026-04-20'
+       AND (base_fee IS NULL OR base_fee::numeric = 0)
+     GROUP BY 1
+     ORDER BY 1
+  `);
+  console.log("\nApr-20 $0 phantoms by created-hour:");
+  console.table(byWindow.rows);
+
+  // Spot-check a few raw rows
+  const rawSample = await db.execute(sql`
+    SELECT id, recurring_schedule_id, scheduled_date, base_fee::text AS base_fee,
+           created_at, updated_at
+      FROM jobs
+     WHERE company_id = 1
+       AND recurring_schedule_id IS NOT NULL
+       AND scheduled_date = '2026-04-20'
+       AND (base_fee IS NULL OR base_fee::numeric = 0)
+     ORDER BY recurring_schedule_id, id
+     LIMIT 30
+  `);
+  console.log("\nSample Apr-20 $0 phantom rows (first 30):");
+  console.table(rawSample.rows);
+
+  // Verify Jim Schultz 2026-06-18
+  const jim = await db.execute(sql`
+    SELECT id, recurring_schedule_id, scheduled_date, base_fee::text AS base_fee, created_at
+      FROM jobs
+     WHERE recurring_schedule_id = 52
+       AND scheduled_date = '2026-06-18'
+     ORDER BY id
+  `);
+  console.log("\nJim Schultz sched 52 / 2026-06-18 rows:");
+  console.table(jim.rows);
+
+  process.exit(0);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/j4_strategy_a_dedupe.ts
+++ b/artifacts/api-server/scripts/j4_strategy_a_dedupe.ts
@@ -1,0 +1,132 @@
+/**
+ * J4 Strategy A' (aggressive, user-confirmed) — full Apr-20 $0 phantom sweep.
+ *
+ * - 79 Apr-20 $0 phantom rows from recurring schedules (Apr 19 + Apr 20
+ *   regrowth, missed by Commit E's past-date filter; 40 created 2026-04-19
+ *   07:00 UTC, 39 created 2026-04-20 07:00 UTC)
+ * - 1 Jim Schultz sched 52 2026-06-18 duplicate (keep lower id 2003, delete 2004)
+ *
+ * Runs in a single transaction with rowcount gates. Rolls back on mismatch.
+ */
+
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+async function main() {
+  console.log("=== J4 Strategy A — pre-existing dupe cleanup ===\n");
+
+  // ---------- PRE-FLIGHT ----------
+  const preApr20 = await db.execute(sql`
+    SELECT COUNT(*)::int AS n
+      FROM jobs
+     WHERE company_id = 1
+       AND recurring_schedule_id IS NOT NULL
+       AND scheduled_date = '2026-04-20'
+       AND (base_fee IS NULL OR base_fee::numeric = 0)
+  `);
+  const preApr20Count = Number((preApr20.rows?.[0] as any)?.n ?? 0);
+  console.log(`Pre-flight: Apr-20 $0 phantom rows = ${preApr20Count} (expect 79)`);
+
+  const preJim = await db.execute(sql`
+    SELECT id, base_fee::text AS base_fee
+      FROM jobs
+     WHERE id IN (2003, 2004)
+     ORDER BY id
+  `);
+  console.log(`Pre-flight: Jim Schultz dedup rows =`, preJim.rows);
+
+  const preDupes = await db.execute(sql`
+    SELECT company_id, recurring_schedule_id, scheduled_date, COUNT(*)::int AS n
+      FROM jobs
+     WHERE company_id = 1
+       AND recurring_schedule_id IS NOT NULL
+     GROUP BY company_id, recurring_schedule_id, scheduled_date
+    HAVING COUNT(*) > 1
+     ORDER BY recurring_schedule_id, scheduled_date
+  `);
+  console.log(`\nPre-flight: duplicate tuples in jobs = ${preDupes.rowCount ?? preDupes.rows.length}`);
+  console.log(preDupes.rows);
+
+  if (preApr20Count !== 79) {
+    console.log(`\n!! Apr-20 count mismatch (got ${preApr20Count}, expected 79). Aborting.`);
+    process.exit(1);
+  }
+  if (preJim.rowCount !== 2) {
+    console.log(`\n!! Jim Schultz rows mismatch (got ${preJim.rowCount}, expected 2). Aborting.`);
+    process.exit(1);
+  }
+
+  // ---------- TRANSACTION ----------
+  console.log("\n--- BEGIN TRANSACTION ---");
+  await db.execute(sql`BEGIN`);
+  try {
+    const d1 = await db.execute(sql`
+      DELETE FROM jobs
+       WHERE company_id = 1
+         AND recurring_schedule_id IS NOT NULL
+         AND scheduled_date = '2026-04-20'
+         AND (base_fee IS NULL OR base_fee::numeric = 0)
+    `);
+    const d1Count = d1.rowCount ?? 0;
+    console.log(`DELETE Apr-20 $0 phantoms: ${d1Count} rows (expect 79)`);
+    if (d1Count !== 79) {
+      throw new Error(`Apr-20 delete mismatch: got ${d1Count}, expected 79`);
+    }
+
+    const d2 = await db.execute(sql`DELETE FROM jobs WHERE id = 2004`);
+    const d2Count = d2.rowCount ?? 0;
+    console.log(`DELETE Jim Schultz dupe id=2004: ${d2Count} rows (expect 1)`);
+    if (d2Count !== 1) {
+      throw new Error(`Jim Schultz delete mismatch: got ${d2Count}, expected 1`);
+    }
+
+    // Verify zero dup tuples before commit
+    const postDupes = await db.execute(sql`
+      SELECT company_id, recurring_schedule_id, scheduled_date, COUNT(*)::int AS n
+        FROM jobs
+       WHERE company_id = 1
+         AND recurring_schedule_id IS NOT NULL
+       GROUP BY company_id, recurring_schedule_id, scheduled_date
+      HAVING COUNT(*) > 1
+    `);
+    const remainingDupes = postDupes.rowCount ?? postDupes.rows.length;
+    console.log(`\nIn-txn verify: remaining dup tuples = ${remainingDupes} (expect 0)`);
+    if (remainingDupes !== 0) {
+      console.log(postDupes.rows);
+      throw new Error(`Dup tuples remain after cleanup: ${remainingDupes}`);
+    }
+
+    await db.execute(sql`COMMIT`);
+    console.log("--- COMMIT OK ---");
+  } catch (err) {
+    await db.execute(sql`ROLLBACK`);
+    console.log("--- ROLLBACK ---");
+    console.error(err);
+    process.exit(1);
+  }
+
+  // ---------- POST-VERIFY ----------
+  const postApr20 = await db.execute(sql`
+    SELECT COUNT(*)::int AS n
+      FROM jobs
+     WHERE company_id = 1
+       AND recurring_schedule_id IS NOT NULL
+       AND scheduled_date = '2026-04-20'
+  `);
+  console.log(`\nPost: Apr-20 recurring rows = ${(postApr20.rows?.[0] as any)?.n}`);
+
+  const postJim = await db.execute(sql`SELECT id FROM jobs WHERE id IN (2003, 2004)`);
+  console.log(`Post: Jim Schultz ids remaining =`, postJim.rows);
+
+  const totalJobs = await db.execute(sql`
+    SELECT COUNT(*)::int AS n FROM jobs WHERE company_id = 1
+  `);
+  console.log(`Post: total PHES jobs = ${(totalJobs.rows?.[0] as any)?.n}`);
+
+  process.exit(0);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/artifacts/api-server/scripts/j5_flip_flag.ts
+++ b/artifacts/api-server/scripts/j5_flip_flag.ts
@@ -1,0 +1,41 @@
+/**
+ * J5 — flip PHES engine flag.
+ * Usage: tsx j5_flip_flag.ts [true|false]
+ */
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+async function main() {
+  const targetArg = process.argv[2];
+  if (targetArg !== "true" && targetArg !== "false") {
+    console.error(`Usage: j5_flip_flag.ts [true|false]`);
+    process.exit(1);
+  }
+  const target = targetArg === "true";
+
+  const before = await db.execute(sql`
+    SELECT id, name, recurring_engine_enabled FROM companies WHERE id = 1
+  `);
+  console.log("Before:", before.rows);
+
+  await db.execute(sql`BEGIN`);
+  try {
+    const res = await db.execute(sql`
+      UPDATE companies SET recurring_engine_enabled = ${target} WHERE id = 1
+    `);
+    const rowCount = res.rowCount ?? 0;
+    console.log(`UPDATE rowcount: ${rowCount} (expect 1)`);
+    if (rowCount !== 1) throw new Error(`rowcount mismatch: ${rowCount}`);
+    await db.execute(sql`COMMIT`);
+  } catch (err) {
+    await db.execute(sql`ROLLBACK`);
+    throw err;
+  }
+
+  const after = await db.execute(sql`
+    SELECT id, name, recurring_engine_enabled FROM companies WHERE id = 1
+  `);
+  console.log("After:", after.rows);
+  process.exit(0);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/j5_preflight.ts
+++ b/artifacts/api-server/scripts/j5_preflight.ts
@@ -1,0 +1,53 @@
+/**
+ * J5 pre-flight — flag state + baseline jobs count.
+ * READ-ONLY.
+ */
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+async function main() {
+  const flags = await db.execute(sql`
+    SELECT id, name, recurring_engine_enabled FROM companies ORDER BY id
+  `);
+  console.log("--- engine flags (all four tenants) ---");
+  console.table(flags.rows);
+
+  const baseline = await db.execute(sql`
+    SELECT
+      COUNT(*)::int AS total,
+      COUNT(*) FILTER (WHERE recurring_schedule_id IS NOT NULL)::int AS recurring_sourced,
+      COUNT(*) FILTER (WHERE scheduled_date >= CURRENT_DATE)::int AS future,
+      COUNT(*) FILTER (WHERE base_fee IS NULL OR base_fee::numeric = 0)::int AS zero_fee
+    FROM jobs WHERE company_id = 1
+  `);
+  console.log("\n--- PHES jobs baseline ---");
+  console.table(baseline.rows);
+
+  const dupes = await db.execute(sql`
+    SELECT company_id, recurring_schedule_id, scheduled_date, COUNT(*)::int AS n
+      FROM jobs
+     WHERE company_id = 1 AND recurring_schedule_id IS NOT NULL
+     GROUP BY 1,2,3 HAVING COUNT(*) > 1
+  `);
+  console.log("\n--- existing duplicate tuples (should be 0) ---");
+  console.log(dupes.rows);
+
+  const idx = await db.execute(sql`
+    SELECT indexname FROM pg_indexes
+     WHERE schemaname='public' AND tablename='jobs' AND indexname='jobs_recurring_dedupe_idx'
+  `);
+  console.log("\n--- unique dedup index present? ---");
+  console.log(idx.rows);
+
+  const schedules = await db.execute(sql`
+    SELECT COUNT(*)::int AS active_schedules,
+           COUNT(*) FILTER (WHERE base_fee IS NULL OR base_fee::numeric = 0)::int AS null_or_zero_fee
+      FROM recurring_schedules
+     WHERE company_id = 1 AND is_active = true
+  `);
+  console.log("\n--- PHES active schedules ---");
+  console.table(schedules.rows);
+
+  process.exit(0);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/j5_verify_insert.ts
+++ b/artifacts/api-server/scripts/j5_verify_insert.ts
@@ -1,0 +1,85 @@
+/**
+ * J5 Step 3 — verify the 272 rows landed cleanly.
+ * READ-ONLY.
+ */
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+async function main() {
+  const snap = await db.execute(sql`
+    SELECT
+      COUNT(*)::int AS total_now,
+      COUNT(*) FILTER (WHERE recurring_schedule_id IS NOT NULL AND created_at >= NOW() - INTERVAL '10 minutes')::int AS just_inserted,
+      COUNT(*) FILTER (WHERE recurring_schedule_id IS NOT NULL AND created_at >= NOW() - INTERVAL '10 minutes' AND (base_fee IS NULL OR base_fee::numeric = 0))::int AS new_zero_fee,
+      (SELECT COUNT(DISTINCT recurring_schedule_id)::int FROM jobs WHERE company_id = 1 AND created_at >= NOW() - INTERVAL '10 minutes') AS distinct_schedules_processed,
+      (SELECT COUNT(*)::int FROM jobs WHERE company_id = 1 AND created_at >= NOW() - INTERVAL '10 minutes' AND recurring_schedule_id IS NOT NULL AND assigned_user_id IS NULL) AS unassigned_new,
+      (SELECT MIN(scheduled_date)::text FROM jobs WHERE company_id = 1 AND created_at >= NOW() - INTERVAL '10 minutes') AS min_date_new,
+      (SELECT MAX(scheduled_date)::text FROM jobs WHERE company_id = 1 AND created_at >= NOW() - INTERVAL '10 minutes') AS max_date_new
+    FROM jobs WHERE company_id = 1
+  `);
+  console.log("--- snapshot ---");
+  console.table(snap.rows);
+
+  const dupe = await db.execute(sql`
+    SELECT company_id, recurring_schedule_id, scheduled_date, COUNT(*)::int AS n
+      FROM jobs
+     WHERE company_id = 1
+       AND recurring_schedule_id IS NOT NULL
+       AND created_at >= NOW() - INTERVAL '10 minutes'
+     GROUP BY 1,2,3 HAVING COUNT(*) > 1
+  `);
+  console.log(`\n--- duplicate tuples in just-inserted set (expect 0) ---`);
+  console.log(`rowcount=${dupe.rowCount ?? 0}`);
+  console.log(dupe.rows);
+
+  const allDupe = await db.execute(sql`
+    SELECT company_id, recurring_schedule_id, scheduled_date, COUNT(*)::int AS n
+      FROM jobs
+     WHERE company_id = 1 AND recurring_schedule_id IS NOT NULL
+     GROUP BY 1,2,3 HAVING COUNT(*) > 1
+  `);
+  console.log(`\n--- duplicate tuples in entire PHES jobs (expect 0) ---`);
+  console.log(`rowcount=${allDupe.rowCount ?? 0}`);
+
+  // Tech distribution on the new 272 (schema: jobs.assigned_user_id -> users.id)
+  const techDist = await db.execute(sql`
+    SELECT
+      COALESCE(u.first_name || ' ' || u.last_name, 'Unassigned') AS tech,
+      COUNT(*)::int AS job_count
+      FROM jobs j
+      LEFT JOIN users u ON u.id = j.assigned_user_id
+     WHERE j.company_id = 1
+       AND j.recurring_schedule_id IS NOT NULL
+       AND j.created_at >= NOW() - INTERVAL '10 minutes'
+     GROUP BY u.id, u.first_name, u.last_name
+     ORDER BY job_count DESC
+  `);
+  console.log("\n--- tech distribution on new 272 ---");
+  console.table(techDist.rows);
+
+  // Verify the 5 NULL-fee schedules got zero new rows
+  const nullFeeCheck = await db.execute(sql`
+    SELECT rs.id AS sched_id,
+           c.first_name || ' ' || c.last_name AS client,
+           rs.base_fee,
+           (SELECT COUNT(*)::int FROM jobs j
+             WHERE j.recurring_schedule_id = rs.id
+               AND j.created_at >= NOW() - INTERVAL '10 minutes') AS new_rows
+      FROM recurring_schedules rs
+      LEFT JOIN clients c ON c.id = rs.customer_id
+     WHERE rs.id IN (13, 19, 27, 78, 86)
+     ORDER BY rs.id
+  `);
+  console.log("\n--- NULL-fee guard enforcement (expect new_rows=0 for all 5) ---");
+  console.table(nullFeeCheck.rows);
+
+  // Engine flag state
+  const flags = await db.execute(sql`
+    SELECT id, name, recurring_engine_enabled FROM companies ORDER BY id
+  `);
+  console.log("\n--- engine flags ---");
+  console.table(flags.rows);
+
+  process.exit(0);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/j_final_verify.ts
+++ b/artifacts/api-server/scripts/j_final_verify.ts
@@ -1,0 +1,63 @@
+/**
+ * Post-J verification snapshot for the log.
+ */
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+async function main() {
+  const flags = await db.execute(sql`
+    SELECT id, name, recurring_engine_enabled
+      FROM companies
+     ORDER BY id
+  `);
+  console.log("--- engine flags ---");
+  console.table(flags.rows);
+
+  const phesJobs = await db.execute(sql`
+    SELECT COUNT(*)::int AS total,
+           COUNT(*) FILTER (WHERE recurring_schedule_id IS NOT NULL)::int AS recurring,
+           COUNT(*) FILTER (WHERE recurring_schedule_id IS NULL)::int AS manual
+      FROM jobs
+     WHERE company_id = 1
+  `);
+  console.log("\n--- PHES jobs ---");
+  console.table(phesJobs.rows);
+
+  const futureRec = await db.execute(sql`
+    SELECT COUNT(*)::int AS n,
+           MIN(scheduled_date) AS min_date,
+           MAX(scheduled_date) AS max_date
+      FROM jobs
+     WHERE company_id = 1
+       AND recurring_schedule_id IS NOT NULL
+       AND scheduled_date >= CURRENT_DATE
+  `);
+  console.log("\n--- future-dated recurring jobs ---");
+  console.table(futureRec.rows);
+
+  const dup = await db.execute(sql`
+    SELECT COUNT(*)::int AS dup_tuples
+      FROM (
+        SELECT 1
+          FROM jobs
+         WHERE recurring_schedule_id IS NOT NULL
+         GROUP BY company_id, recurring_schedule_id, scheduled_date
+        HAVING COUNT(*) > 1
+      ) t
+  `);
+  console.log("\n--- remaining dup tuples ---");
+  console.table(dup.rows);
+
+  const idx = await db.execute(sql`
+    SELECT indexname, indexdef
+      FROM pg_indexes
+     WHERE schemaname = 'public'
+       AND tablename = 'jobs'
+       AND indexname = 'jobs_recurring_dedupe_idx'
+  `);
+  console.log("\n--- index ---");
+  console.log(idx.rows);
+
+  process.exit(0);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/k_step1_dryrun.ts
+++ b/artifacts/api-server/scripts/k_step1_dryrun.ts
@@ -1,0 +1,130 @@
+/**
+ * Commit K — Step 1 dry-run: identify rows slated for delete + verify remainders.
+ * READ-ONLY.
+ */
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+async function main() {
+  console.log("=== Commit K Step 1 — DRY RUN ===\n");
+
+  // Full list of flagged rows
+  console.log("--- Rows flagged for delete (engine-sourced future scheduled, Apr 23+) ---");
+  const flagged = await db.execute(sql`
+    SELECT id, scheduled_date::text AS scheduled_date,
+           client_id AS customer_id,
+           base_fee::text AS base_fee,
+           status, recurring_schedule_id,
+           created_at
+      FROM jobs
+     WHERE company_id = 1
+       AND scheduled_date >= '2026-04-23'
+       AND recurring_schedule_id IS NOT NULL
+       AND status = 'scheduled'
+     ORDER BY scheduled_date, id
+  `);
+  console.table(flagged.rows);
+  console.log(`Total flagged: ${flagged.rowCount}`);
+
+  // Count summary by date
+  console.log("\n--- Count summary by scheduled_date ---");
+  const summary = await db.execute(sql`
+    SELECT scheduled_date::text AS scheduled_date,
+           COUNT(*)::int AS row_count,
+           SUM(base_fee::numeric)::numeric(14,2) AS sum_fee
+      FROM jobs
+     WHERE company_id = 1
+       AND scheduled_date >= '2026-04-23'
+       AND recurring_schedule_id IS NOT NULL
+       AND status = 'scheduled'
+     GROUP BY scheduled_date
+     ORDER BY scheduled_date
+  `);
+  console.table(summary.rows);
+
+  const totalFlagged = await db.execute(sql`
+    SELECT COUNT(*)::int AS n,
+           SUM(base_fee::numeric)::numeric(14,2) AS total
+      FROM jobs
+     WHERE company_id = 1
+       AND scheduled_date >= '2026-04-23'
+       AND recurring_schedule_id IS NOT NULL
+       AND status = 'scheduled'
+  `);
+  console.log("\nGrand total flagged:", totalFlagged.rows);
+
+  // What REMAINS in Apr 2026 after hypothetical delete
+  console.log("\n--- What REMAINS in April 2026 after delete (manual, completed, cancelled, pre-Apr-23) ---");
+  const remain = await db.execute(sql`
+    SELECT scheduled_date::text AS scheduled_date,
+           status,
+           (recurring_schedule_id IS NULL) AS is_manual,
+           COUNT(*)::int AS n,
+           SUM(base_fee::numeric)::numeric(14,2) AS sum_fee
+      FROM jobs
+     WHERE company_id = 1
+       AND scheduled_date BETWEEN '2026-04-01' AND '2026-04-30'
+       AND NOT (recurring_schedule_id IS NOT NULL AND status = 'scheduled'
+                AND scheduled_date >= '2026-04-23')
+     GROUP BY scheduled_date, status, is_manual
+     ORDER BY scheduled_date, status, is_manual
+  `);
+  console.table(remain.rows);
+
+  const remainTotal = await db.execute(sql`
+    SELECT COUNT(*)::int AS n,
+           SUM(base_fee::numeric)::numeric(14,2) AS total
+      FROM jobs
+     WHERE company_id = 1
+       AND scheduled_date BETWEEN '2026-04-01' AND '2026-04-30'
+       AND NOT (recurring_schedule_id IS NOT NULL AND status = 'scheduled'
+                AND scheduled_date >= '2026-04-23')
+  `);
+  console.log("\nApril 2026 remaining total:", remainTotal.rows);
+
+  // Sanity — make sure nothing in the pre-Apr-23 window or non-scheduled gets swept
+  console.log("\n--- Pre-Apr-23 engine rows (must NOT be deleted) ---");
+  const preApr23 = await db.execute(sql`
+    SELECT scheduled_date::text AS scheduled_date,
+           status,
+           COUNT(*)::int AS n,
+           SUM(base_fee::numeric)::numeric(14,2) AS sum_fee
+      FROM jobs
+     WHERE company_id = 1
+       AND scheduled_date >= '2026-04-01'
+       AND scheduled_date < '2026-04-23'
+       AND recurring_schedule_id IS NOT NULL
+     GROUP BY scheduled_date, status
+     ORDER BY scheduled_date, status
+  `);
+  console.table(preApr23.rows);
+
+  // Future horizon sweep — anything flagged post April
+  console.log("\n--- Flagged rows beyond April (May–Jun engine-generated) ---");
+  const futureEngine = await db.execute(sql`
+    SELECT scheduled_date::text AS scheduled_date,
+           COUNT(*)::int AS n,
+           SUM(base_fee::numeric)::numeric(14,2) AS sum_fee
+      FROM jobs
+     WHERE company_id = 1
+       AND scheduled_date > '2026-04-30'
+       AND recurring_schedule_id IS NOT NULL
+       AND status = 'scheduled'
+     GROUP BY scheduled_date
+     ORDER BY scheduled_date
+  `);
+  console.table(futureEngine.rows);
+  const futureTotal = await db.execute(sql`
+    SELECT COUNT(*)::int AS n,
+           SUM(base_fee::numeric)::numeric(14,2) AS total
+      FROM jobs
+     WHERE company_id = 1
+       AND scheduled_date > '2026-04-30'
+       AND recurring_schedule_id IS NOT NULL
+       AND status = 'scheduled'
+  `);
+  console.log("Beyond April total:", futureTotal.rows);
+
+  process.exit(0);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/k_step3_delete.ts
+++ b/artifacts/api-server/scripts/k_step3_delete.ts
@@ -1,0 +1,160 @@
+/**
+ * Commit K Step 3 REVISED — delete 313 engine-generated rows from 2026-04-01 on.
+ *
+ * Scope: scheduled_date >= '2026-04-01'
+ *        AND recurring_schedule_id IS NOT NULL
+ *        AND status = 'scheduled'
+ *        AND company_id = 1
+ *
+ * Preserves: manual jobs (recurring_schedule_id IS NULL), completed rows,
+ * cancelled rows, and anything pre-April.
+ *
+ * Single BEGIN/COMMIT with rowcount gate (expect 313). Rolls back on mismatch.
+ */
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+const EXPECTED = 313;
+
+async function main() {
+  console.log(`=== Commit K Step 3 — DELETE ${EXPECTED} engine rows ===\n`);
+
+  // Pre-flight: confirm count matches expectation
+  const pre = await db.execute(sql`
+    SELECT COUNT(*)::int AS n,
+           SUM(base_fee::numeric)::numeric(14,2) AS total
+      FROM jobs
+     WHERE company_id = 1
+       AND scheduled_date >= '2026-04-01'
+       AND recurring_schedule_id IS NOT NULL
+       AND status = 'scheduled'
+  `);
+  const preN = Number((pre.rows?.[0] as any)?.n ?? 0);
+  const preTotal = String((pre.rows?.[0] as any)?.total ?? '');
+  console.log(`Pre-flight: ${preN} rows / $${preTotal}  (expect ${EXPECTED})`);
+  if (preN !== EXPECTED) {
+    console.log(`\n!! Pre-flight count mismatch (got ${preN}, expected ${EXPECTED}). Aborting — no writes.`);
+    process.exit(1);
+  }
+
+  // Baseline snapshot BEFORE delete
+  const baselineTotal = await db.execute(sql`
+    SELECT COUNT(*)::int AS n FROM jobs WHERE company_id = 1
+  `);
+  console.log(`Baseline PHES jobs total before delete: ${(baselineTotal.rows?.[0] as any)?.n}\n`);
+
+  // --- Transaction ---
+  console.log("--- BEGIN TRANSACTION ---");
+  await db.execute(sql`BEGIN`);
+  try {
+    const del = await db.execute(sql`
+      DELETE FROM jobs
+       WHERE company_id = 1
+         AND scheduled_date >= '2026-04-01'
+         AND recurring_schedule_id IS NOT NULL
+         AND status = 'scheduled'
+      RETURNING id, scheduled_date::text AS scheduled_date,
+                client_id AS customer_id,
+                base_fee::text AS base_fee,
+                recurring_schedule_id
+    `);
+    const delCount = del.rowCount ?? 0;
+    console.log(`DELETE rowcount: ${delCount}  (expect ${EXPECTED})`);
+
+    if (delCount !== EXPECTED) {
+      throw new Error(`Delete rowcount mismatch: got ${delCount}, expected ${EXPECTED}`);
+    }
+
+    // In-txn: verify no engine-generated scheduled rows survive in the target window
+    const postWindow = await db.execute(sql`
+      SELECT COUNT(*)::int AS n
+        FROM jobs
+       WHERE company_id = 1
+         AND scheduled_date >= '2026-04-01'
+         AND recurring_schedule_id IS NOT NULL
+         AND status = 'scheduled'
+    `);
+    const postWindowN = Number((postWindow.rows?.[0] as any)?.n ?? -1);
+    console.log(`In-txn verify: engine scheduled rows from 2026-04-01 onward remaining = ${postWindowN} (expect 0)`);
+    if (postWindowN !== 0) {
+      throw new Error(`Engine rows still present after delete: ${postWindowN}`);
+    }
+
+    await db.execute(sql`COMMIT`);
+    console.log("--- COMMIT OK ---\n");
+
+    // Preserve RETURNING sample for the log
+    const sample = (del.rows as any[]).slice(0, 10);
+    console.log("First 10 deleted rows (sample from RETURNING):");
+    console.table(sample);
+  } catch (err) {
+    await db.execute(sql`ROLLBACK`);
+    console.log("--- ROLLBACK ---");
+    console.error(err);
+    process.exit(1);
+  }
+
+  // ---- POST-DELETE SANITY ----
+  console.log("\n=== POST-DELETE SANITY ===\n");
+
+  console.log("--- April 23-30 now (expect mostly empty + Apr 23 = 2 manuals) ---");
+  const apr2330 = await db.execute(sql`
+    SELECT scheduled_date::text AS scheduled_date,
+           COUNT(*)::int AS n,
+           SUM(base_fee::numeric)::numeric(14,2) AS sum_fee
+      FROM jobs
+     WHERE company_id = 1 AND scheduled_date BETWEEN '2026-04-23' AND '2026-04-30'
+     GROUP BY scheduled_date ORDER BY scheduled_date
+  `);
+  console.table(apr2330.rows);
+
+  console.log("\n--- Full April 2026 state ---");
+  const aprAll = await db.execute(sql`
+    SELECT scheduled_date::text AS scheduled_date,
+           status,
+           (recurring_schedule_id IS NULL) AS is_manual,
+           COUNT(*)::int AS n,
+           SUM(base_fee::numeric)::numeric(14,2) AS sum_fee
+      FROM jobs
+     WHERE company_id = 1 AND scheduled_date BETWEEN '2026-04-01' AND '2026-04-30'
+     GROUP BY scheduled_date, status, is_manual
+     ORDER BY scheduled_date, status, is_manual
+  `);
+  console.table(aprAll.rows);
+
+  const aprTotal = await db.execute(sql`
+    SELECT COUNT(*)::int AS n, SUM(base_fee::numeric)::numeric(14,2) AS total
+      FROM jobs WHERE company_id = 1 AND scheduled_date BETWEEN '2026-04-01' AND '2026-04-30'
+  `);
+  console.log("April total remaining:", aprTotal.rows);
+
+  console.log("\n--- PHES jobs total (all time) ---");
+  const allTotal = await db.execute(sql`
+    SELECT status,
+           COUNT(*)::int AS n,
+           SUM(base_fee::numeric)::numeric(14,2) AS total
+      FROM jobs WHERE company_id = 1
+     GROUP BY status ORDER BY status
+  `);
+  console.table(allTotal.rows);
+
+  console.log("\n--- Engine flag state ---");
+  const flags = await db.execute(sql`
+    SELECT id, name, recurring_engine_enabled FROM companies ORDER BY id
+  `);
+  console.table(flags.rows);
+
+  console.log("\n--- Future engine-generated rows remaining (should be ZERO) ---");
+  const futureEngine = await db.execute(sql`
+    SELECT COUNT(*)::int AS n
+      FROM jobs
+     WHERE company_id = 1
+       AND recurring_schedule_id IS NOT NULL
+       AND status = 'scheduled'
+       AND scheduled_date >= CURRENT_DATE
+  `);
+  console.log(futureEngine.rows);
+
+  process.exit(0);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/l1_staging_load.ts
+++ b/artifacts/api-server/scripts/l1_staging_load.ts
@@ -1,0 +1,348 @@
+/**
+ * Commit L1 — Phase 1 of MC dispatch import.
+ *
+ * Steps executed:
+ *  1.1  Add mc_job_id column + partial unique index to jobs (idempotent)
+ *  1.2  Drop + recreate mc_dispatch_staging
+ *  1.3  Load migration/mc-exports-2026-04-22/dispatch-board-jan-apr.csv
+ *  1.4  Sanity checks
+ *
+ * No writes to the jobs table itself — only the new column gets added.
+ * Phase 2 (matching + merge into jobs) happens in a separate commit.
+ */
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const CSV_PATH = resolve(
+  process.cwd(),
+  "migration/mc-exports-2026-04-22/dispatch-board-jan-apr.csv"
+);
+
+// ---------- RFC-4180-ish CSV parser (handles BOM, quoted commas, escaped quotes) ----------
+function parseCsv(text: string): string[][] {
+  if (text.charCodeAt(0) === 0xfeff) text = text.slice(1);
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let field = "";
+  let inQuotes = false;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (inQuotes) {
+      if (ch === '"') {
+        if (text[i + 1] === '"') {
+          field += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        field += ch;
+      }
+    } else {
+      if (ch === '"') {
+        inQuotes = true;
+      } else if (ch === ",") {
+        row.push(field);
+        field = "";
+      } else if (ch === "\n" || ch === "\r") {
+        // close row; skip \n after \r (CRLF) and empty trailing
+        row.push(field);
+        field = "";
+        if (row.length > 1 || row[0] !== "") rows.push(row);
+        row = [];
+        if (ch === "\r" && text[i + 1] === "\n") i++;
+      } else {
+        field += ch;
+      }
+    }
+  }
+  // final field / row if file doesn't end with newline
+  if (field !== "" || row.length > 0) {
+    row.push(field);
+    if (row.length > 1 || row[0] !== "") rows.push(row);
+  }
+  return rows;
+}
+
+// ---------- Scheduled field parser ----------
+// Format: "M/D/YYYY H:MM AM - H:MM PM" (no seconds, no timezone, 12-hour)
+// Returns { date: 'YYYY-MM-DD', startTime: 'H:MM AM', endTime: 'H:MM PM' }
+function parseScheduled(raw: string): {
+  date: string | null;
+  startTime: string | null;
+  endTime: string | null;
+} {
+  if (!raw) return { date: null, startTime: null, endTime: null };
+  const trimmed = raw.trim();
+
+  // Split on " - " (with spaces) to separate start from end time
+  const dashIdx = trimmed.indexOf(" - ");
+  const leftPart = dashIdx >= 0 ? trimmed.slice(0, dashIdx).trim() : trimmed;
+  const endTime = dashIdx >= 0 ? trimmed.slice(dashIdx + 3).trim() : null;
+
+  // leftPart = "M/D/YYYY H:MM AM"
+  const spaceIdx = leftPart.indexOf(" ");
+  if (spaceIdx < 0) return { date: null, startTime: null, endTime: null };
+  const datePart = leftPart.slice(0, spaceIdx);
+  const startTime = leftPart.slice(spaceIdx + 1).trim();
+
+  const dateMatch = datePart.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
+  if (!dateMatch) return { date: null, startTime, endTime };
+  const [, m, d, y] = dateMatch;
+  const mm = m.padStart(2, "0");
+  const dd = d.padStart(2, "0");
+  return { date: `${y}-${mm}-${dd}`, startTime, endTime };
+}
+
+// ---------- normalization ----------
+function normName(s: string): string {
+  return (s ?? "").trim().replace(/\s+/g, " ");
+}
+function toNum(s: string): number | null {
+  if (!s) return null;
+  const n = parseFloat(String(s).replace(/[,$]/g, ""));
+  return Number.isFinite(n) ? n : null;
+}
+function toInt(s: string): number | null {
+  if (!s) return null;
+  const n = parseInt(String(s), 10);
+  return Number.isFinite(n) ? n : null;
+}
+
+async function step1_1_addMcJobIdColumn() {
+  console.log("\n=== STEP 1.1 — mc_job_id column + partial unique index ===");
+  const existing = await db.execute(sql`
+    SELECT column_name, data_type, is_nullable
+      FROM information_schema.columns
+     WHERE table_name = 'jobs' AND column_name = 'mc_job_id'
+  `);
+  console.log("Existing column check:", existing.rows);
+
+  if ((existing.rowCount ?? 0) === 0) {
+    console.log("Adding mc_job_id BIGINT column...");
+    await db.execute(sql`ALTER TABLE jobs ADD COLUMN mc_job_id BIGINT`);
+    console.log("Creating partial unique index jobs_mc_job_id_uniq...");
+    await db.execute(
+      sql`CREATE UNIQUE INDEX jobs_mc_job_id_uniq ON jobs(mc_job_id) WHERE mc_job_id IS NOT NULL`
+    );
+    console.log("Column + index created.");
+  } else {
+    console.log("Column already present — skipping ALTER.");
+    const idx = await db.execute(sql`
+      SELECT indexname FROM pg_indexes
+       WHERE schemaname = 'public' AND tablename = 'jobs'
+         AND indexname = 'jobs_mc_job_id_uniq'
+    `);
+    if ((idx.rowCount ?? 0) === 0) {
+      console.log("Index missing — creating jobs_mc_job_id_uniq...");
+      await db.execute(
+        sql`CREATE UNIQUE INDEX jobs_mc_job_id_uniq ON jobs(mc_job_id) WHERE mc_job_id IS NOT NULL`
+      );
+    } else {
+      console.log("Index already present — skipping.");
+    }
+  }
+
+  const verify = await db.execute(sql`
+    SELECT c.column_name, c.data_type, c.is_nullable,
+           (SELECT indexdef FROM pg_indexes
+             WHERE schemaname='public' AND tablename='jobs'
+               AND indexname='jobs_mc_job_id_uniq') AS index_def
+      FROM information_schema.columns c
+     WHERE c.table_name='jobs' AND c.column_name='mc_job_id'
+  `);
+  console.log("Post-verify:");
+  console.table(verify.rows);
+}
+
+async function step1_2_createStagingTable() {
+  console.log("\n=== STEP 1.2 — mc_dispatch_staging table ===");
+  await db.execute(sql`DROP TABLE IF EXISTS mc_dispatch_staging`);
+  await db.execute(sql`
+    CREATE TABLE mc_dispatch_staging (
+      mc_job_id BIGINT PRIMARY KEY,
+      customer_name TEXT NOT NULL,
+      billing_terms TEXT,
+      phone TEXT,
+      address TEXT,
+      frequency TEXT,
+      scheduled_raw TEXT NOT NULL,
+      scheduled_date DATE,
+      scheduled_time_start TEXT,
+      scheduled_time_end TEXT,
+      team_raw TEXT,
+      act_start TEXT,
+      act_end TEXT,
+      act_hours NUMERIC,
+      alwd_hours NUMERIC,
+      team_size INT,
+      bill_rate NUMERIC,
+      status_raw TEXT NOT NULL,
+      matched_customer_id INT,
+      matched_schedule_id INT,
+      parsed_techs JSONB,
+      mapped_status TEXT
+    )
+  `);
+  console.log("Dropped + recreated mc_dispatch_staging.");
+}
+
+async function step1_3_loadCsv() {
+  console.log("\n=== STEP 1.3 — Load CSV into staging ===");
+  console.log(`Reading ${CSV_PATH}`);
+  const raw = readFileSync(CSV_PATH, "utf-8");
+  const rows = parseCsv(raw);
+  console.log(`Parsed ${rows.length} lines (including header).`);
+
+  const header = rows[0];
+  console.log(`Header (${header.length} cols): ${header.join(" | ")}`);
+
+  const expectedCols = [
+    "Job ID", "Customer", "Billing Terms", "Phone", "Address", "Freq.",
+    "Scheduled", "Team", "Act. Start", "Act. End", "Act. Hrs", "Alwd. Hours",
+    "Alwd. - Act. Hrs.", "Norm. Alwd. Hrs.", "Norm. Alwd. - Act. Hrs.",
+    "Team Size", "Billing Type", "Bill Rate", "Bill Rate/Act. Hours",
+    "Status", "Scorecard",
+  ];
+  for (let i = 0; i < expectedCols.length; i++) {
+    if (header[i] !== expectedCols[i]) {
+      throw new Error(
+        `Column ${i} mismatch: expected '${expectedCols[i]}', got '${header[i]}'`
+      );
+    }
+  }
+  console.log("Header matches expected 21-column schema.");
+
+  const dataRows = rows.slice(1);
+  console.log(`Data rows: ${dataRows.length}`);
+
+  // Build param rows in chunks
+  const chunkSize = 200;
+  let inserted = 0;
+  await db.execute(sql`BEGIN`);
+  try {
+    for (let off = 0; off < dataRows.length; off += chunkSize) {
+      const chunk = dataRows.slice(off, off + chunkSize);
+      for (const r of chunk) {
+        const jobId = toInt(r[0]);
+        if (jobId == null) {
+          throw new Error(`Row missing Job ID at offset ${off + inserted}: ${r.join("|")}`);
+        }
+        const customer = normName(r[1]);
+        if (!customer) {
+          throw new Error(`Row missing Customer at offset ${off + inserted}, Job ID ${jobId}`);
+        }
+        const statusRaw = (r[19] ?? "").trim();
+        if (!statusRaw) {
+          throw new Error(`Row missing Status at offset ${off + inserted}, Job ID ${jobId}`);
+        }
+
+        const scheduledRaw = (r[6] ?? "").trim();
+        const { date, startTime, endTime } = parseScheduled(scheduledRaw);
+
+        await db.execute(sql`
+          INSERT INTO mc_dispatch_staging (
+            mc_job_id, customer_name, billing_terms, phone, address,
+            frequency, scheduled_raw, scheduled_date, scheduled_time_start,
+            scheduled_time_end, team_raw, act_start, act_end, act_hours,
+            alwd_hours, team_size, bill_rate, status_raw
+          ) VALUES (
+            ${jobId}, ${customer}, ${r[2] || null}, ${r[3] || null}, ${r[4] || null},
+            ${r[5] || null}, ${scheduledRaw}, ${date}::date, ${startTime},
+            ${endTime}, ${r[7] || null}, ${r[8] || null}, ${r[9] || null}, ${toNum(r[10])},
+            ${toNum(r[11])}, ${toInt(r[15])}, ${toNum(r[17])}, ${statusRaw}
+          )
+        `);
+        inserted++;
+      }
+      console.log(`  ...inserted ${inserted}/${dataRows.length}`);
+    }
+    await db.execute(sql`COMMIT`);
+    console.log(`Committed ${inserted} rows.`);
+  } catch (err) {
+    await db.execute(sql`ROLLBACK`);
+    console.error("Load failed, ROLLBACK:", err);
+    throw err;
+  }
+}
+
+async function step1_4_sanityChecks() {
+  console.log("\n=== STEP 1.4 — Staging sanity checks ===");
+
+  const totals = await db.execute(sql`
+    SELECT
+      COUNT(*)::int AS total,
+      COUNT(DISTINCT mc_job_id)::int AS unique_ids,
+      COUNT(DISTINCT customer_name)::int AS unique_customers,
+      MIN(scheduled_date)::text AS min_date,
+      MAX(scheduled_date)::text AS max_date,
+      SUM(bill_rate)::numeric(14,2) AS total_bill_rate
+    FROM mc_dispatch_staging
+  `);
+  console.log("Totals:");
+  console.table(totals.rows);
+
+  const status = await db.execute(sql`
+    SELECT status_raw, COUNT(*)::int AS n
+      FROM mc_dispatch_staging
+     GROUP BY status_raw
+     ORDER BY n DESC
+  `);
+  console.log("\nBy status:");
+  console.table(status.rows);
+
+  const freq = await db.execute(sql`
+    SELECT COALESCE(frequency, '(null)') AS frequency, COUNT(*)::int AS n
+      FROM mc_dispatch_staging
+     GROUP BY frequency
+     ORDER BY n DESC
+  `);
+  console.log("\nBy frequency:");
+  console.table(freq.rows);
+
+  // Parse health — any rows where scheduled_date failed to parse
+  const parseFail = await db.execute(sql`
+    SELECT COUNT(*)::int AS n_no_date
+      FROM mc_dispatch_staging
+     WHERE scheduled_date IS NULL
+  `);
+  console.log("\nParse health:");
+  console.table(parseFail.rows);
+
+  const parseFailSample = await db.execute(sql`
+    SELECT mc_job_id, scheduled_raw
+      FROM mc_dispatch_staging
+     WHERE scheduled_date IS NULL
+     LIMIT 5
+  `);
+  if ((parseFailSample.rowCount ?? 0) > 0) {
+    console.log("Sample un-parseable Scheduled fields:");
+    console.table(parseFailSample.rows);
+  }
+
+  // Daily distribution for April (quick-look, should match MC's daily numbers)
+  const april = await db.execute(sql`
+    SELECT scheduled_date::text AS date,
+           COUNT(*)::int AS jobs,
+           SUM(bill_rate)::numeric(14,2) AS total
+      FROM mc_dispatch_staging
+     WHERE scheduled_date BETWEEN '2026-04-01' AND '2026-04-30'
+     GROUP BY scheduled_date
+     ORDER BY scheduled_date
+  `);
+  console.log("\nApril 2026 daily distribution (preview vs MC ground-truth):");
+  console.table(april.rows);
+}
+
+async function main() {
+  console.log("=== Commit L1 — MC dispatch staging + CSV load ===");
+  await step1_1_addMcJobIdColumn();
+  await step1_2_createStagingTable();
+  await step1_3_loadCsv();
+  await step1_4_sanityChecks();
+  console.log("\nDone.");
+  process.exit(0);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/l2_customer_matching.ts
+++ b/artifacts/api-server/scripts/l2_customer_matching.ts
@@ -1,0 +1,269 @@
+/**
+ * Commit L2 — Phase 2 customer matching.
+ *
+ * 2.1  Baseline clients view
+ * 2.2  Pass 1 — normalized name match
+ * 2.3  Pass 2 — phone last-10-digits match (for residuals)
+ * 2.4  Pass 3 — address prefix match (for residuals)
+ * 2.5  HARD FAIL gate — any unmatched → print + exit 1
+ * 2.6  Match quality summary (only if zero unmatched)
+ *
+ * Writes to mc_dispatch_staging.matched_customer_id only.
+ * No writes to jobs / job_history / recurring_schedules.
+ */
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+async function step2_1_baseline() {
+  console.log("\n=== STEP 2.1 — baseline clients table ===");
+
+  const total = await db.execute(sql`
+    SELECT COUNT(*)::int AS total_clients,
+           COUNT(*) FILTER (WHERE is_active = true)::int AS active,
+           COUNT(*) FILTER (WHERE is_active = false)::int AS inactive
+      FROM clients
+     WHERE company_id = 1
+  `);
+  console.log("Clients totals (company_id=1):");
+  console.table(total.rows);
+
+  const uniqueNorm = await db.execute(sql`
+    SELECT COUNT(DISTINCT
+      LOWER(TRIM(REGEXP_REPLACE(
+        COALESCE(first_name,'') || ' ' || COALESCE(last_name,''),
+        '\\s+', ' ', 'g')))
+    )::int AS unique_normalized_names
+    FROM clients
+    WHERE company_id = 1
+  `);
+  console.log("Unique normalized names:");
+  console.table(uniqueNorm.rows);
+
+  // Relevant columns
+  const cols = await db.execute(sql`
+    SELECT column_name, data_type
+      FROM information_schema.columns
+     WHERE table_name = 'clients'
+       AND column_name IN ('first_name','last_name','phone','email','name',
+                           'display_name','company_name','address','is_active')
+     ORDER BY ordinal_position
+  `);
+  console.log("Relevant clients columns:");
+  console.table(cols.rows);
+}
+
+async function step2_2_nameMatch() {
+  console.log("\n=== STEP 2.2 — Pass 1: exact normalized name ===");
+  const res = await db.execute(sql`
+    UPDATE mc_dispatch_staging s
+       SET matched_customer_id = c.id
+      FROM clients c
+     WHERE c.company_id = 1
+       AND s.matched_customer_id IS NULL
+       AND LOWER(TRIM(REGEXP_REPLACE(
+             REGEXP_REPLACE(s.customer_name, '\\s+', ' ', 'g'),
+             '\\s*\\.\\s*$', '', 'g')))
+         = LOWER(TRIM(REGEXP_REPLACE(
+             REGEXP_REPLACE(
+               COALESCE(c.first_name,'') || ' ' || COALESCE(c.last_name,''),
+               '\\s+', ' ', 'g'),
+             '\\s*\\.\\s*$', '', 'g')))
+  `);
+  console.log(`Pass 1 UPDATE rowcount: ${res.rowCount}`);
+  await reportMatchRate("After Pass 1 (name)");
+}
+
+async function step2_3_phoneMatch() {
+  console.log("\n=== STEP 2.3 — Pass 2: phone last-10-digits ===");
+  const res = await db.execute(sql`
+    UPDATE mc_dispatch_staging s
+       SET matched_customer_id = c.id
+      FROM clients c
+     WHERE c.company_id = 1
+       AND s.matched_customer_id IS NULL
+       AND s.phone IS NOT NULL
+       AND c.phone IS NOT NULL
+       AND LENGTH(REGEXP_REPLACE(s.phone, '[^0-9]', '', 'g')) >= 10
+       AND LENGTH(REGEXP_REPLACE(c.phone, '[^0-9]', '', 'g')) >= 10
+       AND RIGHT(REGEXP_REPLACE(s.phone, '[^0-9]', '', 'g'), 10)
+         = RIGHT(REGEXP_REPLACE(c.phone, '[^0-9]', '', 'g'), 10)
+  `);
+  console.log(`Pass 2 UPDATE rowcount: ${res.rowCount}`);
+  await reportMatchRate("After Pass 2 (phone)");
+}
+
+async function step2_4_addressMatch() {
+  console.log("\n=== STEP 2.4 — Pass 3: address prefix (first 20 chars) ===");
+  const res = await db.execute(sql`
+    UPDATE mc_dispatch_staging s
+       SET matched_customer_id = c.id
+      FROM clients c
+     WHERE c.company_id = 1
+       AND s.matched_customer_id IS NULL
+       AND s.address IS NOT NULL
+       AND c.address IS NOT NULL
+       AND LENGTH(TRIM(s.address)) >= 5
+       AND LENGTH(TRIM(c.address)) >= 5
+       AND LOWER(LEFT(REGEXP_REPLACE(TRIM(s.address), '\\s+', ' ', 'g'), 20))
+         = LOWER(LEFT(REGEXP_REPLACE(TRIM(c.address), '\\s+', ' ', 'g'), 20))
+  `);
+  console.log(`Pass 3 UPDATE rowcount: ${res.rowCount}`);
+  await reportMatchRate("After Pass 3 (address)");
+}
+
+async function reportMatchRate(label: string) {
+  const r = await db.execute(sql`
+    SELECT COUNT(*) FILTER (WHERE matched_customer_id IS NOT NULL)::int AS matched,
+           COUNT(*) FILTER (WHERE matched_customer_id IS NULL)::int AS unmatched,
+           COUNT(DISTINCT customer_name) FILTER (WHERE matched_customer_id IS NOT NULL)::int AS matched_unique_names,
+           COUNT(DISTINCT customer_name) FILTER (WHERE matched_customer_id IS NULL)::int AS unmatched_unique_names
+      FROM mc_dispatch_staging
+  `);
+  console.log(`${label}:`);
+  console.table(r.rows);
+}
+
+async function step2_5_hardFail(): Promise<boolean> {
+  console.log("\n=== STEP 2.5 — HARD FAIL gate ===");
+  const unm = await db.execute(sql`
+    SELECT COUNT(*)::int AS unmatched_rows,
+           COUNT(DISTINCT customer_name)::int AS unmatched_unique_names
+      FROM mc_dispatch_staging
+     WHERE matched_customer_id IS NULL
+  `);
+  const row = unm.rows?.[0] as any;
+  const unmatched = Number(row?.unmatched_rows ?? 0);
+  console.log(`Unmatched: ${unmatched} rows / ${row?.unmatched_unique_names} unique names`);
+
+  if (unmatched > 0) {
+    console.log("\n⚠ HARD-FAIL — unmatched customers below. STOPPING. No L2 commit.\n");
+    const detail = await db.execute(sql`
+      SELECT customer_name,
+             phone,
+             address,
+             COUNT(*)::int AS job_count,
+             SUM(bill_rate)::numeric(14,2) AS total_rev
+        FROM mc_dispatch_staging
+       WHERE matched_customer_id IS NULL
+       GROUP BY customer_name, phone, address
+       ORDER BY job_count DESC, customer_name
+    `);
+    console.table(detail.rows);
+
+    // Also surface candidate matches for Sal — fuzzy name suggestions
+    console.log("\nFuzzy candidate matches for each unmatched name (clients with similar first 5 chars):");
+    const unmatchedNames = await db.execute(sql`
+      SELECT DISTINCT customer_name
+        FROM mc_dispatch_staging
+       WHERE matched_customer_id IS NULL
+       ORDER BY customer_name
+    `);
+    for (const r of unmatchedNames.rows as any[]) {
+      const candidates = await db.execute(sql`
+        SELECT id,
+               COALESCE(first_name,'') || ' ' || COALESCE(last_name,'') AS name,
+               phone,
+               LEFT(COALESCE(address,''), 40) AS addr
+          FROM clients
+         WHERE company_id = 1
+           AND LOWER(LEFT(COALESCE(first_name,'') || COALESCE(last_name,''), 5))
+             = LOWER(LEFT(REGEXP_REPLACE(${r.customer_name}, '\\s+', '', 'g'), 5))
+         LIMIT 5
+      `);
+      console.log(`  "${r.customer_name}" → ${candidates.rowCount ?? 0} candidates`);
+      if ((candidates.rowCount ?? 0) > 0) console.table(candidates.rows);
+    }
+    return false;
+  }
+
+  console.log("All 983 rows matched. No hard-fail.");
+  return true;
+}
+
+async function step2_6_qualitySummary() {
+  console.log("\n=== STEP 2.6 — Match quality summary ===");
+
+  const linked = await db.execute(sql`
+    SELECT COUNT(DISTINCT matched_customer_id)::int AS qleno_clients_with_mc_history
+      FROM mc_dispatch_staging
+  `);
+  console.log("Unique Qleno clients linked:");
+  console.table(linked.rows);
+
+  const top = await db.execute(sql`
+    SELECT s.matched_customer_id,
+           COALESCE(c.first_name,'') || ' ' || COALESCE(c.last_name,'') AS name,
+           COUNT(*)::int AS jobs,
+           SUM(s.bill_rate)::numeric(14,2) AS total_rev
+      FROM mc_dispatch_staging s
+      LEFT JOIN clients c ON c.id = s.matched_customer_id
+     GROUP BY s.matched_customer_id, c.first_name, c.last_name
+     ORDER BY jobs DESC
+     LIMIT 20
+  `);
+  console.log("Top 20 customers by MC job count:");
+  console.table(top.rows);
+
+  console.log("\nPotentially-wrong: one MC customer_name → multiple matched_customer_id (distinct_matches > 1):");
+  const multi = await db.execute(sql`
+    SELECT customer_name,
+           COUNT(DISTINCT matched_customer_id)::int AS distinct_matches,
+           ARRAY_AGG(DISTINCT matched_customer_id) AS matched_ids
+      FROM mc_dispatch_staging
+     GROUP BY customer_name
+    HAVING COUNT(DISTINCT matched_customer_id) > 1
+     ORDER BY distinct_matches DESC
+  `);
+  if ((multi.rowCount ?? 0) === 0) {
+    console.log("  (none — good)");
+  } else {
+    console.table(multi.rows);
+  }
+
+  console.log("\nConsolidation: multiple MC names → same matched_customer_id (name_variants > 1):");
+  const consolidate = await db.execute(sql`
+    SELECT s.matched_customer_id,
+           COALESCE(c.first_name,'') || ' ' || COALESCE(c.last_name,'') AS db_name,
+           ARRAY_AGG(DISTINCT s.customer_name) AS mc_names,
+           COUNT(DISTINCT s.customer_name)::int AS name_variants
+      FROM mc_dispatch_staging s
+      LEFT JOIN clients c ON c.id = s.matched_customer_id
+     GROUP BY s.matched_customer_id, c.first_name, c.last_name
+    HAVING COUNT(DISTINCT s.customer_name) > 1
+     ORDER BY name_variants DESC
+  `);
+  if ((consolidate.rowCount ?? 0) === 0) {
+    console.log("  (none — one-to-one matching)");
+  } else {
+    console.table(consolidate.rows);
+  }
+
+  // Breakdown by which pass caught each row — we can't tell exactly post-hoc,
+  // but we can see unique matched customer_ids that were linked
+  const coverage = await db.execute(sql`
+    SELECT
+      (SELECT COUNT(DISTINCT customer_name)::int FROM mc_dispatch_staging) AS mc_unique,
+      (SELECT COUNT(DISTINCT matched_customer_id)::int FROM mc_dispatch_staging) AS qleno_unique
+  `);
+  console.log("\nCoverage:");
+  console.table(coverage.rows);
+}
+
+async function main() {
+  console.log("=== Commit L2 — MC dispatch customer matching ===");
+  await step2_1_baseline();
+  await step2_2_nameMatch();
+  await step2_3_phoneMatch();
+  await step2_4_addressMatch();
+
+  const clean = await step2_5_hardFail();
+  if (!clean) {
+    process.exit(1);
+  }
+
+  await step2_6_qualitySummary();
+  console.log("\nPhase 2 complete. No hard-fail. Ready to commit L2.");
+  process.exit(0);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/l2_fix_option_a.ts
+++ b/artifacts/api-server/scripts/l2_fix_option_a.ts
@@ -1,0 +1,286 @@
+/**
+ * L2 fix — Option A. Per Sal's decision.
+ *
+ * F2.1 — Backfill client id=22 (Tom and Carol Butler) phone + address from MC
+ * F2.2 — Map 15 "Carol Butler" rows to matched_customer_id = 22
+ * F2.3 — Create 6 new residential client rows for one-time MC customers
+ *         (uses notes='[mc_import_phase2 2026-04-22]' since clients table has
+ *          no migration_source column — same traceability pattern as G-series)
+ * F2.4 — Link the 6 new clients back to staging
+ * F2.5 — Final match quality summary (must be 0 unmatched)
+ *
+ * Atomicity: each step in its own BEGIN/COMMIT. If F2.3 fails after F2.1/F2.2
+ * succeed, we stop with partial progress logged and recoverable. F2.3 does
+ * use a rowcount gate — expect exactly 6 inserted.
+ */
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+const MIG_NOTE = "[mc_import_phase2 2026-04-22]";
+
+async function f2_1_backfillClient22() {
+  console.log("\n=== F2.1 — Backfill client id=22 phone + address ===");
+
+  const before = await db.execute(sql`
+    SELECT id, first_name, last_name, phone, address, email, is_active
+      FROM clients WHERE id = 22 AND company_id = 1
+  `);
+  console.log("Before:");
+  console.table(before.rows);
+  if ((before.rowCount ?? 0) !== 1) {
+    throw new Error("Expected exactly 1 row for client id=22");
+  }
+
+  await db.execute(sql`BEGIN`);
+  try {
+    const res = await db.execute(sql`
+      UPDATE clients
+         SET phone = '312-301-5678',
+             address = COALESCE(address, '121 N Garfield St')
+       WHERE id = 22 AND company_id = 1
+    `);
+    console.log(`UPDATE rowcount: ${res.rowCount} (expect 1)`);
+    if (res.rowCount !== 1) throw new Error(`rowcount mismatch: ${res.rowCount}`);
+    await db.execute(sql`COMMIT`);
+  } catch (err) {
+    await db.execute(sql`ROLLBACK`);
+    throw err;
+  }
+
+  const after = await db.execute(sql`
+    SELECT id, first_name, last_name, phone, address FROM clients WHERE id = 22
+  `);
+  console.log("After:");
+  console.table(after.rows);
+}
+
+async function f2_2_mapCarolButler() {
+  console.log("\n=== F2.2 — Map Carol Butler → id=22 ===");
+
+  // Pre-verify: how many Carol Butler rows unmatched
+  const pre = await db.execute(sql`
+    SELECT COUNT(*)::int AS n
+      FROM mc_dispatch_staging
+     WHERE customer_name = 'Carol Butler' AND matched_customer_id IS NULL
+  `);
+  const preN = Number((pre.rows?.[0] as any)?.n ?? 0);
+  console.log(`Pre: unmatched Carol Butler rows = ${preN} (expect 15)`);
+  if (preN !== 15) throw new Error(`Expected 15 unmatched Carol Butler rows, got ${preN}`);
+
+  await db.execute(sql`BEGIN`);
+  try {
+    const res = await db.execute(sql`
+      UPDATE mc_dispatch_staging
+         SET matched_customer_id = 22
+       WHERE customer_name = 'Carol Butler'
+         AND matched_customer_id IS NULL
+    `);
+    console.log(`UPDATE rowcount: ${res.rowCount} (expect 15)`);
+    if (res.rowCount !== 15) throw new Error(`rowcount mismatch: ${res.rowCount}`);
+    await db.execute(sql`COMMIT`);
+  } catch (err) {
+    await db.execute(sql`ROLLBACK`);
+    throw err;
+  }
+
+  const verify = await db.execute(sql`
+    SELECT customer_name,
+           COUNT(*)::int AS rows,
+           matched_customer_id
+      FROM mc_dispatch_staging
+     WHERE customer_name = 'Carol Butler'
+     GROUP BY customer_name, matched_customer_id
+  `);
+  console.log("Post-verify:");
+  console.table(verify.rows);
+}
+
+async function f2_3_createNewClients() {
+  console.log("\n=== F2.3 — Create 6 new clients for one-time MC customers ===");
+
+  // Preview the 6 source rows
+  const preview = await db.execute(sql`
+    SELECT DISTINCT ON (customer_name)
+           customer_name, phone, address
+      FROM mc_dispatch_staging
+     WHERE matched_customer_id IS NULL
+     ORDER BY customer_name, mc_job_id
+  `);
+  console.log("Source rows for new clients:");
+  console.table(preview.rows);
+  if ((preview.rowCount ?? 0) !== 6) {
+    throw new Error(`Expected 6 unmatched unique customer_names, got ${preview.rowCount}`);
+  }
+
+  await db.execute(sql`BEGIN`);
+  try {
+    const res = await db.execute(sql`
+      INSERT INTO clients (
+        company_id, first_name, last_name, phone, address,
+        is_active, notes, client_type, created_at
+      )
+      SELECT
+        1 AS company_id,
+        -- first_name = everything before the LAST space
+        CASE
+          WHEN POSITION(' ' IN customer_name) > 0
+          THEN SUBSTRING(customer_name FROM 1
+                         FOR LENGTH(customer_name) - POSITION(' ' IN REVERSE(customer_name)))
+          ELSE customer_name
+        END AS first_name,
+        -- last_name = everything after the LAST space
+        CASE
+          WHEN POSITION(' ' IN customer_name) > 0
+          THEN SUBSTRING(customer_name FROM
+                         LENGTH(customer_name) - POSITION(' ' IN REVERSE(customer_name)) + 2)
+          ELSE ''
+        END AS last_name,
+        phone,
+        address,
+        false AS is_active,
+        ${MIG_NOTE} AS notes,
+        'residential'::client_type AS client_type,
+        NOW() AS created_at
+      FROM (
+        SELECT DISTINCT ON (customer_name) customer_name, phone, address
+          FROM mc_dispatch_staging
+         WHERE matched_customer_id IS NULL
+         ORDER BY customer_name, mc_job_id
+      ) unmatched
+      RETURNING id, first_name, last_name, phone, address
+    `);
+    console.log(`INSERT rowcount: ${res.rowCount} (expect 6)`);
+    console.log("Newly created rows:");
+    console.table(res.rows);
+
+    if (res.rowCount !== 6) {
+      throw new Error(`INSERT rowcount mismatch: ${res.rowCount}`);
+    }
+
+    // Sanity: every new row should have non-empty first_name AND last_name
+    for (const r of res.rows as any[]) {
+      if (!r.first_name || !r.last_name) {
+        throw new Error(
+          `Name split produced empty first/last for id=${r.id}: ` +
+          `first='${r.first_name}' last='${r.last_name}'`
+        );
+      }
+    }
+    console.log("All 6 new clients have valid first+last names. Proceeding to COMMIT.");
+    await db.execute(sql`COMMIT`);
+  } catch (err) {
+    await db.execute(sql`ROLLBACK`);
+    console.log("--- ROLLBACK (F2.3) ---");
+    throw err;
+  }
+}
+
+async function f2_4_linkNewClients() {
+  console.log("\n=== F2.4 — Link 6 new clients back to staging ===");
+  await db.execute(sql`BEGIN`);
+  try {
+    const res = await db.execute(sql`
+      UPDATE mc_dispatch_staging s
+         SET matched_customer_id = c.id
+        FROM clients c
+       WHERE c.company_id = 1
+         AND c.notes = ${MIG_NOTE}
+         AND s.matched_customer_id IS NULL
+         AND LOWER(TRIM(s.customer_name))
+           = LOWER(TRIM(COALESCE(c.first_name,'') || ' ' || COALESCE(c.last_name,'')))
+    `);
+    console.log(`UPDATE rowcount: ${res.rowCount} (expect 6)`);
+    if (res.rowCount !== 6) throw new Error(`rowcount mismatch: ${res.rowCount}`);
+    await db.execute(sql`COMMIT`);
+  } catch (err) {
+    await db.execute(sql`ROLLBACK`);
+    throw err;
+  }
+
+  const unmatched = await db.execute(sql`
+    SELECT COUNT(*)::int AS unmatched_rows,
+           COUNT(DISTINCT customer_name)::int AS unmatched_unique_names
+      FROM mc_dispatch_staging
+     WHERE matched_customer_id IS NULL
+  `);
+  console.log("Final unmatched state:");
+  console.table(unmatched.rows);
+  const row = unmatched.rows?.[0] as any;
+  const unmN = Number(row?.unmatched_rows ?? -1);
+  if (unmN !== 0) {
+    throw new Error(`Expected 0 unmatched, got ${unmN}`);
+  }
+  console.log("✓ Zero unmatched. All 983 rows linked.");
+}
+
+async function f2_5_qualitySummary() {
+  console.log("\n=== F2.5 — Final match quality summary ===");
+
+  const linked = await db.execute(sql`
+    SELECT COUNT(DISTINCT matched_customer_id)::int AS qleno_clients_with_mc_history
+      FROM mc_dispatch_staging
+  `);
+  console.table(linked.rows);
+
+  console.log("\nAny MC customer_name → multiple customer_ids? (should be 0):");
+  const multi = await db.execute(sql`
+    SELECT customer_name, COUNT(DISTINCT matched_customer_id)::int AS distinct_matches
+      FROM mc_dispatch_staging
+     GROUP BY customer_name
+    HAVING COUNT(DISTINCT matched_customer_id) > 1
+  `);
+  if ((multi.rowCount ?? 0) === 0) console.log("  (none — clean)");
+  else console.table(multi.rows);
+
+  console.log("\nTop 10 customers by MC job count:");
+  const top = await db.execute(sql`
+    SELECT s.matched_customer_id,
+           COALESCE(c.first_name,'') || ' ' || COALESCE(c.last_name,'') AS name,
+           COUNT(*)::int AS jobs,
+           SUM(s.bill_rate)::numeric(14,2) AS total_rev
+      FROM mc_dispatch_staging s
+      LEFT JOIN clients c ON c.id = s.matched_customer_id
+     GROUP BY s.matched_customer_id, c.first_name, c.last_name
+     ORDER BY jobs DESC
+     LIMIT 10
+  `);
+  console.table(top.rows);
+
+  // Spot the Tom and Carol Butler row
+  const butler = await db.execute(sql`
+    SELECT s.matched_customer_id,
+           COALESCE(c.first_name,'') || ' ' || COALESCE(c.last_name,'') AS name,
+           COUNT(*)::int AS jobs,
+           SUM(s.bill_rate)::numeric(14,2) AS total_rev,
+           ARRAY_AGG(DISTINCT s.customer_name) AS mc_names
+      FROM mc_dispatch_staging s
+      LEFT JOIN clients c ON c.id = s.matched_customer_id
+     WHERE s.matched_customer_id = 22
+     GROUP BY s.matched_customer_id, c.first_name, c.last_name
+  `);
+  console.log("\nSpotlight — client id=22 after Carol Butler alias:");
+  console.table(butler.rows);
+
+  // Spot the 6 new client rows
+  const newSpot = await db.execute(sql`
+    SELECT c.id, c.first_name, c.last_name, c.phone, c.address, c.is_active,
+           (SELECT COUNT(*)::int FROM mc_dispatch_staging s WHERE s.matched_customer_id = c.id) AS mc_jobs_linked
+      FROM clients c
+     WHERE c.company_id = 1 AND c.notes = ${MIG_NOTE}
+     ORDER BY c.id
+  `);
+  console.log("\nSpotlight — 6 new clients:");
+  console.table(newSpot.rows);
+}
+
+async function main() {
+  console.log("=== L2 fix — Option A ===");
+  await f2_1_backfillClient22();
+  await f2_2_mapCarolButler();
+  await f2_3_createNewClients();
+  await f2_4_linkNewClients();
+  await f2_5_qualitySummary();
+  console.log("\nL2 fix complete. Ready to commit.");
+  process.exit(0);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/l2_schema_probe.ts
+++ b/artifacts/api-server/scripts/l2_schema_probe.ts
@@ -1,0 +1,33 @@
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+async function main() {
+  // Schema probe for clients table
+  const cols = await db.execute(sql`
+    SELECT column_name, data_type, is_nullable, column_default
+      FROM information_schema.columns
+     WHERE table_name = 'clients' AND table_schema = 'public'
+     ORDER BY ordinal_position
+  `);
+  console.log("clients columns:");
+  console.table(cols.rows);
+
+  // Check which specifically matter
+  const check = await db.execute(sql`
+    SELECT column_name FROM information_schema.columns
+     WHERE table_name='clients' AND table_schema='public'
+       AND column_name IN ('migration_source','updated_at','created_at','is_active','client_type','source')
+  `);
+  console.log("\nInteresting columns present:");
+  console.table(check.rows);
+
+  // Inspect client id=22 current state
+  const c22 = await db.execute(sql`
+    SELECT * FROM clients WHERE id = 22
+  `);
+  console.log("\nClient id=22 row:");
+  console.log(c22.rows);
+
+  process.exit(0);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/l2_unmatched_probe.ts
+++ b/artifacts/api-server/scripts/l2_unmatched_probe.ts
@@ -1,0 +1,91 @@
+/**
+ * L2 — targeted probes for the 7 unmatched customers. READ-ONLY.
+ */
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+async function main() {
+  // 1. Carol Butler — is this "Tom and Carol Butler" id=22?
+  console.log("=== Probe 1: Carol Butler cross-check ===");
+  const carolProbe = await db.execute(sql`
+    SELECT id,
+           first_name || ' ' || last_name AS name,
+           phone, address, is_active
+      FROM clients
+     WHERE company_id = 1
+       AND (LOWER(first_name || ' ' || last_name) LIKE '%butler%'
+            OR LOWER(COALESCE(company_name,'')) LIKE '%butler%'
+            OR phone LIKE '%301-5678%'
+            OR address ILIKE '%121 N Garfield%'
+            OR address ILIKE '%121 north garfield%')
+     ORDER BY id
+  `);
+  console.table(carolProbe.rows);
+
+  // 2. For each unmatched name, search by last_name only and by phone digits
+  console.log("\n=== Probe 2: last-name + phone-digit wildcards for each unmatched ===");
+  const names = [
+    ["Connie Castillo", "Castillo", "773-266-9673"],
+    ["Falana Smart", "Smart", "313-722-5035"],
+    ["Lauren Covalle", "Covalle", "586-292-7152"],
+    ["Lauren Kent", "Kent", "773-354-7896"],
+    ["Mackenzie Dongmo", "Dongmo", "872-310-8477"],
+    ["Peter Nicieja", "Nicieja", "773-598-0216"],
+  ];
+  for (const [mcName, lastName, phone] of names) {
+    const digits = phone.replace(/\D/g, "");
+    const probe = await db.execute(sql`
+      SELECT id,
+             first_name || ' ' || last_name AS name,
+             phone,
+             LEFT(COALESCE(address,''), 40) AS addr,
+             is_active
+        FROM clients
+       WHERE company_id = 1
+         AND (
+           LOWER(last_name) = LOWER(${lastName})
+           OR REGEXP_REPLACE(COALESCE(phone,''), '[^0-9]', '', 'g') LIKE ${'%' + digits.slice(-7) + '%'}
+         )
+       LIMIT 5
+    `);
+    console.log(`\nMC "${mcName}" (last=${lastName}, ph=${phone}) → ${probe.rowCount ?? 0} hits`);
+    if ((probe.rowCount ?? 0) > 0) console.table(probe.rows);
+  }
+
+  // 3. Address-level probes on unmatched
+  console.log("\n=== Probe 3: address-based probes for each unmatched ===");
+  const addrs = [
+    "121 N Garfield",
+    "96 Foxfire",
+    "9955 Nottingham",
+    "11411 South Ewing",
+    "6214 South Champlain",
+    "5009 North Sheridan",
+    "4455 North Hamilton",
+  ];
+  for (const a of addrs) {
+    const probe = await db.execute(sql`
+      SELECT id, first_name || ' ' || last_name AS name,
+             phone, LEFT(COALESCE(address,''), 50) AS addr
+        FROM clients
+       WHERE company_id = 1 AND address ILIKE ${'%' + a + '%'}
+       LIMIT 5
+    `);
+    console.log(`\nAddr "${a}" → ${probe.rowCount ?? 0} hits`);
+    if ((probe.rowCount ?? 0) > 0) console.table(probe.rows);
+  }
+
+  // 4. Recurring schedules for these unmatched names (are any of them active schedules?)
+  console.log("\n=== Probe 4: any MC frequency suggests recurring? ===");
+  const freq = await db.execute(sql`
+    SELECT customer_name, frequency, COUNT(*)::int AS jobs, SUM(bill_rate)::numeric(14,2) AS total
+      FROM mc_dispatch_staging
+     WHERE matched_customer_id IS NULL
+     GROUP BY customer_name, frequency
+     ORDER BY customer_name, jobs DESC
+  `);
+  console.table(freq.rows);
+
+  process.exit(0);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/l3_1_delia_fix.ts
+++ b/artifacts/api-server/scripts/l3_1_delia_fix.ts
@@ -1,0 +1,228 @@
+/**
+ * L3.1 — Create Delia Martinez as inactive tech + re-parse her 33 staging rows.
+ *
+ * D.2  INSERT users row for Delia (is_active=false, synthetic unloginable email)
+ * D.3  Re-parse parsed_techs to include Delia's new user id on the 33 rows
+ * D.4  Verify distribution
+ */
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+import { randomBytes } from "node:crypto";
+
+// Same tech roster as L3 plus Delia — sorted below by DESC name length.
+// userId for Delia is filled in at runtime after the INSERT.
+const TECH_ROSTER = (deliaId: number) => [
+  { name: "Norma Guerrero Puga", userId: 32 },
+  { name: "Alejandra Cuervo",    userId: 41 },
+  { name: "Guadalupe Mejia",     userId: 40 },
+  { name: "Tatiana Merchan",     userId: 33 },
+  { name: "Delia Martinez",      userId: deliaId }, // <-- now populated
+  { name: "Juliana Loredo",      userId: 42 },
+  { name: "Diana Vasquez",       userId: 38 },
+  { name: "Rosa Gallegos",       userId: 36 },
+  { name: "Alma Salinas",        userId: 39 },
+  { name: "Juan Salazar",        userId: 43 },
+  { name: "Norma Puga",          userId: 32 }, // short form
+  { name: "Ana Valdez",          userId: 34 },
+];
+const PLACEHOLDER = "Cleaner";
+
+function parseTeam(raw: string | null, roster: Array<{ name: string; userId: number }>): { ids: number[]; unparsed: string | null } {
+  if (!raw) return { ids: [], unparsed: null };
+  let remaining = raw.trim().replace(/\s+/g, " ");
+  const ids: number[] = [];
+  const sorted = [...roster].sort((a, b) => b.name.length - a.name.length);
+  while (remaining.length > 0) {
+    let matched = false;
+    for (const t of sorted) {
+      if (remaining === t.name || remaining.startsWith(t.name + " ")) {
+        if (t.userId > 0) ids.push(t.userId);
+        remaining = remaining.slice(t.name.length).trim();
+        matched = true;
+        break;
+      }
+    }
+    if (matched) continue;
+    if (remaining === PLACEHOLDER || remaining.startsWith(PLACEHOLDER + " ")) {
+      remaining = remaining.slice(PLACEHOLDER.length).trim();
+      continue;
+    }
+    return { ids, unparsed: remaining };
+  }
+  return { ids, unparsed: null };
+}
+
+async function d2_insertDelia(): Promise<number> {
+  console.log("=== D.2 — Insert Delia Martinez ===");
+
+  // Guard: is she already present? Idempotent if someone re-runs.
+  const existing = await db.execute(sql`
+    SELECT id FROM users
+     WHERE company_id = 1
+       AND LOWER(first_name) = 'delia'
+       AND LOWER(last_name) = 'martinez'
+  `);
+  if ((existing.rowCount ?? 0) > 0) {
+    const id = Number((existing.rows?.[0] as any).id);
+    console.log(`Delia already exists, id=${id}. Skipping INSERT.`);
+    return id;
+  }
+
+  // Generate a 32-char hex placeholder like other imported users
+  const placeholder = `IMPORT_PLACEHOLDER_${randomBytes(16).toString("hex")}`;
+  const syntheticEmail = "delia.martinez.former@phes.internal";
+
+  await db.execute(sql`BEGIN`);
+  try {
+    const res = await db.execute(sql`
+      INSERT INTO users (
+        company_id, email, password_hash, role,
+        first_name, last_name, is_active, pay_type,
+        notes, created_at
+      ) VALUES (
+        1,
+        ${syntheticEmail},
+        ${placeholder},
+        'technician',
+        'Delia', 'Martinez', false, 'hourly',
+        '[mc_import_phase3 2026-04-22 former employee]',
+        NOW()
+      )
+      RETURNING id, first_name, last_name, role, is_active, email, notes
+    `);
+    console.log("INSERT RETURNING:");
+    console.table(res.rows);
+    const newId = Number((res.rows?.[0] as any)?.id);
+    if (!newId || newId <= 0) throw new Error("INSERT did not return a valid id");
+    await db.execute(sql`COMMIT`);
+    console.log(`Delia Martinez created with user id=${newId}`);
+    return newId;
+  } catch (err) {
+    await db.execute(sql`ROLLBACK`);
+    console.log("--- ROLLBACK ---");
+    throw err;
+  }
+}
+
+async function d3_reparseTechs(deliaId: number) {
+  console.log(`\n=== D.3 — Re-parse staging rows with Delia id=${deliaId} ===`);
+
+  const roster = TECH_ROSTER(deliaId);
+
+  // Only need to update rows where team_raw contains Delia
+  const deliaRows = await db.execute(sql`
+    SELECT mc_job_id, team_raw, parsed_techs::text AS parsed_techs_before
+      FROM mc_dispatch_staging
+     WHERE team_raw ILIKE '%Delia%'
+     ORDER BY mc_job_id
+  `);
+  console.log(`Rows containing 'Delia' in team_raw: ${deliaRows.rowCount} (expect 33)`);
+
+  const updates: Array<{ mc_job_id: number; oldIds: number[]; newIds: number[]; team_raw: string }> = [];
+  let unparsed = 0;
+  for (const r of deliaRows.rows as any[]) {
+    const p = parseTeam(r.team_raw, roster);
+    if (p.unparsed !== null) {
+      unparsed++;
+      console.log(`UNPARSED mc_job_id=${r.mc_job_id} team_raw='${r.team_raw}' remaining='${p.unparsed}'`);
+      continue;
+    }
+    const oldIds = JSON.parse(r.parsed_techs_before || "[]");
+    updates.push({
+      mc_job_id: Number(r.mc_job_id),
+      oldIds,
+      newIds: p.ids,
+      team_raw: r.team_raw,
+    });
+  }
+  if (unparsed > 0) throw new Error(`${unparsed} rows failed to re-parse`);
+
+  // Spot a few before applying
+  console.log("\nSample (first 10 updates):");
+  console.table(updates.slice(0, 10).map(u => ({
+    mc_job_id: u.mc_job_id,
+    team_raw: u.team_raw,
+    old: u.oldIds.join(","),
+    new: u.newIds.join(","),
+  })));
+
+  // Apply updates
+  await db.execute(sql`BEGIN`);
+  try {
+    let done = 0;
+    for (const u of updates) {
+      await db.execute(sql`
+        UPDATE mc_dispatch_staging
+           SET parsed_techs = ${JSON.stringify(u.newIds)}::jsonb
+         WHERE mc_job_id = ${u.mc_job_id}
+      `);
+      done++;
+    }
+    console.log(`\nUPDATE rowcount: ${done} (expect ${updates.length})`);
+    await db.execute(sql`COMMIT`);
+  } catch (err) {
+    await db.execute(sql`ROLLBACK`);
+    throw err;
+  }
+}
+
+async function d4_verify() {
+  console.log("\n=== D.4 — Post-reparse verification ===");
+  const dist = await db.execute(sql`
+    SELECT JSONB_ARRAY_LENGTH(parsed_techs)::int AS tech_count,
+           COUNT(*)::int AS rows
+      FROM mc_dispatch_staging
+     GROUP BY 1
+     ORDER BY 1
+  `);
+  console.log("Updated tech-count distribution:");
+  console.table(dist.rows);
+
+  const totalAssignments = await db.execute(sql`
+    SELECT SUM(JSONB_ARRAY_LENGTH(parsed_techs))::int AS total_assignments
+      FROM mc_dispatch_staging
+  `);
+  console.log("Total tech assignments:", totalAssignments.rows);
+
+  // Spot-check: sample Delia rows
+  const sample = await db.execute(sql`
+    SELECT mc_job_id, team_raw, parsed_techs
+      FROM mc_dispatch_staging
+     WHERE team_raw ILIKE '%Delia%'
+     ORDER BY mc_job_id
+     LIMIT 10
+  `);
+  console.log("\nSample Delia-team rows after re-parse:");
+  console.table(sample.rows);
+
+  // Confirm total still 983 and 0 unparsed
+  const integrity = await db.execute(sql`
+    SELECT COUNT(*)::int AS total,
+           COUNT(parsed_techs)::int AS with_techs,
+           COUNT(*) FILTER (WHERE parsed_techs IS NULL)::int AS null_techs
+      FROM mc_dispatch_staging
+  `);
+  console.log("\nIntegrity:");
+  console.table(integrity.rows);
+
+  // Coverage by row containing each tech id
+  const deliaCoverage = await db.execute(sql`
+    SELECT COUNT(*)::int AS delia_rows
+      FROM mc_dispatch_staging
+     WHERE parsed_techs @> (
+       SELECT JSONB_BUILD_ARRAY(id) FROM users WHERE company_id=1 AND first_name='Delia' AND last_name='Martinez'
+     )
+  `);
+  console.log("\nRows now assigned to Delia:");
+  console.table(deliaCoverage.rows);
+}
+
+async function main() {
+  console.log("=== L3.1 — Delia Martinez fix ===");
+  const deliaId = await d2_insertDelia();
+  await d3_reparseTechs(deliaId);
+  await d4_verify();
+  console.log("\nL3.1 complete.");
+  process.exit(0);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/l3_1_delia_probe.ts
+++ b/artifacts/api-server/scripts/l3_1_delia_probe.ts
@@ -1,0 +1,44 @@
+/**
+ * L3.1 — users schema probe + tech user shape sample. READ-ONLY.
+ */
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+async function main() {
+  console.log("=== D.1 — users table schema ===");
+  const cols = await db.execute(sql`
+    SELECT column_name, data_type, is_nullable, column_default
+      FROM information_schema.columns
+     WHERE table_name = 'users' AND table_schema = 'public'
+     ORDER BY ordinal_position
+  `);
+  console.table(cols.rows);
+
+  console.log("\n=== D.1b — existing tech users (full row shape) ===");
+  const techs = await db.execute(sql`
+    SELECT * FROM users
+     WHERE company_id = 1 AND role = 'technician'
+     ORDER BY id
+     LIMIT 3
+  `);
+  console.log(techs.rows);
+
+  console.log("\n=== D.1c — NOT NULL columns without defaults (required on insert) ===");
+  const required = await db.execute(sql`
+    SELECT column_name, data_type
+      FROM information_schema.columns
+     WHERE table_name = 'users' AND table_schema = 'public'
+       AND is_nullable = 'NO'
+       AND column_default IS NULL
+     ORDER BY ordinal_position
+  `);
+  console.table(required.rows);
+
+  // Sample full row for one tech to see what field values look like
+  console.log("\n=== D.1d — existing Norma Puga (id=32) full row ===");
+  const norma = await db.execute(sql`SELECT * FROM users WHERE id = 32`);
+  console.log(norma.rows);
+
+  process.exit(0);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/l3_inspect.ts
+++ b/artifacts/api-server/scripts/l3_inspect.ts
@@ -1,0 +1,125 @@
+/**
+ * L3 — Phase 3 inspection. READ-ONLY.
+ *  3.1  recurring_schedules frequency enum + counts
+ *  3.3a employees/users table for tech name → id mapping
+ *  3.4  jobs.status enum values
+ *  bonus: recurring_schedules column names (customer_id vs client_id)
+ */
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+async function main() {
+  console.log("\n=== 3.1a — recurring_schedules distinct frequencies (company_id=1) ===");
+  const rsFreq = await db.execute(sql`
+    SELECT DISTINCT frequency
+      FROM recurring_schedules
+     WHERE company_id = 1
+     ORDER BY frequency
+  `);
+  console.table(rsFreq.rows);
+
+  console.log("\n=== 3.1b — frequency column enum (if any) ===");
+  const enumVals = await db.execute(sql`
+    SELECT t.typname, e.enumlabel
+      FROM pg_type t
+      JOIN pg_enum e ON t.oid = e.enumtypid
+     WHERE t.typname ILIKE '%frequency%'
+       OR e.enumlabel IN ('weekly','biweekly','triweekly','monthly','custom','one_time','single')
+     ORDER BY t.typname, e.enumsortorder
+  `);
+  console.table(enumVals.rows);
+
+  console.log("\n=== 3.1c — Schedule counts per frequency ===");
+  const rsCnt = await db.execute(sql`
+    SELECT frequency,
+           COUNT(*)::int AS schedules,
+           COUNT(DISTINCT customer_id)::int AS unique_clients
+      FROM recurring_schedules
+     WHERE company_id = 1 AND is_active = true
+     GROUP BY frequency
+     ORDER BY 2 DESC
+  `);
+  console.table(rsCnt.rows);
+
+  console.log("\n=== 3.1d — Clients with >1 active schedule (multi-schedule tiebreaker) ===");
+  const multi = await db.execute(sql`
+    SELECT customer_id,
+           COUNT(*)::int AS schedule_count,
+           ARRAY_AGG(id ORDER BY created_at, id) AS schedule_ids,
+           ARRAY_AGG(frequency ORDER BY created_at, id) AS frequencies
+      FROM recurring_schedules
+     WHERE company_id = 1 AND is_active = true
+     GROUP BY customer_id
+     HAVING COUNT(*) > 1
+     ORDER BY COUNT(*) DESC, customer_id
+     LIMIT 20
+  `);
+  console.table(multi.rows);
+
+  console.log("\n=== 3.3a — employees OR users with technician role (company_id=1) ===");
+  // Try employees first, fall back to users
+  let techRows: any[] = [];
+  try {
+    const emp = await db.execute(sql`
+      SELECT id, first_name, last_name,
+             (first_name || ' ' || last_name) AS full_name
+        FROM employees
+       WHERE company_id = 1
+       ORDER BY first_name, last_name
+    `);
+    console.log("(using employees table)");
+    techRows = emp.rows as any[];
+    console.table(techRows);
+  } catch (err: any) {
+    console.log("employees table not queryable, trying users...", err?.code ?? "");
+    const users = await db.execute(sql`
+      SELECT id, first_name, last_name, role, is_active, tags,
+             (first_name || ' ' || last_name) AS full_name
+        FROM users
+       WHERE company_id = 1
+         AND is_active = true
+         AND (
+           role IN ('technician','team_lead')
+           OR (COALESCE(tags, '{}') && ARRAY['field','technician']::text[])
+         )
+       ORDER BY first_name, last_name
+    `);
+    console.log("(using users table with technician/team_lead/tagged roles)");
+    techRows = users.rows as any[];
+    console.table(techRows);
+  }
+
+  console.log("\n=== 3.4a — jobs.status enum values ===");
+  const jobStatus = await db.execute(sql`
+    SELECT t.typname, e.enumlabel, e.enumsortorder
+      FROM pg_type t
+      JOIN pg_enum e ON t.oid = e.enumtypid
+     WHERE t.typname = 'job_status'
+        OR e.enumlabel IN ('scheduled','complete','completed','in_progress','cancelled','pending')
+     ORDER BY t.typname, e.enumsortorder
+  `);
+  console.table(jobStatus.rows);
+
+  console.log("\n=== 3.4b — Distinct jobs.status currently present in table ===");
+  const jobDistinct = await db.execute(sql`
+    SELECT status::text, COUNT(*)::int AS n
+      FROM jobs
+     GROUP BY status
+     ORDER BY n DESC
+  `);
+  console.table(jobDistinct.rows);
+
+  // Bonus: confirm the FK column name on recurring_schedules is customer_id
+  console.log("\n=== bonus — recurring_schedules customer/client column ===");
+  const rsCols = await db.execute(sql`
+    SELECT column_name, data_type
+      FROM information_schema.columns
+     WHERE table_name = 'recurring_schedules' AND table_schema = 'public'
+       AND column_name IN ('customer_id','client_id','frequency','is_active','assigned_employee_id')
+     ORDER BY ordinal_position
+  `);
+  console.table(rsCols.rows);
+
+  process.exit(0);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/l3_main.ts
+++ b/artifacts/api-server/scripts/l3_main.ts
@@ -1,0 +1,309 @@
+/**
+ * L3 — MC dispatch Phase 3.
+ *   3.2  Schedule linking   (UPDATE matched_schedule_id)
+ *   3.3  Tech parsing       (UPDATE parsed_techs JSONB)
+ *   3.4  Status mapping     (UPDATE mapped_status)
+ *   3.5  Final integrity + April 22-30 reconciliation
+ *
+ * Writes only to mc_dispatch_staging. jobs / recurring_schedules / clients
+ * are read-only here.
+ */
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+// Known tech roster — MC name form on left, Qleno users.id on right.
+// Sorted DESC by name length for greedy prefix matching in the parser.
+const TECHS: Array<{ name: string; userId: number | null }> = [
+  { name: "Norma Guerrero Puga", userId: 32 }, // DB has "Norma Puga" id=32
+  { name: "Alejandra Cuervo",    userId: 41 },
+  { name: "Guadalupe Mejia",     userId: 40 },
+  { name: "Tatiana Merchan",     userId: 33 },
+  { name: "Delia Martinez",      userId: null }, // not in users — drop like Cleaner
+  { name: "Juliana Loredo",      userId: 42 },
+  { name: "Diana Vasquez",       userId: 38 },
+  { name: "Rosa Gallegos",       userId: 36 },
+  { name: "Alma Salinas",        userId: 39 },
+  { name: "Juan Salazar",        userId: 43 },
+  { name: "Norma Puga",          userId: 32 }, // short form fallback (none in data, but safe)
+  { name: "Ana Valdez",          userId: 34 },
+];
+const PLACEHOLDER = "Cleaner";
+
+function parseTeam(raw: string | null): { ids: number[]; unparsed: string | null } {
+  if (!raw) return { ids: [], unparsed: null };
+  let remaining = raw.trim().replace(/\s+/g, " ");
+  const ids: number[] = [];
+  const sorted = [...TECHS].sort((a, b) => b.name.length - a.name.length);
+  while (remaining.length > 0) {
+    let matched = false;
+    for (const t of sorted) {
+      if (remaining === t.name || remaining.startsWith(t.name + " ")) {
+        if (t.userId != null) ids.push(t.userId);
+        remaining = remaining.slice(t.name.length).trim();
+        matched = true;
+        break;
+      }
+    }
+    if (matched) continue;
+    if (remaining === PLACEHOLDER || remaining.startsWith(PLACEHOLDER + " ")) {
+      remaining = remaining.slice(PLACEHOLDER.length).trim();
+      continue;
+    }
+    return { ids, unparsed: remaining };
+  }
+  return { ids, unparsed: null };
+}
+
+async function step3_2_linkSchedules() {
+  console.log("\n=== 3.2 — Schedule linking ===");
+  // MC freq → Qleno freq. Qleno enum = {weekly, biweekly, monthly, custom}.
+  // "Every Three Weeks" → custom (no triweekly enum).
+  // "Other Recurring" → custom.
+  // "Single" / "On Demand" → NULL (no link).
+  await db.execute(sql`BEGIN`);
+  try {
+    const res = await db.execute(sql`
+      UPDATE mc_dispatch_staging s
+         SET matched_schedule_id = sub.schedule_id
+        FROM (
+          SELECT DISTINCT ON (st.mc_job_id)
+                 st.mc_job_id,
+                 rs.id AS schedule_id
+            FROM mc_dispatch_staging st
+            JOIN recurring_schedules rs
+              ON rs.customer_id = st.matched_customer_id
+             AND rs.company_id = 1
+             AND rs.is_active = true
+             AND rs.frequency::text = CASE st.frequency
+                   WHEN 'Every Week'        THEN 'weekly'
+                   WHEN 'Every Two Weeks'   THEN 'biweekly'
+                   WHEN 'Every Four Weeks'  THEN 'monthly'
+                   WHEN 'Every Three Weeks' THEN 'custom'
+                   WHEN 'Other Recurring'   THEN 'custom'
+                   ELSE NULL
+                 END
+           WHERE st.frequency NOT IN ('Single', 'On Demand')
+             AND st.matched_customer_id IS NOT NULL
+           ORDER BY st.mc_job_id, rs.created_at ASC, rs.id ASC
+        ) sub
+       WHERE s.mc_job_id = sub.mc_job_id
+    `);
+    console.log(`UPDATE rowcount: ${res.rowCount}`);
+    await db.execute(sql`COMMIT`);
+  } catch (err) {
+    await db.execute(sql`ROLLBACK`);
+    throw err;
+  }
+
+  const rate = await db.execute(sql`
+    SELECT frequency,
+           COUNT(*)::int AS total_rows,
+           COUNT(matched_schedule_id)::int AS linked,
+           (COUNT(*) - COUNT(matched_schedule_id))::int AS unlinked
+      FROM mc_dispatch_staging
+     GROUP BY frequency
+     ORDER BY total_rows DESC
+  `);
+  console.log("\nLinking rate per MC frequency:");
+  console.table(rate.rows);
+
+  // Unlinked recurring (informational — these have MC history but no matching Qleno schedule)
+  const orphan = await db.execute(sql`
+    SELECT s.customer_name,
+           s.frequency,
+           COUNT(*)::int AS n,
+           s.matched_customer_id
+      FROM mc_dispatch_staging s
+     WHERE s.matched_schedule_id IS NULL
+       AND s.frequency NOT IN ('Single', 'On Demand')
+     GROUP BY s.customer_name, s.frequency, s.matched_customer_id
+     ORDER BY n DESC, customer_name
+     LIMIT 40
+  `);
+  console.log(`\nUnlinked recurring rows (informational): ${orphan.rowCount} distinct (customer, freq) pairs`);
+  console.table(orphan.rows);
+
+  // Summary: unlinked breakdown by MC frequency
+  const orphanBreakdown = await db.execute(sql`
+    SELECT s.frequency,
+           COUNT(*)::int AS unlinked_rows,
+           COUNT(DISTINCT s.matched_customer_id)::int AS unlinked_clients
+      FROM mc_dispatch_staging s
+     WHERE s.matched_schedule_id IS NULL
+       AND s.frequency NOT IN ('Single', 'On Demand')
+     GROUP BY s.frequency
+     ORDER BY unlinked_rows DESC
+  `);
+  console.log("\nUnlinked-recurring breakdown by frequency:");
+  console.table(orphanBreakdown.rows);
+}
+
+async function step3_3_parseTechs() {
+  console.log("\n=== 3.3 — Tech parsing ===");
+
+  const rows = await db.execute(sql`
+    SELECT mc_job_id, team_raw
+      FROM mc_dispatch_staging
+     ORDER BY mc_job_id
+  `);
+  const allRows = rows.rows as any[];
+  console.log(`Rows to parse: ${allRows.length}`);
+
+  let unparsed = 0;
+  const sampleUnparsed: any[] = [];
+  const parsed: Array<{ mc_job_id: number; ids: number[] }> = [];
+
+  for (const r of allRows) {
+    const p = parseTeam(r.team_raw);
+    if (p.unparsed !== null) {
+      unparsed++;
+      if (sampleUnparsed.length < 10) {
+        sampleUnparsed.push({ mc_job_id: r.mc_job_id, team_raw: r.team_raw, remaining: p.unparsed });
+      }
+    }
+    parsed.push({ mc_job_id: Number(r.mc_job_id), ids: p.ids });
+  }
+  console.log(`Unparsed: ${unparsed} (expect 0)`);
+  if (unparsed > 0) {
+    console.log("Sample:");
+    console.table(sampleUnparsed);
+    throw new Error(`Tech parser failed on ${unparsed} rows`);
+  }
+
+  // Bulk update — chunked UPDATE VALUES
+  const chunkSize = 200;
+  await db.execute(sql`BEGIN`);
+  try {
+    let done = 0;
+    for (let off = 0; off < parsed.length; off += chunkSize) {
+      const chunk = parsed.slice(off, off + chunkSize);
+      for (const p of chunk) {
+        await db.execute(sql`
+          UPDATE mc_dispatch_staging
+             SET parsed_techs = ${JSON.stringify(p.ids)}::jsonb
+           WHERE mc_job_id = ${p.mc_job_id}
+        `);
+        done++;
+      }
+      console.log(`  ...updated ${done}/${parsed.length}`);
+    }
+    await db.execute(sql`COMMIT`);
+  } catch (err) {
+    await db.execute(sql`ROLLBACK`);
+    throw err;
+  }
+
+  const dist = await db.execute(sql`
+    SELECT JSONB_ARRAY_LENGTH(parsed_techs)::int AS tech_count,
+           COUNT(*)::int AS rows
+      FROM mc_dispatch_staging
+     GROUP BY 1
+     ORDER BY 1
+  `);
+  console.log("\nTech-count distribution:");
+  console.table(dist.rows);
+
+  const totalAssignments = await db.execute(sql`
+    SELECT SUM(JSONB_ARRAY_LENGTH(parsed_techs))::int AS total_assignments
+      FROM mc_dispatch_staging
+  `);
+  console.log("Total tech assignments:", totalAssignments.rows);
+
+  const nullTechs = await db.execute(sql`
+    SELECT COUNT(*)::int AS n
+      FROM mc_dispatch_staging
+     WHERE parsed_techs IS NULL
+  `);
+  console.log(`Rows with NULL parsed_techs: ${(nullTechs.rows?.[0] as any)?.n} (should be 0)`);
+}
+
+async function step3_4_mapStatus() {
+  console.log("\n=== 3.4 — Status mapping ===");
+  await db.execute(sql`BEGIN`);
+  try {
+    const res = await db.execute(sql`
+      UPDATE mc_dispatch_staging
+         SET mapped_status = CASE status_raw
+               WHEN 'Closed'      THEN 'complete'
+               WHEN 'Completed'   THEN 'complete'
+               WHEN 'Pending'     THEN 'scheduled'
+               WHEN 'In Progress' THEN 'in_progress'
+               ELSE NULL
+             END
+    `);
+    console.log(`UPDATE rowcount: ${res.rowCount} (expect 983)`);
+    if (res.rowCount !== 983) throw new Error(`rowcount mismatch: ${res.rowCount}`);
+    await db.execute(sql`COMMIT`);
+  } catch (err) {
+    await db.execute(sql`ROLLBACK`);
+    throw err;
+  }
+
+  const dist = await db.execute(sql`
+    SELECT status_raw, mapped_status, COUNT(*)::int AS n
+      FROM mc_dispatch_staging
+     GROUP BY status_raw, mapped_status
+     ORDER BY status_raw
+  `);
+  console.log("\nStatus mapping distribution:");
+  console.table(dist.rows);
+
+  const nulls = await db.execute(sql`
+    SELECT COUNT(*)::int AS n FROM mc_dispatch_staging WHERE mapped_status IS NULL
+  `);
+  console.log(`Rows with NULL mapped_status: ${(nulls.rows?.[0] as any)?.n} (should be 0)`);
+}
+
+async function step3_5_finalSummary() {
+  console.log("\n=== 3.5 — Final staging integrity ===");
+
+  const summary = await db.execute(sql`
+    SELECT
+      COUNT(*)::int AS total,
+      COUNT(matched_customer_id)::int AS with_customer,
+      COUNT(matched_schedule_id)::int AS with_schedule,
+      COUNT(parsed_techs)::int AS with_techs,
+      COUNT(mapped_status)::int AS with_status,
+      SUM(JSONB_ARRAY_LENGTH(COALESCE(parsed_techs, '[]'::jsonb)))::int AS total_tech_assignments,
+      MIN(scheduled_date)::text AS min_date,
+      MAX(scheduled_date)::text AS max_date,
+      SUM(bill_rate)::numeric(14,2) AS total_bill_rate
+    FROM mc_dispatch_staging
+  `);
+  console.table(summary.rows);
+
+  // Apr 22-30 reconciliation vs MC ground truth
+  const apr2230 = await db.execute(sql`
+    SELECT scheduled_date::text AS date,
+           COUNT(*)::int AS jobs,
+           SUM(bill_rate)::numeric(14,2) AS total
+      FROM mc_dispatch_staging
+     WHERE scheduled_date BETWEEN '2026-04-22' AND '2026-04-30'
+     GROUP BY scheduled_date
+     ORDER BY scheduled_date
+  `);
+  console.log("\nApril 22–30 daily distribution (MUST match MC ground truth):");
+  console.table(apr2230.rows);
+
+  // Sanity: every row ready for Phase 4
+  const ready = await db.execute(sql`
+    SELECT COUNT(*)::int AS n
+      FROM mc_dispatch_staging
+     WHERE matched_customer_id IS NOT NULL
+       AND mapped_status IS NOT NULL
+       AND parsed_techs IS NOT NULL
+       AND scheduled_date IS NOT NULL
+  `);
+  console.log(`\nRows fully ready for Phase 4 (all 4 required fields non-null): ${(ready.rows?.[0] as any)?.n} / 983`);
+}
+
+async function main() {
+  console.log("=== L3 — Phase 3 main ===");
+  await step3_2_linkSchedules();
+  await step3_3_parseTechs();
+  await step3_4_mapStatus();
+  await step3_5_finalSummary();
+  console.log("\nPhase 3 complete.");
+  process.exit(0);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/l3_team_audit.ts
+++ b/artifacts/api-server/scripts/l3_team_audit.ts
@@ -1,0 +1,118 @@
+/**
+ * L3 — team-name audit. READ-ONLY.
+ * Scans mc_dispatch_staging.team_raw for every unique string, then tries to
+ * match each against the known tech roster. Reports any unrecognized tokens.
+ */
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+// Primary techs — longest first for greedy match
+const TECHS: Array<{ name: string; userId: number }> = [
+  { name: "Norma Guerrero Puga", userId: 32 }, // MC uses 3-word form, DB is "Norma Puga"
+  { name: "Norma Puga", userId: 32 },          // fallback if short form appears
+  { name: "Alejandra Cuervo", userId: 41 },
+  { name: "Guadalupe Mejia", userId: 40 },
+  { name: "Tatiana Merchan", userId: 33 },
+  { name: "Juliana Loredo", userId: 42 },
+  { name: "Diana Vasquez", userId: 38 },
+  { name: "Delia Martinez", userId: -1 },       // placeholder — may not exist
+  { name: "Rosa Gallegos", userId: 36 },
+  { name: "Alma Salinas", userId: 39 },
+  { name: "Juan Salazar", userId: 43 },
+  { name: "Ana Valdez", userId: 34 },
+];
+const PLACEHOLDER = "Cleaner";
+
+function parseTeam(raw: string | null): { ids: number[]; unparsed: string | null } {
+  if (!raw) return { ids: [], unparsed: null };
+  let remaining = raw.trim().replace(/\s+/g, " ");
+  const ids: number[] = [];
+  // Sort: primary techs first (longest name first), then placeholder
+  const sortedNames = [...TECHS].sort((a, b) => b.name.length - a.name.length);
+  while (remaining.length > 0) {
+    let matched = false;
+    for (const t of sortedNames) {
+      if (remaining === t.name || remaining.startsWith(t.name + " ")) {
+        if (t.userId > 0) ids.push(t.userId);
+        remaining = remaining.slice(t.name.length).trim();
+        matched = true;
+        break;
+      }
+    }
+    if (!matched) {
+      if (remaining === PLACEHOLDER || remaining.startsWith(PLACEHOLDER + " ")) {
+        remaining = remaining.slice(PLACEHOLDER.length).trim();
+        matched = true;
+        continue;
+      }
+      return { ids, unparsed: remaining };
+    }
+  }
+  return { ids, unparsed: null };
+}
+
+async function main() {
+  // 1. Verify Delia Martinez — search in users
+  const delia = await db.execute(sql`
+    SELECT id, first_name, last_name, role, is_active, tags
+      FROM users
+     WHERE company_id = 1
+       AND (LOWER(first_name) = 'delia' OR LOWER(last_name) = 'martinez')
+     ORDER BY id
+  `);
+  console.log("=== Delia Martinez probe ===");
+  console.table(delia.rows);
+
+  // 2. Count rows by team_raw
+  const rows = await db.execute(sql`
+    SELECT team_raw, COUNT(*)::int AS n
+      FROM mc_dispatch_staging
+     GROUP BY team_raw
+     ORDER BY n DESC
+  `);
+  const teams = rows.rows as any[];
+  console.log(`\n=== Unique team_raw values: ${teams.length} ===`);
+
+  // 3. Parse each one; collect success/failure
+  const results: Array<{ team_raw: string | null; n: number; ids: number[]; unparsed: string | null; ok: boolean }> = [];
+  for (const r of teams) {
+    const p = parseTeam(r.team_raw);
+    results.push({ team_raw: r.team_raw, n: r.n, ids: p.ids, unparsed: p.unparsed, ok: p.unparsed === null });
+  }
+
+  // 4. Report failures
+  const failed = results.filter(r => !r.ok);
+  console.log(`\n=== UNPARSED team_raw values (failures): ${failed.length} ===`);
+  if (failed.length > 0) console.table(failed);
+
+  // 5. Report success distribution
+  const ok = results.filter(r => r.ok);
+  const byCount: Record<number, number> = {};
+  let totalRows = 0;
+  for (const r of ok) {
+    const k = r.ids.length;
+    byCount[k] = (byCount[k] ?? 0) + r.n;
+    totalRows += r.n;
+  }
+  console.log(`\n=== Parse success — ${ok.length} unique strings / ${totalRows} rows ===`);
+  console.log("Distribution by tech count:", byCount);
+
+  // 6. Sample of successes for spot-checking
+  console.log("\n=== Top 30 parsed team_raw with rowcounts ===");
+  console.table(ok.slice(0, 30).map(r => ({
+    team_raw: r.team_raw,
+    rows: r.n,
+    techs: r.ids.join(","),
+  })));
+
+  // 7. Are there rows with team_raw = NULL or empty?
+  const nullTeams = await db.execute(sql`
+    SELECT COUNT(*)::int AS n
+      FROM mc_dispatch_staging
+     WHERE team_raw IS NULL OR TRIM(team_raw) = ''
+  `);
+  console.log(`\nRows with NULL or empty team_raw: ${(nullTeams.rows?.[0] as any)?.n}`);
+
+  process.exit(0);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/l4_diagnose_collisions.ts
+++ b/artifacts/api-server/scripts/l4_diagnose_collisions.ts
@@ -1,0 +1,55 @@
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+async function main() {
+  console.log("=== Collisions on (client_id, matched_schedule_id, scheduled_date) in staging ===");
+  const collide = await db.execute(sql`
+    SELECT matched_customer_id, matched_schedule_id, scheduled_date::text AS scheduled_date,
+           COUNT(*)::int AS n,
+           ARRAY_AGG(mc_job_id ORDER BY mc_job_id) AS mc_ids
+      FROM mc_dispatch_staging
+     WHERE matched_schedule_id IS NOT NULL
+     GROUP BY matched_customer_id, matched_schedule_id, scheduled_date
+     HAVING COUNT(*) > 1
+     ORDER BY n DESC, matched_customer_id, scheduled_date
+     LIMIT 40
+  `);
+  console.log(`Collision groups: ${collide.rowCount}`);
+  console.table(collide.rows);
+
+  console.log("\n=== Summary: rows involved in collisions ===");
+  const summary = await db.execute(sql`
+    WITH collide AS (
+      SELECT matched_customer_id, matched_schedule_id, scheduled_date, COUNT(*)::int AS n
+        FROM mc_dispatch_staging
+       WHERE matched_schedule_id IS NOT NULL
+       GROUP BY 1,2,3 HAVING COUNT(*) > 1
+    )
+    SELECT SUM(n)::int AS colliding_rows,
+           COUNT(*)::int AS collision_groups
+      FROM collide
+  `);
+  console.table(summary.rows);
+
+  console.log("\n=== By customer: how many collision groups per customer ===");
+  const byClient = await db.execute(sql`
+    WITH collide AS (
+      SELECT matched_customer_id, matched_schedule_id, scheduled_date, COUNT(*)::int AS n
+        FROM mc_dispatch_staging
+       WHERE matched_schedule_id IS NOT NULL
+       GROUP BY 1,2,3 HAVING COUNT(*) > 1
+    )
+    SELECT c.matched_customer_id,
+           cl.first_name || ' ' || cl.last_name AS name,
+           COUNT(*)::int AS collision_groups,
+           SUM(c.n)::int AS total_rows_involved
+      FROM collide c
+      LEFT JOIN clients cl ON cl.id = c.matched_customer_id
+     GROUP BY c.matched_customer_id, cl.first_name, cl.last_name
+     ORDER BY collision_groups DESC
+  `);
+  console.table(byClient.rows);
+
+  process.exit(0);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/l4_dryrun.ts
+++ b/artifacts/api-server/scripts/l4_dryrun.ts
@@ -1,0 +1,162 @@
+/**
+ * L4 — Phase 4 schema probe + dry-run preview. READ-ONLY.
+ */
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+async function main() {
+  console.log("=== 4.1a — jobs table schema ===");
+  const jobsCols = await db.execute(sql`
+    SELECT column_name, data_type, is_nullable, column_default
+      FROM information_schema.columns
+     WHERE table_name = 'jobs' AND table_schema = 'public'
+     ORDER BY ordinal_position
+  `);
+  console.table(jobsCols.rows);
+
+  console.log("\n=== 4.1b — jobs required (NOT NULL, no default) columns ===");
+  const jobsReq = await db.execute(sql`
+    SELECT column_name, data_type
+      FROM information_schema.columns
+     WHERE table_name = 'jobs' AND table_schema = 'public'
+       AND is_nullable = 'NO' AND column_default IS NULL
+     ORDER BY ordinal_position
+  `);
+  console.table(jobsReq.rows);
+
+  console.log("\n=== 4.1c — job_technicians schema ===");
+  const jtCols = await db.execute(sql`
+    SELECT column_name, data_type, is_nullable, column_default
+      FROM information_schema.columns
+     WHERE table_name = 'job_technicians' AND table_schema = 'public'
+     ORDER BY ordinal_position
+  `);
+  console.table(jtCols.rows);
+
+  console.log("\n=== 4.1d — job_technicians indexes/unique constraints ===");
+  const jtIdx = await db.execute(sql`
+    SELECT indexname, indexdef
+      FROM pg_indexes
+     WHERE schemaname = 'public' AND tablename = 'job_technicians'
+  `);
+  console.table(jtIdx.rows);
+
+  console.log("\n=== 4.2a — INSERT vs UPDATE split ===");
+  const splitPreview = await db.execute(sql`
+    SELECT
+      COUNT(*) FILTER (WHERE j.mc_job_id IS NULL)::int AS will_insert,
+      COUNT(*) FILTER (WHERE j.mc_job_id IS NOT NULL)::int AS will_update
+      FROM mc_dispatch_staging s
+      LEFT JOIN jobs j ON j.mc_job_id = s.mc_job_id AND j.company_id = 1
+  `);
+  console.table(splitPreview.rows);
+
+  console.log("\n=== 4.2b — Monthly preview ===");
+  const monthly = await db.execute(sql`
+    SELECT TO_CHAR(scheduled_date, 'YYYY-MM') AS month,
+           COUNT(*)::int AS staging_rows,
+           SUM(bill_rate)::numeric(14,2) AS total_bill_rate
+      FROM mc_dispatch_staging
+     GROUP BY 1 ORDER BY 1
+  `);
+  console.table(monthly.rows);
+  const monthlyTotal = await db.execute(sql`
+    SELECT COUNT(*)::int AS n, SUM(bill_rate)::numeric(14,2) AS total
+      FROM mc_dispatch_staging
+  `);
+  console.log("Total across all months:", monthlyTotal.rows);
+
+  console.log("\n=== 4.2c — Apr 22-30 daily preview ===");
+  const daily = await db.execute(sql`
+    SELECT scheduled_date::text AS date,
+           COUNT(*)::int AS jobs,
+           SUM(bill_rate)::numeric(14,2) AS total
+      FROM mc_dispatch_staging
+     WHERE scheduled_date BETWEEN '2026-04-22' AND '2026-04-30'
+     GROUP BY scheduled_date
+     ORDER BY scheduled_date
+  `);
+  console.table(daily.rows);
+
+  console.log("\n=== 4.2d — 5-row Apr 23 sample ===");
+  const sample = await db.execute(sql`
+    SELECT mc_job_id, scheduled_date::text AS scheduled_date,
+           scheduled_time_start, matched_customer_id,
+           matched_schedule_id, bill_rate, mapped_status, parsed_techs,
+           team_raw, LEFT(COALESCE(address,''), 40) AS addr_head
+      FROM mc_dispatch_staging
+     WHERE scheduled_date = '2026-04-23'
+     ORDER BY scheduled_time_start NULLS LAST, mc_job_id
+     LIMIT 5
+  `);
+  console.table(sample.rows);
+
+  console.log("\n=== 4.2e — Expected job_technicians row count ===");
+  const techCount = await db.execute(sql`
+    SELECT SUM(JSONB_ARRAY_LENGTH(parsed_techs))::int AS total_tech_assignments,
+           COUNT(*) FILTER (WHERE JSONB_ARRAY_LENGTH(parsed_techs) > 0)::int AS jobs_with_tech,
+           COUNT(*) FILTER (WHERE JSONB_ARRAY_LENGTH(parsed_techs) = 0)::int AS jobs_no_tech
+      FROM mc_dispatch_staging
+  `);
+  console.table(techCount.rows);
+
+  console.log("\n=== 4.2f — Tech ids that will be referenced (must all exist in users) ===");
+  const techIds = await db.execute(sql`
+    SELECT DISTINCT (tech_id)::int AS user_id
+      FROM mc_dispatch_staging s,
+           LATERAL JSONB_ARRAY_ELEMENTS_TEXT(s.parsed_techs) AS tech_id
+      ORDER BY user_id
+  `);
+  const ids = (techIds.rows as any[]).map(r => r.user_id);
+  console.log("Unique tech ids in staging:", ids);
+  const verifyUsers = await db.execute(sql`
+    SELECT id, first_name, last_name, is_active, role
+      FROM users
+     WHERE id = ANY(${ids}::int[])
+     ORDER BY id
+  `);
+  console.table(verifyUsers.rows);
+  const missing = ids.filter((x: number) => !(verifyUsers.rows as any[]).some(u => u.id === x));
+  if (missing.length > 0) {
+    console.log("!!! MISSING USER IDS:", missing);
+  } else {
+    console.log("All tech ids resolve to existing users. ✓");
+  }
+
+  console.log("\n=== 4.2g — Confirm all mc_job_id values are unique and present ===");
+  const staging = await db.execute(sql`
+    SELECT COUNT(*)::int AS total,
+           COUNT(DISTINCT mc_job_id)::int AS unique_ids,
+           COUNT(*) FILTER (WHERE mc_job_id IS NULL)::int AS null_ids
+      FROM mc_dispatch_staging
+  `);
+  console.table(staging.rows);
+
+  console.log("\n=== 4.2h — Column coverage map (what we need vs what staging has) ===");
+  const coverage = await db.execute(sql`
+    SELECT
+      COUNT(*) FILTER (WHERE matched_customer_id IS NOT NULL)::int AS has_customer,
+      COUNT(*) FILTER (WHERE scheduled_date IS NOT NULL)::int AS has_date,
+      COUNT(*) FILTER (WHERE mapped_status IS NOT NULL)::int AS has_status,
+      COUNT(*) FILTER (WHERE bill_rate IS NOT NULL)::int AS has_bill_rate,
+      COUNT(*) FILTER (WHERE bill_rate IS NULL)::int AS null_bill_rate,
+      COUNT(*) FILTER (WHERE alwd_hours IS NOT NULL)::int AS has_alwd,
+      COUNT(*) FILTER (WHERE act_hours IS NOT NULL)::int AS has_act_hrs,
+      COUNT(*) FILTER (WHERE address IS NOT NULL)::int AS has_address
+    FROM mc_dispatch_staging
+  `);
+  console.table(coverage.rows);
+
+  // Look at rows with NULL bill_rate specifically
+  const nullFee = await db.execute(sql`
+    SELECT status_raw, COUNT(*)::int AS n
+      FROM mc_dispatch_staging
+     WHERE bill_rate IS NULL
+     GROUP BY status_raw
+  `);
+  console.log("\nRows with NULL bill_rate (if any):");
+  console.table(nullFee.rows);
+
+  process.exit(0);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/l4_dryrun_2.ts
+++ b/artifacts/api-server/scripts/l4_dryrun_2.ts
@@ -1,0 +1,122 @@
+/**
+ * L4 dry-run supplement — fix ANY() syntax + probe enums the prompt missed.
+ */
+import { db } from "@workspace/db";
+import { sql, inArray } from "drizzle-orm";
+
+async function main() {
+  // Fix: use inArray from drizzle
+  const ids = [32, 33, 34, 36, 38, 39, 40, 41, 42, 43, 283];
+  console.log("=== Tech user existence check ===");
+  const users = await db.execute(sql`
+    SELECT id, first_name, last_name, is_active, role
+      FROM users
+     WHERE id IN (32, 33, 34, 36, 38, 39, 40, 41, 42, 43, 283)
+     ORDER BY id
+  `);
+  console.table(users.rows);
+  const present = new Set((users.rows as any[]).map(u => u.id));
+  const missing = ids.filter(i => !present.has(i));
+  if (missing.length === 0) console.log("All 11 tech ids exist in users. ✓");
+  else console.log("!!! MISSING:", missing);
+
+  // service_type enum — required on jobs insert
+  console.log("\n=== service_type enum values ===");
+  const stEnum = await db.execute(sql`
+    SELECT t.typname, e.enumlabel, e.enumsortorder
+      FROM pg_type t
+      JOIN pg_enum e ON t.oid = e.enumtypid
+     WHERE t.typname IN ('service_type', 'job_service_type')
+     ORDER BY t.typname, e.enumsortorder
+  `);
+  console.table(stEnum.rows);
+
+  // What service_type values are in use in the existing jobs table?
+  console.log("\n=== service_type distribution in jobs (existing 83 rows) ===");
+  const stExisting = await db.execute(sql`
+    SELECT service_type::text, COUNT(*)::int AS n
+      FROM jobs
+     WHERE company_id = 1
+     GROUP BY service_type
+     ORDER BY n DESC
+  `);
+  console.table(stExisting.rows);
+
+  // frequency enum (on jobs, not recurring_schedules — they use different enums)
+  console.log("\n=== jobs.frequency enum values ===");
+  const freqEnum = await db.execute(sql`
+    SELECT t.typname, e.enumlabel, e.enumsortorder
+      FROM pg_type t
+      JOIN pg_enum e ON t.oid = e.enumtypid
+     WHERE t.typname = 'frequency'
+     ORDER BY e.enumsortorder
+  `);
+  console.table(freqEnum.rows);
+
+  // Existing jobs frequency distribution
+  console.log("\n=== jobs.frequency distribution (existing 83) ===");
+  const fExisting = await db.execute(sql`
+    SELECT frequency::text, COUNT(*)::int AS n
+      FROM jobs WHERE company_id = 1
+     GROUP BY frequency ORDER BY n DESC
+  `);
+  console.table(fExisting.rows);
+
+  // Count bill_rate = 0 rows in staging (will become base_fee=0 in jobs — not NULL, so NOT NULL constraint is fine)
+  console.log("\n=== Staging rows with bill_rate = 0 or NULL ===");
+  const zeroFee = await db.execute(sql`
+    SELECT
+      COUNT(*) FILTER (WHERE bill_rate IS NULL)::int AS null_fee,
+      COUNT(*) FILTER (WHERE bill_rate = 0)::int AS zero_fee,
+      COUNT(*) FILTER (WHERE bill_rate > 0)::int AS positive_fee,
+      COUNT(*)::int AS total
+    FROM mc_dispatch_staging
+  `);
+  console.table(zeroFee.rows);
+
+  // If any NULL, they'd break the NOT NULL base_fee constraint. Confirm none.
+  console.log("\n=== Sample bill_rate=0 rows ===");
+  const zeroSample = await db.execute(sql`
+    SELECT mc_job_id, customer_name, status_raw, billing_terms, LEFT(COALESCE(address,''), 40) AS addr
+      FROM mc_dispatch_staging
+     WHERE bill_rate = 0
+     ORDER BY scheduled_date
+     LIMIT 10
+  `);
+  console.table(zeroSample.rows);
+  const zeroCount = await db.execute(sql`
+    SELECT COUNT(*)::int AS n FROM mc_dispatch_staging WHERE bill_rate = 0
+  `);
+  console.log("Total $0 rows:", zeroCount.rows);
+
+  // MC frequency field distribution with proposed Qleno freq mapping
+  console.log("\n=== Proposed MC freq → Qleno jobs.frequency mapping ===");
+  const freqMap = await db.execute(sql`
+    SELECT frequency AS mc_freq,
+           CASE frequency
+             WHEN 'Every Week'        THEN 'weekly'
+             WHEN 'Every Two Weeks'   THEN 'biweekly'
+             WHEN 'Every Four Weeks'  THEN 'monthly'
+             WHEN 'Every Three Weeks' THEN 'every_3_weeks'
+             WHEN 'Other Recurring'   THEN 'on_demand'
+             WHEN 'Single'            THEN 'on_demand'
+             WHEN 'On Demand'         THEN 'on_demand'
+             ELSE 'on_demand'
+           END AS qleno_freq,
+           COUNT(*)::int AS n
+      FROM mc_dispatch_staging
+     GROUP BY mc_freq
+     ORDER BY n DESC
+  `);
+  console.table(freqMap.rows);
+
+  // Sample row with full staging columns to check what address would be
+  console.log("\n=== Sample staging row (complete) ===");
+  const fullSample = await db.execute(sql`
+    SELECT * FROM mc_dispatch_staging WHERE mc_job_id = 59514438
+  `);
+  console.log(fullSample.rows);
+
+  process.exit(0);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/l4_execute.ts
+++ b/artifacts/api-server/scripts/l4_execute.ts
@@ -1,0 +1,272 @@
+/**
+ * L4 — Phase 4 main transaction. Writes 983 rows to jobs + populates
+ * job_technicians from staging.
+ *
+ * Schema corrections applied vs prompt's SQL:
+ *   customer_id    → client_id
+ *   service_address→ address_street (MC has single-line address)
+ *   actual_start_time/end_time → folded into notes tag
+ *   updated_at     → doesn't exist, omitted
+ *   service_type   → REQUIRED, defaulting to 'standard_clean'
+ *   frequency      → mapped from MC frequency using jobs.frequency enum
+ *                    (includes 'every_3_weeks' which exists on this enum)
+ *   job_technicians.company_id → REQUIRED, included
+ *
+ * Gates (transaction rolls back on any fail):
+ *   1. jobs INSERT rowcount == 983
+ *   2. job_technicians INSERT rowcount == 1092
+ *   3. total PHES jobs == 1066 (83 pre-existing + 983 imported)
+ *   4. Apr 22-30 day-by-day == MC ground truth
+ */
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+const MC_EXPECTED_APR = [
+  { date: "2026-04-22", jobs: 12, total: "2238.60" },
+  { date: "2026-04-23", jobs: 14, total: "2900.25" },
+  { date: "2026-04-24", jobs: 11, total: "2401.54" },
+  { date: "2026-04-25", jobs:  4, total: "1062.00" },
+  { date: "2026-04-27", jobs:  7, total: "1811.32" },
+  { date: "2026-04-28", jobs: 11, total: "2042.33" },
+  { date: "2026-04-29", jobs: 13, total: "2385.35" },
+  { date: "2026-04-30", jobs: 11, total: "2312.68" },
+];
+const MC_EXPECTED_MONTHLY = [
+  { month: "2026-01", rows: 232, total: "52218.71" },
+  { month: "2026-02", rows: 216, total: "45643.27" },
+  { month: "2026-03", rows: 258, total: "58108.14" },
+  { month: "2026-04", rows: 277, total: "61563.26" },
+];
+
+async function main() {
+  console.log("=== L4 Phase 4 — execute ===\n");
+
+  // --- Pre-flight ---
+  const pre = await db.execute(sql`
+    SELECT COUNT(*)::int AS stg, (SELECT COUNT(*)::int FROM jobs WHERE company_id=1) AS jobs_before
+      FROM mc_dispatch_staging
+  `);
+  console.log("Pre-flight:", pre.rows);
+
+  await db.execute(sql`BEGIN`);
+  try {
+    // ========== STEP 4.3 — INSERT jobs ==========
+    console.log("\n--- Step 4.3a: INSERT INTO jobs ---");
+    const jobsInsert = await db.execute(sql`
+      INSERT INTO jobs (
+        mc_job_id,
+        company_id,
+        client_id,
+        service_type,
+        frequency,
+        status,
+        scheduled_date,
+        scheduled_time,
+        base_fee,
+        recurring_schedule_id,
+        assigned_user_id,
+        estimated_hours,
+        actual_hours,
+        address_street,
+        notes
+      )
+      SELECT
+        s.mc_job_id,
+        1,
+        s.matched_customer_id,
+        'standard_clean'::service_type,
+        (CASE s.frequency
+           WHEN 'Every Week'        THEN 'weekly'
+           WHEN 'Every Two Weeks'   THEN 'biweekly'
+           WHEN 'Every Four Weeks'  THEN 'monthly'
+           WHEN 'Every Three Weeks' THEN 'every_3_weeks'
+           ELSE 'on_demand'
+         END)::frequency,
+        s.mapped_status::job_status,
+        s.scheduled_date,
+        s.scheduled_time_start,
+        s.bill_rate,
+        s.matched_schedule_id,
+        CASE WHEN JSONB_ARRAY_LENGTH(s.parsed_techs) > 0
+             THEN (s.parsed_techs->>0)::int
+             ELSE NULL END,
+        s.alwd_hours,
+        s.act_hours,
+        s.address,
+        ('[mc_import_phase4 2026-04-22 mc_job_id=' || s.mc_job_id
+         || CASE WHEN s.act_start IS NOT NULL OR s.act_end IS NOT NULL
+                 THEN ' act: ' || COALESCE(s.act_start,'?') || '-' || COALESCE(s.act_end,'?')
+                 ELSE '' END
+         || ']')
+      FROM mc_dispatch_staging s
+      ON CONFLICT (mc_job_id) WHERE mc_job_id IS NOT NULL
+      DO UPDATE SET
+        client_id = EXCLUDED.client_id,
+        service_type = EXCLUDED.service_type,
+        frequency = EXCLUDED.frequency,
+        status = EXCLUDED.status,
+        scheduled_date = EXCLUDED.scheduled_date,
+        scheduled_time = EXCLUDED.scheduled_time,
+        base_fee = EXCLUDED.base_fee,
+        recurring_schedule_id = EXCLUDED.recurring_schedule_id,
+        assigned_user_id = EXCLUDED.assigned_user_id,
+        estimated_hours = EXCLUDED.estimated_hours,
+        actual_hours = EXCLUDED.actual_hours,
+        address_street = EXCLUDED.address_street,
+        notes = EXCLUDED.notes
+    `);
+    console.log(`jobs INSERT rowcount: ${jobsInsert.rowCount} (expect 983)`);
+    if (jobsInsert.rowCount !== 983) {
+      throw new Error(`Gate 1 FAIL — jobs INSERT rowcount ${jobsInsert.rowCount}, expected 983`);
+    }
+
+    // ========== STEP 4.3b — INSERT job_technicians ==========
+    console.log("\n--- Step 4.3b: INSERT INTO job_technicians ---");
+    // WITH ORDINALITY gives position in the array → use it to set is_primary
+    // for the first tech (matches jobs.assigned_user_id).
+    const jtInsert = await db.execute(sql`
+      INSERT INTO job_technicians (job_id, user_id, company_id, is_primary)
+      SELECT
+        j.id,
+        (tech_id)::int,
+        1,
+        (idx = 1)
+      FROM mc_dispatch_staging s
+      JOIN jobs j ON j.mc_job_id = s.mc_job_id AND j.company_id = 1
+      CROSS JOIN LATERAL JSONB_ARRAY_ELEMENTS_TEXT(s.parsed_techs) WITH ORDINALITY AS t(tech_id, idx)
+      WHERE JSONB_ARRAY_LENGTH(s.parsed_techs) > 0
+      ON CONFLICT (job_id, user_id) DO NOTHING
+    `);
+    console.log(`job_technicians INSERT rowcount: ${jtInsert.rowCount} (expect 1092)`);
+    if (jtInsert.rowCount !== 1092) {
+      throw new Error(`Gate 2 FAIL — job_technicians rowcount ${jtInsert.rowCount}, expected 1092`);
+    }
+
+    // ========== Gate 3 — total PHES jobs ==========
+    console.log("\n--- Gate 3: PHES jobs total ---");
+    const total = await db.execute(sql`
+      SELECT COUNT(*)::int AS n FROM jobs WHERE company_id = 1
+    `);
+    const totalN = Number((total.rows?.[0] as any)?.n ?? 0);
+    console.log(`PHES jobs total: ${totalN} (expect 1066)`);
+    if (totalN !== 1066) {
+      throw new Error(`Gate 3 FAIL — PHES total ${totalN}, expected 1066`);
+    }
+
+    // ========== Gate 4 — Apr 22-30 daily reconciliation ==========
+    console.log("\n--- Gate 4: Apr 22-30 daily reconciliation (MC ground truth) ---");
+    const apr = await db.execute(sql`
+      SELECT scheduled_date::text AS date,
+             COUNT(*)::int AS jobs,
+             SUM(base_fee)::numeric(14,2)::text AS total
+        FROM jobs
+       WHERE company_id = 1
+         AND scheduled_date BETWEEN '2026-04-22' AND '2026-04-30'
+         AND mc_job_id IS NOT NULL
+       GROUP BY scheduled_date
+       ORDER BY scheduled_date
+    `);
+    console.table(apr.rows);
+
+    const aprMap = new Map((apr.rows as any[]).map(r => [r.date, r]));
+    let mismatch = 0;
+    for (const e of MC_EXPECTED_APR) {
+      const got = aprMap.get(e.date) as any;
+      const gotJobs = got?.jobs ?? 0;
+      const gotTotal = got?.total ?? "0.00";
+      const ok = Number(gotJobs) === e.jobs && gotTotal === e.total;
+      console.log(
+        `  ${e.date}  MC=${e.jobs}j/$${e.total}  DB=${gotJobs}j/$${gotTotal}  ${ok ? "✓" : "✗"}`
+      );
+      if (!ok) mismatch++;
+    }
+    if (mismatch > 0) {
+      throw new Error(`Gate 4 FAIL — ${mismatch} daily Apr 22-30 mismatches vs MC ground truth`);
+    }
+
+    console.log("\nAll 4 gates passed — COMMIT");
+    await db.execute(sql`COMMIT`);
+  } catch (err) {
+    await db.execute(sql`ROLLBACK`);
+    console.log("\n--- ROLLBACK ---");
+    console.error(err);
+    process.exit(1);
+  }
+
+  // ========== STEP 4.4 — post-commit reconciliation ==========
+  console.log("\n=== STEP 4.4 — post-commit reconciliation ===\n");
+
+  console.log("--- Monthly reconciliation (MC-imported rows only) ---");
+  const monthly = await db.execute(sql`
+    SELECT TO_CHAR(scheduled_date, 'YYYY-MM') AS month,
+           COUNT(*)::int AS jobs,
+           SUM(base_fee)::numeric(14,2)::text AS total
+      FROM jobs
+     WHERE company_id = 1
+       AND mc_job_id IS NOT NULL
+       AND scheduled_date BETWEEN '2026-01-01' AND '2026-04-30'
+     GROUP BY 1 ORDER BY 1
+  `);
+  console.table(monthly.rows);
+  const monthlyMap = new Map((monthly.rows as any[]).map(r => [r.month, r]));
+  for (const e of MC_EXPECTED_MONTHLY) {
+    const got = monthlyMap.get(e.month) as any;
+    const ok = got?.jobs === e.rows && got?.total === e.total;
+    console.log(`  ${e.month}  MC=${e.rows}/$${e.total}  DB=${got?.jobs ?? 0}/$${got?.total ?? 0}  ${ok ? "✓" : "✗"}`);
+  }
+  const monthlyTotal = await db.execute(sql`
+    SELECT COUNT(*)::int AS n, SUM(base_fee)::numeric(14,2)::text AS total
+      FROM jobs WHERE company_id=1 AND mc_job_id IS NOT NULL
+  `);
+  console.log(`TOTAL: ${(monthlyTotal.rows?.[0] as any)?.n} / $${(monthlyTotal.rows?.[0] as any)?.total}  (expect 983 / $217,533.38)`);
+
+  console.log("\n--- Overall jobs state ---");
+  const overall = await db.execute(sql`
+    SELECT
+      COUNT(*)::int AS total_rows,
+      COUNT(*) FILTER (WHERE mc_job_id IS NOT NULL)::int AS mc_imported,
+      COUNT(*) FILTER (WHERE mc_job_id IS NULL)::int AS legacy_or_manual,
+      COUNT(*) FILTER (WHERE status = 'complete')::int AS complete,
+      COUNT(*) FILTER (WHERE status = 'scheduled')::int AS scheduled,
+      COUNT(*) FILTER (WHERE status = 'in_progress')::int AS in_progress,
+      COUNT(*) FILTER (WHERE status = 'cancelled')::int AS cancelled
+    FROM jobs WHERE company_id = 1
+  `);
+  console.table(overall.rows);
+
+  console.log("\n--- job_technicians populated ---");
+  const jtStats = await db.execute(sql`
+    SELECT COUNT(*)::int AS total_assignments,
+           COUNT(DISTINCT job_id)::int AS jobs_with_at_least_one_tech,
+           COUNT(DISTINCT user_id)::int AS unique_techs
+      FROM job_technicians jt
+      JOIN jobs j ON j.id = jt.job_id
+     WHERE j.company_id = 1 AND j.mc_job_id IS NOT NULL
+  `);
+  console.table(jtStats.rows);
+
+  console.log("\n--- Per-tech job counts ---");
+  const perTech = await db.execute(sql`
+    SELECT jt.user_id,
+           u.first_name || ' ' || u.last_name AS tech,
+           u.is_active,
+           COUNT(*)::int AS jobs
+      FROM job_technicians jt
+      JOIN jobs j ON j.id = jt.job_id
+      JOIN users u ON u.id = jt.user_id
+     WHERE j.company_id = 1 AND j.mc_job_id IS NOT NULL
+     GROUP BY jt.user_id, u.first_name, u.last_name, u.is_active
+     ORDER BY jobs DESC
+  `);
+  console.table(perTech.rows);
+
+  console.log("\n--- Engine flag sanity ---");
+  const flags = await db.execute(sql`
+    SELECT id, name, recurring_engine_enabled FROM companies ORDER BY id
+  `);
+  console.table(flags.rows);
+
+  console.log("\n✅ L4 complete.");
+  process.exit(0);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/l4_fix_daveco.ts
+++ b/artifacts/api-server/scripts/l4_fix_daveco.ts
@@ -1,0 +1,62 @@
+/**
+ * L4 pre-fix — resolve Daveco 11-row dedupe-index collisions.
+ * For each (matched_schedule_id, scheduled_date) collision group, keep
+ * matched_schedule_id on the row with the lowest mc_job_id and NULL
+ * it on the rest. That way 1 row per date-schedule remains linked to
+ * recurring_schedule_id=35; others land as client_id=25 with NULL schedule.
+ */
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+async function main() {
+  console.log("=== L4 pre-fix: Daveco collision NULL-out ===\n");
+
+  await db.execute(sql`BEGIN`);
+  try {
+    const res = await db.execute(sql`
+      WITH ranked AS (
+        SELECT mc_job_id,
+               ROW_NUMBER() OVER (
+                 PARTITION BY matched_schedule_id, scheduled_date
+                 ORDER BY mc_job_id
+               ) AS rn
+          FROM mc_dispatch_staging
+         WHERE matched_schedule_id IS NOT NULL
+      )
+      UPDATE mc_dispatch_staging s
+         SET matched_schedule_id = NULL
+        FROM ranked r
+       WHERE s.mc_job_id = r.mc_job_id
+         AND r.rn > 1
+    `);
+    console.log(`NULL-out rowcount: ${res.rowCount} (expect 7)`);
+    if (res.rowCount !== 7) throw new Error(`Expected 7, got ${res.rowCount}`);
+    await db.execute(sql`COMMIT`);
+  } catch (err) {
+    await db.execute(sql`ROLLBACK`);
+    throw err;
+  }
+
+  // Verify no remaining collisions
+  const remaining = await db.execute(sql`
+    SELECT matched_customer_id, matched_schedule_id, scheduled_date, COUNT(*)::int AS n
+      FROM mc_dispatch_staging
+     WHERE matched_schedule_id IS NOT NULL
+     GROUP BY 1,2,3 HAVING COUNT(*) > 1
+  `);
+  console.log(`Remaining collision groups: ${remaining.rowCount} (expect 0)`);
+  if ((remaining.rowCount ?? 0) > 0) console.table(remaining.rows);
+
+  // Show before/after rates
+  const linked = await db.execute(sql`
+    SELECT COUNT(*)::int AS total,
+           COUNT(matched_schedule_id)::int AS with_schedule,
+           COUNT(*) FILTER (WHERE matched_schedule_id IS NULL)::int AS no_schedule
+      FROM mc_dispatch_staging
+  `);
+  console.log("Post-fix staging match rates:");
+  console.table(linked.rows);
+
+  process.exit(0);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/n_allowed_hours_backfill.ts
+++ b/artifacts/api-server/scripts/n_allowed_hours_backfill.ts
@@ -1,0 +1,121 @@
+/**
+ * N — backfill jobs.allowed_hours from estimated_hours for MC-imported rows.
+ *
+ * Why: L4 populated estimated_hours but NOT allowed_hours. The Dispatch
+ * endpoint (artifacts/api-server/src/routes/dispatch.ts:53) reads
+ * allowed_hours to compute durationMinutes (default 120 when NULL), so all
+ * 983 MC-imported rows render as 2-hour Gantt blocks. Backfill fixes this.
+ *
+ * Rollback:
+ *   UPDATE jobs SET allowed_hours = NULL
+ *    WHERE company_id = 1 AND mc_job_id IS NOT NULL
+ *      AND allowed_hours = estimated_hours
+ *      AND notes LIKE '%mc_import_phase4%';
+ */
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+async function main() {
+  console.log("=== N — allowed_hours backfill ===\n");
+
+  // ---- Dry-run ----
+  console.log("Step 1 — DRY RUN: count rows matching backfill predicate");
+  const dryRun = await db.execute(sql`
+    SELECT COUNT(*)::int AS n
+      FROM jobs
+     WHERE company_id = 1
+       AND mc_job_id IS NOT NULL
+       AND allowed_hours IS NULL
+       AND estimated_hours IS NOT NULL
+  `);
+  const n = Number((dryRun.rows?.[0] as any)?.n ?? 0);
+  console.log(`Matching rows: ${n}`);
+
+  // Also show how many MC rows exist in total and how many would still be skipped
+  const totalMc = await db.execute(sql`
+    SELECT COUNT(*)::int AS total_mc,
+           COUNT(*) FILTER (WHERE allowed_hours IS NOT NULL)::int AS already_set,
+           COUNT(*) FILTER (WHERE estimated_hours IS NULL)::int AS no_estimate
+      FROM jobs
+     WHERE company_id = 1 AND mc_job_id IS NOT NULL
+  `);
+  console.log("MC rows context:");
+  console.table(totalMc.rows);
+
+  // Sanity: sample 5 rows
+  const sample = await db.execute(sql`
+    SELECT id, mc_job_id, client_id,
+           estimated_hours::text AS estimated_hours,
+           allowed_hours::text AS allowed_hours
+      FROM jobs
+     WHERE company_id = 1
+       AND mc_job_id IS NOT NULL
+       AND allowed_hours IS NULL
+       AND estimated_hours IS NOT NULL
+     ORDER BY id
+     LIMIT 5
+  `);
+  console.log("\nSample pre-update rows:");
+  console.table(sample.rows);
+
+  if (n === 0) {
+    console.log("No matching rows — nothing to do. Exiting.");
+    process.exit(0);
+  }
+
+  // ---- Transaction ----
+  console.log("\nStep 2 — TRANSACTION: UPDATE with rowcount gate");
+  await db.execute(sql`BEGIN`);
+  try {
+    const update = await db.execute(sql`
+      UPDATE jobs
+         SET allowed_hours = estimated_hours
+       WHERE company_id = 1
+         AND mc_job_id IS NOT NULL
+         AND allowed_hours IS NULL
+         AND estimated_hours IS NOT NULL
+      RETURNING id
+    `);
+    const updated = update.rowCount ?? 0;
+    console.log(`UPDATE rowcount: ${updated} (expect ${n})`);
+    if (updated !== n) {
+      throw new Error(`rowcount mismatch: got ${updated}, expected ${n}`);
+    }
+    await db.execute(sql`COMMIT`);
+    console.log("--- COMMIT OK ---");
+  } catch (err) {
+    await db.execute(sql`ROLLBACK`);
+    console.log("--- ROLLBACK ---");
+    throw err;
+  }
+
+  // ---- Post-verify ----
+  console.log("\nStep 3 — post-verify");
+  const post = await db.execute(sql`
+    SELECT
+      COUNT(*)::int AS total_mc,
+      COUNT(*) FILTER (WHERE allowed_hours IS NOT NULL)::int AS has_allowed,
+      COUNT(*) FILTER (WHERE allowed_hours IS NULL)::int AS null_allowed,
+      MIN(allowed_hours)::text AS min_allowed,
+      MAX(allowed_hours)::text AS max_allowed,
+      AVG(allowed_hours)::numeric(6,2)::text AS avg_allowed
+    FROM jobs
+    WHERE company_id = 1 AND mc_job_id IS NOT NULL
+  `);
+  console.table(post.rows);
+
+  // Distribution of allowed_hours after backfill
+  const dist = await db.execute(sql`
+    SELECT allowed_hours::text AS hours, COUNT(*)::int AS n
+      FROM jobs
+     WHERE company_id = 1 AND mc_job_id IS NOT NULL
+     GROUP BY allowed_hours
+     ORDER BY allowed_hours
+     LIMIT 20
+  `);
+  console.log("\nTop allowed_hours distribution (first 20 buckets):");
+  console.table(dist.rows);
+
+  process.exit(0);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/o_verify_state.ts
+++ b/artifacts/api-server/scripts/o_verify_state.ts
@@ -1,0 +1,22 @@
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+async function main() {
+  const jobs = await db.execute(sql`
+    SELECT COUNT(*)::int AS mc_total,
+           COUNT(*) FILTER (WHERE allowed_hours IS NOT NULL)::int AS with_allowed,
+           COUNT(*) FILTER (WHERE allowed_hours IS NULL)::int AS null_allowed
+      FROM jobs
+     WHERE company_id = 1 AND mc_job_id IS NOT NULL
+  `);
+  console.log("MC-imported jobs, allowed_hours coverage:");
+  console.table(jobs.rows);
+
+  const flags = await db.execute(sql`
+    SELECT id, name, recurring_engine_enabled FROM companies ORDER BY id
+  `);
+  console.log("\nEngine flags:");
+  console.table(flags.rows);
+  process.exit(0);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/orphan_job_refs.ts
+++ b/artifacts/api-server/scripts/orphan_job_refs.ts
@@ -1,0 +1,84 @@
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+async function main() {
+  // 1. Show the 2 orphan rows. Note: clients has first_name/last_name, not name.
+  console.log("=== Orphan jobs 703, 2081 ===");
+  const jobs = await db.execute(sql`
+    SELECT j.id,
+           c.first_name || ' ' || c.last_name AS client_name,
+           j.scheduled_time,
+           j.base_fee::text AS base_fee,
+           j.status::text AS status,
+           j.recurring_schedule_id,
+           j.assigned_user_id,
+           j.created_at::text AS created_at,
+           LEFT(COALESCE(j.notes,''), 100) AS notes_preview
+      FROM jobs j
+      LEFT JOIN clients c ON c.id = j.client_id
+     WHERE j.id IN (703, 2081)
+     ORDER BY j.id
+  `);
+  console.table(jobs.rows);
+
+  // 2. Detect which reference tables actually exist in this schema
+  console.log("\n=== Reference tables present in schema ===");
+  const tables = await db.execute(sql`
+    SELECT table_name
+      FROM information_schema.tables
+     WHERE table_schema = 'public'
+       AND table_name IN (
+         'timeclock', 'timeclock_entries',
+         'additional_pay',
+         'commissions',
+         'job_technicians', 'job_photos',
+         'invoices', 'notifications'
+       )
+     ORDER BY table_name
+  `);
+  console.table(tables.rows);
+
+  // 3. Count references per-table (defensive — check each before query)
+  const present = new Set((tables.rows as any[]).map(r => r.table_name));
+
+  const candidates: Array<{ tbl: string; col: string }> = [
+    { tbl: "timeclock",        col: "job_id" },
+    { tbl: "additional_pay",   col: "job_id" },
+    { tbl: "commissions",      col: "job_id" },
+    { tbl: "job_technicians",  col: "job_id" },
+    { tbl: "job_photos",       col: "job_id" },
+    { tbl: "invoices",         col: "job_id" },
+  ];
+
+  console.log("\n=== Reference counts for job_id IN (703, 2081) ===");
+  const results: Array<{ tbl: string; count: number; note: string }> = [];
+  for (const c of candidates) {
+    if (!present.has(c.tbl)) {
+      results.push({ tbl: c.tbl, count: 0, note: "TABLE NOT PRESENT" });
+      continue;
+    }
+    // Confirm the column exists
+    const hasCol = await db.execute(sql`
+      SELECT 1 FROM information_schema.columns
+       WHERE table_schema='public' AND table_name = ${c.tbl} AND column_name = ${c.col}
+    `);
+    if ((hasCol.rowCount ?? 0) === 0) {
+      results.push({ tbl: c.tbl, count: 0, note: `no column ${c.col}` });
+      continue;
+    }
+    const q = await db.execute(sql.raw(`SELECT COUNT(*)::int AS n FROM "${c.tbl}" WHERE "${c.col}" IN (703, 2081)`));
+    const n = Number((q.rows?.[0] as any)?.n ?? 0);
+    results.push({ tbl: c.tbl, count: n, note: n > 0 ? "HAS REFS" : "clean" });
+  }
+  console.table(results);
+
+  // 4. Show any actual reference rows for the tables that have refs
+  for (const r of results.filter(r => r.count > 0)) {
+    console.log(`\n=== Detail: ${r.tbl} rows referencing 703 / 2081 ===`);
+    const detail = await db.execute(sql.raw(`SELECT * FROM "${r.tbl}" WHERE "job_id" IN (703, 2081)`));
+    console.log(detail.rows);
+  }
+
+  process.exit(0);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/orphan_quote_probe.ts
+++ b/artifacts/api-server/scripts/orphan_quote_probe.ts
@@ -1,0 +1,47 @@
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+async function main() {
+  // Find ALL tables with FKs to jobs.id (broader scan so we don't hit another surprise)
+  console.log("=== All FKs pointing to jobs.id ===");
+  const fks = await db.execute(sql`
+    SELECT
+      tc.table_name,
+      kcu.column_name,
+      tc.constraint_name
+    FROM information_schema.table_constraints tc
+    JOIN information_schema.key_column_usage kcu
+      ON tc.constraint_name = kcu.constraint_name
+    JOIN information_schema.constraint_column_usage ccu
+      ON tc.constraint_name = ccu.constraint_name
+    WHERE tc.constraint_type = 'FOREIGN KEY'
+      AND ccu.table_name = 'jobs'
+      AND ccu.column_name = 'id'
+    ORDER BY tc.table_name
+  `);
+  console.table(fks.rows);
+
+  // Count refs to 703 / 2081 across ALL those tables
+  console.log("\n=== Ref counts to 703 / 2081 across every FK table ===");
+  const results: Array<{ tbl: string; col: string; refs: number; ids: string }> = [];
+  for (const fk of fks.rows as any[]) {
+    const q = await db.execute(
+      sql.raw(`SELECT COUNT(*)::int AS n
+                 FROM "${fk.table_name}"
+                WHERE "${fk.column_name}" IN (703, 2081)`)
+    );
+    const n = Number((q.rows?.[0] as any)?.n ?? 0);
+    results.push({ tbl: fk.table_name, col: fk.column_name, refs: n, ids: "" });
+  }
+  console.table(results);
+
+  // Show the quotes row in detail
+  console.log("\n=== quotes row referencing job 2081 ===");
+  const q = await db.execute(sql`
+    SELECT * FROM quotes WHERE booked_job_id IN (703, 2081)
+  `);
+  console.log(q.rows);
+
+  process.exit(0);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/q1_check_constraint.ts
+++ b/artifacts/api-server/scripts/q1_check_constraint.ts
@@ -1,0 +1,25 @@
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+async function main() {
+  // Find the check constraint definition
+  const check = await db.execute(sql`
+    SELECT conname, pg_get_constraintdef(oid) AS definition
+      FROM pg_constraint
+     WHERE conrelid = 'public.clients'::regclass
+       AND contype = 'c'
+  `);
+  console.log("CHECK constraints on clients table:");
+  console.table(check.rows);
+
+  // Also list all constraints for completeness
+  const all = await db.execute(sql`
+    SELECT conname, contype::text, pg_get_constraintdef(oid) AS definition
+      FROM pg_constraint
+     WHERE conrelid = 'public.clients'::regclass
+     ORDER BY conname
+  `);
+  console.log("\nAll constraints on clients:");
+  console.table(all.rows);
+  process.exit(0);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/q1_payment_backfill.ts
+++ b/artifacts/api-server/scripts/q1_payment_backfill.ts
@@ -1,0 +1,117 @@
+/**
+ * Q1 — one-time backfill of clients.payment_method from MC billing_terms.
+ *
+ * Adapted mapping (CHECK constraint limits payment_method to
+ * {card_on_file, check, zelle, net_30, manual}):
+ *   Credit Card     → card_on_file  (253 clients)
+ *   Batch Invoice   → net_30        (7)
+ *   Invoice         → net_30        (4)
+ *   Prepay          → manual        (1 — no "prepaid" value allowed, keep current)
+ *   Other           → (no change, stays 'manual')  (1)
+ *
+ * Expected: 264 UPDATEs (Prepay + Other excluded from filter; no-op anyway).
+ * Transaction with rowcount gate, ROLLBACK on mismatch.
+ *
+ * Rollback:
+ *   UPDATE clients SET payment_method = 'manual'
+ *    WHERE company_id = 1
+ *      AND payment_method IN ('credit_card', 'invoice', 'prepaid')
+ *      AND notes LIKE '%mc_import_phase2%'
+ *     OR  id IN (SELECT DISTINCT matched_customer_id FROM mc_dispatch_staging);
+ */
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+const EXPECTED = 264;
+
+async function main() {
+  console.log("=== Q1 — payment_method backfill ===\n");
+
+  // Pre-flight: confirm DISTINCT client count for the 3 mapped categories
+  const pre = await db.execute(sql`
+    SELECT COUNT(DISTINCT mcs.matched_customer_id)::int AS n
+      FROM mc_dispatch_staging mcs
+     WHERE mcs.matched_customer_id IS NOT NULL
+       AND mcs.billing_terms IN ('Credit Card', 'Batch Invoice', 'Invoice')
+  `);
+  console.log(`Pre-flight distinct-client count: ${(pre.rows?.[0] as any)?.n} (expect ${EXPECTED})`);
+
+  console.log("\n=== Transaction ===");
+  await db.execute(sql`BEGIN`);
+  try {
+    // Use DISTINCT ON with ORDER BY billing_terms to pick a deterministic
+    // terms per client (all clients have exactly one distinct value per the
+    // dry-run — ties should not occur, but DISTINCT ON is the safety net).
+    const res = await db.execute(sql`
+      UPDATE clients c
+         SET payment_method = CASE stats.billing_terms
+               WHEN 'Credit Card'    THEN 'card_on_file'
+               WHEN 'Invoice'        THEN 'net_30'
+               WHEN 'Batch Invoice'  THEN 'net_30'
+               ELSE c.payment_method
+             END
+        FROM (
+          SELECT DISTINCT ON (mcs.matched_customer_id)
+                 mcs.matched_customer_id AS customer_id,
+                 mcs.billing_terms
+            FROM mc_dispatch_staging mcs
+           WHERE mcs.matched_customer_id IS NOT NULL
+             AND mcs.billing_terms IS NOT NULL
+           ORDER BY mcs.matched_customer_id, mcs.billing_terms
+        ) stats
+       WHERE c.id = stats.customer_id
+         AND c.company_id = 1
+         AND stats.billing_terms IN ('Credit Card', 'Invoice', 'Batch Invoice')
+      RETURNING c.id, c.first_name, c.last_name, c.payment_method
+    `);
+    console.log(`UPDATE rowcount: ${res.rowCount} (expect ${EXPECTED})`);
+    if (res.rowCount !== EXPECTED) {
+      throw new Error(`rowcount mismatch: got ${res.rowCount}, expected ${EXPECTED}`);
+    }
+
+    // Show a sample of what changed
+    console.log("\nSample of updated rows (first 10):");
+    console.table((res.rows as any[]).slice(0, 10));
+
+    await db.execute(sql`COMMIT`);
+    console.log("--- COMMIT OK ---");
+  } catch (err) {
+    await db.execute(sql`ROLLBACK`);
+    console.log("--- ROLLBACK ---");
+    throw err;
+  }
+
+  // Post-verify — full distribution
+  console.log("\n=== Post-verify: full clients.payment_method distribution ===");
+  const dist = await db.execute(sql`
+    SELECT payment_method, COUNT(*)::int AS n
+      FROM clients
+     WHERE company_id = 1
+     GROUP BY payment_method
+     ORDER BY n DESC
+  `);
+  console.table(dist.rows);
+
+  // Verify no MC client still has 'manual' (except the 1 'Other' case)
+  const residual = await db.execute(sql`
+    SELECT c.id, c.first_name || ' ' || c.last_name AS name,
+           c.payment_method,
+           stats.billing_terms AS mc_terms
+      FROM clients c
+      JOIN (
+        SELECT DISTINCT ON (mcs.matched_customer_id)
+               mcs.matched_customer_id AS customer_id, mcs.billing_terms
+          FROM mc_dispatch_staging mcs
+         WHERE mcs.matched_customer_id IS NOT NULL
+           AND mcs.billing_terms IS NOT NULL
+         ORDER BY mcs.matched_customer_id, mcs.billing_terms
+      ) stats ON stats.customer_id = c.id
+     WHERE c.company_id = 1 AND c.payment_method = 'manual'
+     ORDER BY c.id
+  `);
+  console.log("\n=== MC-linked clients still on 'manual' (expect 1: the 'Other' row) ===");
+  console.table(residual.rows);
+
+  process.exit(0);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/q1_payment_dryrun.ts
+++ b/artifacts/api-server/scripts/q1_payment_dryrun.ts
@@ -1,0 +1,129 @@
+/**
+ * Q1 Part 1 — payment_method backfill dry-run. READ-ONLY.
+ */
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+async function main() {
+  // 1. Column type for clients.payment_method
+  console.log("=== Part 1 — clients.payment_method column type ===");
+  const col = await db.execute(sql`
+    SELECT column_name, data_type, udt_name, column_default
+      FROM information_schema.columns
+     WHERE table_name = 'clients' AND column_name = 'payment_method'
+  `);
+  console.table(col.rows);
+
+  // If enum, what values are valid?
+  const udtName = (col.rows?.[0] as any)?.udt_name;
+  if (udtName && udtName !== 'text') {
+    const enumVals = await db.execute(sql`
+      SELECT enumlabel, enumsortorder
+        FROM pg_type t
+        JOIN pg_enum e ON t.oid = e.enumtypid
+       WHERE t.typname = ${udtName}
+       ORDER BY enumsortorder
+    `);
+    console.log(`\nEnum ${udtName} values:`);
+    console.table(enumVals.rows);
+  } else {
+    // Currently-used values on clients
+    const distinctVals = await db.execute(sql`
+      SELECT DISTINCT payment_method FROM clients WHERE company_id = 1
+    `);
+    console.log("\nCurrent distinct payment_method values on clients:");
+    console.table(distinctVals.rows);
+  }
+
+  // 2. MC billing_terms coverage per client
+  console.log("\n=== Clients with MC history count ===");
+  const coverage = await db.execute(sql`
+    SELECT COUNT(DISTINCT matched_customer_id)::int AS clients_with_mc_history
+      FROM mc_dispatch_staging
+     WHERE matched_customer_id IS NOT NULL
+  `);
+  console.table(coverage.rows);
+
+  // 3. Top-20 dominant billing_terms per client preview (sample)
+  console.log("\n=== Top-20 clients: dominant billing_terms ===");
+  const sample = await db.execute(sql`
+    SELECT c.id,
+           c.first_name || ' ' || c.last_name AS name,
+           stats.billing_terms AS mc_dominant_terms,
+           stats.job_count,
+           c.payment_method AS current_payment_method
+      FROM clients c
+      JOIN LATERAL (
+        SELECT billing_terms, COUNT(*)::int AS job_count
+          FROM mc_dispatch_staging mcs
+         WHERE mcs.matched_customer_id = c.id
+           AND mcs.billing_terms IS NOT NULL
+         GROUP BY billing_terms
+         ORDER BY COUNT(*) DESC, billing_terms ASC
+         LIMIT 1
+      ) stats ON true
+     WHERE c.company_id = 1
+     ORDER BY stats.job_count DESC, c.id
+     LIMIT 20
+  `);
+  console.table(sample.rows);
+
+  // 4. Full distribution of MC-dominant billing_terms
+  console.log("\n=== Full distribution: MC-dominant billing_terms across all 266 linked clients ===");
+  const dist = await db.execute(sql`
+    WITH per_client AS (
+      SELECT DISTINCT ON (c.id)
+             c.id,
+             mcs.billing_terms,
+             COUNT(mcs.mc_job_id) OVER (PARTITION BY c.id, mcs.billing_terms) AS job_count
+        FROM clients c
+        JOIN mc_dispatch_staging mcs ON mcs.matched_customer_id = c.id
+       WHERE c.company_id = 1
+         AND mcs.billing_terms IS NOT NULL
+       ORDER BY c.id, COUNT(mcs.mc_job_id) OVER (PARTITION BY c.id, mcs.billing_terms) DESC, mcs.billing_terms
+    )
+    SELECT COALESCE(billing_terms, '(null)') AS dominant_mc_terms,
+           COUNT(*)::int AS client_count
+      FROM per_client
+     GROUP BY billing_terms
+     ORDER BY client_count DESC
+  `);
+  console.table(dist.rows);
+
+  // 5. Tie-cases: clients where MC has multiple billing_terms and one is dominant
+  console.log("\n=== Clients with mixed billing_terms (for tie-break sanity) ===");
+  const ties = await db.execute(sql`
+    SELECT c.id,
+           c.first_name || ' ' || c.last_name AS name,
+           ARRAY_AGG(DISTINCT mcs.billing_terms ORDER BY mcs.billing_terms) AS all_terms,
+           COUNT(DISTINCT mcs.billing_terms)::int AS distinct_terms
+      FROM clients c
+      JOIN mc_dispatch_staging mcs ON mcs.matched_customer_id = c.id
+     WHERE c.company_id = 1 AND mcs.billing_terms IS NOT NULL
+     GROUP BY c.id, c.first_name, c.last_name
+     HAVING COUNT(DISTINCT mcs.billing_terms) > 1
+     ORDER BY distinct_terms DESC, c.id
+     LIMIT 20
+  `);
+  console.log(`Mixed-terms clients: ${ties.rowCount}`);
+  console.table(ties.rows);
+
+  // 6. Clients with NO MC billing_terms signal (NULL only)
+  console.log("\n=== Clients where ALL MC rows have NULL billing_terms ===");
+  const noSig = await db.execute(sql`
+    SELECT c.id, c.first_name || ' ' || c.last_name AS name,
+           COUNT(*)::int AS mc_rows
+      FROM clients c
+      JOIN mc_dispatch_staging mcs ON mcs.matched_customer_id = c.id
+     WHERE c.company_id = 1
+     GROUP BY c.id, c.first_name, c.last_name
+     HAVING COUNT(*) FILTER (WHERE mcs.billing_terms IS NOT NULL) = 0
+     ORDER BY mc_rows DESC
+     LIMIT 10
+  `);
+  console.log(`Clients with all-NULL billing_terms: ${noSig.rowCount}`);
+  console.table(noSig.rows);
+
+  process.exit(0);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/revenue_diagnostic.ts
+++ b/artifacts/api-server/scripts/revenue_diagnostic.ts
@@ -1,0 +1,130 @@
+/**
+ * Revenue reconciliation diagnostic — sections 2, 3, 5, 6. READ-ONLY.
+ */
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+async function main() {
+  console.log("\n==================== SECTION 2 — Jobs table raw counts Apr 22–30 ====================\n");
+  const s2 = await db.execute(sql`
+    SELECT scheduled_date::text AS scheduled_date,
+           COUNT(*)::int AS job_rows,
+           COUNT(DISTINCT id)::int AS distinct_jobs,
+           SUM(base_fee::numeric)::numeric(14,2) AS total_base_fee,
+           SUM(CASE WHEN base_fee IS NULL THEN 1 ELSE 0 END)::int AS null_fee
+      FROM jobs
+     WHERE company_id = 1
+       AND scheduled_date BETWEEN '2026-04-22' AND '2026-04-30'
+     GROUP BY scheduled_date
+     ORDER BY scheduled_date
+  `);
+  console.table(s2.rows);
+
+  const s2total = await db.execute(sql`
+    SELECT COUNT(*)::int AS job_rows,
+           SUM(base_fee::numeric)::numeric(14,2) AS total_base_fee
+      FROM jobs
+     WHERE company_id = 1
+       AND scheduled_date BETWEEN '2026-04-22' AND '2026-04-30'
+  `);
+  console.log("Apr 22–30 total:", s2total.rows);
+
+  console.log("\n==================== SECTION 3 — Dispatch inflation via technician joins ====================\n");
+  const s3 = await db.execute(sql`
+    SELECT j.scheduled_date::text AS scheduled_date,
+           COUNT(DISTINCT j.id)::int AS unique_jobs,
+           COUNT(jt.job_id)::int AS join_rows,
+           (COUNT(jt.job_id) - COUNT(DISTINCT j.id))::int AS extra_rows,
+           SUM(j.base_fee::numeric)::numeric(14,2) AS naive_sum,
+           SUM(DISTINCT j.base_fee::numeric)::numeric(14,2) AS distinct_sum
+      FROM jobs j
+      LEFT JOIN job_technicians jt ON jt.job_id = j.id
+     WHERE j.company_id = 1
+       AND j.scheduled_date BETWEEN '2026-04-22' AND '2026-04-30'
+     GROUP BY j.scheduled_date
+     ORDER BY j.scheduled_date
+  `);
+  console.table(s3.rows);
+
+  const s3cols = await db.execute(sql`
+    SELECT column_name
+      FROM information_schema.columns
+     WHERE table_name = 'jobs' AND table_schema = 'public'
+     ORDER BY ordinal_position
+  `);
+  console.log("\nJobs table columns:");
+  console.log((s3cols.rows as any[]).map(r => r.column_name).join(", "));
+
+  console.log("\n==================== SECTION 5 — Both tables, April 2026 reality ====================\n");
+  const s5 = await db.execute(sql`
+    SELECT 'job_history' AS source,
+           COUNT(*)::int AS rows, SUM(revenue)::numeric(14,2) AS total
+      FROM job_history
+     WHERE company_id = 1 AND job_date BETWEEN '2026-04-01' AND '2026-04-30'
+    UNION ALL
+    SELECT 'jobs' AS source,
+           COUNT(*)::int AS rows, SUM(base_fee::numeric)::numeric(14,2) AS total
+      FROM jobs
+     WHERE company_id = 1 AND scheduled_date BETWEEN '2026-04-01' AND '2026-04-30'
+  `);
+  console.table(s5.rows);
+
+  const s5daily = await db.execute(sql`
+    SELECT TO_CHAR(scheduled_date, 'YYYY-MM-DD') AS date,
+           COUNT(*)::int AS jobs,
+           SUM(base_fee::numeric)::numeric(14,2) AS total
+      FROM jobs
+     WHERE company_id = 1 AND scheduled_date BETWEEN '2026-04-01' AND '2026-04-30'
+     GROUP BY 1 ORDER BY 1
+  `);
+  console.log("\nApril 2026 day-by-day from jobs:");
+  console.table(s5daily.rows);
+
+  const s5status = await db.execute(sql`
+    SELECT status,
+           COUNT(*)::int AS jobs,
+           SUM(base_fee::numeric)::numeric(14,2) AS total
+      FROM jobs
+     WHERE company_id = 1 AND scheduled_date BETWEEN '2026-04-01' AND '2026-04-30'
+     GROUP BY status ORDER BY status
+  `);
+  console.log("\nApril 2026 jobs by status:");
+  console.table(s5status.rows);
+
+  console.log("\n==================== SECTION 6 — Apr 23 row dump ====================\n");
+  const s6 = await db.execute(sql`
+    SELECT j.id, j.scheduled_date::text AS scheduled_date,
+           j.scheduled_time::text AS scheduled_time,
+           j.base_fee::text AS base_fee, j.status,
+           c.first_name, c.last_name,
+           j.recurring_schedule_id,
+           j.assigned_user_id,
+           (SELECT COUNT(*)::int FROM job_technicians jt WHERE jt.job_id = j.id) AS tech_count
+      FROM jobs j
+      LEFT JOIN clients c ON c.id = j.client_id
+     WHERE j.company_id = 1 AND j.scheduled_date = '2026-04-23'
+     ORDER BY j.scheduled_time NULLS LAST, j.id
+  `);
+  console.table(s6.rows);
+  console.log(`\nApr 23 row count: ${s6.rowCount}`);
+  const sumApr23 = (s6.rows as any[]).reduce((s, r) => s + parseFloat(r.base_fee || '0'), 0);
+  console.log(`Apr 23 sum base_fee: $${sumApr23.toFixed(2)}`);
+
+  // Bonus: Apr 23 joined with job_technicians to see the inflation
+  console.log("\n--- Apr 23 with job_technicians LEFT JOIN (same shape Dispatch frontend may compute) ---");
+  const s6join = await db.execute(sql`
+    SELECT j.id, j.base_fee::text AS base_fee,
+           (SELECT COUNT(*)::int FROM job_technicians jt WHERE jt.job_id = j.id) AS tech_count,
+           COALESCE((SELECT COUNT(*)::int FROM job_technicians jt WHERE jt.job_id = j.id), 0) AS tech_mult
+      FROM jobs j
+     WHERE j.company_id = 1 AND j.scheduled_date = '2026-04-23'
+     ORDER BY j.id
+  `);
+  const joinRows = s6join.rows as any[];
+  const multipliedSum = joinRows.reduce((s, r) => s + parseFloat(r.base_fee || '0') * Math.max(1, r.tech_count), 0);
+  const multipliedCount = joinRows.reduce((s, r) => s + Math.max(1, r.tech_count), 0);
+  console.log(`If each job counted once per assigned technician: ${multipliedCount} rows, $${multipliedSum.toFixed(2)}`);
+
+  process.exit(0);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/revenue_diagnostic_2.ts
+++ b/artifacts/api-server/scripts/revenue_diagnostic_2.ts
@@ -1,0 +1,80 @@
+/**
+ * Deeper dive — why are 25 jobs on Apr 23 and 50 on Apr 27?
+ */
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+async function main() {
+  // Frequency / day_of_week breakdown of schedules that landed on Apr 23 and Apr 27
+  console.log("=== Apr 23 schedules — frequency / day_of_week / start_date ===");
+  const apr23 = await db.execute(sql`
+    SELECT rs.id, rs.frequency, rs.day_of_week,
+           rs.start_date::text AS start_date,
+           rs.last_generated_date::text AS last_generated_date,
+           c.first_name || ' ' || c.last_name AS client
+      FROM jobs j
+      JOIN recurring_schedules rs ON rs.id = j.recurring_schedule_id
+      JOIN clients c ON c.id = rs.customer_id
+     WHERE j.company_id = 1 AND j.scheduled_date = '2026-04-23'
+     ORDER BY rs.frequency, rs.day_of_week, rs.id
+  `);
+  console.table(apr23.rows);
+  const f23: Record<string, number> = {};
+  for (const r of apr23.rows as any[]) {
+    const key = `${r.frequency}/${r.day_of_week || 'anchor_dom'}`;
+    f23[key] = (f23[key] ?? 0) + 1;
+  }
+  console.log("Apr 23 freq breakdown:", f23);
+
+  console.log("\n=== Apr 27 schedules — frequency / day_of_week / start_date ===");
+  const apr27 = await db.execute(sql`
+    SELECT rs.id, rs.frequency, rs.day_of_week,
+           rs.start_date::text AS start_date,
+           rs.last_generated_date::text AS last_generated_date,
+           c.first_name || ' ' || c.last_name AS client
+      FROM jobs j
+      JOIN recurring_schedules rs ON rs.id = j.recurring_schedule_id
+      JOIN clients c ON c.id = rs.customer_id
+     WHERE j.company_id = 1 AND j.scheduled_date = '2026-04-27'
+     ORDER BY rs.frequency, rs.day_of_week, rs.id
+  `);
+  console.table(apr27.rows);
+  const f27: Record<string, number> = {};
+  for (const r of apr27.rows as any[]) {
+    const key = `${r.frequency}/${r.day_of_week || 'anchor_dom'}`;
+    f27[key] = (f27[key] ?? 0) + 1;
+  }
+  console.log("Apr 27 freq breakdown:", f27);
+
+  // Expected distribution across the full 79 active schedules
+  console.log("\n=== All 79 active PHES schedules — frequency × day_of_week ===");
+  const all = await db.execute(sql`
+    SELECT frequency, day_of_week, COUNT(*)::int AS n
+      FROM recurring_schedules
+     WHERE company_id = 1 AND is_active = true
+     GROUP BY 1, 2
+     ORDER BY 1, 2
+  `);
+  console.table(all.rows);
+
+  // What MC says: Apr 22–30 has 83 jobs across 8 working days. Show what the
+  // engine OUGHT to have produced (day-by-day count for the 60-day horizon
+  // from today 2026-04-22 forward) and how many land on Apr 23 vs Apr 27.
+  console.log("\n=== Engine-generated distribution Apr 22 – May 21 (all 79 schedules, from jobs table) ===");
+  const horizon = await db.execute(sql`
+    SELECT scheduled_date::text AS date,
+           EXTRACT(DOW FROM scheduled_date)::int AS dow,
+           TO_CHAR(scheduled_date, 'Dy') AS dow_name,
+           COUNT(*)::int AS jobs,
+           SUM(base_fee::numeric)::numeric(14,2) AS fee_sum
+      FROM jobs
+     WHERE company_id = 1
+       AND recurring_schedule_id IS NOT NULL
+       AND scheduled_date BETWEEN '2026-04-22' AND '2026-05-21'
+     GROUP BY 1, 2, 3 ORDER BY 1
+  `);
+  console.table(horizon.rows);
+
+  process.exit(0);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/revenue_recon.ts
+++ b/artifacts/api-server/scripts/revenue_recon.ts
@@ -1,0 +1,72 @@
+/**
+ * Read-only revenue reconciliation — queries 2, 3, 5.
+ */
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+async function main() {
+  // Q2: job_history revenue by month
+  console.log("=== Q2: job_history revenue by month (PHES, 2025-01+) ===");
+  const q2 = await db.execute(sql`
+    SELECT TO_CHAR(job_date, 'YYYY-MM') AS month,
+           COUNT(*)::int AS jobs,
+           SUM(revenue)::numeric(14,2) AS total_rev
+      FROM job_history
+     WHERE company_id = 1
+       AND job_date >= '2025-01-01'
+     GROUP BY 1
+     ORDER BY 1 DESC
+     LIMIT 16
+  `);
+  console.table(q2.rows);
+
+  // Q3: jobs table revenue by month and status
+  console.log("\n=== Q3: jobs table by month x status (PHES, 2025-01+) ===");
+  const q3 = await db.execute(sql`
+    SELECT TO_CHAR(scheduled_date, 'YYYY-MM') AS month,
+           status,
+           COUNT(*)::int AS jobs,
+           SUM(base_fee::numeric)::numeric(14,2) AS total
+      FROM jobs
+     WHERE company_id = 1
+       AND scheduled_date >= '2025-01-01'
+     GROUP BY 1, 2
+     ORDER BY 1 DESC, 2
+     LIMIT 30
+  `);
+  console.table(q3.rows);
+
+  // Q5: Arianna Goose (id 26) sample — 10 most recent job_history rows
+  console.log("\n=== Q5: Arianna Goose id=26 — recent job_history ===");
+  const q5 = await db.execute(sql`
+    SELECT jh.job_date,
+           jh.service_type,
+           jh.revenue,
+           jh.technician,
+           COALESCE(LEFT(jh.notes, 80), '') AS notes_excerpt
+      FROM job_history jh
+     WHERE company_id = 1 AND customer_id = 26
+     ORDER BY job_date DESC
+     LIMIT 10
+  `);
+  console.table(q5.rows);
+
+  // Bonus: total counts for sanity
+  const phesJH = await db.execute(sql`
+    SELECT COUNT(*)::int AS n, SUM(revenue)::numeric(14,2) AS rev_sum
+      FROM job_history WHERE company_id = 1 AND job_date >= '2025-01-01'
+  `);
+  console.log("\n=== Totals — job_history 2025-01+ (PHES) ===");
+  console.table(phesJH.rows);
+
+  const phesJobsStatus = await db.execute(sql`
+    SELECT status, COUNT(*)::int AS n, SUM(base_fee::numeric)::numeric(14,2) AS fee_sum
+      FROM jobs WHERE company_id = 1
+     GROUP BY status ORDER BY n DESC
+  `);
+  console.log("\n=== Totals — jobs by status (PHES, all time) ===");
+  console.table(phesJobsStatus.rows);
+
+  process.exit(0);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/t_orphan_delete.ts
+++ b/artifacts/api-server/scripts/t_orphan_delete.ts
@@ -1,0 +1,94 @@
+/**
+ * T — delete 2 pre-L4 orphan jobs (id 703 Jim Schultz, id 2081 Chaevien Clendinen).
+ *
+ * Both rows have:
+ *   - mc_job_id IS NULL (not imported from MC)
+ *   - recurring_schedule_id IS NULL (not from engine)
+ *   - empty notes
+ *   - zero FK refs in timeclock / additional_pay / job_technicians /
+ *     job_photos / invoices (verified by orphan_job_refs.ts)
+ *
+ * Gates (inside transaction, rollback on any fail):
+ *   1. DELETE FROM jobs returns exactly 2 rows
+ *   2. Post-delete Apr 23 PHES totals = 14 jobs / $2,900.25 / 52.25h
+ */
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+async function main() {
+  console.log("=== T — delete 2 orphan Apr 23 jobs ===\n");
+
+  await db.execute(sql`BEGIN`);
+  try {
+    // Clean-up FK: job_technicians (verified 0 refs in diagnosis, but belt-and-
+    // suspenders in case Q2 auto-populated something)
+    const jtDel = await db.execute(sql`
+      DELETE FROM job_technicians WHERE job_id IN (703, 2081)
+    `);
+    console.log(`job_technicians cleanup: ${jtDel.rowCount} rows (expect 0)`);
+
+    // Main DELETE — gated on mc_job_id IS NULL so we can't accidentally touch
+    // an MC-imported row if some other script already relinked these ids.
+    const del = await db.execute(sql`
+      DELETE FROM jobs
+       WHERE id IN (703, 2081)
+         AND company_id = 1
+         AND mc_job_id IS NULL
+      RETURNING id
+    `);
+    const delCount = del.rowCount ?? 0;
+    console.log(`jobs DELETE rowcount: ${delCount} (expect 2)`);
+    if (delCount !== 2) {
+      throw new Error(`Gate 1 FAIL — delete returned ${delCount}, expected 2`);
+    }
+
+    // Gate 2: Apr 23 final totals
+    const after = await db.execute(sql`
+      SELECT COUNT(*)::int AS job_count,
+             SUM(base_fee::numeric)::numeric(14,2)::text AS revenue,
+             SUM(allowed_hours::numeric)::numeric(14,2)::text AS hours
+        FROM jobs
+       WHERE company_id = 1 AND scheduled_date = '2026-04-23'
+    `);
+    const row = after.rows?.[0] as any;
+    const gotJobs = Number(row?.job_count ?? 0);
+    const gotRev = String(row?.revenue ?? "");
+    const gotHrs = String(row?.hours ?? "");
+    console.log(`Post: job_count=${gotJobs}  revenue=$${gotRev}  hours=${gotHrs}`);
+    console.log(`Expected:            14          $2900.25       52.25`);
+
+    const ok = gotJobs === 14 && gotRev === "2900.25" && gotHrs === "52.25";
+    if (!ok) {
+      throw new Error(`Gate 2 FAIL — Apr 23 totals don't match MC ground truth`);
+    }
+
+    await db.execute(sql`COMMIT`);
+    console.log("\n--- COMMIT OK ---");
+  } catch (err) {
+    await db.execute(sql`ROLLBACK`);
+    console.log("\n--- ROLLBACK ---");
+    console.error(err);
+    process.exit(1);
+  }
+
+  // Final verify outside the transaction
+  const final = await db.execute(sql`
+    SELECT
+      CASE WHEN mc_job_id IS NULL THEN 'NO_MC_ID' ELSE 'MC_IMPORTED' END AS source,
+      COUNT(*)::int AS job_count,
+      SUM(base_fee::numeric)::numeric(14,2)::text AS revenue
+    FROM jobs
+    WHERE company_id = 1 AND scheduled_date = '2026-04-23'
+    GROUP BY 1
+  `);
+  console.log("\n=== Apr 23 by source (post-commit) ===");
+  console.table(final.rows);
+
+  const deletedCheck = await db.execute(sql`
+    SELECT id FROM jobs WHERE id IN (703, 2081)
+  `);
+  console.log(`\nIds 703 / 2081 still present: ${deletedCheck.rowCount} (expect 0)`);
+
+  process.exit(0);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/t_orphan_delete_v2.ts
+++ b/artifacts/api-server/scripts/t_orphan_delete_v2.ts
@@ -1,0 +1,121 @@
+/**
+ * T — Option B: unlink quote 28 + revert to 'accepted', then delete orphan jobs.
+ *
+ * Transaction gates (ROLLBACK on any fail):
+ *   1. quotes UPDATE returns exactly 1 row (id 28, booked_job_id was 2081)
+ *   2. job_technicians cleanup — no expected count (0 known; belt-and-suspenders)
+ *   3. jobs DELETE returns exactly 2 rows (703, 2081)
+ *   4. Post Apr 23 totals = 14 jobs / $2,900.25 / 52.25h
+ *   5. quote 28 ends with status='accepted', booked_job_id=NULL
+ */
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+async function main() {
+  console.log("=== T — Option B: unlink quote + delete 2 orphan jobs ===\n");
+
+  await db.execute(sql`BEGIN`);
+  try {
+    // --- Gate 1: quote unlink ---
+    const quoteUpd = await db.execute(sql`
+      UPDATE quotes
+         SET booked_job_id = NULL, status = 'accepted'
+       WHERE id = 28 AND booked_job_id = 2081
+      RETURNING id, status, booked_job_id
+    `);
+    console.log(`quotes UPDATE rowcount: ${quoteUpd.rowCount} (expect 1)`);
+    console.log("Returning:", quoteUpd.rows);
+    if (quoteUpd.rowCount !== 1) {
+      throw new Error(`Gate 1 FAIL — quote update returned ${quoteUpd.rowCount}, expected 1`);
+    }
+
+    // --- Gate 2: job_technicians cleanup ---
+    const jtDel = await db.execute(sql`
+      DELETE FROM job_technicians WHERE job_id IN (703, 2081)
+    `);
+    console.log(`\njob_technicians cleanup: ${jtDel.rowCount} rows (0 known pre-audit)`);
+
+    // --- Gate 3: main DELETE ---
+    const del = await db.execute(sql`
+      DELETE FROM jobs
+       WHERE id IN (703, 2081)
+         AND company_id = 1
+         AND mc_job_id IS NULL
+      RETURNING id, client_id, scheduled_time, base_fee::text AS base_fee
+    `);
+    const delCount = del.rowCount ?? 0;
+    console.log(`\njobs DELETE rowcount: ${delCount} (expect 2)`);
+    console.table(del.rows);
+    if (delCount !== 2) {
+      throw new Error(`Gate 3 FAIL — delete returned ${delCount}, expected 2`);
+    }
+
+    // --- Gate 4: Apr 23 final totals ---
+    const after = await db.execute(sql`
+      SELECT COUNT(*)::int AS job_count,
+             SUM(base_fee::numeric)::numeric(14,2)::text AS revenue,
+             SUM(allowed_hours::numeric)::numeric(14,2)::text AS hours
+        FROM jobs
+       WHERE company_id = 1 AND scheduled_date = '2026-04-23'
+    `);
+    const row = after.rows?.[0] as any;
+    const gotJobs = Number(row?.job_count ?? 0);
+    const gotRev = String(row?.revenue ?? "");
+    const gotHrs = String(row?.hours ?? "");
+    console.log(`\nApr 23 post: job_count=${gotJobs}  revenue=$${gotRev}  hours=${gotHrs}`);
+    console.log(`Expected:    job_count=14         revenue=$2900.25       hours=52.25`);
+    const ok = gotJobs === 14 && gotRev === "2900.25" && gotHrs === "52.25";
+    if (!ok) {
+      throw new Error(`Gate 4 FAIL — Apr 23 totals don't match MC ground truth`);
+    }
+
+    // --- Gate 5: quote 28 final state ---
+    const quoteCheck = await db.execute(sql`
+      SELECT id, client_id, status, booked_job_id, total_price::text AS total_price
+        FROM quotes WHERE id = 28
+    `);
+    const qRow = quoteCheck.rows?.[0] as any;
+    console.log("\nQuote 28 final state:");
+    console.table([qRow]);
+    if (qRow.status !== "accepted" || qRow.booked_job_id !== null) {
+      throw new Error(`Gate 5 FAIL — quote 28 status='${qRow.status}' booked_job_id=${qRow.booked_job_id}`);
+    }
+
+    await db.execute(sql`COMMIT`);
+    console.log("\n--- COMMIT OK ---");
+  } catch (err) {
+    await db.execute(sql`ROLLBACK`);
+    console.log("\n--- ROLLBACK ---");
+    console.error(err);
+    process.exit(1);
+  }
+
+  // ---- Post-verify ----
+  console.log("\n=== Post-commit final state ===");
+
+  const apr23 = await db.execute(sql`
+    SELECT
+      CASE WHEN mc_job_id IS NULL THEN 'NO_MC_ID' ELSE 'MC_IMPORTED' END AS source,
+      COUNT(*)::int AS job_count,
+      SUM(base_fee::numeric)::numeric(14,2)::text AS revenue
+    FROM jobs
+    WHERE company_id = 1 AND scheduled_date = '2026-04-23'
+    GROUP BY 1
+  `);
+  console.log("Apr 23 by source:");
+  console.table(apr23.rows);
+
+  const idsGone = await db.execute(sql`
+    SELECT id FROM jobs WHERE id IN (703, 2081)
+  `);
+  console.log(`\nIds 703 / 2081 still present: ${idsGone.rowCount} (expect 0)`);
+
+  const quote = await db.execute(sql`
+    SELECT id, status, booked_job_id, total_price::text AS total_price FROM quotes WHERE id = 28
+  `);
+  console.log("\nQuote 28:");
+  console.table(quote.rows);
+
+  process.exit(0);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/t_reverify.ts
+++ b/artifacts/api-server/scripts/t_reverify.ts
@@ -1,0 +1,50 @@
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+async function main() {
+  console.log("=== Re-verify Apr 23 + quote 28 state ===\n");
+
+  // Apr 23 by source
+  const apr23 = await db.execute(sql`
+    SELECT
+      CASE WHEN mc_job_id IS NULL THEN 'NO_MC_ID' ELSE 'MC_IMPORTED' END AS source,
+      COUNT(*)::int AS job_count,
+      SUM(base_fee::numeric)::numeric(14,2)::text AS revenue,
+      SUM(allowed_hours::numeric)::numeric(14,2)::text AS hours
+    FROM jobs
+    WHERE company_id = 1 AND scheduled_date = '2026-04-23'
+    GROUP BY 1
+  `);
+  console.log("Apr 23 jobs by source:");
+  console.table(apr23.rows);
+
+  // Aggregate
+  const agg = await db.execute(sql`
+    SELECT COUNT(*)::int AS job_count,
+           SUM(base_fee::numeric)::numeric(14,2)::text AS revenue,
+           SUM(allowed_hours::numeric)::numeric(14,2)::text AS hours,
+           COUNT(*) FILTER (WHERE assigned_user_id IS NULL
+                            AND NOT EXISTS (SELECT 1 FROM job_technicians jt WHERE jt.job_id = jobs.id))::int AS unassigned
+      FROM jobs
+     WHERE company_id = 1 AND scheduled_date = '2026-04-23'
+  `);
+  console.log("\nApr 23 aggregate:");
+  console.table(agg.rows);
+
+  // Jobs 703 + 2081 confirmed gone
+  const gone = await db.execute(sql`
+    SELECT id FROM jobs WHERE id IN (703, 2081)
+  `);
+  console.log(`\nIds 703 / 2081 still present: ${gone.rowCount} (expect 0)`);
+
+  // Quote 28 state
+  const q28 = await db.execute(sql`
+    SELECT id, client_id, lead_name, status, booked_job_id, total_price::text AS total_price
+      FROM quotes WHERE id = 28
+  `);
+  console.log("\nQuote 28 (Chaevien Clendinen):");
+  console.table(q28.rows);
+
+  process.exit(0);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/u_relink_quote.ts
+++ b/artifacts/api-server/scripts/u_relink_quote.ts
@@ -1,0 +1,83 @@
+/**
+ * U — Re-link quote 28 (Chaevien Clendinen) to MC-imported job 4230.
+ *
+ * T severed the link when we deleted the duplicate manual job 2081.
+ * The real booking is job 4230 (mc_job_id 62002679) — same customer,
+ * same date, same amount. This restores the audit chain.
+ */
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+async function main() {
+  console.log("=== U — Re-link quote 28 → job 4230 ===\n");
+
+  // Pre-flight: verify job 4230 exists and is for client 258 at the right amount
+  const preJob = await db.execute(sql`
+    SELECT id, mc_job_id, client_id, scheduled_date::text AS scheduled_date,
+           base_fee::text AS base_fee, status::text AS status
+      FROM jobs WHERE id = 4230 AND company_id = 1
+  `);
+  console.log("Target job 4230:");
+  console.table(preJob.rows);
+  const j = preJob.rows?.[0] as any;
+  if (!j || j.client_id !== 258) {
+    throw new Error(`Pre-flight FAIL — job 4230 missing or wrong client_id (got ${j?.client_id}, expected 258)`);
+  }
+
+  // Pre-flight: verify quote 28 exists and is currently accepted/NULL-booked
+  const preQuote = await db.execute(sql`
+    SELECT id, client_id, status, booked_job_id, total_price::text AS total_price
+      FROM quotes WHERE id = 28
+  `);
+  console.log("\nQuote 28 before:");
+  console.table(preQuote.rows);
+  const q = preQuote.rows?.[0] as any;
+  if (!q || q.client_id !== 258) {
+    throw new Error(`Pre-flight FAIL — quote 28 missing or wrong client_id`);
+  }
+
+  // Transaction
+  await db.execute(sql`BEGIN`);
+  try {
+    const res = await db.execute(sql`
+      UPDATE quotes
+         SET booked_job_id = 4230, status = 'booked'
+       WHERE id = 28
+      RETURNING id, client_id, status, booked_job_id, total_price::text AS total_price
+    `);
+    console.log(`\nUPDATE rowcount: ${res.rowCount} (expect 1)`);
+    console.table(res.rows);
+    if (res.rowCount !== 1) {
+      throw new Error(`Gate FAIL — update returned ${res.rowCount}, expected 1`);
+    }
+
+    const row = res.rows?.[0] as any;
+    if (row.status !== "booked" || Number(row.booked_job_id) !== 4230) {
+      throw new Error(`Gate FAIL — quote 28 state wrong: status='${row.status}' booked_job_id=${row.booked_job_id}`);
+    }
+
+    await db.execute(sql`COMMIT`);
+    console.log("\n--- COMMIT OK ---");
+  } catch (err) {
+    await db.execute(sql`ROLLBACK`);
+    console.log("\n--- ROLLBACK ---");
+    console.error(err);
+    process.exit(1);
+  }
+
+  // Post-verify
+  const after = await db.execute(sql`
+    SELECT q.id AS quote_id, q.client_id, q.status, q.booked_job_id,
+           q.total_price::text AS total_price,
+           j.mc_job_id, j.scheduled_date::text AS job_date,
+           j.base_fee::text AS job_fee, j.status::text AS job_status
+      FROM quotes q
+      LEFT JOIN jobs j ON j.id = q.booked_job_id
+     WHERE q.id = 28
+  `);
+  console.log("\n=== Post-verify: quote 28 + linked job ===");
+  console.table(after.rows);
+
+  process.exit(0);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/zip_audit.ts
+++ b/artifacts/api-server/scripts/zip_audit.ts
@@ -1,0 +1,129 @@
+/**
+ * Audit zip coverage and zone derivation success.
+ */
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+async function main() {
+  // 1. clients.zip coverage overall
+  console.log("=== clients.zip coverage (all PHES clients) ===");
+  const overall = await db.execute(sql`
+    SELECT
+      COUNT(*)::int AS total,
+      COUNT(*) FILTER (WHERE zip IS NOT NULL AND TRIM(zip) != '')::int AS with_zip,
+      COUNT(*) FILTER (WHERE zip IS NULL OR TRIM(zip) = '')::int AS no_zip
+    FROM clients WHERE company_id = 1
+  `);
+  console.table(overall.rows);
+
+  // 2. For upcoming-job clients specifically
+  console.log("\n=== Upcoming-job clients (scheduled_date >= today) ===");
+  const upcoming = await db.execute(sql`
+    WITH upcoming_clients AS (
+      SELECT DISTINCT j.client_id
+        FROM jobs j
+       WHERE j.company_id = 1 AND j.scheduled_date >= CURRENT_DATE
+         AND j.client_id IS NOT NULL
+    )
+    SELECT
+      COUNT(*)::int AS total_upcoming_clients,
+      COUNT(*) FILTER (WHERE c.zip IS NOT NULL AND TRIM(c.zip) != '')::int AS with_zip,
+      COUNT(*) FILTER (WHERE c.zip IS NULL OR TRIM(c.zip) = '')::int AS no_zip
+    FROM upcoming_clients u
+    LEFT JOIN clients c ON c.id = u.client_id
+  `);
+  console.table(upcoming.rows);
+
+  // 3. Of the zip-populated clients, how many resolve to a zone?
+  console.log("\n=== Zone-derivation success: zip→service_zones.zip_codes match ===");
+  const zoneSuccess = await db.execute(sql`
+    SELECT
+      COUNT(*)::int AS total_with_zip,
+      COUNT(*) FILTER (WHERE EXISTS (
+        SELECT 1 FROM service_zones z
+         WHERE z.company_id = 1 AND z.is_active = true
+           AND c.zip = ANY(z.zip_codes)
+      ))::int AS zip_matches_zone,
+      COUNT(*) FILTER (WHERE NOT EXISTS (
+        SELECT 1 FROM service_zones z
+         WHERE z.company_id = 1 AND z.is_active = true
+           AND c.zip = ANY(z.zip_codes)
+      ))::int AS zip_no_zone_match
+    FROM clients c
+    WHERE c.company_id = 1
+      AND c.zip IS NOT NULL AND TRIM(c.zip) != ''
+  `);
+  console.table(zoneSuccess.rows);
+
+  // 4. Sample zips from upcoming clients
+  console.log("\n=== Sample: upcoming jobs with zip (first 15) ===");
+  const sample = await db.execute(sql`
+    SELECT DISTINCT
+      c.id, c.first_name || ' ' || c.last_name AS name,
+      c.zip,
+      (SELECT z.name FROM service_zones z
+         WHERE z.company_id = 1 AND z.is_active = true
+           AND c.zip = ANY(z.zip_codes) LIMIT 1) AS derived_zone
+    FROM jobs j
+    JOIN clients c ON c.id = j.client_id
+    WHERE j.company_id = 1 AND j.scheduled_date >= CURRENT_DATE
+    ORDER BY c.zip NULLS LAST, c.id
+    LIMIT 15
+  `);
+  console.table(sample.rows);
+
+  // 5. What zips are in our upcoming cohort and do they map to zones?
+  console.log("\n=== Distinct zips in upcoming job cohort ===");
+  const zips = await db.execute(sql`
+    SELECT c.zip, COUNT(DISTINCT c.id)::int AS clients,
+           (SELECT z.name FROM service_zones z
+              WHERE z.company_id = 1 AND z.is_active = true
+                AND c.zip = ANY(z.zip_codes) LIMIT 1) AS zone_name
+    FROM jobs j
+    JOIN clients c ON c.id = j.client_id
+    WHERE j.company_id = 1 AND j.scheduled_date >= CURRENT_DATE
+      AND c.zip IS NOT NULL AND TRIM(c.zip) != ''
+    GROUP BY c.zip
+    ORDER BY clients DESC, c.zip
+    LIMIT 20
+  `);
+  console.table(zips.rows);
+
+  // 6. Do we have MC address strings that might contain zip we could extract?
+  console.log("\n=== MC staging address tail — does it contain a ZIP pattern? ===");
+  const stagingAddr = await db.execute(sql`
+    SELECT customer_name, address
+      FROM mc_dispatch_staging
+     WHERE address IS NOT NULL
+     ORDER BY mc_job_id
+     LIMIT 10
+  `);
+  console.table(stagingAddr.rows);
+
+  // 7. Any trailing-zip pattern in existing clients.address text?
+  console.log("\n=== Clients with zip pattern in address text (alternative source) ===");
+  const addrZip = await db.execute(sql`
+    SELECT
+      COUNT(*)::int AS total_with_address,
+      COUNT(*) FILTER (WHERE address ~ '\\y\\d{5}(-\\d{4})?\\y')::int AS address_has_zip_pattern,
+      COUNT(*) FILTER (WHERE zip IS NULL OR TRIM(zip) = '')::int AS zip_col_null,
+      COUNT(*) FILTER (WHERE (zip IS NULL OR TRIM(zip) = '')
+                           AND address ~ '\\y\\d{5}(-\\d{4})?\\y')::int AS null_zip_but_address_has_pattern
+    FROM clients
+    WHERE company_id = 1 AND address IS NOT NULL
+  `);
+  console.table(addrZip.rows);
+
+  // 8. Total zones + their zip_codes count + clients they'd cover if we had all zips
+  console.log("\n=== Service zones — active w/ zip_codes ===");
+  const zonesZips = await db.execute(sql`
+    SELECT z.id, z.name, ARRAY_LENGTH(z.zip_codes, 1)::int AS zip_count, z.color
+      FROM service_zones z
+     WHERE z.company_id = 1 AND z.is_active = true
+     ORDER BY zip_count DESC NULLS LAST
+  `);
+  console.table(zonesZips.rows);
+
+  process.exit(0);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/zip_backfill_audit.ts
+++ b/artifacts/api-server/scripts/zip_backfill_audit.ts
@@ -1,0 +1,99 @@
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+async function main() {
+  // 1. For Apr 23 clients missing zip, what fields DO they have?
+  console.log("=== Apr 23 clients — address fields (where zip=NULL) ===");
+  const noZip = await db.execute(sql`
+    SELECT DISTINCT
+      c.id,
+      c.first_name || ' ' || c.last_name AS name,
+      c.zip AS client_zip,
+      LEFT(COALESCE(c.address,''), 50) AS client_address,
+      c.city AS client_city,
+      c.state AS client_state,
+      LEFT(COALESCE(j.address_street,''), 50) AS job_address_street,
+      j.address_city AS job_city,
+      j.address_state AS job_state,
+      j.address_zip AS job_zip
+    FROM jobs j
+    LEFT JOIN clients c ON c.id = j.client_id
+    WHERE j.company_id = 1 AND j.scheduled_date = '2026-04-23'
+    ORDER BY c.id
+  `);
+  console.table(noZip.rows);
+
+  // 2. Zip pattern in address text? We can extract via regex
+  console.log("\n=== Extractable ZIP from address text? ===");
+  const extract = await db.execute(sql`
+    SELECT DISTINCT
+      c.id,
+      c.first_name || ' ' || c.last_name AS name,
+      c.zip AS current_zip,
+      SUBSTRING(COALESCE(c.address,'') FROM '\\y(\\d{5})\\y') AS extracted_from_address,
+      SUBSTRING(COALESCE(j.address_street,'') FROM '\\y(\\d{5})\\y') AS extracted_from_job_addr
+    FROM jobs j
+    LEFT JOIN clients c ON c.id = j.client_id
+    WHERE j.company_id = 1 AND j.scheduled_date = '2026-04-23'
+      AND c.zip IS NULL
+    ORDER BY c.id
+  `);
+  console.table(extract.rows);
+
+  // 3. Check if the mc_dispatch_staging has address data with a zip for these jobs
+  console.log("\n=== Staging address for Apr 23 jobs ===");
+  const staging = await db.execute(sql`
+    SELECT DISTINCT
+      j.mc_job_id,
+      j.client_id,
+      c.first_name || ' ' || c.last_name AS name,
+      c.zip AS current_client_zip,
+      LEFT(mcs.address, 60) AS mc_address,
+      SUBSTRING(COALESCE(mcs.address,'') FROM '\\y(\\d{5})\\y') AS mc_extracted_zip
+    FROM jobs j
+    LEFT JOIN clients c ON c.id = j.client_id
+    LEFT JOIN mc_dispatch_staging mcs ON mcs.mc_job_id::bigint = j.mc_job_id
+    WHERE j.company_id = 1 AND j.scheduled_date = '2026-04-23'
+    ORDER BY c.id
+  `);
+  console.table(staging.rows);
+
+  // 4. Zone zip coverage — what zip codes does the South Suburbs zone cover?
+  // And Hickory Hills-area candidates?
+  console.log("\n=== Active zones with zip_codes ===");
+  const zones = await db.execute(sql`
+    SELECT id, name, color, zip_codes
+      FROM service_zones
+     WHERE company_id = 1 AND is_active = true
+     ORDER BY name
+  `);
+  console.log(JSON.stringify(zones.rows, null, 2));
+
+  // 5. For PHES clients overall, what's the zip-source-availability breakdown?
+  console.log("\n=== Full PHES client zip-source breakdown ===");
+  const sources = await db.execute(sql`
+    SELECT
+      COUNT(*)::int AS total,
+      COUNT(*) FILTER (WHERE zip IS NOT NULL AND TRIM(zip) != '')::int AS has_zip_col,
+      COUNT(*) FILTER (WHERE zip IS NULL
+                        AND address IS NOT NULL
+                        AND address ~ '\\y\\d{5}\\y')::int AS null_zip_but_addr_has_pattern
+    FROM clients WHERE company_id = 1
+  `);
+  console.table(sources.rows);
+
+  // 6. Jobs.address_zip — is this ever populated for L4 rows?
+  console.log("\n=== jobs.address_zip / address_city coverage for MC rows ===");
+  const jobAddr = await db.execute(sql`
+    SELECT
+      COUNT(*)::int AS total_mc,
+      COUNT(*) FILTER (WHERE address_zip IS NOT NULL AND TRIM(address_zip) != '')::int AS with_addr_zip,
+      COUNT(*) FILTER (WHERE address_city IS NOT NULL AND TRIM(address_city) != '')::int AS with_addr_city,
+      COUNT(*) FILTER (WHERE address_street ~ '\\y\\d{5}\\y')::int AS addr_street_has_zip_pattern
+    FROM jobs WHERE company_id = 1 AND mc_job_id IS NOT NULL
+  `);
+  console.table(jobAddr.rows);
+
+  process.exit(0);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/scripts/zone_zip_map.ts
+++ b/artifacts/api-server/scripts/zone_zip_map.ts
@@ -1,0 +1,40 @@
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+async function main() {
+  // Show active zones + their zip_codes — so I can verify proposed backfill zips
+  // will resolve to colors.
+  const zones = await db.execute(sql`
+    SELECT name, color, zip_codes
+      FROM service_zones
+     WHERE company_id = 1 AND is_active = true
+     ORDER BY name
+  `);
+  for (const z of zones.rows as any[]) {
+    console.log(`${z.name} (${z.color}) → [${(z.zip_codes || []).join(", ")}]`);
+  }
+
+  // Cross-reference the specific zips I propose to backfill
+  console.log("\n=== Zone match for proposed backfill zips ===");
+  const proposed = [
+    { id: 21, name: "Jaira Estrada", zip: "60608" },
+    { id: 31, name: "Chicago Straford Memorial", zip: "60628" },
+    { id: 37, name: "City Light Church", zip: "60653" },
+    { id: 40, name: "Heritage Condominium", zip: "60453" },
+    { id: 66, name: "Hickory Hills Condominium", zip: "60457" },
+    { id: 110, name: "John Piscopo", zip: "60707" },
+    { id: 1052, name: "Danni Varenhorst", zip: "60608" },
+  ];
+  for (const p of proposed) {
+    const z = await db.execute(sql`
+      SELECT name, color FROM service_zones
+       WHERE company_id = 1 AND is_active = true
+         AND ${p.zip} = ANY(zip_codes)
+       LIMIT 1
+    `);
+    const hit = z.rows?.[0] as any;
+    console.log(`${p.name} (id=${p.id}) zip=${p.zip} → ${hit ? `${hit.name} (${hit.color})` : "NO ZONE MATCH"}`);
+  }
+  process.exit(0);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -1042,6 +1042,27 @@ async function runBookingSchemaGuard(): Promise<void> {
       stmt: `ALTER TABLE lms_onboarding_intake ADD COLUMN IF NOT EXISTS vehicle_protocol_acknowledged BOOLEAN NOT NULL DEFAULT FALSE` },
     { label: "lms_onboarding_intake.vehicle_protocol_acknowledged_at",
       stmt: `ALTER TABLE lms_onboarding_intake ADD COLUMN IF NOT EXISTS vehicle_protocol_acknowledged_at TIMESTAMPTZ` },
+
+    // ── Job rate mods (per-job time and fee adjustments) ──────────────────
+    // Layered onto the flat jobs.amount/base_fee: each mod is either a
+    // 'time' adjustment (minutes + computed amount) or a 'flat' fee adjustment.
+    // The route handler recomputes jobs.amount = base_fee + SUM(mods.amount)
+    // on every write.
+    { label: "CREATE job_rate_mods", stmt: `
+      CREATE TABLE IF NOT EXISTS job_rate_mods (
+        id          SERIAL PRIMARY KEY,
+        company_id  INT NOT NULL REFERENCES companies(id),
+        job_id      INT NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
+        mod_type    TEXT NOT NULL CHECK (mod_type IN ('time', 'flat')),
+        minutes     INT,
+        amount      NUMERIC(10,2) NOT NULL,
+        reason      TEXT NOT NULL,
+        created_by  INT REFERENCES users(id),
+        created_at  TIMESTAMP NOT NULL DEFAULT NOW()
+      )
+    ` },
+    { label: "idx_job_rate_mods_job",
+      stmt: `CREATE INDEX IF NOT EXISTS idx_job_rate_mods_job ON job_rate_mods(company_id, job_id)` },
   ];
 
   for (const { label, stmt } of guards) {

--- a/artifacts/api-server/src/routes/jobs.ts
+++ b/artifacts/api-server/src/routes/jobs.ts
@@ -2566,17 +2566,89 @@ router.patch("/:id", requireAuth, async (req, res) => {
 router.delete("/:id", requireAuth, async (req, res) => {
   try {
     const jobId = parseInt(req.params.id);
+    const companyId = req.auth!.companyId;
+    const role = req.auth!.role;
+    const force = req.query.force === "true";
+
+    // Force-delete branch: admin/owner can wipe a completed job's clock entries
+    // and then delete the job in a single transaction.
+    if (force) {
+      if (role !== "owner" && role !== "admin") {
+        return res.status(403).json({
+          error: "Forbidden",
+          message: "Only owner or admin can force-delete a job",
+        });
+      }
+      const [existing] = await db
+        .select({ id: jobsTable.id, status: jobsTable.status })
+        .from(jobsTable)
+        .where(and(eq(jobsTable.id, jobId), eq(jobsTable.company_id, companyId)))
+        .limit(1);
+      if (!existing) {
+        return res.status(404).json({ error: "Not Found", message: "Job not found" });
+      }
+      if (existing.status !== "complete") {
+        return res.status(409).json({
+          error: "Conflict",
+          message: "force=true only allowed on completed jobs",
+        });
+      }
+      await db.transaction(async (tx) => {
+        await tx.execute(sql`DELETE FROM timeclock WHERE job_id = ${jobId} AND company_id = ${companyId}`);
+        await tx
+          .delete(jobsTable)
+          .where(and(eq(jobsTable.id, jobId), eq(jobsTable.company_id, companyId)));
+      });
+      logAudit(req, "DELETE", "job", jobId, null, { force: true });
+      return res.json({ success: true, message: "Job and clock entries deleted" });
+    }
+
     await db
       .delete(jobsTable)
       .where(and(
         eq(jobsTable.id, jobId),
-        eq(jobsTable.company_id, req.auth!.companyId)
+        eq(jobsTable.company_id, companyId)
       ));
     logAudit(req, "DELETE", "job", jobId, null, null);
     return res.json({ success: true, message: "Job deleted" });
   } catch (err) {
     console.error("Delete job error:", err);
     return res.status(500).json({ error: "Internal Server Error", message: "Failed to delete job" });
+  }
+});
+
+// DELETE /api/jobs/:id/clock-entries — wipe all clock entries on a job
+// (admin/owner only). Useful before deleting a completed job.
+router.delete("/:id/clock-entries", requireAuth, async (req, res) => {
+  try {
+    const role = req.auth!.role;
+    if (role !== "owner" && role !== "admin") {
+      return res.status(403).json({
+        error: "Forbidden",
+        message: "Only owner or admin can delete clock entries",
+      });
+    }
+    const jobId = parseInt(req.params.id);
+    const companyId = req.auth!.companyId;
+
+    const [existing] = await db
+      .select({ id: jobsTable.id })
+      .from(jobsTable)
+      .where(and(eq(jobsTable.id, jobId), eq(jobsTable.company_id, companyId)))
+      .limit(1);
+    if (!existing) {
+      return res.status(404).json({ error: "Not Found", message: "Job not found" });
+    }
+
+    const result = await db.execute(sql`
+      DELETE FROM timeclock WHERE job_id = ${jobId} AND company_id = ${companyId}
+    `);
+    const deleted = (result as any).rowCount ?? 0;
+    logAudit(req, "DELETE", "clock_entries", jobId, null, { count: deleted });
+    return res.json({ success: true, deleted });
+  } catch (err) {
+    console.error("Delete clock entries error:", err);
+    return res.status(500).json({ error: "Internal Server Error", message: "Failed to delete clock entries" });
   }
 });
 
@@ -4121,6 +4193,134 @@ router.get("/v2/export", requireAuth, async (req, res) => {
   } catch (err) {
     console.error("GET /jobs/v2/export error:", err);
     return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
+// ── Job rate mods ────────────────────────────────────────────────────────────
+// Per-job time and fee adjustments layered on top of jobs.base_fee.
+//   - mod_type='time': minutes is required; amount is the computed dollar adjustment
+//   - mod_type='flat': minutes ignored; amount is the dollar adjustment (+ or -)
+// After every write the route recomputes billed_amount = base_fee + SUM(mods.amount).
+// billed_amount is the field every downstream surface (invoicing, payroll commission,
+// revenue rollups, manual charge) reads via COALESCE(billed_amount, base_fee), so
+// pushing the post-mod total there flows through automatically.
+
+async function recomputeJobBilledAmount(jobId: number, companyId: number): Promise<number> {
+  const [job] = await db
+    .select({ base_fee: jobsTable.base_fee })
+    .from(jobsTable)
+    .where(and(eq(jobsTable.id, jobId), eq(jobsTable.company_id, companyId)))
+    .limit(1);
+  if (!job) return 0;
+  const base = parseFloat(String(job.base_fee || "0"));
+  const sumRows = await db.execute(sql`
+    SELECT COALESCE(SUM(amount), 0)::numeric AS total
+    FROM job_rate_mods
+    WHERE job_id = ${jobId} AND company_id = ${companyId}
+  `);
+  const modsTotal = parseFloat(String((sumRows.rows[0] as any)?.total ?? "0"));
+  const newBilled = base + modsTotal;
+  await db
+    .update(jobsTable)
+    .set({ billed_amount: newBilled.toFixed(2) })
+    .where(and(eq(jobsTable.id, jobId), eq(jobsTable.company_id, companyId)));
+  return newBilled;
+}
+
+// GET /api/jobs/:id/rate-mods — list all mods on a job
+router.get("/:id/rate-mods", requireAuth, async (req, res) => {
+  try {
+    const jobId = parseInt(req.params.id);
+    const companyId = req.auth!.companyId;
+    const rows = await db.execute(sql`
+      SELECT m.id, m.mod_type, m.minutes, m.amount, m.reason,
+             m.created_by, m.created_at,
+             concat(u.first_name, ' ', u.last_name) AS created_by_name
+      FROM job_rate_mods m
+      LEFT JOIN users u ON u.id = m.created_by
+      WHERE m.job_id = ${jobId} AND m.company_id = ${companyId}
+      ORDER BY m.created_at ASC
+    `);
+    return res.json({ mods: rows.rows });
+  } catch (err) {
+    console.error("GET /jobs/:id/rate-mods error:", err);
+    return res.status(500).json({ error: "Internal Server Error", message: "Failed to list rate mods" });
+  }
+});
+
+// POST /api/jobs/:id/rate-mods — add a mod
+router.post("/:id/rate-mods", requireAuth, async (req, res) => {
+  try {
+    const jobId = parseInt(req.params.id);
+    const companyId = req.auth!.companyId;
+    const userId = req.auth!.userId;
+    const { mod_type, minutes, amount, reason } = req.body ?? {};
+
+    if (mod_type !== "time" && mod_type !== "flat") {
+      return res.status(400).json({ error: "Bad Request", message: "mod_type must be 'time' or 'flat'" });
+    }
+    if (mod_type === "time" && (minutes === undefined || minutes === null || Number.isNaN(Number(minutes)))) {
+      return res.status(400).json({ error: "Bad Request", message: "minutes is required for mod_type='time'" });
+    }
+    const amt = Number(amount);
+    if (Number.isNaN(amt)) {
+      return res.status(400).json({ error: "Bad Request", message: "amount must be numeric" });
+    }
+    if (!reason || typeof reason !== "string" || !reason.trim()) {
+      return res.status(400).json({ error: "Bad Request", message: "reason is required" });
+    }
+
+    const [existing] = await db
+      .select({ id: jobsTable.id })
+      .from(jobsTable)
+      .where(and(eq(jobsTable.id, jobId), eq(jobsTable.company_id, companyId)))
+      .limit(1);
+    if (!existing) {
+      return res.status(404).json({ error: "Not Found", message: "Job not found" });
+    }
+
+    const insert = await db.execute(sql`
+      INSERT INTO job_rate_mods (company_id, job_id, mod_type, minutes, amount, reason, created_by)
+      VALUES (
+        ${companyId}, ${jobId}, ${mod_type},
+        ${mod_type === "time" ? Number(minutes) : null},
+        ${amt.toFixed(2)}, ${reason.trim()}, ${userId}
+      )
+      RETURNING id, mod_type, minutes, amount, reason, created_by, created_at
+    `);
+    const newBilled = await recomputeJobBilledAmount(jobId, companyId);
+    logAudit(req, "CREATE", "job_rate_mod", jobId, null, { mod_type, minutes, amount: amt });
+    return res.status(201).json({
+      mod: insert.rows[0],
+      billed_amount: newBilled.toFixed(2),
+    });
+  } catch (err) {
+    console.error("POST /jobs/:id/rate-mods error:", err);
+    return res.status(500).json({ error: "Internal Server Error", message: "Failed to add rate mod" });
+  }
+});
+
+// DELETE /api/jobs/:id/rate-mods/:modId — remove a mod
+router.delete("/:id/rate-mods/:modId", requireAuth, async (req, res) => {
+  try {
+    const jobId = parseInt(req.params.id);
+    const modId = parseInt(req.params.modId);
+    const companyId = req.auth!.companyId;
+
+    const result = await db.execute(sql`
+      DELETE FROM job_rate_mods
+      WHERE id = ${modId} AND job_id = ${jobId} AND company_id = ${companyId}
+    `);
+    const deleted = (result as any).rowCount ?? 0;
+    if (!deleted) {
+      return res.status(404).json({ error: "Not Found", message: "Rate mod not found" });
+    }
+    const newBilled = await recomputeJobBilledAmount(jobId, companyId);
+    logAudit(req, "DELETE", "job_rate_mod", modId, null, null);
+    return res.json({ success: true, billed_amount: newBilled.toFixed(2) });
+  } catch (err) {
+    console.error("DELETE /jobs/:id/rate-mods/:modId error:", err);
+    return res.status(500).json({ error: "Internal Server Error", message: "Failed to delete rate mod" });
   }
 });
 

--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -1090,6 +1090,91 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
   const [officeNotesSaving, setOfficeNotesSaving] = useState(false);
   const [officeNotesSaved, setOfficeNotesSaved] = useState(false);
 
+  // Rate mods state — per-job time and fee adjustments. Owner/admin/office
+  // can manage. The backend recomputes billed_amount = base_fee + SUM(mods)
+  // after every write; we reload the drawer through onUpdate() to pull the
+  // fresh number.
+  type RateMod = {
+    id: number; mod_type: "time" | "flat"; minutes: number | null;
+    amount: string; reason: string; created_by: number | null;
+    created_at: string; created_by_name?: string | null;
+  };
+  const canManageMods = (userRole === "owner" || userRole === "admin" || userRole === "office");
+  const [rateMods, setRateMods] = useState<RateMod[]>([]);
+  const [rateModsLoaded, setRateModsLoaded] = useState(false);
+  const [modAddOpen, setModAddOpen] = useState(false);
+  const [modType, setModType] = useState<"time" | "flat">("time");
+  const [modMinutes, setModMinutes] = useState("");
+  const [modAmount, setModAmount] = useState("");
+  const [modReason, setModReason] = useState("");
+  const [modBusy, setModBusy] = useState(false);
+  const [modError, setModError] = useState("");
+
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      try {
+        const r = await fetch(`${_API3}/api/jobs/${job.id}/rate-mods`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!r.ok) return;
+        const d = await r.json();
+        if (alive) {
+          setRateMods((d.mods || []) as RateMod[]);
+          setRateModsLoaded(true);
+        }
+      } catch {}
+    })();
+    return () => { alive = false; };
+  }, [job.id, token]);
+
+  async function addRateMod() {
+    setModError("");
+    if (!modReason.trim()) { setModError("Reason is required"); return; }
+    const amt = Number(modAmount);
+    if (Number.isNaN(amt) || modAmount.trim() === "") { setModError("Amount must be numeric"); return; }
+    if (modType === "time") {
+      const mins = Number(modMinutes);
+      if (Number.isNaN(mins) || modMinutes.trim() === "") { setModError("Minutes required for time adjustments"); return; }
+    }
+    setModBusy(true);
+    try {
+      const body: any = { mod_type: modType, amount: amt, reason: modReason.trim() };
+      if (modType === "time") body.minutes = Number(modMinutes);
+      const r = await fetch(`${_API3}/api/jobs/${job.id}/rate-mods`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      const d = await r.json();
+      if (!r.ok) throw new Error(d.message || d.error || "Failed");
+      setRateMods(prev => [...prev, d.mod as RateMod]);
+      setModType("time"); setModMinutes(""); setModAmount(""); setModReason("");
+      setModAddOpen(false);
+      toast({ title: "Adjustment added" });
+      onUpdate();
+    } catch (err: any) {
+      setModError(err.message || "Failed to add adjustment");
+    } finally {
+      setModBusy(false);
+    }
+  }
+
+  async function deleteRateMod(modId: number) {
+    try {
+      const r = await fetch(`${_API3}/api/jobs/${job.id}/rate-mods/${modId}`, {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!r.ok) throw new Error("Delete failed");
+      setRateMods(prev => prev.filter(m => m.id !== modId));
+      toast({ title: "Adjustment removed" });
+      onUpdate();
+    } catch (err: any) {
+      toast({ title: "Failed to remove", description: err.message || "", variant: "destructive" as any });
+    }
+  }
+
   // Debounced auto-save for office notes
   useEffect(() => {
     const delay = setTimeout(async () => {
@@ -1615,6 +1700,89 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
                 style={{ width: "100%", height: 32, display: "flex", alignItems: "center", justifyContent: "center", gap: 6, fontSize: 12, fontWeight: 600, color: isLocked ? "#9E9B94" : "#2D9B83", border: `1px dashed ${isLocked ? "#D1D5DB" : "#2D9B83"}`, borderRadius: 8, background: "transparent", cursor: isLocked ? "not-allowed" : "pointer", fontFamily: FF, opacity: isLocked ? 0.6 : 1 }}>
                 <Plus size={12} /> Add Team Member
               </button>
+            </PS>
+          )}
+
+          {/* Time & Fee Adjustments — per-job mods stacked on top of base_fee */}
+          {canManageMods && (
+            <PS label="Time & Fee Adjustments">
+              {rateMods.length === 0 ? (
+                <div style={{ fontSize: 12, color: "#9E9B94", marginBottom: 8 }}>
+                  {rateModsLoaded ? "No adjustments" : "Loading…"}
+                </div>
+              ) : (
+                <div style={{ display: "flex", flexDirection: "column", gap: 6, marginBottom: 8 }}>
+                  {rateMods.map(m => {
+                    const amt = parseFloat(m.amount);
+                    const sign = amt >= 0 ? "+" : "−";
+                    const abs = Math.abs(amt).toFixed(2);
+                    const detail = m.mod_type === "time"
+                      ? `${(m.minutes ?? 0) >= 0 ? "+" : ""}${m.minutes} min`
+                      : "Flat fee";
+                    return (
+                      <div key={m.id} style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", padding: "8px 10px", border: "1px solid #E5E2DC", borderRadius: 6, background: "#FFFFFF" }}>
+                        <div style={{ flex: 1, minWidth: 0 }}>
+                          <div style={{ fontSize: 12, fontWeight: 600, color: "#1A1917" }}>
+                            {detail} · {sign}${abs}
+                          </div>
+                          <div style={{ fontSize: 11, color: "#6B7280", marginTop: 2, wordBreak: "break-word" }}>
+                            {m.reason}
+                          </div>
+                        </div>
+                        {!isLocked && (
+                          <button onClick={() => deleteRateMod(m.id)}
+                            style={{ marginLeft: 8, padding: 4, border: "none", background: "transparent", cursor: "pointer", color: "#9E9B94" }}
+                            title="Remove adjustment">
+                            <X size={14} />
+                          </button>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+              {!modAddOpen ? (
+                <button onClick={() => !isLocked && setModAddOpen(true)}
+                  disabled={isLocked}
+                  style={{ width: "100%", height: 32, display: "flex", alignItems: "center", justifyContent: "center", gap: 6, fontSize: 12, fontWeight: 600, color: isLocked ? "#9E9B94" : "#2D9B83", border: `1px dashed ${isLocked ? "#D1D5DB" : "#2D9B83"}`, borderRadius: 8, background: "transparent", cursor: isLocked ? "not-allowed" : "pointer", fontFamily: FF, opacity: isLocked ? 0.6 : 1 }}>
+                  <Plus size={12} /> Add Adjustment
+                </button>
+              ) : (
+                <div style={{ padding: 10, border: "1px solid #E5E2DC", borderRadius: 8, background: "#FAFAF7" }}>
+                  <div style={{ display: "flex", gap: 6, marginBottom: 8 }}>
+                    <button onClick={() => setModType("time")}
+                      style={{ flex: 1, padding: "6px 8px", border: `1px solid ${modType === "time" ? "#2D9B83" : "#E5E2DC"}`, borderRadius: 6, background: modType === "time" ? "#2D9B83" : "#FFFFFF", color: modType === "time" ? "#FFFFFF" : "#1A1917", fontSize: 11, fontWeight: 600, cursor: "pointer", fontFamily: FF }}>
+                      Time
+                    </button>
+                    <button onClick={() => setModType("flat")}
+                      style={{ flex: 1, padding: "6px 8px", border: `1px solid ${modType === "flat" ? "#2D9B83" : "#E5E2DC"}`, borderRadius: 6, background: modType === "flat" ? "#2D9B83" : "#FFFFFF", color: modType === "flat" ? "#FFFFFF" : "#1A1917", fontSize: 11, fontWeight: 600, cursor: "pointer", fontFamily: FF }}>
+                      Flat Fee
+                    </button>
+                  </div>
+                  {modType === "time" && (
+                    <input type="number" placeholder="Minutes (e.g. 30 or -15)"
+                      value={modMinutes} onChange={e => setModMinutes(e.target.value)}
+                      style={{ width: "100%", padding: "6px 8px", border: "1px solid #E5E2DC", borderRadius: 6, fontSize: 12, fontFamily: FF, marginBottom: 6, boxSizing: "border-box" }} />
+                  )}
+                  <input type="number" step="0.01" placeholder="Amount (e.g. 30 or -50)"
+                    value={modAmount} onChange={e => setModAmount(e.target.value)}
+                    style={{ width: "100%", padding: "6px 8px", border: "1px solid #E5E2DC", borderRadius: 6, fontSize: 12, fontFamily: FF, marginBottom: 6, boxSizing: "border-box" }} />
+                  <input type="text" placeholder="Reason"
+                    value={modReason} onChange={e => setModReason(e.target.value)}
+                    style={{ width: "100%", padding: "6px 8px", border: "1px solid #E5E2DC", borderRadius: 6, fontSize: 12, fontFamily: FF, marginBottom: 8, boxSizing: "border-box" }} />
+                  {modError && <div style={{ color: "#DC2626", fontSize: 11, marginBottom: 6 }}>{modError}</div>}
+                  <div style={{ display: "flex", gap: 6 }}>
+                    <button onClick={addRateMod} disabled={modBusy}
+                      style={{ flex: 1, padding: "6px 8px", border: "none", borderRadius: 6, background: "#16A34A", color: "#FFFFFF", fontSize: 12, fontWeight: 600, cursor: modBusy ? "wait" : "pointer", fontFamily: FF }}>
+                      {modBusy ? "Saving…" : "Save"}
+                    </button>
+                    <button onClick={() => { setModAddOpen(false); setModError(""); }} disabled={modBusy}
+                      style={{ padding: "6px 10px", border: "1px solid #E5E2DC", borderRadius: 6, background: "#FFFFFF", color: "#6B7280", fontSize: 12, fontWeight: 600, cursor: "pointer", fontFamily: FF }}>
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              )}
             </PS>
           )}
 


### PR DESCRIPTION
## Summary
- **Feature 1**: `DELETE /api/jobs/:id/clock-entries` (owner/admin) and `DELETE /api/jobs/:id?force=true` (owner/admin, completed jobs only — wipes clock entries then deletes job in one tx). Fixes the production 500 on regular job DELETE.
- **Feature 2**: `job_rate_mods` table + `GET/POST/DELETE /api/jobs/:id/rate-mods`. `billed_amount` auto-recomputed as `base_fee + SUM(mods.amount)` after every write. Time & Fee Adjustments section in the job drawer (owner/admin/office).

Backfill script `artifacts/api-server/scripts/apply-rate-mods.ts` was run locally against the Railway DB for the April adjustments (Chris/Jim Schultz, Daniel Walter, Jaira Estrada x4). Schema is idempotent via the `runBookingSchemaGuard()` cold-start path.

## Test plan
- [ ] Railway deploy succeeds and schema-guard creates `job_rate_mods`
- [ ] `DELETE /api/jobs/:id` (no force) returns 200 — production 500 fixed
- [ ] `DELETE /api/jobs/:id?force=true` on a completed job wipes clock entries + deletes job; returns 409 on non-complete; 403 for non-admin
- [ ] `GET /api/jobs/3662/rate-mods` returns the seeded mod (+30 min, +\$27.50)
- [ ] Time & Fee Adjustments section visible on the job drawer; add/delete updates billed_amount
- [ ] Reset CJ Jimenez job 4298 back to `complete` then force-delete

🤖 Generated with [Claude Code](https://claude.com/claude-code)