### PR TITLE
fix(employees): include NULL home_branch_id in branch-filtered employee list

### DIFF
--- a/artifacts/api-server/src/routes/users.ts
+++ b/artifacts/api-server/src/routes/users.ts
@@ -34,10 +34,20 @@ router.get("/", requireAuth, async (req, res) => {
     // home_branch_id (not branch_id — the column was renamed under cutover 1A).
     // Pass-through when present so the employees list can still filter by
     // home branch within a tenant if one's selected.
+    //
+    // **NULL fall-through.** Cutover 1A's home_branch_id backfill was
+    // reverted, so the column is nullable and most existing Phes techs
+    // are NULL. Strict `home_branch_id = X` would hide every untagged
+    // tech the moment an operator picks a branch — Sal hit this on
+    // 2026-06-01 with all 20 active Phes techs invisible under
+    // Oak Lawn. Treat NULL as "shows under any branch" so the filter
+    // narrows the explicitly-tagged subset without dropping the
+    // unassigned default population. Once techs are individually
+    // tagged to a branch they'll start filtering normally.
     if (branch_id && branch_id !== "all") {
       const branchIdNum = parseInt(branch_id as string, 10);
       if (Number.isFinite(branchIdNum)) {
-        conditions.push(sql`u.home_branch_id = ${branchIdNum}`);
+        conditions.push(sql`(u.home_branch_id = ${branchIdNum} OR u.home_branch_id IS NULL)`);
       }
     }
 


### PR DESCRIPTION
## Symptom

\`/employees\` shows "No team members found" the moment Sal picks the **Oak Lawn** (or any specific) branch — despite Phes having 20 active technicians. Switching back to "All Locations" surfaces them.

## Root cause

\`GET /api/users\` filters \`u.home_branch_id = <branchId>\` when branch_id is passed. But cutover 1A's home_branch_id backfill was reverted ([Task #13](#)) and **all 20 active Phes techs have \`home_branch_id = NULL\`**. Strict equality drops every untagged tech the moment the operator picks a branch.

\`\`\`sql
-- before: 0 rows when branch_id=1 picked
SELECT COUNT(*) FROM users
 WHERE company_id = 1 AND is_active = true AND home_branch_id = 1;
-- → 0

-- without the filter
SELECT COUNT(*) FROM users WHERE company_id = 1 AND is_active = true;
-- → 20
\`\`\`

## Fix

Treat NULL as "shows under any branch" — narrow the explicitly-tagged subset without dropping the unassigned default population:

\`\`\`ts
conditions.push(sql\`(u.home_branch_id = \${branchIdNum} OR u.home_branch_id IS NULL)\`);
\`\`\`

## Behavior matrix

| Branch filter | Returned techs |
|---|---|
| All Locations | all 20 (unchanged) |
| Oak Lawn (id=1) | techs with home_branch_id=1 OR NULL |
| Schaumburg (id=2) | techs with home_branch_id=2 OR NULL |

Same techs may appear under both branches until tagging lands — that's the right behavior given the data (they ARE schedulable at either, per Model B). Tagging via the employee profile narrows it.

## Test plan
- [ ] Deploy. Open /employees with "Oak Lawn" picked → all 20 Phes techs visible.
- [ ] Switch to "Schaumburg" → same 20 (until they're tagged) + Sal Martinez (Schaumburg owner).
- [ ] Switch to "All Locations" → still 20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)