### PR TITLE
Dispatch + accounts: delete-escalation, expandable properties, June fill

### DIFF
--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -2477,6 +2477,34 @@ async function runKmaAccountSetup(): Promise<void> {
   console.log(`[kma-setup] Account ${acctId} ensured; inserted ${inserted} properties (roster ${ROSTER.length}).`);
 }
 
+// One-time June fill: the recurring engine only generates forward from when a
+// schedule is saved, so schedules set up on/after Jun 3 left Jun 1-2 empty and
+// the dashboard showed $0 for those days. This generates each active schedule's
+// visits back to Jun 1, 2026. Idempotent — the engine dedupes on
+// (recurring_schedule_id, scheduled_date), so it won't duplicate days that
+// already have jobs and is safe to re-run on every cold start.
+async function runJuneRecurringFill(): Promise<void> {
+  const { generateJobsFromSchedule, DAYS_AHEAD } = await import("./lib/recurring-jobs.js");
+  const from = new Date("2026-06-01T00:00:00");
+  const horizon = new Date();
+  horizon.setDate(horizon.getDate() + DAYS_AHEAD);
+  const scheds = await db.execute(sql`
+    SELECT * FROM recurring_schedules WHERE company_id = ${PHES} AND is_active = true
+  `);
+  let created = 0;
+  for (const s of scheds.rows as any[]) {
+    try {
+      const cl = await db.execute(sql`SELECT zip FROM clients WHERE id = ${s.customer_id} LIMIT 1`);
+      const zip = (cl.rows[0] as any)?.zip ?? null;
+      const gen = await generateJobsFromSchedule(s as any, from, horizon, null, zip);
+      created += gen.created;
+    } catch (err: any) {
+      console.warn("[june-fill] schedule", s.id, "—", err?.message ?? err);
+    }
+  }
+  console.log(`[june-fill] generated ${created} job(s) from Jun 1 across ${scheds.rows.length} schedules.`);
+}
+
 export async function runPhesDataMigration(): Promise<void> {
   await runBookingSchemaGuard();
 
@@ -2592,6 +2620,12 @@ export async function runPhesDataMigration(): Promise<void> {
     await runKmaAccountSetup();
   } catch (err: any) {
     console.warn("[phes-migration] kma-account-setup — non-fatal:", err?.message ?? err);
+  }
+
+  try {
+    await runJuneRecurringFill();
+  } catch (err: any) {
+    console.warn("[phes-migration] june-recurring-fill — non-fatal:", err?.message ?? err);
   }
 
   try {

--- a/artifacts/qleno/src/pages/account-detail.tsx
+++ b/artifacts/qleno/src/pages/account-detail.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { useParams, Link } from "wouter";
 import {
-  Building2, ChevronLeft, Plus, Pencil, Trash2, DollarSign,
+  Building2, ChevronLeft, ChevronDown, Plus, Pencil, Trash2, DollarSign,
   MapPin, Users, Phone, Mail, Star, Bell, BellOff, Briefcase,
   TrendingUp, AlertCircle, CheckCircle2, Clock, FileText,
   CreditCard, Home, Hash,
@@ -113,6 +113,9 @@ export default function AccountDetailPage() {
   const [jobs, setJobs] = useState<any[]>([]);
   const [upcoming, setUpcoming] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
+  // Expandable property cards — click to drop down details + last service.
+  const [expandedProp, setExpandedProp] = useState<number | null>(null);
+  const [propRecent, setPropRecent] = useState<Record<number, any>>({});
   const [tab, setTab] = useState<Tab>("overview");
 
   // Rate card
@@ -262,6 +265,20 @@ export default function AccountDetailPage() {
     if (!confirm("Remove this property?")) return;
     await fetch(`${API}/api/accounts/${id}/properties/${propId}`, { method: "DELETE", headers: getAuthHeaders() });
     load();
+  }
+
+  // Tap a property card to drop down its full details + last service. The
+  // last-service lookup is lazy and cached so we only hit the API the first
+  // time a card is opened.
+  function toggleProp(propId: number) {
+    setExpandedProp((cur) => (cur === propId ? null : propId));
+    if (propRecent[propId] === undefined) {
+      setPropRecent((m) => ({ ...m, [propId]: "loading" }));
+      fetch(`${API}/api/accounts/${id}/properties/${propId}/recent-job`, { headers: getAuthHeaders() })
+        .then((r) => (r.ok ? r.json() : null))
+        .then((job) => setPropRecent((m) => ({ ...m, [propId]: job ?? "none" })))
+        .catch(() => setPropRecent((m) => ({ ...m, [propId]: "none" })));
+    }
   }
 
   // ─── Contacts ────────────────────────────────────────────────────────────
@@ -557,9 +574,18 @@ export default function AccountDetailPage() {
               </div>
             ) : (
               <div className="space-y-2">
-                {account.properties.map((p: any) => (
-                  <div key={p.id} className="bg-white border border-gray-100 rounded-xl p-4">
-                    <div className="flex items-start justify-between">
+                {account.properties.map((p: any) => {
+                  const open = expandedProp === p.id;
+                  const recent = propRecent[p.id];
+                  return (
+                  <div key={p.id} className="bg-white border border-gray-100 rounded-xl overflow-hidden">
+                    <div
+                      role="button"
+                      tabIndex={0}
+                      onClick={() => toggleProp(p.id)}
+                      onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); toggleProp(p.id); } }}
+                      className="flex items-start justify-between p-4 cursor-pointer hover:bg-gray-50/60 transition-colors"
+                    >
                       <div className="flex items-start gap-3">
                         <div className="w-8 h-8 rounded-lg bg-purple-50 flex items-center justify-center flex-shrink-0 mt-0.5">
                           <Home size={14} className="text-purple-600" />
@@ -590,16 +616,70 @@ export default function AccountDetailPage() {
                         </div>
                       </div>
                       <div className="flex items-center gap-1">
-                        <Button variant="ghost" size="icon" className="h-7 w-7" onClick={() => openEditProperty(p)}>
+                        <Button variant="ghost" size="icon" className="h-7 w-7" onClick={(e) => { e.stopPropagation(); openEditProperty(p); }}>
                           <Pencil size={13} className="text-gray-400" />
                         </Button>
-                        <Button variant="ghost" size="icon" className="h-7 w-7" onClick={() => deleteProperty(p.id)}>
+                        <Button variant="ghost" size="icon" className="h-7 w-7" onClick={(e) => { e.stopPropagation(); deleteProperty(p.id); }}>
                           <Trash2 size={13} className="text-red-400" />
                         </Button>
+                        <ChevronDown size={16} className={`text-gray-400 transition-transform ${open ? "rotate-180" : ""}`} />
                       </div>
                     </div>
+
+                    {open && (
+                      <div className="border-t border-gray-100 bg-gray-50/40 px-4 py-3 space-y-3">
+                        <div className="grid grid-cols-2 gap-x-4 gap-y-2.5">
+                          <Detail label="Property type" value={p.property_type ? (PROPERTY_TYPES.find((t) => t.value === p.property_type)?.label ?? p.property_type) : "—"} />
+                          <Detail label="Units" value={p.unit_count ? `${p.unit_count}` : "—"} />
+                          <Detail
+                            label="Default service"
+                            value={p.default_service_type ? (SERVICE_TYPES.find((s) => s.value === p.default_service_type)?.label ?? p.default_service_type) : "—"}
+                          />
+                          <Detail label="Zone" value={p.zone_name ?? (p.zone_id ? `Zone ${p.zone_id}` : "—")} />
+                          {(p.lat != null && p.lng != null) && (
+                            <Detail label="Map location" value={`${Number(p.lat).toFixed(5)}, ${Number(p.lng).toFixed(5)}`} />
+                          )}
+                        </div>
+
+                        {p.notes && (
+                          <div>
+                            <p className="text-[10px] font-semibold text-gray-400 uppercase tracking-wider mb-1">Notes</p>
+                            <p className="text-xs text-gray-700 whitespace-pre-wrap">{p.notes}</p>
+                          </div>
+                        )}
+
+                        <div>
+                          <p className="text-[10px] font-semibold text-gray-400 uppercase tracking-wider mb-1">Last service</p>
+                          {recent === undefined || recent === "loading" ? (
+                            <p className="text-xs text-gray-400">Loading…</p>
+                          ) : recent && recent !== "none" ? (
+                            <div className="flex items-center justify-between bg-white border border-gray-100 rounded-lg px-3 py-2">
+                              <div>
+                                <p className="text-xs font-medium text-[#0A0E1A]">
+                                  {SERVICE_TYPES.find((s) => s.value === recent.service_type)?.label ?? recent.service_type}
+                                </p>
+                                <p className="text-[11px] text-gray-500 mt-0.5">
+                                  {recent.scheduled_date ? new Date(recent.scheduled_date + "T12:00:00").toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" }) : "—"}
+                                  {recent.frequency && recent.frequency !== "one_time" ? ` · ${recent.frequency}` : ""}
+                                </p>
+                              </div>
+                              <span className="text-xs font-semibold text-[#00C9A0]">
+                                {recent.billing_method === "hourly" && recent.hourly_rate
+                                  ? `${fmtDecimal(parseFloat(recent.hourly_rate))}/hr`
+                                  : recent.base_fee != null
+                                  ? fmtDecimal(parseFloat(recent.base_fee))
+                                  : "—"}
+                              </span>
+                            </div>
+                          ) : (
+                            <p className="text-xs text-gray-400">No service history yet</p>
+                          )}
+                        </div>
+                      </div>
+                    )}
                   </div>
-                ))}
+                  );
+                })}
               </div>
             )}
           </div>
@@ -1019,5 +1099,15 @@ export default function AccountDetailPage() {
         </DialogContent>
       </Dialog>
     </DashboardLayout>
+  );
+}
+
+// Small label/value pair used in the expanded property card.
+function Detail({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <p className="text-[10px] font-semibold text-gray-400 uppercase tracking-wider">{label}</p>
+      <p className="text-xs text-[#0A0E1A] mt-0.5">{value}</p>
+    </div>
   );
 }

--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -1658,8 +1658,18 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
                 onClick={async () => {
                   if (!window.confirm("Delete this job? It's removed from the schedule and recorded in the audit log.")) return;
                   try {
-                    const r = await fetch(`${_API3}/api/jobs/${job.id}`, { method: "DELETE", headers: { Authorization: `Bearer ${token}` } });
-                    const d = await r.json().catch(() => ({}));
+                    let r = await fetch(`${_API3}/api/jobs/${job.id}`, { method: "DELETE", headers: { Authorization: `Bearer ${token}` } });
+                    let d = await r.json().catch(() => ({}));
+                    // A completed job (or one with clock-in / add-on / payment history)
+                    // can't be removed by a plain delete — child rows block it. The
+                    // server's force path cleans those up first. Owner/admin can
+                    // escalate after a second, clearer confirm.
+                    if (!r.ok && canCharge) {
+                      if (window.confirm("This job has clock-in, completion, or billing history. Remove the job and clear that history too?")) {
+                        r = await fetch(`${_API3}/api/jobs/${job.id}?force=true`, { method: "DELETE", headers: { Authorization: `Bearer ${token}` } });
+                        d = await r.json().catch(() => ({}));
+                      }
+                    }
                     if (!r.ok) { toast({ title: "Couldn't delete", description: d.message || d.error || `HTTP ${r.status}` }); return; }
                     toast({ title: "Job deleted" });
                     onClose();


### PR DESCRIPTION
Three changes on this branch:

### 1. Delete a job that won't delete (the Ava Martinez case)
A completed or recurring job that has clock-in, add-on, or billing history can't be removed by a plain delete — child rows block it and the server returns an error, so the button just said "Couldn't delete." Owner/admin now get a second, clearer confirm ("This job has clock-in, completion, or billing history. Remove it and clear that history too?") and the delete retries with `?force=true`, which the server already supports (it cleans up clock entries / add-ons and detaches billing references first).

### 2. Expandable property cards (account Properties tab)
Tap a property card to drop it down and show the full details — property type, units, default service, zone, map location, and notes — plus the most recent service at that property. The last-service lookup is lazy (only fetched the first time a card is opened) and cached. Edit/delete buttons no longer toggle the card.

### 3. One-time June fill (generate from Jun 1)
The recurring engine only generates **forward** from when a schedule is saved. The schedules were set up around Jun 3, so Jun 1 and Jun 2 never got their jobs and the forecast showed $0 for those days. A one-time `runJuneRecurringFill()` generates each active recurring schedule's visits back to Jun 1, 2026. Idempotent — the engine dedupes on `(recurring_schedule_id, scheduled_date)`, so it won't duplicate days that already have jobs and is safe to re-run on cold start.

https://claude.ai/code/session_013KaJXnLShcWKZ8UBfBF2JC

---
_Generated by [Claude Code](https://claude.ai/code/session_013KaJXnLShcWKZ8UBfBF2JC)_