### PR TITLE
feat(jobs): change a job's price inline (dispatch + field)

### DIFF
--- a/artifacts/qleno/src/components/inline-price-edit.tsx
+++ b/artifacts/qleno/src/components/inline-price-edit.tsx
@@ -1,0 +1,104 @@
+import { useState } from "react";
+import { DollarSign, Check, X, Pencil } from "lucide-react";
+import { getAuthHeaders } from "@/lib/auth";
+
+const API = import.meta.env.BASE_URL.replace(/\/$/, "");
+
+// Reusable "change the price" control. Shows a job's price and, for office /
+// admin / owner, lets them edit it inline on whatever screen it appears
+// (dispatch panel, field view, etc.). Saves the new total to the job's
+// base_fee for THIS visit only (the server recomputes billed_amount); the
+// recurring template's rate is changed separately on the customer profile.
+export function InlinePriceEdit({
+  jobId,
+  price,
+  billingMethod,
+  hourlyRate,
+  estimatedHours,
+  canEdit,
+  onUpdated,
+}: {
+  jobId: number;
+  price: number;
+  billingMethod?: string | null;
+  hourlyRate?: number | null;
+  estimatedHours?: number | null;
+  canEdit: boolean;
+  onUpdated?: () => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [val, setVal] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const isHourly = billingMethod === "hourly" && hourlyRate != null;
+  const display = isHourly
+    ? `$${Number(hourlyRate).toFixed(2)}/hr · Hourly${estimatedHours ? ` · est. ${estimatedHours}h` : ""} · $${Number(price).toFixed(2)}`
+    : `$${Number(price).toFixed(2)}`;
+
+  async function save() {
+    const n = parseFloat(val);
+    if (!Number.isFinite(n) || n < 0) { setErr("Enter a valid amount"); return; }
+    setSaving(true); setErr(null);
+    try {
+      const r = await fetch(`${API}/api/jobs/${jobId}`, {
+        method: "PATCH",
+        headers: { ...getAuthHeaders(), "Content-Type": "application/json" },
+        body: JSON.stringify({ base_fee: String(n.toFixed(2)), cascade_scope: "this_job" }),
+      });
+      if (!r.ok) {
+        const d = await r.json().catch(() => ({}));
+        throw new Error(d.message || d.error || `HTTP ${r.status}`);
+      }
+      setEditing(false);
+      onUpdated?.();
+    } catch (e: any) {
+      setErr(e?.message ?? "Couldn't save the price");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (!editing) {
+    return (
+      <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+        <DollarSign size={14} style={{ color: "#6B7280", flexShrink: 0 }} />
+        <span style={{ fontSize: 13, fontWeight: 700, color: "#1A1917" }}>{display}</span>
+        {canEdit && (
+          <button
+            onClick={() => { setVal(Number(price || 0).toFixed(2)); setErr(null); setEditing(true); }}
+            style={{ fontSize: 11, fontWeight: 600, color: "var(--brand, #00C9A0)", background: "none", border: "none", cursor: "pointer", fontFamily: "inherit", padding: 0, display: "inline-flex", alignItems: "center", gap: 3 }}
+          >
+            <Pencil size={11} /> Change price
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <div style={{ position: "relative", flex: 1, maxWidth: 160 }}>
+          <span style={{ position: "absolute", left: 10, top: "50%", transform: "translateY(-50%)", fontSize: 13, color: "#6B7280" }}>$</span>
+          <input
+            type="number" inputMode="decimal" value={val} autoFocus
+            onChange={e => setVal(e.target.value)}
+            onKeyDown={e => { if (e.key === "Enter") save(); if (e.key === "Escape") { setEditing(false); setErr(null); } }}
+            style={{ width: "100%", padding: "8px 10px 8px 22px", border: "1px solid #E5E2DC", borderRadius: 8, fontSize: 13, fontFamily: "inherit", outline: "none", boxSizing: "border-box" }}
+          />
+        </div>
+        <button onClick={save} disabled={saving} title="Save"
+          style={{ padding: "8px 10px", borderRadius: 8, border: "none", background: "var(--brand, #00C9A0)", color: "#fff", cursor: "pointer", display: "inline-flex", alignItems: "center" }}>
+          <Check size={14} />
+        </button>
+        <button onClick={() => { setEditing(false); setErr(null); }} disabled={saving} title="Cancel"
+          style={{ padding: "8px 10px", borderRadius: 8, border: "1px solid #E5E2DC", background: "#fff", color: "#6B7280", cursor: "pointer", display: "inline-flex", alignItems: "center" }}>
+          <X size={14} />
+        </button>
+      </div>
+      {isHourly && <p style={{ margin: 0, fontSize: 11, color: "#9E9B94" }}>Sets this visit's total price (overrides hours × rate for this visit only).</p>}
+      {err && <p style={{ margin: 0, fontSize: 11, color: "#DC2626" }}>{err}</p>}
+    </div>
+  );
+}

--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -16,6 +16,7 @@ import {
 } from "lucide-react";
 import { getJobVisualStatus, STATUS_VISUALS, ensureJobStatusStyles, LIVE_OPS } from "@/lib/job-status";
 import { computePriceDelta } from "@/lib/price-delta";
+import { InlinePriceEdit } from "@/components/inline-price-edit";
 import LegendPopover from "@/components/legend-popover";
 import MobileDateSheet from "@/components/mobile-date-sheet";
 
@@ -1577,10 +1578,15 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
             )}
             {/* [inline-edit] Tech dropdown swaps the primary tech in place. */}
             <InlineTechEdit job={job} onUpdate={onUpdate} />
-            {job.billing_method === "hourly" && job.hourly_rate
-              ? <IR icon={<DollarSign size={14} />} label={`$${job.hourly_rate.toFixed(2)}/hr · Hourly${job.billed_hours ? ` · ${job.billed_hours}h billed` : job.estimated_hours ? ` · est. ${job.estimated_hours}h` : ""}`} bold />
-              : <IR icon={<DollarSign size={14} />} label={`$${(job.billed_amount ?? job.amount ?? 0).toFixed(2)}`} bold />
-            }
+            <InlinePriceEdit
+              jobId={job.id}
+              price={job.billed_amount ?? job.amount ?? 0}
+              billingMethod={job.billing_method}
+              hourlyRate={job.hourly_rate}
+              estimatedHours={job.estimated_hours}
+              canEdit={canEditOfficeNotes}
+              onUpdated={onUpdate}
+            />
           </div>
 
           {job.property_access_notes && (

--- a/artifacts/qleno/src/pages/my-jobs.tsx
+++ b/artifacts/qleno/src/pages/my-jobs.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { useAuthStore } from "@/lib/auth";
+import { useAuthStore, getTokenRole } from "@/lib/auth";
+import { InlinePriceEdit } from "@/components/inline-price-edit";
 import { useToast } from "@/hooks/use-toast";
 import { Car, X, Check, Eye, Navigation, Phone, GraduationCap } from "lucide-react";
 import { Link } from "wouter";
@@ -433,7 +434,9 @@ function JobCard({ job, empPos, onRefresh, isPreviewMode }: { job: Job; empPos: 
         <span style={{ fontSize: 11, fontWeight: 600, padding: "2px 8px", borderRadius: 20, backgroundColor: sc.bg, color: sc.color, textTransform: "capitalize", textDecoration: visual.strikethrough ? "line-through" : "none" }}>
           {job.status.replace("_", " ")}
         </span>
-        <span style={{ fontSize: 20, fontWeight: 700, color: "#1A1917" }}>${job.base_fee.toFixed(2)}</span>
+        {["owner", "admin", "office"].includes(getTokenRole() || "")
+          ? <InlinePriceEdit jobId={job.id} price={job.base_fee} canEdit onUpdated={onRefresh} />
+          : <span style={{ fontSize: 20, fontWeight: 700, color: "#1A1917" }}>${job.base_fee.toFixed(2)}</span>}
       </div>
 
       <div style={{ display: "flex", alignItems: "center", gap: 8, marginTop: 10, marginBottom: 4, flexWrap: "wrap" }}>


### PR DESCRIPTION
## Change a job's price (3 of 4)

Maribel asked *"how do I change the price?"* and you noted it's needed on multiple screens, including in the field.

- **New reusable `InlinePriceEdit`** — shows the price and, for office/admin/owner, a plain **"Change price"** editor inline. Saves the new total to the visit's `base_fee` for **this visit only** (server recomputes the billed amount). The recurring template's rate is still changed on the customer profile, so a one-off price tweak doesn't silently rewrite the whole series.
- **Wired into two screens:** the dispatch **job panel** and the **field view** (my-jobs). Techs see the price read-only; owner/admin/office get the editor — so you can fix a price from the field.
- Plain-English labels only ("Change price") — no rate-log jargon.

Reusable, so we can drop it on any other screen that shows a price later.

## Last one
4. Bulk-edit recurrences

https://claude.ai/code/session_013KaJXnLShcWKZ8UBfBF2JC

---
_Generated by [Claude Code](https://claude.ai/code/session_013KaJXnLShcWKZ8UBfBF2JC)_