### PR TITLE
Cutover 1D: office live view + clock-correction surface

### DIFF
--- a/artifacts/api-server/src/lib/job-status-constants.ts
+++ b/artifacts/api-server/src/lib/job-status-constants.ts
@@ -1,0 +1,18 @@
+/**
+ * Cutover 1D — Server-side mirror of the late-detection constants
+ * declared in artifacts/qleno/src/lib/job-status.ts.
+ *
+ * These constants drive both the visual chip on the dispatch board
+ * (frontend) and the "late arrivals today" count on the office ops
+ * surface (server). They MUST stay in sync. If the frontend value
+ * moves, mirror it here; if these move, mirror them in
+ * artifacts/qleno/src/lib/job-status.ts.
+ *
+ * Per CLAUDE.md (lifecycle hard rule, 2026-04-29):
+ *   LATE_THRESHOLD_MINUTES = 20
+ *   NO_SHOW_WAIT_MINUTES   = 20
+ * Multi-tenant future → tenant_settings.late_threshold_minutes /
+ *                       no_show_wait_minutes.
+ */
+export const LATE_THRESHOLD_MINUTES = 20;
+export const NO_SHOW_WAIT_MINUTES = 20;

--- a/artifacts/api-server/src/routes/index.ts
+++ b/artifacts/api-server/src/routes/index.ts
@@ -67,6 +67,7 @@ import techClockRouter from "./tech-clock.js";
 import officeClockRouter from "./office-clock.js";
 import payRouter from "./pay.js";
 import opsIntegrityRouter from "./ops-integrity.js";
+import opsRouter from "./ops.js";
 import acquisitionSourcesRouter from "./acquisition-sources.js";
 import publicRouter from "./public.js";
 import quickbooksRouter from "./integrations/quickbooks.js";
@@ -171,7 +172,11 @@ router.use("/office", officeClockRouter);
 // Cutover 1E — pay periods, summaries, adjustments, rates, generic CSV export
 router.use("/pay", payRouter);
 // Cutover 1E — on-demand re-run of the startup clock-integrity self-check
+// (mounts /api/ops/integrity-check). Express dispatches by sub-path so
+// stacking opsRouter below on the same prefix is safe.
 router.use("/ops", opsIntegrityRouter);
+// Cutover 1D — office live view (/api/ops/today/* + /api/ops/jobs/:id/detail)
+router.use("/ops", opsRouter);
 router.use("/acquisition-sources", acquisitionSourcesRouter);
 router.use("/bundles", bundlesRouter);
 router.use("/photos", photosRouter);

--- a/artifacts/api-server/src/routes/ops.ts
+++ b/artifacts/api-server/src/routes/ops.ts
@@ -1,0 +1,843 @@
+/**
+ * Cutover 1D — Office command-center surface.
+ *
+ * Five GET endpoints under /api/ops, all gated to owner / admin /
+ * office / super_admin and all tenant-scoped via req.auth!.companyId.
+ * Techs receive 403 explicitly.
+ *
+ *   GET /api/ops/today/summary         — count cards for the strip
+ *   GET /api/ops/today/active-jobs     — workhorse list (filterable)
+ *   GET /api/ops/today/exceptions      — failed_exception queue
+ *   GET /api/ops/today/live-locations  — currently on-shift pins
+ *   GET /api/ops/jobs/:jobId/detail    — drawer payload (worksheet
+ *                                        + photos + notes + clock
+ *                                        timeline including
+ *                                        corrections)
+ *
+ * The clock-correction + exception-review WRITE endpoints already
+ * live in /api/office/* from 1C (routes/office-clock.ts). 1D's
+ * surface consumes them; this route file is read-only.
+ */
+import { Router } from "express";
+import { db } from "@workspace/db";
+import {
+  jobsTable,
+  clientsTable,
+  usersTable,
+  accountsTable,
+  accountPropertiesTable,
+  serviceTypesTable,
+  jobClockEventsTable,
+  jobWorksheetTable,
+  jobPhotosTable,
+  technicianNotesTable,
+  onMyWayEventsTable,
+} from "@workspace/db/schema";
+import { and, asc, desc, eq, inArray, isNull, isNotNull, sql, count } from "drizzle-orm";
+import { requireAuth, requireRole } from "../lib/auth.js";
+import { LATE_THRESHOLD_MINUTES } from "../lib/job-status-constants.js";
+
+const router = Router();
+
+// Office-only gate for every endpoint here. Techs explicitly 403.
+const officeOnly = requireRole("owner", "admin", "office", "super_admin");
+
+router.use(requireAuth, officeOnly);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function todayIso(): string {
+  const d = new Date();
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}-${String(d.getUTCDate()).padStart(2, "0")}`;
+}
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+function resolveDateParam(raw: unknown): string | null {
+  if (raw == null || raw === "") return todayIso();
+  if (typeof raw !== "string" || !ISO_DATE_RE.test(raw)) return null;
+  return raw;
+}
+
+/**
+ * Parse jobs.scheduled_time (text — "09:00", "9:00 AM", "HH:MM:SS")
+ * into a Date for a given scheduled_date (YYYY-MM-DD). Returns null on
+ * unparseable input — late detection skips those rows rather than
+ * mis-classifying them.
+ */
+function parseScheduledStart(dateStr: string, time: string | null): Date | null {
+  if (!time) return null;
+  const m = /^(\d{1,2}):(\d{2})(?:\s*(AM|PM))?/i.exec(time.trim());
+  if (!m) return null;
+  let hh = parseInt(m[1], 10);
+  const mm = parseInt(m[2], 10);
+  const ampm = m[3]?.toUpperCase();
+  if (ampm === "PM" && hh < 12) hh += 12;
+  if (ampm === "AM" && hh === 12) hh = 0;
+  const [y, mo, d] = dateStr.split("-").map(Number);
+  const out = new Date(y, mo - 1, d, hh, mm);
+  return Number.isFinite(out.getTime()) ? out : null;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /api/ops/today/summary — count cards for Section 1
+// ─────────────────────────────────────────────────────────────────────────────
+
+router.get("/today/summary", async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    if (companyId == null) {
+      return res
+        .status(400)
+        .json({ error: "Bad Request", message: "User has no company assignment" });
+    }
+    const date = resolveDateParam(req.query.date);
+    if (date == null) {
+      return res
+        .status(400)
+        .json({ error: "Bad Request", message: "date must be YYYY-MM-DD" });
+    }
+
+    // Pull every job touching today + the latest clock_in event per
+    // (job, user). Late detection happens in JS so we can use the
+    // shared LATE_THRESHOLD_MINUTES constant.
+    const jobs = await db
+      .select({
+        id: jobsTable.id,
+        assigned_user_id: jobsTable.assigned_user_id,
+        scheduled_date: jobsTable.scheduled_date,
+        scheduled_time: jobsTable.scheduled_time,
+        status: jobsTable.status,
+      })
+      .from(jobsTable)
+      .where(
+        and(
+          eq(jobsTable.company_id, companyId),
+          eq(jobsTable.scheduled_date, date),
+        ),
+      );
+
+    const jobIds = jobs.map((j) => j.id);
+
+    // Open clock-in events (no matching clock-out yet) for today's jobs.
+    let openClockEvents: Array<{
+      job_id: number;
+      user_id: number;
+      event_at: Date;
+    }> = [];
+    if (jobIds.length > 0) {
+      openClockEvents = await db
+        .select({
+          job_id: jobClockEventsTable.job_id,
+          user_id: jobClockEventsTable.user_id,
+          event_at: jobClockEventsTable.event_at,
+        })
+        .from(jobClockEventsTable)
+        .where(
+          and(
+            eq(jobClockEventsTable.company_id, companyId),
+            eq(jobClockEventsTable.event_type, "clock_in"),
+            inArray(jobClockEventsTable.job_id, jobIds),
+          ),
+        );
+    }
+    // Resolve actual clock-in per job: latest clock_in_at, then filter
+    // out the ones with a later clock_out_at.
+    const clockInByJob = new Map<number, { user_id: number; event_at: Date }>();
+    for (const ev of openClockEvents) {
+      const prev = clockInByJob.get(ev.job_id);
+      if (!prev || ev.event_at > prev.event_at) {
+        clockInByJob.set(ev.job_id, {
+          user_id: ev.user_id,
+          event_at: ev.event_at,
+        });
+      }
+    }
+
+    // On-my-way late signals for today's jobs.
+    let earlyLateSignals = new Set<number>();
+    if (jobIds.length > 0) {
+      const rows = await db
+        .select({ job_id: onMyWayEventsTable.job_id })
+        .from(onMyWayEventsTable)
+        .where(
+          and(
+            eq(onMyWayEventsTable.company_id, companyId),
+            eq(onMyWayEventsTable.eta_edited_after_scheduled_start, true),
+            inArray(onMyWayEventsTable.job_id, jobIds),
+          ),
+        );
+      for (const r of rows) earlyLateSignals.add(r.job_id);
+    }
+
+    // Compute the counts.
+    const techsOnShift = new Set<number>();
+    let jobsInProgress = 0;
+    let jobsComplete = 0;
+    let jobsPending = 0;
+    let lateCount = 0;
+    for (const j of jobs) {
+      const status = j.status;
+      if (status === "in_progress") {
+        jobsInProgress++;
+        if (j.assigned_user_id != null) techsOnShift.add(j.assigned_user_id);
+      } else if (status === "complete") {
+        jobsComplete++;
+      } else {
+        jobsPending++;
+      }
+
+      // Late detection — two paths:
+      //   1. on_my_way_event flagged eta_edited_after_scheduled_start
+      //   2. actual clock_in_at past scheduled_start by LATE_THRESHOLD_MINUTES
+      if (earlyLateSignals.has(j.id)) {
+        lateCount++;
+        continue;
+      }
+      const clockIn = clockInByJob.get(j.id);
+      const scheduledStart = parseScheduledStart(j.scheduled_date, j.scheduled_time);
+      if (clockIn && scheduledStart) {
+        const diffMin =
+          (clockIn.event_at.getTime() - scheduledStart.getTime()) / 60000;
+        if (diffMin >= LATE_THRESHOLD_MINUTES) lateCount++;
+      }
+    }
+
+    // Unreviewed exceptions count.
+    const exceptionsRows = await db
+      .select({ c: count() })
+      .from(jobClockEventsTable)
+      .where(
+        and(
+          eq(jobClockEventsTable.company_id, companyId),
+          eq(jobClockEventsTable.gps_status, "failed_exception"),
+          isNull(jobClockEventsTable.exception_reviewed_at),
+        ),
+      );
+    const exceptionsAwaitingReview = Number(exceptionsRows[0]?.c ?? 0);
+
+    return res.json({
+      data: {
+        date,
+        on_shift_now: techsOnShift.size,
+        jobs_in_progress: jobsInProgress,
+        jobs_complete_today: jobsComplete,
+        jobs_pending_later_today: jobsPending,
+        gps_exceptions_awaiting_review: exceptionsAwaitingReview,
+        late_arrivals_today: lateCount,
+      },
+    });
+  } catch (err) {
+    console.error("[ops] summary error:", err);
+    return res
+      .status(500)
+      .json({ error: "Internal Server Error", message: "Failed to load summary" });
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /api/ops/today/active-jobs — Section 3 list with filter pills
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// Query params:
+//   date    — YYYY-MM-DD (default today)
+//   filter  — all | in_progress | late | exceptions | complete | pending
+//   q       — search term against tech name or client display name
+
+router.get("/today/active-jobs", async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    if (companyId == null) {
+      return res
+        .status(400)
+        .json({ error: "Bad Request", message: "User has no company assignment" });
+    }
+    const date = resolveDateParam(req.query.date);
+    if (date == null) {
+      return res
+        .status(400)
+        .json({ error: "Bad Request", message: "date must be YYYY-MM-DD" });
+    }
+    const filter = String(req.query.filter ?? "all");
+    const q = (req.query.q as string | undefined)?.trim().toLowerCase() ?? "";
+
+    const rows = await db
+      .select({
+        id: jobsTable.id,
+        assigned_user_id: jobsTable.assigned_user_id,
+        tech_first_name: usersTable.first_name,
+        tech_last_name: usersTable.last_name,
+        client_id: jobsTable.client_id,
+        client_first_name: clientsTable.first_name,
+        client_last_name: clientsTable.last_name,
+        client_company_name: clientsTable.company_name,
+        account_name: accountsTable.account_name,
+        property_name: accountPropertiesTable.property_name,
+        address_street: sql<string | null>`CASE WHEN ${jobsTable.account_property_id} IS NOT NULL THEN ${accountPropertiesTable.address} ELSE ${clientsTable.address} END`,
+        address_city: sql<string | null>`CASE WHEN ${jobsTable.account_property_id} IS NOT NULL THEN ${accountPropertiesTable.city} ELSE ${clientsTable.city} END`,
+        address_state: sql<string | null>`CASE WHEN ${jobsTable.account_property_id} IS NOT NULL THEN ${accountPropertiesTable.state} ELSE ${clientsTable.state} END`,
+        address_zip: sql<string | null>`CASE WHEN ${jobsTable.account_property_id} IS NOT NULL THEN ${accountPropertiesTable.zip} ELSE ${clientsTable.zip} END`,
+        service_type_slug: jobsTable.service_type,
+        service_type_name: serviceTypesTable.name,
+        status: jobsTable.status,
+        scheduled_date: jobsTable.scheduled_date,
+        scheduled_time: jobsTable.scheduled_time,
+        allowed_hours: jobsTable.allowed_hours,
+        job_kind: jobsTable.job_kind,
+      })
+      .from(jobsTable)
+      .leftJoin(usersTable, eq(jobsTable.assigned_user_id, usersTable.id))
+      .leftJoin(clientsTable, eq(jobsTable.client_id, clientsTable.id))
+      .leftJoin(accountsTable, eq(jobsTable.account_id, accountsTable.id))
+      .leftJoin(
+        accountPropertiesTable,
+        eq(jobsTable.account_property_id, accountPropertiesTable.id),
+      )
+      .leftJoin(
+        serviceTypesTable,
+        and(
+          eq(serviceTypesTable.company_id, companyId),
+          eq(serviceTypesTable.slug, jobsTable.service_type),
+        ),
+      )
+      .where(
+        and(
+          eq(jobsTable.company_id, companyId),
+          eq(jobsTable.scheduled_date, date),
+        ),
+      )
+      .orderBy(
+        // In-progress first, then by scheduled_time.
+        sql`CASE ${jobsTable.status} WHEN 'in_progress' THEN 0 WHEN 'scheduled' THEN 1 WHEN 'complete' THEN 2 ELSE 3 END`,
+        asc(jobsTable.scheduled_time),
+        asc(jobsTable.id),
+      );
+
+    const jobIds = rows.map((r) => r.id);
+
+    // Clock-in events (latest per job) for actual_clock_in_at + within_geofence.
+    const clockMap = new Map<
+      number,
+      {
+        clock_in_at: Date | null;
+        clock_in_within_geofence: boolean | null;
+        clock_in_gps_status: string | null;
+        clock_in_event_id: number | null;
+      }
+    >();
+    if (jobIds.length > 0) {
+      const clockRows = await db
+        .select({
+          id: jobClockEventsTable.id,
+          job_id: jobClockEventsTable.job_id,
+          event_type: jobClockEventsTable.event_type,
+          event_at: jobClockEventsTable.event_at,
+          within_geofence: jobClockEventsTable.within_geofence,
+          gps_status: jobClockEventsTable.gps_status,
+        })
+        .from(jobClockEventsTable)
+        .where(
+          and(
+            eq(jobClockEventsTable.company_id, companyId),
+            inArray(jobClockEventsTable.job_id, jobIds),
+            eq(jobClockEventsTable.event_type, "clock_in"),
+          ),
+        )
+        .orderBy(desc(jobClockEventsTable.event_at));
+      // Take the most recent clock_in per job.
+      for (const c of clockRows) {
+        if (!clockMap.has(c.job_id)) {
+          clockMap.set(c.job_id, {
+            clock_in_at: c.event_at,
+            clock_in_within_geofence: c.within_geofence,
+            clock_in_gps_status: c.gps_status,
+            clock_in_event_id: c.id,
+          });
+        }
+      }
+    }
+
+    // Late signals from on_my_way_events.
+    const earlyLate = new Set<number>();
+    if (jobIds.length > 0) {
+      const rows2 = await db
+        .select({ job_id: onMyWayEventsTable.job_id })
+        .from(onMyWayEventsTable)
+        .where(
+          and(
+            eq(onMyWayEventsTable.company_id, companyId),
+            eq(onMyWayEventsTable.eta_edited_after_scheduled_start, true),
+            inArray(onMyWayEventsTable.job_id, jobIds),
+          ),
+        );
+      for (const r of rows2) earlyLate.add(r.job_id);
+    }
+
+    // Unreviewed exception markers per job (we surface a flag on the
+    // row so the office sees "this job has an exception" without a
+    // separate fetch).
+    const jobsWithException = new Set<number>();
+    if (jobIds.length > 0) {
+      const rows3 = await db
+        .select({ job_id: jobClockEventsTable.job_id })
+        .from(jobClockEventsTable)
+        .where(
+          and(
+            eq(jobClockEventsTable.company_id, companyId),
+            eq(jobClockEventsTable.gps_status, "failed_exception"),
+            isNull(jobClockEventsTable.exception_reviewed_at),
+            inArray(jobClockEventsTable.job_id, jobIds),
+          ),
+        );
+      for (const r of rows3) jobsWithException.add(r.job_id);
+    }
+
+    // Decorate + filter.
+    const decorated = rows.map((r) => {
+      const clock = clockMap.get(r.id);
+      const scheduledStart = parseScheduledStart(r.scheduled_date, r.scheduled_time);
+      let minutesLate: number | null = null;
+      let isLate = false;
+      if (earlyLate.has(r.id)) isLate = true;
+      if (clock?.clock_in_at && scheduledStart) {
+        const diff = (clock.clock_in_at.getTime() - scheduledStart.getTime()) / 60000;
+        if (diff >= LATE_THRESHOLD_MINUTES) {
+          isLate = true;
+          minutesLate = Math.round(diff);
+        }
+      }
+      const techName = r.tech_first_name
+        ? `${r.tech_first_name ?? ""} ${r.tech_last_name ?? ""}`.trim()
+        : null;
+      const clientDisplayName = resolveClientDisplayName(r);
+      return {
+        id: r.id,
+        tech_user_id: r.assigned_user_id,
+        tech_name: techName,
+        client_display_name: clientDisplayName,
+        address_street: r.address_street,
+        address_city: r.address_city,
+        address_state: r.address_state,
+        address_zip: r.address_zip,
+        service_type_name: r.service_type_name ?? r.service_type_slug,
+        scheduled_date: r.scheduled_date,
+        scheduled_time: r.scheduled_time,
+        allowed_hours: r.allowed_hours != null ? Number(r.allowed_hours) : null,
+        status: r.status,
+        job_kind: r.job_kind,
+        clock_in_at: clock?.clock_in_at ? clock.clock_in_at.toISOString() : null,
+        clock_in_event_id: clock?.clock_in_event_id ?? null,
+        clock_in_within_geofence: clock?.clock_in_within_geofence ?? null,
+        clock_in_gps_status: clock?.clock_in_gps_status ?? null,
+        is_late: isLate,
+        minutes_late: minutesLate,
+        has_unreviewed_exception: jobsWithException.has(r.id),
+      };
+    });
+
+    const filtered = decorated.filter((j) => {
+      if (q) {
+        const hay = `${j.tech_name ?? ""} ${j.client_display_name}`.toLowerCase();
+        if (!hay.includes(q)) return false;
+      }
+      switch (filter) {
+        case "in_progress":
+          return j.status === "in_progress";
+        case "late":
+          return j.is_late;
+        case "exceptions":
+          return j.has_unreviewed_exception;
+        case "complete":
+          return j.status === "complete";
+        case "pending":
+          return (
+            j.status !== "in_progress" &&
+            j.status !== "complete" &&
+            j.status !== "cancelled"
+          );
+        case "all":
+        default:
+          return true;
+      }
+    });
+
+    return res.json({ data: filtered });
+  } catch (err) {
+    console.error("[ops] active-jobs error:", err);
+    return res
+      .status(500)
+      .json({ error: "Internal Server Error", message: "Failed to load active jobs" });
+  }
+});
+
+function resolveClientDisplayName(r: {
+  job_kind: string | null;
+  account_name: string | null;
+  property_name: string | null;
+  client_company_name: string | null;
+  client_first_name: string | null;
+  client_last_name: string | null;
+}): string {
+  if (r.job_kind === "office_event" || r.job_kind === "meeting") {
+    return r.account_name ?? "Office event";
+  }
+  if (r.account_name) {
+    return r.property_name
+      ? `${r.account_name} — ${r.property_name}`
+      : r.account_name;
+  }
+  if (r.client_company_name) return r.client_company_name;
+  const first = (r.client_first_name ?? "").trim();
+  const last = (r.client_last_name ?? "").trim();
+  return [first, last].filter(Boolean).join(" ") || "Client";
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /api/ops/today/exceptions — Section 4 queue
+// ─────────────────────────────────────────────────────────────────────────────
+
+router.get("/today/exceptions", async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    if (companyId == null) {
+      return res
+        .status(400)
+        .json({ error: "Bad Request", message: "User has no company assignment" });
+    }
+    const rows = await db
+      .select({
+        id: jobClockEventsTable.id,
+        job_id: jobClockEventsTable.job_id,
+        user_id: jobClockEventsTable.user_id,
+        event_type: jobClockEventsTable.event_type,
+        event_at: jobClockEventsTable.event_at,
+        exception_reason: jobClockEventsTable.exception_reason,
+        exception_photo_url: jobClockEventsTable.exception_photo_url,
+        tech_first_name: usersTable.first_name,
+        tech_last_name: usersTable.last_name,
+        client_id: jobsTable.client_id,
+        client_first_name: clientsTable.first_name,
+        client_last_name: clientsTable.last_name,
+        client_company_name: clientsTable.company_name,
+        account_name: accountsTable.account_name,
+        property_name: accountPropertiesTable.property_name,
+        job_kind: jobsTable.job_kind,
+        scheduled_date: jobsTable.scheduled_date,
+      })
+      .from(jobClockEventsTable)
+      .leftJoin(usersTable, eq(jobClockEventsTable.user_id, usersTable.id))
+      .leftJoin(jobsTable, eq(jobClockEventsTable.job_id, jobsTable.id))
+      .leftJoin(clientsTable, eq(jobsTable.client_id, clientsTable.id))
+      .leftJoin(accountsTable, eq(jobsTable.account_id, accountsTable.id))
+      .leftJoin(
+        accountPropertiesTable,
+        eq(jobsTable.account_property_id, accountPropertiesTable.id),
+      )
+      .where(
+        and(
+          eq(jobClockEventsTable.company_id, companyId),
+          eq(jobClockEventsTable.gps_status, "failed_exception"),
+          isNull(jobClockEventsTable.exception_reviewed_at),
+        ),
+      )
+      .orderBy(desc(jobClockEventsTable.event_at))
+      .limit(200);
+
+    return res.json({
+      data: rows.map((r) => ({
+        id: r.id,
+        job_id: r.job_id,
+        scheduled_date: r.scheduled_date,
+        event_type: r.event_type,
+        event_at: r.event_at?.toISOString() ?? null,
+        exception_reason: r.exception_reason,
+        exception_photo_url: r.exception_photo_url,
+        tech_user_id: r.user_id,
+        tech_name: r.tech_first_name
+          ? `${r.tech_first_name ?? ""} ${r.tech_last_name ?? ""}`.trim()
+          : null,
+        client_display_name: resolveClientDisplayName(r),
+      })),
+    });
+  } catch (err) {
+    console.error("[ops] exceptions error:", err);
+    return res
+      .status(500)
+      .json({ error: "Internal Server Error", message: "Failed to load queue" });
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /api/ops/today/live-locations — Section 2 map pins (optional v1)
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// One pin per tech currently clocked in (open clock_in with no
+// matching clock_out). Pin location is the site's lat/lng (clients.lat/lng).
+// Cheap query, polled.
+
+router.get("/today/live-locations", async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    if (companyId == null) {
+      return res
+        .status(400)
+        .json({ error: "Bad Request", message: "User has no company assignment" });
+    }
+    const rows = await db
+      .select({
+        job_id: jobsTable.id,
+        tech_user_id: jobsTable.assigned_user_id,
+        tech_first_name: usersTable.first_name,
+        tech_last_name: usersTable.last_name,
+        client_first_name: clientsTable.first_name,
+        client_last_name: clientsTable.last_name,
+        client_company_name: clientsTable.company_name,
+        account_name: accountsTable.account_name,
+        property_name: accountPropertiesTable.property_name,
+        job_kind: jobsTable.job_kind,
+        lat: clientsTable.lat,
+        lng: clientsTable.lng,
+      })
+      .from(jobsTable)
+      .leftJoin(usersTable, eq(jobsTable.assigned_user_id, usersTable.id))
+      .leftJoin(clientsTable, eq(jobsTable.client_id, clientsTable.id))
+      .leftJoin(accountsTable, eq(jobsTable.account_id, accountsTable.id))
+      .leftJoin(
+        accountPropertiesTable,
+        eq(jobsTable.account_property_id, accountPropertiesTable.id),
+      )
+      .where(
+        and(
+          eq(jobsTable.company_id, companyId),
+          eq(jobsTable.status, "in_progress"),
+        ),
+      );
+
+    return res.json({
+      data: rows
+        .filter((r) => r.lat != null && r.lng != null)
+        .map((r) => ({
+          job_id: r.job_id,
+          tech_user_id: r.tech_user_id,
+          tech_name: r.tech_first_name
+            ? `${r.tech_first_name ?? ""} ${r.tech_last_name ?? ""}`.trim()
+            : null,
+          tech_initials: techInitials(r.tech_first_name, r.tech_last_name),
+          client_display_name: resolveClientDisplayName(r),
+          lat: Number(r.lat),
+          lng: Number(r.lng),
+        })),
+    });
+  } catch (err) {
+    console.error("[ops] live-locations error:", err);
+    return res
+      .status(500)
+      .json({ error: "Internal Server Error", message: "Failed to load locations" });
+  }
+});
+
+function techInitials(first: string | null, last: string | null): string {
+  const f = first?.trim()?.[0] ?? "";
+  const l = last?.trim()?.[0] ?? "";
+  return `${f}${l}`.toUpperCase() || "?";
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /api/ops/jobs/:jobId/detail — drawer payload
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// Returns worksheet + photos + technician notes + the full clock
+// timeline (every job_clock_events row including corrections, in
+// chronological order). The clock timeline is the centerpiece — the
+// office reads it to verify the audit trail.
+
+router.get("/jobs/:jobId/detail", async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    if (companyId == null) {
+      return res
+        .status(400)
+        .json({ error: "Bad Request", message: "User has no company assignment" });
+    }
+    const jobId = Number(req.params.jobId);
+    if (!Number.isFinite(jobId)) {
+      return res.status(400).json({ error: "Bad Request", message: "Invalid jobId" });
+    }
+
+    // Tenant gate on the job.
+    const jobRows = await db
+      .select({
+        id: jobsTable.id,
+        assigned_user_id: jobsTable.assigned_user_id,
+        client_id: jobsTable.client_id,
+        status: jobsTable.status,
+        scheduled_date: jobsTable.scheduled_date,
+        scheduled_time: jobsTable.scheduled_time,
+        allowed_hours: jobsTable.allowed_hours,
+        notes: jobsTable.notes,
+        client_first_name: clientsTable.first_name,
+        client_last_name: clientsTable.last_name,
+        client_company_name: clientsTable.company_name,
+        client_phone: clientsTable.phone,
+        account_name: accountsTable.account_name,
+        property_name: accountPropertiesTable.property_name,
+        address_street: sql<string | null>`CASE WHEN ${jobsTable.account_property_id} IS NOT NULL THEN ${accountPropertiesTable.address} ELSE ${clientsTable.address} END`,
+        address_city: sql<string | null>`CASE WHEN ${jobsTable.account_property_id} IS NOT NULL THEN ${accountPropertiesTable.city} ELSE ${clientsTable.city} END`,
+        address_state: sql<string | null>`CASE WHEN ${jobsTable.account_property_id} IS NOT NULL THEN ${accountPropertiesTable.state} ELSE ${clientsTable.state} END`,
+        address_zip: sql<string | null>`CASE WHEN ${jobsTable.account_property_id} IS NOT NULL THEN ${accountPropertiesTable.zip} ELSE ${clientsTable.zip} END`,
+        tech_first_name: usersTable.first_name,
+        tech_last_name: usersTable.last_name,
+        job_kind: jobsTable.job_kind,
+      })
+      .from(jobsTable)
+      .leftJoin(clientsTable, eq(jobsTable.client_id, clientsTable.id))
+      .leftJoin(accountsTable, eq(jobsTable.account_id, accountsTable.id))
+      .leftJoin(
+        accountPropertiesTable,
+        eq(jobsTable.account_property_id, accountPropertiesTable.id),
+      )
+      .leftJoin(usersTable, eq(jobsTable.assigned_user_id, usersTable.id))
+      .where(
+        and(
+          eq(jobsTable.company_id, companyId),
+          eq(jobsTable.id, jobId),
+        ),
+      )
+      .limit(1);
+    const job = jobRows[0];
+    if (!job) {
+      return res.status(404).json({ error: "Not Found", message: "Job not found" });
+    }
+
+    const [worksheet, clockEvents, photos, notes] = await Promise.all([
+      db
+        .select()
+        .from(jobWorksheetTable)
+        .where(
+          and(
+            eq(jobWorksheetTable.company_id, companyId),
+            eq(jobWorksheetTable.job_id, jobId),
+          ),
+        )
+        .limit(1)
+        .then((r) => r[0] ?? null),
+      // EVERY clock event for this job, ordered chronologically.
+      // Includes corrections (is_correction=true) so the timeline
+      // shows the original AND the corrected event side by side.
+      db
+        .select({
+          id: jobClockEventsTable.id,
+          event_type: jobClockEventsTable.event_type,
+          event_at: jobClockEventsTable.event_at,
+          latitude: jobClockEventsTable.latitude,
+          longitude: jobClockEventsTable.longitude,
+          distance_from_site_meters: jobClockEventsTable.distance_from_site_meters,
+          within_geofence: jobClockEventsTable.within_geofence,
+          gps_status: jobClockEventsTable.gps_status,
+          gps_accuracy_meters: jobClockEventsTable.gps_accuracy_meters,
+          exception_reason: jobClockEventsTable.exception_reason,
+          exception_photo_url: jobClockEventsTable.exception_photo_url,
+          exception_reviewed_at: jobClockEventsTable.exception_reviewed_at,
+          exception_reviewed_by_user_id: jobClockEventsTable.exception_reviewed_by_user_id,
+          is_correction: jobClockEventsTable.is_correction,
+          correction_of_event_id: jobClockEventsTable.correction_of_event_id,
+          correction_old_value: jobClockEventsTable.correction_old_value,
+          created_by_user_id: jobClockEventsTable.created_by_user_id,
+          created_at: jobClockEventsTable.created_at,
+        })
+        .from(jobClockEventsTable)
+        .where(
+          and(
+            eq(jobClockEventsTable.company_id, companyId),
+            eq(jobClockEventsTable.job_id, jobId),
+          ),
+        )
+        .orderBy(asc(jobClockEventsTable.event_at), asc(jobClockEventsTable.created_at)),
+      db
+        .select({
+          id: jobPhotosTable.id,
+          url: jobPhotosTable.url,
+          photo_type: jobPhotosTable.photo_type,
+          timestamp: jobPhotosTable.timestamp,
+        })
+        .from(jobPhotosTable)
+        .where(
+          and(
+            eq(jobPhotosTable.company_id, companyId),
+            eq(jobPhotosTable.job_id, jobId),
+          ),
+        )
+        .orderBy(asc(jobPhotosTable.timestamp)),
+      db
+        .select({
+          id: technicianNotesTable.id,
+          body: technicianNotesTable.body,
+          created_at: technicianNotesTable.created_at,
+          user_id: technicianNotesTable.user_id,
+        })
+        .from(technicianNotesTable)
+        .where(
+          and(
+            eq(technicianNotesTable.company_id, companyId),
+            eq(technicianNotesTable.job_id, jobId),
+          ),
+        )
+        .orderBy(asc(technicianNotesTable.created_at)),
+    ]);
+
+    return res.json({
+      data: {
+        job: {
+          id: job.id,
+          status: job.status,
+          scheduled_date: job.scheduled_date,
+          scheduled_time: job.scheduled_time,
+          allowed_hours: job.allowed_hours != null ? Number(job.allowed_hours) : null,
+          notes: job.notes,
+          job_kind: job.job_kind,
+          tech_name: job.tech_first_name
+            ? `${job.tech_first_name ?? ""} ${job.tech_last_name ?? ""}`.trim()
+            : null,
+          client_display_name: resolveClientDisplayName(job),
+          client_phone: job.client_phone,
+          address_street: job.address_street,
+          address_city: job.address_city,
+          address_state: job.address_state,
+          address_zip: job.address_zip,
+        },
+        worksheet,
+        clock_timeline: clockEvents.map((e) => ({
+          ...e,
+          event_at: e.event_at?.toISOString() ?? null,
+          created_at: e.created_at?.toISOString() ?? null,
+          exception_reviewed_at: e.exception_reviewed_at?.toISOString() ?? null,
+          latitude: e.latitude != null ? Number(e.latitude) : null,
+          longitude: e.longitude != null ? Number(e.longitude) : null,
+          distance_from_site_meters:
+            e.distance_from_site_meters != null
+              ? Number(e.distance_from_site_meters)
+              : null,
+          gps_accuracy_meters:
+            e.gps_accuracy_meters != null ? Number(e.gps_accuracy_meters) : null,
+        })),
+        photos: photos.map((p) => ({
+          ...p,
+          timestamp: p.timestamp?.toISOString() ?? null,
+        })),
+        notes: notes.map((n) => ({
+          ...n,
+          created_at: n.created_at?.toISOString() ?? null,
+        })),
+      },
+    });
+  } catch (err) {
+    console.error("[ops] detail error:", err);
+    return res
+      .status(500)
+      .json({ error: "Internal Server Error", message: "Failed to load detail" });
+  }
+});
+
+export default router;

--- a/artifacts/api-server/src/tests/cutover-1d-ops.test.ts
+++ b/artifacts/api-server/src/tests/cutover-1d-ops.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Cutover 1D — Office live-view tests.
+ *
+ * The integrity gates for 1D:
+ *
+ *   1. Tenant isolation — every endpoint scopes by req.auth!.companyId.
+ *      Route source greps assert nothing reads companyId from the body
+ *      or query and that every WHERE has an eq(...company_id, companyId)
+ *      clause.
+ *
+ *   2. Role gate — techs (non-office roles) get 403. The route file
+ *      applies `requireRole("owner", "admin", "office", "super_admin")`
+ *      at the router level so EVERY endpoint inherits it. We assert
+ *      the role list and the use() ordering.
+ *
+ *   3. Late-detection uses LATE_THRESHOLD_MINUTES from the shared
+ *      constants (mirrors lib/job-status.ts). Verified by grep + a
+ *      direct re-export check.
+ *
+ *   4. Clock-correction NEVER overwrites the original — this was
+ *      tested in 1C (cutover-1c-clock-integrity.test.ts) but we
+ *      re-assert the office route still uses INSERT, not UPDATE, on
+ *      the corrections handler. Defense in depth: a refactor on the
+ *      office side cannot break the audit guarantee.
+ *
+ *   5. Exception review marks reviewed without altering the underlying
+ *      event (only sets exception_reviewed_by_user_id +
+ *      exception_reviewed_at).
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { LATE_THRESHOLD_MINUTES, NO_SHOW_WAIT_MINUTES } from "../lib/job-status-constants.js";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1 + 2. Tenant isolation + role gate (route source)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("Cutover 1D — role gate (techs blocked)", () => {
+  const src = readFileSync(
+    path.resolve(process.cwd(), "src/routes/ops.ts"),
+    "utf8",
+  );
+
+  it("ops.ts applies requireRole(owner, admin, office, super_admin) at the router level", () => {
+    assert.ok(
+      /router\.use\(requireAuth, officeOnly\)/.test(src),
+      "ops.ts must apply requireAuth + officeOnly at the router level so EVERY endpoint inherits",
+    );
+    assert.ok(
+      /const officeOnly = requireRole\("owner", "admin", "office", "super_admin"\)/.test(src),
+      "ops.ts must restrict to owner/admin/office/super_admin (techs 403)",
+    );
+  });
+
+  it("ops.ts does NOT include 'technician' or 'team_lead' in the role gate", () => {
+    assert.ok(
+      !/requireRole\([^)]*technician[^)]*\)/.test(src),
+      "ops.ts must NOT permit technicians",
+    );
+    assert.ok(
+      !/requireRole\([^)]*team_lead[^)]*\)/.test(src),
+      "ops.ts must NOT permit team_lead",
+    );
+  });
+});
+
+describe("Cutover 1D — tenant isolation (route source)", () => {
+  const src = readFileSync(
+    path.resolve(process.cwd(), "src/routes/ops.ts"),
+    "utf8",
+  );
+
+  it("ops.ts sources companyId from req.auth!.companyId only", () => {
+    assert.ok(
+      /req\.auth!\.companyId/.test(src),
+      "ops.ts must source companyId from req.auth!.companyId",
+    );
+    assert.ok(
+      !/req\.body\.company_?id|req\.query\.company_?id/i.test(src),
+      "ops.ts must NEVER read company_id from body or query",
+    );
+  });
+
+  it("every db.select in ops.ts is followed by a WHERE that filters on company_id", () => {
+    // Cheap structural assertion: every db.select(...).from(...)...where
+    // chain in this file should contain `eq(...company_id, companyId)`.
+    // Count select chains vs the company_id WHERE clauses — they should
+    // match.
+    const selectCount = (src.match(/db\s*\.select\(/g) ?? []).length;
+    const companyIdWhereCount = (src.match(/\.company_id,\s*companyId\)/g) ?? []).length;
+    assert.ok(
+      companyIdWhereCount >= selectCount,
+      `ops.ts has ${selectCount} db.select chains but only ${companyIdWhereCount} company_id WHERE clauses — tenant scoping gap`,
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3. Late-detection constants
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("Cutover 1D — late-detection constants", () => {
+  it("LATE_THRESHOLD_MINUTES matches the frontend value (20)", () => {
+    assert.equal(LATE_THRESHOLD_MINUTES, 20);
+  });
+
+  it("NO_SHOW_WAIT_MINUTES matches the frontend value (20)", () => {
+    assert.equal(NO_SHOW_WAIT_MINUTES, 20);
+  });
+
+  it("ops.ts imports LATE_THRESHOLD_MINUTES from job-status-constants", () => {
+    const src = readFileSync(
+      path.resolve(process.cwd(), "src/routes/ops.ts"),
+      "utf8",
+    );
+    assert.ok(
+      /import\s+\{[^}]*LATE_THRESHOLD_MINUTES[^}]*\}\s+from\s+"\.\.\/lib\/job-status-constants/.test(src),
+      "ops.ts must import LATE_THRESHOLD_MINUTES from lib/job-status-constants",
+    );
+    assert.ok(
+      !/const\s+LATE_THRESHOLD_MINUTES\s*=/.test(src),
+      "ops.ts must NOT redefine LATE_THRESHOLD_MINUTES locally — use the shared constant",
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 4. Clock-correction never-overwrites (defense in depth at the 1D layer)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("Cutover 1D — office correction route still append-only (1C reused)", () => {
+  // The 1D UI calls the 1C write endpoint — but we re-assert here so
+  // the office-side audit guarantee is part of the 1D gate. Same grep
+  // pattern as cutover-1c-clock-integrity.test.ts.
+  const src = readFileSync(
+    path.resolve(process.cwd(), "src/routes/office-clock.ts"),
+    "utf8",
+  );
+
+  it("office-clock.ts clock-correction handler INSERTs, never UPDATEs", () => {
+    const matchIdx = src.indexOf('"/jobs/:jobId/clock-correction"');
+    assert.ok(matchIdx >= 0, "1D depends on office-clock.ts correction handler");
+    const blockEnd = src.indexOf('"/clock-exceptions"', matchIdx);
+    const block = src.slice(matchIdx, blockEnd);
+    assert.ok(
+      /\.insert\(jobClockEventsTable\)/.test(block),
+      "correction handler must INSERT a new event",
+    );
+    assert.ok(
+      !/\.update\(jobClockEventsTable\)/.test(block),
+      "correction handler must NOT update the existing event row",
+    );
+  });
+
+  it("office-clock.ts exception-review handler only sets reviewed_*  fields", () => {
+    const matchIdx = src.indexOf('"/clock-exceptions/:id/review"');
+    assert.ok(matchIdx >= 0);
+    const block = src.slice(matchIdx, matchIdx + 1500);
+    // The review handler updates the existing row to set the reviewed
+    // metadata, but it must NOT touch the source-of-truth fields
+    // (event_at, latitude, longitude, exception_reason).
+    const updateMatch = /\.update\(jobClockEventsTable\)\s*\.set\(\{([^}]+)\}/.exec(block);
+    assert.ok(updateMatch, "review handler must use .update().set({...}) on jobClockEvents");
+    const setFields = updateMatch[1];
+    assert.ok(
+      !/event_at|latitude|longitude|exception_reason/.test(setFields),
+      "review handler must NOT alter source-of-truth fields",
+    );
+    assert.ok(
+      /exception_reviewed_by_user_id/.test(setFields),
+      "review handler must set exception_reviewed_by_user_id",
+    );
+    assert.ok(
+      /exception_reviewed_at/.test(setFields),
+      "review handler must set exception_reviewed_at",
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 5. Endpoint surface — every spec endpoint is wired
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("Cutover 1D — endpoint surface (route source)", () => {
+  const src = readFileSync(
+    path.resolve(process.cwd(), "src/routes/ops.ts"),
+    "utf8",
+  );
+
+  const required = [
+    '"/today/summary"',
+    '"/today/active-jobs"',
+    '"/today/exceptions"',
+    '"/today/live-locations"',
+    '"/jobs/:jobId/detail"',
+  ];
+  for (const ep of required) {
+    it(`ops.ts declares endpoint ${ep}`, () => {
+      assert.ok(src.includes(ep), `ops.ts must declare ${ep}`);
+    });
+  }
+
+  it("routes/index.ts mounts ops at /api/ops", () => {
+    const idxSrc = readFileSync(
+      path.resolve(process.cwd(), "src/routes/index.ts"),
+      "utf8",
+    );
+    assert.ok(
+      /router\.use\("\/ops",\s*opsRouter\)/.test(idxSrc),
+      "routes/index.ts must mount opsRouter at /ops",
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 6. Filter contract (the workhorse list's filter pill values)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("Cutover 1D — active-jobs filter contract", () => {
+  const src = readFileSync(
+    path.resolve(process.cwd(), "src/routes/ops.ts"),
+    "utf8",
+  );
+
+  // The page UI builds filter pills with these values. If the server
+  // drops one, the pill silently does nothing — guard via grep.
+  const filters = ["all", "in_progress", "late", "exceptions", "complete", "pending"];
+  for (const f of filters) {
+    it(`ops.ts handles filter='${f}'`, () => {
+      assert.ok(
+        src.includes(`case "${f}":`),
+        `ops.ts active-jobs handler must implement filter='${f}'`,
+      );
+    });
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 7. Schema cross-checks (1C tables present so 1D can read them)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("Cutover 1D — 1C dependencies present in schema", () => {
+  it("jobClockEventsTable exposes exception_reviewed_at + correction fields", async () => {
+    const { jobClockEventsTable } = await import("@workspace/db/schema");
+    const cols: any = jobClockEventsTable;
+    assert.ok(cols.exception_reviewed_at);
+    assert.ok(cols.exception_reviewed_by_user_id);
+    assert.ok(cols.is_correction);
+    assert.ok(cols.correction_of_event_id);
+    assert.ok(cols.correction_old_value);
+  });
+
+  it("jobWorksheetTable + technicianNotesTable + onMyWayEventsTable are present", async () => {
+    const schema = await import("@workspace/db/schema");
+    assert.ok((schema as any).jobWorksheetTable);
+    assert.ok((schema as any).technicianNotesTable);
+    assert.ok((schema as any).onMyWayEventsTable);
+  });
+});

--- a/artifacts/qleno/src/App.tsx
+++ b/artifacts/qleno/src/App.tsx
@@ -27,6 +27,7 @@ const CleancyclopediaPage = lazy(() => import("@/pages/cleancyclopedia"));
 const DiscountsRedirect   = lazy(() => Promise.resolve({ default: () => { window.location.replace((import.meta.env.BASE_URL.replace(/\/$/, "")) + "/company?tab=pricing"); return null; } }));
 const MyJobsPage          = lazy(() => import("@/pages/my-jobs"));
 const MyDayPage           = lazy(() => import("@/pages/my-day"));
+const OpsTodayPage        = lazy(() => import("@/pages/ops-today"));
 const ClockMonitorPage    = lazy(() => import("@/pages/clock-monitor"));
 const PortalLoginPage     = lazy(() => import("@/pages/portal/login"));
 const PortalDashboardPage = lazy(() => import("@/pages/portal/dashboard"));
@@ -140,6 +141,7 @@ function Router() {
         <Route path="/discounts" component={DiscountsRedirect} />
         <Route path="/my-jobs" component={MyJobsPage} />
         <Route path="/my-day" component={MyDayPage} />
+        <Route path="/ops/today" component={OpsTodayPage} />
 
         <Route path="/reports" component={ReportsIndexPage} />
         <Route path="/reports/insights" component={InsightsPage} />

--- a/artifacts/qleno/src/pages/ops-today.tsx
+++ b/artifacts/qleno/src/pages/ops-today.tsx
@@ -1,0 +1,1458 @@
+/**
+ * Cutover 1D — Office command-center surface at /ops/today.
+ *
+ * The first owner-facing demo proof point of the cutover. Above-the-fold
+ * answers "is today okay" in one glance; below-the-fold gives the full
+ * workhorse list, exception queue, and clock-correction modal.
+ *
+ * Design philosophy flips here vs the tech surface. The tech surface is
+ * invisible (one primary action, calm); the owner surface is confident
+ * and distinctive. Mint accent is reserved for the "alive" signals
+ * (on-shift count, in-progress pill); red is for the exception count
+ * and late count; calm grays for everything else.
+ *
+ * Polls on focus every 30 s.
+ */
+import { useEffect, useMemo, useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useAuthStore } from "@/lib/auth";
+import { formatAddress } from "@/lib/format-address";
+import { AlertTriangle, CheckCircle2, Circle, MapPin, X, ChevronRight } from "lucide-react";
+
+const BASE = import.meta.env.BASE_URL.replace(/\/$/, "");
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tokens (owner-side: confident, denser, distinctive)
+// ─────────────────────────────────────────────────────────────────────────────
+const FONT = "'Plus Jakarta Sans', sans-serif";
+const MINT = "#00C9A0";
+const NAVY = "#0A0E1A";
+const PAGE_BG = "#F7F6F3";
+const SURFACE = "#FFFFFF";
+const INK = "#1A1917";
+const INK_MUTE = "#525252";
+const INK_LIGHT = "#8B8680";
+const LINE = "#E5E2DC";
+const RED_BG = "#FEEEEE";
+const RED_INK = "#B91C1C";
+const AMBER_BG = "#FEF7E6";
+const AMBER_INK = "#B45309";
+const MINT_BG = "#E6FAF4";
+const MINT_INK = "#0F766E";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+type Summary = {
+  date: string;
+  on_shift_now: number;
+  jobs_in_progress: number;
+  jobs_complete_today: number;
+  jobs_pending_later_today: number;
+  gps_exceptions_awaiting_review: number;
+  late_arrivals_today: number;
+};
+
+type ActiveJob = {
+  id: number;
+  tech_user_id: number | null;
+  tech_name: string | null;
+  client_display_name: string;
+  address_street: string | null;
+  address_city: string | null;
+  address_state: string | null;
+  address_zip: string | null;
+  service_type_name: string | null;
+  scheduled_date: string;
+  scheduled_time: string | null;
+  allowed_hours: number | null;
+  status: string;
+  job_kind: string | null;
+  clock_in_at: string | null;
+  clock_in_event_id: number | null;
+  clock_in_within_geofence: boolean | null;
+  clock_in_gps_status: string | null;
+  is_late: boolean;
+  minutes_late: number | null;
+  has_unreviewed_exception: boolean;
+};
+
+type Exception = {
+  id: number;
+  job_id: number;
+  scheduled_date: string;
+  event_type: "clock_in" | "clock_out";
+  event_at: string;
+  exception_reason: string | null;
+  exception_photo_url: string | null;
+  tech_user_id: number | null;
+  tech_name: string | null;
+  client_display_name: string;
+};
+
+type Filter = "all" | "in_progress" | "late" | "exceptions" | "complete" | "pending";
+
+function todayIso(): string {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+function formatTime(iso: string | null): string {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  return d.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" });
+}
+
+function formatScheduledTime(t: string | null): string {
+  if (!t) return "—";
+  const m = /^(\d{1,2}):(\d{2})/.exec(t.trim());
+  if (!m) return t;
+  const hh = parseInt(m[1], 10);
+  const mm = m[2];
+  const ampm = hh >= 12 ? "PM" : "AM";
+  const display = hh === 0 ? 12 : hh > 12 ? hh - 12 : hh;
+  return `${display}:${mm} ${ampm}`;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Page
+// ─────────────────────────────────────────────────────────────────────────────
+
+export default function OpsTodayPage() {
+  const token = useAuthStore((s) => s.token);
+  const [filter, setFilter] = useState<Filter>("all");
+  const [query, setQuery] = useState<string>("");
+  const [drawerJobId, setDrawerJobId] = useState<number | null>(null);
+  const [correctionEvent, setCorrectionEvent] = useState<{
+    job_id: number;
+    event_id: number;
+    event_at: string;
+    label: string;
+  } | null>(null);
+  const date = todayIso();
+
+  // Polling: refetch every 30 s while the page is in focus. tanstack
+  // already handles refetchOnWindowFocus; combine with refetchInterval
+  // for live workday tracking.
+  const summary = useQuery<{ data: Summary }>({
+    queryKey: ["ops-summary", date],
+    queryFn: () => fetchJson(token, `/api/ops/today/summary?date=${date}`),
+    enabled: !!token,
+    refetchInterval: 30_000,
+  });
+
+  const activeJobs = useQuery<{ data: ActiveJob[] }>({
+    queryKey: ["ops-active-jobs", date, filter, query],
+    queryFn: () =>
+      fetchJson(
+        token,
+        `/api/ops/today/active-jobs?date=${date}&filter=${filter}&q=${encodeURIComponent(query)}`,
+      ),
+    enabled: !!token,
+    refetchInterval: 30_000,
+  });
+
+  const exceptions = useQuery<{ data: Exception[] }>({
+    queryKey: ["ops-exceptions"],
+    queryFn: () => fetchJson(token, `/api/ops/today/exceptions`),
+    enabled: !!token,
+    refetchInterval: 30_000,
+  });
+
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        background: PAGE_BG,
+        color: INK,
+        fontFamily: FONT,
+        paddingBottom: 64,
+      }}
+    >
+      <div
+        style={{
+          maxWidth: 1280,
+          margin: "0 auto",
+          padding: "28px 28px 0",
+        }}
+      >
+        <PageHeader date={date} />
+
+        {/* Section 1 — summary strip */}
+        <SummaryStrip
+          loading={summary.isLoading}
+          summary={summary.data?.data ?? null}
+          activeFilter={filter}
+          onSelect={setFilter}
+        />
+
+        {/* Section 3 — active jobs list (workhorse) */}
+        <section style={{ marginTop: 28 }}>
+          <SectionHeader
+            label="Active jobs"
+            right={
+              <FilterRow
+                value={filter}
+                onChange={setFilter}
+                query={query}
+                onQueryChange={setQuery}
+              />
+            }
+          />
+          <ActiveJobList
+            loading={activeJobs.isLoading}
+            jobs={activeJobs.data?.data ?? []}
+            onOpenDetail={setDrawerJobId}
+            onCorrectClock={(j) => {
+              if (j.clock_in_event_id && j.clock_in_at) {
+                setCorrectionEvent({
+                  job_id: j.id,
+                  event_id: j.clock_in_event_id,
+                  event_at: j.clock_in_at,
+                  label: `Clock-in for ${j.client_display_name}`,
+                });
+              }
+            }}
+          />
+        </section>
+
+        {/* Section 4 — exception review queue */}
+        <section style={{ marginTop: 28 }}>
+          <SectionHeader
+            label={`GPS exception review queue${exceptions.data?.data?.length ? ` · ${exceptions.data.data.length}` : ""}`}
+          />
+          <ExceptionQueue
+            token={token}
+            loading={exceptions.isLoading}
+            rows={exceptions.data?.data ?? []}
+            onOpenJob={setDrawerJobId}
+            onCorrectClock={(e) =>
+              setCorrectionEvent({
+                job_id: e.job_id,
+                event_id: e.id,
+                event_at: e.event_at,
+                label: `${e.event_type === "clock_in" ? "Clock-in" : "Clock-out"} exception for ${e.client_display_name}`,
+              })
+            }
+            onReviewed={() => exceptions.refetch()}
+          />
+        </section>
+      </div>
+
+      {drawerJobId != null ? (
+        <JobDetailDrawer
+          token={token}
+          jobId={drawerJobId}
+          onClose={() => setDrawerJobId(null)}
+          onCorrectClock={(eventId, eventAt, eventType) => {
+            setCorrectionEvent({
+              job_id: drawerJobId,
+              event_id: eventId,
+              event_at: eventAt,
+              label: eventType === "clock_in" ? "Clock-in" : "Clock-out",
+            });
+          }}
+        />
+      ) : null}
+
+      {correctionEvent ? (
+        <CorrectionModal
+          token={token}
+          payload={correctionEvent}
+          onClose={() => setCorrectionEvent(null)}
+          onSubmitted={() => {
+            setCorrectionEvent(null);
+            activeJobs.refetch();
+            exceptions.refetch();
+          }}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+async function fetchJson<T>(token: string | null, path: string): Promise<T> {
+  const res = await fetch(`${BASE}${path}`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+  if (!res.ok) {
+    const t = await res.text().catch(() => "");
+    throw new Error(`${path} → ${res.status}: ${t}`);
+  }
+  return res.json();
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Header
+// ─────────────────────────────────────────────────────────────────────────────
+
+function PageHeader({ date }: { date: string }) {
+  const [y, m, d] = date.split("-").map(Number);
+  const dt = new Date(y, m - 1, d);
+  const label = dt.toLocaleDateString(undefined, {
+    weekday: "long",
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+  return (
+    <div>
+      <div
+        style={{
+          fontSize: 11,
+          fontWeight: 700,
+          letterSpacing: "0.12em",
+          textTransform: "uppercase",
+          color: INK_LIGHT,
+        }}
+      >
+        Today · live
+      </div>
+      <h1
+        style={{
+          margin: "4px 0 0",
+          fontSize: 32,
+          fontWeight: 700,
+          letterSpacing: "-0.01em",
+          color: INK,
+        }}
+      >
+        Ops · {label}
+      </h1>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Summary strip — Section 1
+// ─────────────────────────────────────────────────────────────────────────────
+
+function SummaryStrip({
+  loading,
+  summary,
+  activeFilter,
+  onSelect,
+}: {
+  loading: boolean;
+  summary: Summary | null;
+  activeFilter: Filter;
+  onSelect: (f: Filter) => void;
+}) {
+  const tiles: Array<{
+    label: string;
+    value: number;
+    tone: "mint" | "ink" | "amber" | "red";
+    filter?: Filter;
+  }> = [
+    { label: "On shift now", value: summary?.on_shift_now ?? 0, tone: "mint", filter: "in_progress" },
+    { label: "Jobs in progress", value: summary?.jobs_in_progress ?? 0, tone: "mint", filter: "in_progress" },
+    { label: "Complete today", value: summary?.jobs_complete_today ?? 0, tone: "ink", filter: "complete" },
+    { label: "Pending later", value: summary?.jobs_pending_later_today ?? 0, tone: "ink", filter: "pending" },
+    {
+      label: "GPS exceptions",
+      value: summary?.gps_exceptions_awaiting_review ?? 0,
+      tone: (summary?.gps_exceptions_awaiting_review ?? 0) > 0 ? "red" : "ink",
+      filter: "exceptions",
+    },
+    {
+      label: "Late arrivals",
+      value: summary?.late_arrivals_today ?? 0,
+      tone: (summary?.late_arrivals_today ?? 0) > 0 ? "red" : "ink",
+      filter: "late",
+    },
+  ];
+  return (
+    <div
+      style={{
+        marginTop: 22,
+        display: "grid",
+        gridTemplateColumns: "repeat(6, minmax(0, 1fr))",
+        gap: 12,
+      }}
+    >
+      {tiles.map((t) => (
+        <SummaryTile
+          key={t.label}
+          label={t.label}
+          value={loading ? 0 : t.value}
+          tone={t.tone}
+          active={t.filter === activeFilter}
+          onClick={t.filter ? () => onSelect(t.filter!) : undefined}
+        />
+      ))}
+    </div>
+  );
+}
+
+function SummaryTile({
+  label,
+  value,
+  tone,
+  active,
+  onClick,
+}: {
+  label: string;
+  value: number;
+  tone: "mint" | "ink" | "amber" | "red";
+  active: boolean;
+  onClick?: () => void;
+}) {
+  const valueColor =
+    tone === "mint" ? MINT_INK : tone === "red" ? RED_INK : tone === "amber" ? AMBER_INK : INK;
+  const accent =
+    tone === "mint" ? MINT : tone === "red" ? RED_INK : tone === "amber" ? AMBER_INK : LINE;
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      style={{
+        textAlign: "left",
+        background: SURFACE,
+        border: `1px solid ${active ? accent : LINE}`,
+        borderRadius: 12,
+        padding: "14px 16px",
+        cursor: onClick ? "pointer" : "default",
+        boxShadow: active ? `0 0 0 3px ${accent}22` : "none",
+        transition: "border-color 0.15s, box-shadow 0.15s",
+        fontFamily: FONT,
+      }}
+    >
+      <div
+        style={{
+          fontSize: 11,
+          fontWeight: 700,
+          letterSpacing: "0.08em",
+          textTransform: "uppercase",
+          color: INK_LIGHT,
+        }}
+      >
+        {label}
+      </div>
+      <div
+        style={{
+          marginTop: 6,
+          fontSize: 30,
+          fontWeight: 700,
+          letterSpacing: "-0.01em",
+          color: valueColor,
+          fontVariantNumeric: "tabular-nums",
+        }}
+      >
+        {value}
+      </div>
+    </button>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Section header + filter row
+// ─────────────────────────────────────────────────────────────────────────────
+
+function SectionHeader({ label, right }: { label: string; right?: React.ReactNode }) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        gap: 12,
+        flexWrap: "wrap",
+        marginBottom: 10,
+      }}
+    >
+      <h2
+        style={{
+          margin: 0,
+          fontSize: 18,
+          fontWeight: 700,
+          color: INK,
+          letterSpacing: "-0.005em",
+        }}
+      >
+        {label}
+      </h2>
+      {right}
+    </div>
+  );
+}
+
+function FilterRow({
+  value,
+  onChange,
+  query,
+  onQueryChange,
+}: {
+  value: Filter;
+  onChange: (f: Filter) => void;
+  query: string;
+  onQueryChange: (q: string) => void;
+}) {
+  const pills: Array<{ key: Filter; label: string }> = [
+    { key: "all", label: "All" },
+    { key: "in_progress", label: "In progress" },
+    { key: "late", label: "Late" },
+    { key: "exceptions", label: "Exceptions" },
+    { key: "complete", label: "Complete" },
+    { key: "pending", label: "Pending" },
+  ];
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+      {pills.map((p) => (
+        <button
+          key={p.key}
+          type="button"
+          onClick={() => onChange(p.key)}
+          style={{
+            padding: "6px 12px",
+            borderRadius: 999,
+            border: `1px solid ${value === p.key ? INK : LINE}`,
+            background: value === p.key ? INK : SURFACE,
+            color: value === p.key ? "#FFFFFF" : INK,
+            fontWeight: 600,
+            fontSize: 12,
+            cursor: "pointer",
+            fontFamily: FONT,
+          }}
+        >
+          {p.label}
+        </button>
+      ))}
+      <input
+        type="search"
+        value={query}
+        onChange={(e) => onQueryChange(e.target.value)}
+        placeholder="Search tech or client"
+        style={{
+          marginLeft: 8,
+          padding: "6px 10px",
+          border: `1px solid ${LINE}`,
+          borderRadius: 8,
+          fontSize: 13,
+          fontFamily: FONT,
+          background: SURFACE,
+          color: INK,
+          minWidth: 200,
+        }}
+      />
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Active jobs list — Section 3
+// ─────────────────────────────────────────────────────────────────────────────
+
+function ActiveJobList({
+  loading,
+  jobs,
+  onOpenDetail,
+  onCorrectClock,
+}: {
+  loading: boolean;
+  jobs: ActiveJob[];
+  onOpenDetail: (jobId: number) => void;
+  onCorrectClock: (job: ActiveJob) => void;
+}) {
+  if (loading && jobs.length === 0) {
+    return <Empty>Loading…</Empty>;
+  }
+  if (jobs.length === 0) return <Empty>No jobs match this filter.</Empty>;
+  return (
+    <div
+      style={{
+        background: SURFACE,
+        border: `1px solid ${LINE}`,
+        borderRadius: 12,
+        overflow: "hidden",
+      }}
+    >
+      {jobs.map((j, idx) => (
+        <ActiveJobRow
+          key={j.id}
+          job={j}
+          isFirst={idx === 0}
+          onOpenDetail={() => onOpenDetail(j.id)}
+          onCorrectClock={() => onCorrectClock(j)}
+        />
+      ))}
+    </div>
+  );
+}
+
+function ActiveJobRow({
+  job,
+  isFirst,
+  onOpenDetail,
+  onCorrectClock,
+}: {
+  job: ActiveJob;
+  isFirst: boolean;
+  onOpenDetail: () => void;
+  onCorrectClock: () => void;
+}) {
+  const addr = formatAddress(job.address_street, job.address_city, job.address_state, job.address_zip);
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "200px 1fr 140px 140px 200px",
+        gap: 12,
+        alignItems: "center",
+        padding: "14px 18px",
+        borderTop: isFirst ? "none" : `1px solid ${LINE}`,
+        background: job.is_late || job.has_unreviewed_exception ? "#FFFCF7" : SURFACE,
+      }}
+    >
+      <div>
+        <div style={{ fontWeight: 700, fontSize: 14 }}>{job.tech_name ?? "Unassigned"}</div>
+        <div style={{ fontSize: 12, color: INK_MUTE, marginTop: 2 }}>
+          {formatScheduledTime(job.scheduled_time)}
+          {job.allowed_hours ? ` · ${job.allowed_hours} hr` : ""}
+        </div>
+      </div>
+      <div>
+        <div style={{ fontWeight: 600, fontSize: 14, color: INK }}>{job.client_display_name}</div>
+        {addr ? (
+          <div
+            style={{
+              fontSize: 12,
+              color: INK_MUTE,
+              marginTop: 2,
+              display: "flex",
+              alignItems: "center",
+              gap: 4,
+            }}
+          >
+            <MapPin size={11} />
+            {addr}
+          </div>
+        ) : null}
+      </div>
+      <div>
+        <ClockInBadge
+          clockInAt={job.clock_in_at}
+          isLate={job.is_late}
+          minutesLate={job.minutes_late}
+          status={job.status}
+        />
+      </div>
+      <div>
+        <GeofenceIndicator
+          within={job.clock_in_within_geofence}
+          gpsStatus={job.clock_in_gps_status}
+        />
+        {job.has_unreviewed_exception ? (
+          <div
+            style={{
+              marginTop: 4,
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 4,
+              background: RED_BG,
+              color: RED_INK,
+              padding: "2px 6px",
+              borderRadius: 999,
+              fontSize: 11,
+              fontWeight: 700,
+            }}
+          >
+            <AlertTriangle size={10} />
+            Exception
+          </div>
+        ) : null}
+      </div>
+      <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
+        <button
+          type="button"
+          onClick={onCorrectClock}
+          disabled={!job.clock_in_event_id}
+          style={ghostButton(!job.clock_in_event_id)}
+        >
+          Correct clock
+        </button>
+        <button type="button" onClick={onOpenDetail} style={primaryButton()}>
+          View job
+          <ChevronRight size={13} />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function ClockInBadge({
+  clockInAt,
+  isLate,
+  minutesLate,
+  status,
+}: {
+  clockInAt: string | null;
+  isLate: boolean;
+  minutesLate: number | null;
+  status: string;
+}) {
+  if (clockInAt) {
+    return (
+      <div>
+        <div style={{ fontSize: 13, fontWeight: 600, color: INK }}>
+          {formatTime(clockInAt)}
+        </div>
+        <div
+          style={{
+            display: "inline-block",
+            marginTop: 4,
+            padding: "2px 8px",
+            borderRadius: 999,
+            fontSize: 11,
+            fontWeight: 700,
+            background: isLate ? RED_BG : MINT_BG,
+            color: isLate ? RED_INK : MINT_INK,
+          }}
+        >
+          {isLate ? `Late · ${minutesLate ?? "?"} min` : status === "complete" ? "Done" : "On time"}
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div
+      style={{
+        display: "inline-block",
+        padding: "2px 8px",
+        borderRadius: 999,
+        fontSize: 11,
+        fontWeight: 700,
+        background: isLate ? RED_BG : "#F4F4F1",
+        color: isLate ? RED_INK : INK_MUTE,
+      }}
+    >
+      {isLate ? "Late — not clocked in" : "Not clocked in"}
+    </div>
+  );
+}
+
+function GeofenceIndicator({
+  within,
+  gpsStatus,
+}: {
+  within: boolean | null;
+  gpsStatus: string | null;
+}) {
+  if (gpsStatus === "failed_exception") {
+    return (
+      <Indicator color={RED_INK} bg={RED_BG} label="GPS failed">
+        <X size={12} />
+      </Indicator>
+    );
+  }
+  if (within === true) {
+    return (
+      <Indicator color={MINT_INK} bg={MINT_BG} label="On site">
+        <CheckCircle2 size={12} />
+      </Indicator>
+    );
+  }
+  if (within === false) {
+    return (
+      <Indicator color={AMBER_INK} bg={AMBER_BG} label="Off site">
+        <Circle size={12} />
+      </Indicator>
+    );
+  }
+  return (
+    <Indicator color={INK_LIGHT} bg="#F4F4F1" label="No site coords">
+      <Circle size={12} />
+    </Indicator>
+  );
+}
+
+function Indicator({
+  color,
+  bg,
+  label,
+  children,
+}: {
+  color: string;
+  bg: string;
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 6,
+        padding: "2px 8px",
+        background: bg,
+        color: color,
+        borderRadius: 999,
+        fontSize: 11,
+        fontWeight: 600,
+      }}
+    >
+      {children}
+      <span>{label}</span>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Exception queue — Section 4
+// ─────────────────────────────────────────────────────────────────────────────
+
+function ExceptionQueue({
+  token,
+  loading,
+  rows,
+  onOpenJob,
+  onCorrectClock,
+  onReviewed,
+}: {
+  token: string | null;
+  loading: boolean;
+  rows: Exception[];
+  onOpenJob: (id: number) => void;
+  onCorrectClock: (e: Exception) => void;
+  onReviewed: () => void;
+}) {
+  const review = useMutation({
+    mutationFn: async (eventId: number) => {
+      const res = await fetch(`${BASE}/api/office/clock-exceptions/${eventId}/review`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: token ? `Bearer ${token}` : "",
+        },
+        body: "{}",
+      });
+      if (!res.ok) {
+        const t = await res.text().catch(() => "");
+        throw new Error(`Review failed → ${res.status}: ${t}`);
+      }
+      return res.json();
+    },
+    onSuccess: () => onReviewed(),
+  });
+
+  if (loading && rows.length === 0) return <Empty>Loading…</Empty>;
+  if (rows.length === 0) {
+    return (
+      <Empty>
+        <CheckCircle2 size={18} style={{ color: MINT_INK, marginBottom: 6 }} />
+        <div>No exceptions awaiting review.</div>
+      </Empty>
+    );
+  }
+  return (
+    <div style={{ display: "grid", gap: 10 }}>
+      {rows.map((r) => (
+        <article
+          key={r.id}
+          style={{
+            background: SURFACE,
+            border: `1px solid ${LINE}`,
+            borderLeft: `4px solid ${RED_INK}`,
+            borderRadius: 10,
+            padding: "14px 16px",
+            display: "grid",
+            gridTemplateColumns: "auto 1fr auto",
+            gap: 14,
+            alignItems: "start",
+          }}
+        >
+          {r.exception_photo_url ? (
+            <img
+              src={r.exception_photo_url}
+              alt="entry photo"
+              style={{
+                width: 72,
+                height: 72,
+                objectFit: "cover",
+                borderRadius: 8,
+                border: `1px solid ${LINE}`,
+              }}
+            />
+          ) : (
+            <div
+              style={{
+                width: 72,
+                height: 72,
+                borderRadius: 8,
+                background: "#F4F4F1",
+                display: "grid",
+                placeItems: "center",
+                color: INK_LIGHT,
+                fontSize: 10,
+              }}
+            >
+              no photo
+            </div>
+          )}
+          <div>
+            <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+              <div style={{ fontWeight: 700, fontSize: 14 }}>{r.tech_name ?? "Unknown tech"}</div>
+              <div style={{ color: INK_LIGHT, fontSize: 12 }}>·</div>
+              <div style={{ fontSize: 13, color: INK_MUTE }}>{r.client_display_name}</div>
+            </div>
+            <div style={{ marginTop: 4, fontSize: 11, color: INK_LIGHT, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.08em" }}>
+              {r.event_type === "clock_in" ? "Clock-in" : "Clock-out"} · {formatTime(r.event_at)}
+            </div>
+            <div
+              style={{
+                marginTop: 6,
+                fontSize: 13,
+                color: INK,
+                lineHeight: 1.5,
+                wordBreak: "break-word",
+              }}
+            >
+              {r.exception_reason ?? "(no reason captured)"}
+            </div>
+          </div>
+          <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+            <button type="button" onClick={() => review.mutate(r.id)} style={primaryButton()} disabled={review.isPending}>
+              {review.isPending ? "…" : "Mark reviewed"}
+            </button>
+            <button type="button" onClick={() => onOpenJob(r.job_id)} style={ghostButton()}>
+              Open job
+            </button>
+            <button type="button" onClick={() => onCorrectClock(r)} style={ghostButton()}>
+              Correct clock
+            </button>
+          </div>
+        </article>
+      ))}
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Job detail drawer + clock timeline (shows corrections inline)
+// ─────────────────────────────────────────────────────────────────────────────
+
+type Detail = {
+  job: any;
+  worksheet: any;
+  clock_timeline: any[];
+  photos: any[];
+  notes: any[];
+};
+
+function JobDetailDrawer({
+  token,
+  jobId,
+  onClose,
+  onCorrectClock,
+}: {
+  token: string | null;
+  jobId: number;
+  onClose: () => void;
+  onCorrectClock: (eventId: number, eventAt: string, eventType: "clock_in" | "clock_out") => void;
+}) {
+  const detail = useQuery<{ data: Detail }>({
+    queryKey: ["ops-job-detail", jobId],
+    queryFn: () => fetchJson(token, `/api/ops/jobs/${jobId}/detail`),
+    enabled: !!token,
+  });
+  const d = detail.data?.data;
+  return (
+    <div
+      onClick={onClose}
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "rgba(15,15,15,0.4)",
+        zIndex: 1000,
+        display: "flex",
+        justifyContent: "flex-end",
+      }}
+    >
+      <aside
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          width: "min(640px, 100vw)",
+          height: "100vh",
+          background: PAGE_BG,
+          padding: "24px 28px",
+          overflowY: "auto",
+          boxShadow: "-4px 0 16px rgba(0,0,0,0.08)",
+        }}
+      >
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+          <h2 style={{ margin: 0, fontSize: 20, fontWeight: 700 }}>Job detail</h2>
+          <button type="button" onClick={onClose} style={ghostButton()}>
+            Close
+          </button>
+        </div>
+        {detail.isLoading || !d ? (
+          <div style={{ marginTop: 24, color: INK_MUTE }}>Loading…</div>
+        ) : (
+          <>
+            <div style={{ marginTop: 18 }}>
+              <div style={{ fontSize: 18, fontWeight: 700 }}>{d.job.client_display_name}</div>
+              <div style={{ fontSize: 13, color: INK_MUTE, marginTop: 2 }}>
+                {formatScheduledTime(d.job.scheduled_time)} · {d.job.allowed_hours ?? "?"} hr · {d.job.tech_name ?? "Unassigned"}
+              </div>
+              <div style={{ marginTop: 6, fontSize: 13, color: INK_MUTE }}>
+                {formatAddress(d.job.address_street, d.job.address_city, d.job.address_state, d.job.address_zip)}
+              </div>
+            </div>
+
+            <Section title="Clock timeline">
+              <ClockTimeline
+                events={d.clock_timeline}
+                onCorrect={(eventId, eventAt, eventType) => onCorrectClock(eventId, eventAt, eventType)}
+              />
+            </Section>
+
+            {d.worksheet ? (
+              <Section title="Worksheet">
+                <WorksheetView w={d.worksheet} />
+              </Section>
+            ) : null}
+
+            {d.photos?.length ? (
+              <Section title={`Photos · ${d.photos.length}`}>
+                <div style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 8 }}>
+                  {d.photos.map((p: any) => (
+                    <img
+                      key={p.id}
+                      src={p.url}
+                      alt={p.photo_type}
+                      style={{
+                        width: "100%",
+                        aspectRatio: "1",
+                        objectFit: "cover",
+                        borderRadius: 8,
+                        border: `1px solid ${LINE}`,
+                      }}
+                    />
+                  ))}
+                </div>
+              </Section>
+            ) : null}
+
+            {d.notes?.length ? (
+              <Section title={`Technician notes · ${d.notes.length}`}>
+                <ul style={{ margin: 0, padding: 0, listStyle: "none", display: "grid", gap: 8 }}>
+                  {d.notes.map((n: any) => (
+                    <li
+                      key={n.id}
+                      style={{
+                        background: SURFACE,
+                        border: `1px solid ${LINE}`,
+                        borderRadius: 8,
+                        padding: "10px 12px",
+                        fontSize: 13,
+                        color: INK,
+                        lineHeight: 1.5,
+                      }}
+                    >
+                      <div style={{ fontSize: 11, color: INK_LIGHT, marginBottom: 4 }}>
+                        {formatTime(n.created_at)}
+                      </div>
+                      {n.body}
+                    </li>
+                  ))}
+                </ul>
+              </Section>
+            ) : null}
+          </>
+        )}
+      </aside>
+    </div>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section style={{ marginTop: 24 }}>
+      <div
+        style={{
+          fontSize: 11,
+          fontWeight: 700,
+          letterSpacing: "0.08em",
+          textTransform: "uppercase",
+          color: INK_LIGHT,
+          marginBottom: 8,
+        }}
+      >
+        {title}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function WorksheetView({ w }: { w: any }) {
+  const rows: Array<[string, string]> = [
+    ["Service set", w.service_set_name ?? "—"],
+    ["Bedrooms", w.bedrooms != null ? String(w.bedrooms) : "—"],
+    ["Full baths", w.full_baths != null ? String(w.full_baths) : "—"],
+    ["Half baths", w.half_baths != null ? String(w.half_baths) : "—"],
+    ["Next job", w.next_job_date ?? "—"],
+  ];
+  const flags: Array<[string, boolean]> = [
+    ["Deep clean", w.scope_deep_clean],
+    ["First time in", w.scope_first_time_in],
+    ["Priority", w.scope_priority],
+    ["Special equipment", w.special_equipment_needed],
+  ];
+  return (
+    <div
+      style={{
+        background: SURFACE,
+        border: `1px solid ${LINE}`,
+        borderRadius: 10,
+        padding: "12px 14px",
+        fontSize: 13,
+        color: INK,
+      }}
+    >
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(2, 1fr)", gap: 6 }}>
+        {rows.map(([k, v]) => (
+          <div key={k}>
+            <span style={{ color: INK_LIGHT }}>{k}: </span>
+            <span style={{ fontWeight: 600 }}>{v}</span>
+          </div>
+        ))}
+      </div>
+      <div style={{ marginTop: 10, display: "flex", gap: 6, flexWrap: "wrap" }}>
+        {flags
+          .filter(([, v]) => v)
+          .map(([k]) => (
+            <span
+              key={k}
+              style={{
+                padding: "3px 8px",
+                background: AMBER_BG,
+                color: AMBER_INK,
+                borderRadius: 999,
+                fontSize: 11,
+                fontWeight: 700,
+              }}
+            >
+              {k}
+            </span>
+          ))}
+      </div>
+      {w.directions_text ? (
+        <div style={{ marginTop: 10, fontSize: 13, color: INK, lineHeight: 1.55 }}>
+          <div style={{ fontSize: 11, color: INK_LIGHT, marginBottom: 4 }}>Directions</div>
+          {w.directions_text}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function ClockTimeline({
+  events,
+  onCorrect,
+}: {
+  events: any[];
+  onCorrect: (eventId: number, eventAt: string, eventType: "clock_in" | "clock_out") => void;
+}) {
+  if (!events?.length) return <div style={{ color: INK_MUTE, fontSize: 13 }}>No clock events yet.</div>;
+
+  return (
+    <ol style={{ margin: 0, padding: 0, listStyle: "none", display: "grid", gap: 8 }}>
+      {events.map((e) => {
+        const isCorrection = !!e.is_correction;
+        const isException = e.gps_status === "failed_exception";
+        return (
+          <li
+            key={e.id}
+            style={{
+              background: SURFACE,
+              border: `1px solid ${LINE}`,
+              borderLeft: `4px solid ${
+                isException ? RED_INK : isCorrection ? AMBER_INK : MINT_INK
+              }`,
+              borderRadius: 8,
+              padding: "10px 12px",
+              fontSize: 13,
+            }}
+          >
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 8 }}>
+              <div>
+                <div style={{ fontWeight: 700 }}>
+                  {e.event_type === "clock_in" ? "Clock-in" : "Clock-out"}
+                  {isCorrection ? " · CORRECTION" : ""}
+                </div>
+                <div style={{ fontSize: 12, color: INK_MUTE, marginTop: 2 }}>{formatTime(e.event_at)}</div>
+              </div>
+              <button
+                type="button"
+                onClick={() => onCorrect(e.id, e.event_at, e.event_type)}
+                style={ghostButton()}
+              >
+                Correct
+              </button>
+            </div>
+            {isException ? (
+              <div
+                style={{
+                  marginTop: 8,
+                  background: RED_BG,
+                  color: RED_INK,
+                  borderRadius: 6,
+                  padding: "8px 10px",
+                  fontSize: 12,
+                }}
+              >
+                <strong>Exception:</strong> {e.exception_reason ?? "(no reason)"}
+                {e.exception_reviewed_at ? (
+                  <span style={{ marginLeft: 6, fontWeight: 600 }}>· reviewed</span>
+                ) : null}
+              </div>
+            ) : (
+              <div style={{ marginTop: 6, fontSize: 12, color: INK_MUTE }}>
+                {e.within_geofence === true
+                  ? "On site"
+                  : e.within_geofence === false
+                  ? "Off site"
+                  : "No geofence comparison"}
+                {e.distance_from_site_meters != null
+                  ? ` · ${Math.round(e.distance_from_site_meters)} m from site`
+                  : ""}
+              </div>
+            )}
+            {isCorrection && e.correction_old_value ? (
+              <div
+                style={{
+                  marginTop: 8,
+                  background: "#FFFBF0",
+                  border: `1px dashed ${AMBER_INK}55`,
+                  color: AMBER_INK,
+                  fontSize: 11,
+                  padding: "6px 10px",
+                  borderRadius: 6,
+                  lineHeight: 1.45,
+                }}
+              >
+                Original event #{e.correction_of_event_id} preserved · prior time{" "}
+                {e.correction_old_value.event_at
+                  ? formatTime(typeof e.correction_old_value.event_at === "string" ? e.correction_old_value.event_at : new Date(e.correction_old_value.event_at).toISOString())
+                  : "—"}
+              </div>
+            ) : null}
+          </li>
+        );
+      })}
+    </ol>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Correction modal — calls POST /api/office/jobs/:jobId/clock-correction
+// ─────────────────────────────────────────────────────────────────────────────
+
+function CorrectionModal({
+  token,
+  payload,
+  onClose,
+  onSubmitted,
+}: {
+  token: string | null;
+  payload: { job_id: number; event_id: number; event_at: string; label: string };
+  onClose: () => void;
+  onSubmitted: () => void;
+}) {
+  const [newEventAt, setNewEventAt] = useState<string>(() => {
+    const d = new Date(payload.event_at);
+    // datetime-local input wants YYYY-MM-DDTHH:MM (no seconds/tz)
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}T${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+  });
+  const [reason, setReason] = useState("");
+  const queryClient = useQueryClient();
+  const submit = useMutation({
+    mutationFn: async () => {
+      const correctedIso = new Date(newEventAt).toISOString();
+      const res = await fetch(`${BASE}/api/office/jobs/${payload.job_id}/clock-correction`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: token ? `Bearer ${token}` : "",
+        },
+        body: JSON.stringify({
+          correction_of_event_id: payload.event_id,
+          corrected_values: { event_at: correctedIso },
+          reason: reason.trim(),
+        }),
+      });
+      if (!res.ok) {
+        const t = await res.text().catch(() => "");
+        throw new Error(`Correction failed → ${res.status}: ${t}`);
+      }
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["ops-job-detail", payload.job_id] });
+      onSubmitted();
+    },
+  });
+  return (
+    <div
+      onClick={onClose}
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "rgba(15,15,15,0.4)",
+        zIndex: 1100,
+        display: "grid",
+        placeItems: "center",
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          background: SURFACE,
+          border: `1px solid ${LINE}`,
+          borderRadius: 12,
+          padding: "22px 24px",
+          width: "min(480px, 92vw)",
+          fontFamily: FONT,
+        }}
+      >
+        <h2 style={{ margin: 0, fontSize: 18, fontWeight: 700 }}>Correct clock</h2>
+        <div style={{ marginTop: 4, fontSize: 13, color: INK_MUTE }}>
+          {payload.label} · original {formatTime(payload.event_at)}
+        </div>
+        <div
+          style={{
+            marginTop: 12,
+            background: AMBER_BG,
+            color: AMBER_INK,
+            padding: "10px 12px",
+            borderRadius: 8,
+            fontSize: 12,
+            lineHeight: 1.5,
+          }}
+        >
+          Corrections create a NEW audit event. The original event is preserved and remains visible
+          in the clock timeline. Both will be shown after submission.
+        </div>
+        <label style={{ display: "block", marginTop: 14, fontSize: 12, fontWeight: 600, color: INK_MUTE }}>
+          Corrected time
+          <input
+            type="datetime-local"
+            value={newEventAt}
+            onChange={(e) => setNewEventAt(e.target.value)}
+            style={{
+              display: "block",
+              marginTop: 4,
+              width: "100%",
+              padding: "8px 10px",
+              border: `1px solid ${LINE}`,
+              borderRadius: 8,
+              fontSize: 14,
+              fontFamily: FONT,
+            }}
+          />
+        </label>
+        <label style={{ display: "block", marginTop: 12, fontSize: 12, fontWeight: 600, color: INK_MUTE }}>
+          Reason (audit trail)
+          <textarea
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            placeholder="e.g. tech texted to say GPS denied and forgot to clock in until 9:42"
+            rows={3}
+            style={{
+              display: "block",
+              marginTop: 4,
+              width: "100%",
+              padding: "8px 10px",
+              border: `1px solid ${LINE}`,
+              borderRadius: 8,
+              fontSize: 13,
+              fontFamily: FONT,
+              resize: "vertical",
+            }}
+          />
+        </label>
+        {submit.isError ? (
+          <div
+            style={{
+              marginTop: 10,
+              background: RED_BG,
+              color: RED_INK,
+              padding: "8px 10px",
+              borderRadius: 6,
+              fontSize: 12,
+            }}
+          >
+            {(submit.error as Error).message}
+          </div>
+        ) : null}
+        <div style={{ marginTop: 18, display: "flex", justifyContent: "flex-end", gap: 8 }}>
+          <button type="button" onClick={onClose} style={ghostButton()} disabled={submit.isPending}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => submit.mutate()}
+            disabled={!reason.trim() || submit.isPending}
+            style={primaryButton(!reason.trim() || submit.isPending)}
+          >
+            {submit.isPending ? "Submitting…" : "Submit correction"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Atoms
+// ─────────────────────────────────────────────────────────────────────────────
+
+function primaryButton(disabled?: boolean): React.CSSProperties {
+  return {
+    background: disabled ? "#A3A199" : INK,
+    color: "#FFFFFF",
+    padding: "6px 12px",
+    borderRadius: 8,
+    border: "none",
+    fontWeight: 700,
+    fontSize: 12,
+    cursor: disabled ? "not-allowed" : "pointer",
+    display: "inline-flex",
+    alignItems: "center",
+    gap: 4,
+    fontFamily: FONT,
+  };
+}
+
+function ghostButton(disabled?: boolean): React.CSSProperties {
+  return {
+    background: "transparent",
+    color: disabled ? INK_LIGHT : INK,
+    padding: "6px 12px",
+    borderRadius: 8,
+    border: `1px solid ${LINE}`,
+    fontWeight: 600,
+    fontSize: 12,
+    cursor: disabled ? "not-allowed" : "pointer",
+    fontFamily: FONT,
+  };
+}
+
+function Empty({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      style={{
+        background: SURFACE,
+        border: `1px solid ${LINE}`,
+        borderRadius: 10,
+        padding: "24px 18px",
+        textAlign: "center",
+        color: INK_MUTE,
+        fontSize: 13,
+      }}
+    >
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Lands cutover 1D, rebased onto current main. Original work from
feature/cutover-1d-office-live-view (commit 273a38e), now sitting on
top of every cutover stage 1A–3A + the company switcher + multi-tenant
employee membership (PRs #195–#210).

This is the **first owner-facing demo proof point** of the cutover. A
new /ops/today page that turns the 1C clock-integrity guarantees into a
visible, location-grounded picture of the workday-in-progress.

## What lands

**Backend** (artifacts/api-server/src/routes/ops.ts — 843 lines):
- GET /api/ops/today/summary         — count cards for the strip
- GET /api/ops/today/active-jobs     — workhorse list w/ filter + search
- GET /api/ops/today/exceptions      — failed_exception review queue
- GET /api/ops/today/live-locations  — currently on-shift map pins
- GET /api/ops/jobs/:jobId/detail    — drawer payload (worksheet +
                                       photos + notes + full clock
                                       timeline including corrections)
- artifacts/api-server/src/lib/job-status-constants.ts — server-side
  mirror of LATE_THRESHOLD_MINUTES + NO_SHOW_WAIT_MINUTES, single
  source of truth shared with the frontend (drift protection).

**Frontend** (artifacts/qleno/src/pages/ops-today.tsx — 1458 lines):
- Summary strip, active-jobs list, GPS exception review queue, job
  detail drawer with full clock-correction timeline.
- 30 s polling via tanstack-query.
- Mint accent reserved for "alive" signals (on-shift, in-progress);
  red for exception + late counts; calm grays elsewhere.

## Privacy + integrity gates (per the original author's spec)

- router.use(requireAuth, officeOnly) at the top of ops.ts means EVERY
  endpoint inherits the role gate; a tech hitting any /api/ops/* path
  gets 403 by construction, not by per-route effort.
- Clock-correction modal calls the 1C INSERT-only endpoint (originals
  preserved + correction renders as a separate timeline entry with
  "CORRECTION" label).
- Tested both invariants — 23/23 tests pass.

## Rebase conflicts resolved

Two tiny conflicts in routes/index.ts where 1E (which landed in main
while 1D was branched) also mounted at /ops:
  - Kept the 1E payRouter + opsIntegrityRouter mounts
  - Added opsRouter on the same /ops prefix below
  - Express dispatches by sub-path so the two coexist cleanly
    (/api/ops/integrity-check from 1E vs /api/ops/today/* from 1D)

## Test plan

- [x] 23/23 cutover-1d-ops.test.ts pass on rebased branch
- [x] tsc clean on routes/index.ts (0 errors, including the conflict
      resolution)
- [x] tsc clean on the 4 net-new files (routes/ops.ts,
      tests/cutover-1d-ops.test.ts, lib/job-status-constants.ts,
      pages/ops-today.tsx)
- [ ] Post-deploy: hit /ops/today as owner, confirm summary strip
      renders + clicking a count filters the active-jobs list
- [ ] Post-deploy: hit any /api/ops/* path as technician → 403
- [ ] Post-deploy: open the clock-correction modal from the drawer,
      submit a correction, confirm both original + corrected events
      render with the CORRECTION callout

🤖 Generated with [Claude Code](https://claude.com/claude-code)