### PR TITLE
refactor(nav): fold Recurring into Customers (remove redundant menu)

### DIFF
--- a/artifacts/qleno/src/components/layout/app-sidebar.tsx
+++ b/artifacts/qleno/src/components/layout/app-sidebar.tsx
@@ -3,7 +3,7 @@ import {
   Briefcase, Users, UserCheck, FileText, DollarSign,
   BarChart2, TrendingUp, FileText as FileTextIcon,
   BookOpen, Settings, AlertTriangle, HeartPulse, Building2,
-  UserPlus, GraduationCap, RefreshCw,
+  UserPlus, GraduationCap,
 } from "lucide-react";
 import { Link, useLocation } from "wouter";
 import { useAuthStore } from "@/lib/auth";
@@ -57,7 +57,6 @@ const NAV_SECTIONS = [
       { title: "Jobs",      url: "/dispatch",  icon: Briefcase },
       { title: "Customers", url: "/customers", icon: Users },
       { title: "Accounts",  url: "/accounts",  icon: Building2, roles: ["owner", "admin", "office"] },
-      { title: "Recurring", url: "/recurring", icon: RefreshCw, roles: ["owner", "admin", "office"] },
     ],
   },
   {

--- a/artifacts/qleno/src/pages/customers.tsx
+++ b/artifacts/qleno/src/pages/customers.tsx
@@ -6,7 +6,7 @@ import { getAuthHeaders } from "@/lib/auth";
 import { useQuery, keepPreviousData } from "@tanstack/react-query";
 import { useBranch } from "@/contexts/branch-context";
 import { toast } from "sonner";
-import { Plus, Search, Phone, Mail, MapPin, Download, MessageSquare, UserPlus, ChevronDown, X, Loader2 } from "lucide-react";
+import { Plus, Search, Phone, Mail, MapPin, Download, MessageSquare, UserPlus, ChevronDown, X, Loader2, RefreshCw } from "lucide-react";
 
 const API = import.meta.env.BASE_URL.replace(/\/$/, "");
 
@@ -138,17 +138,28 @@ export default function CustomersPage() {
               {isLoading ? "Loading..." : `${total.toLocaleString()} total clients`}
             </p>
           </div>
-          <button
-            onClick={() => {
-              if (activeBranchId === "all") { toast({ title: "Select a location first", description: "Choose Oak Lawn or Schaumburg to add a client.", variant: "destructive" }); return; }
-              navigate("/customers/new");
-            }}
-            title={activeBranchId === "all" ? "Select a location to add clients" : undefined}
-            style={{ display: "flex", alignItems: "center", gap: "8px", padding: "8px 16px", backgroundColor: activeBranchId === "all" ? "#9E9B94" : "var(--brand)", color: "#FFFFFF", borderRadius: "8px", fontSize: "13px", fontWeight: 600, border: "none", cursor: activeBranchId === "all" ? "not-allowed" : "pointer", opacity: activeBranchId === "all" ? 0.7 : 1 }}
-          >
-            <Plus size={14} strokeWidth={2} /> Add Client
-            {activeBranchId !== "all" && <kbd style={{ fontSize: 10, border: '1px solid rgba(255,255,255,0.45)', borderRadius: 3, padding: '1px 5px', color: 'rgba(255,255,255,0.8)', fontFamily: 'inherit' }}>⇧C</kbd>}
-          </button>
+          <div style={{ display: "flex", gap: "8px", flexWrap: "wrap" }}>
+            {/* Recurring schedules live here (under Customers) rather than a
+                separate top-level menu — manage the bulk recurring times from
+                the same place you manage clients. */}
+            <button
+              onClick={() => navigate("/recurring")}
+              style={{ display: "flex", alignItems: "center", gap: "8px", padding: "8px 16px", backgroundColor: "#FFFFFF", color: "#1A1917", borderRadius: "8px", fontSize: "13px", fontWeight: 600, border: "1px solid #E5E2DC", cursor: "pointer" }}
+            >
+              <RefreshCw size={14} strokeWidth={2} /> Recurring schedules
+            </button>
+            <button
+              onClick={() => {
+                if (activeBranchId === "all") { toast({ title: "Select a location first", description: "Choose Oak Lawn or Schaumburg to add a client.", variant: "destructive" }); return; }
+                navigate("/customers/new");
+              }}
+              title={activeBranchId === "all" ? "Select a location to add clients" : undefined}
+              style={{ display: "flex", alignItems: "center", gap: "8px", padding: "8px 16px", backgroundColor: activeBranchId === "all" ? "#9E9B94" : "var(--brand)", color: "#FFFFFF", borderRadius: "8px", fontSize: "13px", fontWeight: 600, border: "none", cursor: activeBranchId === "all" ? "not-allowed" : "pointer", opacity: activeBranchId === "all" ? 0.7 : 1 }}
+            >
+              <Plus size={14} strokeWidth={2} /> Add Client
+              {activeBranchId !== "all" && <kbd style={{ fontSize: 10, border: '1px solid rgba(255,255,255,0.45)', borderRadius: 3, padding: '1px 5px', color: 'rgba(255,255,255,0.8)', fontFamily: 'inherit' }}>⇧C</kbd>}
+            </button>
+          </div>
         </div>
 
         {/* Filter Bar */}


### PR DESCRIPTION
## Remove the redundant "Recurring" top-level menu

You're right — **Customers** and a separate **Recurring** menu is redundant.

- Removed the **Recurring** item from the sidebar.
- The bulk recurring-schedule tool is now reached via a **"Recurring schedules"** button on the **Customers** page header — right where the frequency filters (All Freq / Weekly / Bi-weekly / …) already live.
- The `/recurring` route itself stays (still bookmarkable), it's just no longer its own menu entry.

So everything recurring is managed from Customers now. If you'd rather it be a *filter chip* on the customers list (e.g. a "Recurring" view inline) instead of a button, say the word and I'll wire it that way.

https://claude.ai/code/session_013KaJXnLShcWKZ8UBfBF2JC

---
_Generated by [Claude Code](https://claude.ai/code/session_013KaJXnLShcWKZ8UBfBF2JC)_