### PR TITLE
fix(cancel): cancel_service uses is_active, not active

### DIFF
--- a/artifacts/api-server/src/routes/cancellation.ts
+++ b/artifacts/api-server/src/routes/cancellation.ts
@@ -312,10 +312,12 @@ router.post("/action", requireAuth, async (req, res) => {
         RETURNING id
       `);
       futureCancelled = (futureCancel.rows as any[]).length;
-      // Also flag the recurring schedule itself.
+      // Also flag the recurring schedule itself. The column is
+      // `is_active` (Drizzle naming) — referencing `active` here
+      // would 500 the whole transaction.
       await tx.execute(sql`
         UPDATE recurring_schedules
-           SET active = false
+           SET is_active = false
          WHERE id = ${row.recurring_schedule_id} AND company_id = ${companyId}
       `);
     }


### PR DESCRIPTION
Caught during self-test of the cancel flow. `recurring_schedules.is_active` is the actual column name; `active` doesn't exist. The previous code would have 500'd the entire cancel_service transaction at the schedule-deactivation step.