### PR TITLE
fix: employee deactivate (PUT not PATCH) + uniform list-view card footer

### DIFF
--- a/artifacts/qleno/src/pages/employee-profile.tsx
+++ b/artifacts/qleno/src/pages/employee-profile.tsx
@@ -568,7 +568,12 @@ export default function EmployeeProfilePage() {
   async function saveProfile() {
     setSaving(true);
     try {
-      await apiFetch(`/users/${userId}`, { method: 'PATCH', body: JSON.stringify(form) });
+      // [2026-06-02] Method is PUT, not PATCH. The backend only defines
+      // PUT /api/users/:id (routes/users.ts:344); the previous PATCH call
+      // returned 404 silently — toast showed "Save failed" but easy to
+      // miss, so deactivations (is_active=false) never persisted. Reported
+      // when Sal couldn't move Tatiana, Ana Valdez, Katie Fry to inactive.
+      await apiFetch(`/users/${userId}`, { method: 'PUT', body: JSON.stringify(form) });
       showToast('Changes saved');
       refetchUser();
     } catch { showToast('Save failed'); }

--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -5453,8 +5453,28 @@ export default function JobsPage() {
                         line below is list-only context — it doesn't
                         belong on the chip body. */}
                     {allJobs.map(j => {
-                      const estH = j.est_hours_per_tech ?? j.estimated_hours;
-                      const showCommissionLine = estH != null && estH > 0;
+                      // [2026-06-02] Footer was only rendering when
+                      // est_hours_per_tech OR estimated_hours was populated,
+                      // which residential cards always have but commercial
+                      // PPM jobs often don't (allowed_hours is the source
+                      // of truth for commercial — see CLAUDE.md commission
+                      // routing notes). Result: residential rows showed
+                      // "Est X.X hrs · $X commission", commercial rows
+                      // showed nothing, and cards rendered at inconsistent
+                      // heights. Fallback chain now reaches duration_minutes
+                      // so every card has an hours value; commercial pay
+                      // computes as commercial_hourly_rate × hours when
+                      // est_pay_per_tech is null.
+                      const estH = j.est_hours_per_tech
+                        ?? j.estimated_hours
+                        ?? (j.duration_minutes ? j.duration_minutes / 60 : null);
+                      const isCommercial = !!j.account_id || j.client_type === "commercial";
+                      const commercialPay = (isCommercial && j.commercial_hourly_rate != null && estH != null)
+                        ? j.commercial_hourly_rate * estH
+                        : null;
+                      const payValue = j.est_pay_per_tech ?? commercialPay;
+                      const payLabel = isCommercial ? "tech pay" : "commission";
+                      const showLine = estH != null && estH > 0;
                       return (
                         <div key={j.id} style={{ display: "flex", flexDirection: "column", gap: 6 }}>
                           <JobChip
@@ -5463,15 +5483,15 @@ export default function JobsPage() {
                             assignedName={j.assigned_user_name}
                             layout="list"
                           />
-                          {showCommissionLine && (
+                          {showLine && (
                             <div style={{ display: "flex", gap: 10, alignItems: "center", paddingLeft: 14, fontSize: 11, color: "#9E9B94" }}>
                               <span style={{ display: "flex", alignItems: "center", gap: 3 }}>
                                 <Clock size={10} style={{ color: "#C4C0BB" }} />
                                 Est. {(estH ?? 0).toFixed(1)} hrs
                               </span>
-                              {j.est_pay_per_tech != null && j.est_pay_per_tech > 0 && (
+                              {payValue != null && payValue > 0 && (
                                 <span style={{ fontWeight: 700, color: "#16A34A" }}>
-                                  · ${j.est_pay_per_tech.toFixed(2)} commission
+                                  · ${payValue.toFixed(2)} {payLabel}
                                 </span>
                               )}
                             </div>


### PR DESCRIPTION
## Summary

Two small bugs caught while auditing the June 1 dispatch page.

**1. Employee deactivate silently failed.** `employee-profile.tsx saveProfile()` sent `PATCH /api/users/:id`; backend only defines `PUT` (users.ts:344). Every save 404'd, toast showed \"Save failed,\" `is_active` never persisted. Sal reported Tatiana / Ana Valdez / Katie Fry couldn't be moved to inactive. Frontend now sends PUT.

DB-side: I also manually flipped is_active=false on those three so the dispatch board hides them immediately without waiting for the deploy.

**2. List-view card footer was inconsistent.** Residential cards showed \"Est. X hrs · $X commission\" at the bottom; commercial PPM cards didn't. Result: ragged card heights in the 4-column grid. Cause: gate was `(est_hours_per_tech ?? estimated_hours) > 0`, which residential rows always have but commercial PPM jobs (allowed_hours code path) often don't. Fallback chain extended to `duration_minutes / 60`; pay formula picks `commercial_hourly_rate × hours` when `est_pay_per_tech` is null; label flips to \"tech pay\" for commercial per CLAUDE.md commission routing notes.

## Audit results (June 1 dispatch page)

Verified against DB:
- Jobs count: 14 page / 14 DB ✓
- Revenue total: $4369 page / $4369.40 DB (40¢ display rounding) ✓
- Unassigned: 0 ✓
- Techs working: 8 ✓
- Attendance modal: 2 no-shows (Diana, Alma) — derived from \"scheduled job + no clock-in,\" not the no_show_marked_by_tech column. Working as designed.
- Job 4322 (Jaira) post-#229: base \$400 + parking \$20 + 0 mods = **\$420** live ✓

## Test plan
- [ ] Open an employee profile, toggle Active off, hit Save → toast says \"Changes saved\"
- [ ] Refresh /employees → that employee shows in the Inactive list
- [ ] Refresh /dispatch?date=2026-06-01 → that employee no longer shows on the timeline
- [ ] List view shows uniform card footer (\"Est. X.X hrs · \$Y tech pay\") on commercial PPM jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)