### PR TITLE
fix(dashboard): source mobile avg-bill + rate-trend from job_history ledger

### DIFF
--- a/artifacts/api-server/src/routes/dashboard.ts
+++ b/artifacts/api-server/src/routes/dashboard.ts
@@ -1206,7 +1206,7 @@ router.get("/mobile-cards", requireAuth, async (req, res) => {
     const exprBase = jobRevenueExpr(sql`CAST(j.base_fee AS NUMERIC)`, "j", "c");
     const exprBilled = jobRevenueExpr(sql`COALESCE(CAST(j.billed_amount AS NUMERIC), CAST(j.base_fee AS NUMERIC), 0)`, "j", "c");
 
-    const [todayRev, todayCounts, monthRev, avgBill, next7, lateRows, leadsRows, quotesRows, activeRows, rateRows, retentionRows] = await Promise.all([
+    const [todayRev, todayCounts, monthRev, histRows, next7, lateRows, leadsRows, quotesRows, activeRows, retentionRows] = await Promise.all([
       // Daily revenue (completed today, actual) vs Revenue booked today (all non-cancelled scheduled today)
       db.execute(sql`
         SELECT
@@ -1235,13 +1235,30 @@ router.get("/mobile-cards", requireAuth, async (req, res) => {
         WHERE j.company_id = ${companyId} AND j.status != 'cancelled'
           AND j.scheduled_date >= ${monthStart}::date AND j.scheduled_date <= ${today} ${jb}
       `),
-      // Avg bill (last 30 days, excluding $0)
+      // Avg bill + rate trend SOURCE = job_history (the clean MC ledger), NOT
+      // jobs. The jobs table is corrupted for trend purposes (Jan-Mar 2026
+      // billed_amount ~2x, May ~80% missing, no real 12-24 month depth), so
+      // jobs-sourced trends were nonsense (+70.54%). job_history is the
+      // MC-accurate closed-month ledger and is exactly what the desktop
+      // revenue chart reads (dashboard.ts revenue-chart): date = job_date,
+      // amount = revenue. Closed full months only: the partial current month
+      // is excluded. Company-wide: job_history has no branch column.
       db.execute(sql`
-        SELECT COALESCE(AVG(${exprBilled}), 0)::numeric AS v
-        FROM jobs j LEFT JOIN clients c ON c.id = j.client_id
-        WHERE j.company_id = ${companyId} AND j.status != 'cancelled'
-          AND j.scheduled_date >= ${today} - INTERVAL '30 days' AND j.scheduled_date <= ${today}
-          AND ${exprBilled} > 0 ${jb}
+        SELECT
+          COALESCE(AVG(revenue) FILTER (WHERE revenue > 0
+            AND job_date >= date_trunc('month', now()) - INTERVAL '12 months'
+            AND job_date <  date_trunc('month', now())), 0)::numeric AS last12_avg,
+          COUNT(*) FILTER (WHERE revenue > 0
+            AND job_date >= date_trunc('month', now()) - INTERVAL '12 months'
+            AND job_date <  date_trunc('month', now()))::int AS last12_n,
+          COALESCE(AVG(revenue) FILTER (WHERE revenue > 0
+            AND job_date >= date_trunc('month', now()) - INTERVAL '24 months'
+            AND job_date <  date_trunc('month', now()) - INTERVAL '12 months'), 0)::numeric AS prior12_avg,
+          COUNT(*) FILTER (WHERE revenue > 0
+            AND job_date >= date_trunc('month', now()) - INTERVAL '24 months'
+            AND job_date <  date_trunc('month', now()) - INTERVAL '12 months')::int AS prior12_n
+        FROM job_history
+        WHERE company_id = ${companyId}
       `),
       // Next 7 days (jobs + revenue)
       db.execute(sql`
@@ -1278,17 +1295,6 @@ router.get("/mobile-cards", requireAuth, async (req, res) => {
       db.execute(sql`
         SELECT COUNT(*)::int AS v FROM clients
         WHERE company_id = ${companyId} AND is_active = true ${cb}
-      `),
-      // Rate trend = avg bill (same calc as Avg Bill card) trailing 12mo vs prior 12mo.
-      // This is pricing erosion, NOT revenue volatility. First/only implementation.
-      db.execute(sql`
-        SELECT
-          COALESCE(AVG(${exprBilled}) FILTER (WHERE j.scheduled_date >= ${today} - INTERVAL '12 months'), 0)::numeric AS last12,
-          COALESCE(AVG(${exprBilled}) FILTER (WHERE j.scheduled_date >= ${today} - INTERVAL '24 months' AND j.scheduled_date < ${today} - INTERVAL '12 months'), 0)::numeric AS prior12
-        FROM jobs j LEFT JOIN clients c ON c.id = j.client_id
-        WHERE j.company_id = ${companyId} AND j.status != 'cancelled'
-          AND j.scheduled_date >= ${today} - INTERVAL '24 months' AND j.scheduled_date <= ${today}
-          AND ${exprBilled} > 0 ${jb}
       `),
       // Recurring retention = distinct clients with an active recurring schedule /
       // distinct clients with any recurring schedule (company-wide; no branch column).
@@ -1331,16 +1337,18 @@ router.get("/mobile-cards", requireAuth, async (req, res) => {
       closed_quotes: quotesClosed,
       close_rate: quotesTotal > 0 ? Math.round((quotesClosed / quotesTotal) * 100) : 0,
       monthly_revenue: num((monthRev as any).rows[0]?.v),
-      avg_bill: num((avgBill as any).rows[0]?.v),
+      // Avg bill = avg job revenue over the trailing 12 closed months (job_history).
+      avg_bill: num((histRows as any).rows[0]?.last12_avg),
       active_clients: Number((activeRows as any).rows[0]?.v ?? 0),
-      // Rate trend: % change in avg bill, trailing 12mo vs prior 12mo (pricing erosion).
+      // Rate trend: % change in avg bill, trailing 12 closed months vs prior 12,
+      // sourced from job_history (pricing erosion, not jobs-table noise).
       rate_trend: (() => {
-        const r: any = (rateRows as any).rows[0] ?? {};
-        const last12 = Number(r.last12 ?? 0);
-        const prior12 = Number(r.prior12 ?? 0);
+        const r: any = (histRows as any).rows[0] ?? {};
+        const last12 = Number(r.last12_avg ?? 0);
+        const prior12 = Number(r.prior12_avg ?? 0);
         return prior12 > 0 ? Math.round(((last12 - prior12) / prior12) * 10000) / 100 : 0;
       })(),
-      avg_bill_12mo: num((rateRows as any).rows[0]?.last12),
+      avg_bill_12mo: num((histRows as any).rows[0]?.last12_avg),
       // Recurring retention: % of recurring-schedule clients still active.
       retention: (() => {
         const r: any = (retentionRows as any).rows[0] ?? {};

--- a/artifacts/qleno/src/components/mobile-dashboard.tsx
+++ b/artifacts/qleno/src/components/mobile-dashboard.tsx
@@ -71,7 +71,7 @@ const LIBRARY: LibCard[] = [
   { key: "closed_quotes",        label: "Closed Quotes",        sub: "won this month",         render: d => <Big t={String(d.closed_quotes)} /> },
   { key: "close_rate",           label: "Close Rate",           sub: "closed / total, this month", render: d => <Big t={`${d.close_rate}%`} c={MINT} /> },
   { key: "monthly_revenue",      label: "Monthly Revenue",      sub: "month to date",          render: d => <Big t={money(d.monthly_revenue)} /> },
-  { key: "avg_bill",             label: "Avg Bill",             sub: "last 30 days",           render: d => <Big t={money2(d.avg_bill)} /> },
+  { key: "avg_bill",             label: "Avg Bill",             sub: "per job, last 12 months", render: d => <Big t={money2(d.avg_bill)} /> },
   { key: "active_clients",       label: "Active Clients",       render: d => <Big t={String(d.active_clients)} /> },
   { key: "rate_trend",           label: "Rate Trend",           sub: "avg bill, 12mo vs prior 12mo", render: d => <Big t={signPct(d.rate_trend)} c={d.rate_trend < 0 ? RED : MINT} /> },
   { key: "retention",            label: "Retention",            sub: "recurring clients active", render: d => <Big t={`${d.retention}%`} c={MINT} /> },


### PR DESCRIPTION
Single-concern read-source fix. The mobile **rate-trend** and **avg-bill** cards read from the `jobs` table, which is corrupted for trend purposes. Repointed both to `job_history` — the MC-accurate closed-month ledger the desktop revenue chart already uses.

## Change (2 files, ~58 lines, only the KPI source)
- `routes/dashboard.ts`: replaced the two jobs-sourced queries (avg-bill 30-day + rate-trend 12v12) with one `job_history` query (`job_date` window, `revenue` amount), matching the desktop revenue chart pattern.
- `components/mobile-dashboard.tsx`: avg-bill sub-label `last 30 days` → `per job, last 12 months` (the source period changed).

## Decisions (per the spec)
- **Closed full months only** (requirement 3's simpler option): windows are `[month_start − 24mo, month_start − 12mo)` vs `[month_start − 12mo, month_start)`. The partial current month is excluded; `job_history` holds closed months only anyway.
- **Company-wide**: `job_history` has no branch column, so these two cards no longer branch-filter (the desktop chart is company-wide too).
- **Raw `db.execute` (not `.select()`)**: `job_history` is a raw migration table with no Drizzle model; this matches the existing reference reads in `dashboard.ts`. No writes anywhere in this change.

## Before / after
**Before** (jobs source — your verified prod numbers):
- `last12_avg` = $305.38 over 1922 jobs; `prior12_avg` = $220.00 over only 21 jobs → **rate_trend +70.54%**, avg_bill ~$305.

**After** (job_history source — expected): avg_bill ~**$220–226**, rate_trend in the **−10% to +5%** range (real ≈ −10.86%).

> ⚠️ **Verification honesty:** I could **not** execute the prod-DB/API verification myself — `DATABASE_URL` is not present in this build environment (env unset, no `.env`, scanned all 78 vars). I will not paste fabricated "after" numbers. The "after" figures above are the expected values derived from your MC-verified `job_history` ledger. **Please confirm the live mobile-cards API after deploy** returns `avg_bill ≈ $220–226` and `rate_trend` negative/near-flat. If either is off, tell me and I'll trace the window boundaries.

`tsc --noEmit` is net-zero new errors (API + frontend).

## Known follow-up (NOT touched here)
The `jobs` table revenue corruption — Jan–Mar 2026 `billed_amount` ~2x inflated, May 2026 ~80% missing — is a separate data investigation. Flagged, deliberately not addressed in this read-source fix.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_