### PR TITLE
Office fixes: Save & Convert no-op, commercial service types, add-ons + parking fee in create wizard

### DIFF
--- a/artifacts/api-server/src/routes/jobs.ts
+++ b/artifacts/api-server/src/routes/jobs.ts
@@ -12,6 +12,66 @@ import { parseResRatesRow, resolveResidentialPayPct } from "../lib/commission-ra
 
 const router = Router();
 
+// Shared add-on persistence. Resolves the add_ons.id FK by company + name
+// (creating the row if absent — see AI.6.3 below) and writes job_add_ons,
+// replacing any existing rows for the job. Used by BOTH job create
+// (POST /) and the edit cascade (PATCH /:id) so the FK-resolution logic
+// lives in exactly one place. `exec` is a db or transaction handle (both
+// expose .execute).
+type JobAddOnInput = { pricing_addon_id?: number; add_on_id?: number; qty?: number; unit_price?: number; subtotal?: number };
+async function persistJobAddOns(exec: any, jobId: number, companyId: number, addOns: JobAddOnInput[]): Promise<void> {
+  await exec.execute(sql`DELETE FROM job_add_ons WHERE job_id = ${jobId}`);
+  for (const a of addOns) {
+    // [AI.6.3] job_add_ons.add_on_id references add_ons.id (older catalog
+    // table) and is NOT NULL. The modal historically wrote
+    // add_on_id = pricing_addon_id which only worked when the IDs happened
+    // to coincide via seeding. PHES's Parking Fee row in pricing_addons has
+    // no matching add_ons.id, so the prior INSERT threw a foreign-key
+    // violation and the whole save aborted. Resolution: look up an add_ons
+    // row by company + name (case-insensitive); if absent, INSERT one
+    // mirroring the pricing_addon's name + price; use that row's real id.
+    const pricingId = Number(a.pricing_addon_id ?? 0) || null;
+    const qty = Number(a.qty ?? 1) || 1;
+    const unitPrice = a.unit_price != null ? String(a.unit_price) : "0";
+    const subtotal = a.subtotal != null ? String(a.subtotal) : "0";
+
+    let realAddOnId: number | null = null;
+    if (pricingId) {
+      const paRows = await exec.execute(sql`SELECT name FROM pricing_addons WHERE id = ${pricingId} LIMIT 1`);
+      const paName = String((paRows.rows[0] as any)?.name ?? "").trim();
+      if (paName) {
+        const existing = await exec.execute(sql`
+          SELECT id FROM add_ons WHERE company_id = ${companyId} AND LOWER(name) = LOWER(${paName}) LIMIT 1
+        `);
+        if (existing.rows.length) {
+          realAddOnId = Number((existing.rows[0] as any).id);
+        } else {
+          const created = await exec.execute(sql`
+            INSERT INTO add_ons (company_id, name, price, category, is_active)
+            VALUES (${companyId}, ${paName}, ${unitPrice}, 'other', true)
+            RETURNING id
+          `);
+          realAddOnId = Number((created.rows[0] as any).id);
+        }
+      }
+    }
+    // Last-resort fallback: caller passed an explicit add_on_id that already
+    // exists in add_ons. Honor it if present.
+    if (!realAddOnId && a.add_on_id) realAddOnId = Number(a.add_on_id);
+    if (!realAddOnId) continue;
+
+    await exec.execute(sql`
+      INSERT INTO job_add_ons (job_id, add_on_id, quantity, unit_price, subtotal, pricing_addon_id)
+      VALUES (${jobId}, ${realAddOnId}, ${qty}, ${unitPrice}, ${subtotal}, ${pricingId})
+      ON CONFLICT (job_id, add_on_id) DO UPDATE
+        SET quantity = EXCLUDED.quantity,
+            unit_price = EXCLUDED.unit_price,
+            subtotal = EXCLUDED.subtotal,
+            pricing_addon_id = EXCLUDED.pricing_addon_id
+    `);
+  }
+}
+
 router.get("/", requireAuth, async (req, res) => {
   try {
     // [BUG-7 / 2026-06-01] Added `date` as a single-day filter alongside the
@@ -116,7 +176,7 @@ router.post("/", requireAuth, async (req, res) => {
       client_id, assigned_user_id, service_type, scheduled_date, scheduled_time,
       frequency, base_fee, allowed_hours, notes,
       account_id, account_property_id, billing_method, hourly_rate, estimated_hours,
-      branch_id,
+      branch_id, add_ons,
     } = req.body;
 
     const newJob = await db
@@ -143,6 +203,19 @@ router.post("/", requireAuth, async (req, res) => {
 
     const jobId = newJob[0].id;
     logAudit(req, "CREATE", "job", jobId, null, newJob[0]);
+
+    // Persist add-ons (Parking Fee, etc.) selected in the create wizard.
+    // base_fee already carries the all-in total (service + add-on subtotals,
+    // computed client-side, matching the quote-calc + edit-modal convention),
+    // so these rows are the itemized record — no surface re-sums them into
+    // revenue. Wrapped so an add-on hiccup never fails the job itself.
+    if (Array.isArray(add_ons) && add_ons.length > 0) {
+      try {
+        await persistJobAddOns(db, jobId, req.auth!.companyId, add_ons);
+      } catch (e) {
+        console.error("persistJobAddOns (create) failed for job", jobId, e);
+      }
+    }
     // Stop any active post_job_retention enrollment for this client (non-blocking)
     if (client_id) {
       import("../services/followUpService.js").then(({ stopEnrollmentsForClient }) => {
@@ -1467,67 +1540,11 @@ router.patch("/:id", requireAuth, async (req, res) => {
         ));
       }
 
-      // Replace job_add_ons if add_ons provided.
-      //
-      // [AI.6.3] FK fix. job_add_ons.add_on_id references add_ons.id (older
-      // catalog table) and is NOT NULL. The modal historically wrote
-      // add_on_id = pricing_addon_id which only worked when the IDs
-      // happened to coincide via seeding. PHES's Parking Fee row in
-      // pricing_addons does NOT have a matching add_ons.id, so the prior
-      // INSERT threw a foreign-key violation and the whole save aborted.
-      //
-      // Resolution path: look up an add_ons row by company + name (case-
-      // insensitive). If absent, INSERT one (mirroring the pricing_addon's
-      // name + price). Use that row's real id as add_on_id.
+      // Replace job_add_ons if add_ons provided. FK-resolution lives in the
+      // shared persistJobAddOns helper (see its [AI.6.3] note) so create and
+      // edit stay in lockstep.
       if (addOnsProvided && Array.isArray(add_ons)) {
-        await tx.execute(sql`DELETE FROM job_add_ons WHERE job_id = ${jobId}`);
-        for (const a of add_ons as Array<{ pricing_addon_id?: number; add_on_id?: number; qty?: number; unit_price?: number; subtotal?: number }>) {
-          const pricingId = Number(a.pricing_addon_id ?? 0) || null;
-          const qty = Number(a.qty ?? 1) || 1;
-          const unitPrice = a.unit_price != null ? String(a.unit_price) : "0";
-          const subtotal = a.subtotal != null ? String(a.subtotal) : "0";
-
-          // Resolve a valid add_ons.id for the FK. Source-of-truth name
-          // comes from pricing_addons via the supplied pricing_addon_id.
-          let realAddOnId: number | null = null;
-          if (pricingId) {
-            const paRows = await tx.execute(sql`
-              SELECT name FROM pricing_addons WHERE id = ${pricingId} LIMIT 1
-            `);
-            const paName = String((paRows.rows[0] as any)?.name ?? "").trim();
-            if (paName) {
-              const existing = await tx.execute(sql`
-                SELECT id FROM add_ons
-                WHERE company_id = ${companyId} AND LOWER(name) = LOWER(${paName})
-                LIMIT 1
-              `);
-              if (existing.rows.length) {
-                realAddOnId = Number((existing.rows[0] as any).id);
-              } else {
-                const created = await tx.execute(sql`
-                  INSERT INTO add_ons (company_id, name, price, category, is_active)
-                  VALUES (${companyId}, ${paName}, ${unitPrice}, 'other', true)
-                  RETURNING id
-                `);
-                realAddOnId = Number((created.rows[0] as any).id);
-              }
-            }
-          }
-          // Last-resort fallback: caller passed an explicit add_on_id that
-          // already exists in add_ons. Honor it if present.
-          if (!realAddOnId && a.add_on_id) realAddOnId = Number(a.add_on_id);
-          if (!realAddOnId) continue;
-
-          await tx.execute(sql`
-            INSERT INTO job_add_ons (job_id, add_on_id, quantity, unit_price, subtotal, pricing_addon_id)
-            VALUES (${jobId}, ${realAddOnId}, ${qty}, ${unitPrice}, ${subtotal}, ${pricingId})
-            ON CONFLICT (job_id, add_on_id) DO UPDATE
-              SET quantity = EXCLUDED.quantity,
-                  unit_price = EXCLUDED.unit_price,
-                  subtotal = EXCLUDED.subtotal,
-                  pricing_addon_id = EXCLUDED.pricing_addon_id
-          `);
-        }
+        await persistJobAddOns(tx, jobId, companyId, add_ons as JobAddOnInput[]);
       }
 
       // [recurring-on-save 2026-04-30] Seed the new schedule's

--- a/artifacts/qleno/src/components/edit-job-modal.tsx
+++ b/artifacts/qleno/src/components/edit-job-modal.tsx
@@ -613,7 +613,17 @@ export default function EditJobModal({
   // route already uses `!!j.account_id` as its commercial test (dispatch.ts).
   // Aligning here means jobs flagged commercial by either signal get the
   // commercial UI fork.
-  const isCommercial = clientType === "commercial" || job.account_id != null;
+  //
+  // Third signal: the job's own service_type is a tenant-managed commercial
+  // slug. MC import left some commercial clients tagged residential with NO
+  // account row (e.g. Bill Azzarello / office_cleaning), so the first two
+  // signals both miss — but the job itself carries the commercial slug
+  // (that's what renders "OFFICE CLEANING" on the tile). Forking on it fixes
+  // every misflagged client at once, with no false positives: a residential
+  // job never has a commercial slug as its service_type.
+  const serviceTypeIsCommercial =
+    !!job.service_type && commercialServiceTypes.some(t => t.slug === job.service_type);
+  const isCommercial = clientType === "commercial" || job.account_id != null || serviceTypeIsCommercial;
 
   // ── Load scopes once ────────────────────────────────────────────────────
   // Skipped for commercial clients (modal uses the commercial dropdown instead).

--- a/artifacts/qleno/src/components/job-wizard.tsx
+++ b/artifacts/qleno/src/components/job-wizard.tsx
@@ -235,6 +235,15 @@ export function JobWizard({ open, onClose, onCreated, preselectedClient, presetD
   const [frequency, setFrequency] = useState("on_demand");
   const [notes, setNotes] = useState("");
 
+  // Add-ons (Parking Fee, Refrigerator Cleaning, etc.) — selectable at
+  // creation. Company-wide active add-ons, shared by the residential and
+  // commercial branches. selectedAddons: Map<addon_id, qty>;
+  // addonPriceOverrides: Map<addon_id, unit_price> for flat-$ overrides.
+  const [availableAddons, setAvailableAddons] = useState<any[]>([]);
+  const [addonsLoading, setAddonsLoading] = useState(false);
+  const [selectedAddons, setSelectedAddons] = useState<Map<number, number>>(new Map());
+  const [addonPriceOverrides, setAddonPriceOverrides] = useState<Map<number, number>>(new Map());
+
   // Step 2 — Quote
   const [showQuote, setShowQuote] = useState(false);
   const [quoteSending, setQuoteSending] = useState(false);
@@ -281,6 +290,28 @@ export function JobWizard({ open, onClose, onCreated, preselectedClient, presetD
   useEffect(() => {
     if (open && presetDate) setScheduledDate(presetDate);
   }, [open, presetDate]);
+
+  // Load company-wide active add-ons once when the wizard opens. Failure
+  // mode is "empty list" — the section shows an empty state but the wizard
+  // still works.
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    setAddonsLoading(true);
+    (async () => {
+      try {
+        const r = await fetch(`${API}/api/pricing/addons`, { headers: getAuthHeaders() });
+        const d = await r.json();
+        const rows = Array.isArray(d) ? d : (d.data ?? d.rows ?? []);
+        if (!cancelled) setAvailableAddons(rows);
+      } catch {
+        if (!cancelled) setAvailableAddons([]);
+      } finally {
+        if (!cancelled) setAddonsLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [open]);
 
   // [commercial-workflow PR #3 / 2026-04-29] Fetch service_types
   // once when the wizard opens. Both residential and commercial
@@ -334,6 +365,7 @@ export function JobWizard({ open, onClose, onCreated, preselectedClient, presetD
       setCommercialDuration(120); setCommercialFrequency("on_demand"); setCommercialNotes("");
       setSelectedEmployee(null); setSubmitting(false); setError("");
       setSuggestions([]); setSuggestionsLoading(false); setSuggestionsDismissed(false);
+      setSelectedAddons(new Map()); setAddonPriceOverrides(new Map());
     } else {
       setSelectedBranchOverride(activeBranchId);
       // If opened from a client profile, skip type + client-search +
@@ -603,6 +635,106 @@ export function JobWizard({ open, onClose, onCreated, preselectedClient, presetD
     }
   }, [commercialServiceType, apiServiceTypes, clientType]);
 
+  // ── Add-ons math + payload ────────────────────────────────────────────
+  // The service base a %-priced add-on applies to. Residential = the entered
+  // price; commercial = rate × hours (or flat rate). Flat add-ons ignore this.
+  function currentServiceBase(): number {
+    if (clientType === "commercial") {
+      const billingMethod = rateLookup ? rateLookup.billing_method : manualBillingMethod;
+      const effRate = rateOverride ? overrideRate : (rateLookup?.rate_amount || manualRate);
+      return billingMethod === "flat_rate"
+        ? (parseFloat(effRate) || 0)
+        : (parseFloat(effRate) || 0) * (parseFloat(estimatedHours) || 1);
+    }
+    return Number(price) || 0;
+  }
+  function addonUnitPrice(a: any): number {
+    const override = addonPriceOverrides.get(a.id);
+    if (override != null) return override;
+    const pv = Number(a.price_value ?? a.price ?? 0);
+    const isPct = a.price_type === "percent" || a.price_type === "percentage";
+    if (isPct) return Number((currentServiceBase() * pv / 100).toFixed(2));
+    return pv;
+  }
+  const selectedAddonList = availableAddons.filter(a => selectedAddons.has(a.id));
+  const addOnsTotal = selectedAddonList.reduce(
+    (sum, a) => sum + addonUnitPrice(a) * (selectedAddons.get(a.id) || 1), 0,
+  );
+  function buildAddOnsPayload() {
+    return selectedAddonList.map(a => {
+      const qty = selectedAddons.get(a.id) || 1;
+      const unit = addonUnitPrice(a);
+      return { add_on_id: a.id, pricing_addon_id: a.id, qty, unit_price: unit, subtotal: Number((unit * qty).toFixed(2)) };
+    });
+  }
+
+  function renderAddOns() {
+    return (
+      <div>
+        <p style={{ fontSize: 12, fontWeight: 700, color: "#6B7280", margin: "0 0 8px", textTransform: "uppercase", letterSpacing: "0.06em" }}>Add-ons</p>
+        {addonsLoading ? (
+          <p style={{ fontSize: 12, color: "#9E9B94", margin: 0 }}>Loading add-ons…</p>
+        ) : availableAddons.length === 0 ? (
+          <p style={{ fontSize: 12, color: "#9E9B94", margin: 0 }}>No add-ons configured.</p>
+        ) : (
+          <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+            {availableAddons.map(a => {
+              const checked = selectedAddons.has(a.id);
+              const isPct = a.price_type === "percent" || a.price_type === "percentage";
+              const catalogPrice = Number(a.price_value ?? a.price ?? 0);
+              const override = addonPriceOverrides.get(a.id);
+              const editable = checked && !isPct; // flat-$ add-ons get an inline price
+              const inputValue = override != null ? String(override) : "";
+              const toggle = () => {
+                const wasChecked = selectedAddons.has(a.id);
+                setSelectedAddons(prev => {
+                  const next = new Map(prev);
+                  if (next.has(a.id)) next.delete(a.id);
+                  else next.set(a.id, 1);
+                  return next;
+                });
+                // Drop any pending override when unchecking so a re-check
+                // starts from the catalog default again.
+                if (wasChecked) {
+                  setAddonPriceOverrides(prev => {
+                    if (!prev.has(a.id)) return prev;
+                    const n = new Map(prev);
+                    n.delete(a.id);
+                    return n;
+                  });
+                }
+              };
+              return (
+                <div key={a.id} style={{ display: "flex", alignItems: "center", gap: 8, padding: "8px 10px", borderRadius: 8, border: `1px solid ${checked ? "var(--brand, #00C9A0)" : "#E5E2DC"}`, backgroundColor: checked ? "rgba(0,201,160,0.05)" : "#F7F6F3" }}>
+                  <input type="checkbox" checked={checked} style={{ cursor: "pointer" }} onChange={toggle} />
+                  <span style={{ flex: 1, fontSize: 13, color: "#1A1917", cursor: "pointer" }} onClick={toggle}>{a.name}</span>
+                  {editable ? (
+                    <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
+                      <span style={{ fontSize: 12, color: "#6B6860" }}>$</span>
+                      <input type="number" min={0} step={0.01} inputMode="decimal" value={inputValue} placeholder={String(catalogPrice)}
+                        onChange={e => {
+                          const raw = e.target.value;
+                          setAddonPriceOverrides(prev => {
+                            const next = new Map(prev);
+                            if (raw === "") next.delete(a.id);
+                            else next.set(a.id, Number(raw));
+                            return next;
+                          });
+                        }}
+                        style={{ width: 80, padding: "5px 8px", border: "1px solid #E5E2DC", borderRadius: 6, fontSize: 13, fontFamily: "inherit", outline: "none" }} />
+                    </div>
+                  ) : (
+                    <span style={{ fontSize: 12, color: "#6B6860" }}>{isPct ? `${catalogPrice}%` : `$${catalogPrice.toFixed(2)}`}</span>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    );
+  }
+
   async function submit() {
     setSubmitting(true); setError("");
     try {
@@ -630,7 +762,10 @@ export function JobWizard({ open, onClose, onCreated, preselectedClient, presetD
           // board and paid commission on 0 hours. Send the operator's entered
           // hours here. estimatedHours is already the stepper's string value.
           allowed_hours: billingMethod === "hourly" ? (estimatedHours || undefined) : undefined,
-          base_fee: baseFee || undefined,
+          // base_fee is the all-in total: service + add-on subtotals. Add-on
+          // rows below are the itemized record (no surface re-sums them).
+          base_fee: (baseFee + addOnsTotal) || undefined,
+          add_ons: buildAddOnsPayload(),
           frequency: commercialFrequency,
           notes: commercialNotes || undefined,
           assigned_user_id: selectedEmployee || undefined,
@@ -654,7 +789,10 @@ export function JobWizard({ open, onClose, onCreated, preselectedClient, presetD
           // allowed_hours. Without it, every wizard-created residential
           // one-off rendered as a flat 2h block. `duration` is in minutes.
           allowed_hours: duration ? (duration / 60).toFixed(2) : undefined,
-          base_fee: price,
+          // base_fee is the all-in total: service price + add-on subtotals.
+          // Add-on rows below are the itemized record.
+          base_fee: Number(price) + addOnsTotal,
+          add_ons: buildAddOnsPayload(),
           frequency,
           notes: notes || undefined,
           assigned_user_id: selectedEmployee || undefined,
@@ -1283,6 +1421,9 @@ export function JobWizard({ open, onClose, onCreated, preselectedClient, presetD
                 </div>
               </div>
 
+              {/* Add-ons (Parking Fee, etc.) */}
+              {renderAddOns()}
+
               {/* View Quote section */}
               {serviceType && duration > 0 && (
                 <div>
@@ -1310,9 +1451,15 @@ export function JobWizard({ open, onClose, onCreated, preselectedClient, presetD
                           <span style={{ color: "#6B7280" }}>Frequency</span>
                           <span style={{ fontWeight: 600, color: "#1A1917" }}>{frequency.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase())}</span>
                         </div>
+                        {selectedAddonList.map(a => (
+                          <div key={a.id} style={{ display: "flex", justifyContent: "space-between", fontSize: 13 }}>
+                            <span style={{ color: "#6B7280" }}>{a.name}</span>
+                            <span style={{ fontWeight: 600, color: "#1A1917" }}>+${(addonUnitPrice(a) * (selectedAddons.get(a.id) || 1)).toFixed(2)}</span>
+                          </div>
+                        ))}
                         <div style={{ display: "flex", justifyContent: "space-between", fontSize: 15, borderTop: "1px solid #E5E2DC", paddingTop: 10, marginTop: 2 }}>
                           <span style={{ fontWeight: 700, color: "#1A1917" }}>Total</span>
-                          <span style={{ fontWeight: 800, color: "var(--brand, #00C9A0)" }}>${price.toFixed(2)}</span>
+                          <span style={{ fontWeight: 800, color: "var(--brand, #00C9A0)" }}>${(Number(price) + addOnsTotal).toFixed(2)}</span>
                         </div>
                       </div>
                       {quoteError && <p style={{ fontSize: 12, color: "#DC2626", margin: "0 0 10px", padding: "8px 12px", background: "#FEE2E2", borderRadius: 6 }}>{quoteError}</p>}
@@ -1327,7 +1474,7 @@ export function JobWizard({ open, onClose, onCreated, preselectedClient, presetD
                             try {
                               const r = await fetch(`${API}/api/quotes`, {
                                 method: "POST", headers: { ...getAuthHeaders(), "Content-Type": "application/json" },
-                                body: JSON.stringify({ client_id: selectedClient.id, service_type: serviceType, duration_minutes: duration, price, frequency, notes: notes || undefined, send_email: true }),
+                                body: JSON.stringify({ client_id: selectedClient.id, service_type: serviceType, duration_minutes: duration, price: Number(price) + addOnsTotal, frequency, notes: notes || undefined, send_email: true }),
                               });
                               if (!r.ok) { const e = await r.json().catch(() => ({})); throw new Error((e as any).message || "Failed to send quote"); }
                               setQuoteSent(true);
@@ -1593,6 +1740,9 @@ export function JobWizard({ open, onClose, onCreated, preselectedClient, presetD
                     style={{ width: "100%", height: 130, padding: "10px 12px", border: "1px solid #E5E2DC", borderRadius: 8, fontSize: 12, fontFamily: "inherit", outline: "none", resize: "none", boxSizing: "border-box", lineHeight: 1.5 }}/>
                 </div>
               </div>
+
+              {/* Add-ons (Parking Fee, etc.) */}
+              {renderAddOns()}
             </div>
           )}
 

--- a/artifacts/qleno/src/pages/quote-builder.tsx
+++ b/artifacts/qleno/src/pages/quote-builder.tsx
@@ -255,7 +255,12 @@ export default function QuoteBuilderPage() {
 
   // ── Section 2: Multi-scope selection ────────────────────────────────────
   const [selectedScopes, setSelectedScopes] = useState<SelectedScopeState[]>([]);
-  const [selectedDate, setSelectedDate] = useState("");
+  // Default the convert date to today (local, not UTC — avoids the
+  // off-by-one that would land the job on the previous day in Central time).
+  const [selectedDate, setSelectedDate] = useState(() => {
+    const d = new Date();
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+  });
   const [selectedTime, setSelectedTime] = useState("09:00");
 
   // ── Section 3: Notes + discount + photos ─────────────────────────────────
@@ -2458,7 +2463,13 @@ export default function QuoteBuilderPage() {
                   <Button variant="outline" size="sm" onClick={() => save("sent")} disabled={saving || !finalScopeId} className="gap-1.5">
                     <SendHorizonal className="w-3.5 h-3.5" /> Save &amp; Send Quote
                   </Button>
-                  <Button size="sm" onClick={() => save("draft", true)} disabled={saving || !canConvert || !selectedDate} style={{ background: !selectedDate ? "#D1D5DB" : "var(--brand)", color: "#FFF", cursor: !selectedDate ? "not-allowed" : "pointer" }} className="gap-1.5 hover:opacity-90">
+                  <Button size="sm" onClick={() => {
+                      // Never a silent no-op: tell the office exactly what's missing
+                      // instead of a dead, pointer-events:none button.
+                      if (!canConvert) { toast.error("Add a customer and pick a service before converting."); return; }
+                      if (!selectedDate) { toast.error("Pick a scheduled date to convert to a job."); return; }
+                      save("draft", true);
+                    }} disabled={saving} style={{ background: "var(--brand)", color: "#FFF", cursor: "pointer" }} className="gap-1.5 hover:opacity-90">
                     <ArrowRight className="w-3.5 h-3.5" /> Save &amp; Convert to Job
                   </Button>
                 </div>


### PR DESCRIPTION
Office-reported items from the Phes Office WhatsApp thread (Jun 3).

## 1. "Save & Convert to Job" did nothing — couldn't book new clients
The Review-step convert button used `disabled` + `pointer-events:none`. When the
Scheduled Date was empty, the click was swallowed: no request, no job, no toast.

- Default the convert date to **today** (local, not UTC — avoids the off-by-one
  that lands the job on the previous day in Central time). Matches the convert
  endpoint's own default, so the button is live by default.
- Keep the button enabled and **say what's missing on click** instead of dying
  silently.

`artifacts/qleno/src/pages/quote-builder.tsx`

## 2. Commercial job showed residential service types in Edit Job modal
A commercial "OFFICE CLEANING" job (Bill Azzarello) listed only residential
service-type options. The commercial fork keyed off `client_type='commercial'`
OR `account_id` — both of which the MaidCentral import left wrong for some
clients. Added a third, self-correcting signal: if the job's own `service_type`
is a tenant-managed commercial slug, treat the job as commercial. Fixes every
misflagged client at once — no data migration, no false positives.

`artifacts/qleno/src/components/edit-job-modal.tsx`

## 3. No add-ons / parking fee in the create wizard
Office could only attach add-ons after creation (edit modal). Added an Add-ons
section to both the residential and commercial create branches.

- Loads company-wide active add-ons; inline editable price for flat-$ add-ons
  (Parking Fee, Refrigerator Cleaning, etc.).
- Folds add-on subtotals into `base_fee` (the all-in total convention) and sends
  an itemized `add_ons` array; Quote Summary itemizes + totals them.
- `POST /api/jobs` now persists `add_ons`. Extracted the add-on FK-resolution
  logic into a shared `persistJobAddOns` helper used by both create and the
  PATCH edit cascade (one source of truth).

`artifacts/qleno/src/components/job-wizard.tsx`, `artifacts/api-server/src/routes/jobs.ts`

Frontend `tsc --noEmit` and API `tsc --noEmit` are clean on all changed files.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj