### PR TITLE
feat(qb): Sprint F hardening — payment idempotency, customer dedup, Railway callback

### DIFF
--- a/artifacts/api-server/src/routes/integrations/quickbooks.ts
+++ b/artifacts/api-server/src/routes/integrations/quickbooks.ts
@@ -19,14 +19,24 @@ const QB_CLIENT_ID = process.env.QB_CLIENT_ID!;
 const QB_CLIENT_SECRET = process.env.QB_CLIENT_SECRET!;
 const JWT_SECRET = process.env.JWT_SECRET || "qleno-secret";
 
+function getPublicBase(req: any): string {
+  // Prefer the proxied / forwarded host (Railway sets x-forwarded-host),
+  // then req.host, then the Replit fallback. The proto follows the same chain.
+  const host =
+    (req.headers["x-forwarded-host"] as string) ||
+    (req.headers.host as string) ||
+    process.env.REPLIT_DEV_DOMAIN ||
+    "localhost";
+  const proto =
+    (req.headers["x-forwarded-proto"] as string) ||
+    (process.env.NODE_ENV === "production" ? "https" : "http");
+  return `${proto}://${host}`;
+}
+
 function getRedirectUri(req: any): string {
   // Prefer env-configured value for production
   if (process.env.QB_REDIRECT_URI) return process.env.QB_REDIRECT_URI;
-
-  // Construct from Replit domain
-  const domain = process.env.REPLIT_DEV_DOMAIN || req.headers["x-forwarded-host"] || req.headers.host || "localhost";
-  const proto = process.env.NODE_ENV === "production" ? "https" : "https";
-  return `${proto}://${domain}/qleno/api/integrations/quickbooks/callback`;
+  return `${getPublicBase(req)}/qleno/api/integrations/quickbooks/callback`;
 }
 
 // ── GET /api/integrations/quickbooks/connect ───────────────────────────────
@@ -54,9 +64,11 @@ router.get("/connect", requireAuth, requireRole("owner", "admin"), async (req, r
 
 // ── GET /api/integrations/quickbooks/callback ─────────────────────────────
 router.get("/callback", async (req, res) => {
-  const baseFrontend = process.env.REPLIT_DEV_DOMAIN
-    ? `https://${process.env.REPLIT_DEV_DOMAIN}/qleno`
-    : "";
+  // Derive the frontend base from the request (Railway-safe) instead of the
+  // legacy REPLIT_DEV_DOMAIN — an empty REPLIT_DEV_DOMAIN used to produce a
+  // relative redirect to `/company?...` that resolved under `/api/integrations/
+  // quickbooks/`, giving a broken success URL.
+  const baseFrontend = `${getPublicBase(req)}/qleno`;
 
   try {
     const { code, state, realmId } = req.query as Record<string, string>;

--- a/artifacts/api-server/src/services/quickbooks-sync.ts
+++ b/artifacts/api-server/src/services/quickbooks-sync.ts
@@ -125,13 +125,20 @@ export async function refreshQBToken(companyId: number, refreshToken: string, re
     const data = await resp.json();
     const expiresAt = new Date(Date.now() + data.expires_in * 1000);
 
+    // Intuit usually rotates the refresh_token on each access-token refresh, but the
+    // bearer response can omit it. Only overwrite when present so we don't blow away
+    // the existing refresh_token with `encrypt(undefined)`.
+    const updates: Partial<typeof companiesTable.$inferInsert> = {
+      qb_access_token: encrypt(data.access_token),
+      qb_token_expires_at: expiresAt,
+    };
+    if (data.refresh_token) {
+      updates.qb_refresh_token = encrypt(data.refresh_token);
+    }
+
     await db
       .update(companiesTable)
-      .set({
-        qb_access_token: encrypt(data.access_token),
-        qb_refresh_token: encrypt(data.refresh_token),
-        qb_token_expires_at: expiresAt,
-      })
+      .set(updates)
       .where(eq(companiesTable.id, companyId));
 
     serviceItemCache.delete(companyId);
@@ -181,6 +188,45 @@ async function qbPost(token: string, realmId: string, path: string, body: object
   });
   if (!resp.ok) throw new Error(`QB POST ${path} → ${resp.status}: ${await resp.text()}`);
   return resp.json();
+}
+
+// ── Customer dedup lookup ──────────────────────────────────────────────────
+// Match by PrimaryEmailAddr first, then DisplayName. Returns the QB Customer Id
+// if a match exists, else null. Quote single-quotes per QB's QBO query syntax.
+async function findExistingQbCustomer(
+  token: string,
+  realmId: string,
+  email: string | null | undefined,
+  displayName: string | null | undefined,
+): Promise<string | null> {
+  const qbQuote = (s: string) => s.replace(/'/g, "\\'");
+  try {
+    if (email) {
+      const q = await qbGet(
+        token,
+        realmId,
+        `/query?query=${encodeURIComponent(
+          `SELECT Id, DisplayName, PrimaryEmailAddr FROM Customer WHERE PrimaryEmailAddr = '${qbQuote(email)}' MAXRESULTS 1`,
+        )}&`,
+      );
+      const hit = q.QueryResponse?.Customer?.[0]?.Id;
+      if (hit) return hit;
+    }
+    if (displayName) {
+      const q = await qbGet(
+        token,
+        realmId,
+        `/query?query=${encodeURIComponent(
+          `SELECT Id, DisplayName FROM Customer WHERE DisplayName = '${qbQuote(displayName)}' MAXRESULTS 1`,
+        )}&`,
+      );
+      const hit = q.QueryResponse?.Customer?.[0]?.Id;
+      if (hit) return hit;
+    }
+  } catch (e: any) {
+    console.warn(`[QB] findExistingQbCustomer failed (non-fatal):`, e.message);
+  }
+  return null;
 }
 
 // ── Service item resolution ────────────────────────────────────────────────
@@ -317,9 +363,30 @@ export async function syncCustomer(companyId: number, customerId: number): Promi
       });
       qbCustomerId = updateData.Customer?.Id || map.qb_customer_id;
     } else {
-      // Create new QB customer
-      const createData = await qbPost(token, realmId, "/customer", payload);
-      qbCustomerId = createData.Customer?.Id;
+      // No local map yet — dedup against QB first to avoid creating a duplicate
+      // for a customer that already exists in QB (manual entry or earlier import).
+      // Match by email first, then DisplayName.
+      const existingQbId = await findExistingQbCustomer(token, realmId, client.email, payload.DisplayName);
+
+      if (existingQbId) {
+        qbCustomerId = existingQbId;
+        // Refresh QB fields from Qleno (sparse merge), so the linked record stays current.
+        try {
+          const existing = await qbGet(token, realmId, `/customer/${qbCustomerId}?`);
+          const syncToken = existing.Customer?.SyncToken;
+          await qbPost(token, realmId, "/customer", {
+            ...payload,
+            Id: qbCustomerId,
+            SyncToken: syncToken,
+            sparse: true,
+          });
+        } catch (e: any) {
+          console.warn(`[QB] dedup-merge update failed for QB customer ${qbCustomerId} (non-fatal):`, e.message);
+        }
+      } else {
+        const createData = await qbPost(token, realmId, "/customer", payload);
+        qbCustomerId = createData.Customer?.Id;
+      }
 
       await db.insert(qbCustomerMapTable).values({
         company_id: companyId,
@@ -485,6 +552,23 @@ export async function syncInvoice(companyId: number, invoiceId: number): Promise
 // ── SYNC PAYMENT ──────────────────────────────────────────────────────────
 export async function syncPayment(companyId: number, invoiceId: number): Promise<void> {
   try {
+    // Idempotency: if a payment for this invoice was already pushed (queue row
+    // with status='synced' and a stored QB payment Id), do not double-push.
+    // QB's /payment endpoint has no client-side dedup, so a retry would create
+    // a duplicate Payment in the customer ledger.
+    const [existingPaymentSync] = await db
+      .select({ status: qbSyncQueueTable.status, qb_entity_id: qbSyncQueueTable.qb_entity_id })
+      .from(qbSyncQueueTable)
+      .where(and(
+        eq(qbSyncQueueTable.company_id, companyId),
+        eq(qbSyncQueueTable.entity_type, "payment"),
+        eq(qbSyncQueueTable.entity_id, invoiceId),
+      ))
+      .limit(1);
+    if (existingPaymentSync?.status === "synced" && existingPaymentSync.qb_entity_id) {
+      return;
+    }
+
     const auth = await getValidToken(companyId);
     if (!auth) return;
 
@@ -534,7 +618,7 @@ export async function syncPayment(companyId: number, invoiceId: number): Promise
     const re_invoice = await db.select({ qbo_invoice_id: invoicesTable.qbo_invoice_id }).from(invoicesTable).where(eq(invoicesTable.id, invoiceId)).limit(1);
     const qboInvId = re_invoice[0]?.qbo_invoice_id;
 
-    await qbPost(token, realmId, "/payment", {
+    const paymentResp = await qbPost(token, realmId, "/payment", {
       CustomerRef: { value: map.qb_customer_id },
       TotalAmt: parseFloat(invoice.total || "0"),
       TxnDate: invoice.paid_at ? new Date(invoice.paid_at).toISOString().split("T")[0] : new Date().toISOString().split("T")[0],
@@ -547,7 +631,8 @@ export async function syncPayment(companyId: number, invoiceId: number): Promise
       ],
     });
 
-    await upsertQueue(companyId, "payment", invoiceId, "synced");
+    const qbPaymentId = paymentResp.Payment?.Id;
+    await upsertQueue(companyId, "payment", invoiceId, "synced", qbPaymentId);
   } catch (err: any) {
     console.error("[QB] syncPayment failed:", err.message);
     await upsertQueue(companyId, "payment", invoiceId, "failed", undefined, err.message);


### PR DESCRIPTION
## Summary
Pre-production audit of the QuickBooks one-way push integration. Surgical hardening of the existing Sprint F code — **no schema changes, no new env vars, no new dependencies, no rebuild**. Diff is +115/-18 across 2 files.

## Fixes
1. **Payment idempotency** (`syncPayment`). Previously, re-running `syncPayment` for an already-synced invoice POSTed a duplicate `/payment` to QB. Now short-circuits when `qb_sync_queue` has a synced row with a stored QB payment Id, and captures `paymentResp.Payment.Id` on first success.
2. **Customer dedup before create** (`syncCustomer`). When no `qb_customer_map` row exists, query QB by `PrimaryEmailAddr` then `DisplayName` before issuing `POST /customer`. Prevents duplicate QB customers when the client already exists from manual entry or earlier import.
3. **Defensive refresh-token rotation** (`refreshQBToken`). Intuit's bearer response usually rotates the refresh token but can omit it — only overwrite when present so we don't crash on `encrypt(undefined)` or wipe a valid token.
4. **Railway-safe callback base** (`/callback`, `/connect`). The legacy code derived the OAuth callback + post-OAuth redirect from `REPLIT_DEV_DOMAIN`, which on Railway is empty → produced a relative redirect resolving under `/api/integrations/quickbooks/`, giving a broken success URL. New `getPublicBase()` prefers `x-forwarded-host` then `req.host`.

## Additional check: sandbox vs production QB state
- **No hardcoded `realmId` or `QB_ENVIRONMENT` toggle anywhere.** Only sandbox/production switch is `getQbBaseUrl()` in `services/quickbooks-sync.ts:41-44`, which picks the URL purely off `NODE_ENV`. Railway prod with `NODE_ENV=production` hits `https://quickbooks.api.intuit.com`.
- **DB inspection (live Railway DB):** all 4 companies have `qb_connected=false`, no tokens. `qb_sync_queue` and `qb_customer_map` are empty.
- **Production QB OAuth has never been authorized for any tenant.** After merge, Sal must click **Connect QuickBooks** in Settings → Integrations on the live app (app.qleno.com) to mint the first refresh_token for `company_id=1` (Phes). Cannot be exercised from sandbox/CLI — Intuit's OAuth flow requires a real browser callback.
- **Smell flagged (not fixed — would require a new env var → would be Draft):** QB API env is coupled to `NODE_ENV`. A future PR should add an explicit `QB_ENVIRONMENT` toggle so staging deployments can point at sandbox without flipping `NODE_ENV` (wide blast radius).

## Verification
Ran a stub-fetch verification script against test tenant `company_id=2` (Demo Cleaning Co). `global.fetch` was monkey-patched so no real Intuit calls fired. All test rows cleaned up in a `finally{}`.

**STEP 2 — customer → invoice → payment walked end-to-end**
```
qb_customer_map row: { qleno_customer_id: 1345, qb_customer_id: 'C-9001' }
invoices.qbo_invoice_id: INV-7777
qb_sync_queue rows:
  type=customer entity=1345 status=synced qb_entity_id=C-9001 attempts=0
  type=invoice  entity=488  status=synced qb_entity_id=INV-7777 attempts=0
  type=payment  entity=488  status=synced qb_entity_id=PAY-5555 attempts=0
Recorded HTTP calls: GET /query (email dedup) → GET /query (DisplayName dedup) → POST /customer → GET /customer/C-9001 → POST /customer (sparse update) → GET /query (item) → GET /query (income acct) → POST /item → POST /invoice → POST /payment
```

**STEP 3 — payment idempotency**: re-running syncPayment fired 0 POSTs to /payment.

**STEP 4 — forced failure → retry**: forced 2 rows to status=failed, syncAll → `{synced:2, failed:0, skipped:0}`, both rows status=synced afterwards.

**STEP 5 — expired access_token triggers refresh**: setting `qb_token_expires_at = now − 60s` produced 1 POST to `oauth.platform.intuit.com/oauth2/v1/tokens/bearer` with `grant_type=refresh_token`; new expiry rotated forward.

**STEP 6 — refresh failure marks disconnected**: stubbed Intuit token endpoint to 401 → `qb_connected=false`, 1 row added to `notification_log` with `trigger=qb_token_expired` and the reauth-prompt message.

## tsc / bundle
- `pnpm run typecheck`: 16 pre-existing errors in the QB files, **0 new errors introduced** (verified by stashing edits and diffing per-file error sets — identical). Pre-existing errors are `'data' is of type 'unknown'` from Node 22+'s `fetch().json()` return type — repo-wide.
- `esbuild` bundle of `src/index.ts` (matches `pnpm run build`'s server step): clean, 1.7MB output.

## Test plan
- [ ] Sal clicks **Connect QuickBooks** on app.qleno.com Settings → Integrations to authorize production QB for `company_id=1` (Phes). This mints the first real refresh_token and is the only step that cannot be done from CI.
- [ ] After connection: paste one invoice into "Mark Paid" and confirm it appears in QB Online (Customer + Invoice + Payment, all linked).
- [ ] Click "Mark Paid" a second time on the same invoice — confirm no duplicate Payment in QB ledger.
- [ ] Wait 60+ minutes, run another sync — confirm token refresh happens silently with no reauth prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
