### PR TITLE
fix(dashboard): populate revenue KPIs + show all status cards on mobile

### DIFF
--- a/artifacts/api-server/src/routes/dashboard.ts
+++ b/artifacts/api-server/src/routes/dashboard.ts
@@ -400,45 +400,54 @@ router.get("/kpis", requireAuth, async (req, res) => {
       // Invoice sequence check
       invoiceHighId,
     ] = await Promise.all([
-      // Week revenue from job_history (authoritative historical billed revenue)
+      // Week revenue — from jobs (booked/realized). job_history is the legacy
+      // billed-history table and is empty for tenants that didn't import it
+      // (fresh-start tenants showed a blank "—"). Sum the period's
+      // non-cancelled jobs by billed_amount when invoiced, else base_fee.
       db.execute(sql`
-        SELECT COALESCE(SUM(revenue), 0)::numeric AS total
-        FROM job_history
+        SELECT COALESCE(SUM(COALESCE(billed_amount, base_fee, 0)), 0)::numeric AS total
+        FROM jobs
         WHERE company_id = ${companyId}
-          AND job_date >= ${weekStartStr}
-          AND job_date <= ${todayStr}
+          AND status != 'cancelled'
+          AND scheduled_date >= ${weekStartStr}
+          AND scheduled_date <= ${todayStr}
       `),
       // Previous week revenue (for delta calculation)
       db.execute(sql`
-        SELECT COALESCE(SUM(revenue), 0)::numeric AS total
-        FROM job_history
+        SELECT COALESCE(SUM(COALESCE(billed_amount, base_fee, 0)), 0)::numeric AS total
+        FROM jobs
         WHERE company_id = ${companyId}
-          AND job_date >= ${prevWeekStartStr}
-          AND job_date <= ${prevWeekEndStr}
+          AND status != 'cancelled'
+          AND scheduled_date >= ${prevWeekStartStr}
+          AND scheduled_date <= ${prevWeekEndStr}
       `),
       // This month revenue (MTD)
       db.execute(sql`
-        SELECT COALESCE(SUM(revenue), 0)::numeric AS total
-        FROM job_history
+        SELECT COALESCE(SUM(COALESCE(billed_amount, base_fee, 0)), 0)::numeric AS total
+        FROM jobs
         WHERE company_id = ${companyId}
-          AND job_date >= ${monthStartStr}
-          AND job_date <= ${todayStr}
+          AND status != 'cancelled'
+          AND scheduled_date >= ${monthStartStr}
+          AND scheduled_date <= ${todayStr}
       `),
       // Last month revenue (for delta calculation)
       db.execute(sql`
-        SELECT COALESCE(SUM(revenue), 0)::numeric AS total
-        FROM job_history
+        SELECT COALESCE(SUM(COALESCE(billed_amount, base_fee, 0)), 0)::numeric AS total
+        FROM jobs
         WHERE company_id = ${companyId}
-          AND job_date >= ${lastMonthStartStr}
-          AND job_date <= ${lastMonthEndStr}
+          AND status != 'cancelled'
+          AND scheduled_date >= ${lastMonthStartStr}
+          AND scheduled_date <= ${lastMonthEndStr}
       `),
-      // Avg bill — last 30 days
+      // Avg bill — last 30 days (exclude $0 jobs so the average is meaningful)
       db.execute(sql`
-        SELECT COALESCE(AVG(revenue), 0)::numeric AS avg_bill
-        FROM job_history
+        SELECT COALESCE(AVG(COALESCE(billed_amount, base_fee, 0)), 0)::numeric AS avg_bill
+        FROM jobs
         WHERE company_id = ${companyId}
-          AND job_date >= ${thirtyDaysAgoStr}
-          AND job_date <= ${todayStr}
+          AND status != 'cancelled'
+          AND COALESCE(billed_amount, base_fee, 0) > 0
+          AND scheduled_date >= ${thirtyDaysAgoStr}
+          AND scheduled_date <= ${todayStr}
       `),
       // Avg quality score (last 90 days)
       db.execute(sql`

--- a/artifacts/qleno/src/pages/dashboard.tsx
+++ b/artifacts/qleno/src/pages/dashboard.tsx
@@ -469,7 +469,7 @@ export default function Dashboard() {
         {/* ── STATUS CHIPS ─────────────────────────────────────── */}
         <div>
           <p style={{ fontSize: 11, fontWeight: 600, color: '#9E9B94', textTransform: 'uppercase', letterSpacing: '0.08em', margin: '0 0 10px', fontFamily: FF }}>Today's Status</p>
-          <div style={{ display: 'flex', gap: 12, overflowX: 'auto', paddingBottom: 4, scrollbarWidth: 'none' }}>
+          <div style={{ display: 'grid', gridTemplateColumns: isMobile ? 'repeat(3, 1fr)' : 'repeat(5, 1fr)', gap: isMobile ? 8 : 12 }}>
             {STATUS_CARDS.map(card => {
               const val = Number(counts[card.key] ?? 0);
               return (
@@ -697,20 +697,20 @@ function StatusChip({ label, value, bg, color, accentColor, onClick }: { label: 
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
       style={{
-        flexShrink: 0, minWidth: 130,
+        minWidth: 0, width: '100%',
         minHeight: 90,
         backgroundColor: bg,
         border: hovered ? '1px solid #5B9BD5' : '0.5px solid #E5E2DC',
         borderLeft: hasAccent ? `4px solid ${accentColor}` : (hovered ? '1px solid #5B9BD5' : '0.5px solid #E5E2DC'),
         borderRadius: hasAccent ? '0 12px 12px 0' : 12,
-        padding: hasAccent ? '20px 16px 20px 14px' : '20px 16px',
+        padding: hasAccent ? '18px 8px 18px 10px' : '18px 8px',
         cursor: 'pointer',
         display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center',
         fontFamily: FF, transition: 'border-color 0.15s',
       }}
     >
-      <p style={{ fontSize: 36, fontWeight: 600, color, margin: 0, lineHeight: 1, fontFamily: FF }}>{value}</p>
-      <p style={{ fontSize: 12, fontWeight: 500, color: '#4A4845', textTransform: 'uppercase', letterSpacing: '0.04em', margin: '8px 0 0', fontFamily: FF }}>{label}</p>
+      <p style={{ fontSize: 30, fontWeight: 600, color, margin: 0, lineHeight: 1, fontFamily: FF }}>{value}</p>
+      <p style={{ fontSize: 11, fontWeight: 500, color: '#4A4845', textTransform: 'uppercase', letterSpacing: '0.03em', margin: '6px 0 0', fontFamily: FF, textAlign: 'center', lineHeight: 1.15 }}>{label}</p>
     </button>
   );
 }


### PR DESCRIPTION
## Mobile dashboard: blank numbers + cut-off layout

Two problems from the phone dashboard.

### 1. Blank revenue numbers ("—")
**Revenue This Week, Monthly Revenue, Avg Bill** were all blank. They read from the legacy `job_history` table, which is **empty for Phes** (fresh start, nothing billed-to-history yet) — while the forecast and "Next 7 days" read the `jobs` table and showed real values. That's the mismatch.

**Fix:** these KPIs now sum the period's **non-cancelled jobs** (billed amount when invoiced, else base fee) from the `jobs` table — the same basis as the forecast — so they populate for any tenant, imported history or not.

### 2. Status cards cut off
"Today's Status" has **5** cards (In Progress, Scheduled, Complete, Flagged, Unassigned) at a fixed 130px width with horizontal scroll — on a phone only ~2 were visible and Flagged was clipped. **Fix:** a wrapping grid — **3-up on mobile, 5-up on desktop**, fluid chips — so all five are visible.

### Flagged for a separate fix
**"New Jobs Booked – this week = 773"** is an import artifact: it counts jobs by `created_at`, which equals the *import* date for every migrated job, so they all look "new this week." Fixing it right needs a real booking date — want me to tackle that next?

https://claude.ai/code/session_013KaJXnLShcWKZ8UBfBF2JC

---
_Generated by [Claude Code](https://claude.ai/code/session_013KaJXnLShcWKZ8UBfBF2JC)_