### PR TITLE
fix(profile): per-address zones + feat(commercial): per-property rebook

### DIFF
--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -2265,6 +2265,146 @@ async function runPhesAdminPromotions(): Promise<void> {
   );
 }
 
+// ─── PPM (Daniel Walter Properties) account cleanup ──────────────────────────
+// Sal's cleanup pass on the PPM property-management account:
+//   1. Rename "Daniel Walter Properties" → "PPM" (Daniel Walter is the on-site
+//      manager, not the company name) — recorded as a property_manager contact.
+//   2. Backfill the full 47-property roster from MaidCentral. Only MISSING
+//      properties are inserted; existing rows are matched on a normalized
+//      address key (number + direction + street name, suffix-stripped) so the
+//      ~13 already imported under different spellings ("100 W Chestnut" vs
+//      "100 W Chestnut St") are NOT duplicated.
+//   3. Fix the W Addison zips MaidCentral had as 60657 → 60613 (verified: the
+//      632-644 W Addison block is PPM and sits in 60613 / Lakeview).
+// Fully idempotent: rename only fires while the old name is present, contact
+// insert is guarded by NOT EXISTS, property inserts are dedup-checked, and the
+// zip fix is a bounded UPDATE. Safe to re-run on every cold start.
+function normalizeAddrKey(addr: string): string {
+  const SUFFIX = new Set(["st", "street", "dr", "drive", "ave", "av", "avenue", "pl", "place",
+    "pkwy", "parkway", "blvd", "boulevard", "ct", "court", "ln", "lane", "rd", "road",
+    "ter", "terrace", "way", "ct.", "pl."]);
+  const DIR: Record<string, string> = { n: "north", s: "south", e: "east", w: "west" };
+  let s = (addr || "").toLowerCase();
+  s = s.replace(/\b(unit|apt|apartment|ste|suite|#)\b.*$/i, "");
+  s = s.replace(/[.,]/g, " ");
+  return s.split(/\s+/).filter(Boolean)
+    .map(w => (SUFFIX.has(w) ? "" : (DIR[w] ?? w)))
+    .filter(Boolean)
+    .join(" ")
+    .trim();
+}
+
+async function runPpmAccountCleanup(): Promise<void> {
+  // 47-property roster (zips corrected: W Addison → 60613, 55 W Chestnut → 60610).
+  const ROSTER: { address: string; city: string; state: string; zip: string }[] = [
+    { address: "1 E Schiller St Unit 9D", city: "Chicago", state: "IL", zip: "60610" },
+    { address: "100 W Chestnut St", city: "Chicago", state: "IL", zip: "60610" },
+    { address: "1000 N La Salle Dr", city: "Chicago", state: "IL", zip: "60610" },
+    { address: "1049 W Oakdale Ave", city: "Chicago", state: "IL", zip: "60657" },
+    { address: "1111 N Dearborn St", city: "Chicago", state: "IL", zip: "60610" },
+    { address: "1120 N La Salle Dr", city: "Chicago", state: "IL", zip: "60610" },
+    { address: "1133 N Dearborn St", city: "Chicago", state: "IL", zip: "60610" },
+    { address: "1555 N Astor St", city: "Chicago", state: "IL", zip: "60610" },
+    { address: "1940 N Lincoln Ave", city: "Chicago", state: "IL", zip: "60614" },
+    { address: "20 E Scott St", city: "Chicago", state: "IL", zip: "60610" },
+    { address: "2006 N Sedgwick St", city: "Chicago", state: "IL", zip: "60614" },
+    { address: "2007 N Sedgwick St", city: "Chicago", state: "IL", zip: "60614" },
+    { address: "2630 N Hampden Ct", city: "Chicago", state: "IL", zip: "60614" },
+    { address: "2756 N Pine Grove Ave", city: "Chicago", state: "IL", zip: "60614" },
+    { address: "2811 N Pine Grove Ave", city: "Chicago", state: "IL", zip: "60657" },
+    { address: "350 W Oakdale Ave", city: "Chicago", state: "IL", zip: "60657" },
+    { address: "3510 N Pine Grove Ave", city: "Chicago", state: "IL", zip: "60657" },
+    { address: "430 W Diversey Pkwy", city: "Chicago", state: "IL", zip: "60614" },
+    { address: "440 W Diversey Pkwy", city: "Chicago", state: "IL", zip: "60614" },
+    { address: "441 W Barry Ave", city: "Chicago", state: "IL", zip: "60657" },
+    { address: "441 W Oakdale Ave", city: "Chicago", state: "IL", zip: "60657" },
+    { address: "446 W Diversey Pkwy", city: "Chicago", state: "IL", zip: "60657" },
+    { address: "450 W Melrose St", city: "Chicago", state: "IL", zip: "60657" },
+    { address: "455 W Wellington Ave", city: "Chicago", state: "IL", zip: "60657" },
+    { address: "500 W Belmont Ave", city: "Chicago", state: "IL", zip: "60657" },
+    { address: "515 W Briar Pl", city: "Chicago", state: "IL", zip: "60657" },
+    { address: "536 W Addison St", city: "Chicago", state: "IL", zip: "60613" },
+    { address: "537 W Melrose St", city: "Chicago", state: "IL", zip: "60657" },
+    { address: "544 W Melrose St", city: "Chicago", state: "IL", zip: "60657" },
+    { address: "55 Terrace Colony", city: "Olympia Fields", state: "IL", zip: "60461" },
+    { address: "55 W Chestnut St", city: "Chicago", state: "IL", zip: "60610" },
+    { address: "596 W Hawthorne Pl", city: "Chicago", state: "IL", zip: "60657" },
+    { address: "632 W Addison St", city: "Chicago", state: "IL", zip: "60613" },
+    { address: "634 W Addison St", city: "Chicago", state: "IL", zip: "60613" },
+    { address: "634 W Cornelia Ave", city: "Chicago", state: "IL", zip: "60657" },
+    { address: "636 W Addison St", city: "Chicago", state: "IL", zip: "60613" },
+    { address: "636 W Cornelia Ave", city: "Chicago", state: "IL", zip: "60657" },
+    { address: "638 W Addison St", city: "Chicago", state: "IL", zip: "60613" },
+    { address: "638 W Cornelia Ave", city: "Chicago", state: "IL", zip: "60657" },
+    { address: "640 W Addison St", city: "Chicago", state: "IL", zip: "60613" },
+    { address: "640 W Cornelia Ave", city: "Chicago", state: "IL", zip: "60657" },
+    { address: "641 W Cornelia Ave", city: "Chicago", state: "IL", zip: "60657" },
+    { address: "642 W Addison St", city: "Chicago", state: "IL", zip: "60613" },
+    { address: "644 W Addison St", city: "Chicago", state: "IL", zip: "60613" },
+    { address: "750 N Rush St", city: "Chicago", state: "IL", zip: "60611" },
+  ];
+
+  // 1. Rename the account (idempotent — only fires while the old name exists).
+  await db.execute(sql`
+    UPDATE accounts SET account_name = 'PPM', updated_at = now()
+    WHERE company_id = ${PHES} AND lower(account_name) = 'daniel walter properties'
+  `);
+
+  // Resolve the PPM account id (post-rename, or if it was already 'PPM').
+  const acctRes = await db.execute(sql`
+    SELECT id FROM accounts
+    WHERE company_id = ${PHES} AND lower(account_name) = 'ppm'
+    ORDER BY id LIMIT 1
+  `);
+  const acctRow = acctRes.rows[0] as { id: number } | undefined;
+  if (!acctRow) {
+    console.warn("[ppm-cleanup] No 'PPM' (or 'Daniel Walter Properties') account found — skipping.");
+    return;
+  }
+  const acctId = acctRow.id;
+
+  // 2. Record Daniel Walter as the property manager (guarded — won't duplicate).
+  await db.execute(sql`
+    INSERT INTO account_contacts (account_id, company_id, name, role, phone, email, is_primary)
+    SELECT ${acctId}, ${PHES}, 'Daniel Walter', 'property_manager', '312-907-2512', 'dannyw@ppmapartments.com', false
+    WHERE NOT EXISTS (
+      SELECT 1 FROM account_contacts WHERE account_id = ${acctId} AND lower(name) = 'daniel walter'
+    )
+  `);
+
+  // 3. Correct W Addison zips MaidCentral had wrong (or left null).
+  await db.execute(sql`
+    UPDATE account_properties
+    SET zip = '60613', updated_at = now()
+    WHERE account_id = ${acctId} AND address ILIKE '%addison%'
+      AND (zip IS NULL OR zip = '60657')
+  `);
+
+  // 4. Insert only the MISSING properties (dedup on normalized address key).
+  const existing = await db.execute(sql`
+    SELECT address FROM account_properties WHERE account_id = ${acctId} AND company_id = ${PHES}
+  `);
+  const existingKeys = new Set(
+    (existing.rows as { address: string }[]).map(r => normalizeAddrKey(r.address))
+  );
+
+  let inserted = 0;
+  for (const p of ROSTER) {
+    const key = normalizeAddrKey(p.address);
+    if (existingKeys.has(key)) continue;
+    await db.execute(sql`
+      INSERT INTO account_properties
+        (account_id, company_id, property_name, address, city, state, zip, property_type, is_active)
+      VALUES
+        (${acctId}, ${PHES}, ${p.address}, ${p.address}, ${p.city}, ${p.state}, ${p.zip}, 'apartment_building', true)
+    `);
+    existingKeys.add(key); // guard against intra-roster dup keys (e.g. 515 Briar)
+    inserted++;
+  }
+
+  console.log(`[ppm-cleanup] Account ${acctId} → 'PPM'; inserted ${inserted} missing properties (roster ${ROSTER.length}).`);
+}
+
 export async function runPhesDataMigration(): Promise<void> {
   await runBookingSchemaGuard();
 
@@ -2368,6 +2508,12 @@ export async function runPhesDataMigration(): Promise<void> {
     await runAddonFix();
   } catch (err: any) {
     console.warn("[phes-migration] addon-fix — non-fatal:", err?.message ?? err);
+  }
+
+  try {
+    await runPpmAccountCleanup();
+  } catch (err: any) {
+    console.warn("[phes-migration] ppm-account-cleanup — non-fatal:", err?.message ?? err);
   }
 
   try {

--- a/artifacts/api-server/src/routes/accounts.ts
+++ b/artifacts/api-server/src/routes/accounts.ts
@@ -2,9 +2,9 @@ import { Router } from "express";
 import { db } from "@workspace/db";
 import {
   accountsTable, accountRateCardsTable, accountPropertiesTable, accountContactsTable,
-  jobsTable, invoicesTable,
+  jobsTable, invoicesTable, usersTable,
 } from "@workspace/db/schema";
-import { eq, and, sql, inArray, notExists, desc } from "drizzle-orm";
+import { eq, and, sql, inArray, notExists, desc, gte, lte } from "drizzle-orm";
 import { requireAuth, requireRole } from "../lib/auth.js";
 
 const router = Router();
@@ -385,6 +385,54 @@ router.get("/:id/properties/:propId/recent-job", requireAuth, requireRole("owner
   } catch (err) {
     console.error(err);
     res.status(500).json({ error: "Failed to fetch recent job" });
+  }
+});
+
+// GET /api/accounts/:id/jobs-calendar?from=YYYY-MM-DD&to=YYYY-MM-DD
+// Jobs for this account across ALL its properties within a date range —
+// powers the simplified month calendar on the account detail page. Returns a
+// flat list; the frontend buckets by scheduled_date and shows one count per
+// day with a hover popover (per-job time / property / service / tech /
+// amount / status).
+router.get("/:id/jobs-calendar", requireAuth, requireRole("owner", "admin", "office"), async (req, res) => {
+  const id = parseInt(req.params.id);
+  if (isNaN(id)) return res.status(400).json({ error: "Invalid id" });
+  const from = typeof req.query.from === "string" ? req.query.from : null;
+  const to = typeof req.query.to === "string" ? req.query.to : null;
+  if (!from || !to) return res.status(400).json({ error: "from and to are required (YYYY-MM-DD)" });
+
+  try {
+    const rows = await db
+      .select({
+        id: jobsTable.id,
+        scheduled_date: jobsTable.scheduled_date,
+        scheduled_time: jobsTable.scheduled_time,
+        status: jobsTable.status,
+        service_type: jobsTable.service_type,
+        base_fee: jobsTable.base_fee,
+        billing_method: jobsTable.billing_method,
+        allowed_hours: jobsTable.allowed_hours,
+        account_property_id: jobsTable.account_property_id,
+        property_name: accountPropertiesTable.property_name,
+        property_address: accountPropertiesTable.address,
+        tech_first_name: usersTable.first_name,
+        tech_last_name: usersTable.last_name,
+      })
+      .from(jobsTable)
+      .leftJoin(accountPropertiesTable, eq(jobsTable.account_property_id, accountPropertiesTable.id))
+      .leftJoin(usersTable, eq(jobsTable.assigned_user_id, usersTable.id))
+      .where(and(
+        eq(jobsTable.account_id, id),
+        eq(jobsTable.company_id, req.auth!.companyId),
+        gte(jobsTable.scheduled_date, from),
+        lte(jobsTable.scheduled_date, to),
+      ))
+      .orderBy(jobsTable.scheduled_date, jobsTable.scheduled_time);
+
+    res.json(rows);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: "Failed to fetch jobs calendar" });
   }
 });
 

--- a/artifacts/api-server/src/routes/accounts.ts
+++ b/artifacts/api-server/src/routes/accounts.ts
@@ -344,6 +344,50 @@ router.get("/:id/properties", requireAuth, requireRole("owner", "admin", "office
   }
 });
 
+// GET /api/accounts/:id/properties/:propId/recent-job
+// Most recent non-cancelled job at this property — powers the job-wizard
+// "Rebook last service" suggestion. Returns null when the property has no
+// prior jobs (the wizard then falls back to the property's
+// default_service_type). Scoped to the property so each building remembers
+// its own last service (e.g. a turnover at 1120 N La Salle, a common-area
+// clean at 1555 N Astor).
+router.get("/:id/properties/:propId/recent-job", requireAuth, requireRole("owner", "admin", "office"), async (req, res) => {
+  const id = parseInt(req.params.id);
+  const propId = parseInt(req.params.propId);
+  if (isNaN(id) || isNaN(propId)) return res.status(400).json({ error: "Invalid id" });
+
+  try {
+    const [job] = await db
+      .select({
+        id: jobsTable.id,
+        service_type: jobsTable.service_type,
+        billing_method: jobsTable.billing_method,
+        hourly_rate: jobsTable.hourly_rate,
+        allowed_hours: jobsTable.allowed_hours,
+        estimated_hours: jobsTable.estimated_hours,
+        base_fee: jobsTable.base_fee,
+        frequency: jobsTable.frequency,
+        scheduled_date: jobsTable.scheduled_date,
+      })
+      .from(jobsTable)
+      .where(
+        and(
+          eq(jobsTable.account_id, id),
+          eq(jobsTable.account_property_id, propId),
+          eq(jobsTable.company_id, req.auth!.companyId),
+          sql`${jobsTable.status} <> 'cancelled'`,
+        )
+      )
+      .orderBy(desc(jobsTable.scheduled_date), desc(jobsTable.id))
+      .limit(1);
+
+    res.json(job ?? null);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: "Failed to fetch recent job" });
+  }
+});
+
 // POST /api/accounts/:id/properties
 router.post("/:id/properties", requireAuth, requireRole("owner", "admin", "office"), async (req, res) => {
   const id = parseInt(req.params.id);

--- a/artifacts/api-server/src/routes/clients.ts
+++ b/artifacts/api-server/src/routes/clients.ts
@@ -378,6 +378,23 @@ router.get("/:id/full-profile", requireAuth, async (req, res) => {
       if (zone) zoneData = { zone_name: zone.name, zone_color: zone.color };
     }
 
+    // [per-home zone 2026-06-02] Each service address resolves its OWN zone
+    // from its zip. The profile previously showed the single client-level
+    // zone on every address card, so a home in a different area displayed
+    // the wrong zone (Maribel: added a River Forest address, the card kept
+    // the client's old Naperville zone). Match each home's zip against the
+    // active service_zones zip_codes; leave it null when the zip matches no
+    // zone — a visible gap is more honest than a confidently-wrong default.
+    const activeZones = await db
+      .select({ id: serviceZonesTable.id, name: serviceZonesTable.name, color: serviceZonesTable.color, zip_codes: serviceZonesTable.zip_codes })
+      .from(serviceZonesTable)
+      .where(and(eq(serviceZonesTable.company_id, companyId), eq(serviceZonesTable.is_active, true)));
+    const homesWithZone = homes.map(h => {
+      const clean = String(h.zip ?? "").trim().replace(/\D/g, "").slice(0, 5);
+      const match = clean.length === 5 ? activeZones.find(z => z.zip_codes?.includes(clean)) : undefined;
+      return { ...h, zone_id: match?.id ?? null, zone_name: match?.name ?? null, zone_color: match?.color ?? null };
+    });
+
     // QuickBooks status — tenant connected + client synced?
     const [company] = await db.select({ qb_connected: companiesTable.qb_connected })
       .from(companiesTable).where(eq(companiesTable.id, companyId)).limit(1);
@@ -396,7 +413,7 @@ router.get("/:id/full-profile", requireAuth, async (req, res) => {
       ...client,
       ...(zoneData || {}),
       qb_status,
-      homes,
+      homes: homesWithZone,
       tech_preferences: preferences,
       notification_settings: notifications,
       scorecards,

--- a/artifacts/qleno/src/components/account-jobs-calendar.tsx
+++ b/artifacts/qleno/src/components/account-jobs-calendar.tsx
@@ -1,0 +1,210 @@
+import { useEffect, useMemo, useState } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { getAuthHeaders } from "@/lib/auth";
+
+const API = import.meta.env.BASE_URL.replace(/\/$/, "");
+
+// Simplified per-account month calendar. Instead of MaidCentral's wall of
+// one-bar-per-job (5-8 stacked bars per cell), each day shows a SINGLE count
+// pill color-coded by status; the full per-job detail lives in a hover
+// popover. Keeps the at-a-glance scan clean while preserving the drill-down.
+
+type CalJob = {
+  id: number;
+  scheduled_date: string;
+  scheduled_time: string | null;
+  status: string;
+  service_type: string | null;
+  base_fee: string | null;
+  billing_method: string | null;
+  allowed_hours: string | null;
+  account_property_id: number | null;
+  property_name: string | null;
+  property_address: string | null;
+  tech_first_name: string | null;
+  tech_last_name: string | null;
+};
+
+const MONTHS = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
+const WEEKDAYS = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"];
+
+// Most-urgent status wins the pill color for a day.
+const STATUS_COLOR: Record<string, string> = {
+  in_progress: "#F59E0B",
+  scheduled: "#00C9A0",
+  complete: "#16A34A",
+  cancelled: "#9CA3AF",
+};
+const STATUS_PRIORITY = ["in_progress", "scheduled", "complete", "cancelled"];
+
+function pad2(n: number) { return n < 10 ? `0${n}` : String(n); }
+function ymd(y: number, mIdx: number, d: number) { return `${y}-${pad2(mIdx + 1)}-${pad2(d)}`; }
+
+function fmtSvc(s: string | null) {
+  if (!s) return "Service";
+  return s.split("_").map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(" ");
+}
+
+function fmtTime(t: string | null) {
+  if (!t) return "";
+  const [hStr, mStr] = t.split(":");
+  let h = parseInt(hStr, 10);
+  if (isNaN(h)) return "";
+  const ampm = h >= 12 ? "PM" : "AM";
+  h = h % 12; if (h === 0) h = 12;
+  const m = parseInt(mStr ?? "0", 10);
+  return m ? `${h}:${pad2(m)} ${ampm}` : `${h} ${ampm}`;
+}
+
+function fmtMoney(v: string | null) {
+  if (v == null) return "";
+  const n = parseFloat(v);
+  return isNaN(n) ? "" : `$${n.toFixed(0)}`;
+}
+
+export function AccountJobsCalendar({ accountId }: { accountId: number | string }) {
+  const today = new Date();
+  const [year, setYear] = useState(today.getFullYear());
+  const [monthIdx, setMonthIdx] = useState(today.getMonth());
+  const [jobs, setJobs] = useState<CalJob[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [hovered, setHovered] = useState<string | null>(null);
+
+  const daysInMonth = new Date(year, monthIdx + 1, 0).getDate();
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    const from = ymd(year, monthIdx, 1);
+    const to = ymd(year, monthIdx, daysInMonth);
+    fetch(`${API}/api/accounts/${accountId}/jobs-calendar?from=${from}&to=${to}`, { headers: getAuthHeaders() })
+      .then(r => r.ok ? r.json() : [])
+      .then(d => { if (!cancelled) setJobs(Array.isArray(d) ? d : []); })
+      .catch(() => { if (!cancelled) setJobs([]); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [accountId, year, monthIdx, daysInMonth]);
+
+  // Bucket jobs by scheduled_date (string key, no timezone math).
+  const byDate = useMemo(() => {
+    const m: Record<string, CalJob[]> = {};
+    for (const j of jobs) {
+      const key = (j.scheduled_date || "").slice(0, 10);
+      if (!key) continue;
+      (m[key] ||= []).push(j);
+    }
+    return m;
+  }, [jobs]);
+
+  const startWeekday = new Date(year, monthIdx, 1).getDay();
+  const cells: (string | null)[] = [];
+  for (let i = 0; i < startWeekday; i++) cells.push(null);
+  for (let d = 1; d <= daysInMonth; d++) cells.push(ymd(year, monthIdx, d));
+  while (cells.length % 7 !== 0) cells.push(null);
+
+  const todayKey = ymd(today.getFullYear(), today.getMonth(), today.getDate());
+
+  function shiftMonth(delta: number) {
+    let m = monthIdx + delta;
+    let y = year;
+    if (m < 0) { m = 11; y -= 1; }
+    if (m > 11) { m = 0; y += 1; }
+    setMonthIdx(m); setYear(y); setHovered(null);
+  }
+  function goToday() { setYear(today.getFullYear()); setMonthIdx(today.getMonth()); setHovered(null); }
+
+  function dayColor(dayJobs: CalJob[]) {
+    for (const s of STATUS_PRIORITY) {
+      if (dayJobs.some(j => j.status === s)) return STATUS_COLOR[s];
+    }
+    return "#00C9A0";
+  }
+
+  return (
+    <div className="bg-white rounded-xl border border-[#E5E2DC] p-4">
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2">
+          <span className="text-base font-bold text-[#1A1917]">{MONTHS[monthIdx]} {year}</span>
+          {loading && <span className="text-xs text-gray-400">loading…</span>}
+        </div>
+        <div className="flex items-center gap-1">
+          <button onClick={goToday} className="text-xs font-semibold text-[#1A1917] border border-[#E5E2DC] rounded-md px-2.5 py-1 hover:bg-[#F7F6F3]">Today</button>
+          <button onClick={() => shiftMonth(-1)} aria-label="Previous month" className="p-1.5 rounded-md hover:bg-[#F7F6F3] text-gray-500"><ChevronLeft size={16} /></button>
+          <button onClick={() => shiftMonth(1)} aria-label="Next month" className="p-1.5 rounded-md hover:bg-[#F7F6F3] text-gray-500"><ChevronRight size={16} /></button>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-7 gap-1 mb-1">
+        {WEEKDAYS.map(w => (
+          <div key={w} className="text-[10px] font-bold text-gray-400 text-center tracking-wide py-1">{w}</div>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-7 gap-1">
+        {cells.map((key, i) => {
+          if (!key) return <div key={`b${i}`} className="min-h-[64px] rounded-lg bg-[#FAFAF9]" />;
+          const dayJobs = byDate[key] || [];
+          const dayNum = parseInt(key.slice(8, 10), 10);
+          const isToday = key === todayKey;
+          const isHovered = hovered === key;
+          return (
+            <div
+              key={key}
+              className={`relative min-h-[64px] rounded-lg border p-1.5 ${isToday ? "border-[#00C9A0] bg-[#F0FDFB]" : "border-[#E5E2DC] bg-white"}`}
+              style={{ zIndex: isHovered ? 30 : 1 }}
+              onMouseEnter={() => dayJobs.length && setHovered(key)}
+              onMouseLeave={() => setHovered(null)}
+            >
+              <div className={`text-[11px] font-semibold ${isToday ? "text-[#00897B]" : "text-gray-500"}`}>{dayNum}</div>
+
+              {dayJobs.length > 0 && (
+                <div className="mt-1 flex justify-center">
+                  <span
+                    className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-bold text-white cursor-default"
+                    style={{ background: dayColor(dayJobs) }}
+                  >
+                    {dayJobs.length} {dayJobs.length === 1 ? "job" : "jobs"}
+                  </span>
+                </div>
+              )}
+
+              {isHovered && dayJobs.length > 0 && (
+                <div className="absolute left-1/2 top-full mt-1 -translate-x-1/2 w-64 max-h-72 overflow-auto bg-white rounded-xl border border-[#E5E2DC] shadow-xl p-2.5 text-left">
+                  <p className="text-[11px] font-bold text-[#1A1917] mb-2">
+                    {MONTHS[monthIdx]} {dayNum} — {dayJobs.length} {dayJobs.length === 1 ? "job" : "jobs"}
+                  </p>
+                  <div className="flex flex-col gap-1.5">
+                    {dayJobs.map(j => (
+                      <div key={j.id} className="rounded-lg bg-[#F7F6F3] p-2">
+                        <div className="flex items-center justify-between gap-2">
+                          <span className="text-[11px] font-semibold text-[#1A1917] truncate">{j.property_name || j.property_address || "Property"}</span>
+                          <span className="inline-block w-2 h-2 rounded-full flex-shrink-0" style={{ background: STATUS_COLOR[j.status] || "#9CA3AF" }} title={j.status} />
+                        </div>
+                        <div className="text-[10px] text-gray-500 mt-0.5">
+                          {fmtTime(j.scheduled_time)}{j.scheduled_time ? " · " : ""}{fmtSvc(j.service_type)}
+                        </div>
+                        <div className="text-[10px] text-gray-500 mt-0.5 flex justify-between">
+                          <span>{j.tech_first_name ? `${j.tech_first_name} ${j.tech_last_name ?? ""}`.trim() : "Unassigned"}</span>
+                          <span className="font-semibold text-[#6B6860]">{fmtMoney(j.base_fee)}</span>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="flex flex-wrap gap-3 mt-3 pt-3 border-t border-[#E5E2DC]">
+        {[["scheduled", "Scheduled"], ["in_progress", "In progress"], ["complete", "Complete"], ["cancelled", "Cancelled"]].map(([s, label]) => (
+          <div key={s} className="flex items-center gap-1.5">
+            <span className="w-2.5 h-2.5 rounded-full" style={{ background: STATUS_COLOR[s] }} />
+            <span className="text-[10px] text-gray-500">{label}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/artifacts/qleno/src/components/job-wizard.tsx
+++ b/artifacts/qleno/src/components/job-wizard.tsx
@@ -240,6 +240,9 @@ export function JobWizard({ open, onClose, onCreated, preselectedClient, presetD
   const [estimatedHours, setEstimatedHours] = useState("");
   const [manualBillingMethod, setManualBillingMethod] = useState("hourly");
   const [manualRate, setManualRate] = useState("");
+  // Most recent non-cancelled job at the selected property — drives the
+  // "Rebook last service" suggestion on the commercial Service step.
+  const [propertyRecentJob, setPropertyRecentJob] = useState<any>(null);
   const [commercialScheduledDate, setCommercialScheduledDate] = useState(todayStr());
   const [commercialScheduledTime, setCommercialScheduledTime] = useState("09:00");
   const [commercialDuration, setCommercialDuration] = useState(120);
@@ -415,6 +418,54 @@ export function JobWizard({ open, onClose, onCreated, preselectedClient, presetD
       if (!isNaN(n) && n > 0) { setPrice(n); setPriceOverridden(true); }
     }
     if (pastJob.frequency) setFrequency(pastJob.frequency);
+  }
+
+  // Load the most recent job at the selected commercial property. When the
+  // property has history we surface a "Rebook last service" suggestion on
+  // the Service step; when it has none we fall back to the property's
+  // default_service_type so common new bookings still start pre-filled.
+  useEffect(() => {
+    if (clientType !== "commercial" || !selectedAccount || !selectedProperty) {
+      setPropertyRecentJob(null);
+      return;
+    }
+    let cancelled = false;
+    fetch(`${API}/api/accounts/${selectedAccount.id}/properties/${selectedProperty.id}/recent-job`, { headers: getAuthHeaders() })
+      .then(r => r.ok ? r.json() : null)
+      .then(job => {
+        if (cancelled) return;
+        setPropertyRecentJob(job || null);
+        // No history → pre-select the property's usual service if it maps to
+        // an active commercial type. Don't touch the type when history exists;
+        // the operator picks Rebook explicitly.
+        if (!job && selectedProperty.default_service_type) {
+          const valid = apiServiceTypes.some(
+            s => s.parent_slug === "commercial" && s.is_active && s.slug === selectedProperty.default_service_type
+          );
+          if (valid) {
+            setCommercialServiceType(selectedProperty.default_service_type);
+            setRateLookup(null); setRateLookupDone(false); setRateOverride(false);
+          }
+        }
+      })
+      .catch(() => { if (!cancelled) setPropertyRecentJob(null); });
+    return () => { cancelled = true; };
+  }, [selectedAccount, selectedProperty, clientType, apiServiceTypes]);
+
+  // Re-book: copy service type, hours, and rate from this property's last job.
+  // Setting the service type re-triggers the rate-card lookup, so the CURRENT
+  // contracted rate fills in; the historical hourly_rate is kept only as the
+  // no-rate-card fallback. Date and tech are intentionally left untouched.
+  function rebookFromProperty(job: any) {
+    if (!job) return;
+    if (job.service_type) {
+      setCommercialServiceType(job.service_type);
+      setRateLookup(null); setRateLookupDone(false); setRateOverride(false);
+    }
+    const hours = job.allowed_hours ?? job.estimated_hours ?? null;
+    if (hours != null && parseFloat(String(hours)) > 0) setEstimatedHours(String(parseFloat(String(hours))));
+    if (job.billing_method) setManualBillingMethod(job.billing_method);
+    if (job.hourly_rate != null) setManualRate(String(job.hourly_rate));
   }
 
   // Inline payment_method edit — persists via PUT /api/clients/:id
@@ -1292,6 +1343,30 @@ export function JobWizard({ open, onClose, onCreated, preselectedClient, presetD
                   </p>
                 </div>
               )}
+
+              {propertyRecentJob && (() => {
+                const rj = propertyRecentJob;
+                const rjHours = rj.allowed_hours ?? rj.estimated_hours ?? null;
+                const alreadyApplied = commercialServiceType === rj.service_type;
+                return (
+                  <div style={{ background: "#F0FDFB", border: "1px solid #99E6D5", borderRadius: 10, padding: "12px 14px", display: "flex", alignItems: "center", gap: 12 }}>
+                    <RefreshCw size={16} style={{ color: "var(--brand, #00C9A0)", flexShrink: 0 }}/>
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      <p style={{ fontSize: 12, fontWeight: 700, color: "#1A1917", margin: "0 0 2px" }}>
+                        Last service here: {fmtSvcLabel(rj.service_type)}
+                      </p>
+                      <p style={{ fontSize: 11, color: "#6B7280", margin: 0 }}>
+                        {rjHours != null ? `${parseFloat(String(rjHours))} hrs · ` : ""}{rj.scheduled_date || ""}
+                      </p>
+                    </div>
+                    <button type="button" onClick={() => rebookFromProperty(rj)}
+                      style={{ flexShrink: 0, fontSize: 12, fontWeight: 700, color: alreadyApplied ? "#9E9B94" : "#fff", background: alreadyApplied ? "#E5E2DC" : "var(--brand, #00C9A0)", border: "none", borderRadius: 8, padding: "8px 14px", cursor: alreadyApplied ? "default" : "pointer", fontFamily: "inherit" }}
+                      disabled={alreadyApplied}>
+                      {alreadyApplied ? "Applied" : "Rebook"}
+                    </button>
+                  </div>
+                );
+              })()}
 
               <div>
                 <p style={{ fontSize: 12, fontWeight: 700, color: "#6B7280", margin: "0 0 10px", textTransform: "uppercase", letterSpacing: "0.06em" }}>Service Type</p>

--- a/artifacts/qleno/src/pages/account-detail.tsx
+++ b/artifacts/qleno/src/pages/account-detail.tsx
@@ -528,9 +528,6 @@ export default function AccountDetailPage() {
                             {(p.city || p.state || p.zip) && `, ${[p.city, p.state, p.zip].filter(Boolean).join(", ")}`}
                           </p>
                           <div className="flex items-center gap-3 mt-1.5 flex-wrap">
-                            <span className="text-xs bg-gray-100 text-gray-600 px-2 py-0.5 rounded-full">
-                              {PROPERTY_TYPES.find((t) => t.value === p.property_type)?.label ?? p.property_type}
-                            </span>
                             {p.unit_count && (
                               <span className="text-xs text-gray-500 flex items-center gap-1">
                                 <Hash size={11} /> {p.unit_count} units

--- a/artifacts/qleno/src/pages/account-detail.tsx
+++ b/artifacts/qleno/src/pages/account-detail.tsx
@@ -17,6 +17,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "
 import { Switch } from "@/components/ui/switch";
 import { useToast } from "@/hooks/use-toast";
 import { getAuthHeaders } from "@/lib/auth";
+import { AccountJobsCalendar } from "@/components/account-jobs-calendar";
 
 const API = import.meta.env.BASE_URL.replace(/\/$/, "");
 
@@ -79,7 +80,7 @@ const CONTACT_ROLES = [
   { value: "other", label: "Other" },
 ];
 
-type Tab = "overview" | "properties" | "rate_cards" | "contacts" | "jobs";
+type Tab = "overview" | "properties" | "rate_cards" | "contacts" | "calendar" | "jobs";
 
 function fmt(n: number) {
   return n.toLocaleString("en-US", { style: "currency", currency: "USD", minimumFractionDigits: 0, maximumFractionDigits: 0 });
@@ -348,6 +349,7 @@ export default function AccountDetailPage() {
     { key: "properties", label: "Properties", count: account.properties?.length },
     { key: "rate_cards", label: "Rate Cards", count: account.rate_cards?.length },
     { key: "contacts", label: "Contacts", count: account.contacts?.length },
+    { key: "calendar", label: "Calendar" },
     { key: "jobs", label: "Uninvoiced Jobs", count: jobs.length },
   ];
 
@@ -690,6 +692,11 @@ export default function AccountDetailPage() {
               </div>
             )}
           </div>
+        )}
+
+        {/* ─── CALENDAR TAB ────────────────────────────────────────────────── */}
+        {tab === "calendar" && id && (
+          <AccountJobsCalendar accountId={id} />
         )}
 
         {/* ─── JOBS TAB ────────────────────────────────────────────────────── */}

--- a/artifacts/qleno/src/pages/customer-profile.tsx
+++ b/artifacts/qleno/src/pages/customer-profile.tsx
@@ -1186,10 +1186,21 @@ function HomesTab({ clientId, homes, refetch, zoneColor, zoneName }: { clientId:
               </div>
               <p style={{ margin: "4px 0 0", fontSize: "15px", fontWeight: 700, color: "#0A0E1A" }}>{home.address}</p>
               <p style={{ margin: "2px 0 0", fontSize: "13px", fontWeight: 500, color: "#374151" }}>{[home.city, home.state, home.zip].filter(Boolean).join(", ")}</p>
-              {zoneColor && zoneName && (
+              {/* [per-home zone 2026-06-02] Show THIS address's zone, resolved
+                  from its own zip by the API, not the client-level zone — a
+                  new address in a different area must reflect its real zone.
+                  When the zip matches no zone, show an explicit "No zone"
+                  rather than borrowing the client's (which is what made the
+                  old display wrong). */}
+              {home.zone_color && home.zone_name ? (
                 <div style={{ display: "flex", alignItems: "center", gap: 6, marginTop: 6 }}>
-                  <span style={{ width: 11, height: 11, borderRadius: "50%", backgroundColor: zoneColor, display: "inline-block", flexShrink: 0, boxShadow: `0 0 0 2px ${zoneColor}35` }} />
-                  <span style={{ fontSize: "12px", fontWeight: 700, color: zoneColor }}>{zoneName}</span>
+                  <span style={{ width: 11, height: 11, borderRadius: "50%", backgroundColor: home.zone_color, display: "inline-block", flexShrink: 0, boxShadow: `0 0 0 2px ${home.zone_color}35` }} />
+                  <span style={{ fontSize: "12px", fontWeight: 700, color: home.zone_color }}>{home.zone_name}</span>
+                </div>
+              ) : (
+                <div style={{ display: "flex", alignItems: "center", gap: 6, marginTop: 6 }}>
+                  <span style={{ width: 11, height: 11, borderRadius: "50%", backgroundColor: "#D1D5DB", display: "inline-block", flexShrink: 0 }} />
+                  <span style={{ fontSize: "12px", fontWeight: 600, color: "#9E9B94" }}>No zone for this zip</span>
                 </div>
               )}
             </div>


### PR DESCRIPTION
This branch carries two changes.

---

## 1) fix(profile): per-address zone resolution on the client profile

### Problem
Maribel added a new service address (801 Jackson Avenue, River Forest, IL **60305**) to a client profile, but the address card still showed the client's old zone (**Naperville/Woodridge/Lisle**) — wrong for that zip. *"It assigns the Zone to the client, instead of the address or property."*

### Fix
- **Backend** (`routes/clients.ts`): in the profile GET, resolve each home's zone from its own zip against the active `service_zones` and attach `zone_id`/`zone_name`/`zone_color` per home.
- **Frontend** (`customer-profile.tsx`): the address card shows **that address's** zone; when the zip matches no zone it shows **"No zone for this zip"** instead of borrowing the client's zone.

---

## 2) feat(commercial): per-property rebook suggestion in the job wizard

### Problem
Booking recurring commercial work (e.g. Daniel Walter Properties — 47 properties, mostly Common Areas and Apartment Turnovers) meant re-entering the service type, hours, and rate from scratch every time, even when the same building gets the same service repeatedly.

### Fix
- **New endpoint** `GET /api/accounts/:id/properties/:propId/recent-job` — returns the latest non-cancelled job at that property (service type, hours, rate, frequency, date), scoped **per property** so each building remembers its own last service.
- **Job wizard**: on the commercial Service step, a **"Last service here"** card lets you **Rebook** in one click — copies service type + allowed hours + rate. The current account rate card takes precedence; the historical rate is the no-card fallback. **Date and tech are left for the operator** (per Sal's call).
- Properties with **no history** fall back to the property's `default_service_type` when it maps to an active commercial type.

This is generic — every commercial account benefits, not just PPM.

### Verification
- API + frontend: new code carries no new type errors beyond the files' pre-existing baseline (project builds via vite/esbuild).

https://claude.ai/code/session_013KaJXnLShcWKZ8UBfBF2JC

---
_Generated by [Claude Code](https://claude.ai/code/session_013KaJXnLShcWKZ8UBfBF2JC)_