### PR TITLE
feat(ux): client-name profile link + surface real save errors

### DIFF
--- a/artifacts/qleno/src/pages/customer-profile.tsx
+++ b/artifacts/qleno/src/pages/customer-profile.tsx
@@ -3752,7 +3752,15 @@ function ServiceDetailsSection({ client, onUpdate, refetch, recurringSchedule, o
       refetch();
       setEditing(false);
       onToast("Service details saved");
-    } catch { onToast("Failed to save changes", "error"); }
+    } catch (e: any) {
+      // Surface the server's actual reason instead of a blind "Failed to
+      // save changes" — apiFetch throws the response body, so the operator
+      // (and we) can see WHY (e.g. an invalid enum value) instead of guessing.
+      const raw = String(e?.message || "").trim();
+      let detail = raw;
+      try { const j = JSON.parse(raw); detail = j.error || j.message || raw; } catch { /* plain text */ }
+      onToast(detail ? `Couldn't save: ${detail.slice(0, 160)}` : "Failed to save changes", "error");
+    }
     finally { setSaving(false); }
   };
 

--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -1523,7 +1523,21 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
         {mobile && <div style={{ width: 40, height: 4, backgroundColor: "#E5E2DC", borderRadius: 2, margin: "12px auto 0" }} />}
         <div style={{ padding: "16px 20px 14px", borderBottom: "1px solid #EEECE7", flexShrink: 0, display: "flex", justifyContent: "space-between", alignItems: "flex-start" }}>
           <div>
-            <h2 style={{ margin: 0, fontSize: 17, fontWeight: 800, color: "#1A1917" }}>{job.display_name ?? job.client_name}</h2>
+            <h2 style={{ margin: 0, fontSize: 17, fontWeight: 800, color: "#1A1917" }}>
+              {(job.client_id || job.account_id) ? (
+                <a
+                  href={job.client_id ? `/customers/${job.client_id}` : `/accounts/${job.account_id}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  title="Open profile in a new tab"
+                  style={{ color: "#1A1917", textDecoration: "none", cursor: "pointer" }}
+                  onMouseEnter={e => (e.currentTarget.style.textDecoration = "underline")}
+                  onMouseLeave={e => (e.currentTarget.style.textDecoration = "none")}
+                >
+                  {job.display_name ?? job.client_name}
+                </a>
+              ) : (job.display_name ?? job.client_name)}
+            </h2>
             <span style={{ display: "inline-block", marginTop: 5, fontSize: 11, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.05em", padding: "2px 8px", borderRadius: 4, backgroundColor: "var(--brand-dim)", color: "var(--brand)" }}>{fmtSvc(job.service_type)}</span>
           </div>
           <button onClick={onClose} style={{ border: "none", background: "none", cursor: "pointer", color: "#9E9B94", padding: 4 }}><X size={18} /></button>


### PR DESCRIPTION
## Two quick wins from Maribel's batch

1. **Client name → profile link.** *"Would be nice to access [the] profile from here so we don't have to open another tab and look for it — make a link out of the name."* The job-panel header name is now a link that opens the profile in a new tab. Works for both client jobs (`/customers/:id`) and account jobs (`/accounts/:id`). Generic for all tenants.

2. **Real save errors instead of "Failed to save changes."** The recurring/service-details save swallowed the server error behind a generic toast, which is why the church's *"it's not saving, why?"* was a mystery. It now shows the server's actual reason (`Couldn't save: <reason>`), so the next failure is diagnosable.

## Still on the list (bigger, multi-tenant — proposing to do these next, separately)
- **Commercial services as a tenant-configurable set** so non-PPM commercial clients (the church) can pick Common Areas / Turnover etc. — generic mechanism, Phes data = $45/$50/hr bill, $20/hr pay.
- **Edit a job's rate** ("rate logs" equivalent / effective-dated pricing).
- **Bulk-edit recurrence** (imported recurring clients landed same-day/no-time).

https://claude.ai/code/session_013KaJXnLShcWKZ8UBfBF2JC

---
_Generated by [Claude Code](https://claude.ai/code/session_013KaJXnLShcWKZ8UBfBF2JC)_