### PR TITLE
fix(jobs): comprehensive cascade on force-delete (every FK to jobs.id)

### DIFF
--- a/artifacts/api-server/src/routes/jobs.ts
+++ b/artifacts/api-server/src/routes/jobs.ts
@@ -2600,17 +2600,40 @@ router.delete("/:id", requireAuth, async (req, res) => {
         // Cascade child rows that FK to jobs.id with ON DELETE NO ACTION.
         // Tables with ON DELETE CASCADE (job_audit_log, job_rate_mods,
         // job_technicians) drop automatically with the parent row.
+        //
+        // Per-job ephemeral / replaceable data → DELETE child rows.
+        // (All of these have job_id NOT NULL so NULL-out isn't an option.)
         await tx.execute(sql`DELETE FROM timeclock WHERE job_id = ${jobId} AND company_id = ${companyId}`);
         await tx.execute(sql`DELETE FROM job_add_ons WHERE job_id = ${jobId}`);
-        // Soft links — keep the parent row, sever the back-reference. The
-        // quote that converted into this job (if any) survives the deletion.
+        await tx.execute(sql`DELETE FROM clock_in_attempts WHERE job_id = ${jobId}`);
+        await tx.execute(sql`DELETE FROM job_status_logs WHERE job_id = ${jobId}`);
+        await tx.execute(sql`DELETE FROM job_photos WHERE job_id = ${jobId}`);
+        await tx.execute(sql`DELETE FROM job_supplies WHERE job_id = ${jobId}`);
+        await tx.execute(sql`DELETE FROM scorecards WHERE job_id = ${jobId}`);
+        await tx.execute(sql`DELETE FROM client_ratings WHERE job_id = ${jobId}`);
+        await tx.execute(sql`DELETE FROM satisfaction_surveys WHERE job_id = ${jobId}`);
+        await tx.execute(sql`DELETE FROM cancellation_log WHERE job_id = ${jobId}`);
+        //
+        // Financial / legal / cross-entity records → NULL the back-reference.
+        // The parent row stays intact for billing, accounting, loyalty, and
+        // reporting purposes; only the link to the deleted job is severed.
         await tx.execute(sql`UPDATE quotes SET booked_job_id = NULL WHERE booked_job_id = ${jobId}`);
+        await tx.execute(sql`UPDATE invoices SET job_id = NULL WHERE job_id = ${jobId}`);
+        await tx.execute(sql`UPDATE additional_pay SET job_id = NULL WHERE job_id = ${jobId}`);
+        await tx.execute(sql`UPDATE loyalty_points_log SET job_id = NULL WHERE job_id = ${jobId}`);
+        await tx.execute(sql`UPDATE communication_log SET job_id = NULL WHERE job_id = ${jobId}`);
+        await tx.execute(sql`UPDATE contact_tickets SET job_id = NULL WHERE job_id = ${jobId}`);
+        await tx.execute(sql`UPDATE form_submissions SET job_id = NULL WHERE job_id = ${jobId}`);
+        await tx.execute(sql`UPDATE quality_complaints SET job_id = NULL WHERE job_id = ${jobId}`);
+        await tx.execute(sql`UPDATE mileage_requests SET from_job_id = NULL WHERE from_job_id = ${jobId}`);
+        await tx.execute(sql`UPDATE mileage_requests SET to_job_id = NULL WHERE to_job_id = ${jobId}`);
+        await tx.execute(sql`UPDATE cancellation_log SET rescheduled_to_job_id = NULL WHERE rescheduled_to_job_id = ${jobId}`);
         await tx
           .delete(jobsTable)
           .where(and(eq(jobsTable.id, jobId), eq(jobsTable.company_id, companyId)));
       });
       logAudit(req, "DELETE", "job", jobId, null, { force: true });
-      return res.json({ success: true, message: "Job, clock entries, and add-ons deleted" });
+      return res.json({ success: true, message: "Job and dependent records cleaned up" });
     }
 
     await db


### PR DESCRIPTION
Triggered by Jaira Estrada job 4147 failing — had both an invoice and a satisfaction survey. Now handles every FK reference to jobs.id with the right semantic per table (DELETE per-job ephemeral data, NULL financial/legal back-refs). Pre-checked nullability so this won't re-break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)