### PR TITLE
fix(engine): every_4_weeks cadence + start_date boundary + extract pure module

### DIFF
--- a/artifacts/api-server/src/lib/recurring-cadences.ts
+++ b/artifacts/api-server/src/lib/recurring-cadences.ts
@@ -1,0 +1,198 @@
+/**
+ * Pure date-math for the recurring engine. Extracted from recurring-jobs.ts
+ * so unit tests can import without dragging in the Drizzle DB binding.
+ *
+ * Handles every cadence Sal listed on 2026-06-01 as required for July
+ * cutover:
+ *   - weekly / biweekly / every_3_weeks / every_4_weeks
+ *   - custom + custom_frequency_weeks (N-week interval, N >= 1)
+ *   - monthly (day-of-month, sentinel 0 = last day)
+ *   - semi_monthly (two day-of-month anchors)
+ *   - daily / weekdays / custom_days (multi-day per week)
+ *
+ * This file MUST NOT import @workspace/db or any IO-bound module — keeping
+ * it pure is what lets the test suite run without provisioning a DB.
+ */
+
+export const DAY_NAME_TO_NUM: Record<string, number> = {
+  sunday: 0, monday: 1, tuesday: 2, wednesday: 3,
+  thursday: 4, friday: 5, saturday: 6,
+};
+
+export function addDays(date: Date, days: number): Date {
+  const d = new Date(date);
+  d.setDate(d.getDate() + days);
+  return d;
+}
+
+export function addMonths(date: Date, months: number): Date {
+  const d = new Date(date);
+  d.setMonth(d.getMonth() + months);
+  return d;
+}
+
+export function parseDate(str: string): Date {
+  const [y, m, d] = str.split("-").map(Number);
+  return new Date(y, m - 1, d);
+}
+
+export function getFirstOccurrence(start: Date, targetDow: number, fromDate: Date): Date {
+  const d = new Date(fromDate);
+  const diff = (targetDow - d.getDay() + 7) % 7;
+  return addDays(d, diff);
+}
+
+// daily      → every day 0..6
+// weekdays   → Mon-Fri
+// custom_days → operator-picked days_of_week array (e.g., Arianna Wed+Sat)
+// Returns null for all other frequencies (which use the single-day path).
+export function resolveMultiDayPattern(
+  freq: string,
+  daysOfWeek: number[] | null,
+): number[] | null {
+  if (freq === "daily") return [0, 1, 2, 3, 4, 5, 6];
+  if (freq === "weekdays") return [1, 2, 3, 4, 5];
+  if (freq === "custom_days") {
+    const arr = (daysOfWeek ?? []).filter(n => Number.isInteger(n) && n >= 0 && n <= 6);
+    return arr.length > 0 ? Array.from(new Set(arr)).sort() : null;
+  }
+  return null;
+}
+
+// Saturday/Sunday → next Monday. Used for monthly + semi_monthly anchors
+// only, matching Sal's "snap forward" decision (CLAUDE.md, Apr 16).
+export function snapToBusinessDay(d: Date): Date {
+  const dow = d.getDay();
+  if (dow === 6) return addDays(d, 2);
+  if (dow === 0) return addDays(d, 1);
+  return d;
+}
+
+// Resolves day-of-month with two specials:
+//   day=0    → last day of the month
+//   day>last → clamps to last day of the month (e.g., Feb 30 → Feb 28)
+export function resolveDayOfMonth(year: number, month: number, day: number): number {
+  const lastDay = new Date(year, month + 1, 0).getDate();
+  if (day === 0 || day > lastDay) return lastDay;
+  return day;
+}
+
+export interface CadenceInput {
+  frequency: string;
+  day_of_week: string | null;
+  days_of_week?: number[] | null;
+  days_of_month?: number[] | null;
+  custom_frequency_weeks?: number | null;
+  start_date: string;
+  end_date?: string | null;
+}
+
+export function generateCadenceDates(
+  schedule: CadenceInput,
+  fromDate: Date,
+  toDate: Date,
+): Date[] {
+  const start = parseDate(schedule.start_date);
+  const endLimit = schedule.end_date ? parseDate(schedule.end_date) : toDate;
+  const effectiveEnd = endLimit < toDate ? endLimit : toDate;
+
+  const freq = schedule.frequency;
+  const dates: Date[] = [];
+
+  if (schedule.day_of_week && (schedule.days_of_week?.length ?? 0) > 0) {
+    console.warn(
+      `[recurring-engine] schedule has BOTH day_of_week and days_of_week populated — preferring days_of_week`,
+    );
+  }
+
+  // ── Multi-day path: daily / weekdays / custom_days ──────────────────────
+  const multiDay = resolveMultiDayPattern(freq, schedule.days_of_week ?? null);
+  if (multiDay) {
+    const targetSet = new Set(multiDay);
+    let current = new Date(fromDate);
+    while (current <= effectiveEnd) {
+      if (current >= start && targetSet.has(current.getDay())) {
+        dates.push(new Date(current));
+      }
+      current = addDays(current, 1);
+    }
+    return dates;
+  }
+
+  // ── Single-day path ────────────────────────────────────────────────────
+  const targetDow = schedule.day_of_week
+    ? (DAY_NAME_TO_NUM[schedule.day_of_week.toLowerCase()] ?? start.getDay())
+    : start.getDay();
+
+  if (freq === "semi_monthly") {
+    const anchors = schedule.days_of_month && schedule.days_of_month.length > 0
+      ? schedule.days_of_month
+      : [1, 15];
+    let cursor = new Date(fromDate.getFullYear(), fromDate.getMonth(), 1);
+    while (cursor <= effectiveEnd) {
+      const y = cursor.getFullYear();
+      const m = cursor.getMonth();
+      for (const a of anchors) {
+        const day = resolveDayOfMonth(y, m, a);
+        const raw = new Date(y, m, day);
+        const snapped = snapToBusinessDay(raw);
+        if (snapped >= start && snapped >= fromDate && snapped <= effectiveEnd) {
+          dates.push(snapped);
+        }
+      }
+      cursor = addMonths(cursor, 1);
+    }
+    dates.sort((a, b) => a.getTime() - b.getTime());
+    return dates;
+  }
+
+  if (freq === "monthly") {
+    const dayOfMonth = schedule.days_of_month && schedule.days_of_month.length > 0
+      ? schedule.days_of_month[0]
+      : start.getDate();
+    let cursor = new Date(fromDate.getFullYear(), fromDate.getMonth(), 1);
+    while (cursor <= effectiveEnd) {
+      const day = resolveDayOfMonth(cursor.getFullYear(), cursor.getMonth(), dayOfMonth);
+      const raw = new Date(cursor.getFullYear(), cursor.getMonth(), day);
+      const snapped = snapToBusinessDay(raw);
+      if (snapped >= start && snapped >= fromDate && snapped <= effectiveEnd) {
+        dates.push(snapped);
+      }
+      cursor = addMonths(cursor, 1);
+    }
+    return dates;
+  }
+
+  // Interval picker for weekly/biweekly/every_3_weeks/every_4_weeks/custom.
+  // [2026-06-01] every_4_weeks added as first-class to fix Sal's "monthly"
+  // recurring (Wednesdays every 4 weeks) which previously fell through to
+  // the silent biweekly fallback and produced jobs every other week.
+  let intervalDays: number;
+  if (freq === "weekly") {
+    intervalDays = 7;
+  } else if (freq === "biweekly") {
+    intervalDays = 14;
+  } else if (freq === "every_3_weeks") {
+    intervalDays = 21;
+  } else if (freq === "every_4_weeks") {
+    intervalDays = 28;
+  } else if (freq === "custom" && schedule.custom_frequency_weeks != null) {
+    intervalDays = schedule.custom_frequency_weeks * 7;
+  } else {
+    console.warn(
+      `[recurring-engine] Unknown frequency "${freq}" on schedule (start_date=${schedule.start_date}). ` +
+      `Falling back to biweekly intervalDays=14. Add an explicit branch if this frequency is supposed to be supported.`
+    );
+    intervalDays = 14;
+  }
+  // Seed at the later of fromDate or start so we never emit before
+  // start_date. The previous version only gated on fromDate, which let
+  // pre-start dates slip into the output when fromDate < start.
+  const seed = fromDate > start ? fromDate : start;
+  let current = getFirstOccurrence(start, targetDow, seed);
+  while (current <= effectiveEnd) {
+    if (current >= fromDate && current >= start) dates.push(new Date(current));
+    current = addDays(current, intervalDays);
+  }
+  return dates;
+}

--- a/artifacts/api-server/src/lib/recurring-jobs.ts
+++ b/artifacts/api-server/src/lib/recurring-jobs.ts
@@ -1,6 +1,13 @@
 import { db } from "@workspace/db";
 import { recurringSchedulesTable, jobsTable, clientsTable, companiesTable } from "@workspace/db/schema";
 import { eq, and, sql, inArray, gte, lte } from "drizzle-orm";
+// Pure cadence math extracted into its own module so unit tests can
+// import without triggering the Drizzle connection init. See
+// recurring-engine-cadences.test.ts for the test surface.
+import {
+  generateCadenceDates,
+  addDays,
+} from "./recurring-cadences.js";
 
 // [scheduling-engine 2026-04-29] Rolling generation window — extended
 // from 60 to 90 days so dispatchers can see roughly a quarter ahead.
@@ -8,11 +15,6 @@ import { eq, and, sql, inArray, gte, lte } from "drizzle-orm";
 // generateJobsFromSchedule prevents duplicate inserts when the window
 // overlaps existing rows.
 export const DAYS_AHEAD = 90;
-
-const DAY_NAME_TO_NUM: Record<string, number> = {
-  sunday: 0, monday: 1, tuesday: 2, wednesday: 3,
-  thursday: 4, friday: 5, saturday: 6,
-};
 
 function mapServiceType(raw: string | null): string {
   if (!raw) return "recurring";
@@ -204,18 +206,9 @@ export async function insertJobFromSchedule(
   return Number(row.id);
 }
 
-function addDays(date: Date, days: number): Date {
-  const d = new Date(date);
-  d.setDate(d.getDate() + days);
-  return d;
-}
-
-function addMonths(date: Date, months: number): Date {
-  const d = new Date(date);
-  d.setMonth(d.getMonth() + months);
-  return d;
-}
-
+// addDays + cadence math live in recurring-cadences.ts now. toDateStr
+// stays here because it's an engine concern (ISO formatting for the
+// scheduled_date column inserts), not part of the cadence math.
 function toDateStr(d: Date): string {
   const y = d.getFullYear();
   const m = String(d.getMonth() + 1).padStart(2, "0");
@@ -223,61 +216,14 @@ function toDateStr(d: Date): string {
   return `${y}-${m}-${day}`;
 }
 
-function parseDate(str: string): Date {
-  const [y, m, d] = str.split("-").map(Number);
-  return new Date(y, m - 1, d);
-}
-
-function getFirstOccurrence(start: Date, targetDow: number, fromDate: Date): Date {
-  let d = new Date(fromDate);
-  const diff = (targetDow - d.getDay() + 7) % 7;
-  return addDays(d, diff);
-}
-
-// Resolve the multi-day pattern from a schedule's frequency + days_of_week.
-// Returns an array of weekday integers (0=Sunday..6=Saturday) or null when
-// the schedule is single-day (handled by the legacy day_of_week branch).
+// generateOccurrences delegates to the pure generateCadenceDates module
+// so the cadence logic has exactly one definition. Test coverage lives
+// in recurring-engine-cadences.test.ts (imports from the pure module
+// directly, no DB needed).
 //
-// [AI] daily      → [0,1,2,3,4,5,6] regardless of days_of_week column
-// [AI] weekdays   → [1,2,3,4,5]     regardless of days_of_week column
-// [AI] custom_days → days_of_week  (validated at write-time; ≥1 entry)
-function resolveMultiDayPattern(
-  freq: string,
-  daysOfWeek: number[] | null,
-): number[] | null {
-  if (freq === "daily") return [0, 1, 2, 3, 4, 5, 6];
-  if (freq === "weekdays") return [1, 2, 3, 4, 5];
-  if (freq === "custom_days") {
-    const arr = (daysOfWeek ?? []).filter(n => Number.isInteger(n) && n >= 0 && n <= 6);
-    return arr.length > 0 ? Array.from(new Set(arr)).sort() : null;
-  }
-  return null;
-}
-
-// [PR #58] Snap a date forward to the next business day (Mon–Fri) when it
-// falls on a Saturday or Sunday. Used for semi_monthly + monthly anchors —
-// matches the user's "Q1: A — snap forward" design decision. Holidays are
-// not snapped (operator can manually reschedule one-off observed dates).
-function snapToBusinessDay(d: Date): Date {
-  const dow = d.getDay(); // 0=Sun..6=Sat
-  if (dow === 6) return addDays(d, 2); // Saturday -> Monday
-  if (dow === 0) return addDays(d, 1); // Sunday -> Monday
-  return d;
-}
-
-// [PR #58] Resolve the actual day-of-month for a given month, supporting
-// the sentinel 0 = "last day of month". For Feb 30, e.g., returns Feb 28
-// (or 29 in a leap year). For [15, 30] in February, the second anchor
-// resolves to the last day of February. Day-of-month values 29/30/31 in
-// short months also clamp to the month's length.
-function resolveDayOfMonth(year: number, month: number, day: number): number {
-  // Last day of month (month is 0-indexed, +1 then day=0 returns last day).
-  const lastDay = new Date(year, month + 1, 0).getDate();
-  if (day === 0 || day > lastDay) return lastDay;
-  return day;
-}
-
-function generateOccurrences(
+// Kept as a named export here for backward compat — multiple internal
+// callsites import { generateOccurrences } from this file.
+export function generateOccurrences(
   schedule: {
     frequency: string;
     day_of_week: string | null;
@@ -290,115 +236,7 @@ function generateOccurrences(
   fromDate: Date,
   toDate: Date
 ): Date[] {
-  const start = parseDate(schedule.start_date);
-  const endLimit = schedule.end_date ? parseDate(schedule.end_date) : toDate;
-  const effectiveEnd = endLimit < toDate ? endLimit : toDate;
-
-  const freq = schedule.frequency;
-  const dates: Date[] = [];
-
-  // [AI] If both day_of_week and days_of_week are populated, prefer the
-  // multi-day path and warn. PATCH endpoint enforces exclusivity but defend
-  // against bad data (manual SQL, future code paths, etc.).
-  if (schedule.day_of_week && (schedule.days_of_week?.length ?? 0) > 0) {
-    console.warn(
-      `[recurring-engine] schedule has BOTH day_of_week and days_of_week populated — preferring days_of_week`,
-    );
-  }
-
-  // ── Multi-day path: daily / weekdays / custom_days ──────────────────────
-  // Walk every date from fromDate to effectiveEnd, emit when DOW matches.
-  // No interval math — every matching weekday in the window produces a job.
-  const multiDay = resolveMultiDayPattern(freq, schedule.days_of_week ?? null);
-  if (multiDay) {
-    const targetSet = new Set(multiDay);
-    let current = new Date(fromDate);
-    while (current <= effectiveEnd) {
-      if (current >= start && targetSet.has(current.getDay())) {
-        dates.push(new Date(current));
-      }
-      current = addDays(current, 1);
-    }
-    return dates;
-  }
-
-  // ── Single-day path: weekly / biweekly / every_3_weeks / monthly ────────
-  const targetDow = schedule.day_of_week
-    ? (DAY_NAME_TO_NUM[schedule.day_of_week.toLowerCase()] ?? start.getDay())
-    : start.getDay();
-
-  // [PR #58] Semi-monthly path. Anchors stored in days_of_month (e.g.,
-  // [1, 15] or [15, 30]). For each month in the window, emit one
-  // occurrence per anchor, snapping weekend dates forward to Monday.
-  // Sentinel 0 in days_of_month = "last day of month" — handles short
-  // months (Feb 28/29) without operator intervention.
-  if (freq === "semi_monthly") {
-    const anchors = schedule.days_of_month && schedule.days_of_month.length > 0
-      ? schedule.days_of_month
-      : [1, 15]; // safe default if column wasn't populated
-    let cursor = new Date(fromDate.getFullYear(), fromDate.getMonth(), 1);
-    while (cursor <= effectiveEnd) {
-      const y = cursor.getFullYear();
-      const m = cursor.getMonth();
-      for (const a of anchors) {
-        const day = resolveDayOfMonth(y, m, a);
-        const raw = new Date(y, m, day);
-        const snapped = snapToBusinessDay(raw);
-        if (snapped >= start && snapped >= fromDate && snapped <= effectiveEnd) {
-          dates.push(snapped);
-        }
-      }
-      cursor = addMonths(cursor, 1);
-    }
-    // Sort because anchors[0] for month N+1 may land before anchors[1]
-    // for month N once snap-forward kicks in (e.g., 30th of Jan snaps to
-    // Feb 1, then Feb 1 anchor lands the same day).
-    dates.sort((a, b) => a.getTime() - b.getTime());
-    return dates;
-  }
-
-  if (freq === "monthly") {
-    // [PR #58] Prefer days_of_month[0] when set (sentence-builder UI
-    // writes it), fall back to start_date's day for legacy schedules.
-    const dayOfMonth = schedule.days_of_month && schedule.days_of_month.length > 0
-      ? schedule.days_of_month[0]
-      : start.getDate();
-    let cursor = new Date(fromDate.getFullYear(), fromDate.getMonth(), 1);
-    while (cursor <= effectiveEnd) {
-      const day = resolveDayOfMonth(cursor.getFullYear(), cursor.getMonth(), dayOfMonth);
-      const raw = new Date(cursor.getFullYear(), cursor.getMonth(), day);
-      const snapped = snapToBusinessDay(raw);
-      if (snapped >= start && snapped >= fromDate && snapped <= effectiveEnd) {
-        dates.push(snapped);
-      }
-      cursor = addMonths(cursor, 1);
-    }
-  } else {
-    // Interval picker. Order matters — explicit checks before the legacy
-    // fallback. [AI] every_3_weeks honored; AG's custom_frequency_weeks
-    // honored as a fallback when frequency='custom' on recurring_schedules.
-    let intervalDays: number;
-    if (freq === "weekly") {
-      intervalDays = 7;
-    } else if (freq === "biweekly") {
-      intervalDays = 14;
-    } else if (freq === "every_3_weeks") {
-      intervalDays = 21;
-    } else if (freq === "custom" && schedule.custom_frequency_weeks != null) {
-      intervalDays = schedule.custom_frequency_weeks * 7;
-    } else {
-      // Conservative fallback for any unrecognized frequency string. Keeps
-      // historical behavior for rows without custom_frequency_weeks.
-      intervalDays = 14;
-    }
-    let current = getFirstOccurrence(start, targetDow, fromDate);
-    while (current <= effectiveEnd) {
-      if (current >= fromDate) dates.push(new Date(current));
-      current = addDays(current, intervalDays);
-    }
-  }
-
-  return dates;
+  return generateCadenceDates(schedule, fromDate, toDate);
 }
 
 type ScheduleInput = {

--- a/artifacts/api-server/src/tests/recurring-engine-cadences.test.ts
+++ b/artifacts/api-server/src/tests/recurring-engine-cadences.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Tests for the recurring engine cadence logic.
+ *
+ * Defends every cadence Sal listed on 2026-06-01 as required for July
+ * cutover:
+ *   - weekly
+ *   - biweekly
+ *   - every_3_weeks
+ *   - every_4_weeks (was silently producing biweekly before this fix)
+ *   - monthly
+ *   - semi_monthly
+ *   - custom (with custom_frequency_weeks)
+ *   - daily
+ *   - weekdays (Mon–Fri)
+ *   - custom_days (e.g., Wed + Sat for Arianna Goose)
+ *
+ * Pure date-math tests against generateOccurrences — no DB.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { generateCadenceDates as generateOccurrences } from "../lib/recurring-cadences.js";
+
+const DOW = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+const dowOf = (d: Date) => DOW[d.getDay()];
+const isoOf = (d: Date) => {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+};
+
+// Common window: June 2026 (Mon June 1 is a Monday)
+const WINDOW_START = new Date(2026, 5, 1); // Jun 1 2026 — Monday
+const WINDOW_END = new Date(2026, 7, 31);  // Aug 31 2026
+
+function mkSchedule(overrides: Partial<Parameters<typeof generateOccurrences>[0]> & { frequency: string }) {
+  return {
+    day_of_week: null,
+    days_of_week: null,
+    days_of_month: null,
+    custom_frequency_weeks: null,
+    start_date: "2026-06-01",
+    end_date: null,
+    ...overrides,
+  } as Parameters<typeof generateOccurrences>[0];
+}
+
+describe("Recurring engine — weekly cadence", () => {
+  it("weekly + Wednesday → every Wednesday in the window", () => {
+    const dates = generateOccurrences(
+      mkSchedule({ frequency: "weekly", day_of_week: "wednesday" }),
+      WINDOW_START, WINDOW_END,
+    );
+    assert.ok(dates.length >= 12, `Expected ≥12 Wednesdays, got ${dates.length}`);
+    for (const d of dates) {
+      assert.equal(dowOf(d), "Wed", `${isoOf(d)} is not a Wednesday`);
+    }
+    // Verify 7-day spacing
+    for (let i = 1; i < dates.length; i++) {
+      const diff = (dates[i].getTime() - dates[i - 1].getTime()) / 86400000;
+      assert.equal(diff, 7, `Gap between ${isoOf(dates[i - 1])} and ${isoOf(dates[i])} is ${diff}d (expected 7)`);
+    }
+  });
+});
+
+describe("Recurring engine — biweekly cadence", () => {
+  it("biweekly + Tuesday → every other Tuesday", () => {
+    const dates = generateOccurrences(
+      mkSchedule({ frequency: "biweekly", day_of_week: "tuesday" }),
+      WINDOW_START, WINDOW_END,
+    );
+    assert.ok(dates.length >= 6, `Expected ≥6 Tuesdays, got ${dates.length}`);
+    for (const d of dates) assert.equal(dowOf(d), "Tue");
+    for (let i = 1; i < dates.length; i++) {
+      const diff = (dates[i].getTime() - dates[i - 1].getTime()) / 86400000;
+      assert.equal(diff, 14);
+    }
+  });
+});
+
+describe("Recurring engine — every_3_weeks cadence", () => {
+  it("every_3_weeks + Friday → every 3rd Friday", () => {
+    const dates = generateOccurrences(
+      mkSchedule({ frequency: "every_3_weeks", day_of_week: "friday" }),
+      WINDOW_START, WINDOW_END,
+    );
+    assert.ok(dates.length >= 4);
+    for (const d of dates) assert.equal(dowOf(d), "Fri");
+    for (let i = 1; i < dates.length; i++) {
+      const diff = (dates[i].getTime() - dates[i - 1].getTime()) / 86400000;
+      assert.equal(diff, 21);
+    }
+  });
+});
+
+describe("Recurring engine — every_4_weeks cadence (the bug fix)", () => {
+  it("every_4_weeks + Wednesday → every 4th Wednesday (NOT biweekly!)", () => {
+    const dates = generateOccurrences(
+      mkSchedule({ frequency: "every_4_weeks", day_of_week: "wednesday" }),
+      WINDOW_START, WINDOW_END,
+    );
+    assert.ok(dates.length >= 3, `Expected ≥3 Wednesdays over 3 months, got ${dates.length}`);
+    for (const d of dates) assert.equal(dowOf(d), "Wed");
+    // 28-day intervals — this was the broken case (used to be 14)
+    for (let i = 1; i < dates.length; i++) {
+      const diff = (dates[i].getTime() - dates[i - 1].getTime()) / 86400000;
+      assert.equal(diff, 28, `Gap between ${isoOf(dates[i - 1])} and ${isoOf(dates[i])} is ${diff}d (expected 28)`);
+    }
+  });
+});
+
+describe("Recurring engine — custom interval (custom_frequency_weeks)", () => {
+  it("custom + 5 weeks + Thursday → 35-day intervals on Thursday", () => {
+    const dates = generateOccurrences(
+      mkSchedule({ frequency: "custom", day_of_week: "thursday", custom_frequency_weeks: 5 }),
+      WINDOW_START, WINDOW_END,
+    );
+    assert.ok(dates.length >= 2);
+    for (const d of dates) assert.equal(dowOf(d), "Thu");
+    for (let i = 1; i < dates.length; i++) {
+      const diff = (dates[i].getTime() - dates[i - 1].getTime()) / 86400000;
+      assert.equal(diff, 35);
+    }
+  });
+});
+
+describe("Recurring engine — monthly cadence", () => {
+  it("monthly with days_of_month=[15] → 15th of every month (with weekend snap-forward)", () => {
+    const dates = generateOccurrences(
+      mkSchedule({ frequency: "monthly", days_of_month: [15] }),
+      WINDOW_START, WINDOW_END,
+    );
+    assert.ok(dates.length >= 3);
+    // 15th of Jun/Jul is Mon/Wed (no snap), Aug 15 2026 is a Saturday which
+    // snaps forward to Mon Aug 17. Allow either the 15th or the snapped
+    // Monday after it (which can be the 16th or 17th).
+    for (const d of dates) {
+      const dayOfMonth = d.getDate();
+      assert.ok(
+        [15, 16, 17].includes(dayOfMonth),
+        `${d.toISOString()} has dayOfMonth=${dayOfMonth}, expected 15/16/17 (15th or post-weekend snap)`,
+      );
+    }
+  });
+
+  it("monthly with days_of_month=[0] (sentinel) → last day of every month", () => {
+    const dates = generateOccurrences(
+      mkSchedule({ frequency: "monthly", days_of_month: [0] }),
+      WINDOW_START, WINDOW_END,
+    );
+    assert.ok(dates.length >= 3);
+    // Should land on the last day: Jun 30, Jul 31, Aug 31
+    const days = dates.map(d => d.getDate());
+    assert.ok(days.includes(30) || days.includes(31), "Expected 30 or 31 (month-end)");
+  });
+});
+
+describe("Recurring engine — semi_monthly cadence", () => {
+  it("semi_monthly with [1, 15] → 1st and 15th of every month", () => {
+    const dates = generateOccurrences(
+      mkSchedule({ frequency: "semi_monthly", days_of_month: [1, 15] }),
+      WINDOW_START, WINDOW_END,
+    );
+    assert.ok(dates.length >= 6); // 2 per month × 3 months
+    const days = dates.map(d => d.getDate());
+    // After weekend snap-forward, may have 2 or 3 (Saturday Aug 1 snaps to Monday Aug 3)
+    // So check that 15 is present and 1 (or its snap) is too
+    assert.ok(days.includes(15));
+  });
+
+  it("semi_monthly defaults to [1, 15] when days_of_month is null", () => {
+    const dates = generateOccurrences(
+      mkSchedule({ frequency: "semi_monthly" }),
+      WINDOW_START, WINDOW_END,
+    );
+    assert.ok(dates.length >= 6);
+  });
+});
+
+describe("Recurring engine — multi-day: daily", () => {
+  it("daily → every day in window", () => {
+    const dates = generateOccurrences(
+      mkSchedule({ frequency: "daily", start_date: "2026-06-01" }),
+      WINDOW_START, new Date(2026, 5, 7), // 1-week window
+    );
+    assert.equal(dates.length, 7, "Expected 7 days");
+  });
+});
+
+describe("Recurring engine — multi-day: weekdays", () => {
+  it("weekdays → only Mon-Fri", () => {
+    const dates = generateOccurrences(
+      mkSchedule({ frequency: "weekdays", start_date: "2026-06-01" }),
+      WINDOW_START, new Date(2026, 5, 7), // 1-week window
+    );
+    assert.equal(dates.length, 5);
+    for (const d of dates) {
+      const dow = d.getDay();
+      assert.ok(dow >= 1 && dow <= 5, `${isoOf(d)} (${dowOf(d)}) is a weekend`);
+    }
+  });
+});
+
+describe("Recurring engine — multi-day: custom_days (Arianna Goose)", () => {
+  it("custom_days with [3, 6] → Wednesdays AND Saturdays only", () => {
+    const dates = generateOccurrences(
+      mkSchedule({ frequency: "custom_days", days_of_week: [3, 6], start_date: "2026-06-01" }),
+      WINDOW_START, new Date(2026, 5, 14), // 2-week window
+    );
+    // 2 Wednesdays + 2 Saturdays = 4 occurrences
+    assert.equal(dates.length, 4);
+    const dows = dates.map(dowOf).sort();
+    assert.deepEqual(dows, ["Sat", "Sat", "Wed", "Wed"]);
+  });
+
+  it("custom_days with [1, 3, 5] → 3 days/week (Mon/Wed/Fri)", () => {
+    const dates = generateOccurrences(
+      mkSchedule({ frequency: "custom_days", days_of_week: [1, 3, 5], start_date: "2026-06-01" }),
+      WINDOW_START, new Date(2026, 5, 7), // 1-week window
+    );
+    assert.equal(dates.length, 3);
+  });
+
+  it("custom_days with empty days_of_week → produces nothing (guarded)", () => {
+    const dates = generateOccurrences(
+      mkSchedule({ frequency: "custom_days", days_of_week: [], start_date: "2026-06-01" }),
+      WINDOW_START, new Date(2026, 5, 7),
+    );
+    // Falls through to single-day path (multi-day returns null when array
+    // is empty). Then single-day uses start_date's DOW. Either way the
+    // operator should never have an empty days_of_week — but the engine
+    // shouldn't crash.
+    assert.ok(Array.isArray(dates));
+  });
+});
+
+describe("Recurring engine — unknown frequency fallback", () => {
+  it("unknown frequency falls back to biweekly + logs warning", () => {
+    // Hijack console.warn to capture
+    const warnings: string[] = [];
+    const origWarn = console.warn;
+    console.warn = (msg: string) => warnings.push(String(msg));
+    try {
+      const dates = generateOccurrences(
+        mkSchedule({ frequency: "bogus_freq" as any, day_of_week: "monday", start_date: "2026-06-01" }),
+        WINDOW_START, WINDOW_END,
+      );
+      // Should still produce SOMETHING (biweekly Mondays) so historical
+      // schedules don't silently stop generating.
+      assert.ok(dates.length >= 4);
+      for (const d of dates) assert.equal(dowOf(d), "Mon");
+      // And should have logged the warning
+      assert.ok(
+        warnings.some(w => w.includes("Unknown frequency") && w.includes("bogus_freq")),
+        `Expected warning about bogus_freq, got: ${warnings.join(" | ")}`
+      );
+    } finally {
+      console.warn = origWarn;
+    }
+  });
+});
+
+describe("Recurring engine — start_date and end_date boundaries", () => {
+  it("doesn't emit dates before start_date", () => {
+    const dates = generateOccurrences(
+      mkSchedule({ frequency: "weekly", day_of_week: "monday", start_date: "2026-06-15" }),
+      WINDOW_START, WINDOW_END,
+    );
+    for (const d of dates) {
+      assert.ok(
+        d >= new Date(2026, 5, 15),
+        `${isoOf(d)} is before start_date 2026-06-15`,
+      );
+    }
+  });
+
+  it("doesn't emit dates after end_date", () => {
+    const dates = generateOccurrences(
+      mkSchedule({ frequency: "weekly", day_of_week: "monday", start_date: "2026-06-01", end_date: "2026-06-30" }),
+      WINDOW_START, WINDOW_END,
+    );
+    for (const d of dates) {
+      assert.ok(d <= new Date(2026, 5, 30), `${isoOf(d)} is after end_date`);
+    }
+  });
+});


### PR DESCRIPTION
## Symptom

Sal flagged 2026-06-01: \`We do various cadences, weekly, biweekly, semi monthly, every 3 weeks, 4 weeks, monthly. Whatever we need to accommodate.\` Audit revealed three real bugs.

## Bugs fixed

### 1. \`every_4_weeks\` silently produced biweekly intervals
The interval chain only had explicit branches for weekly / biweekly / every_3_weeks. \`every_4_weeks\` schedules fell through to the conservative \`else intervalDays = 14\` fallback, producing jobs every other week instead of once a month. Any client set to "every 4 weeks on Wednesday" got cleanings every other Wednesday.

### 2. Single-day path leaked dates before \`start_date\`
The engine seeded the first occurrence from \`fromDate\` and only gated on \`current >= fromDate\`. When \`fromDate < start_date\` (e.g., the generation window opens before the schedule's start), the engine emitted dates between the two. Multi-day path already checked \`start\`; single-day didn't.

### 3. Unknown frequency strings silently became biweekly
The catch-all fallback hid any future migration that introduced a new frequency string the engine doesn't recognise — no console line, no error. Now logs a clear \`console.warn\` so the next operator catches it.

## Restructure

Extracted the pure date-math into a new module \`recurring-cadences.ts\`. This is what lets the test suite import the cadence logic without dragging in \`@workspace/db\` (which can't init under \`tsx --test\` without a configured DB).

\`recurring-jobs.ts\` still exports \`generateOccurrences\` as a thin delegate so all internal callers (\`computeOccurrencesForSchedule\`, \`generateRecurringJobs\`, the dry-run path) stay unchanged.

## Test coverage — 17/17 pass

| Cadence | Test |
|---|---|
| weekly | 7-day intervals, day-of-week respected |
| biweekly | 14-day intervals |
| every_3_weeks | 21-day intervals |
| **every_4_weeks** | 28-day intervals (the bug fix) |
| custom + custom_frequency_weeks | N×7-day intervals |
| monthly + days_of_month | day-of-month respected + weekend snap-forward |
| monthly + last-day sentinel | days_of_month=[0] resolves to month-end |
| semi_monthly + [1, 15] | both anchors emit per month |
| semi_monthly defaults | empty days_of_month → [1, 15] |
| daily | every day |
| weekdays | only Mon-Fri |
| custom_days [3, 6] | Arianna Goose pattern (Wed + Sat) |
| custom_days [1, 3, 5] | 3 days/week (Mon/Wed/Fri) |
| custom_days empty array | doesn't crash (guarded) |
| unknown frequency | falls back to biweekly + emits console.warn |
| start_date boundary | no dates before start_date |
| end_date boundary | no dates after end_date |

## No data writes

This PR is pure engine + test code. The day_of_week backfill from earlier in the session is unrelated — that fixed legacy data; this fixes the code path that generates new jobs going forward.

## Test plan
- [ ] After deploy, the next 2 AM cron run should regenerate correct intervals for any \`every_4_weeks\` schedules without manual touch
- [ ] No regression to existing weekly/biweekly/every_3_weeks/monthly/semi_monthly schedules

🤖 Generated with [Claude Code](https://claude.com/claude-code)