### PR TITLE
fix(recurring): selectable time + commercial service types on recurring schedule

### DIFF
--- a/artifacts/api-server/src/lib/recurring-jobs.ts
+++ b/artifacts/api-server/src/lib/recurring-jobs.ts
@@ -191,7 +191,7 @@ export async function insertJobFromSchedule(
       service_type: mapServiceType(schedule.service_type) as any,
       status: "scheduled" as const,
       scheduled_date: toDateStr(date),
-      scheduled_time: null as any,
+      scheduled_time: (schedule.scheduled_time ?? null) as any,
       frequency: mapFrequency(schedule.frequency) as any,
       base_fee: schedule.base_fee ? String(parseFloat(schedule.base_fee).toFixed(2)) : "0.00",
       allowed_hours: schedule.duration_minutes
@@ -258,6 +258,10 @@ type ScheduleInput = {
   end_date?: string | null;
   assigned_employee_id: number | null;
   service_type: string | null;
+  // Time-of-day for the recurring visit ("HH:MM:SS"). Stamped onto each
+  // generated job so recurring visits land at the office-set time instead
+  // of a null/midnight default.
+  scheduled_time?: string | null;
   duration_minutes: number | null;
   base_fee: string | null;
   notes: string | null;
@@ -322,7 +326,7 @@ export async function computeOccurrencesForSchedule(
       service_type: mapServiceType(schedule.service_type) as any,
       status: "scheduled" as const,
       scheduled_date: toDateStr(d),
-      scheduled_time: null as any,
+      scheduled_time: (schedule.scheduled_time ?? null) as any,
       frequency: mapFrequency(schedule.frequency) as any,
       base_fee: schedule.base_fee ? String(parseFloat(schedule.base_fee).toFixed(2)) : "0.00",
       allowed_hours: schedule.duration_minutes ? String((schedule.duration_minutes / 60).toFixed(2)) : null as any,

--- a/artifacts/api-server/src/routes/clients.ts
+++ b/artifacts/api-server/src/routes/clients.ts
@@ -1319,6 +1319,8 @@ router.patch("/:id/recurring-schedule", requireAuth, async (req, res) => {
     const companyId = req.auth!.companyId;
     const {
       frequency, day_of_week, duration_minutes, base_fee, service_type, notes,
+      // Time-of-day for the recurring visit ("HH:MM"). null clears it.
+      scheduled_time,
       // [AI.6] Parking fee per-occurrence config. days uses 0=Sun..6=Sat;
       // null/empty days = "apply to every scheduled occurrence."
       parking_fee_enabled, parking_fee_amount, parking_fee_days,
@@ -1339,6 +1341,7 @@ router.patch("/:id/recurring-schedule", requireAuth, async (req, res) => {
       ...(duration_minutes !== undefined && { duration_minutes: duration_minutes === "" ? null : parseInt(String(duration_minutes)) || null }),
       ...(base_fee !== undefined && { base_fee: base_fee === "" ? null : String(base_fee) }),
       ...(service_type !== undefined && { service_type }),
+      ...(scheduled_time !== undefined && { scheduled_time: scheduled_time === "" || scheduled_time === null ? null : scheduled_time }),
       ...(notes !== undefined && { notes }),
       ...(parking_fee_enabled !== undefined && { parking_fee_enabled: !!parking_fee_enabled }),
       ...(parking_fee_amount !== undefined && {
@@ -1386,6 +1389,7 @@ router.patch("/:id/recurring-schedule", requireAuth, async (req, res) => {
         start_date: today,
         is_active: true,
         service_type: service_type ?? null,
+        scheduled_time: scheduled_time || null,
         duration_minutes: duration_minutes === "" || duration_minutes == null
           ? null
           : (parseInt(String(duration_minutes)) || null),
@@ -1783,6 +1787,7 @@ router.get("/:id/recurring-schedule", requireAuth, async (req, res) => {
       start_date: recurringSchedulesTable.start_date,
       end_date: recurringSchedulesTable.end_date,
       service_type: recurringSchedulesTable.service_type,
+      scheduled_time: recurringSchedulesTable.scheduled_time,
       duration_minutes: recurringSchedulesTable.duration_minutes,
       base_fee: recurringSchedulesTable.base_fee,
       notes: recurringSchedulesTable.notes,

--- a/artifacts/qleno/src/pages/customer-profile.tsx
+++ b/artifacts/qleno/src/pages/customer-profile.tsx
@@ -3647,6 +3647,11 @@ function ServiceDetailsSection({ client, onUpdate, refetch, recurringSchedule, o
       : "",
     rec_base_fee: recurringSchedule?.base_fee || "",
     rec_service_type: recurringSchedule?.service_type || "",
+    // Time-of-day for the recurring visit. Stored as "HH:MM:SS"; the
+    // <input type="time"> wants "HH:MM".
+    rec_time: recurringSchedule?.scheduled_time
+      ? String(recurringSchedule.scheduled_time).slice(0, 5)
+      : "",
     rec_notes: recurringSchedule?.notes || "",
     // [PR #58] Anchor days for monthly + semi_monthly (sentence-builder UI).
     // Default to [1, 15] for semi_monthly when nothing's saved — matches
@@ -3716,6 +3721,7 @@ function ServiceDetailsSection({ client, onUpdate, refetch, recurringSchedule, o
               : Math.round(parseFloat(String(form.rec_duration)) * 60),
             base_fee: form.rec_base_fee,
             service_type: form.rec_service_type, notes: form.rec_notes,
+            scheduled_time: form.rec_time === "" ? null : form.rec_time,
             days_of_month: daysOfMonthToSend,
             custom_frequency_weeks: customWeeksToSend,
             parking_fee_enabled: form.rec_parking_fee_enabled,
@@ -4034,6 +4040,10 @@ function ServiceDetailsSection({ client, onUpdate, refetch, recurringSchedule, o
                   })()}
                 </div>
               </div>
+              <div>{lbl("Start Time")}
+                <input type="time" value={form.rec_time} onChange={upd("rec_time")} style={inp} />
+              </div>
+
               <div>{lbl("Service Type")}
                 {(() => {
                   // [PR #58] Filter Service Type by Frequency. Per the user's
@@ -4064,6 +4074,12 @@ function ServiceDetailsSection({ client, onUpdate, refetch, recurringSchedule, o
                   const oneTimeOk = (n: string) => /standard clean|deep clean|move in|move out|hourly standard|hourly deep/i.test(n) && !recurringNoise.test(n);
                   const scopeFiltered = filteredScopes.filter(s => {
                     if (recurringNoise.test(s.name)) return false;
+                    // Commercial scopes (PPM Common Areas, Turnover, etc.) don't
+                    // follow the residential standard/deep naming, so the
+                    // residential recurring/one-time name filters would hide
+                    // them all — leaving the dropdown empty. Show commercial
+                    // clients their full (Residential-group-stripped) scope list.
+                    if (isCommercialClient) return true;
                     if (isRecurring) return recurringOk(s.name);
                     if (isOneTime) return oneTimeOk(s.name);
                     return true; // commercial multi-day or unset frequency: keep filteredScopes as-is


### PR DESCRIPTION
## Maribel's report: *"can't select type ot time"* on the recurring schedule

Two problems on the customer-profile recurring-schedule editor, plus a hidden third that would've made the time cosmetic:

### 1. Service Type dropdown was empty
The options ran through residential name filters (`standard` / `deep` / `hourly recurring`). A commercial client's scopes (PPM Common Areas, Turnover, etc.) match none of those, so the dropdown showed only "— Select —". Commercial clients now get their full scope list (Residential-group stripped) instead of nothing.

### 2. No Time field at all
The form had Frequency + Day of Week but no time-of-day input — even though `recurring_schedules.scheduled_time` already exists. Added a **Start Time** input, wired through the form, the PATCH payload, the PATCH/INSERT handlers, and the GET that loads the schedule (so an existing time pre-fills).

### 3. (caught while wiring) The time wouldn't have applied
The recurring engine hard-coded `scheduled_time: null` on every generated job. Now it stamps the schedule's `scheduled_time`, so recurring visits actually land at the set time.

## Note
The Service-Type dropdown reads from `pricing_scopes`. If a tenant has no **Commercial**-group scopes there, the list can still be short — that's a data setup gap, not this filter. Flagging in case the church's list still looks thin after deploy.

## Verification
- API + frontend type-clean for the changed code (same baseline patterns otherwise; CI `tsc-check`/builds gate it).

https://claude.ai/code/session_013KaJXnLShcWKZ8UBfBF2JC

---
_Generated by [Claude Code](https://claude.ai/code/session_013KaJXnLShcWKZ8UBfBF2JC)_