### PR TITLE
feat(clients): per-client cancel/lockout fee % overrides on profile

### DIFF
--- a/artifacts/api-server/src/routes/clients.ts
+++ b/artifacts/api-server/src/routes/clients.ts
@@ -561,6 +561,7 @@ router.put("/:id", requireAuth, async (req, res) => {
       commercial_hourly_rate,    // [AH] Per-client commercial hourly rate (commission engine)
       hourly_rate,               // [PR #60] Per-client hourly rate (Schedule Rate auto-calc)
       parking_fee_enabled, parking_fee_amount,
+      cancel_fee_pct, lockout_fee_pct,  // Cancellation policy overrides (null = use tenant default)
     } = req.body;
 
     // [AH] Snapshot the previous commercial_hourly_rate so we can write a
@@ -628,6 +629,19 @@ router.put("/:id", requireAuth, async (req, res) => {
         parking_fee_amount: parking_fee_amount === null || parking_fee_amount === ""
           ? null
           : String(parking_fee_amount),
+      }),
+      // Cancellation policy overrides — null/empty means "use tenant
+      // default" (the dispatch cancel modal reads companies.default_*
+      // when these are null). Clamp 0-100 so the UI can't push bad data.
+      ...(cancel_fee_pct !== undefined && {
+        cancel_fee_pct: cancel_fee_pct === null || cancel_fee_pct === ""
+          ? null
+          : String(Math.max(0, Math.min(100, Number(cancel_fee_pct)))),
+      }),
+      ...(lockout_fee_pct !== undefined && {
+        lockout_fee_pct: lockout_fee_pct === null || lockout_fee_pct === ""
+          ? null
+          : String(Math.max(0, Math.min(100, Number(lockout_fee_pct)))),
       }),
     }).where(and(eq(clientsTable.id, clientId), eq(clientsTable.company_id, req.auth!.companyId))).returning();
     if (!updated[0]) return res.status(404).json({ error: "Not Found" });

--- a/artifacts/qleno/src/pages/customer-profile.tsx
+++ b/artifacts/qleno/src/pages/customer-profile.tsx
@@ -446,6 +446,11 @@ function EditProfileDrawer({ client, onClose, onSave, onToast }: { client: any; 
     home_access_notes: client.home_access_notes || "", alarm_code: client.alarm_code || "",
     pets: client.pets || "", referral_source: client.referral_source || "", notes: client.notes || "",
     client_since: client.client_since ? String(client.client_since).slice(0, 10) : "",
+    // Cancellation policy overrides — empty string in the form means
+    // "use the tenant default". The save handler converts "" back to
+    // null before sending.
+    cancel_fee_pct: client.cancel_fee_pct != null ? String(client.cancel_fee_pct) : "",
+    lockout_fee_pct: client.lockout_fee_pct != null ? String(client.lockout_fee_pct) : "",
   });
   const [saving, setSaving] = useState(false);
 
@@ -594,7 +599,13 @@ function EditProfileDrawer({ client, onClose, onSave, onToast }: { client: any; 
   const save = async () => {
     setSaving(true);
     try {
-      await onSave(form);
+      // Cancellation overrides go to the server as null when the input
+      // is blank — that's the signal to fall back to the tenant default.
+      await onSave({
+        ...form,
+        cancel_fee_pct: form.cancel_fee_pct === "" ? null : Number(form.cancel_fee_pct),
+        lockout_fee_pct: form.lockout_fee_pct === "" ? null : Number(form.lockout_fee_pct),
+      });
       onToast("Profile updated");
       onClose();
     } catch { onToast("Failed to save profile", "error"); }
@@ -735,6 +746,50 @@ function EditProfileDrawer({ client, onClose, onSave, onToast }: { client: any; 
               </div>
               <div>{lbl("Client Since")}<input value={form.client_since} onChange={upd("client_since")} type="date" style={inp} /></div>
               <div>{lbl("Internal Notes")}<textarea value={form.notes} onChange={upd("notes")} rows={3} style={{ ...inp, resize: "vertical" as const }} /></div>
+            </div>
+          </div>
+          {/* Cancellation policy overrides — both blank means "use the
+              tenant default". Set when an anchor client negotiated a
+              non-standard fee (e.g. 0% no-fault clause). The dispatch
+              cancel modal reads these via /api/cancellations/action. */}
+          <div style={{ borderTop: "1px solid #E5E2DC", paddingTop: 12 }}>
+            <div style={{ fontSize: 11, fontWeight: 700, color: "#6B6860", textTransform: "uppercase" as const, letterSpacing: "0.07em", marginBottom: 4 }}>
+              Cancellation Policy Override
+            </div>
+            <div style={{ fontSize: 11, color: "#9E9B94", marginBottom: 12 }}>
+              Leave blank to use the tenant default. Set 0–100 % to override for this client only.
+            </div>
+            <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
+              <div>
+                {lbl("Late Cancel %")}
+                <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                  <input
+                    value={form.cancel_fee_pct}
+                    onChange={upd("cancel_fee_pct")}
+                    type="number"
+                    min={0}
+                    max={100}
+                    step={1}
+                    placeholder="default"
+                    style={inp}
+                  />
+                </div>
+              </div>
+              <div>
+                {lbl("Lockout %")}
+                <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                  <input
+                    value={form.lockout_fee_pct}
+                    onChange={upd("lockout_fee_pct")}
+                    type="number"
+                    min={0}
+                    max={100}
+                    step={1}
+                    placeholder="default"
+                    style={inp}
+                  />
+                </div>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Adds the missing per-customer override UI for the cancellation policy. The columns \`clients.cancel_fee_pct\` / \`.lockout_fee_pct\` shipped with PR #216 but had no editor — office could only set the tenant-wide default.

### Frontend
- **Edit Profile drawer** → new "Cancellation Policy Override" section with two numeric inputs (cancel %, lockout %). Empty = use the tenant default.

### Backend
- \`PUT /api/clients/:id\` accepts \`cancel_fee_pct\` + \`lockout_fee_pct\`, clamps 0-100, stores null when blank.

### Behavior
The dispatch cancel modal already reads these via \`resolveCancellationPolicy()\` — per-client wins when set, else tenant default. So once an operator sets 0% on (say) a corporate account with a no-fault clause, every late cancel for that client waives the fee automatically.

## Test plan
- [ ] Open a client → Edit Profile → scroll to Cancellation Policy Override
- [ ] Confirm both inputs are blank by default (= use tenant default)
- [ ] Set Late Cancel % to 50, save → toast confirms
- [ ] Cancel a job for that client; verify the charge is 50% (not 100%)
- [ ] Clear the input + save → confirm fee falls back to tenant default

🤖 Generated with [Claude Code](https://claude.com/claude-code)