### PR TITLE
feat: KMA account + delete-job button + mobile add-note

### DIFF
--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -2410,6 +2410,73 @@ async function runPpmAccountCleanup(): Promise<void> {
   console.log(`[ppm-cleanup] Account ${acctId} → 'PPM'; inserted ${inserted} missing properties (roster ${ROSTER.length}).`);
 }
 
+// KMA Property Management — a commercial PM account like PPM, smaller. Created
+// fresh in Qleno (the office-role attempt hit 'Forbidden'). Account + its
+// properties seeded idempotently. Commercial work is quoted per visit, so no
+// fixed property rates here. Dedup on normalized address (so 4846 W North Ave,
+// which had two service sets in MaidCentral, lands as one property).
+async function runKmaAccountSetup(): Promise<void> {
+  const ROSTER: { address: string; city: string; state: string; zip: string }[] = [
+    { address: "12013 S Eggleston Ave", city: "Chicago",   state: "IL", zip: "60628" },
+    { address: "14050 S Tracy Ave",     city: "Riverdale", state: "IL", zip: "60827" },
+    { address: "1641 N Lamon Ave",      city: "Chicago",   state: "IL", zip: "60639" },
+    { address: "1930 S Wabash Ave",     city: "Chicago",   state: "IL", zip: "60616" },
+    { address: "2503 W 63rd St",        city: "Chicago",   state: "IL", zip: "60629" },
+    { address: "3421 N Ashland Ave",    city: "Chicago",   state: "IL", zip: "60657" },
+    { address: "4846 W North Ave",      city: "Chicago",   state: "IL", zip: "60639" },
+  ];
+
+  // 1. Create the account if it doesn't exist.
+  await db.execute(sql`
+    INSERT INTO accounts
+      (company_id, account_name, account_type, payment_method, invoice_frequency,
+       payment_terms_days, auto_charge_on_completion, is_active, notes)
+    SELECT ${PHES}, 'KMA Property Management', 'property_management'::account_type,
+           'invoice_only'::account_payment_method, 'monthly'::invoice_frequency,
+           30, false, true,
+           'Commercial property management (common areas + office cleaning). Billing: lflores@kmapm.com'
+    WHERE NOT EXISTS (
+      SELECT 1 FROM accounts WHERE company_id = ${PHES} AND lower(account_name) = 'kma property management'
+    )
+  `);
+
+  const acctRes = await db.execute(sql`
+    SELECT id FROM accounts WHERE company_id = ${PHES} AND lower(account_name) = 'kma property management' ORDER BY id LIMIT 1
+  `);
+  const acctRow = acctRes.rows[0] as { id: number } | undefined;
+  if (!acctRow) { console.warn("[kma-setup] account not found after insert — skipping"); return; }
+  const acctId = acctRow.id;
+
+  // 2. Billing contact (guarded).
+  await db.execute(sql`
+    INSERT INTO account_contacts (account_id, company_id, name, role, email, receives_invoices, is_primary)
+    SELECT ${acctId}, ${PHES}, 'KMA Billing', 'billing'::account_contact_role, 'lflores@kmapm.com', true, true
+    WHERE NOT EXISTS (
+      SELECT 1 FROM account_contacts WHERE account_id = ${acctId} AND lower(email) = 'lflores@kmapm.com'
+    )
+  `);
+
+  // 3. Insert missing properties (dedup on normalized address).
+  const existing = await db.execute(sql`
+    SELECT address FROM account_properties WHERE account_id = ${acctId} AND company_id = ${PHES}
+  `);
+  const existingKeys = new Set((existing.rows as { address: string }[]).map(r => normalizeAddrKey(r.address)));
+  let inserted = 0;
+  for (const p of ROSTER) {
+    const key = normalizeAddrKey(p.address);
+    if (existingKeys.has(key)) continue;
+    await db.execute(sql`
+      INSERT INTO account_properties
+        (account_id, company_id, property_name, address, city, state, zip, property_type, is_active)
+      VALUES
+        (${acctId}, ${PHES}, ${p.address}, ${p.address}, ${p.city}, ${p.state}, ${p.zip}, 'apartment_building', true)
+    `);
+    existingKeys.add(key);
+    inserted++;
+  }
+  console.log(`[kma-setup] Account ${acctId} ensured; inserted ${inserted} properties (roster ${ROSTER.length}).`);
+}
+
 export async function runPhesDataMigration(): Promise<void> {
   await runBookingSchemaGuard();
 
@@ -2519,6 +2586,12 @@ export async function runPhesDataMigration(): Promise<void> {
     await runPpmAccountCleanup();
   } catch (err: any) {
     console.warn("[phes-migration] ppm-account-cleanup — non-fatal:", err?.message ?? err);
+  }
+
+  try {
+    await runKmaAccountSetup();
+  } catch (err: any) {
+    console.warn("[phes-migration] kma-account-setup — non-fatal:", err?.message ?? err);
   }
 
   try {

--- a/artifacts/api-server/src/routes/jobs.ts
+++ b/artifacts/api-server/src/routes/jobs.ts
@@ -4572,5 +4572,79 @@ router.delete("/:id/rate-mods/:modId", requireAuth, async (req, res) => {
   }
 });
 
+// ─── DELETE A JOB ────────────────────────────────────────────────────────────
+// For made-up / test jobs. Recorded in the audit trail. Clears child rows that
+// would block the delete (clock entries, photos, add-ons, status logs, etc.)
+// and detaches (nulls) records we keep — invoices, payroll, mileage. Returns
+// 409 if the job has links that can't be safely removed → cancel it instead.
+router.delete("/:id", requireAuth, async (req, res) => {
+  const role = req.auth!.role;
+  if (!["owner", "admin", "office"].includes(role)) {
+    return res.status(403).json({ error: "Forbidden", message: "Only office, admin, or owner can delete a job." });
+  }
+  const jobId = parseInt(req.params.id);
+  if (isNaN(jobId)) return res.status(400).json({ error: "Invalid id" });
+  const [job] = await db.select().from(jobsTable)
+    .where(and(eq(jobsTable.id, jobId), eq(jobsTable.company_id, req.auth!.companyId))).limit(1);
+  if (!job) return res.status(404).json({ error: "Not found" });
+  try {
+    await db.transaction(async (tx) => {
+      const childTables = [
+        "job_add_ons", "job_photos", "job_supplies", "job_status_logs", "job_clock_events",
+        "job_worksheet", "client_ratings", "cancellation_log", "timeclock", "clock_in_attempts",
+        "attendance_proposals", "job_technicians",
+      ];
+      for (const t of childTables) await tx.execute(sql.raw(`DELETE FROM ${t} WHERE job_id = ${jobId}`));
+      const detach: [string, string][] = [
+        ["additional_pay", "job_id"], ["communication_log", "job_id"], ["contact_tickets", "job_id"],
+        ["form_submissions", "job_id"], ["hr_logs", "job_id"], ["loyalty", "job_id"], ["invoices", "job_id"],
+        ["mileage", "from_job_id"], ["mileage", "to_job_id"],
+        ["mileage_requests", "from_job_id"], ["mileage_requests", "to_job_id"],
+        ["cancellation_log", "rescheduled_to_job_id"],
+      ];
+      for (const [t, c] of detach) await tx.execute(sql.raw(`UPDATE ${t} SET ${c} = NULL WHERE ${c} = ${jobId}`));
+      await tx.execute(sql.raw(`DELETE FROM jobs WHERE id = ${jobId}`));
+    });
+    logAudit(req, "DELETE", "job", jobId, null, {
+      client_id: job.client_id, scheduled_date: job.scheduled_date,
+      service_type: job.service_type, base_fee: job.base_fee,
+    });
+    return res.json({ ok: true });
+  } catch (err) {
+    console.error("Delete job error:", err);
+    return res.status(409).json({
+      error: "Could not delete",
+      message: "This job has linked records (e.g. an invoice or payroll entry) and can't be deleted. Cancel it instead.",
+    });
+  }
+});
+
+// ─── APPEND A NOTE TO A JOB ──────────────────────────────────────────────────
+// Field techs add notes from mobile. Server-side append (never clobbers
+// existing notes), stamped with the date so the history reads cleanly.
+router.post("/:id/note", requireAuth, async (req, res) => {
+  const jobId = parseInt(req.params.id);
+  if (isNaN(jobId)) return res.status(400).json({ error: "Invalid id" });
+  const note = String(req.body?.note ?? "").trim();
+  if (!note) return res.status(400).json({ error: "note required" });
+  const stamp = new Date().toLocaleString("en-US", {
+    timeZone: "America/Chicago", month: "short", day: "numeric", hour: "numeric", minute: "2-digit",
+  });
+  const line = `[${stamp}] ${note}`;
+  try {
+    const [updated] = await db.execute(sql`
+      UPDATE jobs
+      SET notes = CASE WHEN notes IS NULL OR notes = '' THEN ${line} ELSE notes || E'\n' || ${line} END
+      WHERE id = ${jobId} AND company_id = ${req.auth!.companyId}
+      RETURNING notes
+    `).then((r: any) => r.rows);
+    if (!updated) return res.status(404).json({ error: "Not found" });
+    return res.json({ ok: true, notes: (updated as any).notes });
+  } catch (err) {
+    console.error("Append job note error:", err);
+    return res.status(500).json({ error: "Could not save note" });
+  }
+});
+
 export { calculateTechPay };
 export default router;

--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -12,7 +12,7 @@ import {
 import {
   ChevronLeft, ChevronRight, ChevronDown, Plus, Clock, Camera, X, MapPin, User,
   DollarSign, CheckCircle, AlertCircle, LayoutGrid, List, Calendar,
-  Building2, AlertTriangle, Repeat, Phone, MessageSquare, Send, Check, Info,
+  Building2, AlertTriangle, Repeat, Phone, MessageSquare, Send, Check, Info, Trash2,
 } from "lucide-react";
 import { getJobVisualStatus, STATUS_VISUALS, ensureJobStatusStyles, LIVE_OPS } from "@/lib/job-status";
 import { computePriceDelta } from "@/lib/price-delta";
@@ -1648,6 +1648,30 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
                 onBlur={e => (e.target.style.borderColor = "#E5E2DC")}
               />
               <p style={{ fontSize: 10, color: "#C0BDB8", marginTop: 4, fontFamily: FF }}>Auto-saves 2 s after you stop typing</p>
+            </div>
+          )}
+
+          {/* Delete (office/admin/owner) — for made-up/test jobs. Audit-logged. */}
+          {canEditOfficeNotes && (
+            <div style={{ marginTop: 12 }}>
+              <button
+                onClick={async () => {
+                  if (!window.confirm("Delete this job? It's removed from the schedule and recorded in the audit log.")) return;
+                  try {
+                    const r = await fetch(`${_API3}/api/jobs/${job.id}`, { method: "DELETE", headers: { Authorization: `Bearer ${token}` } });
+                    const d = await r.json().catch(() => ({}));
+                    if (!r.ok) { toast({ title: "Couldn't delete", description: d.message || d.error || `HTTP ${r.status}` }); return; }
+                    toast({ title: "Job deleted" });
+                    onClose();
+                    onUpdate();
+                  } catch (e: any) {
+                    toast({ title: "Couldn't delete", description: e?.message ?? "Network error" });
+                  }
+                }}
+                style={{ display: "inline-flex", alignItems: "center", gap: 6, fontSize: 12, fontWeight: 600, color: "#DC2626", background: "none", border: "1px solid #FECACA", borderRadius: 8, padding: "7px 12px", cursor: "pointer", fontFamily: FF }}
+              >
+                <Trash2 size={13} /> Delete job
+              </button>
             </div>
           )}
 

--- a/artifacts/qleno/src/pages/my-jobs.tsx
+++ b/artifacts/qleno/src/pages/my-jobs.tsx
@@ -257,6 +257,48 @@ function OfficeAttachments({ jobId }: { jobId: number }) {
   );
 }
 
+// Field techs add a note from their phone. Prominent full-width button (easy
+// to find), 44px+ tap targets. Server appends to the job's notes (timestamped),
+// so the office sees it without the tech clobbering anything.
+function AddNote({ jobId, onSaved }: { jobId: number; onSaved: () => void }) {
+  const [open, setOpen] = useState(false);
+  const [text, setText] = useState("");
+  const [saving, setSaving] = useState(false);
+  async function save() {
+    const note = text.trim();
+    if (!note) return;
+    setSaving(true);
+    try {
+      const r = await apiFetch(`/jobs/${jobId}/note`, { method: "POST", body: JSON.stringify({ note }) });
+      if (r.ok) { setText(""); setOpen(false); onSaved(); }
+    } finally { setSaving(false); }
+  }
+  if (!open) {
+    return (
+      <button onClick={() => setOpen(true)}
+        style={{ marginTop: 12, width: "100%", display: "flex", alignItems: "center", justifyContent: "center", gap: 6, padding: "12px", borderRadius: 10, border: "1px dashed #C9C5BD", background: "#FAFAF8", color: "#1A1917", fontSize: 15, fontWeight: 600, fontFamily: "inherit", cursor: "pointer" }}>
+        + Add note
+      </button>
+    );
+  }
+  return (
+    <div style={{ marginTop: 12 }}>
+      <textarea value={text} onChange={e => setText(e.target.value)} autoFocus rows={3} placeholder="Add a note for this job…"
+        style={{ width: "100%", boxSizing: "border-box", border: "1px solid #E5E2DC", borderRadius: 10, padding: "10px 12px", fontSize: 15, fontFamily: "inherit", outline: "none", resize: "vertical" }} />
+      <div style={{ display: "flex", gap: 8, marginTop: 8 }}>
+        <button onClick={save} disabled={saving || !text.trim()}
+          style={{ flex: 1, padding: "12px", borderRadius: 10, border: "none", background: text.trim() && !saving ? "var(--brand, #00C9A0)" : "#D1D5DB", color: "#fff", fontSize: 15, fontWeight: 700, cursor: text.trim() && !saving ? "pointer" : "default", fontFamily: "inherit" }}>
+          {saving ? "Saving…" : "Save note"}
+        </button>
+        <button onClick={() => { setOpen(false); setText(""); }} disabled={saving}
+          style={{ padding: "12px 16px", borderRadius: 10, border: "1px solid #E5E2DC", background: "#fff", color: "#6B7280", fontSize: 15, fontWeight: 600, cursor: "pointer", fontFamily: "inherit" }}>
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}
+
 function JobCard({ job, empPos, onRefresh, isPreviewMode }: { job: Job; empPos: { lat: number; lng: number } | null; onRefresh: () => void; isPreviewMode?: boolean }) {
   const { toast } = useToast();
   const qc = useQueryClient();
@@ -542,6 +584,8 @@ function JobCard({ job, empPos, onRefresh, isPreviewMode }: { job: Job; empPos: 
           <p style={{ fontSize: 12, color: "#1A1917", margin: 0 }}>{job.client_notes}</p>
         </div>
       )}
+
+      <AddNote jobId={job.id} onSaved={onRefresh} />
 
       {/* [quote-attachments] Files the office attached on the source quote.
           Read-only here — techs see photos/PDFs the client sent or the


### PR DESCRIPTION
## End-of-day batch — three asks

### 1. Add KMA Property Management
Created fresh in Qleno (the office-role attempt hit "Forbidden") with its **7 properties**, idempotent in the Phes migration. Commercial, quoted per visit. 4846 W North Ave (two service sets in MaidCentral) dedups to one property.

### 2. Delete a job
- `DELETE /api/jobs/:id` (office/admin/owner), **logged to the audit trail**. Clears blocking child rows (clock entries, photos, add-ons, status logs…), detaches kept records (invoices/payroll/mileage), then deletes. Returns **409 "cancel it instead"** if a job has links that can't be safely removed.
- Red **"Delete job"** button on the dispatch job panel, with a confirm. (Made-up/test jobs like the Ava Martinez one.)

### 3. Add notes from mobile
- Prominent full-width **"+ Add note"** on every field (my-jobs) card — easy to find, 44px+ tap targets.
- New `POST /api/jobs/:id/note` **appends** a timestamped note server-side (never clobbers existing notes), so the office sees what the tech logged.

Note: the tech's added notes save to the job (office sees them); surfacing the running note history back on the field card is a small follow-up if you want it.

https://claude.ai/code/session_013KaJXnLShcWKZ8UBfBF2JC

---
_Generated by [Claude Code](https://claude.ai/code/session_013KaJXnLShcWKZ8UBfBF2JC)_