### PR TITLE
fix(jobs): allow manual flat price on existing commercial jobs (unblock billing)

### DIFF
--- a/artifacts/qleno/src/components/edit-job-modal.tsx
+++ b/artifacts/qleno/src/components/edit-job-modal.tsx
@@ -847,12 +847,15 @@ export default function EditJobModal({
     && allowedHours > 0
     && selectedTechIds.length > 0
     && /^\d{2}:\d{2}$/.test(scheduledTime)
-    // [AH] Commercial requires a positive hourly rate.
-    && (!isCommercial || hourlyRate > 0)
+    // [AH] Commercial requires a positive hourly rate — UNLESS a manual flat
+    // price is set, which ignores the hourly math entirely.
+    && (!isCommercial || manualRate || hourlyRate > 0)
     // [AI] custom_days requires at least one day checked.
     && (frequency !== "custom_days" || daysOfWeek.length > 0)
-    // [AI.4] Commercial requires a valid service type from the active list.
-    && commercialServiceTypeValid;
+    // [AI.4] Commercial requires a valid service type — UNLESS a manual flat
+    // price is set. Billing an arbitrary amount ("$1000 on whichever service")
+    // must never be blocked by service-type validity. (Sal, 2026-06-03.)
+    && (manualRate || commercialServiceTypeValid);
 
   // ── Cascade prompt or direct submit ─────────────────────────────────────
   // [recurring-on-save 2026-04-30] Three branches now:
@@ -1049,8 +1052,13 @@ export default function EditJobModal({
       // user picked from the commercial dropdown; hourly_rate persists to
       // jobs.hourly_rate (and cascades to recurring_schedules.commercial_hourly_rate).
       if (isCommercial) {
-        payload.service_type = commercialServiceType;
-        payload.hourly_rate = hourlyRate;
+        // Only send service_type when the operator actually has one selected.
+        // If the dropdown was auto-blanked for a legacy slug (AI.4) and they're
+        // just setting a manual price, sending "" would WIPE the job's existing
+        // service_type — so omit it and leave the stored value untouched.
+        if (commercialServiceType !== "") payload.service_type = commercialServiceType;
+        // Don't overwrite a real hourly_rate with 0 on a manual-price save.
+        if (hourlyRate > 0) payload.hourly_rate = hourlyRate;
       }
       // [AI] Multi-day fields. days_of_week is only meaningful when frequency
       // is one of the multi-day values; PATCH endpoint validates exclusivity.


### PR DESCRIPTION
Office could not edit the billed amount on an **already-scheduled commercial job** (worked on new ones — Maribel: "I can only edit hours and rate… editing an already scheduled job doesn't work"). Single-concern, one file.

## Root cause (client-side only)
The backend PATCH already persists a free `base_fee` verbatim. The block was two gates in the edit-job modal's `canSave`:
1. **Service-type gate** — commercial required an *active* tenant-managed `service_type`, but an existing job carrying a legacy/inactive slug opens with the dropdown **auto-blanked** (AI.4), so Save stayed disabled until they re-picked a type.
2. **`hourly_rate > 0` gate** — required even when the price is a manual flat override that ignores the hours×rate math.

## Fix
When a **manual flat price** is set (`manual_rate_override`), both gates are bypassed — billing an arbitrary amount ("$1,000 on whichever service of the month, send invoice") must never be blocked by service-type validity or the hourly math. Also stop sending an empty `service_type` on save, so a manual-price save can't wipe the job's existing slug.

This intentionally relaxes the AI.4 "service type required" gate **for the manual-price case only**, per Sal's directive: "it shouldn't matter what service… ultimately we are still billing 1000." A normal commercial edit (no manual price) still enforces both gates.

`artifacts/qleno/src/components/edit-job-modal.tsx` — `tsc` clean.

## What this unblocks
The office's real commercial workflow with **no new engine**: month total on the first/last service of the month ($0 the rest), Circle-style splits ($300 → $150 × 2), KMA, Bill. The full aggregated-invoice feature (per `docs/COMMERCIAL_BILLING_DESIGN.md`, monthly aggregation is deferred there) remains a separate future build.

## Verify post-deploy
Open an existing commercial job (e.g. Bill Azzarello) → Override rate → type an amount → Save succeeds and the amount sticks on the tile/panel, regardless of service type or hourly rate.

## Related (not in this PR)
- Phantom $0 recurring jobs (Yates cleaned via DB; Anthony/Ciana real, missing address — data backfill).
- Payroll % dynamic-window build still parked awaiting Q1/Q2 results.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_