### PR TITLE
feat(cancel): tech payroll + tenant policy settings

### DIFF
--- a/artifacts/api-server/src/cutover-data-migration.ts
+++ b/artifacts/api-server/src/cutover-data-migration.ts
@@ -84,6 +84,14 @@ export async function runCutoverDataMigration(): Promise<void> {
     );
   }
   try {
+    await addCancellationTechPayColumns();
+  } catch (err) {
+    console.error(
+      "[cutover-migration] cancellation tech-pay columns failed (non-fatal):",
+      err,
+    );
+  }
+  try {
     await addLeaveCascadeColumns();
   } catch (err) {
     console.error(
@@ -274,6 +282,37 @@ async function addCancellationPolicyColumns(): Promise<void> {
         WHERE table_schema='public' AND table_name='cancellation_log' AND column_name='affects_future_jobs'
       ) THEN
         ALTER TABLE cancellation_log ADD COLUMN affects_future_jobs boolean NOT NULL DEFAULT false;
+      END IF;
+    END $$;
+  `),
+  );
+}
+
+/**
+ * Cancellation tech-pay policy columns. Adds:
+ *   companies.cancellation_tech_pay_mode  ('flat' | 'percent', default 'flat')
+ *   companies.cancellation_tech_pay_amount (numeric(10,4), default 60.0000)
+ *
+ * Phes default: $60 flat per cancel/lockout, matching the cleanup-trip
+ * fee techs were historically paid. Tenants flip to 'percent' to share
+ * the customer charge instead.
+ */
+async function addCancellationTechPayColumns(): Promise<void> {
+  await db.execute(
+    sql.raw(`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema='public' AND table_name='companies' AND column_name='cancellation_tech_pay_mode'
+      ) THEN
+        ALTER TABLE companies ADD COLUMN cancellation_tech_pay_mode text NOT NULL DEFAULT 'flat';
+      END IF;
+      IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema='public' AND table_name='companies' AND column_name='cancellation_tech_pay_amount'
+      ) THEN
+        ALTER TABLE companies ADD COLUMN cancellation_tech_pay_amount numeric(10,4) NOT NULL DEFAULT 60.0000;
       END IF;
     END $$;
   `),

--- a/artifacts/api-server/src/lib/cancellation-tech-pay.ts
+++ b/artifacts/api-server/src/lib/cancellation-tech-pay.ts
@@ -1,0 +1,76 @@
+/**
+ * Cancellation tech-pay resolver.
+ *
+ * When a charging cancellation fires (cancel / lockout), the assigned
+ * tech(s) still earn something — they were on the schedule, may have
+ * driven out, may have shown up to a locked door. Two modes per the
+ * tenant's policy:
+ *
+ *   flat    — fixed dollar amount per cancellation event, regardless of
+ *             job size. Phes default $60.
+ *   percent — percentage of the customer's charge_amount. Lets the
+ *             tenant say "tech keeps 40% of whatever we collected".
+ *
+ * Free actions (move / bump / skip / cancel_service) pay nothing —
+ * there's no charge to share and the visit wasn't fulfilled.
+ *
+ * The total is split equally across the assigned tech(s). We do NOT do
+ * proportional-by-minutes here because nobody actually worked — there's
+ * no clock data to weight by.
+ *
+ * Pure function. The route layer fetches the tenant policy + assigned
+ * tech list and the calling caller decides how to write the
+ * additional_pay rows.
+ */
+
+import type { CancelAction } from "./cancellation-policy.js";
+import { CHARGING_ACTIONS } from "./cancellation-policy.js";
+
+export type CancellationTechPayMode = "flat" | "percent";
+
+export interface TechPayPolicy {
+  mode: CancellationTechPayMode;
+  /** Dollars when mode='flat'; percentage 0-100 when mode='percent'. */
+  amount: number;
+}
+
+export interface TechPayInput {
+  action: CancelAction;
+  /** Customer-side charge for this cancellation (post-override). */
+  customerChargeAmount: number;
+  /** Number of assigned techs to split the pay across. */
+  numTechs: number;
+  policy: TechPayPolicy;
+}
+
+export interface TechPayResult {
+  /** Total dollars to distribute across the assigned techs. */
+  total_pay: number;
+  /** Each tech's slice (total_pay / numTechs, rounded). */
+  pay_per_tech: number;
+  /** True when policy resolved to a non-zero payout. */
+  pays_tech: boolean;
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+export function resolveCancellationTechPay(input: TechPayInput): TechPayResult {
+  const empty: TechPayResult = { total_pay: 0, pay_per_tech: 0, pays_tech: false };
+
+  if (!CHARGING_ACTIONS.has(input.action)) return empty;
+  if (input.numTechs <= 0) return empty;
+
+  const total = input.policy.mode === "percent"
+    ? round2(Math.max(0, input.customerChargeAmount) * (input.policy.amount / 100))
+    : round2(Math.max(0, input.policy.amount));
+
+  if (total === 0) return empty;
+
+  return {
+    total_pay: total,
+    pay_per_tech: round2(total / input.numTechs),
+    pays_tech: true,
+  };
+}

--- a/artifacts/api-server/src/routes/cancellation.ts
+++ b/artifacts/api-server/src/routes/cancellation.ts
@@ -8,6 +8,10 @@ import {
   CANCEL_ACTIONS,
   type CancelAction,
 } from "../lib/cancellation-policy.js";
+import {
+  resolveCancellationTechPay,
+  type CancellationTechPayMode,
+} from "../lib/cancellation-tech-pay.js";
 
 const router = Router();
 
@@ -172,12 +176,15 @@ router.post("/action", requireAuth, async (req, res) => {
     });
   }
 
-  // Load job + client + company defaults in one round trip.
+  // Load job + client + company defaults in one round trip. Tech-pay
+  // policy fields piggyback here so we don't need a second query.
   const ctx = await db.execute(sql`
     SELECT j.id, j.client_id, j.status::text AS status, j.billed_amount, j.base_fee,
            j.notes AS job_notes, j.recurring_schedule_id,
            c.cancel_fee_pct AS client_cancel_pct, c.lockout_fee_pct AS client_lockout_pct,
-           co.default_cancel_fee_pct, co.default_lockout_fee_pct
+           c.first_name || ' ' || COALESCE(c.last_name,'') AS client_name,
+           co.default_cancel_fee_pct, co.default_lockout_fee_pct,
+           co.cancellation_tech_pay_mode, co.cancellation_tech_pay_amount
       FROM jobs j
       JOIN clients c ON c.id = j.client_id
       JOIN companies co ON co.id = j.company_id
@@ -216,6 +223,7 @@ router.post("/action", requireAuth, async (req, res) => {
   const appendedNotes = `${row.job_notes ?? ""}${row.job_notes ? "\n" : ""}${actionNote}${operatorNote}`.trim();
 
   let futureCancelled = 0;
+  let techPayWritten: Array<{ user_id: number; amount: number }> = [];
   const logRow = await db.transaction(async (tx) => {
     // Update the job row itself.
     if (policy.next_job_status === "complete") {
@@ -281,6 +289,42 @@ router.post("/action", requireAuth, async (req, res) => {
         notes: body.notes ?? null,
       })
       .returning();
+
+    // Tech pay — charging actions still owe the assigned tech(s)
+    // something (they were on the schedule, may have driven out, may
+    // have shown up to a locked door). Resolve via tenant policy +
+    // split across assigned techs.
+    if (policy.charges_customer) {
+      const techRows = await tx.execute(sql`
+        SELECT user_id FROM job_technicians WHERE job_id = ${body.job_id}
+      `);
+      const techIds = (techRows.rows as Array<{ user_id: number }>).map(r => r.user_id);
+      if (techIds.length > 0) {
+        const techPay = resolveCancellationTechPay({
+          action,
+          customerChargeAmount: finalCharge,
+          numTechs: techIds.length,
+          policy: {
+            mode: (row.cancellation_tech_pay_mode ?? "flat") as CancellationTechPayMode,
+            amount: parseFloat(String(row.cancellation_tech_pay_amount ?? 60)),
+          },
+        });
+        if (techPay.pays_tech) {
+          const noteLabel = `${action === "lockout" ? "Lockout" : "Cancel"} pay — ${row.client_name ?? "Customer"} (job #${body.job_id})`;
+          for (const tid of techIds) {
+            await tx.execute(sql`
+              INSERT INTO additional_pay
+                (company_id, user_id, amount, type, notes, job_id, status)
+              VALUES
+                (${companyId}, ${tid}, ${techPay.pay_per_tech.toFixed(2)},
+                 'cancellation_pay', ${noteLabel}, ${body.job_id}, 'pending')
+            `);
+            techPayWritten.push({ user_id: tid, amount: techPay.pay_per_tech });
+          }
+        }
+      }
+    }
+
     return logged;
   });
 
@@ -291,6 +335,7 @@ router.post("/action", requireAuth, async (req, res) => {
     fee_pct_applied: policy.fee_pct_applied,
     next_status: policy.next_job_status,
     future_cancelled_count: futureCancelled,
+    tech_pay: techPayWritten,
   });
 });
 

--- a/artifacts/api-server/src/routes/companies.ts
+++ b/artifacts/api-server/src/routes/companies.ts
@@ -284,4 +284,80 @@ router.put("/booking-settings", requireAuth, async (req, res) => {
   }
 });
 
+// ── GET /api/companies/cancellation-policy ───────────────────────────────────
+// Tenant-level cancellation policy: customer fee % defaults + tech-pay mode.
+// Per-client overrides live on clients.cancel_fee_pct / .lockout_fee_pct.
+router.get("/cancellation-policy", requireAuth, async (req, res) => {
+  try {
+    const { sql: drSql } = await import("drizzle-orm");
+    const companyId = req.auth!.companyId;
+    const r = await db.execute(drSql`
+      SELECT default_cancel_fee_pct, default_lockout_fee_pct,
+             cancellation_tech_pay_mode, cancellation_tech_pay_amount
+        FROM companies
+       WHERE id = ${companyId}
+       LIMIT 1
+    `);
+    const row = r.rows[0] as any;
+    if (!row) return res.status(404).json({ error: "Company not found" });
+    return res.json({
+      default_cancel_fee_pct: parseFloat(String(row.default_cancel_fee_pct ?? 100)),
+      default_lockout_fee_pct: parseFloat(String(row.default_lockout_fee_pct ?? 100)),
+      cancellation_tech_pay_mode: row.cancellation_tech_pay_mode ?? "flat",
+      cancellation_tech_pay_amount: parseFloat(String(row.cancellation_tech_pay_amount ?? 60)),
+    });
+  } catch (err) {
+    console.error("GET cancellation-policy:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
+// ── PUT /api/companies/cancellation-policy ───────────────────────────────────
+router.put("/cancellation-policy", requireAuth, async (req, res) => {
+  try {
+    const { sql: drSql } = await import("drizzle-orm");
+    const companyId = req.auth!.companyId;
+    const {
+      default_cancel_fee_pct,
+      default_lockout_fee_pct,
+      cancellation_tech_pay_mode,
+      cancellation_tech_pay_amount,
+    } = req.body ?? {};
+
+    // Validate ranges. Pct fields are 0-100, mode is enum, amount must be
+    // non-negative. Clamp rather than reject so the UI can't get stuck.
+    const cancelPct = clampPct(default_cancel_fee_pct, 100);
+    const lockoutPct = clampPct(default_lockout_fee_pct, 100);
+    const mode = cancellation_tech_pay_mode === "percent" ? "percent" : "flat";
+    const amount = Number.isFinite(Number(cancellation_tech_pay_amount))
+      ? Math.max(0, Number(cancellation_tech_pay_amount))
+      : 60;
+
+    await db.execute(drSql`
+      UPDATE companies
+         SET default_cancel_fee_pct = ${cancelPct.toFixed(2)},
+             default_lockout_fee_pct = ${lockoutPct.toFixed(2)},
+             cancellation_tech_pay_mode = ${mode},
+             cancellation_tech_pay_amount = ${amount.toFixed(4)}
+       WHERE id = ${companyId}
+    `);
+
+    return res.json({
+      default_cancel_fee_pct: cancelPct,
+      default_lockout_fee_pct: lockoutPct,
+      cancellation_tech_pay_mode: mode,
+      cancellation_tech_pay_amount: amount,
+    });
+  } catch (err) {
+    console.error("PUT cancellation-policy:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
+function clampPct(v: unknown, fallback: number): number {
+  const n = Number(v);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.max(0, Math.min(100, n));
+}
+
 export default router;

--- a/artifacts/api-server/src/tests/cancellation-tech-pay.test.ts
+++ b/artifacts/api-server/src/tests/cancellation-tech-pay.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Tests for the cancellation tech-pay resolver.
+ *
+ * Defends:
+ *   A. Charging actions (cancel/lockout) pay; free actions don't.
+ *   B. Flat mode = fixed dollars regardless of customer charge.
+ *   C. Percent mode = % of customer charge.
+ *   D. Equal split across the assigned tech count.
+ *   E. Zero techs → zero pay (no divide-by-zero).
+ *   F. Rounding to 2 decimals.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  resolveCancellationTechPay,
+  type CancellationTechPayMode,
+} from "../lib/cancellation-tech-pay.js";
+import type { CancelAction } from "../lib/cancellation-policy.js";
+
+const flatPhes = { mode: "flat" as CancellationTechPayMode, amount: 60 };
+
+describe("Cancellation tech-pay — action routing", () => {
+  it("free actions pay nothing", () => {
+    for (const action of ["move", "bump", "skip", "cancel_service"] as CancelAction[]) {
+      const r = resolveCancellationTechPay({
+        action, customerChargeAmount: 200, numTechs: 1, policy: flatPhes,
+      });
+      assert.equal(r.total_pay, 0, `${action} should not pay`);
+      assert.equal(r.pays_tech, false, `${action} pays_tech`);
+    }
+  });
+
+  it("cancel and lockout both pay (charging actions)", () => {
+    for (const action of ["cancel", "lockout"] as CancelAction[]) {
+      const r = resolveCancellationTechPay({
+        action, customerChargeAmount: 200, numTechs: 1, policy: flatPhes,
+      });
+      assert.equal(r.total_pay, 60, `${action} should pay`);
+      assert.equal(r.pays_tech, true);
+    }
+  });
+});
+
+describe("Cancellation tech-pay — modes", () => {
+  it("flat mode = fixed dollars regardless of customer charge", () => {
+    const a = resolveCancellationTechPay({
+      action: "cancel", customerChargeAmount: 50, numTechs: 1, policy: flatPhes,
+    });
+    const b = resolveCancellationTechPay({
+      action: "cancel", customerChargeAmount: 500, numTechs: 1, policy: flatPhes,
+    });
+    assert.equal(a.total_pay, 60);
+    assert.equal(b.total_pay, 60);
+  });
+
+  it("percent mode = % of customer charge", () => {
+    const r = resolveCancellationTechPay({
+      action: "cancel", customerChargeAmount: 200, numTechs: 1,
+      policy: { mode: "percent", amount: 40 },
+    });
+    assert.equal(r.total_pay, 80); // 200 × 0.40
+  });
+
+  it("percent mode at 0% → zero pay, pays_tech=false", () => {
+    const r = resolveCancellationTechPay({
+      action: "cancel", customerChargeAmount: 200, numTechs: 1,
+      policy: { mode: "percent", amount: 0 },
+    });
+    assert.equal(r.total_pay, 0);
+    assert.equal(r.pays_tech, false);
+  });
+});
+
+describe("Cancellation tech-pay — splitting", () => {
+  it("flat $60 / 2 techs = $30 each", () => {
+    const r = resolveCancellationTechPay({
+      action: "cancel", customerChargeAmount: 200, numTechs: 2, policy: flatPhes,
+    });
+    assert.equal(r.total_pay, 60);
+    assert.equal(r.pay_per_tech, 30);
+  });
+
+  it("flat $60 / 3 techs = $20 each (clean divide)", () => {
+    const r = resolveCancellationTechPay({
+      action: "cancel", customerChargeAmount: 200, numTechs: 3, policy: flatPhes,
+    });
+    assert.equal(r.pay_per_tech, 20);
+  });
+
+  it("percent 33.33% / 3 techs handles fractional split", () => {
+    const r = resolveCancellationTechPay({
+      action: "cancel", customerChargeAmount: 100, numTechs: 3,
+      policy: { mode: "percent", amount: 33.33 },
+    });
+    // 100 × 0.3333 = 33.33 → split 3 → 11.11
+    assert.equal(r.total_pay, 33.33);
+    assert.equal(r.pay_per_tech, 11.11);
+  });
+});
+
+describe("Cancellation tech-pay — edge cases", () => {
+  it("zero techs → zero pay (no divide-by-zero)", () => {
+    const r = resolveCancellationTechPay({
+      action: "cancel", customerChargeAmount: 200, numTechs: 0, policy: flatPhes,
+    });
+    assert.equal(r.total_pay, 0);
+    assert.equal(r.pay_per_tech, 0);
+    assert.equal(r.pays_tech, false);
+  });
+
+  it("negative customer charge clamps to 0 (percent mode)", () => {
+    const r = resolveCancellationTechPay({
+      action: "cancel", customerChargeAmount: -50, numTechs: 1,
+      policy: { mode: "percent", amount: 50 },
+    });
+    assert.equal(r.total_pay, 0);
+  });
+
+  it("negative flat amount clamps to 0", () => {
+    const r = resolveCancellationTechPay({
+      action: "cancel", customerChargeAmount: 200, numTechs: 1,
+      policy: { mode: "flat", amount: -60 },
+    });
+    assert.equal(r.total_pay, 0);
+  });
+});

--- a/artifacts/qleno/src/pages/company/pricing.tsx
+++ b/artifacts/qleno/src/pages/company/pricing.tsx
@@ -423,6 +423,9 @@ export function PricingTab() {
       {/* ── Fee Rules ───────────────────────────────────────────────────── */}
       <FeesSection fees={fees} />
 
+      {/* ── Cancellation Policy (action-picker defaults + tech pay) ─────── */}
+      <CancellationPolicySection />
+
       {/* ── Bundles & Promotions ────────────────────────────────────────── */}
       <BundlesSection />
 
@@ -912,6 +915,198 @@ function FeesSection({ fees }: { fees: FeeRule[] }) {
       </div>
     </div>
   );
+}
+
+// ── Cancellation Policy Section ────────────────────────────────────────────────
+//
+// Tenant-wide defaults consumed by the dispatch cancel modal (PR #216):
+//   - default_cancel_fee_pct  — % charged when a customer cancels late
+//   - default_lockout_fee_pct — % charged when the crew can't get in
+//   - cancellation_tech_pay_mode ('flat' | 'percent')
+//   - cancellation_tech_pay_amount — $ when flat, % when percent
+//
+// Per-client overrides on cancel/lockout % live on the customer profile
+// (clients.cancel_fee_pct / .lockout_fee_pct). When set there, those win.
+
+interface CancellationPolicy {
+  default_cancel_fee_pct: number;
+  default_lockout_fee_pct: number;
+  cancellation_tech_pay_mode: "flat" | "percent";
+  cancellation_tech_pay_amount: number;
+}
+
+function CancellationPolicySection() {
+  const { toast } = useToast();
+  const qc = useQueryClient();
+  const { data, isLoading } = useQuery<CancellationPolicy>({
+    queryKey: ["cancellation-policy"],
+    queryFn: () => apiFetch("/api/companies/cancellation-policy"),
+  });
+
+  // Local edit buffer so the input never feels laggy (default values seed
+  // from server on first load, then user edits drive state).
+  const [form, setForm] = useState<CancellationPolicy | null>(null);
+  useEffect(() => { if (data && !form) setForm(data); }, [data]);
+
+  const save = useMutation({
+    mutationFn: (body: CancellationPolicy) => apiFetch("/api/companies/cancellation-policy", {
+      method: "PUT",
+      body: JSON.stringify(body),
+    }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["cancellation-policy"] });
+      toast({ title: "Cancellation policy saved" });
+    },
+    onError: () => toast({ title: "Failed to save policy", variant: "destructive" }),
+  });
+
+  if (isLoading || !form) {
+    return (
+      <div style={card}>
+        <div style={sectionHead}>Cancellation Policy</div>
+        <div style={{ ...sectionSub, marginBottom: 0 }}>Loading…</div>
+      </div>
+    );
+  }
+
+  // Preview the dollar implication of the current tech-pay setting against
+  // a representative $200 visit fee. Helps the operator gut-check %-mode.
+  const previewJob = 200;
+  const techPreview = form.cancellation_tech_pay_mode === "percent"
+    ? Math.round(previewJob * (form.cancellation_tech_pay_amount / 100) * 100) / 100
+    : form.cancellation_tech_pay_amount;
+
+  const dirty = !!data && JSON.stringify(form) !== JSON.stringify(data);
+
+  return (
+    <div style={card}>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 12 }}>
+        <div>
+          <div style={sectionHead}>Cancellation Policy</div>
+          <div style={sectionSub}>
+            Defaults the dispatch Cancel button applies for this tenant. Per-customer
+            overrides live on the client profile.
+          </div>
+        </div>
+        <button
+          style={btn("primary")}
+          onClick={() => save.mutate(form)}
+          disabled={!dirty || save.isPending}
+        >
+          <Save size={13} />Save
+        </button>
+      </div>
+
+      {/* Customer-side fee defaults */}
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16, marginBottom: 20 }}>
+        <div>
+          <div style={{ fontSize: 11, fontWeight: 700, color: "#9E9B94", marginBottom: 4, textTransform: "uppercase", letterSpacing: "0.04em" }}>
+            Late Cancel Fee
+          </div>
+          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            <input
+              style={{ ...inp, maxWidth: 100 }}
+              type="number"
+              min={0}
+              max={100}
+              step={1}
+              value={form.default_cancel_fee_pct}
+              onChange={e => setForm(p => p && ({ ...p, default_cancel_fee_pct: Number(e.target.value) }))}
+            />
+            <span style={{ fontSize: 13, color: "#6B6860" }}>% of visit fee</span>
+          </div>
+          <div style={{ fontSize: 11, color: "#9E9B94", marginTop: 6 }}>
+            Charged when a customer cancels late. Phes default: 100%.
+          </div>
+        </div>
+
+        <div>
+          <div style={{ fontSize: 11, fontWeight: 700, color: "#9E9B94", marginBottom: 4, textTransform: "uppercase", letterSpacing: "0.04em" }}>
+            Lockout Fee
+          </div>
+          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            <input
+              style={{ ...inp, maxWidth: 100 }}
+              type="number"
+              min={0}
+              max={100}
+              step={1}
+              value={form.default_lockout_fee_pct}
+              onChange={e => setForm(p => p && ({ ...p, default_lockout_fee_pct: Number(e.target.value) }))}
+            />
+            <span style={{ fontSize: 13, color: "#6B6860" }}>% of visit fee</span>
+          </div>
+          <div style={{ fontSize: 11, color: "#9E9B94", marginTop: 6 }}>
+            Charged when the crew can't get in. Phes default: 100%.
+          </div>
+        </div>
+      </div>
+
+      {/* Tech-pay side */}
+      <div style={{ borderTop: "1px solid #E5E2DC", paddingTop: 16 }}>
+        <div style={{ fontSize: 13, fontWeight: 700, color: "#1A1917", marginBottom: 4 }}>
+          Tech pay on cancel / lockout
+        </div>
+        <div style={{ fontSize: 12, color: "#6B6860", marginBottom: 12 }}>
+          What each assigned tech earns for a charged cancellation — they were on the
+          schedule. Split equally across assigned techs.
+        </div>
+
+        <div style={{ display: "grid", gridTemplateColumns: "180px 1fr 1fr", gap: 16, alignItems: "end" }}>
+          <div>
+            <div style={{ fontSize: 11, fontWeight: 700, color: "#9E9B94", marginBottom: 4, textTransform: "uppercase", letterSpacing: "0.04em" }}>
+              Pay Mode
+            </div>
+            <select
+              style={inp}
+              value={form.cancellation_tech_pay_mode}
+              onChange={e => setForm(p => p && ({ ...p, cancellation_tech_pay_mode: e.target.value as "flat" | "percent" }))}
+            >
+              <option value="flat">Flat dollars</option>
+              <option value="percent">% of customer charge</option>
+            </select>
+          </div>
+
+          <div>
+            <div style={{ fontSize: 11, fontWeight: 700, color: "#9E9B94", marginBottom: 4, textTransform: "uppercase", letterSpacing: "0.04em" }}>
+              {form.cancellation_tech_pay_mode === "flat" ? "Amount ($)" : "Percent (%)"}
+            </div>
+            <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+              <span style={{ fontSize: 13, color: "#6B6860", minWidth: 10 }}>
+                {form.cancellation_tech_pay_mode === "flat" ? "$" : ""}
+              </span>
+              <input
+                style={{ ...inp, maxWidth: 140 }}
+                type="number"
+                min={0}
+                step={form.cancellation_tech_pay_mode === "flat" ? 1 : 0.5}
+                value={form.cancellation_tech_pay_amount}
+                onChange={e => setForm(p => p && ({ ...p, cancellation_tech_pay_amount: Number(e.target.value) }))}
+              />
+              <span style={{ fontSize: 13, color: "#6B6860" }}>
+                {form.cancellation_tech_pay_mode === "flat" ? "per cancel" : "%"}
+              </span>
+            </div>
+          </div>
+
+          <div style={{ fontSize: 12, color: "#6B6860" }}>
+            <div style={{ fontSize: 11, fontWeight: 700, color: "#9E9B94", marginBottom: 4, textTransform: "uppercase", letterSpacing: "0.04em" }}>
+              Preview
+            </div>
+            On a {currency(previewJob)} visit, the assigned tech earns{" "}
+            <strong style={{ color: "#1A1917" }}>{currency(techPreview)}</strong>
+            {form.cancellation_tech_pay_mode === "percent" ? " (varies with charge)" : " (fixed)"}.
+            <br />
+            <span style={{ color: "#9E9B94" }}>2 techs → {currency(techPreview / 2)} each.</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function currency(n: number): string {
+  return n.toLocaleString("en-US", { style: "currency", currency: "USD" });
 }
 
 // ── Bundles & Promotions Section ───────────────────────────────────────────────

--- a/lib/db/src/schema/companies.ts
+++ b/lib/db/src/schema/companies.ts
@@ -84,6 +84,20 @@ export const companiesTable = pgTable("companies", {
   // clients.cancel_fee_pct / clients.lockout_fee_pct.
   default_cancel_fee_pct: numeric("default_cancel_fee_pct", { precision: 5, scale: 2 }).notNull().default("100.00"),
   default_lockout_fee_pct: numeric("default_lockout_fee_pct", { precision: 5, scale: 2 }).notNull().default("100.00"),
+  // Tech-pay-on-cancellation policy. When a charging action (cancel /
+  // lockout) fires we still owe the assigned tech(s) something — they
+  // showed up. Two modes:
+  //   'flat'    — fixed dollar amount per cancellation, regardless of job
+  //               size. Phes default $60 (matches the cleanup-trip fee
+  //               techs were historically paid in the old MC system).
+  //   'percent' — percentage of the customer charge_amount. Lets a tenant
+  //               say "tech keeps 40% of whatever we collected".
+  // The amount field is interpreted by the mode: dollars when 'flat',
+  // percentage (0-100) when 'percent'. Total pay is split equally across
+  // the assigned tech(s); proportional-by-clock-in doesn't apply because
+  // nobody worked.
+  cancellation_tech_pay_mode: text("cancellation_tech_pay_mode").notNull().default("flat"),
+  cancellation_tech_pay_amount: numeric("cancellation_tech_pay_amount", { precision: 10, scale: 4 }).notNull().default("60.0000"),
   created_at: timestamp("created_at").notNull().defaultNow(),
 });
 


### PR DESCRIPTION
## Summary

When a customer is charged for a cancellation (cancel / lockout), the assigned tech(s) still earn something — they were on the schedule, may have driven out, may have shown up to a locked door. Until now Qleno only handled the customer-billing side. This PR adds the tech-payroll side **plus** the tenant Settings UI to configure all four cancellation policy knobs.

### Schema (applied to prod already)

- \`companies.cancellation_tech_pay_mode\` — \`'flat' | 'percent'\`, default \`'flat'\`
- \`companies.cancellation_tech_pay_amount\` — \`numeric(10,4)\`, default \`60.0000\`

### Backend

- \`lib/cancellation-tech-pay.ts\` — pure resolver. Charging actions only. Equal split across assigned techs (no proportional-by-minutes because nobody clocked in).
- \`routes/cancellation.ts\` \`/action\` — after writing the \`cancellation_log\` row, inserts \`additional_pay\` rows (\`type='cancellation_pay'\`) for every assigned tech on the cancelled job. Returns \`tech_pay[]\` in the response.
- \`GET/PUT /api/companies/cancellation-policy\` — tenant-level settings endpoint.

### Frontend

Settings → Pricing → new "Cancellation Policy" section:
- **Late Cancel Fee %** (default 100)
- **Lockout Fee %** (default 100)
- **Tech-pay mode** picker (Flat dollars / % of customer charge)
- **Tech-pay amount** input (dollars when flat, % when percent)
- **Live preview** showing what a \$200 visit pays per tech under current settings, including the 2-tech split

### Tests

11 unit tests covering action routing, mode switching, splitting (clean and fractional), and edge cases (zero techs, negative amounts). All pass.

### Behavior

- Phes default: \$60 flat per cancel/lockout, split equally across assigned techs. Matches the cleanup-trip fee techs were historically paid.
- Tenants flip to \`percent\` to share a fraction of the customer charge instead.
- Free actions (move/bump/skip/cancel_service) pay nothing — there's no charge to share and the visit wasn't fulfilled.

### Out of scope (next PRs)

- Per-client cancel/lockout fee % override UI on customer profile (#27)
- "Modify" action wiring in the cancel modal (#28)
- Dockerfile drizzle-kit push fix (#29)

## Test plan
- [ ] After deploy, open Settings → Pricing → Cancellation Policy
- [ ] Confirm default values: 100 / 100 / flat / \$60
- [ ] Change Tech Pay to "% of customer charge", set to 40%, save → toast confirms
- [ ] Cancel a job with the "Cancel" action; verify tech sees the \$60 (or %-derived) row in their payroll
- [ ] Cancel a multi-tech job; verify split is equal

🤖 Generated with [Claude Code](https://claude.com/claude-code)