### PR TITLE
feat(profile): main-address picker drives client zone

### DIFF
--- a/artifacts/api-server/src/routes/clients.ts
+++ b/artifacts/api-server/src/routes/clients.ts
@@ -7,7 +7,7 @@ import {
   serviceZonesTable, quotesTable, contactTicketsTable, clientAttachmentsTable,
   recurringSchedulesTable, jobPhotosTable, qbCustomerMapTable, companiesTable,
 } from "@workspace/db/schema";
-import { eq, and, ilike, or, count, sum, desc, sql, gte, inArray } from "drizzle-orm";
+import { eq, and, ilike, or, count, sum, desc, sql, gte, inArray, ne } from "drizzle-orm";
 import { requireAuth, requireRole } from "../lib/auth.js";
 import { logAudit } from "../lib/audit.js";
 import { syncCustomer, queueSync } from "../services/quickbooks-sync.js";
@@ -784,6 +784,24 @@ router.patch("/:id/homes/:homeId", requireAuth, async (req, res) => {
       ...(allowed_hours !== undefined && { allowed_hours: String(allowed_hours) }),
       ...(geo && { lat: String(geo.lat), lng: String(geo.lng) }),
     }).where(and(eq(clientHomesTable.id, homeId), eq(clientHomesTable.company_id, req.auth!.companyId))).returning();
+
+    // When an address is promoted to the main one, it must be the ONLY primary,
+    // and the client-level zone follows it — the main address is what routing
+    // (comms/assignments) keys off when there's no per-job address context.
+    if (is_primary === true && home) {
+      const clientId = parseInt(req.params.id);
+      await db.update(clientHomesTable).set({ is_primary: false })
+        .where(and(
+          eq(clientHomesTable.client_id, clientId),
+          eq(clientHomesTable.company_id, req.auth!.companyId),
+          ne(clientHomesTable.id, homeId),
+        ));
+      const zoneId = await resolveZoneForZip(req.auth!.companyId, home.zip ?? "");
+      if (zoneId) {
+        await db.update(clientsTable).set({ zone_id: zoneId })
+          .where(and(eq(clientsTable.id, clientId), eq(clientsTable.company_id, req.auth!.companyId)));
+      }
+    }
     return res.json(home);
   } catch (err) {
     return res.status(500).json({ error: "Internal Server Error" });

--- a/artifacts/qleno/src/pages/customer-profile.tsx
+++ b/artifacts/qleno/src/pages/customer-profile.tsx
@@ -1165,6 +1165,13 @@ function HomesTab({ clientId, homes, refetch, zoneColor, zoneName }: { clientId:
     onSuccess: () => refetch(),
   });
 
+  // Promote an address to the main one. The server makes it the sole primary
+  // and re-points the client's zone to this address's zone.
+  const setPrimaryMut = useMutation({
+    mutationFn: (homeId: number) => apiFetch(`/api/clients/${clientId}/homes/${homeId}`, { method: "PATCH", body: JSON.stringify({ is_primary: true }) }),
+    onSuccess: () => refetch(),
+  });
+
   const F = (field: string, label: string, type = "text", placeholder = "", extraProps?: Record<string, any>) => (
     <div>
       <label style={{ display: "block", fontSize: "11px", fontWeight: 600, color: "#6B7280", marginBottom: "4px" }}>{label}</label>
@@ -1182,7 +1189,7 @@ function HomesTab({ clientId, homes, refetch, zoneColor, zoneName }: { clientId:
             <div>
               <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
                 <h3 style={{ margin: 0, fontSize: "15px", fontWeight: 700, color: "#1A1917" }}>{home.name || "Home"}</h3>
-                {home.is_primary && <span style={{ background: "var(--brand-dim)", color: "var(--brand)", padding: "2px 8px", borderRadius: "4px", fontSize: "10px", fontWeight: 700, textTransform: "uppercase" }}>Default</span>}
+                {home.is_primary && <span style={{ background: "var(--brand-dim)", color: "var(--brand)", padding: "2px 8px", borderRadius: "4px", fontSize: "10px", fontWeight: 700, textTransform: "uppercase" }}>Main</span>}
               </div>
               <p style={{ margin: "4px 0 0", fontSize: "15px", fontWeight: 700, color: "#0A0E1A" }}>{home.address}</p>
               <p style={{ margin: "2px 0 0", fontSize: "13px", fontWeight: 500, color: "#374151" }}>{[home.city, home.state, home.zip].filter(Boolean).join(", ")}</p>
@@ -1204,9 +1211,17 @@ function HomesTab({ clientId, homes, refetch, zoneColor, zoneName }: { clientId:
                 </div>
               )}
             </div>
-            <button onClick={() => deleteMut.mutate(home.id)} style={{ background: "none", border: "none", cursor: "pointer", color: "#9E9B94", padding: "4px" }}>
-              <Trash2 size={14} />
-            </button>
+            <div style={{ display: "flex", alignItems: "center", gap: "8px", flexShrink: 0 }}>
+              {!home.is_primary && (
+                <button onClick={() => setPrimaryMut.mutate(home.id)} disabled={setPrimaryMut.isPending}
+                  style={{ background: "none", border: "1px solid #E5E2DC", borderRadius: "6px", cursor: "pointer", color: "var(--brand)", padding: "4px 10px", fontSize: "11px", fontWeight: 700, fontFamily: "inherit", whiteSpace: "nowrap" }}>
+                  Set as main
+                </button>
+              )}
+              <button onClick={() => deleteMut.mutate(home.id)} style={{ background: "none", border: "none", cursor: "pointer", color: "#9E9B94", padding: "4px" }}>
+                <Trash2 size={14} />
+              </button>
+            </div>
           </div>
 
           {/* Property details */}
@@ -1282,7 +1297,7 @@ function HomesTab({ clientId, homes, refetch, zoneColor, zoneName }: { clientId:
               {F("base_fee", "Rate ($)", "number")} {F("allowed_hours", "Allowed Hours", "number")}
             </div>
             <label style={{ display: "flex", alignItems: "center", gap: "8px", fontSize: "13px", cursor: "pointer" }}>
-              <input type="checkbox" checked={form.is_primary} onChange={e => setForm(f => ({ ...f, is_primary: e.target.checked }))} /> Set as primary address
+              <input type="checkbox" checked={form.is_primary} onChange={e => setForm(f => ({ ...f, is_primary: e.target.checked }))} /> Set as main address
             </label>
           </div>
           <div style={{ display: "flex", gap: "8px", marginTop: "16px" }}>


### PR DESCRIPTION
## What Maribel hit

Two reports from the client profile:
1. **"From the profile I can't see the cleaners"** — the job-create Assign step showed *"No active employees found."*
2. **Zone follows the client, not the address.** She added a River Forest address (60305) but the card kept the client's old Naperville zone, and there was no way to say which address is the main one.

## This PR

**Main-address picker** (the new work):
- Each address card gets a **"Set as main"** button (non-primary only); the main address shows a **"Main"** badge.
- `PATCH /clients/:id/homes/:homeId` with `is_primary=true` now makes that address the **sole** primary (unsets the others) **and re-points the client's `zone_id`** to that address's zip-resolved zone — so the main address drives client-level routing instead of a stale zone.
- This complements the per-address zone *display* already shipped in #239 (each card shows its own zip's zone, or "No zone for this zip").

## Already handled by the deploy (not this PR)

- **"Can't see the cleaners"** was the assignable-roles filter bug fixed in #238/#239 (the Assign step reads the role-corrected `employees` list). Those screenshots are from 10:58 AM — **before** #239 deployed — so cleaners should populate on the new build. Flagged to re-test; will dig into live role data if it still shows empty.

## Verification

- New symbols (`setPrimaryMut`, the PATCH primary/zone-sync block) type-clean; remaining tsc notes are the file's pre-existing baseline patterns that already pass CI's `tsc-check`.

https://claude.ai/code/session_013KaJXnLShcWKZ8UBfBF2JC

---
_Generated by [Claude Code](https://claude.ai/code/session_013KaJXnLShcWKZ8UBfBF2JC)_