### PR TITLE
fix(jobs): cancel-button no-op — PATCH whitelist dropped 'status'

### DIFF
--- a/artifacts/api-server/src/routes/jobs.ts
+++ b/artifacts/api-server/src/routes/jobs.ts
@@ -1106,7 +1106,7 @@ router.patch("/:id", requireAuth, async (req, res) => {
     type FieldName =
       | "service_type" | "frequency" | "scheduled_date" | "scheduled_time"
       | "allowed_hours" | "base_fee" | "hourly_rate" | "manual_rate_override"
-      | "instructions" | "add_ons" | "team_user_ids";
+      | "instructions" | "add_ons" | "team_user_ids" | "status";
     const changes: Array<{ field: FieldName; old: unknown; next: unknown }> = [];
     const pushChange = (field: FieldName, next: unknown, prev: unknown) => {
       const norm = (v: unknown) => v === null || v === undefined ? null : v;
@@ -1124,6 +1124,24 @@ router.patch("/:id", requireAuth, async (req, res) => {
     if (hourly_rate !== undefined) pushChange("hourly_rate", String(hourly_rate), String(before.hourly_rate ?? ""));
     if (manual_rate_override !== undefined) pushChange("manual_rate_override", !!manual_rate_override, !!before.manual_rate_override);
     if (instructions !== undefined) pushChange("instructions", instructions, before.notes);
+    // Status transitions via PATCH are scoped to cancellation only — the
+    // 'complete' path goes through POST /:id/complete (which writes the
+    // completion artifacts: actual_end_time, locked_at, etc.). Allowing
+    // status='cancelled' here unblocks the cancel modal in the dispatch
+    // drawer; before this, the modal called PATCH { status:'cancelled' }
+    // which silently dropped because status wasn't in the whitelist —
+    // the row never changed, the UI optimistically removed the job, and
+    // on the next refresh the job reappeared ("cancel makes a new one
+    // pop in"). Now the status sticks.
+    if (status !== undefined && status !== before.status) {
+      if (status !== "cancelled") {
+        return res.status(400).json({
+          error: "Bad Request",
+          message: "PATCH /:id only accepts status='cancelled'. Use POST /:id/complete for completions.",
+        });
+      }
+      pushChange("status", status, before.status);
+    }
 
     // For add_ons + team_user_ids we always emit an audit row when payload is present,
     // since per-row diff is verbose; the JSON payload carries the full new value.
@@ -1191,6 +1209,9 @@ router.patch("/:id", requireAuth, async (req, res) => {
       if (hourly_rate !== undefined) setParts.hourly_rate = hourly_rate === null ? null : String(hourly_rate);
       if (nextManualOverride !== undefined) setParts.manual_rate_override = nextManualOverride;
       if (instructions !== undefined) setParts.notes = instructions;
+      // Status: pushChange validated above that status==='cancelled' only.
+      // Writing it here lets the cancel modal's PATCH actually take effect.
+      if (status !== undefined && status !== before.status) setParts.status = status;
 
       // [PR / 2026-05-01 — re-implementation of yesterday's PR #34]
       // When the anchor is a completed job AND the operator picked a


### PR DESCRIPTION
## Summary

Live bug Sal hit while testing for July go-live: cancelling a job did
nothing, then the same job re-appeared on refresh — looking like "a new
job populates out of nowhere."

**Root cause:** PATCH /api/jobs/:id has a FieldName whitelist that
doesn't include 'status'. The dispatch drawer's Cancel modal posts
\`{ status: "cancelled" }\` via patchJob() — every field check in the
handler saw undefined, changes[] stayed empty, and it returned
\`{ ok: true, changed: false, message: "No changes detected" }\`
without ever touching the row. UI optimistically removed the job, next
refetch showed it back.

## Fix

- Add 'status' to FieldName
- pushChange when status differs from current
- Guardrail: only accept status='cancelled' here. POST /:id/complete
  remains the canonical completion path (it writes locked_at +
  actual_end_time which we must not bypass)
- Mirror to setParts.status inside the transaction so UPDATE actually fires

## Repro (before fix)

\`\`\`bash
$ curl -X PATCH .../api/jobs/4252 -d '{"status":"cancelled","cascade_scope":"this_job"}'
{"ok":true,"changed":false,"message":"No changes detected"}
$ # status still 'scheduled'
\`\`\`

Post-fix: status flips to 'cancelled' atomically.

## Test plan

- [x] tsc clean
- [ ] Post-deploy: open any active job's drawer → Cancel → confirm
      reason → job actually goes to 'cancelled' status + stays gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)