### PR TITLE
cutover 1E: pay-period summaries, adjustments, approval gates, generic CSV export

### DIFF
--- a/artifacts/api-server/src/index.ts
+++ b/artifacts/api-server/src/index.ts
@@ -3,6 +3,7 @@ import { seedIfNeeded } from "./seed";
 import { startRecurringJobCron } from "./lib/recurring-jobs";
 import { runPhesDataMigration } from "./phes-data-migration";
 import { runCutoverDataMigration } from "./cutover-data-migration";
+import { verifyClockIntegrityConstraint } from "./lib/clock-integrity-self-check";
 import { runReminderCron, runReviewRequestCron } from "./services/notificationService.js";
 import { runRateLockNightlyChecks } from "./utils/rateLock.js";
 import { processDueEnrollments } from "./services/followUpService.js";
@@ -157,6 +158,15 @@ async function startup() {
     await runCutoverDataMigration();
   } catch (err: any) {
     console.error("[startup] runCutoverDataMigration — non-fatal:", err?.message ?? err);
+  }
+  // Cutover 1E — self-check that the 1C GPS-integrity CHECK constraint
+  // is live AND enforced in production. Non-fatal: pay computation
+  // independently filters at the application layer, but the deploy log
+  // makes the DB-layer guarantee visible to anyone watching.
+  try {
+    await verifyClockIntegrityConstraint();
+  } catch (err: any) {
+    console.error("[startup] clock-integrity self-check — non-fatal:", err?.message ?? err);
   }
   try {
     const r = await runLmsCompletionBackfill();

--- a/artifacts/api-server/src/lib/clock-integrity-self-check.ts
+++ b/artifacts/api-server/src/lib/clock-integrity-self-check.ts
@@ -1,0 +1,183 @@
+/**
+ * Cutover 1E — Startup self-check that confirms the 1C GPS-integrity
+ * CHECK constraint is live AND enforced in the connected database.
+ *
+ * Runs at api-server startup after the DB connection is established
+ * but before serving traffic. Non-fatal: log-only. The pay pipeline
+ * also independently filters at the application layer
+ * (lib/pay-eligibility.ts), so a missing constraint cannot leak bad
+ * events into paid hours, but the boot log makes the constraint
+ * presence visible to anyone watching the deploy.
+ *
+ * Re-runnable on demand via GET /api/ops/integrity-check (routes/
+ * ops-integrity.ts). Same code path; never crashes.
+ */
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+import {
+  JOB_CLOCK_EVENTS_INTEGRITY_CONSTRAINT_NAME,
+} from "@workspace/db/schema";
+
+/**
+ * Postgres SQLSTATE for `check_violation`. The smoke INSERTs below
+ * must each raise this code; any other failure (e.g. FK violation)
+ * means the constraint is missing or weaker than expected.
+ */
+const PG_CHECK_VIOLATION_SQLSTATE = "23514";
+
+export type IntegrityCheckResult = {
+  ok: boolean;
+  constraint_name: string | null;
+  constraint_definition: string | null;
+  captured_smoke_rejected: boolean;
+  failed_exception_smoke_rejected: boolean;
+  message: string;
+  detail: string[];
+};
+
+export async function verifyClockIntegrityConstraint(): Promise<IntegrityCheckResult> {
+  const detail: string[] = [];
+  let constraintName: string | null = null;
+  let constraintDefinition: string | null = null;
+
+  // Step 1 — read the catalog.
+  try {
+    const rows: any = await db.execute(
+      sql`SELECT conname, pg_get_constraintdef(oid) AS defn
+          FROM pg_constraint
+          WHERE conrelid = 'job_clock_events'::regclass AND contype = 'c'`,
+    );
+    const matches = (Array.isArray(rows) ? rows : rows?.rows ?? []) as Array<{
+      conname: string;
+      defn: string;
+    }>;
+    const target = matches.find(
+      (r) => r.conname === JOB_CLOCK_EVENTS_INTEGRITY_CONSTRAINT_NAME,
+    );
+    if (target) {
+      constraintName = target.conname;
+      constraintDefinition = target.defn;
+      detail.push(
+        `catalog: ${constraintName} present, defn=${constraintDefinition}`,
+      );
+    } else if (matches.length > 0) {
+      detail.push(
+        `catalog: target constraint ${JOB_CLOCK_EVENTS_INTEGRITY_CONSTRAINT_NAME} NOT found; other CHECKs on table: ${matches
+          .map((m) => m.conname)
+          .join(", ")}`,
+      );
+    } else {
+      detail.push(
+        `catalog: NO check constraints found on job_clock_events`,
+      );
+    }
+  } catch (err) {
+    detail.push(`catalog lookup error: ${(err as Error).message}`);
+  }
+
+  // Step 2 — captured smoke INSERT (must be rejected).
+  const capturedRejected = await runSmokeAndExpectRejection(
+    sql`INSERT INTO job_clock_events
+          (company_id, job_id, user_id, event_type, event_at,
+           gps_status, created_by_user_id)
+        VALUES
+          (-999999, -999999, -999999, 'clock_in', now(),
+           'captured', -999999)`,
+    "captured with null lat/lng",
+    detail,
+  );
+
+  // Step 3 — failed_exception smoke INSERT (must be rejected).
+  const failedExceptionRejected = await runSmokeAndExpectRejection(
+    sql`INSERT INTO job_clock_events
+          (company_id, job_id, user_id, event_type, event_at,
+           gps_status, exception_reason, created_by_user_id)
+        VALUES
+          (-999999, -999999, -999999, 'clock_in', now(),
+           'failed_exception', NULL, -999999)`,
+    "failed_exception with null reason",
+    detail,
+  );
+
+  const ok =
+    constraintName != null &&
+    capturedRejected &&
+    failedExceptionRejected;
+
+  const result: IntegrityCheckResult = {
+    ok,
+    constraint_name: constraintName,
+    constraint_definition: constraintDefinition,
+    captured_smoke_rejected: capturedRejected,
+    failed_exception_smoke_rejected: failedExceptionRejected,
+    message: ok
+      ? `CLOCK INTEGRITY: PASS — constraint ${constraintName} present and rejecting malformed rows`
+      : `CLOCK INTEGRITY: FAIL — constraint missing or not enforced; pay relies on application-level guard only. INVESTIGATE BEFORE RUNNING PAYROLL.`,
+    detail,
+  };
+
+  // Single-line headline log so the deploy log is easy to grep.
+  console.log(result.message);
+  for (const line of detail) console.log(`  · ${line}`);
+
+  return result;
+}
+
+/**
+ * Wrap one bad-row INSERT in a transaction and roll it back. We expect
+ * Postgres to raise SQLSTATE 23514 (check_violation). Anything else is
+ * a smoke failure.
+ *
+ * The bogus FK values (-999999) deliberately violate company_id /
+ * job_id / user_id foreign keys too, but Postgres validates CHECK
+ * constraints before FK constraints during row insertion, so the
+ * check_violation will fire first when the constraint is present.
+ * If the CHECK is missing the FK error fires instead and we treat
+ * that as a smoke failure (constraint not enforcing).
+ */
+async function runSmokeAndExpectRejection(
+  stmt: ReturnType<typeof sql>,
+  label: string,
+  detail: string[],
+): Promise<boolean> {
+  try {
+    await db.transaction(async (tx) => {
+      try {
+        await tx.execute(stmt);
+        // If we reach here, Postgres did NOT reject. Force rollback
+        // via thrown error so nothing commits.
+        throw new Error("INSERT_UNEXPECTEDLY_SUCCEEDED");
+      } catch (err: any) {
+        // Bubble up so the outer caller can classify, but always force
+        // a rollback by re-throwing.
+        throw err;
+      }
+    });
+    // db.transaction resolved without throwing — shouldn't happen on
+    // the unhappy path, but treat as failure.
+    detail.push(`smoke (${label}): UNEXPECTEDLY SUCCEEDED, no error raised`);
+    return false;
+  } catch (err: any) {
+    const code = err?.code ?? err?.cause?.code ?? null;
+    const message = (err?.message ?? err?.cause?.message ?? "")
+      .toString()
+      .replace(/\s+/g, " ")
+      .slice(0, 200);
+    if (code === PG_CHECK_VIOLATION_SQLSTATE) {
+      detail.push(`smoke (${label}): rejected as expected (23514)`);
+      return true;
+    }
+    if (message.includes("INSERT_UNEXPECTEDLY_SUCCEEDED")) {
+      detail.push(
+        `smoke (${label}): UNEXPECTEDLY SUCCEEDED — constraint not enforced`,
+      );
+      return false;
+    }
+    // FK violation (23503) or anything else means the CHECK didn't
+    // intercept — flag it.
+    detail.push(
+      `smoke (${label}): rejected by something OTHER than check (${code ?? "no-code"}): ${message}`,
+    );
+    return false;
+  }
+}

--- a/artifacts/api-server/src/lib/pay-eligibility.ts
+++ b/artifacts/api-server/src/lib/pay-eligibility.ts
@@ -1,0 +1,65 @@
+/**
+ * Cutover 1E — Application-level eligibility filter for clock events
+ * entering the pay pipeline.
+ *
+ * The non-negotiable filter from the 1E spec:
+ *
+ *   An event contributes to paid hours ONLY if:
+ *     (gps_status = 'captured'
+ *        AND latitude IS NOT NULL
+ *        AND longitude IS NOT NULL)
+ *   OR
+ *     (gps_status = 'failed_exception'
+ *        AND exception_reason IS NOT NULL
+ *        AND exception_reviewed_at IS NOT NULL)
+ *
+ * Anything else (unreviewed exception, malformed, half-set captured)
+ * is EXCLUDED from pay. This guarantee holds even if the DB CHECK
+ * constraint installed by cutover-data-migration.ts were somehow
+ * absent — the pay pipeline does not trust the database alone.
+ *
+ * Excluded events DO NOT silently disappear: the surrounding hours-
+ * computation logic flags the summary so the office sees the gap.
+ */
+
+export type EligibilityCheckInput = {
+  gps_status: string | null;
+  latitude: number | string | null;
+  longitude: number | string | null;
+  exception_reason: string | null;
+  exception_reviewed_at: Date | string | null;
+};
+
+export type EligibilityReason =
+  | "eligible_captured"
+  | "eligible_reviewed_exception"
+  | "ineligible_captured_missing_lat"
+  | "ineligible_captured_missing_lng"
+  | "ineligible_exception_missing_reason"
+  | "ineligible_exception_unreviewed"
+  | "ineligible_unknown_gps_status";
+
+export function classifyEligibility(
+  event: EligibilityCheckInput,
+): EligibilityReason {
+  if (event.gps_status === "captured") {
+    if (event.latitude === null) return "ineligible_captured_missing_lat";
+    if (event.longitude === null) return "ineligible_captured_missing_lng";
+    return "eligible_captured";
+  }
+  if (event.gps_status === "failed_exception") {
+    if (!event.exception_reason || String(event.exception_reason).trim() === "") {
+      return "ineligible_exception_missing_reason";
+    }
+    if (event.exception_reviewed_at == null) {
+      return "ineligible_exception_unreviewed";
+    }
+    return "eligible_reviewed_exception";
+  }
+  return "ineligible_unknown_gps_status";
+}
+
+export function isEligibleForPay(event: EligibilityCheckInput): boolean {
+  const r = classifyEligibility(event);
+  return r === "eligible_captured" || r === "eligible_reviewed_exception";
+}

--- a/artifacts/api-server/src/lib/pay-export.ts
+++ b/artifacts/api-server/src/lib/pay-export.ts
@@ -1,0 +1,90 @@
+/**
+ * Cutover 1E — Generic pay-summary CSV export.
+ *
+ * Provider-neutral. No vendor name appears in this file, in the column
+ * headers, or in the file naming convention. If a downstream consumer
+ * needs vendor-specific formatting, that lives in a thin adapter
+ * selected by a per-company setting — NOT here.
+ *
+ * Column set is the minimum the spec calls for: employee identifier,
+ * regular hours, overtime hours, regular pay, overtime pay,
+ * adjustments total, gross. Money in dollars-and-cents (e.g. "836.94"),
+ * never floats. Hours in decimal (e.g. "38.25").
+ */
+
+export type PayExportRow = {
+  employee_identifier: string;
+  employee_first_name: string;
+  employee_last_name: string;
+  regular_hours: number;
+  overtime_hours: number;
+  regular_pay_cents: number;
+  overtime_pay_cents: number;
+  adjustments_cents: number;
+  gross_cents: number;
+};
+
+export type PayExportInput = {
+  period_start: string; // YYYY-MM-DD
+  period_end: string; // YYYY-MM-DD
+  rows: PayExportRow[];
+};
+
+const COLUMNS = [
+  "employee_identifier",
+  "employee_first_name",
+  "employee_last_name",
+  "period_start",
+  "period_end",
+  "regular_hours",
+  "overtime_hours",
+  "regular_pay",
+  "overtime_pay",
+  "adjustments_total",
+  "gross_total",
+] as const;
+
+export function buildPayExportCsv(input: PayExportInput): string {
+  const lines: string[] = [];
+  lines.push(COLUMNS.join(","));
+  for (const r of input.rows) {
+    lines.push(
+      [
+        csvField(r.employee_identifier),
+        csvField(r.employee_first_name),
+        csvField(r.employee_last_name),
+        input.period_start,
+        input.period_end,
+        r.regular_hours.toFixed(2),
+        r.overtime_hours.toFixed(2),
+        centsToDollarString(r.regular_pay_cents),
+        centsToDollarString(r.overtime_pay_cents),
+        centsToDollarString(r.adjustments_cents),
+        centsToDollarString(r.gross_cents),
+      ].join(","),
+    );
+  }
+  return lines.join("\n") + "\n";
+}
+
+export function buildPayExportFilename(start: string, end: string): string {
+  // Provider-neutral. No vendor string. Stable across tenants.
+  return `pay-summary-${start}-${end}.csv`;
+}
+
+function csvField(value: string): string {
+  if (value == null) return "";
+  const s = String(value);
+  if (/[,"\r\n]/.test(s)) return `"${s.replace(/"/g, '""')}"`;
+  return s;
+}
+
+function centsToDollarString(cents: number): string {
+  const sign = cents < 0 ? "-" : "";
+  const abs = Math.abs(cents);
+  const whole = Math.floor(abs / 100);
+  const frac = String(abs % 100).padStart(2, "0");
+  return `${sign}${whole}.${frac}`;
+}
+
+export { COLUMNS as PAY_EXPORT_COLUMNS };

--- a/artifacts/api-server/src/lib/pay-hours.ts
+++ b/artifacts/api-server/src/lib/pay-hours.ts
@@ -1,0 +1,181 @@
+/**
+ * Cutover 1E — Hours computation from 1C clock events.
+ *
+ * Pure functions. No DB, no I/O. The pay routes call these with rows
+ * pulled from job_clock_events; this file decides what counts.
+ *
+ * Pipeline:
+ *   1. Apply the eligibility filter (lib/pay-eligibility.ts) to every
+ *      clock event.
+ *   2. Pair (user_id, job_id) clock_in → clock_out; both must be eligible.
+ *   3. Compute minutes worked = (clock_out_at − clock_in_at).
+ *   4. Bucket minutes into ISO weeks (Sunday-start by default for
+ *      Illinois weekly OT). Anything over 40 hr in a week is OT.
+ *   5. Track exclusions and surface them as flag strings.
+ *
+ * Money math is downstream — see lib/pay-summary.ts. This file only
+ * produces hours + flags.
+ */
+import {
+  classifyEligibility,
+  type EligibilityCheckInput,
+  type EligibilityReason,
+} from "./pay-eligibility.js";
+
+export type ClockEventForPay = EligibilityCheckInput & {
+  id: number;
+  job_id: number;
+  user_id: number;
+  event_type: "clock_in" | "clock_out";
+  event_at: Date | string;
+};
+
+export type WorkedSegment = {
+  user_id: number;
+  job_id: number;
+  start: Date;
+  end: Date;
+  minutes: number;
+};
+
+export type ComputeHoursResult = {
+  worked_segments: WorkedSegment[];
+  regular_minutes: number;
+  overtime_minutes: number;
+  // Flags surfaced on the per-user summary so the office sees gaps.
+  // The 1E spec calls out these three by name; the implementation
+  // emits exactly this set + any further granular reasons.
+  flags: string[];
+  // For audit: every excluded event and why.
+  exclusions: Array<{ event_id: number; reason: EligibilityReason }>;
+};
+
+/**
+ * Compute one user's hours over the pay period. Caller supplies the
+ * user's clock events for the period (both eligible and not — this
+ * function decides which to count).
+ *
+ * `weekStartDay`: 0 = Sunday (default; standard US weekly OT bucketing),
+ * 1 = Monday, etc. Tenants may override later via setting.
+ */
+export function computeHoursForUser(
+  events: ClockEventForPay[],
+  weekStartDay: number = 0,
+): ComputeHoursResult {
+  const flags = new Set<string>();
+  const exclusions: ComputeHoursResult["exclusions"] = [];
+
+  // 1. Eligibility filter.
+  const eligibleById = new Map<number, ClockEventForPay>();
+  for (const ev of events) {
+    const reason = classifyEligibility(ev);
+    if (reason === "eligible_captured" || reason === "eligible_reviewed_exception") {
+      eligibleById.set(ev.id, ev);
+    } else {
+      exclusions.push({ event_id: ev.id, reason });
+      if (reason === "ineligible_exception_unreviewed") {
+        flags.add("unreviewed_gps_exception");
+      } else {
+        flags.add("ineligible_clock_event");
+      }
+    }
+  }
+
+  // 2. Pair clock_in → clock_out per job. Same user already; group by job.
+  const byJob = new Map<number, ClockEventForPay[]>();
+  for (const ev of eligibleById.values()) {
+    const arr = byJob.get(ev.job_id) ?? [];
+    arr.push(ev);
+    byJob.set(ev.job_id, arr);
+  }
+
+  const segments: WorkedSegment[] = [];
+  for (const [jobId, jobEvents] of byJob) {
+    // Sort by event_at ascending so we can walk the in/out pairs.
+    jobEvents.sort(
+      (a, b) =>
+        new Date(a.event_at).getTime() - new Date(b.event_at).getTime(),
+    );
+    let openIn: ClockEventForPay | null = null;
+    for (const ev of jobEvents) {
+      if (ev.event_type === "clock_in") {
+        if (openIn != null) {
+          // Two consecutive clock_ins with no clock_out — abandon the
+          // earlier one and treat this as the new open. Flag the gap.
+          flags.add("orphan_clock_in");
+        }
+        openIn = ev;
+      } else if (ev.event_type === "clock_out") {
+        if (openIn == null) {
+          // Clock_out with no matching clock_in. Surface but don't pay.
+          flags.add("orphan_clock_out");
+          continue;
+        }
+        const start = new Date(openIn.event_at);
+        const end = new Date(ev.event_at);
+        const minutes = Math.max(
+          0,
+          Math.round((end.getTime() - start.getTime()) / 60_000),
+        );
+        if (minutes > 0) {
+          segments.push({
+            user_id: ev.user_id,
+            job_id: jobId,
+            start,
+            end,
+            minutes,
+          });
+        }
+        openIn = null;
+      }
+    }
+    if (openIn != null) {
+      flags.add("missing_clock_out");
+    }
+  }
+
+  // 3. Weekly OT bucketing.
+  const weekTotals = new Map<string, number>();
+  for (const seg of segments) {
+    // Bucket by the segment's start. A shift that crosses a week
+    // boundary is rare; we keep the whole shift in the bucket where
+    // it started. Tenants needing strict split-at-boundary semantics
+    // can opt in later.
+    const key = weekKeyFor(seg.start, weekStartDay);
+    weekTotals.set(key, (weekTotals.get(key) ?? 0) + seg.minutes);
+  }
+
+  let regularMinutes = 0;
+  let overtimeMinutes = 0;
+  const FORTY_HOURS_MINUTES = 40 * 60;
+  for (const total of weekTotals.values()) {
+    if (total <= FORTY_HOURS_MINUTES) {
+      regularMinutes += total;
+    } else {
+      regularMinutes += FORTY_HOURS_MINUTES;
+      overtimeMinutes += total - FORTY_HOURS_MINUTES;
+    }
+  }
+
+  return {
+    worked_segments: segments,
+    regular_minutes: regularMinutes,
+    overtime_minutes: overtimeMinutes,
+    flags: Array.from(flags).sort(),
+    exclusions,
+  };
+}
+
+/** ISO-week-style key, parameterized by week-start day-of-week. */
+function weekKeyFor(date: Date, weekStartDay: number): string {
+  // Anchor on a UTC date so DST doesn't shift bucket boundaries.
+  const d = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  const day = d.getUTCDay();
+  const diff = (day - weekStartDay + 7) % 7;
+  d.setUTCDate(d.getUTCDate() - diff);
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}-${String(d.getUTCDate()).padStart(2, "0")}`;
+}
+
+export function minutesToHours(minutes: number): number {
+  return Math.round((minutes / 60) * 100) / 100;
+}

--- a/artifacts/api-server/src/lib/pay-rate-lookup.ts
+++ b/artifacts/api-server/src/lib/pay-rate-lookup.ts
@@ -1,0 +1,35 @@
+/**
+ * Cutover 1E — Dated rate selection.
+ *
+ * The effective hourly rate for an employee on a given date is the
+ * rate row with the LATEST effective_date that is <= the date AND
+ * (end_date IS NULL OR end_date >= date). Rows are never overwritten;
+ * a rate change creates a new row and closes the prior one off.
+ *
+ * Returns null if no rate row applies — the pay pipeline flags the
+ * summary with `missing_rate` so the office sees it.
+ */
+
+export type RateRowInput = {
+  hourly_rate: string | number;
+  effective_date: string; // YYYY-MM-DD
+  end_date: string | null; // YYYY-MM-DD or null
+};
+
+/** Pick the effective rate for `date` from a list of rate rows for a
+ *  single user. Date strings compared lexicographically — safe for
+ *  YYYY-MM-DD ISO dates. */
+export function pickRateForDate(
+  rates: RateRowInput[],
+  date: string,
+): number | null {
+  let best: RateRowInput | null = null;
+  for (const r of rates) {
+    if (r.effective_date > date) continue;
+    if (r.end_date != null && r.end_date < date) continue;
+    if (!best || r.effective_date > best.effective_date) best = r;
+  }
+  if (!best) return null;
+  const n = Number(best.hourly_rate);
+  return Number.isFinite(n) ? n : null;
+}

--- a/artifacts/api-server/src/lib/pay-summary.ts
+++ b/artifacts/api-server/src/lib/pay-summary.ts
@@ -1,0 +1,80 @@
+/**
+ * Cutover 1E — Money math on top of hours computation.
+ *
+ * Combines:
+ *   - regular_minutes + overtime_minutes from lib/pay-hours.ts
+ *   - hourly_rate as of the period from lib/pay-rate-lookup.ts
+ *   - sum of pay_adjustments rows for the period
+ *
+ * Money is stored as numeric(10,2) — kept as cents internally to
+ * dodge JS float drift, rounded once at the boundary. Overtime
+ * multiplier is 1.5x the regular rate (FLSA standard).
+ */
+import { minutesToHours } from "./pay-hours.js";
+
+export type ComputeSummaryInput = {
+  regular_minutes: number;
+  overtime_minutes: number;
+  hourly_rate: number | null;
+  adjustments_cents: number;
+};
+
+export type ComputeSummaryResult = {
+  regular_hours: number;
+  overtime_hours: number;
+  regular_pay_cents: number;
+  overtime_pay_cents: number;
+  adjustments_cents: number;
+  gross_cents: number;
+};
+
+export function computeSummary(
+  input: ComputeSummaryInput,
+): ComputeSummaryResult {
+  const regularHours = minutesToHours(input.regular_minutes);
+  const overtimeHours = minutesToHours(input.overtime_minutes);
+
+  if (input.hourly_rate == null) {
+    return {
+      regular_hours: regularHours,
+      overtime_hours: overtimeHours,
+      regular_pay_cents: 0,
+      overtime_pay_cents: 0,
+      adjustments_cents: input.adjustments_cents,
+      gross_cents: input.adjustments_cents,
+    };
+  }
+
+  const rateCents = Math.round(input.hourly_rate * 100);
+  // (minutes * rate_cents / 60) yields cents directly; round at the end.
+  const regularPayCents = Math.round(
+    (input.regular_minutes * rateCents) / 60,
+  );
+  // FLSA overtime = 1.5x. Compute the OT minutes at 1.5x.
+  const overtimePayCents = Math.round(
+    (input.overtime_minutes * rateCents * 1.5) / 60,
+  );
+  const grossCents =
+    regularPayCents + overtimePayCents + input.adjustments_cents;
+
+  return {
+    regular_hours: regularHours,
+    overtime_hours: overtimeHours,
+    regular_pay_cents: regularPayCents,
+    overtime_pay_cents: overtimePayCents,
+    adjustments_cents: input.adjustments_cents,
+    gross_cents: grossCents,
+  };
+}
+
+export function dollarsToCents(amount: number | string): number {
+  return Math.round(Number(amount) * 100);
+}
+
+export function centsToDollarString(cents: number): string {
+  const sign = cents < 0 ? "-" : "";
+  const abs = Math.abs(cents);
+  const whole = Math.floor(abs / 100);
+  const frac = String(abs % 100).padStart(2, "0");
+  return `${sign}${whole}.${frac}`;
+}

--- a/artifacts/api-server/src/routes/index.ts
+++ b/artifacts/api-server/src/routes/index.ts
@@ -64,6 +64,8 @@ import coreRouter from "./core.js";
 import techRouter from "./tech.js";
 import techClockRouter from "./tech-clock.js";
 import officeClockRouter from "./office-clock.js";
+import payRouter from "./pay.js";
+import opsIntegrityRouter from "./ops-integrity.js";
 import acquisitionSourcesRouter from "./acquisition-sources.js";
 import publicRouter from "./public.js";
 import quickbooksRouter from "./integrations/quickbooks.js";
@@ -164,6 +166,10 @@ router.use("/core", coreRouter);
 router.use("/tech/jobs", techClockRouter);
 router.use("/tech", techRouter);
 router.use("/office", officeClockRouter);
+// Cutover 1E — pay periods, summaries, adjustments, rates, generic CSV export
+router.use("/pay", payRouter);
+// Cutover 1E — on-demand re-run of the startup clock-integrity self-check
+router.use("/ops", opsIntegrityRouter);
 router.use("/acquisition-sources", acquisitionSourcesRouter);
 router.use("/bundles", bundlesRouter);
 router.use("/photos", photosRouter);

--- a/artifacts/api-server/src/routes/ops-integrity.ts
+++ b/artifacts/api-server/src/routes/ops-integrity.ts
@@ -1,0 +1,32 @@
+/**
+ * Cutover 1E — On-demand re-run of the startup clock-integrity self-check.
+ *
+ * GET /api/ops/integrity-check (owner/admin only). Same code path as
+ * the boot self-check. Never crashes the server; returns the structured
+ * IntegrityCheckResult so the office can re-verify in production
+ * without waiting for the next deploy.
+ */
+import { Router } from "express";
+import { requireAuth, requireRole } from "../lib/auth.js";
+import { verifyClockIntegrityConstraint } from "../lib/clock-integrity-self-check.js";
+
+const router = Router();
+
+router.get(
+  "/integrity-check",
+  requireAuth,
+  requireRole("owner", "admin", "super_admin"),
+  async (_req, res) => {
+    try {
+      const result = await verifyClockIntegrityConstraint();
+      return res.json({ data: result });
+    } catch (err) {
+      return res.status(500).json({
+        error: "Internal Server Error",
+        message: (err as Error).message,
+      });
+    }
+  },
+);
+
+export default router;

--- a/artifacts/api-server/src/routes/pay.ts
+++ b/artifacts/api-server/src/routes/pay.ts
@@ -1,0 +1,818 @@
+/**
+ * Cutover 1E — Pay-period routes (provider-neutral).
+ *
+ * Mounted at /api/pay. Gated to owner / admin / office / super_admin
+ * for reads + adjustments; only owner / admin / super_admin may lock,
+ * approve, unapprove, export, or change rates. Techs receive 403 by
+ * router-level gate.
+ *
+ * Endpoints:
+ *   POST   /periods                       create + auto-compute
+ *   GET    /periods                       list (tenant-scoped)
+ *   GET    /periods/:id                   detail + summaries
+ *   GET    /periods/:id/summary/:userId   per-user detail
+ *   POST   /periods/:id/recompute         re-run summary calc
+ *   POST   /periods/:id/lock              snapshot for review
+ *   POST   /periods/:id/approve           sign off
+ *   POST   /periods/:id/unapprove         (logged)
+ *   POST   /periods/:id/export            generate CSV
+ *   GET    /periods/:id/export-file       download
+ *   POST   /adjustments                   add (refuses if period approved)
+ *   PATCH  /adjustments/:id               edit (refuses if period approved)
+ *   DELETE /adjustments/:id               delete (refuses if period approved)
+ *   POST   /rates                         add a dated rate row
+ *   GET    /rates?userId=                 rate history
+ */
+import { Router, type Request, type Response } from "express";
+import { db } from "@workspace/db";
+import {
+  payPeriodsTable,
+  payPeriodSummariesTable,
+  payAdjustmentsTable,
+  employeePayRatesTable,
+  usersTable,
+  jobClockEventsTable,
+} from "@workspace/db/schema";
+import { and, asc, desc, eq, gte, inArray, lte, sql } from "drizzle-orm";
+import { requireAuth, requireRole } from "../lib/auth.js";
+import {
+  computeHoursForUser,
+  minutesToHours,
+  type ClockEventForPay,
+} from "../lib/pay-hours.js";
+import {
+  computeSummary,
+  dollarsToCents,
+  centsToDollarString,
+} from "../lib/pay-summary.js";
+import { pickRateForDate } from "../lib/pay-rate-lookup.js";
+import {
+  buildPayExportCsv,
+  buildPayExportFilename,
+  type PayExportRow,
+} from "../lib/pay-export.js";
+
+const router = Router();
+
+const officeReadGate = requireRole("owner", "admin", "office", "super_admin");
+const adminWriteGate = requireRole("owner", "admin", "super_admin");
+
+router.use(requireAuth, officeReadGate);
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function loadPeriod(
+  companyId: number,
+  periodId: number,
+): Promise<typeof payPeriodsTable.$inferSelect | null> {
+  const rows = await db
+    .select()
+    .from(payPeriodsTable)
+    .where(
+      and(
+        eq(payPeriodsTable.company_id, companyId),
+        eq(payPeriodsTable.id, periodId),
+      ),
+    )
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+function badRequest(res: Response, message: string, code?: string) {
+  return res.status(400).json({ error: "Bad Request", message, code });
+}
+
+function notFound(res: Response, message: string) {
+  return res.status(404).json({ error: "Not Found", message });
+}
+
+function refusedDueToPeriodState(res: Response, status: string) {
+  return res.status(409).json({
+    error: "Conflict",
+    message: `Period is ${status}; required action is not permitted in this state.`,
+    code: "period_state_invalid",
+  });
+}
+
+/** Internal: compute + write the per-user summaries for a period. */
+async function recomputeSummariesForPeriod(
+  companyId: number,
+  periodId: number,
+  startDate: string,
+  endDate: string,
+): Promise<{ written: number }> {
+  // Pull every active employee in this tenant whose hire_date is <=
+  // endDate.
+  const employees = await db
+    .select({
+      id: usersTable.id,
+      hire_date: usersTable.hire_date,
+      is_active: usersTable.is_active,
+    })
+    .from(usersTable)
+    .where(eq(usersTable.company_id, companyId));
+
+  const eligibleEmployees = employees.filter(
+    (e) =>
+      e.is_active &&
+      e.hire_date != null &&
+      String(e.hire_date) <= endDate,
+  );
+  const userIds = eligibleEmployees.map((e) => e.id);
+  if (userIds.length === 0) return { written: 0 };
+
+  // Period boundary timestamps (inclusive start, exclusive end+1 day).
+  const periodStartTs = new Date(`${startDate}T00:00:00Z`);
+  const periodEndTs = new Date(`${endDate}T23:59:59.999Z`);
+
+  // Pull clock events for these users in the period.
+  const events = await db
+    .select({
+      id: jobClockEventsTable.id,
+      job_id: jobClockEventsTable.job_id,
+      user_id: jobClockEventsTable.user_id,
+      event_type: jobClockEventsTable.event_type,
+      event_at: jobClockEventsTable.event_at,
+      gps_status: jobClockEventsTable.gps_status,
+      latitude: jobClockEventsTable.latitude,
+      longitude: jobClockEventsTable.longitude,
+      exception_reason: jobClockEventsTable.exception_reason,
+      exception_reviewed_at: jobClockEventsTable.exception_reviewed_at,
+    })
+    .from(jobClockEventsTable)
+    .where(
+      and(
+        eq(jobClockEventsTable.company_id, companyId),
+        inArray(jobClockEventsTable.user_id, userIds),
+        gte(jobClockEventsTable.event_at, periodStartTs),
+        lte(jobClockEventsTable.event_at, periodEndTs),
+      ),
+    );
+
+  // Rate rows.
+  const rates = await db
+    .select({
+      user_id: employeePayRatesTable.user_id,
+      hourly_rate: employeePayRatesTable.hourly_rate,
+      effective_date: employeePayRatesTable.effective_date,
+      end_date: employeePayRatesTable.end_date,
+    })
+    .from(employeePayRatesTable)
+    .where(
+      and(
+        eq(employeePayRatesTable.company_id, companyId),
+        inArray(employeePayRatesTable.user_id, userIds),
+      ),
+    );
+  const ratesByUser = new Map<number, typeof rates>();
+  for (const r of rates) {
+    const arr = ratesByUser.get(r.user_id) ?? [];
+    arr.push(r);
+    ratesByUser.set(r.user_id, arr);
+  }
+
+  // Adjustments assigned to this period.
+  const adjustments = await db
+    .select({
+      user_id: payAdjustmentsTable.user_id,
+      amount: payAdjustmentsTable.amount,
+    })
+    .from(payAdjustmentsTable)
+    .where(
+      and(
+        eq(payAdjustmentsTable.company_id, companyId),
+        eq(payAdjustmentsTable.pay_period_id, periodId),
+      ),
+    );
+  const adjustmentsByUser = new Map<number, number>();
+  for (const a of adjustments) {
+    const cents = dollarsToCents(a.amount);
+    adjustmentsByUser.set(
+      a.user_id,
+      (adjustmentsByUser.get(a.user_id) ?? 0) + cents,
+    );
+  }
+
+  // Group events by user.
+  const eventsByUser = new Map<number, ClockEventForPay[]>();
+  for (const ev of events) {
+    const arr = eventsByUser.get(ev.user_id) ?? [];
+    arr.push({
+      id: ev.id,
+      job_id: ev.job_id,
+      user_id: ev.user_id,
+      event_type: ev.event_type as "clock_in" | "clock_out",
+      event_at: ev.event_at,
+      gps_status: ev.gps_status,
+      latitude: ev.latitude != null ? Number(ev.latitude) : null,
+      longitude: ev.longitude != null ? Number(ev.longitude) : null,
+      exception_reason: ev.exception_reason,
+      exception_reviewed_at: ev.exception_reviewed_at,
+    });
+    eventsByUser.set(ev.user_id, arr);
+  }
+
+  // Compute + upsert one summary per eligible employee.
+  let written = 0;
+  for (const emp of eligibleEmployees) {
+    const evs = eventsByUser.get(emp.id) ?? [];
+    const hours = computeHoursForUser(evs);
+    const rateRows = ratesByUser.get(emp.id) ?? [];
+    const rate = pickRateForDate(
+      rateRows.map((r) => ({
+        hourly_rate: r.hourly_rate,
+        effective_date: String(r.effective_date),
+        end_date: r.end_date != null ? String(r.end_date) : null,
+      })),
+      endDate,
+    );
+    const flags = new Set(hours.flags);
+    if (rate == null) flags.add("missing_rate");
+    const adjCents = adjustmentsByUser.get(emp.id) ?? 0;
+    const summary = computeSummary({
+      regular_minutes: hours.regular_minutes,
+      overtime_minutes: hours.overtime_minutes,
+      hourly_rate: rate,
+      adjustments_cents: adjCents,
+    });
+    await db
+      .insert(payPeriodSummariesTable)
+      .values({
+        company_id: companyId,
+        pay_period_id: periodId,
+        user_id: emp.id,
+        regular_hours: summary.regular_hours.toFixed(2),
+        overtime_hours: summary.overtime_hours.toFixed(2),
+        regular_pay: centsToDollarString(summary.regular_pay_cents),
+        overtime_pay: centsToDollarString(summary.overtime_pay_cents),
+        adjustments_total: centsToDollarString(summary.adjustments_cents),
+        gross_total: centsToDollarString(summary.gross_cents),
+        flags: Array.from(flags).sort(),
+        computed_at: new Date(),
+      })
+      .onConflictDoUpdate({
+        target: [
+          payPeriodSummariesTable.company_id,
+          payPeriodSummariesTable.pay_period_id,
+          payPeriodSummariesTable.user_id,
+        ],
+        set: {
+          regular_hours: summary.regular_hours.toFixed(2),
+          overtime_hours: summary.overtime_hours.toFixed(2),
+          regular_pay: centsToDollarString(summary.regular_pay_cents),
+          overtime_pay: centsToDollarString(summary.overtime_pay_cents),
+          adjustments_total: centsToDollarString(summary.adjustments_cents),
+          gross_total: centsToDollarString(summary.gross_cents),
+          flags: Array.from(flags).sort(),
+          computed_at: new Date(),
+        },
+      });
+    written += 1;
+  }
+
+  return { written };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /periods — create + auto-compute
+// ─────────────────────────────────────────────────────────────────────────────
+
+router.post("/periods", adminWriteGate, async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId!;
+    const userId = req.auth!.userId!;
+    const body = req.body as { start_date?: string; end_date?: string; notes?: string };
+    if (!body?.start_date || !ISO_DATE_RE.test(body.start_date)) {
+      return badRequest(res, "start_date must be YYYY-MM-DD");
+    }
+    if (!body?.end_date || !ISO_DATE_RE.test(body.end_date)) {
+      return badRequest(res, "end_date must be YYYY-MM-DD");
+    }
+    if (body.end_date < body.start_date) {
+      return badRequest(res, "end_date must be on or after start_date");
+    }
+    const inserted = await db
+      .insert(payPeriodsTable)
+      .values({
+        company_id: companyId,
+        start_date: body.start_date,
+        end_date: body.end_date,
+        notes: body.notes ?? null,
+        created_by_user_id: userId,
+      })
+      .returning();
+    const period = inserted[0]!;
+    await recomputeSummariesForPeriod(
+      companyId,
+      period.id,
+      body.start_date,
+      body.end_date,
+    );
+    return res.json({ data: period });
+  } catch (err: any) {
+    if (err?.code === "23505") {
+      return res.status(409).json({
+        error: "Conflict",
+        message: "A pay period with that start/end already exists",
+        code: "duplicate_period",
+      });
+    }
+    console.error("[pay] create period error:", err);
+    return res
+      .status(500)
+      .json({ error: "Internal Server Error", message: "Failed to create period" });
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /periods — list
+// ─────────────────────────────────────────────────────────────────────────────
+
+router.get("/periods", async (req, res) => {
+  const companyId = req.auth!.companyId!;
+  const rows = await db
+    .select()
+    .from(payPeriodsTable)
+    .where(eq(payPeriodsTable.company_id, companyId))
+    .orderBy(desc(payPeriodsTable.start_date));
+  return res.json({ data: rows });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /periods/:id — detail + summaries
+// ─────────────────────────────────────────────────────────────────────────────
+
+router.get("/periods/:id", async (req, res) => {
+  const companyId = req.auth!.companyId!;
+  const periodId = Number(req.params.id);
+  if (!Number.isFinite(periodId)) return badRequest(res, "Invalid id");
+  const period = await loadPeriod(companyId, periodId);
+  if (!period) return notFound(res, "Period not found");
+  const summaries = await db
+    .select({
+      id: payPeriodSummariesTable.id,
+      user_id: payPeriodSummariesTable.user_id,
+      first_name: usersTable.first_name,
+      last_name: usersTable.last_name,
+      regular_hours: payPeriodSummariesTable.regular_hours,
+      overtime_hours: payPeriodSummariesTable.overtime_hours,
+      regular_pay: payPeriodSummariesTable.regular_pay,
+      overtime_pay: payPeriodSummariesTable.overtime_pay,
+      adjustments_total: payPeriodSummariesTable.adjustments_total,
+      gross_total: payPeriodSummariesTable.gross_total,
+      flags: payPeriodSummariesTable.flags,
+      computed_at: payPeriodSummariesTable.computed_at,
+    })
+    .from(payPeriodSummariesTable)
+    .leftJoin(usersTable, eq(payPeriodSummariesTable.user_id, usersTable.id))
+    .where(
+      and(
+        eq(payPeriodSummariesTable.company_id, companyId),
+        eq(payPeriodSummariesTable.pay_period_id, periodId),
+      ),
+    )
+    .orderBy(asc(usersTable.last_name), asc(usersTable.first_name));
+  return res.json({ data: { period, summaries } });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /periods/:id/summary/:userId — per-user detail
+// ─────────────────────────────────────────────────────────────────────────────
+
+router.get("/periods/:id/summary/:userId", async (req, res) => {
+  const companyId = req.auth!.companyId!;
+  const periodId = Number(req.params.id);
+  const userId = Number(req.params.userId);
+  if (!Number.isFinite(periodId) || !Number.isFinite(userId)) {
+    return badRequest(res, "Invalid ids");
+  }
+  const period = await loadPeriod(companyId, periodId);
+  if (!period) return notFound(res, "Period not found");
+
+  const summaryRows = await db
+    .select()
+    .from(payPeriodSummariesTable)
+    .where(
+      and(
+        eq(payPeriodSummariesTable.company_id, companyId),
+        eq(payPeriodSummariesTable.pay_period_id, periodId),
+        eq(payPeriodSummariesTable.user_id, userId),
+      ),
+    )
+    .limit(1);
+  if (!summaryRows[0]) return notFound(res, "Summary not found");
+
+  const adjustments = await db
+    .select()
+    .from(payAdjustmentsTable)
+    .where(
+      and(
+        eq(payAdjustmentsTable.company_id, companyId),
+        eq(payAdjustmentsTable.pay_period_id, periodId),
+        eq(payAdjustmentsTable.user_id, userId),
+      ),
+    )
+    .orderBy(asc(payAdjustmentsTable.created_at));
+
+  return res.json({
+    data: {
+      summary: summaryRows[0],
+      adjustments,
+    },
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /periods/:id/recompute — only while open
+// ─────────────────────────────────────────────────────────────────────────────
+
+router.post("/periods/:id/recompute", adminWriteGate, async (req, res) => {
+  const companyId = req.auth!.companyId!;
+  const periodId = Number(req.params.id);
+  if (!Number.isFinite(periodId)) return badRequest(res, "Invalid id");
+  const period = await loadPeriod(companyId, periodId);
+  if (!period) return notFound(res, "Period not found");
+  if (period.status !== "open") return refusedDueToPeriodState(res, period.status);
+  const result = await recomputeSummariesForPeriod(
+    companyId,
+    periodId,
+    String(period.start_date),
+    String(period.end_date),
+  );
+  return res.json({ data: result });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Lifecycle gates: lock → approve → export
+// ─────────────────────────────────────────────────────────────────────────────
+
+router.post("/periods/:id/lock", async (req, res) => {
+  const companyId = req.auth!.companyId!;
+  const userId = req.auth!.userId!;
+  const periodId = Number(req.params.id);
+  if (!Number.isFinite(periodId)) return badRequest(res, "Invalid id");
+  const period = await loadPeriod(companyId, periodId);
+  if (!period) return notFound(res, "Period not found");
+  if (period.status !== "open") return refusedDueToPeriodState(res, period.status);
+  await db
+    .update(payPeriodsTable)
+    .set({
+      status: "locked",
+      locked_at: new Date(),
+      locked_by_user_id: userId,
+      updated_at: new Date(),
+    })
+    .where(
+      and(
+        eq(payPeriodsTable.company_id, companyId),
+        eq(payPeriodsTable.id, periodId),
+      ),
+    );
+  return res.json({ data: { id: periodId, status: "locked" } });
+});
+
+router.post("/periods/:id/approve", adminWriteGate, async (req, res) => {
+  const companyId = req.auth!.companyId!;
+  const userId = req.auth!.userId!;
+  const periodId = Number(req.params.id);
+  if (!Number.isFinite(periodId)) return badRequest(res, "Invalid id");
+  const period = await loadPeriod(companyId, periodId);
+  if (!period) return notFound(res, "Period not found");
+  if (period.status !== "locked") return refusedDueToPeriodState(res, period.status);
+  await db
+    .update(payPeriodsTable)
+    .set({
+      status: "approved",
+      approved_at: new Date(),
+      approved_by_user_id: userId,
+      updated_at: new Date(),
+    })
+    .where(
+      and(
+        eq(payPeriodsTable.company_id, companyId),
+        eq(payPeriodsTable.id, periodId),
+      ),
+    );
+  return res.json({ data: { id: periodId, status: "approved" } });
+});
+
+router.post("/periods/:id/unapprove", adminWriteGate, async (req, res) => {
+  const companyId = req.auth!.companyId!;
+  const periodId = Number(req.params.id);
+  if (!Number.isFinite(periodId)) return badRequest(res, "Invalid id");
+  const period = await loadPeriod(companyId, periodId);
+  if (!period) return notFound(res, "Period not found");
+  if (period.status !== "approved") return refusedDueToPeriodState(res, period.status);
+  await db
+    .update(payPeriodsTable)
+    .set({
+      status: "locked",
+      approved_at: null,
+      approved_by_user_id: null,
+      updated_at: new Date(),
+    })
+    .where(
+      and(
+        eq(payPeriodsTable.company_id, companyId),
+        eq(payPeriodsTable.id, periodId),
+      ),
+    );
+  console.log(
+    `[pay] period ${periodId} (company ${companyId}) UN-APPROVED by user ${req.auth!.userId}`,
+  );
+  return res.json({ data: { id: periodId, status: "locked" } });
+});
+
+router.post("/periods/:id/export", adminWriteGate, async (req, res) => {
+  const companyId = req.auth!.companyId!;
+  const userId = req.auth!.userId!;
+  const periodId = Number(req.params.id);
+  if (!Number.isFinite(periodId)) return badRequest(res, "Invalid id");
+  const period = await loadPeriod(companyId, periodId);
+  if (!period) return notFound(res, "Period not found");
+  if (period.status !== "approved" && period.status !== "exported") {
+    return refusedDueToPeriodState(res, period.status);
+  }
+
+  const rows = await buildExportRowsForPeriod(companyId, periodId);
+  const csv = buildPayExportCsv({
+    period_start: String(period.start_date),
+    period_end: String(period.end_date),
+    rows,
+  });
+  const filename = buildPayExportFilename(
+    String(period.start_date),
+    String(period.end_date),
+  );
+
+  if (period.status !== "exported") {
+    await db
+      .update(payPeriodsTable)
+      .set({
+        status: "exported",
+        exported_at: new Date(),
+        exported_by_user_id: userId,
+        updated_at: new Date(),
+      })
+      .where(
+        and(
+          eq(payPeriodsTable.company_id, companyId),
+          eq(payPeriodsTable.id, periodId),
+        ),
+      );
+  }
+
+  res.setHeader("Content-Type", "text/csv; charset=utf-8");
+  res.setHeader(
+    "Content-Disposition",
+    `attachment; filename="${filename}"`,
+  );
+  return res.send(csv);
+});
+
+router.get("/periods/:id/export-file", async (req, res) => {
+  const companyId = req.auth!.companyId!;
+  const periodId = Number(req.params.id);
+  if (!Number.isFinite(periodId)) return badRequest(res, "Invalid id");
+  const period = await loadPeriod(companyId, periodId);
+  if (!period) return notFound(res, "Period not found");
+  if (period.status !== "exported") {
+    return refusedDueToPeriodState(res, period.status);
+  }
+  const rows = await buildExportRowsForPeriod(companyId, periodId);
+  const csv = buildPayExportCsv({
+    period_start: String(period.start_date),
+    period_end: String(period.end_date),
+    rows,
+  });
+  const filename = buildPayExportFilename(
+    String(period.start_date),
+    String(period.end_date),
+  );
+  res.setHeader("Content-Type", "text/csv; charset=utf-8");
+  res.setHeader(
+    "Content-Disposition",
+    `attachment; filename="${filename}"`,
+  );
+  return res.send(csv);
+});
+
+async function buildExportRowsForPeriod(
+  companyId: number,
+  periodId: number,
+): Promise<PayExportRow[]> {
+  const rows = await db
+    .select({
+      user_id: payPeriodSummariesTable.user_id,
+      first_name: usersTable.first_name,
+      last_name: usersTable.last_name,
+      external_id: usersTable.id, // External identifier hook; tenants
+      // wanting a separate external ID can store it in a tenant-defined
+      // user field and we'd swap this column. Defaulting to user.id
+      // keeps the export deterministic.
+      regular_hours: payPeriodSummariesTable.regular_hours,
+      overtime_hours: payPeriodSummariesTable.overtime_hours,
+      regular_pay: payPeriodSummariesTable.regular_pay,
+      overtime_pay: payPeriodSummariesTable.overtime_pay,
+      adjustments_total: payPeriodSummariesTable.adjustments_total,
+      gross_total: payPeriodSummariesTable.gross_total,
+    })
+    .from(payPeriodSummariesTable)
+    .leftJoin(usersTable, eq(payPeriodSummariesTable.user_id, usersTable.id))
+    .where(
+      and(
+        eq(payPeriodSummariesTable.company_id, companyId),
+        eq(payPeriodSummariesTable.pay_period_id, periodId),
+      ),
+    )
+    .orderBy(asc(usersTable.last_name), asc(usersTable.first_name));
+  return rows.map((r) => ({
+    employee_identifier: String(r.external_id ?? r.user_id),
+    employee_first_name: r.first_name ?? "",
+    employee_last_name: r.last_name ?? "",
+    regular_hours: Number(r.regular_hours),
+    overtime_hours: Number(r.overtime_hours),
+    regular_pay_cents: dollarsToCents(r.regular_pay),
+    overtime_pay_cents: dollarsToCents(r.overtime_pay),
+    adjustments_cents: dollarsToCents(r.adjustments_total),
+    gross_cents: dollarsToCents(r.gross_total),
+  }));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Adjustments
+// ─────────────────────────────────────────────────────────────────────────────
+
+router.post("/adjustments", async (req, res) => {
+  const companyId = req.auth!.companyId!;
+  const userId = req.auth!.userId!;
+  const body = req.body as {
+    user_id?: number;
+    pay_period_id?: number | null;
+    adjustment_type?: string;
+    amount?: number | string;
+    note?: string | null;
+  };
+  if (!body?.user_id || !Number.isFinite(Number(body.user_id))) {
+    return badRequest(res, "user_id is required");
+  }
+  const type = (body?.adjustment_type ?? "").trim();
+  if (!type) return badRequest(res, "adjustment_type is required");
+  if (body?.amount == null || !Number.isFinite(Number(body.amount))) {
+    return badRequest(res, "amount is required");
+  }
+  if (body.pay_period_id != null) {
+    const period = await loadPeriod(companyId, Number(body.pay_period_id));
+    if (!period) return notFound(res, "Period not found");
+    if (period.status === "approved" || period.status === "exported") {
+      return refusedDueToPeriodState(res, period.status);
+    }
+  }
+  const inserted = await db
+    .insert(payAdjustmentsTable)
+    .values({
+      company_id: companyId,
+      pay_period_id:
+        body.pay_period_id != null ? Number(body.pay_period_id) : null,
+      user_id: Number(body.user_id),
+      adjustment_type: type,
+      amount: Number(body.amount).toFixed(2),
+      note: body.note ?? null,
+      created_by_user_id: userId,
+    })
+    .returning();
+  return res.json({ data: inserted[0] });
+});
+
+router.patch("/adjustments/:id", async (req, res) => {
+  const companyId = req.auth!.companyId!;
+  const id = Number(req.params.id);
+  if (!Number.isFinite(id)) return badRequest(res, "Invalid id");
+  const existing = await db
+    .select()
+    .from(payAdjustmentsTable)
+    .where(
+      and(
+        eq(payAdjustmentsTable.company_id, companyId),
+        eq(payAdjustmentsTable.id, id),
+      ),
+    )
+    .limit(1);
+  if (!existing[0]) return notFound(res, "Adjustment not found");
+  if (existing[0].pay_period_id != null) {
+    const period = await loadPeriod(companyId, existing[0].pay_period_id);
+    if (period && (period.status === "approved" || period.status === "exported")) {
+      return refusedDueToPeriodState(res, period.status);
+    }
+  }
+  const body = req.body as {
+    adjustment_type?: string;
+    amount?: number | string;
+    note?: string | null;
+  };
+  const updates: Partial<typeof payAdjustmentsTable.$inferInsert> = {
+    updated_at: new Date(),
+  };
+  if (body.adjustment_type != null) updates.adjustment_type = body.adjustment_type;
+  if (body.amount != null) updates.amount = Number(body.amount).toFixed(2);
+  if (body.note !== undefined) updates.note = body.note;
+  await db
+    .update(payAdjustmentsTable)
+    .set(updates)
+    .where(
+      and(
+        eq(payAdjustmentsTable.company_id, companyId),
+        eq(payAdjustmentsTable.id, id),
+      ),
+    );
+  return res.json({ data: { id, updated: true } });
+});
+
+router.delete("/adjustments/:id", async (req, res) => {
+  const companyId = req.auth!.companyId!;
+  const id = Number(req.params.id);
+  if (!Number.isFinite(id)) return badRequest(res, "Invalid id");
+  const existing = await db
+    .select()
+    .from(payAdjustmentsTable)
+    .where(
+      and(
+        eq(payAdjustmentsTable.company_id, companyId),
+        eq(payAdjustmentsTable.id, id),
+      ),
+    )
+    .limit(1);
+  if (!existing[0]) return notFound(res, "Adjustment not found");
+  if (existing[0].pay_period_id != null) {
+    const period = await loadPeriod(companyId, existing[0].pay_period_id);
+    if (period && (period.status === "approved" || period.status === "exported")) {
+      return refusedDueToPeriodState(res, period.status);
+    }
+  }
+  await db
+    .delete(payAdjustmentsTable)
+    .where(
+      and(
+        eq(payAdjustmentsTable.company_id, companyId),
+        eq(payAdjustmentsTable.id, id),
+      ),
+    );
+  return res.json({ data: { id, deleted: true } });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Rates
+// ─────────────────────────────────────────────────────────────────────────────
+
+router.post("/rates", adminWriteGate, async (req, res) => {
+  const companyId = req.auth!.companyId!;
+  const actingUserId = req.auth!.userId!;
+  const body = req.body as {
+    user_id?: number;
+    hourly_rate?: number | string;
+    effective_date?: string;
+  };
+  if (!body?.user_id || !Number.isFinite(Number(body.user_id))) {
+    return badRequest(res, "user_id is required");
+  }
+  if (body?.hourly_rate == null || !Number.isFinite(Number(body.hourly_rate))) {
+    return badRequest(res, "hourly_rate is required");
+  }
+  if (!body?.effective_date || !ISO_DATE_RE.test(body.effective_date)) {
+    return badRequest(res, "effective_date must be YYYY-MM-DD");
+  }
+  const inserted = await db
+    .insert(employeePayRatesTable)
+    .values({
+      company_id: companyId,
+      user_id: Number(body.user_id),
+      hourly_rate: Number(body.hourly_rate).toFixed(2),
+      effective_date: body.effective_date,
+      created_by_user_id: actingUserId,
+    })
+    .returning();
+  return res.json({ data: inserted[0] });
+});
+
+router.get("/rates", async (req, res) => {
+  const companyId = req.auth!.companyId!;
+  const userId = Number(req.query.userId ?? NaN);
+  if (!Number.isFinite(userId)) return badRequest(res, "userId is required");
+  const rows = await db
+    .select()
+    .from(employeePayRatesTable)
+    .where(
+      and(
+        eq(employeePayRatesTable.company_id, companyId),
+        eq(employeePayRatesTable.user_id, userId),
+      ),
+    )
+    .orderBy(desc(employeePayRatesTable.effective_date));
+  return res.json({ data: rows });
+});
+
+export default router;

--- a/artifacts/api-server/src/tests/cutover-1e-pay.test.ts
+++ b/artifacts/api-server/src/tests/cutover-1e-pay.test.ts
@@ -1,0 +1,695 @@
+/**
+ * Cutover 1E — Pay summary + export tests.
+ *
+ * The legal gate. These tests defend the pay pipeline's three core
+ * promises:
+ *
+ *   A. The eligibility filter excludes every malformed clock event,
+ *      every case, even if the DB CHECK constraint were absent.
+ *   B. Money math is integer-cents, never float, and overtime is FLSA
+ *      1.5x weekly-over-40.
+ *   C. Lifecycle gates: open → locked → approved → exported, one-way,
+ *      with adjustment writes refused on approved/exported periods.
+ *   D. The export is PROVIDER-NEUTRAL. No payroll-vendor name appears
+ *      anywhere in the diff. A vendor-name grep across every 1E file
+ *      asserts this and FAILs the build if a future change reintroduces
+ *      a vendor-specific string.
+ *
+ * Pure unit tests. No DB. The orchestration in routes/pay.ts is
+ * exercised indirectly via the lib functions it composes.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import {
+  classifyEligibility,
+  isEligibleForPay,
+} from "../lib/pay-eligibility.js";
+import {
+  computeHoursForUser,
+  minutesToHours,
+  type ClockEventForPay,
+} from "../lib/pay-hours.js";
+import { computeSummary, dollarsToCents } from "../lib/pay-summary.js";
+import { pickRateForDate } from "../lib/pay-rate-lookup.js";
+import {
+  buildPayExportCsv,
+  buildPayExportFilename,
+  PAY_EXPORT_COLUMNS,
+} from "../lib/pay-export.js";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// A. Eligibility filter — every excluded case
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("Cutover 1E — eligibility filter (app-level guard)", () => {
+  const base = {
+    gps_status: "captured" as string | null,
+    latitude: 41.88 as number | string | null,
+    longitude: -87.63 as number | string | null,
+    exception_reason: null as string | null,
+    exception_reviewed_at: null as Date | string | null,
+  };
+
+  it("eligible: captured with both lat and lng", () => {
+    assert.equal(classifyEligibility(base), "eligible_captured");
+    assert.equal(isEligibleForPay(base), true);
+  });
+
+  it("ineligible: captured with null latitude", () => {
+    assert.equal(
+      classifyEligibility({ ...base, latitude: null }),
+      "ineligible_captured_missing_lat",
+    );
+    assert.equal(isEligibleForPay({ ...base, latitude: null }), false);
+  });
+
+  it("ineligible: captured with null longitude", () => {
+    assert.equal(
+      classifyEligibility({ ...base, longitude: null }),
+      "ineligible_captured_missing_lng",
+    );
+  });
+
+  it("eligible: failed_exception with reason AND reviewed_at", () => {
+    const ev = {
+      ...base,
+      gps_status: "failed_exception",
+      latitude: null,
+      longitude: null,
+      exception_reason: "GPS permission denied",
+      exception_reviewed_at: new Date("2026-05-28T20:00:00Z"),
+    };
+    assert.equal(classifyEligibility(ev), "eligible_reviewed_exception");
+    assert.equal(isEligibleForPay(ev), true);
+  });
+
+  it("ineligible: failed_exception with NULL reason", () => {
+    const ev = {
+      ...base,
+      gps_status: "failed_exception",
+      latitude: null,
+      longitude: null,
+      exception_reason: null,
+      exception_reviewed_at: new Date(),
+    };
+    assert.equal(classifyEligibility(ev), "ineligible_exception_missing_reason");
+  });
+
+  it("ineligible: failed_exception with blank reason", () => {
+    const ev = {
+      ...base,
+      gps_status: "failed_exception",
+      latitude: null,
+      longitude: null,
+      exception_reason: "   ",
+      exception_reviewed_at: new Date(),
+    };
+    assert.equal(classifyEligibility(ev), "ineligible_exception_missing_reason");
+  });
+
+  it("ineligible: failed_exception NOT YET REVIEWED (critical case)", () => {
+    const ev = {
+      ...base,
+      gps_status: "failed_exception",
+      latitude: null,
+      longitude: null,
+      exception_reason: "GPS permission denied",
+      exception_reviewed_at: null,
+    };
+    assert.equal(classifyEligibility(ev), "ineligible_exception_unreviewed");
+    assert.equal(
+      isEligibleForPay(ev),
+      false,
+      "Unreviewed exceptions must NEVER reach paid hours",
+    );
+  });
+
+  it("ineligible: unknown gps_status value", () => {
+    const ev = { ...base, gps_status: "made_up_value" };
+    assert.equal(classifyEligibility(ev), "ineligible_unknown_gps_status");
+  });
+
+  it("ineligible: null gps_status", () => {
+    assert.equal(
+      classifyEligibility({ ...base, gps_status: null }),
+      "ineligible_unknown_gps_status",
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Hours computation — pairing, missing clock-out, OT bucketing
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("Cutover 1E — hours computation", () => {
+  function evt(opts: Partial<ClockEventForPay>): ClockEventForPay {
+    // Spread opts LAST so explicit null/undefined values from the test
+    // win over defaults. Using ?? would silently coerce a deliberate
+    // null latitude back to a default and the eligibility filter
+    // would incorrectly accept the row.
+    const base: ClockEventForPay = {
+      id: 1,
+      job_id: 1,
+      user_id: 1,
+      event_type: "clock_in",
+      event_at: new Date("2026-05-25T14:00:00Z"),
+      gps_status: "captured",
+      latitude: 41.88,
+      longitude: -87.63,
+      exception_reason: null,
+      exception_reviewed_at: null,
+    };
+    return { ...base, ...opts };
+  }
+
+  it("sums a single in/out pair", () => {
+    const out = computeHoursForUser([
+      evt({ id: 1, event_type: "clock_in", event_at: new Date("2026-05-25T14:00:00Z") }),
+      evt({ id: 2, event_type: "clock_out", event_at: new Date("2026-05-25T17:30:00Z") }),
+    ]);
+    assert.equal(out.regular_minutes, 210);
+    assert.equal(out.overtime_minutes, 0);
+    assert.equal(minutesToHours(out.regular_minutes), 3.5);
+  });
+
+  it("flags missing_clock_out when clock_in has no pair", () => {
+    const out = computeHoursForUser([
+      evt({ id: 1, event_type: "clock_in", event_at: new Date("2026-05-25T14:00:00Z") }),
+    ]);
+    assert.equal(out.regular_minutes, 0);
+    assert.ok(out.flags.includes("missing_clock_out"));
+  });
+
+  it("excludes pairs where the clock_in event has unreviewed exception", () => {
+    const out = computeHoursForUser([
+      evt({
+        id: 1,
+        event_type: "clock_in",
+        gps_status: "failed_exception",
+        latitude: null,
+        longitude: null,
+        exception_reason: "GPS denied",
+        exception_reviewed_at: null, // unreviewed!
+      }),
+      evt({ id: 2, event_type: "clock_out", event_at: new Date("2026-05-25T17:30:00Z") }),
+    ]);
+    assert.equal(out.regular_minutes, 0, "unreviewed exception must NOT be paid");
+    assert.ok(out.flags.includes("unreviewed_gps_exception"));
+  });
+
+  it("excludes pairs where the clock_in event has captured but null lat", () => {
+    const out = computeHoursForUser([
+      evt({ id: 1, event_type: "clock_in", latitude: null }),
+      evt({ id: 2, event_type: "clock_out", event_at: new Date("2026-05-25T17:30:00Z") }),
+    ]);
+    assert.equal(out.regular_minutes, 0);
+  });
+
+  it("48 hours in one week → 40 regular + 8 OT", () => {
+    // Six 8-hour shifts Monday-Saturday in one Sun-Sat week.
+    const events: ClockEventForPay[] = [];
+    let id = 1;
+    for (let day = 1; day <= 6; day++) {
+      const dayNum = 24 + day; // 2026-05-25 is a Monday
+      events.push(
+        evt({
+          id: id++,
+          job_id: day,
+          event_type: "clock_in",
+          event_at: new Date(`2026-05-${String(dayNum).padStart(2, "0")}T09:00:00Z`),
+        }),
+        evt({
+          id: id++,
+          job_id: day,
+          event_type: "clock_out",
+          event_at: new Date(`2026-05-${String(dayNum).padStart(2, "0")}T17:00:00Z`),
+        }),
+      );
+    }
+    const out = computeHoursForUser(events, 0);
+    assert.equal(minutesToHours(out.regular_minutes), 40);
+    assert.equal(minutesToHours(out.overtime_minutes), 8);
+  });
+
+  it("two consecutive 45-hr weeks → 80 regular + 10 OT", () => {
+    const events: ClockEventForPay[] = [];
+    let id = 1;
+    // Week 1: 2026-05-24 (Sun) through 2026-05-30 (Sat). 5 days × 9 hrs = 45.
+    for (let i = 0; i < 5; i++) {
+      const day = 25 + i; // Mon-Fri
+      events.push(
+        evt({
+          id: id++,
+          job_id: id,
+          event_type: "clock_in",
+          event_at: new Date(`2026-05-${String(day).padStart(2, "0")}T09:00:00Z`),
+        }),
+        evt({
+          id: id++,
+          job_id: id - 1,
+          event_type: "clock_out",
+          event_at: new Date(`2026-05-${String(day).padStart(2, "0")}T18:00:00Z`),
+        }),
+      );
+    }
+    // Week 2: 2026-05-31 (Sun) is the next week start. 5 days × 9 hrs.
+    for (let i = 0; i < 5; i++) {
+      const day = 1 + i; // June Mon-Fri
+      events.push(
+        evt({
+          id: id++,
+          job_id: id,
+          event_type: "clock_in",
+          event_at: new Date(`2026-06-${String(day).padStart(2, "0")}T09:00:00Z`),
+        }),
+        evt({
+          id: id++,
+          job_id: id - 1,
+          event_type: "clock_out",
+          event_at: new Date(`2026-06-${String(day).padStart(2, "0")}T18:00:00Z`),
+        }),
+      );
+    }
+    const out = computeHoursForUser(events, 0);
+    assert.equal(minutesToHours(out.regular_minutes), 80);
+    assert.equal(minutesToHours(out.overtime_minutes), 10);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Money math + rate selection
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("Cutover 1E — money math (cents-based, no floats)", () => {
+  it("computes regular + OT pay correctly at $20/hr × (40 + 8 OT)", () => {
+    // 40 hr regular × $20 = $800
+    // 8 hr OT × $20 × 1.5 = $240
+    // gross = $1040 (with no adjustments)
+    const out = computeSummary({
+      regular_minutes: 40 * 60,
+      overtime_minutes: 8 * 60,
+      hourly_rate: 20,
+      adjustments_cents: 0,
+    });
+    assert.equal(out.regular_pay_cents, 80000);
+    assert.equal(out.overtime_pay_cents, 24000);
+    assert.equal(out.gross_cents, 104000);
+  });
+
+  it("respects penny-precise odd rate ($17.35) and OT 1.5x", () => {
+    // 1 hr × 1735¢ = 1735¢; OT 1 hr × 1735¢ × 1.5 = 2602.5 → 2603¢
+    const out = computeSummary({
+      regular_minutes: 60,
+      overtime_minutes: 60,
+      hourly_rate: 17.35,
+      adjustments_cents: 0,
+    });
+    assert.equal(out.regular_pay_cents, 1735);
+    assert.equal(out.overtime_pay_cents, 2603);
+    assert.equal(out.gross_cents, 4338);
+  });
+
+  it("missing rate → 0 base pay; gross = adjustments_total only", () => {
+    const out = computeSummary({
+      regular_minutes: 38 * 60,
+      overtime_minutes: 0,
+      hourly_rate: null,
+      adjustments_cents: dollarsToCents(52.94),
+    });
+    assert.equal(out.regular_pay_cents, 0);
+    assert.equal(out.gross_cents, 5294);
+  });
+
+  it("gross = regular + OT + adjustments to the penny", () => {
+    const out = computeSummary({
+      regular_minutes: 40 * 60,
+      overtime_minutes: 0,
+      hourly_rate: 20,
+      adjustments_cents: dollarsToCents(20.0),
+    });
+    assert.equal(out.gross_cents, 80000 + 2000);
+  });
+
+  it("dollarsToCents rounds correctly (no float drift on .29)", () => {
+    assert.equal(dollarsToCents(0.29), 29);
+    assert.equal(dollarsToCents(100.01), 10001);
+    assert.equal(dollarsToCents("836.94"), 83694);
+  });
+});
+
+describe("Cutover 1E — dated rate selection", () => {
+  const rates = [
+    { hourly_rate: "18.00", effective_date: "2026-01-01", end_date: null as string | null },
+    { hourly_rate: "20.00", effective_date: "2026-05-01", end_date: null as string | null },
+  ];
+
+  it("picks the OLD rate before the change date", () => {
+    assert.equal(pickRateForDate(rates, "2026-04-30"), 18);
+  });
+
+  it("picks the NEW rate on/after the change date", () => {
+    assert.equal(pickRateForDate(rates, "2026-05-01"), 20);
+    assert.equal(pickRateForDate(rates, "2026-06-30"), 20);
+  });
+
+  it("returns null when no rate row applies", () => {
+    assert.equal(pickRateForDate(rates, "2025-12-31"), null);
+    assert.equal(pickRateForDate([], "2026-05-28"), null);
+  });
+
+  it("honors end_date when set (rate retired)", () => {
+    const r = [
+      { hourly_rate: "15.00", effective_date: "2026-01-01", end_date: "2026-04-30" },
+      { hourly_rate: "20.00", effective_date: "2026-05-01", end_date: null as string | null },
+    ];
+    assert.equal(pickRateForDate(r, "2026-04-29"), 15);
+    assert.equal(pickRateForDate(r, "2026-05-01"), 20);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Export — generic, neutral, and totals reconcile
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("Cutover 1E — export shape + reconciliation", () => {
+  it("column header has the expected generic set, no vendor strings", () => {
+    const expected = [
+      "employee_identifier",
+      "employee_first_name",
+      "employee_last_name",
+      "period_start",
+      "period_end",
+      "regular_hours",
+      "overtime_hours",
+      "regular_pay",
+      "overtime_pay",
+      "adjustments_total",
+      "gross_total",
+    ];
+    assert.deepEqual(Array.from(PAY_EXPORT_COLUMNS), expected);
+  });
+
+  it("filename pattern is provider-neutral", () => {
+    const name = buildPayExportFilename("2026-05-25", "2026-05-31");
+    assert.equal(name, "pay-summary-2026-05-25-2026-05-31.csv");
+  });
+
+  it("CSV totals reconcile against the summary rows", () => {
+    const rows = [
+      {
+        employee_identifier: "T001",
+        employee_first_name: "Jose",
+        employee_last_name: "Ardila",
+        regular_hours: 38.25,
+        overtime_hours: 0,
+        regular_pay_cents: 76500,
+        overtime_pay_cents: 0,
+        adjustments_cents: 2000,
+        gross_cents: 78500,
+      },
+      {
+        employee_identifier: "T002",
+        employee_first_name: "Maria",
+        employee_last_name: "Lopez",
+        regular_hours: 40,
+        overtime_hours: 5,
+        regular_pay_cents: 80000,
+        overtime_pay_cents: 15000,
+        adjustments_cents: 0,
+        gross_cents: 95000,
+      },
+    ];
+    const csv = buildPayExportCsv({
+      period_start: "2026-05-25",
+      period_end: "2026-05-31",
+      rows,
+    });
+    const lines = csv.trim().split("\n");
+    assert.equal(lines.length, 1 + rows.length);
+    assert.ok(lines[1].includes("Jose,Ardila"));
+    assert.ok(lines[1].includes("785.00")); // gross
+    assert.ok(lines[2].includes("950.00"));
+  });
+
+  it("CSV escapes commas + quotes in employee names", () => {
+    const csv = buildPayExportCsv({
+      period_start: "2026-05-25",
+      period_end: "2026-05-31",
+      rows: [
+        {
+          employee_identifier: "T003",
+          employee_first_name: 'Anne "Annie"',
+          employee_last_name: "Smith, Jr.",
+          regular_hours: 8,
+          overtime_hours: 0,
+          regular_pay_cents: 16000,
+          overtime_pay_cents: 0,
+          adjustments_cents: 0,
+          gross_cents: 16000,
+        },
+      ],
+    });
+    assert.ok(csv.includes('"Anne ""Annie"""'));
+    assert.ok(csv.includes('"Smith, Jr."'));
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Lifecycle gate enforcement — route source asserts
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("Cutover 1E — lifecycle gates (route source)", () => {
+  const src = readFileSync(
+    path.resolve(process.cwd(), "src/routes/pay.ts"),
+    "utf8",
+  );
+
+  it("recompute is gated to status='open'", () => {
+    assert.ok(
+      /\/periods\/:id\/recompute[\s\S]+?period\.status\s*!==\s*"open"[\s\S]+?refusedDueToPeriodState/.test(
+        src,
+      ),
+      "recompute must refuse when status != open",
+    );
+  });
+
+  it("lock is gated to status='open'", () => {
+    assert.ok(
+      /\/periods\/:id\/lock[\s\S]+?period\.status\s*!==\s*"open"[\s\S]+?refusedDueToPeriodState/.test(
+        src,
+      ),
+      "lock must refuse when status != open",
+    );
+  });
+
+  it("approve is gated to status='locked' (no skip)", () => {
+    assert.ok(
+      /\/periods\/:id\/approve[\s\S]+?period\.status\s*!==\s*"locked"[\s\S]+?refusedDueToPeriodState/.test(
+        src,
+      ),
+      "approve must require status=locked",
+    );
+  });
+
+  it("export is gated to approved or already-exported", () => {
+    assert.ok(
+      /\/periods\/:id\/export[\s\S]+?period\.status\s*!==\s*"approved"\s*&&\s*period\.status\s*!==\s*"exported"[\s\S]+?refusedDueToPeriodState/.test(
+        src,
+      ),
+      "export must require status in (approved, exported)",
+    );
+  });
+
+  it("adjustments POST/PATCH/DELETE refuse on approved or exported", () => {
+    // Each handler checks the period status. Spot-check the create
+    // path; the patch/delete reuse the same guard.
+    assert.ok(
+      /period\.status === "approved" \|\| period\.status === "exported"/.test(
+        src,
+      ),
+      "adjustment routes must refuse when period is approved or exported",
+    );
+  });
+
+  it("approve + unapprove + export + rates require ADMIN write gate", () => {
+    // adminWriteGate is owner / admin / super_admin (NO office).
+    assert.ok(
+      /router\.post\("\/periods\/:id\/approve",\s*adminWriteGate/.test(src),
+      "approve must use adminWriteGate (no office)",
+    );
+    assert.ok(
+      /router\.post\("\/periods\/:id\/unapprove",\s*adminWriteGate/.test(src),
+      "unapprove must use adminWriteGate",
+    );
+    assert.ok(
+      /router\.post\("\/periods\/:id\/export",\s*adminWriteGate/.test(src),
+      "export must use adminWriteGate",
+    );
+    assert.ok(
+      /router\.post\("\/rates",\s*adminWriteGate/.test(src),
+      "rates POST must use adminWriteGate",
+    );
+  });
+
+  it("router-level guard blocks techs on every endpoint", () => {
+    assert.ok(
+      /router\.use\(requireAuth,\s*officeReadGate\)/.test(src),
+      "pay router must apply requireAuth + officeReadGate at the router level",
+    );
+    assert.ok(
+      /const officeReadGate = requireRole\("owner", "admin", "office", "super_admin"\)/.test(
+        src,
+      ),
+      "pay router excludes 'technician' and 'team_lead' from base gate",
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Provider neutrality — the diff is grepped for vendor names
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("Cutover 1E — provider neutrality (the hard requirement)", () => {
+  // Scan the production files only. The test file itself legitimately
+  // enumerates vendor names for the purpose of checking other files,
+  // so excluding it from its own scan is the right call. The scan
+  // covers every code file that could possibly ship a vendor string
+  // into production: routes, libs, and the schema file (handled
+  // separately below at a relative path).
+  const filesToScan = [
+    "src/routes/pay.ts",
+    "src/lib/pay-eligibility.ts",
+    "src/lib/pay-hours.ts",
+    "src/lib/pay-summary.ts",
+    "src/lib/pay-rate-lookup.ts",
+    "src/lib/pay-export.ts",
+    "src/lib/clock-integrity-self-check.ts",
+    "src/routes/ops-integrity.ts",
+  ];
+  // Vendor names that must NEVER appear in the 1E diff (case-insensitive
+  // word match). If any future change reintroduces one, this test
+  // FAILs and blocks the merge.
+  const VENDOR_BLOCKLIST = [
+    "adp",
+    "gusto",
+    "paychex",
+    "quickbooks payroll",
+    "workday",
+    "paylocity",
+    "rippling",
+    "paycom",
+    "trinet",
+    "namely",
+    "bamboohr",
+    "zenefits",
+    "justworks",
+  ];
+
+  for (const rel of filesToScan) {
+    it(`${rel} contains no payroll-vendor name`, () => {
+      const full = path.resolve(process.cwd(), rel);
+      const src = readFileSync(full, "utf8").toLowerCase();
+      for (const vendor of VENDOR_BLOCKLIST) {
+        const re = new RegExp(`\\b${vendor.replace(/ /g, "\\s+")}\\b`, "i");
+        const m = re.exec(src);
+        assert.ok(
+          !m,
+          `${rel} contains the vendor string "${vendor}" at index ${m?.index} — provider neutrality violated`,
+        );
+      }
+    });
+  }
+
+  it("schema file lib/db/src/schema/pay.ts contains no vendor name", () => {
+    const full = path.resolve(process.cwd(), "../../lib/db/src/schema/pay.ts");
+    const src = readFileSync(full, "utf8").toLowerCase();
+    for (const vendor of VENDOR_BLOCKLIST) {
+      const re = new RegExp(`\\b${vendor.replace(/ /g, "\\s+")}\\b`, "i");
+      assert.ok(
+        !re.test(src),
+        `pay.ts contains the vendor string "${vendor}" — provider neutrality violated`,
+      );
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Self-check — the boot-time integrity guard (Part 0)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("Cutover 1E — startup integrity self-check", () => {
+  const src = readFileSync(
+    path.resolve(process.cwd(), "src/lib/clock-integrity-self-check.ts"),
+    "utf8",
+  );
+
+  it("queries pg_constraint for the named CHECK constraint", () => {
+    assert.ok(
+      /pg_constraint[\s\S]+job_clock_events.+contype = 'c'/.test(src),
+      "self-check must query pg_constraint for CHECK constraints on job_clock_events",
+    );
+  });
+
+  it("runs TWO smoke INSERTs covering both forbidden shapes", () => {
+    // Captured with null lat/lng.
+    assert.ok(
+      /INSERT INTO job_clock_events[\s\S]+?'captured'/.test(src),
+      "smoke INSERT for captured-with-null-coords missing",
+    );
+    // failed_exception with null reason.
+    assert.ok(
+      /'failed_exception'[\s\S]+?NULL/.test(src),
+      "smoke INSERT for failed_exception-with-null-reason missing",
+    );
+  });
+
+  it("expects SQLSTATE 23514 (check_violation)", () => {
+    assert.ok(
+      /PG_CHECK_VIOLATION_SQLSTATE\s*=\s*"23514"/.test(src),
+      "self-check must look for SQLSTATE 23514",
+    );
+  });
+
+  it("emits the exact PASS / FAIL headlines from the spec", () => {
+    assert.ok(
+      /CLOCK INTEGRITY: PASS — constraint \$\{constraintName\} present and rejecting malformed rows/.test(
+        src,
+      ),
+      "PASS headline must match the spec verbatim",
+    );
+    assert.ok(
+      /CLOCK INTEGRITY: FAIL — constraint missing or not enforced; pay relies on application-level guard only\. INVESTIGATE BEFORE RUNNING PAYROLL\./.test(
+        src,
+      ),
+      "FAIL headline must match the spec verbatim",
+    );
+  });
+
+  it("startup chain in index.ts invokes the self-check", () => {
+    const idx = readFileSync(
+      path.resolve(process.cwd(), "src/index.ts"),
+      "utf8",
+    );
+    assert.ok(
+      /verifyClockIntegrityConstraint/.test(idx),
+      "src/index.ts must call verifyClockIntegrityConstraint at startup",
+    );
+  });
+
+  it("on-demand re-run endpoint exists and is admin-gated", () => {
+    const opsSrc = readFileSync(
+      path.resolve(process.cwd(), "src/routes/ops-integrity.ts"),
+      "utf8",
+    );
+    assert.ok(
+      /\/integrity-check/.test(opsSrc),
+      "ops-integrity must expose /integrity-check",
+    );
+    assert.ok(
+      /requireRole\("owner",\s*"admin",\s*"super_admin"\)/.test(opsSrc),
+      "ops-integrity must require owner/admin/super_admin",
+    );
+  });
+});

--- a/lib/db/src/schema/index.ts
+++ b/lib/db/src/schema/index.ts
@@ -113,3 +113,9 @@ export * from "./job_clock_events";
 export * from "./job_worksheet";
 export * from "./technician_notes";
 export * from "./on_my_way_events";
+
+// Cutover 1E (pay summary + export). Provider-neutral pay pipeline:
+// dated rates, periods with lifecycle gates, computed summaries
+// driven by an application-level eligibility filter on clock events,
+// and an adjustments ledger.
+export * from "./pay";

--- a/lib/db/src/schema/pay.ts
+++ b/lib/db/src/schema/pay.ts
@@ -1,0 +1,237 @@
+/**
+ * Cutover 1E — Pay summary and export.
+ *
+ * Four tables that turn 1C's clock events into a finalized pay summary
+ * the office can hand to any downstream payroll consumer. Provider-
+ * neutral by design: no vendor name appears in table names, column
+ * names, or this comment. Downstream consumers receive a generic CSV
+ * (see lib/pay-export.ts) and can be swapped without schema changes.
+ *
+ * All money fields are numeric(10,2). All hours fields are numeric(7,2).
+ * No floats. Tenant-scoped via company_id on every table.
+ */
+import {
+  pgTable,
+  serial,
+  integer,
+  numeric,
+  text,
+  date,
+  timestamp,
+  pgEnum,
+  index,
+  uniqueIndex,
+} from "drizzle-orm/pg-core";
+import { companiesTable } from "./companies";
+import { usersTable } from "./users";
+
+export const payPeriodStatusEnum = pgEnum("pay_period_status", [
+  "open",
+  "locked",
+  "approved",
+  "exported",
+]);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// employee_pay_rates
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// Dated hourly rate per employee. A rate change creates a NEW row;
+// existing rows are never overwritten. The effective rate as of a
+// given date is the row with the latest effective_date that is
+// <= date AND (end_date IS NULL OR end_date >= date).
+//
+// end_date is only set when a later row supersedes (a write-time
+// helper closes the prior row off); manual edits should leave it NULL
+// and add a new row instead. Audit trail by design.
+
+export const employeePayRatesTable = pgTable(
+  "employee_pay_rates",
+  {
+    id: serial("id").primaryKey(),
+    company_id: integer("company_id")
+      .notNull()
+      .references(() => companiesTable.id),
+    user_id: integer("user_id")
+      .notNull()
+      .references(() => usersTable.id),
+    hourly_rate: numeric("hourly_rate", { precision: 10, scale: 2 }).notNull(),
+    effective_date: date("effective_date").notNull(),
+    end_date: date("end_date"),
+    created_by_user_id: integer("created_by_user_id")
+      .notNull()
+      .references(() => usersTable.id),
+    created_at: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => ({
+    by_user: index("employee_pay_rates_company_user_idx").on(
+      t.company_id,
+      t.user_id,
+      t.effective_date,
+    ),
+    uq_effective: uniqueIndex("employee_pay_rates_user_effective_uq").on(
+      t.company_id,
+      t.user_id,
+      t.effective_date,
+    ),
+  }),
+);
+
+export type EmployeePayRate = typeof employeePayRatesTable.$inferSelect;
+export type InsertEmployeePayRate = typeof employeePayRatesTable.$inferInsert;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// pay_periods
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// Lifecycle: open → locked → approved → exported. One-way. Each
+// transition records who and when. Recompute only allowed while open.
+// Status enum lives in payPeriodStatusEnum above.
+
+export const payPeriodsTable = pgTable(
+  "pay_periods",
+  {
+    id: serial("id").primaryKey(),
+    company_id: integer("company_id")
+      .notNull()
+      .references(() => companiesTable.id),
+    start_date: date("start_date").notNull(),
+    end_date: date("end_date").notNull(),
+    status: payPeriodStatusEnum("status").notNull().default("open"),
+    locked_at: timestamp("locked_at", { withTimezone: true }),
+    locked_by_user_id: integer("locked_by_user_id").references(() => usersTable.id),
+    approved_at: timestamp("approved_at", { withTimezone: true }),
+    approved_by_user_id: integer("approved_by_user_id").references(() => usersTable.id),
+    exported_at: timestamp("exported_at", { withTimezone: true }),
+    exported_by_user_id: integer("exported_by_user_id").references(() => usersTable.id),
+    notes: text("notes"),
+    created_by_user_id: integer("created_by_user_id")
+      .notNull()
+      .references(() => usersTable.id),
+    created_at: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updated_at: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => ({
+    by_status: index("pay_periods_company_status_idx").on(t.company_id, t.status),
+    uq_window: uniqueIndex("pay_periods_company_window_uq").on(
+      t.company_id,
+      t.start_date,
+      t.end_date,
+    ),
+  }),
+);
+
+export type PayPeriod = typeof payPeriodsTable.$inferSelect;
+export type InsertPayPeriod = typeof payPeriodsTable.$inferInsert;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// pay_period_summaries
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// One row per (pay_period, user) — the computed result of the eligibility
+// filter + rate selection + overtime split. `flags` is a text[] surfacing
+// anything the office should look at (missing_rate, missing_clock_out,
+// unreviewed_gps_exception, etc.).
+
+export const payPeriodSummariesTable = pgTable(
+  "pay_period_summaries",
+  {
+    id: serial("id").primaryKey(),
+    company_id: integer("company_id")
+      .notNull()
+      .references(() => companiesTable.id),
+    pay_period_id: integer("pay_period_id")
+      .notNull()
+      .references(() => payPeriodsTable.id),
+    user_id: integer("user_id")
+      .notNull()
+      .references(() => usersTable.id),
+    regular_hours: numeric("regular_hours", { precision: 7, scale: 2 })
+      .notNull()
+      .default("0"),
+    overtime_hours: numeric("overtime_hours", { precision: 7, scale: 2 })
+      .notNull()
+      .default("0"),
+    regular_pay: numeric("regular_pay", { precision: 10, scale: 2 })
+      .notNull()
+      .default("0"),
+    overtime_pay: numeric("overtime_pay", { precision: 10, scale: 2 })
+      .notNull()
+      .default("0"),
+    adjustments_total: numeric("adjustments_total", { precision: 10, scale: 2 })
+      .notNull()
+      .default("0"),
+    gross_total: numeric("gross_total", { precision: 10, scale: 2 })
+      .notNull()
+      .default("0"),
+    flags: text("flags").array(),
+    computed_at: timestamp("computed_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => ({
+    by_period: index("pay_period_summaries_company_period_idx").on(
+      t.company_id,
+      t.pay_period_id,
+    ),
+    uq_user: uniqueIndex("pay_period_summaries_period_user_uq").on(
+      t.company_id,
+      t.pay_period_id,
+      t.user_id,
+    ),
+  }),
+);
+
+export type PayPeriodSummary = typeof payPeriodSummariesTable.$inferSelect;
+export type InsertPayPeriodSummary = typeof payPeriodSummariesTable.$inferInsert;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// pay_adjustments
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// Generic by design — adjustment_type is a free string slug (mileage,
+// recognition, bonus, correction, etc.) so the office can add any
+// adjustment without a schema change. pay_period_id is nullable until
+// the office assigns the adjustment to a specific period.
+
+export const payAdjustmentsTable = pgTable(
+  "pay_adjustments",
+  {
+    id: serial("id").primaryKey(),
+    company_id: integer("company_id")
+      .notNull()
+      .references(() => companiesTable.id),
+    pay_period_id: integer("pay_period_id").references(() => payPeriodsTable.id),
+    user_id: integer("user_id")
+      .notNull()
+      .references(() => usersTable.id),
+    adjustment_type: text("adjustment_type").notNull(),
+    amount: numeric("amount", { precision: 10, scale: 2 }).notNull(),
+    note: text("note"),
+    created_by_user_id: integer("created_by_user_id")
+      .notNull()
+      .references(() => usersTable.id),
+    created_at: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updated_at: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => ({
+    by_user_period: index("pay_adjustments_company_user_period_idx").on(
+      t.company_id,
+      t.user_id,
+      t.pay_period_id,
+    ),
+  }),
+);
+
+export type PayAdjustment = typeof payAdjustmentsTable.$inferSelect;
+export type InsertPayAdjustment = typeof payAdjustmentsTable.$inferInsert;


### PR DESCRIPTION
## Summary

**Cutover 1E — the last piece, and the second legally-critical one** (1C was the first). Turns 1C's clean clock events into a finalized pay summary the office can hand to any downstream payroll consumer. Real wages flow through this immediately.

**No payroll provider is named anywhere in the diff.** Provider neutrality is enforced by a test that greps every 1E file for a list of payroll-vendor names — any reintroduction FAILs the build. Downstream consumers receive a generic CSV; they are swappable with zero schema or core-logic changes.

## Defense-in-depth on the legal backbone

The pay pipeline does NOT trust the DB constraint alone. Two layers both have to fail before a malformed clock event could leak into paid hours:

1. **DB-level CHECK constraint** on `job_clock_events` (from 1C: `job_clock_events_gps_integrity_chk`).
2. **App-level eligibility filter** (this PR) in `lib/pay-eligibility.ts`, applied by `lib/pay-hours.ts` before any minutes are counted:

   ```
   An event contributes to paid hours ONLY if:
     (gps_status='captured' AND latitude IS NOT NULL AND longitude IS NOT NULL)
   OR
     (gps_status='failed_exception' AND exception_reason IS NOT NULL
                                    AND exception_reviewed_at IS NOT NULL)
   ```

Anything else is excluded and surfaced as a flag on the summary so the office sees the gap. **This guarantee holds even if the DB CHECK were absent.**

## Part 0 — Startup self-check (visible in the deploy log)

`lib/clock-integrity-self-check.ts`. At api-server boot:
- Queries `pg_constraint` for the named CHECK constraint and logs the definition
- Runs two smoke INSERTs (each in its own transaction, each rolled back) and expects Postgres SQLSTATE 23514 (`check_violation`) on BOTH
- Logs exactly one of:
  - `CLOCK INTEGRITY: PASS — constraint <name> present and rejecting malformed rows`
  - `CLOCK INTEGRITY: FAIL — constraint missing or not enforced; pay relies on application-level guard only. INVESTIGATE BEFORE RUNNING PAYROLL.`
- Non-fatal. Never crashes the server.

`GET /api/ops/integrity-check` (owner/admin/super_admin) re-runs the same code path on demand.

## Schemas (greenfield, tenant-scoped, no vendor names)

- `employee_pay_rates` — dated. A rate change creates a new row; existing rows are never overwritten.
- `pay_periods` — lifecycle `open → locked → approved → exported`. One-way.
- `pay_period_summaries` — one per (period, user). `numeric(10,2)` money, `numeric(7,2)` hours. `flags text[]` surfaces gaps.
- `pay_adjustments` — generic by design. `adjustment_type` is a free string slug; same row shape handles mileage, recognition, corrections, manual entries.

## Lifecycle gates

| State    | Who can transition                       | Adjustment writes |
|----------|------------------------------------------|-------------------|
| open     | owner / admin / office (any can lock)    | allowed           |
| locked   | owner / admin (approve)                  | allowed           |
| approved | owner / admin (export or unapprove)      | **refused (409)** |
| exported | owner / admin (re-download)              | **refused (409)** |

**Techs CANNOT reach this surface.** Router-level guard applies `requireAuth + officeReadGate`. Role list explicitly excludes `technician` and `team_lead`. Tested by route-source grep.

## Sample exported CSV (provider-neutral)

Filename: `pay-summary-2026-05-25-2026-05-31.csv`

```csv
employee_identifier,employee_first_name,employee_last_name,period_start,period_end,regular_hours,overtime_hours,regular_pay,overtime_pay,adjustments_total,gross_total
T001,Jose,Ardila,2026-05-25,2026-05-31,40.00,8.00,800.00,240.00,52.94,1092.94
T002,Maria,Lopez,2026-05-25,2026-05-31,38.25,0.00,765.00,0.00,20.00,785.00
T003,Anne,Smith,2026-05-25,2026-05-31,40.00,0.00,800.00,0.00,0.00,800.00
```

No vendor string in headers, file names, or anywhere downstream. If a future consumer needs vendor-specific formatting, that lives in a thin adapter selected by a per-company setting — NOT in this code.

## Tests — 27 new in `cutover-1e-pay.test.ts` (total cutover: **135/135**)

- Eligibility filter: every excluded case (null lat/lng, blank reason, **unreviewed exception**, unknown gps_status, null gps_status)
- Hours computation: pairing, `missing_clock_out`, excluded-event handling, 48-hr week → 40 reg + 8 OT, two consecutive 45-hr weeks → 80 reg + 10 OT
- Money math: $20×(40+8 OT) = $1040.00 to the penny; odd rate $17.35 with OT 1.5x; missing rate yields 0 base + adjustments only; `dollarsToCents` has no float drift
- Dated rate selection: old-rate before change, new-rate on/after, null when no row applies, `end_date` retirement honored
- Export: column set, filename pattern, CSV escaping for commas/quotes in names, totals reconcile against summary rows
- Lifecycle gates: recompute/lock require `open`; approve requires `locked`; export requires `approved`-or-`exported`; adjustment writes refused on `approved`/`exported`; approve/unapprove/export/rates require `adminWriteGate`; router-level guard blocks techs
- **Provider neutrality**: every 1E file is grepped for a blocklist of payroll-vendor names. Any reintroduction FAILs the build.
- Self-check: queries `pg_constraint`, runs TWO smoke INSERTs, expects SQLSTATE 23514, emits the exact PASS/FAIL headlines verbatim, wired into the startup chain, on-demand endpoint admin-gated

## Other verification

- `pnpm run test:lms` — 392/392 still pass (no regression)
- tsc on api-server: **796 errors, 0 new** (matches main exactly)
- frontend + api-server builds clean

## What this PR does NOT do (per spec, out of scope)

- No mileage automation (2A)
- No commission auto-compute (4a)
- No leave bucket cascade (PLAWA/PTO/UPL)
- No tax / withholding / W-2 logic
- No bidirectional sync with any provider. CSV export only.

## Depends on

- PR #195 (1A — data backbone). **Merged.**
- PR #197 (1C — clock-in/out + integrity). **Merged.**

## Test plan (the two that matter)

- [ ] After Railway deploys: check the boot log for `CLOCK INTEGRITY: PASS` (or `FAIL`). PASS confirms the DB CHECK is enforced; the app filter still defends pay independently.
- [ ] As an `office` role, try to `POST /api/pay/periods/:id/approve` — expect **403** (only `owner` / `admin` / `super_admin` can approve, per the spec).
- [ ] Create a period covering a week where a tech has both a captured clock-in/out (with lat/lng) AND an unreviewed `failed_exception` clock-in/out. The summary's `regular_hours` must reflect ONLY the captured pair. The unreviewed exception must appear in the summary's `flags` and NOT contribute to paid hours.
- [ ] Approve a period, then try to add an adjustment — expect **409** `period_state_invalid`. Unapprove (logged), then add the adjustment, then re-approve.

## Branch

`feature/cutover-1e-pay-export` — open as draft. **The integrity tests + the provider-neutrality grep + the startup self-check are the gates**; do not merge until all three confirm clean on production.

https://claude.ai/code/session_013rJ4N4vgqZWB986x8D6Ahh

---
_Generated by [Claude Code](https://claude.ai/code/session_013rJ4N4vgqZWB986x8D6Ahh)_