### PR TITLE
cutover 1C: GPS-mandatory clock-in/out, on-my-way, worksheet (execution engine)

### DIFF
--- a/artifacts/api-server/src/cutover-data-migration.ts
+++ b/artifacts/api-server/src/cutover-data-migration.ts
@@ -1,0 +1,69 @@
+/**
+ * Cutover data migrations.
+ *
+ * Runs once per cold start (idempotent). Mirrors phes-data-migration's
+ * pattern but scoped to the MaidCentral cutover pieces (1A onward).
+ *
+ * Currently does ONE thing — installs the integrity CHECK constraint
+ * on job_clock_events (1C). The constraint is the legal backbone of
+ * the wage record; without it the route layer would be the only line
+ * of defense and a future direct-INSERT (admin tool, script, migration
+ * helper) could silently produce a bad row. With it, the bad shape is
+ * rejected by the database itself.
+ *
+ * The constraint name + SQL text come from the schema file so the
+ * runtime SQL and the test assertion read the same string.
+ */
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+import {
+  JOB_CLOCK_EVENTS_INTEGRITY_CONSTRAINT_NAME,
+  JOB_CLOCK_EVENTS_INTEGRITY_CONSTRAINT_SQL,
+} from "@workspace/db/schema";
+
+export async function runCutoverDataMigration(): Promise<void> {
+  try {
+    await runClockEventsIntegrityConstraint();
+  } catch (err) {
+    console.error("[cutover-migration] failed (non-fatal):", err);
+  }
+}
+
+/**
+ * Install the CHECK constraint on job_clock_events. Idempotent:
+ *   - skips when the table doesn't exist yet (first deploy where
+ *     drizzle-kit push has not run)
+ *   - skips when the constraint already exists
+ *   - never alters existing rows; the constraint is added with NOT
+ *     VALID semantics on PostgreSQL only if we ever need to introduce
+ *     it onto a table with legacy data. As of 1C the table is brand
+ *     new so the constraint is added in full-validate mode.
+ */
+async function runClockEventsIntegrityConstraint(): Promise<void> {
+  // Skip when the table is not yet provisioned (drizzle-kit push hasn't
+  // run for this deploy). The DO block guards both lookups.
+  await db.execute(sql.raw(`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = 'public' AND table_name = 'job_clock_events'
+      ) THEN
+        RAISE NOTICE 'cutover-migration: job_clock_events table not present yet, skipping CHECK install';
+        RETURN;
+      END IF;
+
+      IF EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = '${JOB_CLOCK_EVENTS_INTEGRITY_CONSTRAINT_NAME}'
+      ) THEN
+        RAISE NOTICE 'cutover-migration: CHECK constraint already present';
+        RETURN;
+      END IF;
+
+      EXECUTE 'ALTER TABLE job_clock_events ADD CONSTRAINT ${JOB_CLOCK_EVENTS_INTEGRITY_CONSTRAINT_NAME} CHECK ${JOB_CLOCK_EVENTS_INTEGRITY_CONSTRAINT_SQL.replace(/'/g, "''")}';
+      RAISE NOTICE 'cutover-migration: installed ${JOB_CLOCK_EVENTS_INTEGRITY_CONSTRAINT_NAME}';
+    END
+    $$;
+  `));
+}

--- a/artifacts/api-server/src/index.ts
+++ b/artifacts/api-server/src/index.ts
@@ -2,6 +2,7 @@ import app from "./app";
 import { seedIfNeeded } from "./seed";
 import { startRecurringJobCron } from "./lib/recurring-jobs";
 import { runPhesDataMigration } from "./phes-data-migration";
+import { runCutoverDataMigration } from "./cutover-data-migration";
 import { runReminderCron, runReviewRequestCron } from "./services/notificationService.js";
 import { runRateLockNightlyChecks } from "./utils/rateLock.js";
 import { processDueEnrollments } from "./services/followUpService.js";
@@ -151,6 +152,11 @@ async function startup() {
     await runPhesDataMigration();
   } catch (err: any) {
     console.error("[startup] runPhesDataMigration — non-fatal:", err?.message ?? err);
+  }
+  try {
+    await runCutoverDataMigration();
+  } catch (err: any) {
+    console.error("[startup] runCutoverDataMigration — non-fatal:", err?.message ?? err);
   }
   try {
     const r = await runLmsCompletionBackfill();

--- a/artifacts/api-server/src/lib/clock-integrity.ts
+++ b/artifacts/api-server/src/lib/clock-integrity.ts
@@ -1,0 +1,157 @@
+/**
+ * Cutover 1C — Clock-event integrity guard at the route layer.
+ *
+ * Single source of truth for "is this request shape allowed to produce
+ * a clock event row?" There are exactly two valid shapes:
+ *
+ *   1. captured       — latitude + longitude + gps_accuracy_meters
+ *                       provided. Distance + within_geofence are
+ *                       computed downstream by the route handler.
+ *
+ *   2. failed_exception — gps_status='failed_exception' explicitly set
+ *                         AND exception_reason populated AND
+ *                         exception_photo_url populated.
+ *
+ * Anything else is rejected. There is NO "skip", "decline",
+ * "continue without location", or any equivalent. The route returns
+ * 400 with a structured error so the client cannot guess its way past.
+ *
+ * This module is the route-layer half of the defense-in-depth pair.
+ * The DB CHECK constraint
+ * (`JOB_CLOCK_EVENTS_INTEGRITY_CONSTRAINT_SQL`) is the other half —
+ * installed by artifacts/api-server/src/cutover-data-migration.ts and
+ * verified by cutover-1c tests. Either layer alone is enough to keep
+ * the bad shape out of the table; both together are belt-and-suspenders.
+ */
+
+export type CapturedPayload = {
+  kind: "captured";
+  latitude: number;
+  longitude: number;
+  gps_accuracy_meters: number;
+};
+
+export type FailedExceptionPayload = {
+  kind: "failed_exception";
+  exception_reason: string;
+  exception_photo_url: string;
+};
+
+export type ClockGpsPayload = CapturedPayload | FailedExceptionPayload;
+
+export type ClockIntegrityRejection = {
+  ok: false;
+  status: 400;
+  error: "Bad Request";
+  message: string;
+  // A stable code so the client can branch UI on the failure mode.
+  code:
+    | "gps_required"
+    | "lat_lng_required"
+    | "lat_lng_invalid"
+    | "accuracy_invalid"
+    | "exception_reason_required"
+    | "exception_photo_required"
+    | "ambiguous_payload";
+};
+
+/**
+ * Validate a clock event request body. Returns either the parsed
+ * payload (`{ ok: true, payload }`) or a structured rejection that
+ * the route handler can serialize directly into the JSON response.
+ *
+ * NOTE — the spec rule: there is no "skip" flag and there is no
+ * decline path. Both the route AND the DB CHECK enforce this. If you
+ * are tempted to add a `force=true` query param or a `skip_gps` body
+ * field — don't. Add a new exception kind first, write the test, and
+ * extend the DB CHECK constraint to match.
+ */
+export function validateClockGpsPayload(
+  body: unknown,
+): { ok: true; payload: ClockGpsPayload } | ClockIntegrityRejection {
+  if (!body || typeof body !== "object") {
+    return rejection(
+      "gps_required",
+      "Body must include either a captured GPS fix or a failed_exception with reason + photo.",
+    );
+  }
+  const raw = body as Record<string, unknown>;
+  const explicitFailure = raw.gps_status === "failed_exception";
+  const hasLatOrLng = raw.latitude !== undefined || raw.longitude !== undefined;
+
+  // Ambiguous: client tried to send both shapes at once. Reject.
+  if (explicitFailure && hasLatOrLng) {
+    return rejection(
+      "ambiguous_payload",
+      "Cannot send a captured GPS fix and a failed_exception in the same request.",
+    );
+  }
+
+  if (explicitFailure) {
+    const reason = typeof raw.exception_reason === "string"
+      ? raw.exception_reason.trim()
+      : "";
+    if (!reason) {
+      return rejection(
+        "exception_reason_required",
+        "When GPS capture fails, you must provide a short reason. There is no skip.",
+      );
+    }
+    const photo = typeof raw.exception_photo_url === "string"
+      ? raw.exception_photo_url.trim()
+      : "";
+    if (!photo) {
+      return rejection(
+        "exception_photo_required",
+        "When GPS capture fails, you must provide an entry photo URL.",
+      );
+    }
+    return {
+      ok: true,
+      payload: {
+        kind: "failed_exception",
+        exception_reason: reason,
+        exception_photo_url: photo,
+      },
+    };
+  }
+
+  // Captured path — require latitude + longitude + accuracy.
+  if (raw.latitude === undefined || raw.longitude === undefined) {
+    return rejection(
+      "lat_lng_required",
+      "Latitude and longitude are required for a GPS-captured clock event.",
+    );
+  }
+  const lat = Number(raw.latitude);
+  const lng = Number(raw.longitude);
+  if (!Number.isFinite(lat) || lat < -90 || lat > 90) {
+    return rejection("lat_lng_invalid", "latitude must be a number in [-90, 90]");
+  }
+  if (!Number.isFinite(lng) || lng < -180 || lng > 180) {
+    return rejection("lat_lng_invalid", "longitude must be a number in [-180, 180]");
+  }
+  const accuracy = Number(raw.gps_accuracy_meters);
+  if (!Number.isFinite(accuracy) || accuracy < 0) {
+    return rejection(
+      "accuracy_invalid",
+      "gps_accuracy_meters must be a non-negative number.",
+    );
+  }
+  return {
+    ok: true,
+    payload: {
+      kind: "captured",
+      latitude: lat,
+      longitude: lng,
+      gps_accuracy_meters: accuracy,
+    },
+  };
+}
+
+function rejection(
+  code: ClockIntegrityRejection["code"],
+  message: string,
+): ClockIntegrityRejection {
+  return { ok: false, status: 400, error: "Bad Request", code, message };
+}

--- a/artifacts/api-server/src/lib/comms.ts
+++ b/artifacts/api-server/src/lib/comms.ts
@@ -1,0 +1,87 @@
+/**
+ * Cutover 1C — Minimal SMS wrapper for the on-my-way send.
+ *
+ * Mirrors the gating already enforced in routes/job-sms.ts but exposed
+ * as a small library function so the 1C on-my-way route doesn't need
+ * to duplicate the Twilio handshake. Returns a structured result so
+ * the caller can persist `client_notified` accurately:
+ *   - "sent"        — Twilio accepted the message
+ *   - "suppressed_comms_disabled"  — COMMS_ENABLED env not "true"
+ *   - "suppressed_tenant_disabled" — tenant flipped sms_on_my_way_enabled off
+ *   - "suppressed_client_opted_out" — clients.wants_on_my_way_notifications=false
+ *   - "suppressed_no_phone"  — client has no phone on file
+ *   - "error"       — Twilio API rejected; logged but never thrown
+ *                     so the on-my-way row still gets written.
+ *
+ * The route layer maps "sent" → client_notified=true; everything else
+ * → client_notified=false. The route never throws on SMS failure;
+ * the wage record (on_my_way_event row) always lands.
+ */
+
+export type OnMyWaySmsResult =
+  | { status: "sent"; sid: string }
+  | { status: "suppressed_comms_disabled" }
+  | { status: "suppressed_tenant_disabled" }
+  | { status: "suppressed_client_opted_out" }
+  | { status: "suppressed_no_phone" }
+  | { status: "error"; message: string };
+
+export async function sendOnMyWaySms(opts: {
+  toPhone: string | null | undefined;
+  fromPhone: string | null | undefined;
+  techName: string;
+  clientFirstName: string;
+  serviceAddress: string;
+  promisedArrivalLabel: string;
+  tenantSmsEnabled: boolean;
+  clientOptedIn: boolean;
+}): Promise<OnMyWaySmsResult> {
+  if (process.env.COMMS_ENABLED !== "true") {
+    console.log(
+      "[COMMS BLOCKED] on-my-way SMS suppressed — COMMS_ENABLED!=true",
+    );
+    return { status: "suppressed_comms_disabled" };
+  }
+  if (!opts.tenantSmsEnabled) return { status: "suppressed_tenant_disabled" };
+  if (!opts.clientOptedIn) return { status: "suppressed_client_opted_out" };
+  if (!opts.toPhone || !opts.fromPhone) return { status: "suppressed_no_phone" };
+
+  const body = `Hi ${opts.clientFirstName || "there"}! Your cleaner ${
+    opts.techName
+  } is on the way to ${
+    opts.serviceAddress
+  }. Estimated arrival: ${opts.promisedArrivalLabel}.`;
+
+  const accountSid = process.env.TWILIO_ACCOUNT_SID;
+  const authToken = process.env.TWILIO_AUTH_TOKEN;
+  if (!accountSid || !authToken) {
+    return { status: "error", message: "Twilio credentials not configured" };
+  }
+  try {
+    const res = await fetch(
+      `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/Messages.json`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Basic ${Buffer.from(
+            `${accountSid}:${authToken}`,
+          ).toString("base64")}`,
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: new URLSearchParams({
+          To: opts.toPhone,
+          From: opts.fromPhone,
+          Body: body,
+        }).toString(),
+      },
+    );
+    if (!res.ok) {
+      const errBody = await res.text().catch(() => "");
+      return { status: "error", message: `Twilio HTTP ${res.status}: ${errBody}` };
+    }
+    const json: any = await res.json().catch(() => ({}));
+    return { status: "sent", sid: json?.sid ?? "unknown" };
+  } catch (err) {
+    return { status: "error", message: (err as Error).message };
+  }
+}

--- a/artifacts/api-server/src/lib/distance.ts
+++ b/artifacts/api-server/src/lib/distance.ts
@@ -1,0 +1,57 @@
+/**
+ * Cutover 1C — Distance utilities for clock geofence math.
+ *
+ * Haversine over the WGS-84 mean earth radius. Used by the clock-in /
+ * clock-out routes to compute distance_from_site_meters and to decide
+ * within_geofence. Tenant geofence threshold lives on
+ * companies.geofence_clockin_radius_ft (default 500ft; spec called for
+ * 600ft / ~183m — Sal can flip the tenant value if he wants the wider
+ * radius). The conversion ft→m is documented in
+ * companyGeofenceMeters() below so the route uses the same constant.
+ */
+
+const EARTH_RADIUS_METERS = 6_371_000;
+const METERS_PER_FOOT = 0.3048;
+
+/**
+ * Great-circle distance between two lat/lng points in meters.
+ * Both points are degrees; conversion happens inside.
+ */
+export function haversineMeters(
+  lat1: number,
+  lng1: number,
+  lat2: number,
+  lng2: number,
+): number {
+  const toRad = (d: number) => (d * Math.PI) / 180;
+  const dLat = toRad(lat2 - lat1);
+  const dLng = toRad(lng2 - lng1);
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(lat1)) *
+      Math.cos(toRad(lat2)) *
+      Math.sin(dLng / 2) ** 2;
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return EARTH_RADIUS_METERS * c;
+}
+
+/**
+ * Convert the tenant's geofence_clockin_radius_ft setting to meters.
+ * Centralized so route code never inlines the ft→m conversion.
+ */
+export function feetToMeters(feet: number): number {
+  return feet * METERS_PER_FOOT;
+}
+
+/**
+ * The companies row carries the radius in feet (legacy field). Wrap
+ * the lookup so the route reads a meter value directly. NULL/zero
+ * fallback is the spec default (~183m / 600ft) — never block a clock
+ * event on a missing tenant setting.
+ */
+export function companyGeofenceMeters(
+  radiusFt: number | null | undefined,
+): number {
+  const ft = radiusFt && radiusFt > 0 ? radiusFt : 600;
+  return feetToMeters(ft);
+}

--- a/artifacts/api-server/src/lib/eta.ts
+++ b/artifacts/api-server/src/lib/eta.ts
@@ -1,0 +1,86 @@
+/**
+ * Cutover 1C — ETA computation for one-tap on-my-way.
+ *
+ * Two strategies in priority order:
+ *   1. Google Distance Matrix API (when GOOGLE_MAPS_API_KEY is set).
+ *      Real driving time including traffic conditions.
+ *   2. Haversine fallback at 25 mph average — only used when the
+ *      Distance Matrix call fails or the key is missing. Better than
+ *      forcing the tech to type their own guess.
+ *
+ * The function never throws — a failed API call falls through to the
+ * haversine fallback and logs a warning. The on-my-way send must not
+ * be blocked by an ETA lookup; the worst case is a slightly off
+ * estimate, and the spec rule is "don't make the tech type."
+ */
+
+const EARTH_RADIUS_MILES = 3958.8;
+const FALLBACK_AVG_MPH = 25;
+
+export async function estimateEtaMinutes(
+  fromLat: number,
+  fromLng: number,
+  toLat: number,
+  toLng: number,
+): Promise<number> {
+  const fromMatrix = await tryDistanceMatrix(fromLat, fromLng, toLat, toLng);
+  if (fromMatrix != null) return fromMatrix;
+  return haversineEtaMinutes(fromLat, fromLng, toLat, toLng);
+}
+
+async function tryDistanceMatrix(
+  fromLat: number,
+  fromLng: number,
+  toLat: number,
+  toLng: number,
+): Promise<number | null> {
+  const apiKey = process.env.GOOGLE_MAPS_API_KEY;
+  if (!apiKey) return null;
+  try {
+    const origins = `${fromLat},${fromLng}`;
+    const destinations = `${toLat},${toLng}`;
+    const url =
+      `https://maps.googleapis.com/maps/api/distancematrix/json` +
+      `?origins=${encodeURIComponent(origins)}` +
+      `&destinations=${encodeURIComponent(destinations)}` +
+      `&mode=driving` +
+      `&departure_time=now` +
+      `&key=${apiKey}`;
+    const res = await fetch(url);
+    if (!res.ok) {
+      console.warn("[eta] Distance Matrix HTTP error", res.status);
+      return null;
+    }
+    const data = (await res.json()) as any;
+    const elem = data?.rows?.[0]?.elements?.[0];
+    if (!elem || elem.status !== "OK") {
+      console.warn("[eta] Distance Matrix non-OK status:", elem?.status);
+      return null;
+    }
+    const dur =
+      elem.duration_in_traffic?.value ?? elem.duration?.value ?? null;
+    if (typeof dur !== "number") return null;
+    return Math.max(1, Math.round(dur / 60));
+  } catch (err) {
+    console.warn("[eta] Distance Matrix error:", err);
+    return null;
+  }
+}
+
+function haversineEtaMinutes(
+  lat1: number,
+  lng1: number,
+  lat2: number,
+  lng2: number,
+): number {
+  const toRad = (d: number) => (d * Math.PI) / 180;
+  const dLat = toRad(lat2 - lat1);
+  const dLng = toRad(lng2 - lng1);
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLng / 2) ** 2;
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  const miles = EARTH_RADIUS_MILES * c;
+  const minutes = (miles / FALLBACK_AVG_MPH) * 60;
+  return Math.max(1, Math.round(minutes));
+}

--- a/artifacts/api-server/src/routes/index.ts
+++ b/artifacts/api-server/src/routes/index.ts
@@ -62,6 +62,8 @@ import commercialServiceTypesRouter from "./commercial-service-types.js";
 import serviceTypesRouter from "./service-types.js";
 import coreRouter from "./core.js";
 import techRouter from "./tech.js";
+import techClockRouter from "./tech-clock.js";
+import officeClockRouter from "./office-clock.js";
 import acquisitionSourcesRouter from "./acquisition-sources.js";
 import publicRouter from "./public.js";
 import quickbooksRouter from "./integrations/quickbooks.js";
@@ -155,7 +157,13 @@ router.use("/pricing", pricingRouter);
 router.use("/commercial-service-types", commercialServiceTypesRouter);
 router.use("/service-types", serviceTypesRouter);
 router.use("/core", coreRouter);
+// Cutover 1B — tech day view (read-only timeline at /api/tech/today)
+// Cutover 1C — execution engine at /api/tech/jobs/:jobId/* and office
+// correction/exception review at /api/office/*. Mount the more
+// specific /tech/jobs path BEFORE /tech so Express dispatches correctly.
+router.use("/tech/jobs", techClockRouter);
 router.use("/tech", techRouter);
+router.use("/office", officeClockRouter);
 router.use("/acquisition-sources", acquisitionSourcesRouter);
 router.use("/bundles", bundlesRouter);
 router.use("/photos", photosRouter);

--- a/artifacts/api-server/src/routes/office-clock.ts
+++ b/artifacts/api-server/src/routes/office-clock.ts
@@ -1,0 +1,265 @@
+/**
+ * Cutover 1C — Office-side clock corrections + exception review.
+ *
+ * Mounted at /api/office. Three endpoints:
+ *   POST /jobs/:jobId/clock-correction       — append-only correction event
+ *   GET  /clock-exceptions                    — review queue (unreviewed)
+ *   POST /clock-exceptions/:id/review         — mark exception reviewed
+ *
+ * Office-only: requireRole('owner', 'admin', 'office', 'super_admin').
+ * Corrections NEVER overwrite or delete an original event. The
+ * correction is a NEW row with is_correction=true, correction_of_event_id
+ * pointing at the original, and correction_old_value carrying a JSON
+ * snapshot of prior values. Surfaces that read clock history must show
+ * both the original AND the correction (the office UI for this lands
+ * in 1D / 1E; the data model is complete here).
+ */
+import { Router } from "express";
+import { db } from "@workspace/db";
+import {
+  jobClockEventsTable,
+  jobsTable,
+} from "@workspace/db/schema";
+import { and, eq, isNull, desc } from "drizzle-orm";
+import { requireAuth, requireRole } from "../lib/auth.js";
+
+const router = Router();
+
+const officeOnly = requireRole("owner", "admin", "office", "super_admin");
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /jobs/:jobId/clock-correction
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// Body:
+//   {
+//     correction_of_event_id: number,        // original event being corrected
+//     corrected_values: { event_at?, latitude?, longitude?, within_geofence? },
+//     reason: string                          // free-text audit reason
+//   }
+//
+// Writes a NEW jobClockEvents row with is_correction=true. Sets
+// correction_old_value to a JSON snapshot of the original's mutable
+// fields so the audit trail captures what changed.
+
+router.post(
+  "/jobs/:jobId/clock-correction",
+  requireAuth,
+  officeOnly,
+  async (req, res) => {
+    try {
+      const companyId = req.auth!.companyId;
+      const userId = req.auth!.userId;
+      if (companyId == null) {
+        return res
+          .status(400)
+          .json({ error: "Bad Request", message: "User has no company assignment" });
+      }
+      const jobId = Number(req.params.jobId);
+      if (!Number.isFinite(jobId)) {
+        return res.status(400).json({ error: "Bad Request", message: "Invalid jobId" });
+      }
+
+      const body = (req.body ?? {}) as Record<string, unknown>;
+      const correctionOfEventId = Number(body.correction_of_event_id);
+      if (!Number.isFinite(correctionOfEventId)) {
+        return res.status(400).json({
+          error: "Bad Request",
+          message: "correction_of_event_id is required",
+        });
+      }
+      const reason = typeof body.reason === "string" ? body.reason.trim() : "";
+      if (!reason) {
+        return res
+          .status(400)
+          .json({ error: "Bad Request", message: "reason is required" });
+      }
+
+      // Load the original. Must be in this tenant + this job.
+      const originalRows = await db
+        .select()
+        .from(jobClockEventsTable)
+        .where(
+          and(
+            eq(jobClockEventsTable.id, correctionOfEventId),
+            eq(jobClockEventsTable.company_id, companyId),
+            eq(jobClockEventsTable.job_id, jobId),
+          ),
+        )
+        .limit(1);
+      const original = originalRows[0];
+      if (!original) {
+        return res
+          .status(404)
+          .json({ error: "Not Found", message: "Original event not found in this tenant + job" });
+      }
+
+      // Build corrected payload. New row inherits original values
+      // except for what's explicitly being corrected. The DB CHECK
+      // constraint still applies — a correction cannot produce a
+      // shape that lacks GPS or a flagged exception.
+      const corrected = (body.corrected_values ?? {}) as Record<string, unknown>;
+      const newEventAt =
+        typeof corrected.event_at === "string"
+          ? new Date(corrected.event_at)
+          : original.event_at;
+      const newLat =
+        corrected.latitude !== undefined
+          ? corrected.latitude == null
+            ? null
+            : String(corrected.latitude)
+          : original.latitude;
+      const newLng =
+        corrected.longitude !== undefined
+          ? corrected.longitude == null
+            ? null
+            : String(corrected.longitude)
+          : original.longitude;
+      const newWithinGeofence =
+        corrected.within_geofence !== undefined
+          ? (corrected.within_geofence as boolean | null)
+          : original.within_geofence;
+
+      const snapshot = {
+        event_at: original.event_at,
+        latitude: original.latitude,
+        longitude: original.longitude,
+        within_geofence: original.within_geofence,
+        distance_from_site_meters: original.distance_from_site_meters,
+        gps_status: original.gps_status,
+        exception_reason: original.exception_reason,
+        reason,
+      };
+
+      const inserted = await db
+        .insert(jobClockEventsTable)
+        .values({
+          company_id: companyId,
+          job_id: jobId,
+          user_id: original.user_id,
+          event_type: original.event_type,
+          event_at: newEventAt,
+          latitude: newLat,
+          longitude: newLng,
+          gps_accuracy_meters: original.gps_accuracy_meters,
+          distance_from_site_meters: original.distance_from_site_meters,
+          within_geofence: newWithinGeofence,
+          gps_status: original.gps_status,
+          exception_reason: original.exception_reason,
+          exception_photo_url: original.exception_photo_url,
+          is_correction: true,
+          correction_of_event_id: original.id,
+          correction_old_value: snapshot,
+          created_by_user_id: userId,
+        })
+        .returning({ id: jobClockEventsTable.id });
+
+      return res.json({
+        data: {
+          id: inserted[0]!.id,
+          correction_of_event_id: original.id,
+          reason,
+        },
+      });
+    } catch (err) {
+      console.error("[office-clock] correction error:", err);
+      return res
+        .status(500)
+        .json({ error: "Internal Server Error", message: "Failed to record correction" });
+    }
+  },
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /clock-exceptions — queue of failed_exception events awaiting review
+// ─────────────────────────────────────────────────────────────────────────────
+
+router.get("/clock-exceptions", requireAuth, officeOnly, async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    if (companyId == null) {
+      return res
+        .status(400)
+        .json({ error: "Bad Request", message: "User has no company assignment" });
+    }
+    const rows = await db
+      .select({
+        id: jobClockEventsTable.id,
+        job_id: jobClockEventsTable.job_id,
+        user_id: jobClockEventsTable.user_id,
+        event_type: jobClockEventsTable.event_type,
+        event_at: jobClockEventsTable.event_at,
+        exception_reason: jobClockEventsTable.exception_reason,
+        exception_photo_url: jobClockEventsTable.exception_photo_url,
+      })
+      .from(jobClockEventsTable)
+      .where(
+        and(
+          eq(jobClockEventsTable.company_id, companyId),
+          eq(jobClockEventsTable.gps_status, "failed_exception"),
+          isNull(jobClockEventsTable.exception_reviewed_at),
+        ),
+      )
+      .orderBy(desc(jobClockEventsTable.event_at))
+      .limit(200);
+    return res.json({ data: rows });
+  } catch (err) {
+    console.error("[office-clock] exceptions queue error:", err);
+    return res
+      .status(500)
+      .json({ error: "Internal Server Error", message: "Failed to load queue" });
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /clock-exceptions/:id/review — mark a failed_exception reviewed
+// ─────────────────────────────────────────────────────────────────────────────
+
+router.post(
+  "/clock-exceptions/:id/review",
+  requireAuth,
+  officeOnly,
+  async (req, res) => {
+    try {
+      const companyId = req.auth!.companyId;
+      const reviewerId = req.auth!.userId;
+      if (companyId == null) {
+        return res
+          .status(400)
+          .json({ error: "Bad Request", message: "User has no company assignment" });
+      }
+      const id = Number(req.params.id);
+      if (!Number.isFinite(id)) {
+        return res.status(400).json({ error: "Bad Request", message: "Invalid id" });
+      }
+
+      const result = await db
+        .update(jobClockEventsTable)
+        .set({
+          exception_reviewed_by_user_id: reviewerId,
+          exception_reviewed_at: new Date(),
+        })
+        .where(
+          and(
+            eq(jobClockEventsTable.id, id),
+            eq(jobClockEventsTable.company_id, companyId),
+            eq(jobClockEventsTable.gps_status, "failed_exception"),
+          ),
+        )
+        .returning({ id: jobClockEventsTable.id });
+      if (!result[0]) {
+        return res
+          .status(404)
+          .json({ error: "Not Found", message: "Exception not found" });
+      }
+      return res.json({ data: { id: result[0].id, reviewed: true } });
+    } catch (err) {
+      console.error("[office-clock] review error:", err);
+      return res
+        .status(500)
+        .json({ error: "Internal Server Error", message: "Failed to review" });
+    }
+  },
+);
+
+export default router;

--- a/artifacts/api-server/src/routes/tech-clock.ts
+++ b/artifacts/api-server/src/routes/tech-clock.ts
@@ -1,0 +1,688 @@
+/**
+ * Cutover 1C — Tech execution engine routes.
+ *
+ * Routes mounted at /api/tech/jobs (alongside the 1B day view):
+ *   POST   /:jobId/on-my-way        — one-tap; computes ETA; sends SMS
+ *                                      gated by COMMS_ENABLED + tenant
+ *                                      + client opt-in; records leg
+ *                                      for the mileage piece (2A)
+ *   POST   /:jobId/clock-in         — GPS MANDATORY; no skip path
+ *   POST   /:jobId/clock-out        — same GPS rules; closes the shift
+ *   GET    /:jobId/worksheet        — read-only worksheet payload
+ *                                      (seeded from job + client on
+ *                                      first read)
+ *   POST   /:jobId/photos           — append a photo to the job
+ *   POST   /:jobId/notes            — append a technician note
+ *
+ * Every route is tenant-scoped via req.auth!.companyId AND assigned-
+ * to-this-tech-scoped via assigned_user_id = req.auth!.userId. There is
+ * no admin override on this surface. The office-side correction +
+ * exception-review routes live in routes/office-clock.ts.
+ */
+import { Router } from "express";
+import { db } from "@workspace/db";
+import {
+  jobsTable,
+  clientsTable,
+  usersTable,
+  companiesTable,
+  jobClockEventsTable,
+  jobWorksheetTable,
+  jobPhotosTable,
+  technicianNotesTable,
+  onMyWayEventsTable,
+} from "@workspace/db/schema";
+import { and, eq, desc, isNull, sql } from "drizzle-orm";
+import { requireAuth } from "../lib/auth.js";
+import { validateClockGpsPayload } from "../lib/clock-integrity.js";
+import { haversineMeters, companyGeofenceMeters } from "../lib/distance.js";
+import { estimateEtaMinutes } from "../lib/eta.js";
+import { sendOnMyWaySms } from "../lib/comms.js";
+import { geocodeAddress } from "../lib/geocode.js";
+
+const router = Router();
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Job ownership helper — every tech route routes through this so the
+// "this is your job and your tenant" check is one line, not five.
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function loadOwnedJob(
+  companyId: number,
+  userId: number,
+  jobId: number,
+): Promise<{
+  id: number;
+  company_id: number;
+  assigned_user_id: number | null;
+  client_id: number | null;
+  scheduled_date: string;
+  scheduled_time: string | null;
+  status: string;
+} | null> {
+  const rows = await db
+    .select({
+      id: jobsTable.id,
+      company_id: jobsTable.company_id,
+      assigned_user_id: jobsTable.assigned_user_id,
+      client_id: jobsTable.client_id,
+      scheduled_date: jobsTable.scheduled_date,
+      scheduled_time: jobsTable.scheduled_time,
+      status: jobsTable.status,
+    })
+    .from(jobsTable)
+    .where(
+      and(eq(jobsTable.company_id, companyId), eq(jobsTable.id, jobId)),
+    )
+    .limit(1);
+  const job = rows[0];
+  if (!job) return null;
+  if (job.assigned_user_id !== userId) return null;
+  return job;
+}
+
+// Lazy geocode the client/job site coords. Cached on the clients row
+// once resolved. NEVER blocks the clock event — returns null on miss.
+async function ensureSiteCoords(
+  companyId: number,
+  clientId: number | null,
+): Promise<{ lat: number; lng: number } | null> {
+  if (!clientId) return null;
+  const rows = await db
+    .select({
+      id: clientsTable.id,
+      lat: clientsTable.lat,
+      lng: clientsTable.lng,
+      address: clientsTable.address,
+      city: clientsTable.city,
+      state: clientsTable.state,
+      zip: clientsTable.zip,
+    })
+    .from(clientsTable)
+    .where(
+      and(eq(clientsTable.company_id, companyId), eq(clientsTable.id, clientId)),
+    )
+    .limit(1);
+  const c = rows[0];
+  if (!c) return null;
+  const lat = c.lat ? Number(c.lat) : null;
+  const lng = c.lng ? Number(c.lng) : null;
+  if (lat != null && lng != null) return { lat, lng };
+  // Try to geocode. Compose the full address string; bail if we have
+  // nothing to work with.
+  const parts = [c.address, c.city, c.state, c.zip].filter(Boolean);
+  if (parts.length === 0) return null;
+  const result = await geocodeAddress(parts.join(", "));
+  if (!result) return null;
+  // Cache on the client row so the next event is instant.
+  await db
+    .update(clientsTable)
+    .set({ lat: String(result.lat), lng: String(result.lng) })
+    .where(
+      and(eq(clientsTable.company_id, companyId), eq(clientsTable.id, clientId)),
+    );
+  return result;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /:jobId/on-my-way — one-tap, ETA pre-solved, SMS gated, leg captured
+// ─────────────────────────────────────────────────────────────────────────────
+
+router.post("/:jobId/on-my-way", requireAuth, async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    const userId = req.auth!.userId;
+    if (companyId == null) {
+      return res
+        .status(400)
+        .json({ error: "Bad Request", message: "User has no company assignment" });
+    }
+    const jobId = Number(req.params.jobId);
+    if (!Number.isFinite(jobId)) {
+      return res.status(400).json({ error: "Bad Request", message: "Invalid jobId" });
+    }
+    const job = await loadOwnedJob(companyId, userId, jobId);
+    if (!job) {
+      return res
+        .status(404)
+        .json({ error: "Not Found", message: "Job not found or not assigned to you" });
+    }
+
+    // Optional inputs from the client (tech's current location, ETA
+    // adjustment, deferred flag, from_job_id). All optional. Defaults
+    // keep the one-tap happy path frictionless.
+    const body = (req.body ?? {}) as Record<string, unknown>;
+    const fromLatRaw = body.from_latitude;
+    const fromLngRaw = body.from_longitude;
+    const fromLat =
+      typeof fromLatRaw === "number" && Number.isFinite(fromLatRaw) ? fromLatRaw : null;
+    const fromLng =
+      typeof fromLngRaw === "number" && Number.isFinite(fromLngRaw) ? fromLngRaw : null;
+    const fromJobId =
+      typeof body.from_job_id === "number" && Number.isFinite(body.from_job_id)
+        ? (body.from_job_id as number)
+        : null;
+    const techAdjustedEtaMinutesRaw = body.adjusted_eta_minutes;
+    const techAdjustedEtaMinutes =
+      typeof techAdjustedEtaMinutesRaw === "number" &&
+      Number.isFinite(techAdjustedEtaMinutesRaw)
+        ? Math.max(1, Math.round(techAdjustedEtaMinutesRaw))
+        : null;
+    const deferred = body.deferred === true;
+
+    // Compute ETA. Try Distance Matrix → haversine fallback. If we
+    // can't get a site coord at all (geocode fails AND tech sent no
+    // from-coords) we skip the ETA estimate; the SMS still goes with
+    // "shortly."
+    const siteCoords = await ensureSiteCoords(companyId, job.client_id);
+    let estimatedEtaMinutes: number | null = null;
+    if (fromLat != null && fromLng != null && siteCoords) {
+      estimatedEtaMinutes = await estimateEtaMinutes(
+        fromLat,
+        fromLng,
+        siteCoords.lat,
+        siteCoords.lng,
+      );
+    }
+    const effectiveEta = techAdjustedEtaMinutes ?? estimatedEtaMinutes;
+    const now = new Date();
+    const promisedArrivalAt =
+      effectiveEta != null
+        ? new Date(now.getTime() + effectiveEta * 60_000)
+        : null;
+
+    // Late signal: tech-edited ETA puts the promised arrival AFTER the
+    // scheduled start.
+    let etaEditedAfterScheduledStart = false;
+    if (techAdjustedEtaMinutes != null && promisedArrivalAt && job.scheduled_time) {
+      const scheduledStart = parseScheduledStart(
+        job.scheduled_date,
+        job.scheduled_time,
+      );
+      if (scheduledStart && promisedArrivalAt.getTime() > scheduledStart.getTime()) {
+        etaEditedAfterScheduledStart = true;
+      }
+    }
+
+    // SMS send (only when not deferred).
+    let smsResult: Awaited<ReturnType<typeof sendOnMyWaySms>> | null = null;
+    if (!deferred) {
+      smsResult = await sendOnMyWayForJob(companyId, userId, job, promisedArrivalAt);
+    }
+    const clientNotified = smsResult?.status === "sent";
+
+    const inserted = await db
+      .insert(onMyWayEventsTable)
+      .values({
+        company_id: companyId,
+        job_id: job.id,
+        user_id: userId,
+        from_job_id: fromJobId,
+        from_latitude: fromLat != null ? String(fromLat) : null,
+        from_longitude: fromLng != null ? String(fromLng) : null,
+        estimated_eta_minutes: estimatedEtaMinutes,
+        promised_arrival_at: promisedArrivalAt,
+        eta_adjusted_by_tech: techAdjustedEtaMinutes != null,
+        eta_edited_after_scheduled_start: etaEditedAfterScheduledStart,
+        sent_at: deferred ? null : now,
+        client_notified: clientNotified,
+        deferred,
+      })
+      .returning({ id: onMyWayEventsTable.id });
+
+    return res.json({
+      data: {
+        id: inserted[0]!.id,
+        estimated_eta_minutes: estimatedEtaMinutes,
+        promised_arrival_at: promisedArrivalAt?.toISOString() ?? null,
+        eta_adjusted_by_tech: techAdjustedEtaMinutes != null,
+        eta_edited_after_scheduled_start: etaEditedAfterScheduledStart,
+        client_notified: clientNotified,
+        deferred,
+        sms_result: smsResult?.status ?? null,
+      },
+    });
+  } catch (err) {
+    console.error("[tech-clock] on-my-way error:", err);
+    return res
+      .status(500)
+      .json({ error: "Internal Server Error", message: "Failed to record on-my-way" });
+  }
+});
+
+async function sendOnMyWayForJob(
+  companyId: number,
+  userId: number,
+  job: { id: number; client_id: number | null },
+  promisedArrivalAt: Date | null,
+) {
+  // Load tenant SMS flag, tenant from-number, client phone + opt-in,
+  // tech first/last. Everything we need to compose the SMS.
+  const [tenantRows, clientRows, techRows] = await Promise.all([
+    db
+      .select({
+        sms_on_my_way_enabled: companiesTable.sms_on_my_way_enabled,
+        twilio_from_number: companiesTable.twilio_from_number,
+      })
+      .from(companiesTable)
+      .where(eq(companiesTable.id, companyId))
+      .limit(1),
+    job.client_id != null
+      ? db
+          .select({
+            first_name: clientsTable.first_name,
+            phone: clientsTable.phone,
+            address: clientsTable.address,
+            city: clientsTable.city,
+            state: clientsTable.state,
+            zip: clientsTable.zip,
+            wants_on_my_way_notifications: clientsTable.wants_on_my_way_notifications,
+          })
+          .from(clientsTable)
+          .where(
+            and(
+              eq(clientsTable.company_id, companyId),
+              eq(clientsTable.id, job.client_id),
+            ),
+          )
+          .limit(1)
+      : Promise.resolve([] as Array<{
+          first_name: string | null;
+          phone: string | null;
+          address: string | null;
+          city: string | null;
+          state: string | null;
+          zip: string | null;
+          wants_on_my_way_notifications: boolean | null;
+        }>),
+    db
+      .select({
+        first_name: usersTable.first_name,
+        last_name: usersTable.last_name,
+      })
+      .from(usersTable)
+      .where(eq(usersTable.id, userId))
+      .limit(1),
+  ]);
+  const tenant = tenantRows[0];
+  const client = clientRows[0];
+  const tech = techRows[0];
+  const serviceAddress = [
+    client?.address,
+    client?.city,
+    client?.state,
+    client?.zip,
+  ]
+    .filter(Boolean)
+    .join(", ");
+  const promisedLabel = promisedArrivalAt
+    ? promisedArrivalAt.toLocaleTimeString("en-US", {
+        hour: "numeric",
+        minute: "2-digit",
+      })
+    : "shortly";
+  return sendOnMyWaySms({
+    toPhone: client?.phone ?? null,
+    fromPhone: tenant?.twilio_from_number ?? null,
+    techName: `${tech?.first_name ?? ""} ${tech?.last_name ?? ""}`.trim(),
+    clientFirstName: client?.first_name ?? "",
+    serviceAddress,
+    promisedArrivalLabel: promisedLabel,
+    tenantSmsEnabled: !!tenant?.sms_on_my_way_enabled,
+    clientOptedIn: client?.wants_on_my_way_notifications !== false,
+  });
+}
+
+function parseScheduledStart(dateStr: string, time: string): Date | null {
+  // scheduled_time is text on jobs — could be "09:00", "9:00 AM", or
+  // "HH:MM:SS". Best-effort parse.
+  const m = /^(\d{1,2}):(\d{2})(?:\s*(AM|PM))?/i.exec(time.trim());
+  if (!m) return null;
+  let hh = parseInt(m[1], 10);
+  const mm = parseInt(m[2], 10);
+  const ampm = m[3]?.toUpperCase();
+  if (ampm === "PM" && hh < 12) hh += 12;
+  if (ampm === "AM" && hh === 12) hh = 0;
+  const [y, mo, d] = dateStr.split("-").map(Number);
+  const out = new Date(y, mo - 1, d, hh, mm);
+  return Number.isFinite(out.getTime()) ? out : null;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /:jobId/clock-in — GPS MANDATORY, no decline path
+// ─────────────────────────────────────────────────────────────────────────────
+
+router.post("/:jobId/clock-in", requireAuth, async (req, res) => {
+  return handleClockEvent(req, res, "clock_in");
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /:jobId/clock-out — same GPS rules as clock-in
+// ─────────────────────────────────────────────────────────────────────────────
+
+router.post("/:jobId/clock-out", requireAuth, async (req, res) => {
+  return handleClockEvent(req, res, "clock_out");
+});
+
+async function handleClockEvent(
+  req: any,
+  res: any,
+  eventType: "clock_in" | "clock_out",
+) {
+  try {
+    const companyId = req.auth!.companyId;
+    const userId = req.auth!.userId;
+    if (companyId == null) {
+      return res
+        .status(400)
+        .json({ error: "Bad Request", message: "User has no company assignment" });
+    }
+    const jobId = Number(req.params.jobId);
+    if (!Number.isFinite(jobId)) {
+      return res.status(400).json({ error: "Bad Request", message: "Invalid jobId" });
+    }
+    const job = await loadOwnedJob(companyId, userId, jobId);
+    if (!job) {
+      return res
+        .status(404)
+        .json({ error: "Not Found", message: "Job not found or not assigned to you" });
+    }
+
+    // Route-layer half of the integrity guarantee. The DB CHECK is the
+    // other half. Together they reject any shape that lacks either a
+    // captured GPS fix or a flagged exception with reason + photo.
+    const parsed = validateClockGpsPayload(req.body);
+    if (!parsed.ok) {
+      return res.status(parsed.status).json({
+        error: parsed.error,
+        message: parsed.message,
+        code: parsed.code,
+      });
+    }
+
+    // Compute distance + within_geofence on the captured path.
+    let distanceMeters: number | null = null;
+    let withinGeofence: boolean | null = null;
+    if (parsed.payload.kind === "captured") {
+      const siteCoords = await ensureSiteCoords(companyId, job.client_id);
+      if (siteCoords) {
+        distanceMeters = haversineMeters(
+          parsed.payload.latitude,
+          parsed.payload.longitude,
+          siteCoords.lat,
+          siteCoords.lng,
+        );
+        const tenantRows = await db
+          .select({
+            geofence_clockin_radius_ft: companiesTable.geofence_clockin_radius_ft,
+          })
+          .from(companiesTable)
+          .where(eq(companiesTable.id, companyId))
+          .limit(1);
+        const radiusMeters = companyGeofenceMeters(
+          tenantRows[0]?.geofence_clockin_radius_ft ?? null,
+        );
+        withinGeofence = distanceMeters <= radiusMeters;
+      }
+      // siteCoords missing → withinGeofence stays null + distance stays
+      // null. The event still gets the GPS fix (spec: geocode failure
+      // must not block the clock event). Office review queue can see
+      // this case by filtering on within_geofence IS NULL.
+    }
+
+    const eventAt = new Date();
+
+    // Insert event. The DB CHECK constraint enforces the same rule we
+    // already validated at the route layer.
+    const inserted = await db
+      .insert(jobClockEventsTable)
+      .values(
+        parsed.payload.kind === "captured"
+          ? {
+              company_id: companyId,
+              job_id: job.id,
+              user_id: userId,
+              event_type: eventType,
+              event_at: eventAt,
+              latitude: String(parsed.payload.latitude),
+              longitude: String(parsed.payload.longitude),
+              gps_accuracy_meters: String(parsed.payload.gps_accuracy_meters),
+              distance_from_site_meters:
+                distanceMeters != null ? String(distanceMeters.toFixed(1)) : null,
+              within_geofence: withinGeofence,
+              gps_status: "captured" as const,
+              created_by_user_id: userId,
+            }
+          : {
+              company_id: companyId,
+              job_id: job.id,
+              user_id: userId,
+              event_type: eventType,
+              event_at: eventAt,
+              gps_status: "failed_exception" as const,
+              exception_reason: parsed.payload.exception_reason,
+              exception_photo_url: parsed.payload.exception_photo_url,
+              created_by_user_id: userId,
+            },
+      )
+      .returning({ id: jobClockEventsTable.id });
+
+    // Mirror job status. clock_in → in_progress, clock_out → complete.
+    // Status transitions live on jobs.status which the dispatch UI reads.
+    if (eventType === "clock_in" && job.status !== "in_progress") {
+      await db
+        .update(jobsTable)
+        .set({ status: "in_progress" })
+        .where(
+          and(eq(jobsTable.company_id, companyId), eq(jobsTable.id, job.id)),
+        );
+    } else if (eventType === "clock_out" && job.status !== "complete") {
+      await db
+        .update(jobsTable)
+        .set({ status: "complete" })
+        .where(
+          and(eq(jobsTable.company_id, companyId), eq(jobsTable.id, job.id)),
+        );
+    }
+
+    return res.json({
+      data: {
+        id: inserted[0]!.id,
+        event_type: eventType,
+        event_at: eventAt.toISOString(),
+        gps_status: parsed.payload.kind === "captured" ? "captured" : "failed_exception",
+        distance_from_site_meters: distanceMeters,
+        within_geofence: withinGeofence,
+      },
+    });
+  } catch (err) {
+    console.error(`[tech-clock] ${eventType} error:`, err);
+    return res
+      .status(500)
+      .json({ error: "Internal Server Error", message: "Failed to record clock event" });
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /:jobId/worksheet — read worksheet; seed defaults on first read
+// ─────────────────────────────────────────────────────────────────────────────
+
+router.get("/:jobId/worksheet", requireAuth, async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    const userId = req.auth!.userId;
+    if (companyId == null) {
+      return res
+        .status(400)
+        .json({ error: "Bad Request", message: "User has no company assignment" });
+    }
+    const jobId = Number(req.params.jobId);
+    if (!Number.isFinite(jobId)) {
+      return res.status(400).json({ error: "Bad Request", message: "Invalid jobId" });
+    }
+    const job = await loadOwnedJob(companyId, userId, jobId);
+    if (!job) {
+      return res
+        .status(404)
+        .json({ error: "Not Found", message: "Job not found or not assigned to you" });
+    }
+
+    const existing = await db
+      .select()
+      .from(jobWorksheetTable)
+      .where(
+        and(
+          eq(jobWorksheetTable.company_id, companyId),
+          eq(jobWorksheetTable.job_id, job.id),
+        ),
+      )
+      .limit(1);
+    if (existing[0]) return res.json({ data: existing[0] });
+
+    // Seed defaults from jobs + clients. One-time on first GET.
+    const jobFull = await db
+      .select({
+        scope_deep_clean: jobsTable.scope_deep_clean,
+        scope_first_time_in: jobsTable.scope_first_time_in,
+        scope_priority: jobsTable.scope_priority,
+        special_equipment_needed: jobsTable.special_equipment_needed,
+        service_type: jobsTable.service_type,
+        notes: jobsTable.notes,
+      })
+      .from(jobsTable)
+      .where(
+        and(eq(jobsTable.company_id, companyId), eq(jobsTable.id, job.id)),
+      )
+      .limit(1);
+    const j = jobFull[0]!;
+    const seeded = await db
+      .insert(jobWorksheetTable)
+      .values({
+        company_id: companyId,
+        job_id: job.id,
+        service_set_name: j.service_type ?? null,
+        scope_deep_clean: j.scope_deep_clean ?? false,
+        scope_first_time_in: j.scope_first_time_in ?? false,
+        scope_priority: j.scope_priority ?? false,
+        special_equipment_needed: j.special_equipment_needed ?? false,
+        directions_text: j.notes ?? null,
+      })
+      .returning();
+    return res.json({ data: seeded[0] });
+  } catch (err) {
+    console.error("[tech-clock] worksheet error:", err);
+    return res
+      .status(500)
+      .json({ error: "Internal Server Error", message: "Failed to load worksheet" });
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /:jobId/photos — append a photo (URL-based; uploader provides URL)
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// The existing /api/photos service handles the actual upload + R2
+// storage. This route is just the "associate the URL with the job"
+// step. Body: { photo_url, photo_type?: "before"|"after", caption? }.
+
+router.post("/:jobId/photos", requireAuth, async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    const userId = req.auth!.userId;
+    if (companyId == null) {
+      return res
+        .status(400)
+        .json({ error: "Bad Request", message: "User has no company assignment" });
+    }
+    const jobId = Number(req.params.jobId);
+    if (!Number.isFinite(jobId)) {
+      return res.status(400).json({ error: "Bad Request", message: "Invalid jobId" });
+    }
+    const job = await loadOwnedJob(companyId, userId, jobId);
+    if (!job) {
+      return res
+        .status(404)
+        .json({ error: "Not Found", message: "Job not found or not assigned to you" });
+    }
+    const body = (req.body ?? {}) as Record<string, unknown>;
+    const photoUrl = typeof body.photo_url === "string" ? body.photo_url.trim() : "";
+    if (!photoUrl) {
+      return res
+        .status(400)
+        .json({ error: "Bad Request", message: "photo_url is required" });
+    }
+    const photoType = body.photo_type === "after" ? "after" : "before";
+    const inserted = await db
+      .insert(jobPhotosTable)
+      .values({
+        company_id: companyId,
+        job_id: job.id,
+        photo_type: photoType,
+        url: photoUrl,
+        uploaded_by: userId,
+      })
+      .returning({ id: jobPhotosTable.id });
+    return res.json({ data: { id: inserted[0]!.id, photo_url: photoUrl, photo_type: photoType } });
+  } catch (err) {
+    console.error("[tech-clock] photos error:", err);
+    return res
+      .status(500)
+      .json({ error: "Internal Server Error", message: "Failed to attach photo" });
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /:jobId/notes — append a technician note
+// ─────────────────────────────────────────────────────────────────────────────
+
+router.post("/:jobId/notes", requireAuth, async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    const userId = req.auth!.userId;
+    if (companyId == null) {
+      return res
+        .status(400)
+        .json({ error: "Bad Request", message: "User has no company assignment" });
+    }
+    const jobId = Number(req.params.jobId);
+    if (!Number.isFinite(jobId)) {
+      return res.status(400).json({ error: "Bad Request", message: "Invalid jobId" });
+    }
+    const job = await loadOwnedJob(companyId, userId, jobId);
+    if (!job) {
+      return res
+        .status(404)
+        .json({ error: "Not Found", message: "Job not found or not assigned to you" });
+    }
+    const body = (req.body ?? {}) as Record<string, unknown>;
+    const text = typeof body.body === "string" ? body.body.trim() : "";
+    if (!text) {
+      return res
+        .status(400)
+        .json({ error: "Bad Request", message: "body is required" });
+    }
+    const inserted = await db
+      .insert(technicianNotesTable)
+      .values({
+        company_id: companyId,
+        job_id: job.id,
+        user_id: userId,
+        body: text,
+      })
+      .returning({ id: technicianNotesTable.id, created_at: technicianNotesTable.created_at });
+    return res.json({
+      data: {
+        id: inserted[0]!.id,
+        body: text,
+        created_at: inserted[0]!.created_at,
+      },
+    });
+  } catch (err) {
+    console.error("[tech-clock] notes error:", err);
+    return res
+      .status(500)
+      .json({ error: "Internal Server Error", message: "Failed to attach note" });
+  }
+});
+
+export default router;

--- a/artifacts/api-server/src/tests/cutover-1c-clock-integrity.test.ts
+++ b/artifacts/api-server/src/tests/cutover-1c-clock-integrity.test.ts
@@ -1,0 +1,549 @@
+/**
+ * Cutover 1C — The integrity tests. This is the legal gate.
+ *
+ * The whole piece lives or dies on these guarantees:
+ *
+ *   1. NO API path produces a clock event with neither a captured GPS
+ *      fix nor a flagged failed_exception+reason. We assert the
+ *      route-layer validator rejects every bad shape AND that the
+ *      DB CHECK constraint SQL text matches the spec exactly.
+ *
+ *   2. The route layer does NOT expose a "skip", "decline",
+ *      "force=true", or any equivalent flag that bypasses the check.
+ *      We grep the route source to assert this; refactors that
+ *      reintroduce a skip break the test immediately.
+ *
+ *   3. Genuine GPS failure produces a flagged exception requiring
+ *      BOTH a reason AND a photo. Neither alone is enough.
+ *
+ *   4. Tenant + assignment isolation: the route layer scopes by
+ *      companyId + assigned_user_id. We grep + functionally assert.
+ *
+ *   5. The DB CHECK constraint SQL text + name are exported from the
+ *      schema file and re-asserted here so a future migration can't
+ *      silently weaken the constraint.
+ *
+ *   6. Distance / geofence math: haversine returns the expected
+ *      distance for known reference points; companyGeofenceMeters
+ *      converts feet → meters correctly and falls back to 600ft
+ *      when the tenant value is missing/zero.
+ *
+ *   7. On-my-way: SMS gating cascade is correct (COMMS_ENABLED →
+ *      tenant → client → phone presence); deferred=true sends
+ *      nothing; eta_edited_after_scheduled_start is set when
+ *      promised_arrival > scheduled_start.
+ *
+ *   8. Correction never overwrites: a correction is an INSERT with
+ *      is_correction=true and correction_of_event_id set. We verify
+ *      the route source uses INSERT, not UPDATE, on the corrections
+ *      path.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import {
+  JOB_CLOCK_EVENTS_INTEGRITY_CONSTRAINT_NAME,
+  JOB_CLOCK_EVENTS_INTEGRITY_CONSTRAINT_SQL,
+} from "@workspace/db/schema";
+import { validateClockGpsPayload } from "../lib/clock-integrity.js";
+import { haversineMeters, companyGeofenceMeters, feetToMeters } from "../lib/distance.js";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. Route-layer integrity validator — every bad shape rejected
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("Cutover 1C — clock integrity (route-layer validator)", () => {
+  it("rejects an empty body", () => {
+    const r = validateClockGpsPayload({});
+    assert.equal(r.ok, false);
+    if (r.ok === false) {
+      assert.equal(r.code, "lat_lng_required");
+    }
+  });
+
+  it("rejects null body", () => {
+    const r = validateClockGpsPayload(null);
+    assert.equal(r.ok, false);
+  });
+
+  it("rejects a body with only latitude (missing longitude)", () => {
+    const r = validateClockGpsPayload({ latitude: 41.8781 });
+    assert.equal(r.ok, false);
+    if (r.ok === false) assert.equal(r.code, "lat_lng_required");
+  });
+
+  it("rejects a body with only longitude (missing latitude)", () => {
+    const r = validateClockGpsPayload({ longitude: -87.6298 });
+    assert.equal(r.ok, false);
+    if (r.ok === false) assert.equal(r.code, "lat_lng_required");
+  });
+
+  it("rejects lat outside [-90, 90]", () => {
+    const r = validateClockGpsPayload({
+      latitude: 999,
+      longitude: 0,
+      gps_accuracy_meters: 10,
+    });
+    assert.equal(r.ok, false);
+    if (r.ok === false) assert.equal(r.code, "lat_lng_invalid");
+  });
+
+  it("rejects lng outside [-180, 180]", () => {
+    const r = validateClockGpsPayload({
+      latitude: 0,
+      longitude: 999,
+      gps_accuracy_meters: 10,
+    });
+    assert.equal(r.ok, false);
+    if (r.ok === false) assert.equal(r.code, "lat_lng_invalid");
+  });
+
+  it("rejects missing gps_accuracy_meters on captured path", () => {
+    const r = validateClockGpsPayload({
+      latitude: 41.8781,
+      longitude: -87.6298,
+    });
+    assert.equal(r.ok, false);
+    if (r.ok === false) assert.equal(r.code, "accuracy_invalid");
+  });
+
+  it("rejects negative gps_accuracy_meters", () => {
+    const r = validateClockGpsPayload({
+      latitude: 41.8781,
+      longitude: -87.6298,
+      gps_accuracy_meters: -1,
+    });
+    assert.equal(r.ok, false);
+    if (r.ok === false) assert.equal(r.code, "accuracy_invalid");
+  });
+
+  it("accepts a clean captured payload", () => {
+    const r = validateClockGpsPayload({
+      latitude: 41.8781,
+      longitude: -87.6298,
+      gps_accuracy_meters: 12.5,
+    });
+    assert.equal(r.ok, true);
+    if (r.ok === true) {
+      assert.equal(r.payload.kind, "captured");
+      if (r.payload.kind === "captured") {
+        assert.equal(r.payload.latitude, 41.8781);
+        assert.equal(r.payload.longitude, -87.6298);
+        assert.equal(r.payload.gps_accuracy_meters, 12.5);
+      }
+    }
+  });
+
+  it("rejects failed_exception without reason", () => {
+    const r = validateClockGpsPayload({
+      gps_status: "failed_exception",
+      exception_photo_url: "https://uploads.example.com/abc.jpg",
+    });
+    assert.equal(r.ok, false);
+    if (r.ok === false) assert.equal(r.code, "exception_reason_required");
+  });
+
+  it("rejects failed_exception without photo", () => {
+    const r = validateClockGpsPayload({
+      gps_status: "failed_exception",
+      exception_reason: "GPS permission denied on device",
+    });
+    assert.equal(r.ok, false);
+    if (r.ok === false) assert.equal(r.code, "exception_photo_required");
+  });
+
+  it("rejects failed_exception with blank reason", () => {
+    const r = validateClockGpsPayload({
+      gps_status: "failed_exception",
+      exception_reason: "   ",
+      exception_photo_url: "https://uploads.example.com/abc.jpg",
+    });
+    assert.equal(r.ok, false);
+    if (r.ok === false) assert.equal(r.code, "exception_reason_required");
+  });
+
+  it("accepts a clean failed_exception payload", () => {
+    const r = validateClockGpsPayload({
+      gps_status: "failed_exception",
+      exception_reason: "GPS permission denied on device",
+      exception_photo_url: "https://uploads.example.com/abc.jpg",
+    });
+    assert.equal(r.ok, true);
+    if (r.ok === true) {
+      assert.equal(r.payload.kind, "failed_exception");
+    }
+  });
+
+  it("rejects ambiguous mixed payload (captured + failed_exception together)", () => {
+    const r = validateClockGpsPayload({
+      latitude: 41.8781,
+      longitude: -87.6298,
+      gps_accuracy_meters: 10,
+      gps_status: "failed_exception",
+      exception_reason: "trying to game it",
+      exception_photo_url: "https://uploads.example.com/abc.jpg",
+    });
+    assert.equal(r.ok, false);
+    if (r.ok === false) assert.equal(r.code, "ambiguous_payload");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. The anti-decline guarantee — no skip path in the route source
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("Cutover 1C — anti-decline guarantee (route source)", () => {
+  const src = readFileSync(
+    path.resolve(process.cwd(), "src/routes/tech-clock.ts"),
+    "utf8",
+  );
+
+  it("tech-clock.ts does NOT contain a 'skip_gps' or 'decline' flag", () => {
+    assert.ok(
+      !/skip_gps|decline_gps|skip_location|gps_optional/.test(src),
+      "tech-clock.ts must NOT expose a skip/decline path for GPS",
+    );
+  });
+
+  it("tech-clock.ts does NOT support a 'force=true' bypass query param", () => {
+    assert.ok(
+      !/req\.query\.force/i.test(src),
+      "tech-clock.ts must NOT honor a force=true bypass",
+    );
+  });
+
+  it("tech-clock.ts routes through validateClockGpsPayload before any DB insert", () => {
+    assert.ok(
+      /validateClockGpsPayload\(req\.body\)/.test(src),
+      "tech-clock.ts must call validateClockGpsPayload before inserting",
+    );
+  });
+
+  it("tech-clock.ts does NOT read userId from request body or query (tenant isolation)", () => {
+    assert.ok(
+      !/req\.body\.user_?id|req\.query\.user_?id|req\.query\.employee_id/i.test(src),
+      "tech-clock.ts must source userId from req.auth!.userId — never the client",
+    );
+    assert.ok(
+      /req\.auth!\.userId/.test(src),
+      "tech-clock.ts must source userId from req.auth!.userId",
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3. DB CHECK constraint — text and name match spec
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("Cutover 1C — DB CHECK constraint", () => {
+  it("the constraint name matches the spec contract", () => {
+    assert.equal(
+      JOB_CLOCK_EVENTS_INTEGRITY_CONSTRAINT_NAME,
+      "job_clock_events_gps_integrity_chk",
+    );
+  });
+
+  it("the constraint SQL requires (captured AND lat AND lng) OR (failed_exception AND reason)", () => {
+    // Normalize whitespace so layout changes don't break the test.
+    const sqlNorm = JOB_CLOCK_EVENTS_INTEGRITY_CONSTRAINT_SQL.replace(/\s+/g, " ").trim();
+    assert.ok(
+      sqlNorm.includes(
+        "gps_status = 'captured' AND latitude IS NOT NULL AND longitude IS NOT NULL",
+      ),
+      "captured branch must require lat AND lng",
+    );
+    assert.ok(
+      sqlNorm.includes(
+        "gps_status = 'failed_exception' AND exception_reason IS NOT NULL",
+      ),
+      "failed_exception branch must require exception_reason",
+    );
+    assert.ok(sqlNorm.includes(" OR "), "constraint must allow either branch");
+  });
+
+  it("cutover-data-migration.ts installs the constraint idempotently", () => {
+    const src = readFileSync(
+      path.resolve(process.cwd(), "src/cutover-data-migration.ts"),
+      "utf8",
+    );
+    assert.ok(
+      /JOB_CLOCK_EVENTS_INTEGRITY_CONSTRAINT_NAME/.test(src),
+      "migration must reference the named constant",
+    );
+    assert.ok(
+      /JOB_CLOCK_EVENTS_INTEGRITY_CONSTRAINT_SQL/.test(src),
+      "migration must reference the named SQL constant",
+    );
+    assert.ok(
+      /pg_constraint[^;]*conname = '\$\{JOB_CLOCK_EVENTS_INTEGRITY_CONSTRAINT_NAME\}'/s.test(src),
+      "migration must skip when the constraint already exists",
+    );
+    assert.ok(
+      /ADD CONSTRAINT \$\{JOB_CLOCK_EVENTS_INTEGRITY_CONSTRAINT_NAME\}/s.test(src),
+      "migration must ALTER TABLE ADD CONSTRAINT using the named constant",
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 4. Distance + geofence math
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("Cutover 1C — distance + geofence math", () => {
+  it("haversine returns 0 for identical points", () => {
+    assert.equal(haversineMeters(41.8781, -87.6298, 41.8781, -87.6298), 0);
+  });
+
+  it("haversine matches a known reference distance (Chicago Loop to O'Hare ≈ 25 km great-circle)", () => {
+    // Loop (41.8781, -87.6298) to O'Hare (41.9742, -87.9073) is ~25 km
+    // great-circle (the 27-mile driving distance includes road routing,
+    // not direct flight). Allow ±1 km tolerance on the great-circle math.
+    const m = haversineMeters(41.8781, -87.6298, 41.9742, -87.9073);
+    assert.ok(
+      m > 24_500 && m < 26_500,
+      `expected ~25 km great-circle, got ${m.toFixed(0)} m`,
+    );
+  });
+
+  it("feetToMeters: 600 ft ≈ 182.88 m", () => {
+    assert.equal(feetToMeters(600).toFixed(2), "182.88");
+  });
+
+  it("companyGeofenceMeters: tenant value wins when present", () => {
+    assert.equal(
+      companyGeofenceMeters(500).toFixed(2),
+      feetToMeters(500).toFixed(2),
+    );
+  });
+
+  it("companyGeofenceMeters: falls back to 600 ft when tenant value is null", () => {
+    assert.equal(
+      companyGeofenceMeters(null).toFixed(2),
+      feetToMeters(600).toFixed(2),
+    );
+  });
+
+  it("companyGeofenceMeters: falls back to 600 ft when tenant value is zero or negative", () => {
+    assert.equal(
+      companyGeofenceMeters(0).toFixed(2),
+      feetToMeters(600).toFixed(2),
+    );
+    assert.equal(
+      companyGeofenceMeters(-1).toFixed(2),
+      feetToMeters(600).toFixed(2),
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 5. Office correction — append-only invariant (route source)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("Cutover 1C — office correction is append-only", () => {
+  const src = readFileSync(
+    path.resolve(process.cwd(), "src/routes/office-clock.ts"),
+    "utf8",
+  );
+
+  it("clock-correction handler uses INSERT, not UPDATE, on jobClockEventsTable", () => {
+    // Pinpoint the correction handler block and confirm no .update(jobClockEventsTable)
+    // appears between the route declaration and the next route declaration.
+    const matchIdx = src.indexOf('"/jobs/:jobId/clock-correction"');
+    const nextRouteIdx = src.indexOf("router.", matchIdx + 1);
+    const blockEnd = src.indexOf('"/clock-exceptions"', matchIdx);
+    const end = nextRouteIdx > -1 && nextRouteIdx < blockEnd ? nextRouteIdx : blockEnd;
+    const block = src.slice(matchIdx, end);
+    assert.ok(
+      /\.insert\(jobClockEventsTable\)/.test(block),
+      "correction handler must INSERT a new event",
+    );
+    assert.ok(
+      !/\.update\(jobClockEventsTable\)/.test(block),
+      "correction handler must NOT update the existing event row",
+    );
+  });
+
+  it("correction sets is_correction=true and correction_of_event_id", () => {
+    assert.ok(
+      /is_correction: true/.test(src),
+      "correction must mark the new row is_correction=true",
+    );
+    assert.ok(
+      /correction_of_event_id: original\.id/.test(src),
+      "correction must point at the original via correction_of_event_id",
+    );
+    assert.ok(
+      /correction_old_value: snapshot/.test(src),
+      "correction must snapshot prior values",
+    );
+  });
+
+  it("office routes require role gate", () => {
+    assert.ok(
+      /requireRole\("owner", "admin", "office", "super_admin"\)/.test(src),
+      "office routes must require owner/admin/office/super_admin",
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 6. On-my-way: SMS gating cascade + leg capture
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("Cutover 1C — on-my-way SMS gating cascade", () => {
+  // The route delegates to lib/comms.ts → sendOnMyWaySms. We test the
+  // cascade in lib/comms.ts directly so we don't need a Twilio mock.
+  it("sendOnMyWaySms blocks when COMMS_ENABLED is not 'true'", async () => {
+    const prev = process.env.COMMS_ENABLED;
+    delete process.env.COMMS_ENABLED;
+    try {
+      const { sendOnMyWaySms } = await import("../lib/comms.js");
+      const r = await sendOnMyWaySms({
+        toPhone: "+15551234567",
+        fromPhone: "+15557654321",
+        techName: "Jose Ardila",
+        clientFirstName: "Daniel",
+        serviceAddress: "123 Test St, Chicago, IL 60639",
+        promisedArrivalLabel: "10:25 AM",
+        tenantSmsEnabled: true,
+        clientOptedIn: true,
+      });
+      assert.equal(r.status, "suppressed_comms_disabled");
+    } finally {
+      if (prev !== undefined) process.env.COMMS_ENABLED = prev;
+    }
+  });
+
+  it("sendOnMyWaySms blocks when tenant SMS disabled (even with COMMS_ENABLED=true)", async () => {
+    process.env.COMMS_ENABLED = "true";
+    const { sendOnMyWaySms } = await import("../lib/comms.js");
+    const r = await sendOnMyWaySms({
+      toPhone: "+15551234567",
+      fromPhone: "+15557654321",
+      techName: "Jose Ardila",
+      clientFirstName: "Daniel",
+      serviceAddress: "123 Test St",
+      promisedArrivalLabel: "10:25 AM",
+      tenantSmsEnabled: false,
+      clientOptedIn: true,
+    });
+    assert.equal(r.status, "suppressed_tenant_disabled");
+  });
+
+  it("sendOnMyWaySms blocks when client opted out", async () => {
+    process.env.COMMS_ENABLED = "true";
+    const { sendOnMyWaySms } = await import("../lib/comms.js");
+    const r = await sendOnMyWaySms({
+      toPhone: "+15551234567",
+      fromPhone: "+15557654321",
+      techName: "Jose Ardila",
+      clientFirstName: "Daniel",
+      serviceAddress: "123 Test St",
+      promisedArrivalLabel: "10:25 AM",
+      tenantSmsEnabled: true,
+      clientOptedIn: false,
+    });
+    assert.equal(r.status, "suppressed_client_opted_out");
+  });
+
+  it("sendOnMyWaySms blocks when client has no phone", async () => {
+    process.env.COMMS_ENABLED = "true";
+    const { sendOnMyWaySms } = await import("../lib/comms.js");
+    const r = await sendOnMyWaySms({
+      toPhone: null,
+      fromPhone: "+15557654321",
+      techName: "Jose Ardila",
+      clientFirstName: "Daniel",
+      serviceAddress: "123 Test St",
+      promisedArrivalLabel: "10:25 AM",
+      tenantSmsEnabled: true,
+      clientOptedIn: true,
+    });
+    assert.equal(r.status, "suppressed_no_phone");
+  });
+
+  it("on-my-way route captures from_job_id and from coordinates (route source)", () => {
+    const src = readFileSync(
+      path.resolve(process.cwd(), "src/routes/tech-clock.ts"),
+      "utf8",
+    );
+    assert.ok(
+      /from_job_id: fromJobId/.test(src),
+      "on-my-way must persist from_job_id for the mileage piece",
+    );
+    assert.ok(
+      /from_latitude: fromLat/.test(src),
+      "on-my-way must persist from_latitude",
+    );
+    assert.ok(
+      /from_longitude: fromLng/.test(src),
+      "on-my-way must persist from_longitude",
+    );
+  });
+
+  it("on-my-way route honors deferred=true (no send, no sent_at)", () => {
+    const src = readFileSync(
+      path.resolve(process.cwd(), "src/routes/tech-clock.ts"),
+      "utf8",
+    );
+    assert.ok(
+      /sent_at: deferred \? null : now/.test(src),
+      "deferred=true must leave sent_at null",
+    );
+    assert.ok(
+      /if \(!deferred\) \{[\s\S]*smsResult = await sendOnMyWayForJob/.test(src),
+      "deferred=true must skip the SMS send",
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 7. Schema cross-checks (1C tables present and shaped per spec)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("Cutover 1C — schema cross-checks", () => {
+  it("job_clock_events table is present with required columns", async () => {
+    const { jobClockEventsTable } = await import("@workspace/db/schema");
+    const cols: any = jobClockEventsTable;
+    assert.ok(cols.company_id);
+    assert.ok(cols.job_id);
+    assert.ok(cols.user_id);
+    assert.ok(cols.event_type);
+    assert.ok(cols.event_at);
+    assert.ok(cols.latitude);
+    assert.ok(cols.longitude);
+    assert.ok(cols.gps_accuracy_meters);
+    assert.ok(cols.distance_from_site_meters);
+    assert.ok(cols.within_geofence);
+    assert.ok(cols.gps_status);
+    assert.ok(cols.exception_reason);
+    assert.ok(cols.exception_photo_url);
+    assert.ok(cols.is_correction);
+    assert.ok(cols.correction_of_event_id);
+    assert.ok(cols.correction_old_value);
+    assert.ok(cols.created_by_user_id);
+  });
+
+  it("on_my_way_events table is present with leg-capture columns", async () => {
+    const { onMyWayEventsTable } = await import("@workspace/db/schema");
+    const cols: any = onMyWayEventsTable;
+    assert.ok(cols.from_job_id, "from_job_id required for mileage piece");
+    assert.ok(cols.from_latitude);
+    assert.ok(cols.from_longitude);
+    assert.ok(cols.estimated_eta_minutes);
+    assert.ok(cols.promised_arrival_at);
+    assert.ok(cols.eta_adjusted_by_tech);
+    assert.ok(cols.eta_edited_after_scheduled_start);
+    assert.ok(cols.deferred);
+    assert.ok(cols.client_notified);
+  });
+
+  it("clients.wants_on_my_way_notifications is present", async () => {
+    const { clientsTable } = await import("@workspace/db/schema");
+    assert.ok(
+      (clientsTable as any).wants_on_my_way_notifications,
+      "clients.wants_on_my_way_notifications required by 1C",
+    );
+  });
+});

--- a/lib/db/src/schema/clients.ts
+++ b/lib/db/src/schema/clients.ts
@@ -91,6 +91,12 @@ export const clientsTable = pgTable("clients", {
   // by recurring_schedules.parking_fee_enabled or a manual modal toggle.
   parking_fee_enabled: boolean("parking_fee_enabled").notNull().default(false),
   parking_fee_amount: numeric("parking_fee_amount", { precision: 10, scale: 2 }),
+  // Cutover 1C — per-client opt-in/out for on-my-way SMS. Tenant-level
+  // gating via companies.sms_on_my_way_enabled still wins; this is the
+  // client's per-record preference. Default true (most clients want
+  // the heads-up); office flips false when a specific client asks not
+  // to receive them.
+  wants_on_my_way_notifications: boolean("wants_on_my_way_notifications").notNull().default(true),
   created_at: timestamp("created_at").notNull().defaultNow(),
 });
 

--- a/lib/db/src/schema/index.ts
+++ b/lib/db/src/schema/index.ts
@@ -103,3 +103,13 @@ export * from "./lms-settings";
 // insurance for techs who drive, languages, preferred name + pronouns.
 // Multi-tenant via company_id; one row per (company_id, user_id).
 export * from "./lms-onboarding-intake";
+
+// Cutover 1C (execution engine). Clock events carry the GPS integrity
+// guarantees enforced both at the route layer and via the CHECK
+// constraint installed by cutover-data-migration.ts. Worksheet +
+// technician notes + on-my-way events round out the per-job working
+// surface that the tech writes to during a shift.
+export * from "./job_clock_events";
+export * from "./job_worksheet";
+export * from "./technician_notes";
+export * from "./on_my_way_events";

--- a/lib/db/src/schema/job_clock_events.ts
+++ b/lib/db/src/schema/job_clock_events.ts
@@ -1,0 +1,98 @@
+/**
+ * Cutover 1C — Job clock events with GPS integrity (the legal backbone).
+ *
+ * Every clock event written here is a wage record. The CHECK constraint
+ * (enforced at the DB level by runCutoverClockIntegrityConstraint() in
+ * artifacts/api-server/src/cutover-data-migration.ts) guarantees that
+ * a row CANNOT exist with neither a captured GPS fix nor a flagged
+ * failed_exception with a reason. There is no third state. The route
+ * layer enforces the same rule before the row hits the DB; the
+ * constraint is defense-in-depth.
+ *
+ * This is greenfield. The legacy `timeclock` table stays in place for
+ * backwards compatibility and the existing /api/timeclock surface;
+ * 1C and everything downstream write to job_clock_events.
+ */
+import { pgTable, serial, integer, text, timestamp, boolean, numeric, jsonb, pgEnum, index } from "drizzle-orm/pg-core";
+import { companiesTable } from "./companies";
+import { jobsTable } from "./jobs";
+import { usersTable } from "./users";
+
+export const clockEventTypeEnum = pgEnum("clock_event_type", [
+  "clock_in",
+  "clock_out",
+]);
+
+export const clockGpsStatusEnum = pgEnum("clock_gps_status", [
+  "captured",
+  "failed_exception",
+]);
+
+export const jobClockEventsTable = pgTable(
+  "job_clock_events",
+  {
+    id: serial("id").primaryKey(),
+    company_id: integer("company_id").notNull().references(() => companiesTable.id),
+    job_id: integer("job_id").notNull().references(() => jobsTable.id),
+    user_id: integer("user_id").notNull().references(() => usersTable.id),
+    event_type: clockEventTypeEnum("event_type").notNull(),
+    event_at: timestamp("event_at", { withTimezone: true }).notNull().defaultNow(),
+    // GPS payload — populated when gps_status='captured'. Left NULL when
+    // 'failed_exception'. The CHECK constraint forbids the mixed state.
+    latitude: numeric("latitude", { precision: 9, scale: 6 }),
+    longitude: numeric("longitude", { precision: 9, scale: 6 }),
+    gps_accuracy_meters: numeric("gps_accuracy_meters", { precision: 6, scale: 1 }),
+    distance_from_site_meters: numeric("distance_from_site_meters", { precision: 8, scale: 1 }),
+    within_geofence: boolean("within_geofence"),
+    gps_status: clockGpsStatusEnum("gps_status").notNull(),
+    // Exception fields — populated when gps_status='failed_exception'.
+    // exception_reason is REQUIRED in that state (CHECK constraint).
+    // exception_photo_url is required by the route handler but not the
+    // DB constraint (photo upload could complete after-the-fact on
+    // intermittent connections; the office review queue flags any row
+    // missing it).
+    exception_reason: text("exception_reason"),
+    exception_photo_url: text("exception_photo_url"),
+    exception_reviewed_by_user_id: integer("exception_reviewed_by_user_id").references(() => usersTable.id),
+    exception_reviewed_at: timestamp("exception_reviewed_at", { withTimezone: true }),
+    // Correction trail — never overwrite or delete an original event.
+    // A correction INSERTs a new row with is_correction=true pointing
+    // at the original via correction_of_event_id, snapshotting prior
+    // values in correction_old_value.
+    is_correction: boolean("is_correction").notNull().default(false),
+    correction_of_event_id: integer("correction_of_event_id"),
+    correction_old_value: jsonb("correction_old_value"),
+    created_by_user_id: integer("created_by_user_id").notNull().references(() => usersTable.id),
+    created_at: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    by_job: index("job_clock_events_company_job_idx").on(t.company_id, t.job_id),
+    by_user: index("job_clock_events_company_user_event_at_idx").on(
+      t.company_id,
+      t.user_id,
+      t.event_at,
+    ),
+  }),
+);
+
+export type JobClockEvent = typeof jobClockEventsTable.$inferSelect;
+export type InsertJobClockEvent = typeof jobClockEventsTable.$inferInsert;
+
+/**
+ * Constant name for the CHECK constraint — referenced by the runtime
+ * migration that installs it and by the tests that assert it exists.
+ * Keeping the name in one place protects against drift on rename.
+ */
+export const JOB_CLOCK_EVENTS_INTEGRITY_CONSTRAINT_NAME =
+  "job_clock_events_gps_integrity_chk";
+
+/**
+ * The exact SQL of the integrity CHECK. Either the GPS fix is captured
+ * (lat + lng populated) OR it failed with a reason. No third state.
+ * Exported so the runtime migration uses the same text as the tests.
+ */
+export const JOB_CLOCK_EVENTS_INTEGRITY_CONSTRAINT_SQL = `(
+  (gps_status = 'captured' AND latitude IS NOT NULL AND longitude IS NOT NULL)
+  OR
+  (gps_status = 'failed_exception' AND exception_reason IS NOT NULL)
+)`;

--- a/lib/db/src/schema/job_worksheet.ts
+++ b/lib/db/src/schema/job_worksheet.ts
@@ -1,0 +1,44 @@
+/**
+ * Cutover 1C — Per-job worksheet payload.
+ *
+ * Holds the worksheet-specific fields that don't belong on jobs itself
+ * (directions, entry photo, bedroom/bath counts captured at booking,
+ * next-job date for follow-on planning). Other 1A fields (scope flags,
+ * service type) already live on jobs and are mirrored here only when
+ * the office wants to override the worksheet display without altering
+ * the job record itself.
+ *
+ * One row per job. Created lazily on first GET /worksheet when a job
+ * doesn't have one yet (the GET seeds defaults from jobs+clients).
+ */
+import { pgTable, serial, integer, text, timestamp, boolean, date, index } from "drizzle-orm/pg-core";
+import { companiesTable } from "./companies";
+import { jobsTable } from "./jobs";
+
+export const jobWorksheetTable = pgTable(
+  "job_worksheet",
+  {
+    id: serial("id").primaryKey(),
+    company_id: integer("company_id").notNull().references(() => companiesTable.id),
+    job_id: integer("job_id").notNull().references(() => jobsTable.id).unique(),
+    service_set_name: text("service_set_name"),
+    scope_deep_clean: boolean("scope_deep_clean").notNull().default(false),
+    scope_first_time_in: boolean("scope_first_time_in").notNull().default(false),
+    scope_priority: boolean("scope_priority").notNull().default(false),
+    special_equipment_needed: boolean("special_equipment_needed").notNull().default(false),
+    directions_text: text("directions_text"),
+    entry_photo_url: text("entry_photo_url"),
+    bedrooms: integer("bedrooms"),
+    full_baths: integer("full_baths"),
+    half_baths: integer("half_baths"),
+    next_job_date: date("next_job_date"),
+    billing_terms: text("billing_terms"),
+    updated_at: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    by_job: index("job_worksheet_company_job_idx").on(t.company_id, t.job_id),
+  }),
+);
+
+export type JobWorksheet = typeof jobWorksheetTable.$inferSelect;
+export type InsertJobWorksheet = typeof jobWorksheetTable.$inferInsert;

--- a/lib/db/src/schema/on_my_way_events.ts
+++ b/lib/db/src/schema/on_my_way_events.ts
@@ -1,0 +1,55 @@
+/**
+ * Cutover 1C — On-my-way event log.
+ *
+ * Captures the one-tap "I'm on my way" action with a pre-solved ETA.
+ * Critically, the row also captures `from_job_id` + from coordinates
+ * so the mileage piece (2A) gets the client-to-client leg for free —
+ * no separate "log a mileage leg" surface required from the tech.
+ *
+ * `eta_edited_after_scheduled_start` is the late signal: when the
+ * tech adjusts the ETA such that promised_arrival_at lands AFTER the
+ * job's scheduled_start_time, the row flags it. The attendance /
+ * discipline piece (later) decides what to do with that signal; 1C
+ * just captures it.
+ *
+ * `deferred=true` records the "wait to send" choice and sends nothing.
+ */
+import { pgTable, serial, integer, text, timestamp, boolean, numeric, index } from "drizzle-orm/pg-core";
+import { companiesTable } from "./companies";
+import { jobsTable } from "./jobs";
+import { usersTable } from "./users";
+
+export const onMyWayEventsTable = pgTable(
+  "on_my_way_events",
+  {
+    id: serial("id").primaryKey(),
+    company_id: integer("company_id").notNull().references(() => companiesTable.id),
+    job_id: integer("job_id").notNull().references(() => jobsTable.id),
+    user_id: integer("user_id").notNull().references(() => usersTable.id),
+    // The job the tech is LEAVING (for ETA + mileage leg in 2A). NULL
+    // when this is the first job of the day (home-to-first-job is not
+    // a reimbursable leg per the handbook).
+    from_job_id: integer("from_job_id").references(() => jobsTable.id),
+    from_latitude: numeric("from_latitude", { precision: 9, scale: 6 }),
+    from_longitude: numeric("from_longitude", { precision: 9, scale: 6 }),
+    estimated_eta_minutes: integer("estimated_eta_minutes"),
+    promised_arrival_at: timestamp("promised_arrival_at", { withTimezone: true }),
+    eta_adjusted_by_tech: boolean("eta_adjusted_by_tech").notNull().default(false),
+    eta_edited_after_scheduled_start: boolean("eta_edited_after_scheduled_start").notNull().default(false),
+    sent_at: timestamp("sent_at", { withTimezone: true }),
+    client_notified: boolean("client_notified").notNull().default(false),
+    deferred: boolean("deferred").notNull().default(false),
+    created_at: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    by_job: index("on_my_way_events_company_job_idx").on(t.company_id, t.job_id),
+    by_user: index("on_my_way_events_company_user_created_at_idx").on(
+      t.company_id,
+      t.user_id,
+      t.created_at,
+    ),
+  }),
+);
+
+export type OnMyWayEvent = typeof onMyWayEventsTable.$inferSelect;
+export type InsertOnMyWayEvent = typeof onMyWayEventsTable.$inferInsert;

--- a/lib/db/src/schema/technician_notes.ts
+++ b/lib/db/src/schema/technician_notes.ts
@@ -1,0 +1,31 @@
+/**
+ * Cutover 1C — Technician's own notes attached to a job.
+ *
+ * Distinct from the existing `employee_notes` table (HR-side notes
+ * about the employee). technician_notes is the tech's own working
+ * notes about the job — color of damage, where the cat is hiding,
+ * which closet has the spare vacuum bags. The office can read them;
+ * the tech is the author.
+ */
+import { pgTable, serial, integer, text, timestamp, index } from "drizzle-orm/pg-core";
+import { companiesTable } from "./companies";
+import { jobsTable } from "./jobs";
+import { usersTable } from "./users";
+
+export const technicianNotesTable = pgTable(
+  "technician_notes",
+  {
+    id: serial("id").primaryKey(),
+    company_id: integer("company_id").notNull().references(() => companiesTable.id),
+    job_id: integer("job_id").notNull().references(() => jobsTable.id),
+    user_id: integer("user_id").notNull().references(() => usersTable.id),
+    body: text("body").notNull(),
+    created_at: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    by_job: index("technician_notes_company_job_idx").on(t.company_id, t.job_id),
+  }),
+);
+
+export type TechnicianNote = typeof technicianNotesTable.$inferSelect;
+export type InsertTechnicianNote = typeof technicianNotesTable.$inferInsert;


### PR DESCRIPTION
## Summary

Cutover 1C — the legally-critical piece. Job execution engine: one-tap on-my-way with pre-solved ETA and silent mileage-leg capture, GPS-MANDATORY clock-in/out with no decline path, worksheet, photos, technician notes, and office-side clock corrections + exception review queue.

**Anti-decline guarantee is enforced at TWO layers** (defense in depth):

1. **Route layer** (`lib/clock-integrity.ts → validateClockGpsPayload()`): every `POST /api/tech/jobs/:jobId/clock-in|clock-out` request must carry either a captured GPS fix (lat + lng + accuracy) OR a `failed_exception` with both a reason AND a photo. Anything else returns 400 with a stable error code. No skip flag, no force=true, no role override.
2. **DB layer** (`job_clock_events_gps_integrity_chk` CHECK constraint): installed at runtime by `cutover-data-migration.ts` on cold start. The constraint SQL is exported from the schema file so the migration and the tests reference the same string. A direct INSERT bypassing the route (admin tool, future script) is rejected by Postgres itself.

Constraint SQL:
```
(gps_status = 'captured' AND latitude IS NOT NULL AND longitude IS NOT NULL)
OR
(gps_status = 'failed_exception' AND exception_reason IS NOT NULL)
```

There is no third state.

## What this PR adds

### Greenfield schemas (all tenant-scoped via `company_id`)
- `job_clock_events` — every clock event with GPS + exception + correction-trail fields. Carries the CHECK constraint.
- `job_worksheet` — per-job worksheet payload (directions, entry photo, bed/bath, billing terms). Seeded from jobs+clients on first GET.
- `technician_notes` — tech's own working notes on a job.
- `on_my_way_events` — one-tap log with `from_job_id` + `from_latitude` + `from_longitude` so the mileage piece (2A) gets the client-to-client leg for free.
- `clients.wants_on_my_way_notifications` boolean default true (additive)

### Helpers
- `lib/clock-integrity.ts` — route-layer validator with structured error codes
- `lib/distance.ts` — `haversineMeters()` + `companyGeofenceMeters()` with feet→meters conversion (tenant value wins; 600 ft default)
- `lib/eta.ts` — `estimateEtaMinutes()` via Google Distance Matrix → haversine fallback at 25 mph. Never throws.
- `lib/comms.ts` — `sendOnMyWaySms()` with full gating cascade: `COMMS_ENABLED → tenant.sms_on_my_way_enabled → client.wants_on_my_way_notifications → phone present`. Returns structured result.

### Runtime migration
- `cutover-data-migration.ts` — installs the CHECK constraint idempotently on cold start. Wired into `index.ts` after `runPhesDataMigration()`.

### Tech routes (`POST /api/tech/jobs/:jobId/*`)
- `/on-my-way` — one-tap; ETA pre-solved; SMS gated by cascade; leg captured for mileage. Honors `deferred=true` (wait-to-send) and `adjusted_eta_minutes` (secondary affordance). Records `eta_edited_after_scheduled_start` as the late signal.
- `/clock-in` — GPS mandatory; computes distance + within_geofence; lazily geocodes client address if site coords missing (does NOT block the event on geocode failure — captures GPS fix and leaves `within_geofence` null + flagged for office review); mirrors job status to `in_progress`.
- `/clock-out` — identical rules; mirrors job status to `complete`.
- `/worksheet GET` — read worksheet; seeds defaults on first read.
- `/photos POST` — append photo URL (reuses existing `job_photos`).
- `/notes POST` — append technician note.

### Office routes (`/api/office`, role-gated owner/admin/office/super_admin)
- `POST /jobs/:jobId/clock-correction` — APPEND-ONLY. Writes a NEW row with `is_correction=true`, `correction_of_event_id` pointing at the original, `correction_old_value` snapshotting prior values. NEVER overwrites or deletes.
- `GET /clock-exceptions` — review queue.
- `POST /clock-exceptions/:id/review` — mark reviewed.

## Tests — the gate

**65/65 cutover tests passing** (1A: 26, 1B: 20, 1C: 39 subtests).

1C coverage:
- Validator rejects every bad shape (empty body, partial lat/lng, out of range, missing accuracy, blank reason, missing photo, ambiguous mixed payload)
- Route source grep asserts no `skip_gps` / `decline_gps` / `force=true` affordance was reintroduced; positively asserts the route routes through `validateClockGpsPayload` and sources userId from `req.auth`, never the client
- DB CHECK constraint name + SQL match the schema-exported constants (drift-protection)
- Office correction handler uses INSERT (not UPDATE) on `jobClockEventsTable`; sets `is_correction=true` + `correction_of_event_id`; snapshots prior values
- SMS gating cascade: `COMMS_ENABLED → tenant → client → phone`
- On-my-way captures `from_job_id` + `from_latitude` + `from_longitude` for mileage 2A
- On-my-way honors `deferred=true` (no SMS, no `sent_at`)
- Distance / geofence math: haversine sanity (Loop ↔ O'Hare great-circle), feet → meters (600 ft → 182.88 m), tenant value precedence, default fallback
- Schema cross-checks: all four new tables present with required columns; `clients.wants_on_my_way_notifications` present

Other:
- `pnpm run test:lms` — 392/392 still pass (no regression)
- tsc-libs clean
- frontend + api-server builds clean
- tsc on api-server: **796 errors, 0 new** (matches main exactly)

## Test plan

- [ ] On production, hit `POST /api/tech/jobs/:jobId/clock-in` with an empty body → expect 400 with `code: lat_lng_required`
- [ ] Hit it with `{ gps_status: "failed_exception" }` (missing reason + photo) → expect 400 with `code: exception_reason_required`
- [ ] Hit it with `{ gps_status: "failed_exception", exception_reason: "no signal" }` (missing photo) → expect 400 with `code: exception_photo_required`
- [ ] Try to INSERT a raw row into `job_clock_events` with `gps_status='captured'` but `latitude IS NULL` via a direct DB tool → expect Postgres `check constraint violation` (this is the DB-layer defense)
- [ ] Real flow on a phone: clock into a job with location permission → expect `gps_status='captured'` + `distance_from_site_meters` populated + `within_geofence` set
- [ ] Real flow on a phone: deny location permission, then try to clock in → expect the UI to demand a reason + entry photo (no skip button anywhere; this is the whole point of the piece)
- [ ] Office: hit `GET /api/office/clock-exceptions` as an `office` user → expect the queue of unreviewed failed_exception events for the tenant
- [ ] Office: hit `POST /api/office/jobs/:jobId/clock-correction` with a `correction_of_event_id` → expect a NEW row created with `is_correction=true`; verify the original row is unchanged
- [ ] On-my-way: tap once with COMMS_ENABLED=false → expect `sms_result: 'suppressed_comms_disabled'`, `client_notified: false`, but the `on_my_way_events` row IS written

## What this PR does NOT do (per spec, out of scope)

- No mileage money computation, no pay (2A + 1E own that; 1C only captures the leg data)
- No scorecards, no commission, no attendance buckets, no leave
- No owner analytics, triptych, activity grid
- Minimal office UI; full office employee profile comes later. Data model + endpoints are complete and audited.
- **No UI hero-CTA wiring on `/my-day`.** That route ships in PR #196 (cutover 1B, still in CI). Once 1B merges, a small follow-up PR wires the hero's primary action to `POST /api/tech/jobs/:jobId/on-my-way` and the clock-in/out flows. The `/api/tech/jobs/*` routes are reachable in production immediately; only the new UX surface waits on 1B.

## Depends on

- PR #195 (1A — data backbone). **Merged.**
- PR #196 (1B — tech day view). Not required for 1C routes to function.

## Branch

`feature/cutover-1c-clock-worksheet` — open as draft. **The integrity tests are the gate**; do not merge on green build alone. Verify the two-layer guarantee by reading the validator (`lib/clock-integrity.ts`) AND the runtime constraint installer (`cutover-data-migration.ts`).

https://claude.ai/code/session_013rJ4N4vgqZWB986x8D6Ahh

---
_Generated by [Claude Code](https://claude.ai/code/session_013rJ4N4vgqZWB986x8D6Ahh)_