### PR TITLE
feat(reports): cancellation revenue + lockout fees KPI breakdown

### DIFF
--- a/artifacts/api-server/src/cutover-data-migration.ts
+++ b/artifacts/api-server/src/cutover-data-migration.ts
@@ -76,6 +76,14 @@ export async function runCutoverDataMigration(): Promise<void> {
     );
   }
   try {
+    await addCancellationPolicyColumns();
+  } catch (err) {
+    console.error(
+      "[cutover-migration] cancellation policy columns failed (non-fatal):",
+      err,
+    );
+  }
+  try {
     await addLeaveCascadeColumns();
   } catch (err) {
     console.error(
@@ -195,6 +203,77 @@ async function addLeaveCascadeColumns(): Promise<void> {
       ) THEN
         CREATE INDEX leave_requests_cascade_group_idx
           ON leave_requests (cascade_group_id);
+      END IF;
+    END $$;
+  `),
+  );
+}
+
+/**
+ * Cancellation policy + action picker columns.
+ *
+ * Three migrations bundled because they shape one feature:
+ *   1. companies.default_cancel_fee_pct + default_lockout_fee_pct
+ *      (per-tenant defaults; 100% for Phes per stated policy).
+ *   2. clients.cancel_fee_pct + lockout_fee_pct
+ *      (nullable per-client overrides).
+ *   3. cancellation_log.cancel_action + customer_charge_amount +
+ *      affects_future_jobs (the per-event audit + reporting hooks).
+ *
+ * Idempotent guards on every ADD. Defaults match the schema definition
+ * so the row default and the migration default never drift.
+ */
+async function addCancellationPolicyColumns(): Promise<void> {
+  await db.execute(
+    sql.raw(`
+    DO $$
+    BEGIN
+      -- companies: per-tenant defaults
+      IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema='public' AND table_name='companies' AND column_name='default_cancel_fee_pct'
+      ) THEN
+        ALTER TABLE companies ADD COLUMN default_cancel_fee_pct numeric(5,2) NOT NULL DEFAULT 100.00;
+      END IF;
+      IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema='public' AND table_name='companies' AND column_name='default_lockout_fee_pct'
+      ) THEN
+        ALTER TABLE companies ADD COLUMN default_lockout_fee_pct numeric(5,2) NOT NULL DEFAULT 100.00;
+      END IF;
+
+      -- clients: per-record overrides (nullable on purpose)
+      IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema='public' AND table_name='clients' AND column_name='cancel_fee_pct'
+      ) THEN
+        ALTER TABLE clients ADD COLUMN cancel_fee_pct numeric(5,2);
+      END IF;
+      IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema='public' AND table_name='clients' AND column_name='lockout_fee_pct'
+      ) THEN
+        ALTER TABLE clients ADD COLUMN lockout_fee_pct numeric(5,2);
+      END IF;
+
+      -- cancellation_log: action picker + charged amount + future-jobs flag
+      IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema='public' AND table_name='cancellation_log' AND column_name='cancel_action'
+      ) THEN
+        ALTER TABLE cancellation_log ADD COLUMN cancel_action text;
+      END IF;
+      IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema='public' AND table_name='cancellation_log' AND column_name='customer_charge_amount'
+      ) THEN
+        ALTER TABLE cancellation_log ADD COLUMN customer_charge_amount numeric(10,2) NOT NULL DEFAULT 0;
+      END IF;
+      IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema='public' AND table_name='cancellation_log' AND column_name='affects_future_jobs'
+      ) THEN
+        ALTER TABLE cancellation_log ADD COLUMN affects_future_jobs boolean NOT NULL DEFAULT false;
       END IF;
     END $$;
   `),

--- a/artifacts/api-server/src/lib/cancellation-policy.ts
+++ b/artifacts/api-server/src/lib/cancellation-policy.ts
@@ -1,0 +1,92 @@
+/**
+ * Cancellation policy — resolves the customer charge for a given (action,
+ * client, company, job) tuple.
+ *
+ * Charging rules (Sal's stated policy, June 2026):
+ *   - cancel  → full charge (per-client cancel_fee_pct ?? company default)
+ *   - lockout → full charge (per-client lockout_fee_pct ?? company default)
+ *   - move / bump / skip / cancel_service → no charge
+ *   - modify is NOT a cancellation; it routes to the schedule editor
+ *
+ * For charging actions, we DO NOT mark the job 'cancelled' with a zero
+ * billed_amount — instead, the existing billed_amount stays. Per Sal:
+ * "Job's base_fee + billed_amount stays — mark job 'complete' with
+ * cancellation note." The cancellation_log row carries the audit.
+ *
+ * This module is pure: it reads the inputs, returns the decision. The
+ * route layer does the DB write + status flip + log row.
+ */
+
+export type CancelAction =
+  | "move"
+  | "bump"
+  | "skip"
+  | "cancel"
+  | "lockout"
+  | "cancel_service";
+
+export const CANCEL_ACTIONS: readonly CancelAction[] = [
+  "move", "bump", "skip", "cancel", "lockout", "cancel_service",
+];
+
+/** Actions that auto-charge the customer. */
+export const CHARGING_ACTIONS: ReadonlySet<CancelAction> = new Set(["cancel", "lockout"]);
+
+/** Actions that terminate the recurring schedule (affects future jobs). */
+export const FUTURE_AFFECTING_ACTIONS: ReadonlySet<CancelAction> = new Set(["cancel_service"]);
+
+export interface PolicyInput {
+  action: CancelAction;
+  /** Effective amount on the job (billed_amount ?? base_fee). */
+  jobAmount: number;
+  /** Per-tenant defaults — always non-null in practice (DB defaults to 100). */
+  companyDefaultCancelFeePct: number;
+  companyDefaultLockoutFeePct: number;
+  /** Per-client overrides — NULL means "use the company default". */
+  clientCancelFeePct: number | null;
+  clientLockoutFeePct: number | null;
+}
+
+export interface PolicyResult {
+  charge_amount: number;
+  fee_pct_applied: number;
+  charges_customer: boolean;
+  affects_future_jobs: boolean;
+  /** Status the job row should end up in after this action. */
+  next_job_status: "cancelled" | "complete";
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+export function resolveCancellationPolicy(input: PolicyInput): PolicyResult {
+  const charges = CHARGING_ACTIONS.has(input.action);
+  const affectsFuture = FUTURE_AFFECTING_ACTIONS.has(input.action);
+
+  if (!charges) {
+    return {
+      charge_amount: 0,
+      fee_pct_applied: 0,
+      charges_customer: false,
+      affects_future_jobs: affectsFuture,
+      next_job_status: "cancelled",
+    };
+  }
+
+  const pct = input.action === "lockout"
+    ? (input.clientLockoutFeePct ?? input.companyDefaultLockoutFeePct)
+    : (input.clientCancelFeePct ?? input.companyDefaultCancelFeePct);
+
+  const charge_amount = round2(Math.max(0, input.jobAmount) * (pct / 100));
+
+  return {
+    charge_amount,
+    fee_pct_applied: pct,
+    charges_customer: charge_amount > 0,
+    affects_future_jobs: affectsFuture,
+    // Per Sal: charged cancellations stay as a 'complete' artifact so the
+    // billed_amount lands on the revenue reports unchanged.
+    next_job_status: "complete",
+  };
+}

--- a/artifacts/api-server/src/routes/cancellation.ts
+++ b/artifacts/api-server/src/routes/cancellation.ts
@@ -1,8 +1,13 @@
 import { Router } from "express";
 import { db } from "@workspace/db";
-import { cancellationLogTable, jobsTable, clientsTable, usersTable } from "@workspace/db/schema";
+import { cancellationLogTable, jobsTable, clientsTable, companiesTable, usersTable } from "@workspace/db/schema";
 import { eq, and, gte, lte, desc, sql, count } from "drizzle-orm";
 import { requireAuth } from "../lib/auth.js";
+import {
+  resolveCancellationPolicy,
+  CANCEL_ACTIONS,
+  type CancelAction,
+} from "../lib/cancellation-policy.js";
 
 const router = Router();
 
@@ -18,12 +23,26 @@ const REASON_MAP: Record<string, "customer_request" | "no_show" | "weather" | "e
   other: "other",
 };
 
+/**
+ * Map an MC-style cancel_action to the legacy cancel_reason enum so the
+ * existing pre-action-picker reports keep working. The action is the
+ * source of truth going forward; cancel_reason is for back-compat.
+ */
+const ACTION_TO_LEGACY_REASON: Record<CancelAction, "customer_request" | "no_show" | "weather" | "emergency" | "other"> = {
+  move: "customer_request",
+  bump: "other",
+  skip: "customer_request",
+  cancel: "customer_request",
+  lockout: "no_show",
+  cancel_service: "customer_request",
+};
+
 // GET /api/cancellations/reschedule-count — count reschedule records for a client in last N days
 router.get("/reschedule-count", requireAuth, async (req, res) => {
   try {
     const { client_id, days = "90" } = req.query;
     if (!client_id) return res.status(400).json({ error: "client_id required" });
-    const companyId = req.auth!.companyId;
+    const companyId = req.auth!.companyId!;
     const cutoff = new Date();
     cutoff.setDate(cutoff.getDate() - parseInt(days as string));
     const cutoffStr = cutoff.toISOString();
@@ -49,7 +68,7 @@ router.get("/reschedule-count", requireAuth, async (req, res) => {
 router.get("/", requireAuth, async (req, res) => {
   try {
     const { date_from, date_to, customer_id, employee_id } = req.query;
-    const conditions: any[] = [eq(cancellationLogTable.company_id, req.auth!.companyId)];
+    const conditions: any[] = [eq(cancellationLogTable.company_id, req.auth!.companyId!)];
     if (date_from) conditions.push(sql`${cancellationLogTable.cancelled_at} >= ${date_from as string}`);
     if (date_to) conditions.push(sql`${cancellationLogTable.cancelled_at} <= ${date_to as string}`);
     if (customer_id) conditions.push(eq(cancellationLogTable.customer_id, parseInt(customer_id as string)));
@@ -86,7 +105,7 @@ router.post("/", requireAuth, async (req, res) => {
     if (!job_id || !customer_id || !cancel_reason) {
       return res.status(400).json({ error: "job_id, customer_id, and cancel_reason required" });
     }
-    const companyId = req.auth!.companyId;
+    const companyId = req.auth!.companyId!;
     const mappedReason = REASON_MAP[cancel_reason as string] ?? "other";
 
     const [row] = await db.insert(cancellationLogTable).values({
@@ -103,6 +122,176 @@ router.post("/", requireAuth, async (req, res) => {
     console.error("[cancellations POST]", err);
     return res.status(500).json({ error: "Server error" });
   }
+});
+
+/**
+ * POST /api/cancellations/action — MC-style cancellation action.
+ *
+ * Body:
+ *   {
+ *     job_id: number,
+ *     action: 'move'|'bump'|'skip'|'cancel'|'lockout'|'cancel_service',
+ *     notes?: string,
+ *     // Optional override of the resolved charge. Operator can dial it
+ *     // down or up at the modal (e.g. partial-fee gesture).
+ *     charge_amount_override?: number,
+ *   }
+ *
+ * Behavior:
+ *   1. Resolves the customer charge via cancellation-policy.ts (action +
+ *      per-client fee % + company default + job amount).
+ *   2. Flips the job to the right status:
+ *        - 'cancel' / 'lockout' → status='complete', billed_amount untouched,
+ *          notes appended with the action + fee marker.
+ *        - free actions → status='cancelled', billed_amount cleared to 0.
+ *   3. If action='cancel_service', sets the recurring schedule's cancelled_at
+ *      and cancels future not-yet-completed jobs on the same schedule.
+ *   4. Writes the cancellation_log row with cancel_action +
+ *      customer_charge_amount + affects_future_jobs.
+ *
+ * All in one transaction. Returns { ok, log_row, charge_amount,
+ * next_status, future_cancelled_count }.
+ */
+router.post("/action", requireAuth, async (req, res) => {
+  const companyId = req.auth!.companyId!;
+  const userId = req.auth!.userId!;
+  const body = req.body as {
+    job_id?: number;
+    action?: string;
+    notes?: string;
+    charge_amount_override?: number;
+  };
+  if (!body?.job_id || !Number.isFinite(Number(body.job_id))) {
+    return res.status(400).json({ error: "job_id required" });
+  }
+  const action = body.action as CancelAction | undefined;
+  if (!action || !CANCEL_ACTIONS.includes(action)) {
+    return res.status(400).json({
+      error: "Bad Request",
+      message: `action must be one of: ${CANCEL_ACTIONS.join(", ")}`,
+    });
+  }
+
+  // Load job + client + company defaults in one round trip.
+  const ctx = await db.execute(sql`
+    SELECT j.id, j.client_id, j.status::text AS status, j.billed_amount, j.base_fee,
+           j.notes AS job_notes, j.recurring_schedule_id,
+           c.cancel_fee_pct AS client_cancel_pct, c.lockout_fee_pct AS client_lockout_pct,
+           co.default_cancel_fee_pct, co.default_lockout_fee_pct
+      FROM jobs j
+      JOIN clients c ON c.id = j.client_id
+      JOIN companies co ON co.id = j.company_id
+     WHERE j.id = ${body.job_id} AND j.company_id = ${companyId}
+     LIMIT 1
+  `);
+  const row = ctx.rows[0] as any;
+  if (!row) return res.status(404).json({ error: "Not Found", message: "Job not found" });
+  if (row.status === "complete" || row.status === "cancelled") {
+    return res.status(409).json({
+      error: "Conflict",
+      message: `Job already ${row.status}. Cancellation actions only apply to active jobs.`,
+    });
+  }
+
+  const jobAmount = parseFloat(String(row.billed_amount ?? row.base_fee ?? 0));
+  const policy = resolveCancellationPolicy({
+    action,
+    jobAmount,
+    companyDefaultCancelFeePct: parseFloat(String(row.default_cancel_fee_pct ?? 100)),
+    companyDefaultLockoutFeePct: parseFloat(String(row.default_lockout_fee_pct ?? 100)),
+    clientCancelFeePct: row.client_cancel_pct != null ? parseFloat(String(row.client_cancel_pct)) : null,
+    clientLockoutFeePct: row.client_lockout_pct != null ? parseFloat(String(row.client_lockout_pct)) : null,
+  });
+
+  // Operator override on the modal — clamp to >= 0, allow setting to 0
+  // (waive the fee).
+  const finalCharge = body.charge_amount_override != null && Number.isFinite(Number(body.charge_amount_override))
+    ? Math.max(0, Number(body.charge_amount_override))
+    : policy.charge_amount;
+
+  const actionNote = policy.charges_customer
+    ? `[${action}_fee_charged: $${finalCharge.toFixed(2)} (${policy.fee_pct_applied}%)]`
+    : `[${action}]`;
+  const operatorNote = body.notes?.trim() ? ` ${body.notes.trim()}` : "";
+  const appendedNotes = `${row.job_notes ?? ""}${row.job_notes ? "\n" : ""}${actionNote}${operatorNote}`.trim();
+
+  let futureCancelled = 0;
+  const logRow = await db.transaction(async (tx) => {
+    // Update the job row itself.
+    if (policy.next_job_status === "complete") {
+      // Charged cancellation — billed_amount becomes the cancellation fee
+      // (so revenue reports pick it up cleanly).
+      await tx.execute(sql`
+        UPDATE jobs
+           SET status = 'complete'::job_status,
+               billed_amount = ${finalCharge.toFixed(2)},
+               notes = ${appendedNotes},
+               locked_at = NOW()
+         WHERE id = ${body.job_id} AND company_id = ${companyId}
+      `);
+    } else {
+      // Free action — job is cancelled, billed_amount zeroed.
+      await tx.execute(sql`
+        UPDATE jobs
+           SET status = 'cancelled'::job_status,
+               billed_amount = 0,
+               notes = ${appendedNotes}
+         WHERE id = ${body.job_id} AND company_id = ${companyId}
+      `);
+    }
+
+    // Cancel Service — terminate future occurrences of the same schedule.
+    if (policy.affects_future_jobs && row.recurring_schedule_id != null) {
+      const futureCancel = await tx.execute(sql`
+        UPDATE jobs
+           SET status = 'cancelled'::job_status,
+               billed_amount = 0,
+               notes = COALESCE(notes, '') ||
+                       (CASE WHEN notes IS NULL OR notes = '' THEN '' ELSE E'\n' END) ||
+                       '[cancel_service_propagated from job ' || ${body.job_id} || ']'
+         WHERE recurring_schedule_id = ${row.recurring_schedule_id}
+           AND company_id = ${companyId}
+           AND status::text IN ('scheduled','in_progress')
+           AND id != ${body.job_id}
+        RETURNING id
+      `);
+      futureCancelled = (futureCancel.rows as any[]).length;
+      // Also flag the recurring schedule itself.
+      await tx.execute(sql`
+        UPDATE recurring_schedules
+           SET active = false
+         WHERE id = ${row.recurring_schedule_id} AND company_id = ${companyId}
+      `);
+    }
+
+    // Cancellation log row — the audit trail. cancel_reason stays for
+    // back-compat with existing /reports/cancellations; cancel_action is
+    // the new source of truth.
+    const [logged] = await tx
+      .insert(cancellationLogTable)
+      .values({
+        company_id: companyId,
+        job_id: body.job_id!,
+        customer_id: row.client_id,
+        cancelled_by: userId,
+        cancel_reason: ACTION_TO_LEGACY_REASON[action],
+        cancel_action: action,
+        customer_charge_amount: finalCharge.toFixed(2),
+        affects_future_jobs: policy.affects_future_jobs,
+        notes: body.notes ?? null,
+      })
+      .returning();
+    return logged;
+  });
+
+  return res.status(201).json({
+    ok: true,
+    log: logRow,
+    charge_amount: finalCharge,
+    fee_pct_applied: policy.fee_pct_applied,
+    next_status: policy.next_job_status,
+    future_cancelled_count: futureCancelled,
+  });
 });
 
 export default router;

--- a/artifacts/api-server/src/routes/reports.ts
+++ b/artifacts/api-server/src/routes/reports.ts
@@ -814,13 +814,50 @@ router.get("/cancellations", requireAuth, ROLE, async (req, res) => {
       };
     });
 
+    // By-action breakdown — sourced from cancellation_log so we pick up
+    // the charging actions (status='complete') that the legacy
+    // `WHERE status='cancelled'` query above misses. Groups by
+    // cancel_action so the UI can render "Lockout fees" / "Cancel fees"
+    // as separate KPIs.
+    const byActionRows = await db.execute(sql`
+      SELECT COALESCE(cl.cancel_action, 'legacy') AS action,
+             COUNT(*)::int AS count,
+             COALESCE(SUM(cl.customer_charge_amount), 0)::text AS total_charged
+        FROM cancellation_log cl
+        JOIN jobs j ON j.id = cl.job_id
+       WHERE cl.company_id = ${companyId}
+         ${branchFilter(req, "j.branch_id")}
+         AND j.scheduled_date BETWEEN ${fromStr} AND ${toStr}
+       GROUP BY cl.cancel_action
+       ORDER BY action
+    `);
+    const by_action = (byActionRows.rows as any[]).map(r => ({
+      action: r.action,
+      count: r.count,
+      total_charged: parseF(r.total_charged),
+    }));
+    const lockout_total = by_action.find(a => a.action === "lockout")?.total_charged ?? 0;
+    const lockout_count = by_action.find(a => a.action === "lockout")?.count ?? 0;
+    const cancel_total = by_action.find(a => a.action === "cancel")?.total_charged ?? 0;
+    const cancel_count = by_action.find(a => a.action === "cancel")?.count ?? 0;
+    const cancellation_revenue = by_action.reduce((s, a) => s + a.total_charged, 0);
+
     return res.json({
       from: fromStr, to: toStr, data,
       summary: {
         total: data.length,
         avg_tenure_days: data.length > 0 ? data.reduce((s, r) => s + r.tenure_days, 0) / data.length : 0,
         revenue_lost: data.reduce((s, r) => s + r.bill_rate, 0),
+        // Cancellation-fee revenue (the money we DID collect from charging
+        // cancellations) — sits alongside revenue_lost (the money we'd
+        // have collected if the visits had happened).
+        cancellation_revenue,
+        lockout_total,
+        lockout_count,
+        cancel_total,
+        cancel_count,
       },
+      by_action,
     });
   } catch (err) {
     console.error("Cancellations error:", err);

--- a/artifacts/api-server/src/tests/cancellation-policy.test.ts
+++ b/artifacts/api-server/src/tests/cancellation-policy.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Tests for the cancellation policy resolver.
+ *
+ * Defends:
+ *   A. Action routing — only 'cancel' and 'lockout' charge; others free.
+ *   B. Per-client override beats company default.
+ *   C. Lockout uses lockout_fee_pct, cancel uses cancel_fee_pct.
+ *   D. cancel_service flags affects_future_jobs.
+ *   E. Status transitions — charged → 'complete' (per Sal); free → 'cancelled'.
+ *   F. Rounding to 2 decimals.
+ *   G. Zero / negative job amount handled gracefully.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  resolveCancellationPolicy,
+  CANCEL_ACTIONS,
+  CHARGING_ACTIONS,
+  FUTURE_AFFECTING_ACTIONS,
+  type CancelAction,
+} from "../lib/cancellation-policy.js";
+
+const phesDefaults = {
+  companyDefaultCancelFeePct: 100,
+  companyDefaultLockoutFeePct: 100,
+  clientCancelFeePct: null,
+  clientLockoutFeePct: null,
+};
+
+describe("Cancellation policy — action routing", () => {
+  it("only 'cancel' and 'lockout' are charging actions", () => {
+    assert.deepEqual([...CHARGING_ACTIONS].sort(), ["cancel", "lockout"]);
+  });
+
+  it("only 'cancel_service' affects future jobs", () => {
+    assert.deepEqual([...FUTURE_AFFECTING_ACTIONS], ["cancel_service"]);
+  });
+
+  it("free actions return charge=0 and status=cancelled", () => {
+    for (const action of ["move", "bump", "skip", "cancel_service"] as CancelAction[]) {
+      const r = resolveCancellationPolicy({ action, jobAmount: 200, ...phesDefaults });
+      assert.equal(r.charge_amount, 0, `${action} should not charge`);
+      assert.equal(r.charges_customer, false, `${action} charges_customer`);
+      assert.equal(r.next_job_status, "cancelled", `${action} should cancel`);
+    }
+  });
+
+  it("'cancel' charges full at 100% — status=complete (per Sal's policy)", () => {
+    const r = resolveCancellationPolicy({ action: "cancel", jobAmount: 200, ...phesDefaults });
+    assert.equal(r.charge_amount, 200);
+    assert.equal(r.fee_pct_applied, 100);
+    assert.equal(r.charges_customer, true);
+    assert.equal(r.next_job_status, "complete");
+    assert.equal(r.affects_future_jobs, false);
+  });
+
+  it("'lockout' charges full at 100% — status=complete", () => {
+    const r = resolveCancellationPolicy({ action: "lockout", jobAmount: 200, ...phesDefaults });
+    assert.equal(r.charge_amount, 200);
+    assert.equal(r.next_job_status, "complete");
+  });
+
+  it("'cancel_service' is free + affects future", () => {
+    const r = resolveCancellationPolicy({ action: "cancel_service", jobAmount: 200, ...phesDefaults });
+    assert.equal(r.charge_amount, 0);
+    assert.equal(r.affects_future_jobs, true);
+    assert.equal(r.next_job_status, "cancelled");
+  });
+});
+
+describe("Cancellation policy — per-client overrides", () => {
+  it("client cancel_fee_pct=50 overrides company default", () => {
+    const r = resolveCancellationPolicy({
+      action: "cancel",
+      jobAmount: 200,
+      ...phesDefaults,
+      clientCancelFeePct: 50,
+    });
+    assert.equal(r.charge_amount, 100); // 200 × 0.50
+    assert.equal(r.fee_pct_applied, 50);
+  });
+
+  it("client lockout_fee_pct=0 (waived) — still goes to status=complete", () => {
+    const r = resolveCancellationPolicy({
+      action: "lockout",
+      jobAmount: 200,
+      ...phesDefaults,
+      clientLockoutFeePct: 0,
+    });
+    assert.equal(r.charge_amount, 0);
+    assert.equal(r.fee_pct_applied, 0);
+    assert.equal(r.charges_customer, false); // explicit waive
+    assert.equal(r.next_job_status, "complete"); // still a charging-class action
+  });
+
+  it("client cancel override does NOT apply to lockout action (different field)", () => {
+    const r = resolveCancellationPolicy({
+      action: "lockout",
+      jobAmount: 200,
+      ...phesDefaults,
+      clientCancelFeePct: 25,
+      // clientLockoutFeePct stays null → uses company default 100
+    });
+    assert.equal(r.charge_amount, 200);
+    assert.equal(r.fee_pct_applied, 100);
+  });
+});
+
+describe("Cancellation policy — edge cases", () => {
+  it("zero job amount → zero charge even on charging actions", () => {
+    const r = resolveCancellationPolicy({ action: "cancel", jobAmount: 0, ...phesDefaults });
+    assert.equal(r.charge_amount, 0);
+    assert.equal(r.charges_customer, false);
+    assert.equal(r.next_job_status, "complete"); // still a charging-class action
+  });
+
+  it("negative job amount clamps to 0", () => {
+    const r = resolveCancellationPolicy({ action: "cancel", jobAmount: -50, ...phesDefaults });
+    assert.equal(r.charge_amount, 0);
+  });
+
+  it("rounds to 2 decimals (no float drift)", () => {
+    const r = resolveCancellationPolicy({
+      action: "cancel",
+      jobAmount: 0.65,
+      ...phesDefaults,
+      clientCancelFeePct: 35,
+    });
+    // 0.65 × 0.35 = 0.2275 → round2 → 0.23
+    assert.equal(r.charge_amount, 0.23);
+  });
+
+  it("all 6 CANCEL_ACTIONS resolve without throwing", () => {
+    for (const action of CANCEL_ACTIONS) {
+      const r = resolveCancellationPolicy({ action, jobAmount: 100, ...phesDefaults });
+      assert.ok(["cancelled", "complete"].includes(r.next_job_status));
+    }
+    assert.equal(CANCEL_ACTIONS.length, 6);
+  });
+});

--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -1057,6 +1057,11 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
   const [cancelOpen, setCancelOpen] = useState(false);
   const [cancelReason, setCancelReason] = useState("customer_request");
   const [cancelNote, setCancelNote] = useState("");
+  // MC-style cancel action picker. Two-step modal:
+  //   step 1 → pick action (move/bump/skip/cancel/lockout/cancel_service)
+  //   step 2 → review computed charge + optional override + notes → confirm
+  const [cancelAction, setCancelAction] = useState<null | "move" | "bump" | "skip" | "cancel" | "lockout" | "cancel_service">(null);
+  const [chargeOverride, setChargeOverride] = useState<string>("");
 
   const [rescheduleOpen, setRescheduleOpen] = useState(false);
   const [rescheduleReason, setRescheduleReason] = useState("");
@@ -1360,21 +1365,51 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
   }
 
   async function cancelJob() {
+    if (!cancelAction) return; // shouldn't happen — confirm button only enabled when action picked
     setBusy(true);
     const API2 = import.meta.env.BASE_URL.replace(/\/$/, "");
     try {
-      await patchJob(job.id, { status: "cancelled" }, token);
-      await fetch(`${API2}/api/cancellations`, {
-        method: "POST", // Note: cancellations is read-only GET; the cancel log gets created by a trigger in production
+      // POST /api/cancellations/action handles the full transaction:
+      //   - resolves the customer charge from company + per-client policy
+      //   - flips job status (complete for charged, cancelled for free)
+      //   - marks recurring schedule cancelled when action='cancel_service'
+      //   - writes the cancellation_log row
+      const overrideNum = chargeOverride.trim() !== "" ? Number(chargeOverride) : undefined;
+      const res = await fetch(`${API2}/api/cancellations/action`, {
+        method: "POST",
         headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
-        body: JSON.stringify({ job_id: job.id, customer_id: job.client_id, cancel_reason: cancelReason, notes: cancelNote || null }),
-      }).catch(() => {});
-      toast({ title: "Job cancelled" });
+        body: JSON.stringify({
+          job_id: job.id,
+          action: cancelAction,
+          notes: cancelNote || undefined,
+          charge_amount_override: Number.isFinite(overrideNum) ? overrideNum : undefined,
+        }),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.message || "Cancellation failed");
+      }
+      const body = await res.json();
+      const charge = Number(body.charge_amount || 0);
+      const labelByAction: Record<string, string> = {
+        move: "Job marked as moved", bump: "Job marked as bumped",
+        skip: "Job skipped", cancel: "Job cancelled with full fee",
+        lockout: "Lockout recorded with full fee",
+        cancel_service: `Service cancelled (${body.future_cancelled_count} future jobs ended)`,
+      };
+      toast({
+        title: labelByAction[cancelAction] ?? "Cancellation recorded",
+        description: charge > 0 ? `Customer charged $${charge.toFixed(2)}` : undefined,
+      });
       setCancelOpen(false);
+      setCancelAction(null);
+      setChargeOverride("");
+      setCancelNote("");
       onUpdate();
       onClose();
-    } catch { toast({ title: "Error", variant: "destructive" }); }
-    finally { setBusy(false); }
+    } catch (e) {
+      toast({ title: (e as Error).message || "Error", variant: "destructive" });
+    } finally { setBusy(false); }
   }
 
   const panelStyle: React.CSSProperties = mobile ? {
@@ -2202,40 +2237,120 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
         );
       })()}
 
-      {/* Cancel modal */}
-      {cancelOpen && (
-        <div style={{ position: "fixed", inset: 0, backgroundColor: "rgba(0,0,0,0.5)", display: "flex", alignItems: "center", justifyContent: "center", zIndex: 300, fontFamily: FF }}>
-          <div style={{ backgroundColor: "#FFFFFF", borderRadius: 12, padding: 28, width: 420, boxShadow: "0 20px 60px rgba(0,0,0,0.2)" }}>
-            <h3 style={{ margin: "0 0 16px", fontSize: 16, fontWeight: 700, color: "#1A1917" }}>Cancel Job</h3>
-            <p style={{ margin: "0 0 14px", fontSize: 13, color: "#6B7280" }}>
-              Job for <strong>{job.display_name ?? job.client_name}</strong> on {new Date(job.scheduled_date + "T12:00").toLocaleDateString("en-US", { month: "short", day: "numeric" })}
-            </p>
-            <div style={{ marginBottom: 14 }}>
-              <label style={{ fontSize: 11, fontWeight: 600, color: "#9E9B94", textTransform: "uppercase", letterSpacing: "0.06em", display: "block", marginBottom: 6 }}>Reason</label>
-              <select value={cancelReason} onChange={e => setCancelReason(e.target.value)}
-                style={{ width: "100%", height: 36, padding: "0 10px", border: "1px solid #E5E2DC", borderRadius: 8, fontSize: 13, outline: "none", background: "#FFFFFF" }}>
-                <option value="customer_request">Customer Request</option>
-                <option value="no_show">No Show</option>
-                <option value="weather">Weather</option>
-                <option value="emergency">Emergency</option>
-                <option value="other">Other</option>
-              </select>
-            </div>
-            <div style={{ marginBottom: 20 }}>
-              <label style={{ fontSize: 11, fontWeight: 600, color: "#9E9B94", textTransform: "uppercase", letterSpacing: "0.06em", display: "block", marginBottom: 6 }}>Notes (optional)</label>
-              <textarea value={cancelNote} onChange={e => setCancelNote(e.target.value)} rows={2}
-                style={{ width: "100%", padding: "8px 12px", border: "1px solid #E5E2DC", borderRadius: 8, fontSize: 13, resize: "vertical", fontFamily: FF, outline: "none", boxSizing: "border-box" }} />
-            </div>
-            <div style={{ display: "flex", gap: 10, justifyContent: "flex-end" }}>
-              <button onClick={() => setCancelOpen(false)} style={{ padding: "8px 16px", border: "1px solid #E5E2DC", borderRadius: 8, fontSize: 13, background: "#FFFFFF", cursor: "pointer", fontFamily: FF }}>Keep Job</button>
-              <button onClick={cancelJob} disabled={busy}
-                style={{ padding: "8px 20px", background: "#EF4444", color: "#FFFFFF", border: "none", borderRadius: 8, fontSize: 13, fontWeight: 700, cursor: "pointer", fontFamily: FF }}>
-                {busy ? "Cancelling..." : "Confirm Cancel"}
-              </button>
+      {/* Cancel / cancellation-action modal — MC-style action picker.
+          Step 1: 6 action cards. Step 2: review charge + notes + confirm.
+          Picking an action populates cancelAction; "Back" clears it. */}
+      {cancelOpen && (() => {
+        const ACTIONS: Array<{
+          key: "move" | "bump" | "skip" | "cancel" | "lockout" | "cancel_service";
+          label: string; sub: string; bg: string; color: string; charges: boolean; ends_service?: boolean;
+        }> = [
+          { key: "move",   label: "Move",   sub: "Customer changes the date",   bg: "#F3E8FF", color: "#7E22CE", charges: false },
+          { key: "bump",   label: "Bump",   sub: "We change the date",          bg: "#FCE7F3", color: "#BE185D", charges: false },
+          { key: "skip",   label: "Skip",   sub: "Customer skips this visit",   bg: "#FEE2E2", color: "#B91C1C", charges: false },
+          { key: "cancel", label: "Cancel", sub: "Customer cancels (full fee)", bg: "#FCA5A5", color: "#7F1D1D", charges: true },
+          { key: "lockout",label: "Lockout",sub: "Couldn't get in (full fee)",  bg: "#1E293B", color: "#FFFFFF", charges: true },
+          { key: "cancel_service", label: "Cancel Service", sub: "End all future jobs", bg: "#DC2626", color: "#FFFFFF", charges: false, ends_service: true },
+        ];
+        const jobAmount = (job.billed_amount as number | undefined) ?? job.base_fee ?? 0;
+        const previewCharge = (a: typeof ACTIONS[number]) => a.charges ? jobAmount : 0;
+        const selected = ACTIONS.find(a => a.key === cancelAction);
+        return (
+          <div style={{ position: "fixed", inset: 0, backgroundColor: "rgba(0,0,0,0.5)", display: "flex", alignItems: "center", justifyContent: "center", zIndex: 300, fontFamily: FF }}>
+            <div style={{ backgroundColor: "#FFFFFF", borderRadius: 14, padding: 24, width: 540, maxWidth: "92vw", maxHeight: "90vh", overflowY: "auto", boxShadow: "0 20px 60px rgba(0,0,0,0.25)" }}>
+              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", marginBottom: 6 }}>
+                <h3 style={{ margin: 0, fontSize: 17, fontWeight: 800, color: "#1A1917" }}>
+                  {selected ? selected.label : "What do you want to do?"}
+                </h3>
+                <button onClick={() => { setCancelOpen(false); setCancelAction(null); setChargeOverride(""); setCancelNote(""); }}
+                  aria-label="Close"
+                  style={{ background: "transparent", border: 0, fontSize: 22, color: "#9E9B94", cursor: "pointer" }}>×</button>
+              </div>
+              <p style={{ margin: "0 0 18px", fontSize: 13, color: "#6B7280" }}>
+                {job.display_name ?? job.client_name} on {new Date(job.scheduled_date + "T12:00").toLocaleDateString("en-US", { month: "short", day: "numeric" })}
+              </p>
+
+              {/* STEP 1 — action picker */}
+              {!selected && (
+                <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
+                  {ACTIONS.map(a => (
+                    <button key={a.key} onClick={() => { setCancelAction(a.key); setChargeOverride(""); }}
+                      style={{
+                        background: a.bg, color: a.color, border: 0, borderRadius: 12,
+                        padding: "14px 14px", textAlign: "left", cursor: "pointer",
+                        fontFamily: FF, transition: "transform 0.08s",
+                      }}
+                      onMouseDown={(e) => (e.currentTarget.style.transform = "scale(0.98)")}
+                      onMouseUp={(e) => (e.currentTarget.style.transform = "scale(1)")}
+                      onMouseLeave={(e) => (e.currentTarget.style.transform = "scale(1)")}
+                    >
+                      <div style={{ fontSize: 15, fontWeight: 800, marginBottom: 4 }}>{a.label}</div>
+                      <div style={{ fontSize: 11, opacity: 0.85, lineHeight: 1.35 }}>{a.sub}</div>
+                      {a.charges && (
+                        <div style={{ marginTop: 6, fontSize: 10, fontWeight: 700, opacity: 0.9 }}>
+                          Charges ${jobAmount.toFixed(2)}
+                        </div>
+                      )}
+                    </button>
+                  ))}
+                </div>
+              )}
+
+              {/* STEP 2 — review + confirm */}
+              {selected && (
+                <>
+                  <div style={{
+                    padding: 14, borderRadius: 10, marginBottom: 14,
+                    background: selected.charges ? "#FEF2F2" : "#F0FDF4",
+                    border: `1px solid ${selected.charges ? "#FECACA" : "#BBF7D0"}`,
+                  }}>
+                    <div style={{ fontSize: 12, fontWeight: 700, color: selected.charges ? "#991B1B" : "#166534", marginBottom: 4 }}>
+                      {selected.charges ? "Customer will be charged" : "No charge"}
+                    </div>
+                    {selected.charges && (
+                      <div style={{ fontSize: 24, fontWeight: 800, color: "#1A1917" }}>
+                        ${(chargeOverride.trim() === "" ? previewCharge(selected) : Number(chargeOverride)).toFixed(2)}
+                      </div>
+                    )}
+                    {selected.ends_service && (
+                      <div style={{ fontSize: 12, fontWeight: 700, color: "#991B1B", marginTop: 6 }}>
+                        All future jobs on this recurring schedule will be cancelled.
+                      </div>
+                    )}
+                  </div>
+
+                  {selected.charges && (
+                    <div style={{ marginBottom: 14 }}>
+                      <label style={{ fontSize: 11, fontWeight: 600, color: "#9E9B94", textTransform: "uppercase", letterSpacing: "0.06em", display: "block", marginBottom: 6 }}>
+                        Override charge (optional)
+                      </label>
+                      <input type="number" min="0" step="0.01" value={chargeOverride}
+                        placeholder={previewCharge(selected).toFixed(2)}
+                        onChange={e => setChargeOverride(e.target.value)}
+                        style={{ width: "100%", height: 36, padding: "0 10px", border: "1px solid #E5E2DC", borderRadius: 8, fontSize: 13, outline: "none", background: "#FFFFFF", fontFamily: FF, boxSizing: "border-box" }} />
+                    </div>
+                  )}
+
+                  <div style={{ marginBottom: 18 }}>
+                    <label style={{ fontSize: 11, fontWeight: 600, color: "#9E9B94", textTransform: "uppercase", letterSpacing: "0.06em", display: "block", marginBottom: 6 }}>Notes (optional)</label>
+                    <textarea value={cancelNote} onChange={e => setCancelNote(e.target.value)} rows={2}
+                      style={{ width: "100%", padding: "8px 12px", border: "1px solid #E5E2DC", borderRadius: 8, fontSize: 13, resize: "vertical", fontFamily: FF, outline: "none", boxSizing: "border-box" }} />
+                  </div>
+
+                  <div style={{ display: "flex", gap: 10, justifyContent: "space-between" }}>
+                    <button onClick={() => setCancelAction(null)} disabled={busy}
+                      style={{ padding: "8px 16px", border: "1px solid #E5E2DC", borderRadius: 8, fontSize: 13, background: "#FFFFFF", cursor: "pointer", fontFamily: FF }}>Back</button>
+                    <button onClick={cancelJob} disabled={busy}
+                      style={{ padding: "8px 22px", background: selected.charges ? "#DC2626" : "#1A1917", color: "#FFFFFF", border: "none", borderRadius: 8, fontSize: 13, fontWeight: 700, cursor: busy ? "not-allowed" : "pointer", fontFamily: FF, opacity: busy ? 0.6 : 1 }}>
+                      {busy ? "Saving..." : `Confirm ${selected.label}`}
+                    </button>
+                  </div>
+                </>
+              )}
             </div>
           </div>
-        </div>
-      )}
+        );
+      })()}
 
       {/* [AG] Edit Job modal */}
       {editOpen && (

--- a/artifacts/qleno/src/pages/reports/cancellations.tsx
+++ b/artifacts/qleno/src/pages/reports/cancellations.tsx
@@ -6,7 +6,32 @@ function today() { return new Date().toISOString().split("T")[0]; }
 function daysAgo(n: number) { const d = new Date(); d.setDate(d.getDate()-n); return d.toISOString().split("T")[0]; }
 
 interface CancelRow { id: number; name: string; email: string; client_since: string; cancelled_date: string; tenure_days: number; bill_rate: number; last_score: number | null; notes: string | null; }
-interface CancelData { from: string; to: string; data: CancelRow[]; summary: { total: number; avg_tenure_days: number; revenue_lost: number }; }
+interface ByActionRow { action: string; count: number; total_charged: number; }
+interface CancelData {
+  from: string; to: string; data: CancelRow[];
+  summary: {
+    total: number; avg_tenure_days: number; revenue_lost: number;
+    // Cancellation-fee revenue (the money we DID collect) — distinct
+    // from revenue_lost (the money we'd have made if the visits ran).
+    cancellation_revenue?: number;
+    lockout_total?: number; lockout_count?: number;
+    cancel_total?: number; cancel_count?: number;
+  };
+  by_action?: ByActionRow[];
+}
+
+// Human label + accent color per cancel_action. Mirrors the dispatch
+// modal so the office sees consistent vocabulary between cancelling
+// and reporting.
+const ACTION_META: Record<string, { label: string; color: string }> = {
+  move:           { label: "Move",           color: "#7E22CE" },
+  bump:           { label: "Bump",           color: "#BE185D" },
+  skip:           { label: "Skip",           color: "#B91C1C" },
+  cancel:         { label: "Cancel",         color: "#7F1D1D" },
+  lockout:        { label: "Lockout",        color: "#1E293B" },
+  cancel_service: { label: "Cancel Service", color: "#DC2626" },
+  legacy:         { label: "Legacy (no action)", color: "#9CA3AF" },
+};
 
 export default function CancellationsPage() {
   const [from, setFrom] = useState(daysAgo(90));
@@ -44,11 +69,64 @@ export default function CancellationsPage() {
           filters={<DateRange from={from} to={to} onChange={(f,t) => { setFrom(f); setTo(t); }} />}
         />
 
-        <div style={{ display: "flex", gap: 14, flexWrap: "wrap", marginBottom: 24 }}>
+        <div style={{ display: "flex", gap: 14, flexWrap: "wrap", marginBottom: 16 }}>
           <KpiCard label="Total Cancellations" value={String(s?.total ?? 0)} color={clr.red} />
           <KpiCard label="Avg Client Tenure" value={`${Math.round((s?.avg_tenure_days ?? 0)/30)} mo`} color={clr.secondary} />
           <KpiCard label="Revenue at Risk" value={fmt$c(s?.revenue_lost ?? 0)} color={clr.amber} sub="Based on last bill rate" />
         </div>
+
+        {/* Cancellation revenue strip — the fees we DID collect. Separate
+            from "Revenue at Risk" above which is what we didn't earn from
+            the missed visits. Both numbers are useful for forecasting. */}
+        <div style={{ display: "flex", gap: 14, flexWrap: "wrap", marginBottom: 24 }}>
+          <KpiCard
+            label="Cancellation Revenue"
+            value={fmt$c(s?.cancellation_revenue ?? 0)}
+            color={clr.green}
+            sub="Fees collected from cancel + lockout"
+          />
+          <KpiCard
+            label="Lockout Fees"
+            value={fmt$c(s?.lockout_total ?? 0)}
+            color={clr.green}
+            sub={`${s?.lockout_count ?? 0} lockout${(s?.lockout_count ?? 0) === 1 ? "" : "s"}`}
+          />
+          <KpiCard
+            label="Cancel Fees"
+            value={fmt$c(s?.cancel_total ?? 0)}
+            color={clr.green}
+            sub={`${s?.cancel_count ?? 0} chargeable cancel${(s?.cancel_count ?? 0) === 1 ? "" : "s"}`}
+          />
+        </div>
+
+        {/* Per-action breakdown table — show count + total $ for every
+            action that appeared in the window. Helps spot patterns
+            (e.g. "we're bumping a lot, why?"). */}
+        {data?.by_action && data.by_action.length > 0 && (
+          <div style={{ background: "#FFFFFF", border: `1px solid ${clr.border}`, borderRadius: 10, padding: "14px 18px", marginBottom: 24 }}>
+            <div style={{ fontSize: 11, fontWeight: 700, color: clr.muted, textTransform: "uppercase", letterSpacing: "0.06em", marginBottom: 10 }}>
+              By Action
+            </div>
+            <div style={{ display: "grid", gridTemplateColumns: "1.5fr 1fr 1fr", rowGap: 8, columnGap: 16, alignItems: "center" }}>
+              <div style={{ fontSize: 11, color: clr.muted, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.04em" }}>Action</div>
+              <div style={{ fontSize: 11, color: clr.muted, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.04em", textAlign: "right" }}>Count</div>
+              <div style={{ fontSize: 11, color: clr.muted, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.04em", textAlign: "right" }}>Total Charged</div>
+              {data.by_action.map(r => {
+                const meta = ACTION_META[r.action] ?? { label: r.action, color: clr.muted };
+                return (
+                  <>
+                    <div key={`${r.action}-l`} style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                      <span style={{ width: 8, height: 8, borderRadius: 4, background: meta.color, display: "inline-block" }} />
+                      <span style={{ fontSize: 13, fontWeight: 600, color: clr.text }}>{meta.label}</span>
+                    </div>
+                    <div key={`${r.action}-c`} style={{ fontSize: 13, textAlign: "right", color: clr.text }}>{r.count}</div>
+                    <div key={`${r.action}-t`} style={{ fontSize: 13, textAlign: "right", color: r.total_charged > 0 ? clr.green : clr.muted, fontWeight: r.total_charged > 0 ? 700 : 400 }}>{fmt$c(r.total_charged)}</div>
+                  </>
+                );
+              })}
+            </div>
+          </div>
+        )}
 
         <DataTable cols={cols} rows={rows} loading={loading} emptyMsg="No cancellations in this date range." />
       </div>

--- a/lib/db/src/schema/cancellation_log.ts
+++ b/lib/db/src/schema/cancellation_log.ts
@@ -1,4 +1,4 @@
-import { pgTable, serial, integer, text, boolean, timestamp, pgEnum } from "drizzle-orm/pg-core";
+import { pgTable, serial, integer, text, boolean, timestamp, numeric, pgEnum } from "drizzle-orm/pg-core";
 import { companiesTable } from "./companies";
 import { clientsTable } from "./clients";
 import { usersTable } from "./users";
@@ -19,6 +19,27 @@ export const cancellationLogTable = pgTable("cancellation_log", {
   rescheduled_to_job_id: integer("rescheduled_to_job_id").references(() => jobsTable.id),
   notes: text("notes"),
   refund_issued: boolean("refund_issued").notNull().default(false),
+  // Action picker matching MaidCentral's vocabulary so the operator can
+  // pick the right SEMANTIC outcome without us pre-categorizing it as
+  // "customer fault" vs "tech fault". Drives whether a fee is charged
+  // and what status the job ends up in.
+  //   move          customer reschedule — free
+  //   bump          we reschedule       — free
+  //   skip          customer one-time   — free
+  //   cancel        customer late cancel — CHARGES (per company default)
+  //   lockout       crew couldn't get in — CHARGES (per company default)
+  //   cancel_service terminate recurring schedule — free
+  // Text not enum: the action vocabulary is small and stable, but we
+  // also want tenants to add their own (e.g. "weather_cancel") without a
+  // migration. Caller validates against a small allowlist.
+  cancel_action: text("cancel_action"),
+  // Dollars charged to the customer for this cancellation. 0 when the
+  // action is free. Populated for cancel + lockout per the per-company
+  // default × job amount (or per-client override).
+  customer_charge_amount: numeric("customer_charge_amount", { precision: 10, scale: 2 }).notNull().default("0"),
+  // Cancel Service terminates the recurring schedule. Flag set so reports
+  // can split "single visit cancelled" from "service lost" attribution.
+  affects_future_jobs: boolean("affects_future_jobs").notNull().default(false),
 });
 
 export type CancellationLog = typeof cancellationLogTable.$inferSelect;

--- a/lib/db/src/schema/clients.ts
+++ b/lib/db/src/schema/clients.ts
@@ -97,6 +97,12 @@ export const clientsTable = pgTable("clients", {
   // the heads-up); office flips false when a specific client asks not
   // to receive them.
   wants_on_my_way_notifications: boolean("wants_on_my_way_notifications").notNull().default(true),
+  // Cancellation policy overrides — NULL means "use the tenant default
+  // from companies.default_{cancel,lockout}_fee_pct". Office can set per
+  // client when negotiating exceptions (e.g. anchor commercial accounts
+  // with a 0% no-fault clause).
+  cancel_fee_pct: numeric("cancel_fee_pct", { precision: 5, scale: 2 }),
+  lockout_fee_pct: numeric("lockout_fee_pct", { precision: 5, scale: 2 }),
   created_at: timestamp("created_at").notNull().defaultNow(),
 });
 

--- a/lib/db/src/schema/companies.ts
+++ b/lib/db/src/schema/companies.ts
@@ -77,6 +77,13 @@ export const companiesTable = pgTable("companies", {
   qb_company_name: text("qb_company_name"),
   overhead_rate_pct: numeric("overhead_rate_pct", { precision: 5, scale: 2 }).default("10.00"),
   recurring_engine_enabled: boolean("recurring_engine_enabled").notNull().default(true),
+  // Cancellation policy — per-tenant defaults. Both expressed as a
+  // percentage of the cancelled job's effective amount (billed_amount ||
+  // base_fee). Phes default is 100% on both — a true cancellation or
+  // lockout charges the full visit fee. Per-client overrides live on
+  // clients.cancel_fee_pct / clients.lockout_fee_pct.
+  default_cancel_fee_pct: numeric("default_cancel_fee_pct", { precision: 5, scale: 2 }).notNull().default("100.00"),
+  default_lockout_fee_pct: numeric("default_lockout_fee_pct", { precision: 5, scale: 2 }).notNull().default("100.00"),
   created_at: timestamp("created_at").notNull().defaultNow(),
 });
 


### PR DESCRIPTION
## Summary

Phase B of the cancellation feature. PR #216 ships the action picker;
this PR surfaces the resulting charges as visible KPIs on
/reports/cancellations.

Sal explicitly asked: *"We need to know how many lockout fees we charged
that were part of our revenue and such."*

## What lands

**API** — /reports/cancellations response gains:
- summary.cancellation_revenue (total fees collected)
- summary.lockout_total + lockout_count
- summary.cancel_total + cancel_count
- by_action[] grouped from cancellation_log

**UI** — 3 new green KPI cards + a By Action breakdown panel that
mirrors the action picker's color vocabulary. Hides the panel when
no actions are present in the window.

## Test plan

- [x] tsc clean both sides
- [ ] Post-deploy: hit /reports/cancellations → see new KPI strip
- [ ] After a Cancel or Lockout via the modal: numbers populate

## Depends on

PR #216 (cancellation action picker) — already merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)