### PR TITLE
feat(earnings): real-time wage/commission tracking (office + techs)

### DIFF
--- a/artifacts/qleno/src/components/earnings-panel.tsx
+++ b/artifacts/qleno/src/components/earnings-panel.tsx
@@ -1,0 +1,170 @@
+import { useEffect, useMemo, useState } from "react";
+import { DollarSign, Clock, TrendingUp } from "lucide-react";
+import { getAuthHeaders } from "@/lib/auth";
+
+const API = import.meta.env.BASE_URL.replace(/\/$/, "");
+
+// Real-time earnings view. Office opens it on an employee's profile (pass
+// userId); a tech opens it for themselves (omit userId — the server scopes a
+// technician to their own data). Shows commission earned so far for the period,
+// hours, tips/extra, and a day-by-day job list. Qleno-native design — not a
+// copy of any other tool's layout.
+
+type JobRow = {
+  job_id: number; date: string; client: string; scope: string | null;
+  commission: number; hrs_worked: number; hrs_scheduled: number;
+  effective_rate: number | null; commission_basis?: string | null;
+};
+type EmpEarnings = {
+  user_id: number; name: string; jobs: JobRow[];
+  additional_pay: Record<string, number>;
+  totals: { job_count: number; job_total: number; commission: number; hrs_scheduled: number; hrs_worked: number };
+};
+
+function ymd(d: Date) { return d.toISOString().slice(0, 10); }
+function thisWeek() {
+  const t = new Date();
+  const start = new Date(t); start.setDate(t.getDate() - t.getDay());
+  const end = new Date(start); end.setDate(start.getDate() + 6);
+  return { start: ymd(start), end: ymd(end) };
+}
+function lastWeek() {
+  const t = new Date();
+  const start = new Date(t); start.setDate(t.getDate() - t.getDay() - 7);
+  const end = new Date(start); end.setDate(start.getDate() + 6);
+  return { start: ymd(start), end: ymd(end) };
+}
+function thisMonth() {
+  const t = new Date();
+  return { start: ymd(new Date(t.getFullYear(), t.getMonth(), 1)), end: ymd(t) };
+}
+const money = (n: number) => `$${(n || 0).toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+const fmtScope = (s: string | null) => (s ? s.split("_").map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(" ") : "—");
+const fmtDay = (d: string) => new Date(d + "T12:00:00").toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric" });
+
+export function EarningsPanel({ userId, title = "Earnings" }: { userId?: number; title?: string }) {
+  const [period, setPeriod] = useState(thisWeek());
+  const [preset, setPreset] = useState<"this" | "last" | "month" | "custom">("this");
+  const [data, setData] = useState<EmpEarnings | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    const uq = userId ? `&user_id=${userId}` : "";
+    fetch(`${API}/api/payroll/detail?pay_period_start=${period.start}&pay_period_end=${period.end}${uq}`, { headers: getAuthHeaders() })
+      .then(r => r.ok ? r.json() : null)
+      .then(d => { if (!cancelled) setData((d?.data && d.data[0]) || null); })
+      .catch(() => { if (!cancelled) setData(null); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [userId, period.start, period.end]);
+
+  const tips = useMemo(() => Object.values(data?.additional_pay || {}).reduce((s, v) => s + v, 0), [data]);
+  const commission = data?.totals?.commission ?? 0;
+  const earned = commission + tips;
+  const hours = data?.totals?.hrs_worked ?? 0;
+
+  const byDay = useMemo(() => {
+    const m: Record<string, JobRow[]> = {};
+    for (const j of data?.jobs || []) (m[j.date] ||= []).push(j);
+    return Object.entries(m).sort((a, b) => b[0].localeCompare(a[0]));
+  }, [data]);
+
+  function applyPreset(p: "this" | "last" | "month") {
+    setPreset(p);
+    setPeriod(p === "this" ? thisWeek() : p === "last" ? lastWeek() : thisMonth());
+  }
+  const presetBtn = (active: boolean): React.CSSProperties => ({
+    padding: "6px 12px", borderRadius: 8, fontSize: 12, fontWeight: 600, fontFamily: "inherit", cursor: "pointer",
+    border: `1px solid ${active ? "var(--brand, #00C9A0)" : "#E5E2DC"}`,
+    background: active ? "rgba(0,201,160,0.08)" : "#fff",
+    color: active ? "var(--brand, #00C9A0)" : "#1A1917",
+  });
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+      {/* Period controls */}
+      <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+        <span style={{ fontSize: 13, fontWeight: 700, color: "#1A1917" }}>{title}</span>
+        <div style={{ flex: 1 }} />
+        <button style={presetBtn(preset === "this")} onClick={() => applyPreset("this")}>This week</button>
+        <button style={presetBtn(preset === "last")} onClick={() => applyPreset("last")}>Last week</button>
+        <button style={presetBtn(preset === "month")} onClick={() => applyPreset("month")}>This month</button>
+        <input type="date" value={period.start} onChange={e => { setPreset("custom"); setPeriod(p => ({ ...p, start: e.target.value })); }}
+          style={{ padding: "5px 8px", border: "1px solid #E5E2DC", borderRadius: 8, fontSize: 12, fontFamily: "inherit" }} />
+        <span style={{ color: "#9E9B94", fontSize: 12 }}>to</span>
+        <input type="date" value={period.end} onChange={e => { setPreset("custom"); setPeriod(p => ({ ...p, end: e.target.value })); }}
+          style={{ padding: "5px 8px", border: "1px solid #E5E2DC", borderRadius: 8, fontSize: 12, fontFamily: "inherit" }} />
+      </div>
+
+      {/* Summary */}
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(150px, 1fr))", gap: 10 }}>
+        <SummaryCard icon={<TrendingUp size={14} />} label="Commission earned" value={money(commission)} accent />
+        <SummaryCard icon={<Clock size={14} />} label="Hours worked" value={`${hours.toFixed(1)} hrs`} />
+        <SummaryCard icon={<DollarSign size={14} />} label="Tips & extra" value={money(tips)} />
+        <SummaryCard icon={<DollarSign size={14} />} label="Total earned" value={money(earned)} strong />
+      </div>
+
+      {/* Additional pay broken out by type — tips, sick pay paid out, bonuses,
+          holiday, employee-of-the-month, reimbursements, etc. */}
+      {Object.keys(data?.additional_pay || {}).length > 0 && (
+        <div style={{ background: "#fff", border: "1px solid #E5E2DC", borderRadius: 12, padding: "12px 14px" }}>
+          <p style={{ fontSize: 11, fontWeight: 700, color: "#6B7280", textTransform: "uppercase", letterSpacing: "0.05em", margin: "0 0 8px" }}>Tips, bonuses & extra pay</p>
+          <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+            {Object.entries(data!.additional_pay).sort((a, b) => b[1] - a[1]).map(([type, amt]) => (
+              <div key={type} style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+                <span style={{ fontSize: 13, color: "#1A1917" }}>{fmtScope(type)}</span>
+                <span style={{ fontSize: 13, fontWeight: 700, color: amt < 0 ? "#DC2626" : "#1A1917" }}>{money(amt)}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Day-by-day */}
+      <div style={{ background: "#fff", border: "1px solid #E5E2DC", borderRadius: 12, overflow: "hidden" }}>
+        {loading ? (
+          <p style={{ padding: 20, textAlign: "center", color: "#9E9B94", fontSize: 13, margin: 0 }}>Loading…</p>
+        ) : byDay.length === 0 ? (
+          <p style={{ padding: 20, textAlign: "center", color: "#9E9B94", fontSize: 13, margin: 0 }}>No completed jobs in this period yet.</p>
+        ) : byDay.map(([day, jobs]) => {
+          const dayTotal = jobs.reduce((s, j) => s + j.commission, 0);
+          const dayHrs = jobs.reduce((s, j) => s + j.hrs_worked, 0);
+          return (
+            <div key={day} style={{ borderBottom: "1px solid #F3F4F6" }}>
+              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", padding: "10px 14px", background: "#FAFAF8" }}>
+                <span style={{ fontSize: 12, fontWeight: 700, color: "#1A1917" }}>{fmtDay(day)}</span>
+                <span style={{ fontSize: 12, fontWeight: 700, color: "var(--brand, #00C9A0)" }}>{money(dayTotal)} <span style={{ color: "#9E9B94", fontWeight: 500 }}>· {dayHrs.toFixed(1)}h</span></span>
+              </div>
+              {jobs.map(j => (
+                <div key={j.job_id} style={{ display: "flex", justifyContent: "space-between", alignItems: "center", padding: "8px 14px", borderTop: "1px solid #F7F6F3" }}>
+                  <div style={{ minWidth: 0 }}>
+                    <p style={{ fontSize: 12, fontWeight: 600, color: "#1A1917", margin: 0 }}>{j.client || "—"}</p>
+                    <p style={{ fontSize: 11, color: "#9E9B94", margin: "1px 0 0" }}>
+                      {fmtScope(j.scope)} · {j.hrs_worked > 0 ? `${j.hrs_worked.toFixed(1)}h` : `${j.hrs_scheduled.toFixed(1)}h est`}
+                      {j.commission_basis === "commercial_hourly" ? " · hourly" : ""}
+                    </p>
+                  </div>
+                  <span style={{ fontSize: 13, fontWeight: 700, color: "#1A1917", flexShrink: 0 }}>{money(j.commission)}</span>
+                </div>
+              ))}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function SummaryCard({ icon, label, value, accent, strong }: { icon: React.ReactNode; label: string; value: string; accent?: boolean; strong?: boolean }) {
+  return (
+    <div style={{ background: "#fff", border: `1px solid ${accent ? "#99E6D5" : "#E5E2DC"}`, borderRadius: 12, padding: "12px 14px" }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 6, color: accent ? "var(--brand, #00C9A0)" : "#6B7280", marginBottom: 6 }}>
+        {icon}
+        <span style={{ fontSize: 10, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.05em" }}>{label}</span>
+      </div>
+      <p style={{ fontSize: strong ? 22 : 20, fontWeight: 700, color: "#1A1917", margin: 0, lineHeight: 1 }}>{value}</p>
+    </div>
+  );
+}

--- a/artifacts/qleno/src/pages/employee-profile.tsx
+++ b/artifacts/qleno/src/pages/employee-profile.tsx
@@ -10,6 +10,7 @@ import {
   Ban, ChevronDown, ChevronUp, DollarSign, Clock, TrendingUp, Download, Users,
 } from "lucide-react";
 import { useEmployeeView } from "@/contexts/employee-view-context";
+import { EarningsPanel } from "@/components/earnings-panel";
 import { HRAttendanceTab, LeaveBalanceTab, DisciplineTab, QualityTab } from "./employee-profile-hr-tabs";
 
 const API = import.meta.env.BASE_URL.replace(/\/$/, "");
@@ -59,7 +60,7 @@ const SCORE_BGS   = ['', '#FEE2E2', '#FEF3C7', '#DBEAFE', '#DCFCE7'];
 const DAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
 const DAY_IDX: Record<string, number> = { Mon:0,Tue:1,Wed:2,Thu:3,Fri:4,Sat:5,Sun:6 };
 const TABS = [
-  'Information','Tags & Skills','Attendance','Availability',
+  'Information','Earnings','Tags & Skills','Attendance','Availability',
   'User Account','Contacts','Scorecards','Pay Configuration','Additional Pay',
   'Payroll History',
   'Contact Tickets','Jobs','Notes','Incentives',
@@ -844,6 +845,11 @@ export default function EmployeeProfilePage() {
 
         {/* ── TAB CONTENT ── */}
         <div style={{ marginBottom:40 }}>
+
+          {/* ── EARNINGS TAB ── (real-time commission/pay for the period) */}
+          {activeTab === 'Earnings' && (
+            <EarningsPanel userId={userId} />
+          )}
 
           {/* ── INFORMATION TAB ── */}
           {activeTab === 'Information' && (

--- a/artifacts/qleno/src/pages/my-jobs.tsx
+++ b/artifacts/qleno/src/pages/my-jobs.tsx
@@ -2,8 +2,9 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAuthStore, getTokenRole } from "@/lib/auth";
 import { InlinePriceEdit } from "@/components/inline-price-edit";
+import { EarningsPanel } from "@/components/earnings-panel";
 import { useToast } from "@/hooks/use-toast";
-import { Car, X, Check, Eye, Navigation, Phone, GraduationCap } from "lucide-react";
+import { Car, X, Check, Eye, Navigation, Phone, GraduationCap, DollarSign } from "lucide-react";
 import { Link } from "wouter";
 import { useEmployeeView } from "@/contexts/employee-view-context";
 import { getJobVisualStatus, STATUS_VISUALS, ensureJobStatusStyles } from "@/lib/job-status";
@@ -825,6 +826,7 @@ export default function MyJobsPage() {
   const qc = useQueryClient();
   const [empPos, setEmpPos] = useState<{ lat: number; lng: number } | null>(null);
   const [showMileage, setShowMileage] = useState(false);
+  const [showPay, setShowPay] = useState(false);
 
   let userInfo: { firstName: string; lastName: string } | null = null;
   if (token) {
@@ -890,6 +892,10 @@ export default function MyJobsPage() {
                 <GraduationCap size={13}/> Training
               </a>
             </Link>
+            <button onClick={() => setShowPay(p => !p)}
+              style={{ display: 'flex', alignItems: 'center', gap: 4, padding: '6px 10px', background: showPay ? 'var(--brand)' : 'var(--brand-dim)', color: showPay ? '#fff' : 'var(--brand)', border: '1px solid rgba(0,201,160,0.2)', borderRadius: 8, fontSize: 12, fontWeight: 700, cursor: 'pointer', fontFamily: 'inherit' }}>
+              <DollarSign size={13}/> Pay
+            </button>
             <button onClick={() => setShowMileage(true)}
               style={{ display: 'flex', alignItems: 'center', gap: 4, padding: '6px 10px', background: 'var(--brand-dim)', color: 'var(--brand)', border: '1px solid rgba(0,201,160,0.2)', borderRadius: 8, fontSize: 12, fontWeight: 700, cursor: 'pointer', fontFamily: 'inherit' }}>
               <Car size={13}/> Mileage
@@ -910,6 +916,12 @@ export default function MyJobsPage() {
               style={{ fontSize: 12, fontWeight: 700, color: "var(--brand, #00C9A0)", background: "#fff", border: "none", borderRadius: 6, padding: "4px 10px", cursor: "pointer", fontFamily: "inherit" }}>
               Exit
             </button>
+          </div>
+        )}
+
+        {showPay && (
+          <div style={{ padding: "16px 14px", borderBottom: "1px solid #E5E2DC", background: "#FBFAF8" }}>
+            <EarningsPanel title="My pay" />
           </div>
         )}
 


### PR DESCRIPTION
## Real-time earnings — for the office *and* the tech

You needed to open an employee (e.g. Alejandra) and see how much commission she's earned so far — and the tech couldn't see their own either. This adds that, as a **Qleno-native "Earnings" view** (our own design and naming — deliberately *not* a copy of MaidCentral's layout).

**New `EarningsPanel`:**
- Period presets (This week / Last week / This month / custom).
- Summary: **Commission earned**, **Hours worked**, **Total earned**.
- **Tips, bonuses & extra pay broken out by type** — tips, sick pay paid out, holiday, bonuses, employee-of-the-month, reimbursements — and rolled into Total earned.
- Clean **day-by-day** job list with daily subtotals.

**Where it shows:**
- **Office** → a new **"Earnings"** tab on the employee profile (uses the existing `payroll/detail` endpoint with `user_id`).
- **Tech** → a **"Pay"** toggle in the field view (my-jobs) showing *their own* pay so far. The endpoint already scopes a technician to their own data, so no new endpoint and no data leak.

It reads the same data the payroll engine uses (completed jobs through the commission rules + additional pay), so it's consistent with payroll.

https://claude.ai/code/session_013KaJXnLShcWKZ8UBfBF2JC

---
_Generated by [Claude Code](https://claude.ai/code/session_013KaJXnLShcWKZ8UBfBF2JC)_