### PR TITLE
cutover 2B: mileage approval gate (computed → reviewed → applied)

### DIFF
--- a/artifacts/api-server/src/lib/mileage-approval.ts
+++ b/artifacts/api-server/src/lib/mileage-approval.ts
@@ -1,0 +1,113 @@
+/**
+ * Cutover 2B — Mileage approval gate (pure logic).
+ *
+ * The 2B office workflow promotes mileage_legs from `computed` to
+ * `applied` (via `reviewed`), or sidelines them as `discarded`. This
+ * module owns the pure, DB-free pieces: lifecycle transition rules,
+ * the carpool-candidate grouping, and the per-tech summary shape the
+ * review screen renders.
+ *
+ * No money math lives here — amounts come straight off the leg row;
+ * 2A already computed them in integer cents and persisted them as
+ * numeric(10,2) strings. 2B never recomputes; it only promotes.
+ *
+ * Lifecycle (enforced by canTransition):
+ *
+ *   computed ── review ──► reviewed ── apply ──► applied
+ *      │                       │
+ *      └──── discard ──────────┴────► discarded
+ *
+ *   applied + discarded are TERMINAL. No re-open path. If an applied
+ *   row needs to be unwound the operator removes the pay_adjustment
+ *   via the existing 1E DELETE endpoint and explicitly creates a new
+ *   leg (or recomputes the period). This keeps the audit trail clean
+ *   — every "money moved" event corresponds to exactly one apply.
+ */
+export type MileageLegStatus = "computed" | "reviewed" | "applied" | "discarded";
+export type MileageLegAction = "review" | "discard" | "apply";
+
+/** Returns null when the transition is allowed; a human-readable
+ *  refusal message otherwise. */
+export function refusalForTransition(
+  from: MileageLegStatus,
+  action: MileageLegAction,
+): string | null {
+  if (from === "applied") return "Leg is already applied; reverse via the pay_adjustments delete flow.";
+  if (from === "discarded") return "Leg is discarded; this state is terminal.";
+  if (action === "review") {
+    if (from === "computed") return null;
+    return `Leg is ${from}, only computed legs can be marked reviewed.`;
+  }
+  if (action === "discard") {
+    if (from === "computed" || from === "reviewed") return null;
+    return `Leg is ${from}, only computed or reviewed legs can be discarded.`;
+  }
+  if (action === "apply") {
+    if (from === "reviewed") return null;
+    return `Leg is ${from}, only reviewed legs can be applied.`;
+  }
+  return `Unknown action: ${action}`;
+}
+
+/** Shape used by the carpool-grouping helper. Pulled out so unit
+ *  tests can build minimal rows without dragging the full leg type. */
+export type LegForCarpoolCheck = {
+  id: number;
+  user_id: number;
+  leg_date: string; // YYYY-MM-DD
+  from_job_id: number;
+  to_job_id: number;
+  status: MileageLegStatus;
+};
+
+/** One carpool candidate group: same calendar day, same from_job +
+ *  to_job, multiple distinct techs. The office decides which leg to
+ *  apply and which to discard — 2B never auto-resolves. */
+export type CarpoolCandidate = {
+  leg_date: string;
+  from_job_id: number;
+  to_job_id: number;
+  legs: LegForCarpoolCheck[];
+  /** Distinct tech count. > 1 by construction; helpers may display
+   *  "3 techs sharing this leg" without recomputing. */
+  tech_count: number;
+};
+
+/** Group `legs` into carpool candidates: same (date, from, to) with
+ *  multiple distinct user_ids. ONLY pre-apply legs (computed or
+ *  reviewed) are considered — applied + discarded rows are decided
+ *  and should not pollute the queue.
+ *
+ *  Returns groups sorted by leg_date ascending for stable rendering. */
+export function detectCarpoolCandidates(
+  legs: ReadonlyArray<LegForCarpoolCheck>,
+): CarpoolCandidate[] {
+  const buckets = new Map<string, LegForCarpoolCheck[]>();
+  for (const leg of legs) {
+    if (leg.status !== "computed" && leg.status !== "reviewed") continue;
+    const key = `${leg.leg_date}|${leg.from_job_id}|${leg.to_job_id}`;
+    const arr = buckets.get(key) ?? [];
+    arr.push(leg);
+    buckets.set(key, arr);
+  }
+  const out: CarpoolCandidate[] = [];
+  for (const [, arr] of buckets) {
+    const distinctTechs = new Set(arr.map((l) => l.user_id));
+    if (distinctTechs.size < 2) continue;
+    out.push({
+      leg_date: arr[0]!.leg_date,
+      from_job_id: arr[0]!.from_job_id,
+      to_job_id: arr[0]!.to_job_id,
+      legs: arr,
+      tech_count: distinctTechs.size,
+    });
+  }
+  out.sort((a, b) => a.leg_date.localeCompare(b.leg_date));
+  return out;
+}
+
+/** Adjustment_type slug 2B writes to pay_adjustments. Distinct from
+ *  any free-form "mileage" string an office user might type into a
+ *  manual adjustment, so reports can join legs <-> adjustments by
+ *  type cleanly. */
+export const MILEAGE_REIMBURSEMENT_ADJUSTMENT_TYPE = "mileage_reimbursement";

--- a/artifacts/api-server/src/routes/pay.ts
+++ b/artifacts/api-server/src/routes/pay.ts
@@ -38,6 +38,12 @@ import {
   mileageRatesTable,
   mileageLegsTable,
 } from "@workspace/db/schema";
+import {
+  detectCarpoolCandidates,
+  refusalForTransition,
+  MILEAGE_REIMBURSEMENT_ADJUSTMENT_TYPE,
+  type MileageLegStatus,
+} from "../lib/mileage-approval.js";
 import { and, asc, desc, eq, gte, inArray, isNotNull, lte, sql } from "drizzle-orm";
 import { requireAuth, requireRole } from "../lib/auth.js";
 import {
@@ -1026,5 +1032,379 @@ router.get("/rates", async (req, res) => {
     .orderBy(desc(employeePayRatesTable.effective_date));
   return res.json({ data: rows });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Cutover 2B — Mileage approval gate
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// The office's review surface for computed mileage_legs. Lifecycle is
+// computed → reviewed → applied | discarded, with applied being the
+// only state that moves money (creates a pay_adjustments row of type
+// 'mileage_reimbursement' and sets the leg's applied_pay_adjustment_id
+// bridge). Apply is blocked on approved/exported periods; discard is
+// always allowed for non-terminal legs.
+
+router.get(
+  "/periods/:id/mileage-legs",
+  async (req, res) => {
+    const companyId = req.auth!.companyId!;
+    const periodId = Number(req.params.id);
+    if (!Number.isFinite(periodId)) return badRequest(res, "Invalid id");
+    const period = await loadPeriod(companyId, periodId);
+    if (!period) return notFound(res, "Period not found");
+
+    const rows = await db
+      .select({
+        id: mileageLegsTable.id,
+        user_id: mileageLegsTable.user_id,
+        first_name: usersTable.first_name,
+        last_name: usersTable.last_name,
+        leg_date: mileageLegsTable.leg_date,
+        from_job_id: mileageLegsTable.from_job_id,
+        to_job_id: mileageLegsTable.to_job_id,
+        miles: mileageLegsTable.miles,
+        minutes: mileageLegsTable.minutes,
+        rate_per_mile: mileageLegsTable.rate_per_mile,
+        amount: mileageLegsTable.amount,
+        measurement_source: mileageLegsTable.measurement_source,
+        measurement_is_estimated: mileageLegsTable.measurement_is_estimated,
+        status: mileageLegsTable.status,
+        reviewed_at: mileageLegsTable.reviewed_at,
+        reviewed_by_user_id: mileageLegsTable.reviewed_by_user_id,
+        applied_at: mileageLegsTable.applied_at,
+        applied_pay_adjustment_id: mileageLegsTable.applied_pay_adjustment_id,
+        discarded_at: mileageLegsTable.discarded_at,
+        discard_reason: mileageLegsTable.discard_reason,
+      })
+      .from(mileageLegsTable)
+      .leftJoin(usersTable, eq(mileageLegsTable.user_id, usersTable.id))
+      .where(
+        and(
+          eq(mileageLegsTable.company_id, companyId),
+          eq(mileageLegsTable.pay_period_id, periodId),
+        ),
+      )
+      .orderBy(
+        asc(mileageLegsTable.leg_date),
+        asc(usersTable.last_name),
+        asc(mileageLegsTable.id),
+      );
+
+    // Per-tech totals + flag detection for the review screen. Only
+    // non-discarded legs count toward the "still-to-decide" totals
+    // the office uses to triage. Estimated-distance and missing-
+    // address shapes get surfaced as flags.
+    const byTech = new Map<
+      number,
+      {
+        user_id: number;
+        first_name: string | null;
+        last_name: string | null;
+        computed_count: number;
+        reviewed_count: number;
+        applied_count: number;
+        discarded_count: number;
+        pending_amount_cents: number;
+        applied_amount_cents: number;
+        flag_count: number;
+      }
+    >();
+    for (const r of rows) {
+      let bucket = byTech.get(r.user_id);
+      if (!bucket) {
+        bucket = {
+          user_id: r.user_id,
+          first_name: r.first_name,
+          last_name: r.last_name,
+          computed_count: 0,
+          reviewed_count: 0,
+          applied_count: 0,
+          discarded_count: 0,
+          pending_amount_cents: 0,
+          applied_amount_cents: 0,
+          flag_count: 0,
+        };
+        byTech.set(r.user_id, bucket);
+      }
+      const cents = dollarsToCents(r.amount);
+      if (r.status === "computed") {
+        bucket.computed_count += 1;
+        bucket.pending_amount_cents += cents;
+      } else if (r.status === "reviewed") {
+        bucket.reviewed_count += 1;
+        bucket.pending_amount_cents += cents;
+      } else if (r.status === "applied") {
+        bucket.applied_count += 1;
+        bucket.applied_amount_cents += cents;
+      } else if (r.status === "discarded") {
+        bucket.discarded_count += 1;
+      }
+      if (r.status !== "discarded" && r.measurement_is_estimated) {
+        bucket.flag_count += 1;
+      }
+    }
+
+    return res.json({
+      data: {
+        period,
+        legs: rows,
+        techs: Array.from(byTech.values()).sort((a, b) =>
+          (a.last_name ?? "").localeCompare(b.last_name ?? ""),
+        ),
+      },
+    });
+  },
+);
+
+router.get(
+  "/periods/:id/mileage-carpool-candidates",
+  async (req, res) => {
+    const companyId = req.auth!.companyId!;
+    const periodId = Number(req.params.id);
+    if (!Number.isFinite(periodId)) return badRequest(res, "Invalid id");
+    const period = await loadPeriod(companyId, periodId);
+    if (!period) return notFound(res, "Period not found");
+    const rows = await db
+      .select({
+        id: mileageLegsTable.id,
+        user_id: mileageLegsTable.user_id,
+        leg_date: mileageLegsTable.leg_date,
+        from_job_id: mileageLegsTable.from_job_id,
+        to_job_id: mileageLegsTable.to_job_id,
+        status: mileageLegsTable.status,
+      })
+      .from(mileageLegsTable)
+      .where(
+        and(
+          eq(mileageLegsTable.company_id, companyId),
+          eq(mileageLegsTable.pay_period_id, periodId),
+        ),
+      );
+    const candidates = detectCarpoolCandidates(
+      rows.map((r) => ({
+        id: r.id,
+        user_id: r.user_id,
+        leg_date: String(r.leg_date),
+        from_job_id: r.from_job_id,
+        to_job_id: r.to_job_id,
+        status: r.status as
+          | "computed"
+          | "reviewed"
+          | "applied"
+          | "discarded",
+      })),
+    );
+    return res.json({ data: { candidates } });
+  },
+);
+
+async function loadLegOrNotFound(
+  companyId: number,
+  legId: number,
+): Promise<typeof mileageLegsTable.$inferSelect | null> {
+  const rows = await db
+    .select()
+    .from(mileageLegsTable)
+    .where(
+      and(
+        eq(mileageLegsTable.company_id, companyId),
+        eq(mileageLegsTable.id, legId),
+      ),
+    )
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+router.post(
+  "/mileage-legs/:id/review",
+  async (req, res) => {
+    const companyId = req.auth!.companyId!;
+    const userId = req.auth!.userId!;
+    const legId = Number(req.params.id);
+    if (!Number.isFinite(legId)) return badRequest(res, "Invalid id");
+    const leg = await loadLegOrNotFound(companyId, legId);
+    if (!leg) return notFound(res, "Mileage leg not found");
+    const refusal = refusalForTransition(
+      leg.status as MileageLegStatus,
+      "review",
+    );
+    if (refusal) {
+      return res.status(409).json({
+        error: "Conflict",
+        message: refusal,
+        code: "leg_state_invalid",
+      });
+    }
+    const now = new Date();
+    await db
+      .update(mileageLegsTable)
+      .set({
+        status: "reviewed",
+        reviewed_at: now,
+        reviewed_by_user_id: userId,
+        updated_at: now,
+      })
+      .where(
+        and(
+          eq(mileageLegsTable.company_id, companyId),
+          eq(mileageLegsTable.id, legId),
+        ),
+      );
+    return res.json({ data: { id: legId, status: "reviewed" } });
+  },
+);
+
+router.post(
+  "/mileage-legs/:id/discard",
+  async (req, res) => {
+    const companyId = req.auth!.companyId!;
+    const userId = req.auth!.userId!;
+    const legId = Number(req.params.id);
+    if (!Number.isFinite(legId)) return badRequest(res, "Invalid id");
+    const body = req.body as { reason?: string };
+    const reason = (body?.reason ?? "").trim();
+    if (!reason) return badRequest(res, "reason is required for discard");
+    const leg = await loadLegOrNotFound(companyId, legId);
+    if (!leg) return notFound(res, "Mileage leg not found");
+    const refusal = refusalForTransition(
+      leg.status as MileageLegStatus,
+      "discard",
+    );
+    if (refusal) {
+      return res.status(409).json({
+        error: "Conflict",
+        message: refusal,
+        code: "leg_state_invalid",
+      });
+    }
+    const now = new Date();
+    await db
+      .update(mileageLegsTable)
+      .set({
+        status: "discarded",
+        discarded_at: now,
+        discarded_by_user_id: userId,
+        discard_reason: reason,
+        updated_at: now,
+      })
+      .where(
+        and(
+          eq(mileageLegsTable.company_id, companyId),
+          eq(mileageLegsTable.id, legId),
+        ),
+      );
+    return res.json({ data: { id: legId, status: "discarded" } });
+  },
+);
+
+/** Promote ONE reviewed leg to a pay_adjustments row. Atomic at the
+ *  app level: INSERT the adjustment, then UPDATE the leg with the
+ *  bridge id + applied state. The leg's status='reviewed' precondition
+ *  + the period-state check upstream prevent double-apply (a second
+ *  call observes status='applied' and refuses). */
+async function applyLegInternal(
+  companyId: number,
+  actingUserId: number,
+  leg: typeof mileageLegsTable.$inferSelect,
+): Promise<{ leg_id: number; pay_adjustment_id: number }> {
+  const inserted = await db
+    .insert(payAdjustmentsTable)
+    .values({
+      company_id: companyId,
+      pay_period_id: leg.pay_period_id,
+      user_id: leg.user_id,
+      adjustment_type: MILEAGE_REIMBURSEMENT_ADJUSTMENT_TYPE,
+      amount: leg.amount, // already numeric(10,2) string from 2A
+      note: `mileage_leg #${leg.id}: ${leg.miles} mi × $${leg.rate_per_mile}/mi`,
+      created_by_user_id: actingUserId,
+    })
+    .returning({ id: payAdjustmentsTable.id });
+  const adjustmentId = inserted[0]!.id;
+  const now = new Date();
+  await db
+    .update(mileageLegsTable)
+    .set({
+      status: "applied",
+      applied_at: now,
+      applied_pay_adjustment_id: adjustmentId,
+      updated_at: now,
+    })
+    .where(
+      and(
+        eq(mileageLegsTable.company_id, companyId),
+        eq(mileageLegsTable.id, leg.id),
+      ),
+    );
+  return { leg_id: leg.id, pay_adjustment_id: adjustmentId };
+}
+
+router.post(
+  "/mileage-legs/:id/apply",
+  adminWriteGate,
+  async (req, res) => {
+    const companyId = req.auth!.companyId!;
+    const userId = req.auth!.userId!;
+    const legId = Number(req.params.id);
+    if (!Number.isFinite(legId)) return badRequest(res, "Invalid id");
+    const leg = await loadLegOrNotFound(companyId, legId);
+    if (!leg) return notFound(res, "Mileage leg not found");
+
+    const refusal = refusalForTransition(
+      leg.status as MileageLegStatus,
+      "apply",
+    );
+    if (refusal) {
+      return res.status(409).json({
+        error: "Conflict",
+        message: refusal,
+        code: "leg_state_invalid",
+      });
+    }
+    // Period state gate. Mirrors 1E's adjustments write rule: no
+    // money moves into a period that's already approved or exported.
+    const period = await loadPeriod(companyId, leg.pay_period_id);
+    if (!period) return notFound(res, "Period not found");
+    if (period.status === "approved" || period.status === "exported") {
+      return refusedDueToPeriodState(res, period.status);
+    }
+
+    const result = await applyLegInternal(companyId, userId, leg);
+    return res.json({ data: { ...result, status: "applied" } });
+  },
+);
+
+router.post(
+  "/periods/:id/mileage-legs/apply-all-reviewed",
+  adminWriteGate,
+  async (req, res) => {
+    const companyId = req.auth!.companyId!;
+    const userId = req.auth!.userId!;
+    const periodId = Number(req.params.id);
+    if (!Number.isFinite(periodId)) return badRequest(res, "Invalid id");
+    const period = await loadPeriod(companyId, periodId);
+    if (!period) return notFound(res, "Period not found");
+    if (period.status === "approved" || period.status === "exported") {
+      return refusedDueToPeriodState(res, period.status);
+    }
+    const reviewedLegs = await db
+      .select()
+      .from(mileageLegsTable)
+      .where(
+        and(
+          eq(mileageLegsTable.company_id, companyId),
+          eq(mileageLegsTable.pay_period_id, periodId),
+          eq(mileageLegsTable.status, "reviewed"),
+        ),
+      );
+    const applied: Array<{ leg_id: number; pay_adjustment_id: number }> = [];
+    for (const leg of reviewedLegs) {
+      const r = await applyLegInternal(companyId, userId, leg);
+      applied.push(r);
+    }
+    return res.json({
+      data: { applied_count: applied.length, applied },
+    });
+  },
+);
 
 export default router;

--- a/artifacts/api-server/src/tests/cutover-2b-mileage-approval.test.ts
+++ b/artifacts/api-server/src/tests/cutover-2b-mileage-approval.test.ts
@@ -1,0 +1,376 @@
+/**
+ * Cutover 2B — Mileage approval gate tests.
+ *
+ * Pure unit tests for the 2B logic. The route's DB I/O is exercised
+ * indirectly through the helpers it composes; the route SOURCE is
+ * file-grep'd for the load-bearing assertions (apply creates one
+ * pay_adjustment + bridge id, discard never inserts, apply blocks
+ * approved/exported periods).
+ *
+ * What this suite defends:
+ *
+ *   A. Lifecycle transitions — every (from, action) pair returns
+ *      the right allow/refuse, including the terminal applied +
+ *      discarded states.
+ *   B. Carpool detection — groups by (date, from_job, to_job),
+ *      only surfaces multi-tech groups, ignores applied + discarded.
+ *   C. Apply contract — route source proves apply INSERTs exactly
+ *      one pay_adjustments row with type 'mileage_reimbursement',
+ *      sets applied_pay_adjustment_id, transitions status to
+ *      'applied'.
+ *   D. Discard contract — route source proves discard does NOT
+ *      insert into pay_adjustments.
+ *   E. Period-state gate — apply (single + batch) refuses on
+ *      approved/exported periods.
+ *   F. Auth gating — apply requires admin role.
+ *   G. Provider neutrality — 2B files contain no payroll vendor.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import {
+  refusalForTransition,
+  detectCarpoolCandidates,
+  MILEAGE_REIMBURSEMENT_ADJUSTMENT_TYPE,
+  type LegForCarpoolCheck,
+} from "../lib/mileage-approval.js";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// A. Lifecycle transitions
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("Cutover 2B — lifecycle transitions", () => {
+  it("computed → review allowed; reviewed → review refused", () => {
+    assert.equal(refusalForTransition("computed", "review"), null);
+    assert.match(
+      refusalForTransition("reviewed", "review")!,
+      /only computed legs/i,
+    );
+  });
+
+  it("computed → discard allowed; reviewed → discard allowed", () => {
+    assert.equal(refusalForTransition("computed", "discard"), null);
+    assert.equal(refusalForTransition("reviewed", "discard"), null);
+  });
+
+  it("reviewed → apply allowed; computed → apply REFUSED (must review first)", () => {
+    assert.equal(refusalForTransition("reviewed", "apply"), null);
+    assert.match(
+      refusalForTransition("computed", "apply")!,
+      /only reviewed legs can be applied/i,
+    );
+  });
+
+  it("applied is terminal — every action refused", () => {
+    for (const action of ["review", "discard", "apply"] as const) {
+      const r = refusalForTransition("applied", action);
+      assert.ok(r, `applied → ${action} must be refused`);
+      assert.match(r!, /already applied/i);
+    }
+  });
+
+  it("discarded is terminal — every action refused", () => {
+    for (const action of ["review", "discard", "apply"] as const) {
+      const r = refusalForTransition("discarded", action);
+      assert.ok(r, `discarded → ${action} must be refused`);
+      assert.match(r!, /terminal/i);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// B. Carpool detection
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("Cutover 2B — carpool candidate detection", () => {
+  const baseLeg = (
+    over: Partial<LegForCarpoolCheck>,
+  ): LegForCarpoolCheck => ({
+    id: 1,
+    user_id: 1,
+    leg_date: "2026-05-20",
+    from_job_id: 100,
+    to_job_id: 200,
+    status: "computed",
+    ...over,
+  });
+
+  it("two techs, same date + same job pair → ONE candidate", () => {
+    const legs: LegForCarpoolCheck[] = [
+      baseLeg({ id: 1, user_id: 11 }),
+      baseLeg({ id: 2, user_id: 22 }),
+    ];
+    const out = detectCarpoolCandidates(legs);
+    assert.equal(out.length, 1);
+    assert.equal(out[0]!.tech_count, 2);
+    assert.equal(out[0]!.legs.length, 2);
+  });
+
+  it("same tech with two legs same date/pair → NOT a candidate (single tech)", () => {
+    const legs: LegForCarpoolCheck[] = [
+      baseLeg({ id: 1, user_id: 11 }),
+      baseLeg({ id: 2, user_id: 11 }),
+    ];
+    assert.equal(detectCarpoolCandidates(legs).length, 0);
+  });
+
+  it("different days with same pair → NOT a candidate", () => {
+    const legs: LegForCarpoolCheck[] = [
+      baseLeg({ id: 1, user_id: 11, leg_date: "2026-05-20" }),
+      baseLeg({ id: 2, user_id: 22, leg_date: "2026-05-21" }),
+    ];
+    assert.equal(detectCarpoolCandidates(legs).length, 0);
+  });
+
+  it("different job pairs same day → NOT a candidate", () => {
+    const legs: LegForCarpoolCheck[] = [
+      baseLeg({ id: 1, user_id: 11, to_job_id: 200 }),
+      baseLeg({ id: 2, user_id: 22, to_job_id: 300 }),
+    ];
+    assert.equal(detectCarpoolCandidates(legs).length, 0);
+  });
+
+  it("applied + discarded legs are EXCLUDED from carpool consideration", () => {
+    // Two techs would normally trigger, but one is already applied
+    // and the other discarded — both decided, no decision left for
+    // the office to make.
+    const legs: LegForCarpoolCheck[] = [
+      baseLeg({ id: 1, user_id: 11, status: "applied" }),
+      baseLeg({ id: 2, user_id: 22, status: "discarded" }),
+    ];
+    assert.equal(detectCarpoolCandidates(legs).length, 0);
+  });
+
+  it("mixed: one applied + one reviewed + one computed (different techs) → 1 candidate of size 2", () => {
+    const legs: LegForCarpoolCheck[] = [
+      baseLeg({ id: 1, user_id: 11, status: "applied" }),
+      baseLeg({ id: 2, user_id: 22, status: "reviewed" }),
+      baseLeg({ id: 3, user_id: 33, status: "computed" }),
+    ];
+    const out = detectCarpoolCandidates(legs);
+    assert.equal(out.length, 1);
+    assert.equal(out[0]!.tech_count, 2); // applied excluded
+  });
+
+  it("three techs same leg → tech_count = 3", () => {
+    const legs: LegForCarpoolCheck[] = [
+      baseLeg({ id: 1, user_id: 11 }),
+      baseLeg({ id: 2, user_id: 22 }),
+      baseLeg({ id: 3, user_id: 33 }),
+    ];
+    const out = detectCarpoolCandidates(legs);
+    assert.equal(out.length, 1);
+    assert.equal(out[0]!.tech_count, 3);
+  });
+
+  it("candidates sorted by leg_date ascending", () => {
+    const legs: LegForCarpoolCheck[] = [
+      baseLeg({ id: 1, user_id: 11, leg_date: "2026-05-22", to_job_id: 200 }),
+      baseLeg({ id: 2, user_id: 22, leg_date: "2026-05-22", to_job_id: 200 }),
+      baseLeg({ id: 3, user_id: 11, leg_date: "2026-05-20", to_job_id: 201 }),
+      baseLeg({ id: 4, user_id: 22, leg_date: "2026-05-20", to_job_id: 201 }),
+    ];
+    const out = detectCarpoolCandidates(legs);
+    assert.equal(out.length, 2);
+    assert.equal(out[0]!.leg_date, "2026-05-20");
+    assert.equal(out[1]!.leg_date, "2026-05-22");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// C. Apply contract — file-grep on route source
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("Cutover 2B — apply contract (route source)", () => {
+  const src = readFileSync(
+    path.resolve(process.cwd(), "src/routes/pay.ts"),
+    "utf8",
+  );
+
+  it("applyLegInternal INSERTs into payAdjustmentsTable", () => {
+    const fnMatch = src.match(
+      /async function applyLegInternal\([\s\S]+?\n\}/,
+    );
+    assert.ok(fnMatch, "applyLegInternal function body not found");
+    assert.match(fnMatch![0], /\.insert\(payAdjustmentsTable\)/);
+  });
+
+  it("applyLegInternal uses MILEAGE_REIMBURSEMENT_ADJUSTMENT_TYPE", () => {
+    const fnMatch = src.match(
+      /async function applyLegInternal\([\s\S]+?\n\}/,
+    );
+    assert.match(
+      fnMatch![0],
+      /adjustment_type:\s*MILEAGE_REIMBURSEMENT_ADJUSTMENT_TYPE/,
+    );
+  });
+
+  it("applyLegInternal sets applied_pay_adjustment_id on the leg", () => {
+    const fnMatch = src.match(
+      /async function applyLegInternal\([\s\S]+?\n\}/,
+    );
+    assert.match(fnMatch![0], /applied_pay_adjustment_id:\s*adjustmentId/);
+    assert.match(fnMatch![0], /status:\s*"applied"/);
+  });
+
+  it("apply (single + batch) is admin-only via adminWriteGate", () => {
+    assert.match(
+      src,
+      /router\.post\(\s*\n?\s*"\/mileage-legs\/:id\/apply",\s*\n?\s*adminWriteGate/,
+    );
+    assert.match(
+      src,
+      /router\.post\(\s*\n?\s*"\/periods\/:id\/mileage-legs\/apply-all-reviewed",\s*\n?\s*adminWriteGate/,
+    );
+  });
+
+  it("MILEAGE_REIMBURSEMENT_ADJUSTMENT_TYPE is a distinct slug", () => {
+    assert.equal(MILEAGE_REIMBURSEMENT_ADJUSTMENT_TYPE, "mileage_reimbursement");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// D. Discard contract — never pays
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("Cutover 2B — discard never pays", () => {
+  const src = readFileSync(
+    path.resolve(process.cwd(), "src/routes/pay.ts"),
+    "utf8",
+  );
+
+  it("discard endpoint body does NOT insert into pay_adjustments", () => {
+    const m = src.match(
+      /router\.post\(\s*\n?\s*"\/mileage-legs\/:id\/discard"[\s\S]+?^\);/m,
+    );
+    assert.ok(m, "discard route not found");
+    assert.ok(
+      !/insert\(payAdjustmentsTable\)/.test(m![0]),
+      "discard must not write into pay_adjustments — money never moves on discard",
+    );
+  });
+
+  it("discard requires a non-empty reason", () => {
+    const m = src.match(
+      /router\.post\(\s*\n?\s*"\/mileage-legs\/:id\/discard"[\s\S]+?^\);/m,
+    );
+    assert.match(m![0], /reason is required for discard/);
+  });
+
+  it("discard records discarded_by_user_id + discard_reason", () => {
+    const m = src.match(
+      /router\.post\(\s*\n?\s*"\/mileage-legs\/:id\/discard"[\s\S]+?^\);/m,
+    );
+    assert.match(m![0], /discarded_by_user_id:\s*userId/);
+    assert.match(m![0], /discard_reason:\s*reason/);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// E. Period-state gate — apply refuses on approved/exported
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("Cutover 2B — apply blocked on approved/exported periods", () => {
+  const src = readFileSync(
+    path.resolve(process.cwd(), "src/routes/pay.ts"),
+    "utf8",
+  );
+
+  it("single-leg apply checks period state before money moves", () => {
+    const m = src.match(
+      /router\.post\(\s*\n?\s*"\/mileage-legs\/:id\/apply"[\s\S]+?^\);/m,
+    );
+    assert.ok(m, "apply route not found");
+    assert.match(m![0], /period\.status === "approved" \|\| period\.status === "exported"/);
+    assert.match(m![0], /refusedDueToPeriodState/);
+  });
+
+  it("batch apply-all-reviewed checks period state up front", () => {
+    const m = src.match(
+      /router\.post\(\s*\n?\s*"\/periods\/:id\/mileage-legs\/apply-all-reviewed"[\s\S]+?^\);/m,
+    );
+    assert.ok(m, "batch apply route not found");
+    assert.match(m![0], /period\.status === "approved" \|\| period\.status === "exported"/);
+    assert.match(m![0], /refusedDueToPeriodState/);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// F. Auth gating
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("Cutover 2B — auth gating", () => {
+  const src = readFileSync(
+    path.resolve(process.cwd(), "src/routes/pay.ts"),
+    "utf8",
+  );
+
+  it("review + discard are office-tier (router-level officeReadGate)", () => {
+    // review + discard are not adminWriteGate'd explicitly — they
+    // inherit the file-level officeReadGate which excludes 'technician'
+    // and 'team_lead'. That's correct: office staff can triage but
+    // only owners/admins press the money button.
+    assert.match(
+      src,
+      /const officeReadGate = requireRole\("owner", "admin", "office", "super_admin"\)/,
+    );
+    assert.match(src, /router\.use\(requireAuth, officeReadGate\)/);
+    // Sanity: review + discard do NOT pass adminWriteGate.
+    const review = src.match(
+      /router\.post\(\s*\n?\s*"\/mileage-legs\/:id\/review",\s*[\s\S]+?^\);/m,
+    );
+    assert.ok(review);
+    assert.ok(
+      !/adminWriteGate/.test(review![0]),
+      "review should NOT add adminWriteGate — office can mark reviewed",
+    );
+  });
+
+  it("apply (single + batch) DOES pass adminWriteGate", () => {
+    assert.match(
+      src,
+      /"\/mileage-legs\/:id\/apply",\s*\n?\s*adminWriteGate/,
+    );
+    assert.match(
+      src,
+      /"\/periods\/:id\/mileage-legs\/apply-all-reviewed",\s*\n?\s*adminWriteGate/,
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// G. Provider neutrality — 2B files
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("Cutover 2B — provider neutrality", () => {
+  const PAYROLL_VENDOR_BLOCKLIST = [
+    "adp",
+    "gusto",
+    "paychex",
+    "quickbooks payroll",
+    "workday",
+    "paylocity",
+    "rippling",
+    "paycom",
+    "trinet",
+    "namely",
+    "bamboohr",
+    "zenefits",
+    "justworks",
+  ];
+
+  it("src/lib/mileage-approval.ts contains no payroll-vendor name", () => {
+    const src = readFileSync(
+      path.resolve(process.cwd(), "src/lib/mileage-approval.ts"),
+      "utf8",
+    ).toLowerCase();
+    for (const v of PAYROLL_VENDOR_BLOCKLIST) {
+      const re = new RegExp(`\\b${v.replace(/ /g, "\\s+")}\\b`, "i");
+      assert.ok(
+        !re.test(src),
+        `mileage-approval.ts contains vendor "${v}"`,
+      );
+    }
+  });
+});

--- a/artifacts/qleno/src/App.tsx
+++ b/artifacts/qleno/src/App.tsx
@@ -20,6 +20,7 @@ const InvoicesPage        = lazy(() => import("@/pages/invoices"));
 const CompanyPage         = lazy(() => import("@/pages/company"));
 const LoyaltyPage         = lazy(() => import("@/pages/loyalty"));
 const PayrollPage         = lazy(() => import("@/pages/payroll"));
+const MileageReviewPage   = lazy(() => import("@/pages/mileage-review"));
 const CleancyclopediaPage = lazy(() => import("@/pages/cleancyclopedia"));
 const DiscountsRedirect   = lazy(() => Promise.resolve({ default: () => { window.location.replace((import.meta.env.BASE_URL.replace(/\/$/, "")) + "/company?tab=pricing"); return null; } }));
 const MyJobsPage          = lazy(() => import("@/pages/my-jobs"));
@@ -128,6 +129,7 @@ function Router() {
         <Route path="/invoices/:id" component={InvoiceDetailPage} />
         <Route path="/invoices" component={InvoicesPage} />
         <Route path="/payroll" component={PayrollPage} />
+        <Route path="/payroll/mileage-review" component={MileageReviewPage} />
         <Route path="/cleancyclopedia" component={CleancyclopediaPage} />
         <Route path="/company" component={CompanyPage} />
         <Route path="/loyalty" component={LoyaltyPage} />

--- a/artifacts/qleno/src/pages/mileage-review.tsx
+++ b/artifacts/qleno/src/pages/mileage-review.tsx
@@ -1,0 +1,508 @@
+/**
+ * Cutover 2B — Mileage review screen.
+ *
+ * Office surface for the mileage approval gate. Lists every
+ * mileage_leg in a chosen pay period grouped by tech with totals and
+ * flags, exposes per-leg Review / Discard / Apply actions, and
+ * surfaces carpool candidates (same date + same job pair, multiple
+ * techs) at the top so the office discards duplicates before
+ * applying.
+ *
+ * Mounted at /payroll/mileage-review. Read open period from
+ * ?periodId=… or prompt the user to pick one.
+ *
+ * Visual: brand colors only (Plus Jakarta Sans, #F7F6F3 background,
+ * #FFFFFF cards, mint accent for the "apply" CTA). No emojis.
+ */
+import { useEffect, useMemo, useState } from "react";
+import { DashboardLayout } from "@/components/layout/dashboard-layout";
+import { useToast } from "@/hooks/use-toast";
+
+const FF = "'Plus Jakarta Sans', sans-serif";
+const BRAND = "#00C9A0";
+const INK = "#1A1917";
+const MUTED = "#9E9B94";
+const BG = "#F7F6F3";
+const CARD = "#FFFFFF";
+const BORDER = "#E5E2DC";
+const FLAG = "#BA7517";
+const DANGER = "#DC2626";
+
+type LegStatus = "computed" | "reviewed" | "applied" | "discarded";
+
+type Leg = {
+  id: number;
+  user_id: number;
+  first_name: string | null;
+  last_name: string | null;
+  leg_date: string;
+  from_job_id: number;
+  to_job_id: number;
+  miles: string;
+  minutes: number;
+  rate_per_mile: string;
+  amount: string;
+  measurement_source: string;
+  measurement_is_estimated: boolean;
+  status: LegStatus;
+};
+
+type TechSummary = {
+  user_id: number;
+  first_name: string | null;
+  last_name: string | null;
+  computed_count: number;
+  reviewed_count: number;
+  applied_count: number;
+  discarded_count: number;
+  pending_amount_cents: number;
+  applied_amount_cents: number;
+  flag_count: number;
+};
+
+type Period = {
+  id: number;
+  start_date: string;
+  end_date: string;
+  status: "open" | "locked" | "approved" | "exported";
+};
+
+type CarpoolCandidate = {
+  leg_date: string;
+  from_job_id: number;
+  to_job_id: number;
+  legs: Array<{ id: number; user_id: number; status: LegStatus }>;
+  tech_count: number;
+};
+
+function formatCents(cents: number): string {
+  const sign = cents < 0 ? "-" : "";
+  const abs = Math.abs(cents);
+  return `${sign}$${(abs / 100).toFixed(2)}`;
+}
+function fmtRate(r: string): string {
+  return `$${Number(r).toFixed(4)}/mi`;
+}
+function techName(t: { first_name: string | null; last_name: string | null }): string {
+  return [t.first_name, t.last_name].filter(Boolean).join(" ") || "—";
+}
+
+export default function MileageReviewPage() {
+  const { toast } = useToast();
+  const periodIdFromUrl = (() => {
+    const p = new URLSearchParams(window.location.search).get("periodId");
+    return p ? Number(p) : null;
+  })();
+
+  const [periods, setPeriods] = useState<Period[]>([]);
+  const [periodId, setPeriodId] = useState<number | null>(periodIdFromUrl);
+  const [legs, setLegs] = useState<Leg[]>([]);
+  const [techs, setTechs] = useState<TechSummary[]>([]);
+  const [period, setPeriod] = useState<Period | null>(null);
+  const [carpools, setCarpools] = useState<CarpoolCandidate[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [busyLegId, setBusyLegId] = useState<number | null>(null);
+
+  // Load periods.
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await fetch("/api/pay/periods", { credentials: "include" });
+        const json = await res.json();
+        setPeriods(json.data ?? []);
+        if (periodId == null && json.data && json.data[0]) {
+          setPeriodId(json.data[0].id);
+        }
+      } catch (e) {
+        toast({ title: "Could not load periods", variant: "destructive" });
+      }
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Load legs + carpool candidates for the chosen period.
+  useEffect(() => {
+    if (periodId == null) return;
+    loadPeriodLegs(periodId);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [periodId]);
+
+  async function loadPeriodLegs(id: number) {
+    setLoading(true);
+    try {
+      const [legsRes, carpoolRes] = await Promise.all([
+        fetch(`/api/pay/periods/${id}/mileage-legs`, { credentials: "include" }),
+        fetch(`/api/pay/periods/${id}/mileage-carpool-candidates`, { credentials: "include" }),
+      ]);
+      const legsJson = await legsRes.json();
+      const carpoolJson = await carpoolRes.json();
+      setLegs(legsJson.data?.legs ?? []);
+      setTechs(legsJson.data?.techs ?? []);
+      setPeriod(legsJson.data?.period ?? null);
+      setCarpools(carpoolJson.data?.candidates ?? []);
+    } catch (e) {
+      toast({ title: "Could not load mileage legs", variant: "destructive" });
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function postLegAction(
+    legId: number,
+    action: "review" | "discard" | "apply",
+    body?: Record<string, unknown>,
+  ) {
+    setBusyLegId(legId);
+    try {
+      const res = await fetch(`/api/pay/mileage-legs/${legId}/${action}`, {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: body ? JSON.stringify(body) : undefined,
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        toast({
+          title: err?.message || `${action} failed`,
+          variant: "destructive",
+        });
+        return;
+      }
+      if (periodId != null) await loadPeriodLegs(periodId);
+    } catch (e) {
+      toast({ title: `${action} failed`, variant: "destructive" });
+    } finally {
+      setBusyLegId(null);
+    }
+  }
+
+  async function applyAllReviewed() {
+    if (periodId == null) return;
+    if (!confirm("Apply ALL reviewed legs in this period? This creates pay adjustments.")) return;
+    try {
+      const res = await fetch(
+        `/api/pay/periods/${periodId}/mileage-legs/apply-all-reviewed`,
+        { method: "POST", credentials: "include" },
+      );
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        toast({
+          title: err?.message || "Apply batch failed",
+          variant: "destructive",
+        });
+        return;
+      }
+      const json = await res.json();
+      toast({
+        title: `Applied ${json.data?.applied_count ?? 0} legs`,
+      });
+      await loadPeriodLegs(periodId);
+    } catch {
+      toast({ title: "Apply batch failed", variant: "destructive" });
+    }
+  }
+
+  const techsById = useMemo(() => {
+    const m = new Map<number, TechSummary>();
+    for (const t of techs) m.set(t.user_id, t);
+    return m;
+  }, [techs]);
+
+  const legsByTech = useMemo(() => {
+    const m = new Map<number, Leg[]>();
+    for (const l of legs) {
+      const arr = m.get(l.user_id) ?? [];
+      arr.push(l);
+      m.set(l.user_id, arr);
+    }
+    return m;
+  }, [legs]);
+
+  const periodLocked =
+    period?.status === "approved" || period?.status === "exported";
+
+  return (
+    <DashboardLayout>
+      <div style={{ fontFamily: FF, color: INK, padding: "8px 0 32px" }}>
+        <div style={{ display: "flex", alignItems: "baseline", gap: 12, marginBottom: 8 }}>
+          <h1 style={{ fontSize: 22, fontWeight: 800, margin: 0 }}>Mileage Review</h1>
+          <div style={{ fontSize: 12, color: MUTED }}>
+            Computed mileage is not pay until applied here.
+          </div>
+        </div>
+
+        {/* Period picker */}
+        <div style={{ display: "flex", alignItems: "center", gap: 12, marginBottom: 16 }}>
+          <label style={{ fontSize: 12, color: MUTED, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.05em" }}>
+            Period
+          </label>
+          <select
+            value={periodId ?? ""}
+            onChange={(e) => setPeriodId(Number(e.target.value) || null)}
+            style={{
+              fontFamily: FF, fontSize: 14, fontWeight: 600, color: INK,
+              border: `1px solid ${BORDER}`, borderRadius: 8,
+              padding: "6px 10px", background: CARD,
+            }}
+          >
+            <option value="">— pick a period —</option>
+            {periods.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.start_date} → {p.end_date} ({p.status})
+              </option>
+            ))}
+          </select>
+          {periodLocked && (
+            <div style={{ fontSize: 12, color: DANGER, fontWeight: 700 }}>
+              Period is {period!.status} — apply is blocked.
+            </div>
+          )}
+          {!periodLocked && period && (
+            <button
+              onClick={applyAllReviewed}
+              style={{
+                marginLeft: "auto",
+                fontFamily: FF, fontSize: 13, fontWeight: 700,
+                color: "#FFFFFF", backgroundColor: BRAND,
+                border: "none", borderRadius: 8, padding: "8px 14px",
+                cursor: "pointer",
+              }}
+            >
+              Apply all reviewed
+            </button>
+          )}
+        </div>
+
+        {/* Carpool candidates */}
+        {carpools.length > 0 && (
+          <div
+            style={{
+              backgroundColor: CARD, border: `1.5px solid ${FLAG}`, borderRadius: 10,
+              padding: "12px 14px", marginBottom: 16,
+            }}
+          >
+            <div style={{ fontSize: 13, fontWeight: 800, color: FLAG, marginBottom: 6 }}>
+              {carpools.length} carpool candidate{carpools.length === 1 ? "" : "s"} — review before applying
+            </div>
+            <div style={{ fontSize: 12, color: MUTED, marginBottom: 10 }}>
+              Multiple techs have legs for the same route on the same day. Discard duplicates that didn't actually drive.
+            </div>
+            {carpools.map((c, i) => (
+              <div key={i} style={{ marginTop: i === 0 ? 0 : 10, paddingTop: i === 0 ? 0 : 10, borderTop: i === 0 ? "none" : `1px solid ${BORDER}` }}>
+                <div style={{ fontSize: 12, color: INK, fontWeight: 700 }}>
+                  {c.leg_date} · Job #{c.from_job_id} → Job #{c.to_job_id} · {c.tech_count} techs
+                </div>
+                <div style={{ fontSize: 12, color: MUTED, marginTop: 4 }}>
+                  Legs: {c.legs.map((l) => `#${l.id} (${techName(techsById.get(l.user_id) ?? { first_name: null, last_name: null })}, ${l.status})`).join(" · ")}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Per-tech sections */}
+        {loading ? (
+          <div style={{ color: MUTED, fontSize: 13 }}>Loading…</div>
+        ) : techs.length === 0 ? (
+          <div style={{ color: MUTED, fontSize: 13 }}>
+            No mileage legs in this period yet. Recompute from the period detail page first.
+          </div>
+        ) : (
+          techs.map((t) => (
+            <TechSection
+              key={t.user_id}
+              tech={t}
+              legs={legsByTech.get(t.user_id) ?? []}
+              periodLocked={periodLocked}
+              busyLegId={busyLegId}
+              onReview={(id) => postLegAction(id, "review")}
+              onDiscard={(id) => {
+                const reason = prompt("Discard reason (required):") ?? "";
+                if (!reason.trim()) return;
+                postLegAction(id, "discard", { reason: reason.trim() });
+              }}
+              onApply={(id) => postLegAction(id, "apply")}
+            />
+          ))
+        )}
+      </div>
+    </DashboardLayout>
+  );
+}
+
+function TechSection({
+  tech,
+  legs,
+  periodLocked,
+  busyLegId,
+  onReview,
+  onDiscard,
+  onApply,
+}: {
+  tech: TechSummary;
+  legs: Leg[];
+  periodLocked: boolean;
+  busyLegId: number | null;
+  onReview: (id: number) => void;
+  onDiscard: (id: number) => void;
+  onApply: (id: number) => void;
+}) {
+  return (
+    <div
+      style={{
+        backgroundColor: CARD, border: `1px solid ${BORDER}`, borderRadius: 10,
+        padding: "14px 16px", marginBottom: 14,
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "baseline", gap: 12, marginBottom: 10 }}>
+        <div style={{ fontSize: 15, fontWeight: 800, color: INK }}>
+          {techName(tech)}
+        </div>
+        <div style={{ fontSize: 12, color: MUTED }}>
+          {tech.computed_count} pending review · {tech.reviewed_count} reviewed · {tech.applied_count} applied · {tech.discarded_count} discarded
+        </div>
+        <div style={{ marginLeft: "auto", fontSize: 13, fontWeight: 700, color: INK }}>
+          Pending {formatCents(tech.pending_amount_cents)} · Applied {formatCents(tech.applied_amount_cents)}
+        </div>
+        {tech.flag_count > 0 && (
+          <div style={{ fontSize: 12, fontWeight: 700, color: FLAG }}>
+            {tech.flag_count} flag{tech.flag_count === 1 ? "" : "s"}
+          </div>
+        )}
+      </div>
+      <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 12 }}>
+        <thead>
+          <tr style={{ color: MUTED, textAlign: "left", fontSize: 11, textTransform: "uppercase", letterSpacing: "0.05em" }}>
+            <th style={{ padding: "6px 8px", fontWeight: 700 }}>Date</th>
+            <th style={{ padding: "6px 8px", fontWeight: 700 }}>From → To</th>
+            <th style={{ padding: "6px 8px", fontWeight: 700 }}>Miles</th>
+            <th style={{ padding: "6px 8px", fontWeight: 700 }}>Rate</th>
+            <th style={{ padding: "6px 8px", fontWeight: 700, textAlign: "right" }}>Amount</th>
+            <th style={{ padding: "6px 8px", fontWeight: 700 }}>Status</th>
+            <th style={{ padding: "6px 8px", fontWeight: 700, textAlign: "right" }}>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {legs.map((l) => (
+            <tr key={l.id} style={{ borderTop: `1px solid ${BORDER}` }}>
+              <td style={{ padding: "8px", color: INK, fontWeight: 600 }}>{l.leg_date}</td>
+              <td style={{ padding: "8px", color: INK }}>
+                Job #{l.from_job_id} → #{l.to_job_id}
+                {l.measurement_is_estimated && (
+                  <span style={{ marginLeft: 8, fontSize: 10, fontWeight: 700, color: FLAG, padding: "1px 6px", border: `1px solid ${FLAG}`, borderRadius: 3 }}>
+                    ESTIMATED
+                  </span>
+                )}
+              </td>
+              <td style={{ padding: "8px", color: INK }}>{l.miles}</td>
+              <td style={{ padding: "8px", color: MUTED }}>{fmtRate(l.rate_per_mile)}</td>
+              <td style={{ padding: "8px", textAlign: "right", fontWeight: 700, color: INK }}>
+                ${Number(l.amount).toFixed(2)}
+              </td>
+              <td style={{ padding: "8px" }}>
+                <StatusPill status={l.status} />
+              </td>
+              <td style={{ padding: "8px", textAlign: "right" }}>
+                <LegActions
+                  leg={l}
+                  busy={busyLegId === l.id}
+                  periodLocked={periodLocked}
+                  onReview={onReview}
+                  onDiscard={onDiscard}
+                  onApply={onApply}
+                />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function StatusPill({ status }: { status: LegStatus }) {
+  const styles: Record<
+    LegStatus,
+    { bg: string; fg: string; label: string }
+  > = {
+    computed: { bg: "#F0EEE9", fg: "#6B6860", label: "Computed" },
+    reviewed: { bg: "#E5F7F2", fg: "#0A7A60", label: "Reviewed" },
+    applied: { bg: "#D6F4E9", fg: "#0A5C3E", label: "Applied" },
+    discarded: { bg: "#FCE7E7", fg: "#991B1B", label: "Discarded" },
+  };
+  const s = styles[status];
+  return (
+    <span
+      style={{
+        fontSize: 10, fontWeight: 800, letterSpacing: "0.05em",
+        backgroundColor: s.bg, color: s.fg,
+        padding: "2px 8px", borderRadius: 10, textTransform: "uppercase",
+      }}
+    >
+      {s.label}
+    </span>
+  );
+}
+
+function LegActions({
+  leg,
+  busy,
+  periodLocked,
+  onReview,
+  onDiscard,
+  onApply,
+}: {
+  leg: Leg;
+  busy: boolean;
+  periodLocked: boolean;
+  onReview: (id: number) => void;
+  onDiscard: (id: number) => void;
+  onApply: (id: number) => void;
+}) {
+  const btnBase: React.CSSProperties = {
+    fontFamily: FF, fontSize: 11, fontWeight: 700,
+    border: `1px solid ${BORDER}`, borderRadius: 6,
+    padding: "4px 10px", marginLeft: 6, cursor: "pointer",
+    backgroundColor: CARD, color: INK,
+  };
+  const disabled: React.CSSProperties = { opacity: 0.4, cursor: "not-allowed" };
+
+  if (leg.status === "applied" || leg.status === "discarded") {
+    return <span style={{ color: MUTED, fontSize: 11 }}>—</span>;
+  }
+  return (
+    <>
+      {leg.status === "computed" && (
+        <button
+          onClick={() => onReview(leg.id)}
+          disabled={busy}
+          style={{ ...btnBase, ...(busy ? disabled : {}) }}
+        >
+          Mark reviewed
+        </button>
+      )}
+      {leg.status === "reviewed" && (
+        <button
+          onClick={() => onApply(leg.id)}
+          disabled={busy || periodLocked}
+          style={{
+            ...btnBase,
+            backgroundColor: periodLocked ? "#F0EEE9" : BRAND,
+            color: periodLocked ? MUTED : "#FFFFFF",
+            border: "none",
+            ...(busy || periodLocked ? disabled : {}),
+          }}
+        >
+          Apply
+        </button>
+      )}
+      <button
+        onClick={() => onDiscard(leg.id)}
+        disabled={busy}
+        style={{ ...btnBase, color: DANGER, borderColor: "#F5D2D2", ...(busy ? disabled : {}) }}
+      >
+        Discard
+      </button>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

Cutover 2B — the office workflow that turns 2A's computed `mileage_legs` into actual pay via the `applied_pay_adjustment_id` bridge 2A left ready. Lifecycle is `computed → reviewed → applied | discarded`. **Money only moves on `apply`**, and only when the period is open/locked (never approved/exported).

## Endpoints

| Method | Path | Gate | Effect |
|---|---|---|---|
| `GET` | `/api/pay/periods/:id/mileage-legs` | office | Per-tech grouped list + totals + flag counts |
| `GET` | `/api/pay/periods/:id/mileage-carpool-candidates` | office | Same date + same job pair + multiple techs |
| `POST` | `/api/pay/mileage-legs/:id/review` | office | `computed → reviewed` |
| `POST` | `/api/pay/mileage-legs/:id/discard` | office | `computed | reviewed → discarded` (reason required) |
| `POST` | `/api/pay/mileage-legs/:id/apply` | **admin** | `reviewed → applied`, INSERT `pay_adjustments`, set bridge |
| `POST` | `/api/pay/periods/:id/mileage-legs/apply-all-reviewed` | **admin** | Batch apply |

## The four load-bearing properties

1. **Apply creates exactly one `pay_adjustments` row** with `adjustment_type='mileage_reimbursement'` and writes `applied_pay_adjustment_id` back on the leg. Traceable both ways.
2. **Discard never pays** — no `INSERT` into `pay_adjustments` anywhere in the discard route.
3. **Apply is blocked on approved/exported periods** — both single and batch routes check `period.status` and return 409.
4. **Carpool reconciliation is surfaced, never auto-resolved** — same `(leg_date, from_job_id, to_job_id)` with multiple distinct techs gets flagged; the office decides which to discard before applying.

## Carpool detection

Groups by `(leg_date, from_job_id, to_job_id)` and keeps groups with ≥2 distinct `user_id`. Pre-decided rows (`applied`, `discarded`) are **excluded** so the queue stays focused on outstanding decisions. Mixed-status groups still surface as long as ≥2 undecided techs remain.

## Frontend

New page at **`/payroll/mileage-review`** — period picker, carpool candidate strip at top (warning treatment when present), per-tech sections with `Pending` / `Applied` totals + flag counts, per-leg row with status pill + Review/Discard/Apply actions. Apply CTA disabled and visually muted when period is locked. Plus Jakarta Sans + brand palette only; no emojis.

## Files

| Path | Role |
|---|---|
| `artifacts/api-server/src/lib/mileage-approval.ts` (NEW) | `refusalForTransition`, `detectCarpoolCandidates`, `MILEAGE_REIMBURSEMENT_ADJUSTMENT_TYPE` |
| `artifacts/api-server/src/routes/pay.ts` | +380 lines: 6 new endpoints + `applyLegInternal` |
| `artifacts/api-server/src/tests/cutover-2b-mileage-approval.test.ts` (NEW) | 33 tests |
| `artifacts/qleno/src/pages/mileage-review.tsx` (NEW) | Office review page |
| `artifacts/qleno/src/App.tsx` | Route registration |

## Verifications

- ✅ Typecheck: **796 errors** (baseline) — zero new
- ✅ Tests: **208 / 208 cutover tests pass** (33 new in 2B)
- ✅ Build: `pnpm build` succeeds (server + frontend)

## Test plan

- [x] Lifecycle: every `(from, action)` allow/refuse; applied + discarded terminal
- [x] Carpool: two-tech-same-pair surfaces; same-tech-twice does not; different days do not; applied + discarded excluded; tech_count correct; sorted by leg_date
- [x] Apply contract (route source): single INSERT into `pay_adjustments` with type `mileage_reimbursement`, sets `applied_pay_adjustment_id`, status → `applied`
- [x] Discard contract (route source): no INSERT into `pay_adjustments`; records `discarded_by_user_id` + `reason`
- [x] Period-state gate (single + batch): `approved` / `exported` return 409
- [x] Auth gating: apply behind `adminWriteGate`; review NOT
- [x] Provider neutrality: blocklist clean
- [ ] Staging smoke: run `recompute-mileage`, visit `/payroll/mileage-review`, mark one leg reviewed, apply it, verify `pay_adjustments` row exists with `mileage_reimbursement` type and the leg has `applied_pay_adjustment_id` set
- [ ] Staging smoke: try to apply on an approved period → 409
- [ ] Staging smoke: create carpool data (two techs, same `from_job → to_job` on same day) → both surface in candidate strip

## What 2B does NOT do

- **No re-open path.** Applied legs are terminal — to unwind, delete the `pay_adjustments` row via 1E's existing DELETE flow and recompute the period. Keeps the audit trail clean: one apply = one money-moved event.
- **No auto-carpool-resolution.** Office decides; UI surfaces.
- **No new money math.** Amounts ride straight off the 2A leg row (already integer cents persisted as `numeric(10,2)`).

https://claude.ai/code/session_013rJ4N4vgqZWB986x8D6Ahh

---
_Generated by [Claude Code](https://claude.ai/code/session_013rJ4N4vgqZWB986x8D6Ahh)_