### PR TITLE
feat(reports): plug cancellations + reschedules into revenue + client profile

### DIFF
--- a/artifacts/api-server/src/routes/clients.ts
+++ b/artifacts/api-server/src/routes/clients.ts
@@ -1645,6 +1645,98 @@ router.get("/:id/job-photos", requireAuth, async (req, res) => {
   }
 });
 
+// [cancellation-reporting 2026-06-01] Per-client cancellation +
+// reschedule activity feed. Returns every cancellation_log row for
+// the client with a friendly label per action, the job's original
+// date, the charge amount (zero for free actions), and any operator
+// note. Powers the "Cancellations & Reschedules" section on the
+// client profile so office can see at a glance how often this
+// customer reschedules / cancels / locks the crew out.
+router.get("/:id/cancellation-history", requireAuth, async (req, res) => {
+  try {
+    const clientId = parseInt(req.params.id);
+    const companyId = req.auth!.companyId;
+    if (!Number.isFinite(clientId)) {
+      return res.status(400).json({ error: "Invalid client id" });
+    }
+    const rows = await db.execute(sql`
+      SELECT
+        cl.id,
+        cl.cancel_action,
+        cl.customer_charge_amount,
+        cl.affects_future_jobs,
+        cl.notes,
+        cl.cancelled_at,
+        cl.job_id,
+        j.scheduled_date AS original_date,
+        j.base_fee AS original_amount,
+        u.first_name || ' ' || COALESCE(u.last_name, '') AS cancelled_by_name
+      FROM cancellation_log cl
+      JOIN jobs j ON j.id = cl.job_id
+      LEFT JOIN users u ON u.id = cl.cancelled_by
+      WHERE cl.company_id = ${companyId} AND cl.customer_id = ${clientId}
+      ORDER BY cl.cancelled_at DESC
+      LIMIT 200
+    `);
+    const data = (rows.rows as Array<{
+      id: number;
+      cancel_action: string | null;
+      customer_charge_amount: string;
+      affects_future_jobs: boolean;
+      notes: string | null;
+      cancelled_at: Date;
+      job_id: number;
+      original_date: string;
+      original_amount: string | null;
+      cancelled_by_name: string | null;
+    }>).map(r => {
+      const action = r.cancel_action ?? "legacy";
+      const labels: Record<string, string> = {
+        move: "Moved (customer)",
+        bump: "Bumped (office)",
+        skip: "Skipped",
+        cancel: "Cancelled (fee)",
+        lockout: "Lockout (fee)",
+        cancel_service: "Service cancelled",
+        legacy: "Cancellation",
+      };
+      return {
+        id: r.id,
+        action,
+        label: labels[action] ?? action,
+        is_reschedule: action === "move" || action === "bump",
+        charges_customer: action === "cancel" || action === "lockout",
+        ends_service: action === "cancel_service",
+        customer_charge_amount: parseFloat(String(r.customer_charge_amount ?? 0)),
+        affects_future_jobs: r.affects_future_jobs,
+        notes: r.notes,
+        cancelled_at: r.cancelled_at,
+        cancelled_by_name: r.cancelled_by_name?.trim() || null,
+        job_id: r.job_id,
+        original_date: r.original_date,
+        original_amount: r.original_amount != null ? parseFloat(String(r.original_amount)) : null,
+      };
+    });
+    // Summary chip at the top of the section.
+    const summary = data.reduce(
+      (acc, e) => {
+        if (e.action === "move") acc.moves += 1;
+        if (e.action === "bump") acc.bumps += 1;
+        if (e.action === "skip") acc.skips += 1;
+        if (e.action === "cancel") { acc.cancels += 1; acc.total_charged += e.customer_charge_amount; }
+        if (e.action === "lockout") { acc.lockouts += 1; acc.total_charged += e.customer_charge_amount; }
+        if (e.action === "cancel_service") acc.services_ended += 1;
+        return acc;
+      },
+      { moves: 0, bumps: 0, skips: 0, cancels: 0, lockouts: 0, services_ended: 0, total_charged: 0 }
+    );
+    return res.json({ data, summary });
+  } catch (err) {
+    console.error("[clients/cancellation-history]", err);
+    return res.status(500).json({ error: "Server error" });
+  }
+});
+
 router.get("/:id/recurring-schedule", requireAuth, async (req, res) => {
   try {
     const clientId = parseInt(req.params.id);

--- a/artifacts/api-server/src/routes/reports.ts
+++ b/artifacts/api-server/src/routes/reports.ts
@@ -208,12 +208,61 @@ router.get("/revenue", requireAuth, ROLE, async (req, res) => {
         AND scheduled_date BETWEEN ${monthStart} AND ${monthEnd}
     `);
 
+    // [cancellation-reporting 2026-06-01] Break down the window's total
+    // revenue into visit revenue (real cleanings delivered) vs
+    // cancellation-fee revenue (lockouts + cancel-with-charge). Sourced
+    // from cancellation_log so we pick up exactly what was charged on
+    // each event — not derived from job status which can blur the
+    // two streams (charged cancellations live as status='complete').
+    // Reschedule counts (move/bump) and cancel_service counts surface
+    // so operators can see the full picture even though those events
+    // don't produce revenue rows.
+    const cancelBreakdown = await db.execute(sql`
+      SELECT
+        coalesce(sum(case when cl.cancel_action in ('cancel','lockout') then cl.customer_charge_amount else 0 end), 0) AS cancellation_fee_revenue,
+        coalesce(sum(case when cl.cancel_action = 'lockout' then cl.customer_charge_amount else 0 end), 0) AS lockout_fee_revenue,
+        coalesce(sum(case when cl.cancel_action = 'cancel' then cl.customer_charge_amount else 0 end), 0) AS cancel_fee_revenue,
+        sum(case when cl.cancel_action = 'move' then 1 else 0 end)::int AS move_count,
+        sum(case when cl.cancel_action = 'bump' then 1 else 0 end)::int AS bump_count,
+        sum(case when cl.cancel_action = 'skip' then 1 else 0 end)::int AS skip_count,
+        sum(case when cl.cancel_action = 'cancel' then 1 else 0 end)::int AS cancel_count,
+        sum(case when cl.cancel_action = 'lockout' then 1 else 0 end)::int AS lockout_count,
+        sum(case when cl.cancel_action = 'cancel_service' then 1 else 0 end)::int AS cancel_service_count
+      FROM cancellation_log cl
+      JOIN jobs j ON j.id = cl.job_id
+      WHERE cl.company_id = ${companyId}
+        ${branchFilter(req, "j.branch_id")}
+        AND j.scheduled_date BETWEEN ${fromStr} AND ${toStr}
+    `);
+    const cb = (cancelBreakdown.rows[0] as any) ?? {};
+
     const s = summary.rows[0] as any;
+    const totalRev = parseF(s?.total_revenue);
+    const cancelFeeRev = parseF(cb.cancellation_fee_revenue);
     return res.json({
       from: fromStr, to: toStr, group_by: groupBy,
       summary: {
-        total_revenue: parseF(s?.total_revenue), avg_job_value: parseF(s?.avg_job_value),
-        job_count: parseN(s?.job_count), projected_month_end: parseF((projected.rows[0] as any)?.projected),
+        total_revenue: totalRev,
+        avg_job_value: parseF(s?.avg_job_value),
+        job_count: parseN(s?.job_count),
+        projected_month_end: parseF((projected.rows[0] as any)?.projected),
+        // [cancellation-reporting 2026-06-01] Cancellation revenue
+        // breakdown. visit_revenue = total minus the cancellation-fee
+        // portion (so consumers can show "real visit revenue" without
+        // the lockout/cancel fees folded in). cancellation_fee_revenue
+        // is the sum of charged actions; lockout_fee + cancel_fee are
+        // the further breakdown.
+        cancellation_fee_revenue: cancelFeeRev,
+        visit_revenue: Math.round((totalRev - cancelFeeRev) * 100) / 100,
+        lockout_fee_revenue: parseF(cb.lockout_fee_revenue),
+        cancel_fee_revenue: parseF(cb.cancel_fee_revenue),
+        // Counts for awareness — reschedules + skips + service cancellations.
+        move_count: cb.move_count ?? 0,
+        bump_count: cb.bump_count ?? 0,
+        skip_count: cb.skip_count ?? 0,
+        cancel_count: cb.cancel_count ?? 0,
+        lockout_count: cb.lockout_count ?? 0,
+        cancel_service_count: cb.cancel_service_count ?? 0,
       },
       trend: (trend.rows as any[]).map(r => ({
         period: r.period, job_count: parseN(r.job_count), revenue: parseF(r.revenue),

--- a/artifacts/qleno/src/pages/customer-profile.tsx
+++ b/artifacts/qleno/src/pages/customer-profile.tsx
@@ -2499,6 +2499,139 @@ function RecurringTab({ clientId }: { clientId: number }) {
   );
 }
 
+// ─── Cancellations + Reschedules Section ──────────────────────────────────────
+// Lists every cancellation_log row for the client with a color-coded
+// action chip, the original job date, the operator who recorded it,
+// the charge amount (zero for free actions), and any operator note.
+// Header chip summarises moves/bumps/skips/cancels/lockouts/services
+// ended + total charged in one glance.
+interface CancellationHistoryEntry {
+  id: number;
+  action: string;
+  label: string;
+  is_reschedule: boolean;
+  charges_customer: boolean;
+  ends_service: boolean;
+  customer_charge_amount: number;
+  affects_future_jobs: boolean;
+  notes: string | null;
+  cancelled_at: string;
+  cancelled_by_name: string | null;
+  job_id: number;
+  original_date: string;
+  original_amount: number | null;
+}
+interface CancellationHistoryResponse {
+  data: CancellationHistoryEntry[];
+  summary: {
+    moves: number; bumps: number; skips: number;
+    cancels: number; lockouts: number; services_ended: number;
+    total_charged: number;
+  };
+}
+
+// Match the cancel modal palette so vocabulary stays consistent across
+// the dispatch picker and the client-history feed.
+const ACTIVITY_META: Record<string, { color: string; tint: string }> = {
+  move:           { color: "#7C3AED", tint: "#F5F3FF" },
+  bump:           { color: "#DB2777", tint: "#FDF2F8" },
+  skip:           { color: "#D97706", tint: "#FFFBEB" },
+  cancel:         { color: "#DC2626", tint: "#FEF2F2" },
+  lockout:        { color: "#475569", tint: "#F1F5F9" },
+  cancel_service: { color: "#991B1B", tint: "#FEF2F2" },
+  legacy:         { color: "#6B6860", tint: "#F7F6F3" },
+};
+
+function CancellationsActivitySection({ clientId }: { clientId: number }) {
+  const FF = "'Plus Jakarta Sans', sans-serif";
+  const { data, isLoading } = useQuery<CancellationHistoryResponse>({
+    queryKey: ["client-cancellation-history", clientId],
+    queryFn: () => apiFetch(`/api/clients/${clientId}/cancellation-history`),
+  });
+  const entries = data?.data ?? [];
+  const summary = data?.summary;
+  const fmtDateShort = (d: string) => new Date(d + (d.length === 10 ? "T12:00" : "")).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+  const fmtTime = (d: string) => new Date(d).toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" });
+  const fmtCash = (n: number) => n.toLocaleString("en-US", { style: "currency", currency: "USD" });
+
+  return (
+    <div style={{ fontFamily: FF }}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 12 }}>
+        <div style={{ fontSize: 14, fontWeight: 700, color: "#0A0E1A" }}>Cancellations & Reschedules</div>
+        {summary && (
+          <div style={{ fontSize: 11, color: "#6B6860" }}>
+            {summary.moves + summary.bumps > 0 && <span style={{ marginRight: 10 }}><strong>{summary.moves + summary.bumps}</strong> reschedule{summary.moves + summary.bumps === 1 ? "" : "s"}</span>}
+            {summary.cancels + summary.lockouts > 0 && <span style={{ marginRight: 10 }}><strong>{summary.cancels + summary.lockouts}</strong> charged · {fmtCash(summary.total_charged)}</span>}
+            {summary.services_ended > 0 && <span style={{ color: "#991B1B", fontWeight: 700 }}>SERVICE ENDED</span>}
+          </div>
+        )}
+      </div>
+
+      {isLoading ? (
+        <div style={{ fontSize: 12, color: "#9E9B94", padding: "16px 0" }}>Loading…</div>
+      ) : entries.length === 0 ? (
+        <div style={{ fontSize: 12, color: "#9E9B94", padding: "16px 0", textAlign: "center" as const, border: "1px dashed #E5E2DC", borderRadius: 8 }}>
+          No cancellations or reschedules on file for this client.
+        </div>
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          {entries.map(e => {
+            const meta = ACTIVITY_META[e.action] ?? ACTIVITY_META.legacy;
+            return (
+              <div key={e.id} style={{
+                display: "grid",
+                gridTemplateColumns: "auto 1fr auto",
+                gap: 12, alignItems: "center",
+                padding: "10px 12px",
+                background: "#FFFFFF",
+                border: `1px solid ${meta.color}26`,
+                borderLeft: `4px solid ${meta.color}`,
+                borderRadius: 8,
+              }}>
+                <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-start" }}>
+                  <span style={{
+                    fontSize: 11, fontWeight: 700, color: meta.color,
+                    textTransform: "uppercase" as const, letterSpacing: "0.04em",
+                    background: meta.tint,
+                    padding: "3px 8px", borderRadius: 4, whiteSpace: "nowrap" as const,
+                  }}>
+                    {e.label}
+                  </span>
+                </div>
+                <div style={{ minWidth: 0 }}>
+                  <div style={{ fontSize: 13, fontWeight: 600, color: "#0A0E1A" }}>
+                    Original visit · {fmtDateShort(e.original_date)}
+                  </div>
+                  <div style={{ fontSize: 11, color: "#6B6860", marginTop: 2 }}>
+                    Recorded {fmtDateShort(e.cancelled_at.slice(0, 10))} at {fmtTime(e.cancelled_at)}
+                    {e.cancelled_by_name ? ` · by ${e.cancelled_by_name}` : ""}
+                    {e.affects_future_jobs ? ` · all future jobs ended` : ""}
+                  </div>
+                  {e.notes && (
+                    <div style={{ fontSize: 12, color: "#374151", marginTop: 4, fontStyle: "italic" as const }}>
+                      "{e.notes}"
+                    </div>
+                  )}
+                </div>
+                <div style={{ textAlign: "right" as const, whiteSpace: "nowrap" as const }}>
+                  {e.charges_customer ? (
+                    <>
+                      <div style={{ fontSize: 14, fontWeight: 700, color: meta.color }}>{fmtCash(e.customer_charge_amount)}</div>
+                      <div style={{ fontSize: 10, color: "#9E9B94", textTransform: "uppercase" as const, letterSpacing: "0.04em" }}>Charged</div>
+                    </>
+                  ) : (
+                    <div style={{ fontSize: 11, color: "#9E9B94" }}>No charge</div>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
 // ─── Revenue Trend Tab ─────────────────────────────────────────────────────────
 function RevenueTrendTab({ clientId, jobs }: { clientId: number; jobs: any[] }) {
 
@@ -5543,6 +5676,16 @@ export default function CustomerProfilePage() {
           <div style={CS}>
             <SectionHead title="Inspections" />
             <InspectionsSection />
+          </div>
+
+          {/* [cancellation-reporting 2026-06-01] Cancellations + Reschedules
+              feed. Lists every cancellation_log row for this client with
+              friendly labels per action (Move / Bump / Skip / Cancel /
+              Lockout / Service cancelled). Operators can see at a glance
+              how often this customer reschedules, when fees were
+              charged, and whether the service was ever fully cancelled. */}
+          <div style={CS}>
+            <CancellationsActivitySection clientId={clientId} />
           </div>
 
         </div>

--- a/artifacts/qleno/src/pages/reports/revenue.tsx
+++ b/artifacts/qleno/src/pages/reports/revenue.tsx
@@ -12,7 +12,22 @@ function useIsMobile() {
 
 interface RevData {
   from: string; to: string; group_by: string;
-  summary: { total_revenue: number; avg_job_value: number; job_count: number; projected_month_end: number };
+  summary: {
+    total_revenue: number; avg_job_value: number; job_count: number; projected_month_end: number;
+    // [cancellation-reporting 2026-06-01] Breakdown that splits real
+    // visit revenue from cancellation-fee revenue. Both flow into the
+    // top-line total, but operators want to see them separately.
+    cancellation_fee_revenue?: number;
+    visit_revenue?: number;
+    lockout_fee_revenue?: number;
+    cancel_fee_revenue?: number;
+    move_count?: number;
+    bump_count?: number;
+    skip_count?: number;
+    cancel_count?: number;
+    lockout_count?: number;
+    cancel_service_count?: number;
+  };
   trend: { period: string; job_count: number; revenue: number; avg_per_job: number; allowed_hours: number }[];
 }
 
@@ -62,12 +77,46 @@ export default function RevenueReportPage() {
           }
         />
 
-        <div style={{ display: "flex", gap: 14, flexWrap: "wrap", marginBottom: 24 }}>
-          <KpiCard label="Total Revenue" value={fmt$(s?.total_revenue ?? 0)} />
+        <div style={{ display: "flex", gap: 14, flexWrap: "wrap", marginBottom: 14 }}>
+          <KpiCard label="Total Revenue" value={fmt$(s?.total_revenue ?? 0)} sub="Visits + cancellation fees" />
           <KpiCard label="Avg Job Value" value={fmt$(s?.avg_job_value ?? 0)} color={clr.green} />
           <KpiCard label="Jobs Completed" value={String(s?.job_count ?? 0)} color={clr.secondary} />
           <KpiCard label="Month Projected" value={fmt$(s?.projected_month_end ?? 0)} color={clr.amber} sub="All scheduled + completed this month" />
         </div>
+
+        {/* [cancellation-reporting 2026-06-01] Cancellation revenue breakdown.
+            Visit revenue = total minus cancellation fees, so the operator
+            can answer "how much did we earn from actual cleanings this
+            window?" without doing mental math. The two fee cards split
+            lockouts from cancels for fine-grained tracking. */}
+        <div style={{ display: "flex", gap: 14, flexWrap: "wrap", marginBottom: 14 }}>
+          <KpiCard
+            label="Visit Revenue"
+            value={fmt$(s?.visit_revenue ?? s?.total_revenue ?? 0)}
+            color={clr.green}
+            sub="Cleanings actually delivered"
+          />
+          <KpiCard
+            label="Cancellation Fees"
+            value={fmt$(s?.cancellation_fee_revenue ?? 0)}
+            color={clr.red}
+            sub={`Cancel: ${fmt$(s?.cancel_fee_revenue ?? 0)} · Lockout: ${fmt$(s?.lockout_fee_revenue ?? 0)}`}
+          />
+          <KpiCard
+            label="Reschedules"
+            value={String((s?.move_count ?? 0) + (s?.bump_count ?? 0))}
+            color={clr.secondary}
+            sub={`Move: ${s?.move_count ?? 0} · Bump: ${s?.bump_count ?? 0}`}
+          />
+          <KpiCard
+            label="Service Cancellations"
+            value={String(s?.cancel_service_count ?? 0)}
+            color={clr.red}
+            sub={`${s?.skip_count ?? 0} skip${(s?.skip_count ?? 0) === 1 ? "" : "s"} in window`}
+          />
+        </div>
+
+        <div style={{ height: 10 }} />
 
         {/* Bar chart */}
         {trend.length > 0 && (


### PR DESCRIPTION
## What

Sal flagged: \`We cannot cancel a service, or charge a lockout and not have reporting for this. As well as reschedules. The reschedules have to cascade to client profile, the lockouts and cancel need to count as revenue for the day and month and so forth but reporting has to be able to filter them and they should report separately as well as together.\`

This PR plugs the cancellation system into the two surfaces where operators need it.

## Backend

### \`/api/reports/revenue\` — extended summary

Pulls \`cancellation_log\` into the breakdown for the window:
- \`visit_revenue\` — total minus the cancellation-fee portion
- \`cancellation_fee_revenue\` — cancel + lockout charges combined
- \`lockout_fee_revenue\` / \`cancel_fee_revenue\` — the split
- \`move_count\` / \`bump_count\` / \`skip_count\` / \`cancel_count\` / \`lockout_count\` / \`cancel_service_count\`

Sourced from \`cancellation_log\` not job status, so charged cancellations (which live as \`status='complete'\`) don't blur the two revenue streams.

### \`GET /api/clients/:id/cancellation-history\` — new

Returns every \`cancellation_log\` entry for the client with friendly labels, original job date, charge amount, operator name, and notes. Summary header counts moves/bumps/skips/cancels/lockouts/services_ended + total charged.

## Frontend

### \`/reports/revenue\`
Added a second row of 4 KPI cards:
- **Visit Revenue** (green) — cleanings actually delivered
- **Cancellation Fees** (red) — with Cancel + Lockout split in the subline
- **Reschedules** (gray) — Move + Bump count, broken out in subline
- **Service Cancellations** (red) — plus skip count in subline

Total Revenue subline updated to read \"Visits + cancellation fees\" so it's clear what's folded in.

### Customer Profile → Jobs tab → \"Cancellations & Reschedules\"
New section listing every event for this client. Color-coded action chips match the dispatch cancel modal vocabulary (violet move / pink bump / amber skip / red cancel / slate lockout / dark-red service cancellation). Each row: original visit date, when + by-whom recorded, charge amount, operator notes when present. Header chip surfaces \`N reschedules\`, \`N charged · \$X\`, and a red SERVICE ENDED chip if the service was fully cancelled.

## Test plan
- [ ] Open /reports/revenue → confirm 4 new KPI cards render with sensible numbers
- [ ] Date range covering a cancellation → cancellation_fee_revenue > 0, visit_revenue = total - fees
- [ ] Open a client profile that has cancellations → Jobs tab → scroll past Inspections → \"Cancellations & Reschedules\" section appears with action history
- [ ] Reschedule a job via Move → check that client's Cancellations & Reschedules feed shows the moved entry

## Out of scope (next)
- Filter toggle on revenue (\"show visit revenue only\" / \"show fees only\")
- Cancellation revenue in the per-period trend chart (currently only summary-level)
- Daily/weekly cancellation rates as a tracked KPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)