### PR TITLE
feat(permissions): owner-controlled admin privileges

### DIFF
--- a/artifacts/api-server/src/routes/users.ts
+++ b/artifacts/api-server/src/routes/users.ts
@@ -382,6 +382,24 @@ router.put("/:id", requireAuth, requireRole("owner", "admin", "office"), async (
       commercial_pay_type,  commercial_pay_rate,
     } = req.body;
 
+    // Only the OWNER may change a user's role (grant/revoke admin etc.).
+    // Per Sal: admin privileges are owner-controlled — office/admin cannot
+    // elevate anyone (or themselves). Same-role passthrough is allowed so
+    // non-owners can still edit other fields without tripping this.
+    if (role !== undefined && callerRole !== "owner") {
+      const cur = await db
+        .select({ role: usersTable.role })
+        .from(usersTable)
+        .where(and(eq(usersTable.id, userId), eq(usersTable.company_id, req.auth!.companyId)))
+        .limit(1);
+      if (cur[0] && cur[0].role !== role) {
+        return res.status(403).json({
+          error: "Forbidden",
+          message: "Only the owner can change a user's role.",
+        });
+      }
+    }
+
     // Validate matrix inputs if provided.
     const validateMatrixPair = (type: any, rate: any, label: string) => {
       if (type !== undefined && type !== "commission" && type !== "hourly") {

--- a/artifacts/qleno/src/pages/employee-profile.tsx
+++ b/artifacts/qleno/src/pages/employee-profile.tsx
@@ -1111,10 +1111,20 @@ export default function EmployeeProfilePage() {
                 <div style={{ display:'grid', gridTemplateColumns:'repeat(2,1fr)', gap:16 }}>
                   <Field label="Login Email"><Input value={form.email||''} onChange={v=>setField('email',v)}/></Field>
                   <Field label="Role">
-                    <Select value={form.role||''} onChange={v=>setField('role',v)} options={[
-                      {value:'owner',label:'Owner'},{value:'admin',label:'Admin'},
-                      {value:'office',label:'Office'},{value:'technician',label:'Technician'}
-                    ]}/>
+                    {/* Admin privileges are owner-controlled: only the owner can
+                        change a role (grant/revoke admin). Everyone else sees it
+                        read-only — the server enforces this too. */}
+                    {isOwner ? (
+                      <Select value={form.role||''} onChange={v=>setField('role',v)} options={[
+                        {value:'owner',label:'Owner'},{value:'admin',label:'Admin'},
+                        {value:'office',label:'Office'},{value:'technician',label:'Technician'}
+                      ]}/>
+                    ) : (
+                      <div style={{ padding:'8px 12px', border:'1px solid #E5E2DC', borderRadius:8, background:'#FAFAF8', fontSize:13, color:'#1A1917', textTransform:'capitalize' }}>
+                        {(form.role||'').replace('_',' ') || '—'}
+                        <span style={{ marginLeft:8, fontSize:11, color:'#9E9B94' }}>· only the owner can change this</span>
+                      </div>
+                    )}
                   </Field>
                 </div>
                 <div style={{ marginTop:16 }}>


### PR DESCRIPTION
## Owner-controlled admin privileges (1 of 4)

Maribel (office) got **"Forbidden"** creating the KMA account because account creation is admin+. Per your call: *admin privileges live in the user's profile and only you (owner) can toggle them.*

- **Backend** (`users` PUT): only the **owner** can change a user's role. A non-owner trying to change someone's role gets 403; editing other fields still works (same-role passthrough).
- **Frontend** (employee profile → User Account): the **Role** field is an editable dropdown only for the owner. Everyone else sees it read-only with "only the owner can change this."

So you flip an employee to **Admin** in their profile, and that unlocks admin actions like creating accounts — no blanket opening of permissions.

## Next (one at a time, per your "all four")
2. Quick wizard bugs (Rebook does nothing + property search)
3. Change a job's price
4. Bulk-edit recurrences

https://claude.ai/code/session_013KaJXnLShcWKZ8UBfBF2JC

---
_Generated by [Claude Code](https://claude.ai/code/session_013KaJXnLShcWKZ8UBfBF2JC)_