### PR TITLE
fix(quotes): surface real save/convert error instead of generic toast

### DIFF
--- a/artifacts/qleno/src/pages/quote-builder.tsx
+++ b/artifacts/qleno/src/pages/quote-builder.tsx
@@ -858,7 +858,14 @@ export default function QuoteBuilderPage() {
       qc.invalidateQueries({ queryKey: ["quotes"] });
       qc.invalidateQueries({ queryKey: ["quote-stats"] });
       const savedId = result?.id ?? id;
-      if (thenConvert && savedId) {
+      if (thenConvert) {
+        // If the save didn't return an id we can't convert — say so instead
+        // of silently falling through to the "saved as draft" branch (which
+        // looked like "nothing happened" to the office).
+        if (!savedId) {
+          toast.error("Couldn't convert — the quote didn't save. Try again.");
+          return;
+        }
         await apiFetch(`/api/quotes/${savedId}/convert`, {
           method: "POST",
           body: {
@@ -876,8 +883,13 @@ export default function QuoteBuilderPage() {
         toast.success("Quote saved as draft");
         navigate(`/quotes/${savedId}`);
       }
-    } catch {
-      toast.error("Failed to save quote");
+    } catch (e: any) {
+      // Surface the real reason instead of a generic message, so a failed
+      // save/convert is self-diagnosing on the live site. apiFetch throws
+      // Error(responseBodyText); that body is often JSON ({error|message}).
+      let msg = String(e?.message || "").trim();
+      try { const j = JSON.parse(msg); msg = j.message || j.error || msg; } catch { /* plain text body */ }
+      toast.error(msg ? `Couldn't save: ${msg.slice(0, 200)}` : "Failed to save quote");
     } finally {
       setSaving(false);
     }


### PR DESCRIPTION
Follow-up to #263 (Save & Convert). Makes a failed quote save/convert
self-diagnosing on the live site instead of a dead-end.

- The catch in `save()` now shows the **actual server reason** (parsed from
  the JSON error body when present) instead of a generic "Failed to save
  quote" — which the office read as "nothing happened" and which gave us
  nothing to debug.
- Closes a silent path: if a convert is requested but the save returns no
  id, report it explicitly instead of falling through to the misleading
  "Quote saved as draft" branch.

So if that Save & Convert quote ever misbehaves again, the office sees the
precise reason on screen.

`artifacts/qleno/src/pages/quote-builder.tsx` — frontend `tsc --noEmit` clean.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_