### PR TITLE
feat(dashboard): role-based, user-customizable mobile dashboard

### DIFF
--- a/artifacts/api-server/src/routes/dashboard.ts
+++ b/artifacts/api-server/src/routes/dashboard.ts
@@ -1186,4 +1186,230 @@ router.get("/weekly-forecast", requireAuth, async (req, res) => {
   }
 });
 
+// ── Mobile customizable dashboard ────────────────────────────────────────────
+// Read-only aggregate feeding the role-based, user-customizable MOBILE dashboard.
+// One payload = every card's value, so the mobile surface does a single fetch.
+// Branch-aware for job/client-based cards (jobs.branch_id / clients.branch_id);
+// leads + quotes are company-wide (quotes has no reliable branch_id column).
+// Desktop endpoints are untouched.
+router.get("/mobile-cards", requireAuth, async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    const branchRaw = req.query.branch_id;
+    const branchId = branchRaw && branchRaw !== "all" ? parseInt(branchRaw as string) : null;
+    const jb = branchId ? sql`AND j.branch_id = ${branchId}` : sql``;
+    const cb = branchId ? sql`AND branch_id = ${branchId}` : sql``;
+    // "Today" / month boundaries in Central time (Phes), not UTC.
+    const today = sql`(now() AT TIME ZONE 'America/Chicago')::date`;
+    const monthStart = sql`date_trunc('month', (now() AT TIME ZONE 'America/Chicago'))`;
+    // Revenue: completed/booked use base_fee; rollups use billed_amount fallback.
+    const exprBase = jobRevenueExpr(sql`CAST(j.base_fee AS NUMERIC)`, "j", "c");
+    const exprBilled = jobRevenueExpr(sql`COALESCE(CAST(j.billed_amount AS NUMERIC), CAST(j.base_fee AS NUMERIC), 0)`, "j", "c");
+
+    const [todayRev, todayCounts, monthRev, avgBill, next7, lateRows, leadsRows, quotesRows, activeRows, rateRows, retentionRows] = await Promise.all([
+      // Daily revenue (completed today, actual) vs Revenue booked today (all non-cancelled scheduled today)
+      db.execute(sql`
+        SELECT
+          COALESCE(SUM(${exprBase}) FILTER (WHERE j.status = 'complete'), 0)::numeric AS daily,
+          COALESCE(SUM(${exprBase}) FILTER (WHERE j.status != 'cancelled'), 0)::numeric AS booked
+        FROM jobs j LEFT JOIN clients c ON c.id = j.client_id
+        WHERE j.company_id = ${companyId} AND j.scheduled_date = ${today} ${jb}
+      `),
+      // Today's counts + status breakdown + techs working
+      db.execute(sql`
+        SELECT
+          COUNT(*) FILTER (WHERE status != 'cancelled')::int AS jobs_today,
+          COUNT(*) FILTER (WHERE status = 'scheduled')::int AS scheduled,
+          COUNT(*) FILTER (WHERE status = 'in_progress')::int AS in_progress,
+          COUNT(*) FILTER (WHERE status = 'complete')::int AS complete,
+          COUNT(*) FILTER (WHERE flagged = true AND status != 'cancelled')::int AS flagged,
+          COUNT(*) FILTER (WHERE status = 'scheduled' AND assigned_user_id IS NULL)::int AS unassigned,
+          COUNT(DISTINCT assigned_user_id) FILTER (WHERE status != 'cancelled' AND assigned_user_id IS NOT NULL)::int AS techs_today
+        FROM jobs j
+        WHERE j.company_id = ${companyId} AND j.scheduled_date = ${today} ${jb}
+      `),
+      // Monthly revenue (month-to-date)
+      db.execute(sql`
+        SELECT COALESCE(SUM(${exprBilled}), 0)::numeric AS v
+        FROM jobs j LEFT JOIN clients c ON c.id = j.client_id
+        WHERE j.company_id = ${companyId} AND j.status != 'cancelled'
+          AND j.scheduled_date >= ${monthStart}::date AND j.scheduled_date <= ${today} ${jb}
+      `),
+      // Avg bill (last 30 days, excluding $0)
+      db.execute(sql`
+        SELECT COALESCE(AVG(${exprBilled}), 0)::numeric AS v
+        FROM jobs j LEFT JOIN clients c ON c.id = j.client_id
+        WHERE j.company_id = ${companyId} AND j.status != 'cancelled'
+          AND j.scheduled_date >= ${today} - INTERVAL '30 days' AND j.scheduled_date <= ${today}
+          AND ${exprBilled} > 0 ${jb}
+      `),
+      // Next 7 days (jobs + revenue)
+      db.execute(sql`
+        SELECT
+          COUNT(*) FILTER (WHERE j.status != 'cancelled')::int AS jobs,
+          COALESCE(SUM(${exprBilled}) FILTER (WHERE j.status != 'cancelled'), 0)::numeric AS revenue
+        FROM jobs j LEFT JOIN clients c ON c.id = j.client_id
+        WHERE j.company_id = ${companyId}
+          AND j.scheduled_date >= ${today} AND j.scheduled_date <= ${today} + INTERVAL '7 days' ${jb}
+      `),
+      // Late clock-ins: scheduled today, assigned, no clock-in for the job, now ≥ start+20m (Central)
+      db.execute(sql`
+        SELECT COUNT(*)::int AS v
+        FROM jobs j
+        WHERE j.company_id = ${companyId} AND j.scheduled_date = ${today}
+          AND j.status = 'scheduled' AND j.assigned_user_id IS NOT NULL
+          AND j.scheduled_time IS NOT NULL
+          AND (now() AT TIME ZONE 'America/Chicago')::time >= (j.scheduled_time::time + INTERVAL '20 minutes')
+          AND NOT EXISTS (SELECT 1 FROM timeclock tc WHERE tc.job_id = j.id AND tc.company_id = ${companyId})
+          ${jb}
+      `),
+      // Leads this month (company-wide)
+      db.execute(sql`
+        SELECT COUNT(*)::int AS v FROM leads
+        WHERE company_id = ${companyId} AND created_at >= ${monthStart}
+      `),
+      // Quotes + closed (won) this month (company-wide). Closed = booked / converted.
+      db.execute(sql`
+        SELECT COUNT(*)::int AS total,
+               COUNT(*) FILTER (WHERE status = 'booked' OR booked_job_id IS NOT NULL)::int AS closed
+        FROM quotes WHERE company_id = ${companyId} AND created_at >= ${monthStart}
+      `),
+      // Active clients (branch-aware)
+      db.execute(sql`
+        SELECT COUNT(*)::int AS v FROM clients
+        WHERE company_id = ${companyId} AND is_active = true ${cb}
+      `),
+      // Rate trend = avg bill (same calc as Avg Bill card) trailing 12mo vs prior 12mo.
+      // This is pricing erosion, NOT revenue volatility. First/only implementation.
+      db.execute(sql`
+        SELECT
+          COALESCE(AVG(${exprBilled}) FILTER (WHERE j.scheduled_date >= ${today} - INTERVAL '12 months'), 0)::numeric AS last12,
+          COALESCE(AVG(${exprBilled}) FILTER (WHERE j.scheduled_date >= ${today} - INTERVAL '24 months' AND j.scheduled_date < ${today} - INTERVAL '12 months'), 0)::numeric AS prior12
+        FROM jobs j LEFT JOIN clients c ON c.id = j.client_id
+        WHERE j.company_id = ${companyId} AND j.status != 'cancelled'
+          AND j.scheduled_date >= ${today} - INTERVAL '24 months' AND j.scheduled_date <= ${today}
+          AND ${exprBilled} > 0 ${jb}
+      `),
+      // Recurring retention = distinct clients with an active recurring schedule /
+      // distinct clients with any recurring schedule (company-wide; no branch column).
+      db.execute(sql`
+        SELECT
+          COUNT(DISTINCT customer_id)::int AS total,
+          COUNT(DISTINCT customer_id) FILTER (WHERE is_active = true)::int AS active
+        FROM recurring_schedules WHERE company_id = ${companyId}
+      `),
+    ]);
+
+    const tc: any = (todayCounts as any).rows[0] ?? {};
+    const tr: any = (todayRev as any).rows[0] ?? {};
+    const n7: any = (next7 as any).rows[0] ?? {};
+    const q: any = (quotesRows as any).rows[0] ?? {};
+    const quotesTotal = Number(q.total ?? 0);
+    const quotesClosed = Number(q.closed ?? 0);
+    const num = (v: any) => Math.round(Number(v ?? 0) * 100) / 100;
+
+    return res.json({
+      branch_id: branchId,
+      daily_revenue: num(tr.daily),
+      revenue_booked_today: num(tr.booked),
+      jobs_today: Number(tc.jobs_today ?? 0),
+      jobs_scheduled_today: Number(tc.scheduled ?? 0),
+      late_clockins: Number((lateRows as any).rows[0]?.v ?? 0),
+      todays_status: {
+        in_progress: Number(tc.in_progress ?? 0),
+        scheduled: Number(tc.scheduled ?? 0),
+        complete: Number(tc.complete ?? 0),
+        flagged: Number(tc.flagged ?? 0),
+        unassigned: Number(tc.unassigned ?? 0),
+      },
+      unassigned_jobs: Number(tc.unassigned ?? 0),
+      techs_today: Number(tc.techs_today ?? 0),
+      next_7_days_jobs: Number(n7.jobs ?? 0),
+      next_7_days_revenue: num(n7.revenue),
+      leads: Number((leadsRows as any).rows[0]?.v ?? 0),
+      quotes: quotesTotal,
+      closed_quotes: quotesClosed,
+      close_rate: quotesTotal > 0 ? Math.round((quotesClosed / quotesTotal) * 100) : 0,
+      monthly_revenue: num((monthRev as any).rows[0]?.v),
+      avg_bill: num((avgBill as any).rows[0]?.v),
+      active_clients: Number((activeRows as any).rows[0]?.v ?? 0),
+      // Rate trend: % change in avg bill, trailing 12mo vs prior 12mo (pricing erosion).
+      rate_trend: (() => {
+        const r: any = (rateRows as any).rows[0] ?? {};
+        const last12 = Number(r.last12 ?? 0);
+        const prior12 = Number(r.prior12 ?? 0);
+        return prior12 > 0 ? Math.round(((last12 - prior12) / prior12) * 10000) / 100 : 0;
+      })(),
+      avg_bill_12mo: num((rateRows as any).rows[0]?.last12),
+      // Recurring retention: % of recurring-schedule clients still active.
+      retention: (() => {
+        const r: any = (retentionRows as any).rows[0] ?? {};
+        const total = Number(r.total ?? 0);
+        return total > 0 ? Math.round((Number(r.active ?? 0) / total) * 100) : 0;
+      })(),
+    });
+  } catch (err) {
+    console.error("GET /dashboard/mobile-cards error:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
+// Per-user mobile dashboard card preference (selected cards + order).
+// Reuses user_column_preferences with page='mobile_dashboard' — no schema change.
+// No rows = user hasn't customized → frontend shows the role default.
+router.get("/card-prefs", requireAuth, async (req, res) => {
+  try {
+    const userId = req.auth!.userId;
+    const companyId = req.auth!.companyId;
+    const result = await db.execute(sql`
+      SELECT column_key AS card_key, visible, sort_order
+      FROM user_column_preferences
+      WHERE user_id = ${userId} AND company_id = ${companyId} AND page = 'mobile_dashboard'
+      ORDER BY sort_order ASC
+    `);
+    return res.json((result as any).rows ?? []);
+  } catch (err) {
+    console.error("GET /dashboard/card-prefs error:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
+router.put("/card-prefs", requireAuth, async (req, res) => {
+  try {
+    const userId = req.auth!.userId;
+    const companyId = req.auth!.companyId;
+    const cards: Array<{ card_key: string; visible: boolean; sort_order: number }> = req.body?.cards;
+    if (!Array.isArray(cards)) return res.status(400).json({ error: "cards array required" });
+    // Pure upsert (no DELETE+INSERT): one row per card with visible flag + order.
+    for (const c of cards) {
+      await db.execute(sql`
+        INSERT INTO user_column_preferences (user_id, company_id, page, column_key, visible, sort_order)
+        VALUES (${userId}, ${companyId}, 'mobile_dashboard', ${String(c.card_key).slice(0, 50)}, ${!!c.visible}, ${parseInt(String(c.sort_order)) || 0})
+        ON CONFLICT (user_id, page, column_key)
+        DO UPDATE SET visible = EXCLUDED.visible, sort_order = EXCLUDED.sort_order
+      `);
+    }
+    return res.json({ success: true });
+  } catch (err) {
+    console.error("PUT /dashboard/card-prefs error:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
+// Reset to role default = remove this user's customization rows.
+router.delete("/card-prefs", requireAuth, async (req, res) => {
+  try {
+    const userId = req.auth!.userId;
+    const companyId = req.auth!.companyId;
+    await db.execute(sql`
+      DELETE FROM user_column_preferences
+      WHERE user_id = ${userId} AND company_id = ${companyId} AND page = 'mobile_dashboard'
+    `);
+    return res.json({ success: true });
+  } catch (err) {
+    console.error("DELETE /dashboard/card-prefs error:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
 export default router;

--- a/artifacts/qleno/src/components/mobile-dashboard.tsx
+++ b/artifacts/qleno/src/components/mobile-dashboard.tsx
@@ -1,0 +1,274 @@
+import { useState, useEffect } from "react";
+import type { ReactNode, CSSProperties } from "react";
+import { getAuthHeaders, getTokenRole } from "@/lib/auth";
+import { useBranch } from "@/contexts/branch-context";
+import { Settings2, ArrowUp, ArrowDown, X, RotateCcw } from "lucide-react";
+
+// Role-based, user-customizable MOBILE dashboard. Each user picks which cards
+// to show and in what order; defaults differ by role but every card is in the
+// shared library (no card is hidden by role). Preference persists per user via
+// GET/PUT/DELETE /api/dashboard/card-prefs (reuses user_column_preferences,
+// page='mobile_dashboard' — no schema change). Read-only on all metric data;
+// the only writes are the user's own preference rows. Desktop is untouched.
+
+const API = import.meta.env.BASE_URL.replace(/\/$/, "");
+const FF = "'Plus Jakarta Sans', sans-serif";
+const CARD: CSSProperties = { backgroundColor: "#FFFFFF", border: "0.5px solid #E5E2DC", borderRadius: 12 };
+const INK = "#1A1917";
+const MUTE = "#6B7280";
+const MINT = "#2D9B83";
+const RED = "#E24B4A";
+
+interface CardData {
+  daily_revenue: number; revenue_booked_today: number; jobs_today: number; jobs_scheduled_today: number;
+  late_clockins: number;
+  todays_status: { in_progress: number; scheduled: number; complete: number; flagged: number; unassigned: number };
+  unassigned_jobs: number; techs_today: number; next_7_days_jobs: number; next_7_days_revenue: number;
+  leads: number; quotes: number; closed_quotes: number; close_rate: number; monthly_revenue: number;
+  avg_bill: number; active_clients: number; rate_trend: number; avg_bill_12mo: number; retention: number;
+}
+
+const money = (n: number) => `$${Math.round(n || 0).toLocaleString("en-US")}`;
+const money2 = (n: number) => `$${(n || 0).toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+const signPct = (n: number) => `${n > 0 ? "+" : ""}${n ?? 0}%`;
+
+function Big({ t, c = INK }: { t: string; c?: string }) {
+  return <span style={{ fontSize: 28, fontWeight: 800, color: c, fontFamily: FF, lineHeight: 1.1 }}>{t}</span>;
+}
+
+interface LibCard { key: string; label: string; sub?: string; render: (d: CardData, payroll: number | null) => ReactNode; }
+
+// Full card library — every card available to every user.
+const LIBRARY: LibCard[] = [
+  { key: "daily_revenue",        label: "Daily Revenue",        sub: "completed today",        render: d => <Big t={money(d.daily_revenue)} /> },
+  { key: "revenue_booked_today", label: "Revenue Booked Today", sub: "on schedule today",      render: d => <Big t={money(d.revenue_booked_today)} /> },
+  { key: "jobs_today",           label: "Jobs Today",           render: d => <Big t={String(d.jobs_today)} /> },
+  { key: "jobs_scheduled_today", label: "Jobs Scheduled Today", render: d => <Big t={String(d.jobs_scheduled_today)} /> },
+  { key: "late_clockins",        label: "Late Clock-ins",       sub: "no clock-in past start +20m", render: d => <Big t={String(d.late_clockins)} c={d.late_clockins > 0 ? RED : INK} /> },
+  { key: "todays_status",        label: "Today's Status",       render: d => {
+      const s = d.todays_status;
+      const items: [string, number][] = [["In progress", s.in_progress], ["Scheduled", s.scheduled], ["Complete", s.complete], ["Flagged", s.flagged], ["Unassigned", s.unassigned]];
+      return (
+        <div style={{ display: "flex", flexWrap: "wrap", gap: "6px 14px", marginTop: 2 }}>
+          {items.map(([l, v]) => (
+            <span key={l} style={{ fontSize: 13, fontFamily: FF, color: MUTE }}>
+              <b style={{ color: INK, fontWeight: 800 }}>{v}</b> {l}
+            </span>
+          ))}
+        </div>
+      );
+    } },
+  { key: "unassigned_jobs",      label: "Unassigned Jobs",      render: d => <Big t={String(d.unassigned_jobs)} c={d.unassigned_jobs > 0 ? RED : INK} /> },
+  { key: "techs_today",          label: "Techs Today",          sub: "working today",          render: d => <Big t={String(d.techs_today)} /> },
+  { key: "next_7_days",          label: "Next 7 Days",          render: d => (
+      <div style={{ display: "flex", alignItems: "baseline", gap: 10 }}>
+        <Big t={money(d.next_7_days_revenue)} />
+        <span style={{ fontSize: 13, color: MUTE, fontFamily: FF }}>{d.next_7_days_jobs} jobs</span>
+      </div>
+    ) },
+  { key: "leads",                label: "Leads",                sub: "this month",             render: d => <Big t={String(d.leads)} /> },
+  { key: "quotes",               label: "Quotes",               sub: "this month",             render: d => <Big t={String(d.quotes)} /> },
+  { key: "closed_quotes",        label: "Closed Quotes",        sub: "won this month",         render: d => <Big t={String(d.closed_quotes)} /> },
+  { key: "close_rate",           label: "Close Rate",           sub: "closed / total, this month", render: d => <Big t={`${d.close_rate}%`} c={MINT} /> },
+  { key: "monthly_revenue",      label: "Monthly Revenue",      sub: "month to date",          render: d => <Big t={money(d.monthly_revenue)} /> },
+  { key: "avg_bill",             label: "Avg Bill",             sub: "last 30 days",           render: d => <Big t={money2(d.avg_bill)} /> },
+  { key: "active_clients",       label: "Active Clients",       render: d => <Big t={String(d.active_clients)} /> },
+  { key: "rate_trend",           label: "Rate Trend",           sub: "avg bill, 12mo vs prior 12mo", render: d => <Big t={signPct(d.rate_trend)} c={d.rate_trend < 0 ? RED : MINT} /> },
+  { key: "retention",            label: "Retention",            sub: "recurring clients active", render: d => <Big t={`${d.retention}%`} c={MINT} /> },
+  { key: "payroll_pct",          label: "Payroll %",            sub: "payroll / revenue",      render: (_d, payroll) => <Big t={payroll == null ? "—" : `${payroll.toFixed(1)}%`} /> },
+];
+const LIB_KEYS = LIBRARY.map(l => l.key);
+const cardDef = (k: string) => LIBRARY.find(l => l.key === k);
+
+// Default sets shown before any customization.
+const OWNER_DEFAULT = ["daily_revenue", "jobs_today", "revenue_booked_today", "leads", "quotes", "closed_quotes", "close_rate"];
+const OFFICE_DEFAULT = ["jobs_scheduled_today", "late_clockins", "todays_status", "unassigned_jobs", "techs_today", "next_7_days"];
+const roleDefault = (role: string) => (role === "owner" ? OWNER_DEFAULT : OFFICE_DEFAULT);
+
+export default function MobileDashboard() {
+  const { activeBranchId } = useBranch();
+  const role = getTokenRole() || "office";
+
+  const [data, setData] = useState<CardData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [payroll, setPayroll] = useState<number | null>(null);
+  const [order, setOrder] = useState<string[]>([]);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [customizing, setCustomizing] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  function applyDefault() {
+    const def = roleDefault(role);
+    setOrder([...def, ...LIB_KEYS.filter(k => !def.includes(k))]);
+    setSelected(new Set(def));
+  }
+
+  // Load this user's saved preference (or fall back to the role default).
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const r = await fetch(`${API}/api/dashboard/card-prefs`, { headers: getAuthHeaders() });
+        const rows = await r.json();
+        if (cancelled) return;
+        const known = Array.isArray(rows) ? rows.filter((x: any) => LIB_KEYS.includes(x.card_key)) : [];
+        if (known.length) {
+          const ord = known.map((x: any) => x.card_key);
+          for (const k of LIB_KEYS) if (!ord.includes(k)) ord.push(k);
+          setOrder(ord);
+          setSelected(new Set(known.filter((x: any) => x.visible).map((x: any) => x.card_key)));
+        } else {
+          applyDefault();
+        }
+      } catch {
+        if (!cancelled) applyDefault();
+      }
+    })();
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Load metric data; re-fetch when the branch toggle changes.
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    (async () => {
+      try {
+        const q = activeBranchId && activeBranchId !== "all" ? `?branch_id=${activeBranchId}` : "";
+        const r = await fetch(`${API}/api/dashboard/mobile-cards${q}`, { headers: getAuthHeaders() });
+        const d = await r.json();
+        if (!cancelled) setData(d);
+      } catch {
+        if (!cancelled) setData(null);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [activeBranchId]);
+
+  // Payroll % comes from the existing reports endpoint; fetch only if shown.
+  useEffect(() => {
+    if (!selected.has("payroll_pct") || payroll !== null) return;
+    (async () => {
+      try {
+        const r = await fetch(`${API}/api/reports/payroll-to-revenue`, { headers: getAuthHeaders() });
+        const d = await r.json();
+        setPayroll(d?.current?.pct ?? null);
+      } catch { /* leave as — */ }
+    })();
+  }, [selected, payroll]);
+
+  const visibleKeys = order.filter(k => selected.has(k));
+
+  async function savePrefs() {
+    setSaving(true);
+    try {
+      const cards = order.map((k, i) => ({ card_key: k, visible: selected.has(k), sort_order: i }));
+      await fetch(`${API}/api/dashboard/card-prefs`, {
+        method: "PUT",
+        headers: { ...getAuthHeaders(), "Content-Type": "application/json" },
+        body: JSON.stringify({ cards }),
+      });
+      setCustomizing(false);
+    } catch { /* keep picker open on failure */ }
+    finally { setSaving(false); }
+  }
+
+  async function resetPrefs() {
+    try { await fetch(`${API}/api/dashboard/card-prefs`, { method: "DELETE", headers: getAuthHeaders() }); } catch { /* ignore */ }
+    applyDefault();
+  }
+
+  function toggle(k: string) {
+    setSelected(prev => { const n = new Set(prev); if (n.has(k)) n.delete(k); else n.add(k); return n; });
+  }
+  function move(k: string, dir: -1 | 1) {
+    setOrder(prev => {
+      const i = prev.indexOf(k);
+      const j = i + dir;
+      if (i < 0 || j < 0 || j >= prev.length) return prev;
+      const next = [...prev];
+      [next[i], next[j]] = [next[j], next[i]];
+      return next;
+    });
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 12, fontFamily: FF, paddingBottom: 24 }}>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        <span style={{ fontSize: 18, fontWeight: 800, color: INK }}>Dashboard</span>
+        <button
+          onClick={() => setCustomizing(true)}
+          style={{ display: "inline-flex", alignItems: "center", gap: 6, padding: "8px 12px", borderRadius: 10, border: "1px solid #E5E2DC", background: "#FFFFFF", color: INK, fontSize: 13, fontWeight: 600, fontFamily: FF, cursor: "pointer" }}
+        >
+          <Settings2 size={15} /> Customize
+        </button>
+      </div>
+
+      {loading && !data ? (
+        <div style={{ ...CARD, padding: 24, textAlign: "center", color: MUTE, fontSize: 13 }}>Loading…</div>
+      ) : visibleKeys.length === 0 ? (
+        <div style={{ ...CARD, padding: 24, textAlign: "center", color: MUTE, fontSize: 13 }}>
+          No cards selected. Tap Customize to add some.
+        </div>
+      ) : (
+        visibleKeys.map(k => {
+          const def = cardDef(k);
+          if (!def || !data) return null;
+          return (
+            <div key={k} style={{ ...CARD, padding: 16 }}>
+              <div style={{ fontSize: 12, fontWeight: 700, color: MUTE, textTransform: "uppercase", letterSpacing: "0.06em" }}>{def.label}</div>
+              <div style={{ marginTop: 6 }}>{def.render(data, payroll)}</div>
+              {def.sub && <div style={{ fontSize: 11, color: "#9E9B94", marginTop: 4 }}>{def.sub}</div>}
+            </div>
+          );
+        })
+      )}
+
+      {customizing && (
+        <div
+          onClick={() => setCustomizing(false)}
+          style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,0.45)", zIndex: 9998, display: "flex", alignItems: "flex-end" }}
+        >
+          <div
+            onClick={e => e.stopPropagation()}
+            style={{ background: "#FFFFFF", borderTopLeftRadius: 16, borderTopRightRadius: 16, width: "100%", maxHeight: "85vh", display: "flex", flexDirection: "column", fontFamily: FF }}
+          >
+            <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", padding: "16px 16px 8px" }}>
+              <span style={{ fontSize: 16, fontWeight: 800, color: INK }}>Customize dashboard</span>
+              <button onClick={() => setCustomizing(false)} style={{ background: "none", border: "none", cursor: "pointer", color: MUTE, padding: 4 }}><X size={18} /></button>
+            </div>
+            <div style={{ overflowY: "auto", padding: "0 12px 8px" }}>
+              {order.map((k, i) => {
+                const def = cardDef(k);
+                if (!def) return null;
+                const on = selected.has(k);
+                return (
+                  <div key={k} style={{ display: "flex", alignItems: "center", gap: 10, padding: "10px 8px", borderBottom: "0.5px solid #E5E2DC" }}>
+                    <input type="checkbox" checked={on} onChange={() => toggle(k)} style={{ cursor: "pointer", width: 16, height: 16 }} />
+                    <span style={{ flex: 1, fontSize: 14, color: INK }}>{def.label}</span>
+                    <button onClick={() => move(k, -1)} disabled={i === 0} style={arrowBtn(i === 0)}><ArrowUp size={15} /></button>
+                    <button onClick={() => move(k, 1)} disabled={i === order.length - 1} style={arrowBtn(i === order.length - 1)}><ArrowDown size={15} /></button>
+                  </div>
+                );
+              })}
+            </div>
+            <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", padding: 12, borderTop: "0.5px solid #E5E2DC", gap: 8 }}>
+              <button onClick={resetPrefs} style={{ display: "inline-flex", alignItems: "center", gap: 6, padding: "10px 12px", borderRadius: 10, border: "1px solid #E5E2DC", background: "#FFFFFF", color: MUTE, fontSize: 13, fontWeight: 600, fontFamily: FF, cursor: "pointer" }}>
+                <RotateCcw size={14} /> Reset to default
+              </button>
+              <button onClick={savePrefs} disabled={saving} style={{ padding: "10px 18px", borderRadius: 10, border: "none", background: MINT, color: "#FFFFFF", fontSize: 14, fontWeight: 700, fontFamily: FF, cursor: "pointer", opacity: saving ? 0.7 : 1 }}>
+                {saving ? "Saving…" : "Save"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function arrowBtn(disabled: boolean): CSSProperties {
+  return { display: "inline-flex", alignItems: "center", justifyContent: "center", width: 32, height: 32, borderRadius: 8, border: "1px solid #E5E2DC", background: "#FFFFFF", color: disabled ? "#C9C6BF" : "#6B6860", cursor: disabled ? "not-allowed" : "pointer" };
+}

--- a/artifacts/qleno/src/pages/dashboard.tsx
+++ b/artifacts/qleno/src/pages/dashboard.tsx
@@ -6,6 +6,7 @@ import { useLocation } from "wouter";
 import { ChevronRight, Calendar, ShieldAlert, Building2, Car, Check, X } from "lucide-react";
 import { CloseDayModal } from "@/components/close-day-modal";
 import { useBranch } from "@/contexts/branch-context";
+import MobileDashboard from "@/components/mobile-dashboard";
 import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid } from "recharts";
 
 const API = import.meta.env.BASE_URL.replace(/\/$/, "");
@@ -420,6 +421,17 @@ export default function Dashboard() {
   const ytdTotal = revenueChart.data
     .filter(r => r.month.endsWith(currentYearSuffix))
     .reduce((s, r) => s + r.revenue, 0);
+
+  // Mobile gets the role-based, user-customizable card dashboard. Desktop
+  // (below) is unchanged. All hooks above run in both paths, so this early
+  // return is safe re: rules-of-hooks.
+  if (isMobile) {
+    return (
+      <DashboardLayout>
+        <MobileDashboard />
+      </DashboardLayout>
+    );
+  }
 
   return (
     <DashboardLayout>


### PR DESCRIPTION
**DRAFT** — >400 line diff (summary below so you can see nothing unrelated rode in). Mobile-only. Desktop dashboard untouched.

## What's in it (3 files, ~510 lines, nothing else)
- `artifacts/api-server/src/routes/dashboard.ts` (+226): new `mobile-cards` read endpoint + 3 `card-prefs` endpoints.
- `artifacts/qleno/src/components/mobile-dashboard.tsx` (new, 274): the card dashboard + picker.
- `artifacts/qleno/src/pages/dashboard.tsx` (+12): `if (isMobile) return <MobileDashboard/>` after all hooks. Desktop path byte-for-byte unchanged.

## Schema gate → N/A (no schema change)
Per your pick, prefs reuse the existing **`user_column_preferences`** table with `page='mobile_dashboard'` (one row per card: `column_key`, `visible`, `sort_order`; unique on `(user_id,page,column_key)`). PUT is pure upsert (`ON CONFLICT DO UPDATE`). Reset = delete the user's `mobile_dashboard` rows → role default applies. No new table, no column, no migration, no schema push.

## Card library (19) + defaults
- **Owner default:** Daily revenue, Jobs today, Revenue booked today, Leads, Quotes, Closed quotes, Close rate.
- **Office / fallback default:** Jobs scheduled today, Late clock-ins, Today's status, Unassigned jobs, Team/techs today, Next 7 days.
- **Library-only, out of v1 defaults:** Monthly revenue, Avg bill, Active clients, **Rate trend**, **Retention**, Payroll %.
- Role only sets the *default*; every card is pickable by everyone.

## Key data decisions
- **Daily revenue ≠ Revenue booked today** — kept as two cards. Daily = jobs `complete` today (commercial hourly applied). Booked = all non-cancelled scheduled today. They diverge whenever jobs are still open or any commercial job exists. (Also: booked-today now routes through `jobRevenueExpr`, fixing the old `/kpis` undervaluation of commercial.)
- **Rate trend** = avg bill **trailing 12mo vs prior 12mo** (% change) — pricing erosion, your definition. First/only implementation (no prior calc existed to match — `rate trend` had 0 refs in the repo; #264 was the quotes fix, not the KPI PR).
- **Retention** = recurring-schedule clients active ÷ all recurring-schedule clients.
- **Late clock-ins** = scheduled today, assigned, no clock-in for the job, now ≥ start+20m (Central) — matches the dispatch board's `late_clockin`.
- **Closed quotes** = `booked` or `booked_job_id` set; **Close rate** = closed ÷ total this month.
- **Branch awareness:** job/client cards filter by the active branch; leads/quotes/retention are company-wide (quotes has no reliable `branch_id`; recurring_schedules has no branch column). Called out so it's not a surprise.

## Verification
- ✅ `tsc --noEmit` clean (API + frontend) on all changed files.
- ✅ Diff scope = the 3 files above only.
- ⚠️ **Live numbers are yours to confirm.** I can't reach the prod DB from the sandbox, so I will **not** paste a fabricated −10.86%. After deploy, on a narrow viewport: (1) owner login shows the owner default set in order; (2) office login shows the office set; (3) customize + save + reload persists, and a second user's set is unaffected; (4) Reset restores the role default; (5) `SELECT * FROM user_column_preferences WHERE page='mobile_dashboard'` returns your saved row; (6) Rate trend lands near −10.86% if rates are eroding as expected. Tell me any number that looks off and I'll trace it.

## Punch list (logged here, NOT built in this PR)
1. **Commercial flat-total / rate override on *existing* scheduled jobs** — office can edit rate on new jobs but not already-scheduled ones; needs billed amount to resolve from a real per-client source. Group with the **$0.00 Cancel/Lockout fee bug** (same root cause).
2. **Discounts flow** — needs a spec (where it applies, % vs flat, new + existing jobs) before building.
3. **Save & Convert (#263)** — verify post-deploy; reopen if still greyed.
4. **Standalone desktop KPI cards** (Rate trend, Payroll %, Retention under a BUSINESS HEALTH section) — specced earlier, never built.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_