### PR TITLE
fix(address): Places autocomplete attaches reliably in the New Customer modal

### DIFF
--- a/artifacts/qleno/src/hooks/use-address-autocomplete.ts
+++ b/artifacts/qleno/src/hooks/use-address-autocomplete.ts
@@ -11,8 +11,10 @@ export type AddressParts = { street: string; city: string; state: string; zip: s
 // runtime config endpoint (Railway env) with the build-time var as fallback.
 let mapsLoadPromise: Promise<boolean> | null = null;
 
+const ready = () => !!(window as any).google?.maps?.places?.Autocomplete;
+
 function loadGoogleMaps(): Promise<boolean> {
-  if ((window as any).google?.maps?.places) return Promise.resolve(true);
+  if (ready()) return Promise.resolve(true);
   if (mapsLoadPromise) return mapsLoadPromise;
   mapsLoadPromise = (async () => {
     let key = "";
@@ -21,24 +23,30 @@ function loadGoogleMaps(): Promise<boolean> {
       if (r.ok) { const b = await r.json().catch(() => ({})); key = String((b as any)?.key ?? ""); }
     } catch { /* fall through to build-time key */ }
     if (!key) key = (import.meta as any).env?.VITE_GOOGLE_MAPS_API_KEY ?? "";
-    if (!key) return false;
-    if ((window as any).google?.maps?.places) return true;
-    return await new Promise<boolean>((resolve) => {
-      const id = "gmap-places-script";
-      const existing = document.getElementById(id) as HTMLScriptElement | null;
-      if (existing) {
-        existing.addEventListener("load", () => resolve(true));
-        if ((window as any).google?.maps?.places) resolve(true);
-        return;
-      }
+    // No key configured — don't cache the failure so a later call (after the
+    // env is fixed) can retry instead of being stuck on a poisoned promise.
+    if (!key) { mapsLoadPromise = null; return false; }
+
+    // Inject the script once. Another page may have already added it (same id),
+    // in which case we just wait for the library to come online below — we do
+    // NOT rely on catching its load event, which may have already fired.
+    const id = "gmap-places-script";
+    if (!document.getElementById(id)) {
       const s = document.createElement("script");
       s.id = id;
       s.src = `https://maps.googleapis.com/maps/api/js?key=${key}&libraries=places`;
       s.async = true; s.defer = true;
-      s.onload = () => resolve(true);
-      s.onerror = () => resolve(false);
       document.head.appendChild(s);
-    });
+    }
+
+    // Poll for readiness regardless of who injected the script. ~10s ceiling.
+    for (let i = 0; i < 100; i++) {
+      if (ready()) return true;
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    // Timed out — clear the cache so a future attempt can try again.
+    mapsLoadPromise = null;
+    return false;
   })();
   return mapsLoadPromise;
 }
@@ -59,10 +67,19 @@ export function useAddressAutocomplete(
     let listener: any = null;
     let cancelled = false;
 
-    loadGoogleMaps().then(ok => {
-      if (!ok || cancelled || !inputRef.current) return;
+    (async () => {
+      const ok = await loadGoogleMaps();
+      if (!ok || cancelled) return;
       const g = (window as any).google;
       if (!g?.maps?.places?.Autocomplete) return;
+      // The input often mounts a render after `enabled` flips true (e.g. the
+      // wizard's New Customer form opens, then the address field appears). Wait
+      // briefly for the ref instead of bailing — this was the silent failure
+      // where autocomplete never attached inside the modal.
+      for (let i = 0; i < 40 && !inputRef.current && !cancelled; i++) {
+        await new Promise((r) => setTimeout(r, 50));
+      }
+      if (cancelled || !inputRef.current) return;
       ac = new g.maps.places.Autocomplete(inputRef.current, {
         componentRestrictions: { country: "us" },
         fields: ["address_components", "formatted_address"],
@@ -81,7 +98,7 @@ export function useAddressAutocomplete(
         const zip = get("postal_code");
         cb.current({ street, city, state, zip, formatted: place.formatted_address ?? "" });
       });
-    });
+    })();
 
     return () => { cancelled = true; listener?.remove?.(); };
   }, [enabled, inputRef]);


### PR DESCRIPTION
## Address autocomplete didn't work when adding a new customer from Jobs

Maribel reported no address suggestions in the "Create New Job → New Customer" form. The shared autocomplete hook was wired correctly, but had two timing/caching fragilities that left it un-attached:

1. **Input mounts a beat late.** The hook bailed if the input ref wasn't set the instant Google Maps resolved — but the wizard renders the address field a render *after* the New Customer form opens. It now waits briefly for the input to mount before attaching.
2. **Failures got cached / load event missed.** A transient key-fetch failure cached a rejected promise for the whole session, and it relied on catching the script's `load` event, which may have already fired when another page (e.g. the dispatch inline editor) injected the script first. The loader now **polls for `google.maps.places` readiness** regardless of who injected the script, and **never caches a failure**.

Degrades cleanly to plain manual entry when no key is configured.

### If suggestions still don't appear after deploy
That would point to a Google Cloud config issue rather than code — open the browser console on the Jobs page, type in the address field, and look for a red Google Maps error (e.g. `RefererNotAllowedMapError`, `ApiNotActivatedMapError`, or "this API key is not authorized"). That's fixed in the Google Cloud console by allowing the `app.qleno.com` referrer / enabling the Places API, not in code.

https://claude.ai/code/session_013KaJXnLShcWKZ8UBfBF2JC

---
_Generated by [Claude Code](https://claude.ai/code/session_013KaJXnLShcWKZ8UBfBF2JC)_