### PR TITLE
feat(settings): tenant toggle for GPS-unavailable flag — schema shown first

### DIFF
--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -30,6 +30,7 @@ async function runBookingSchemaGuard(): Promise<void> {
     { label: "jobs.bundle_discount_total", stmt: "ALTER TABLE jobs ADD COLUMN IF NOT EXISTS bundle_discount_total NUMERIC(10,2)" },
     { label: "jobs.office_notes_updated_by", stmt: "ALTER TABLE jobs ADD COLUMN IF NOT EXISTS office_notes_updated_by INTEGER" },
     { label: "jobs.office_notes_updated_at", stmt: "ALTER TABLE jobs ADD COLUMN IF NOT EXISTS office_notes_updated_at TIMESTAMP" },
+    { label: "companies.flag_missing_gps", stmt: "ALTER TABLE companies ADD COLUMN IF NOT EXISTS flag_missing_gps BOOLEAN NOT NULL DEFAULT true" },
     { label: "jobs.last_cleaned_response", stmt: "ALTER TABLE jobs ADD COLUMN IF NOT EXISTS last_cleaned_response TEXT" },
     { label: "jobs.last_cleaned_flag",     stmt: "ALTER TABLE jobs ADD COLUMN IF NOT EXISTS last_cleaned_flag TEXT" },
     { label: "jobs.overage_disclaimer_acknowledged", stmt: "ALTER TABLE jobs ADD COLUMN IF NOT EXISTS overage_disclaimer_acknowledged BOOLEAN DEFAULT false" },

--- a/artifacts/api-server/src/routes/companies.ts
+++ b/artifacts/api-server/src/routes/companies.ts
@@ -105,7 +105,7 @@ router.patch("/me", requireAuth, async (req, res) => {
       sms_on_my_way_enabled, sms_arrived_enabled, sms_paused_enabled,
       sms_complete_enabled, twilio_from_number,
       geofence_enabled, geofence_clockin_radius_ft, geofence_clockout_radius_ft,
-      geofence_override_allowed, geofence_soft_mode,
+      geofence_override_allowed, geofence_soft_mode, flag_missing_gps,
     } = req.body;
 
     const patch: Record<string, unknown> = {};
@@ -124,6 +124,7 @@ router.patch("/me", requireAuth, async (req, res) => {
     if (geofence_clockout_radius_ft !== undefined) patch.geofence_clockout_radius_ft = geofence_clockout_radius_ft;
     if (geofence_override_allowed !== undefined) patch.geofence_override_allowed = geofence_override_allowed;
     if (geofence_soft_mode !== undefined) patch.geofence_soft_mode = geofence_soft_mode;
+    if (flag_missing_gps !== undefined) patch.flag_missing_gps = flag_missing_gps;
     const {
       default_payment_terms_residential, default_payment_terms_commercial,
       default_invoice_notes_residential, default_invoice_notes_commercial,

--- a/artifacts/api-server/src/routes/dispatch.ts
+++ b/artifacts/api-server/src/routes/dispatch.ts
@@ -353,6 +353,10 @@ router.get("/", requireAuth, async (req, res) => {
     const userNameById = new Map<number, string>();
     for (const u of allCompanyUsers) userNameById.set(u.id, `${u.first_name ?? ""} ${u.last_name ?? ""}`.trim());
 
+    // [gps-flag] Tenant toggle — when off, suppress the "GPS unavailable" flag.
+    const gpsFlagRow = await db.execute(sql`SELECT flag_missing_gps FROM companies WHERE id = ${companyId} LIMIT 1`);
+    const flagMissingGps = (gpsFlagRow.rows[0] as any)?.flag_missing_gps ?? true;
+
     const photoMap = new Map<number, { before: number; after: number }>();
     for (const row of photoCounts) {
       if (!photoMap.has(row.job_id)) photoMap.set(row.job_id, { before: 0, after: 0 });
@@ -771,7 +775,7 @@ router.get("/", requireAuth, async (req, res) => {
           clock_out_outside_geofence: clock.clock_out_outside_geofence ?? false,
           // GPS unavailable = no coordinates captured at clock-in. Suppressed
           // for synthetic 'estimated' completion stamps (legitimately no GPS).
-          gps_missing: clock.source !== "estimated" && (clock.clock_in_lat == null || clock.clock_in_lng == null),
+          gps_missing: flagMissingGps && clock.source !== "estimated" && (clock.clock_in_lat == null || clock.clock_in_lng == null),
         } : null,
         technicians,
         est_hours_per_tech: estHoursPerTech,

--- a/artifacts/qleno/src/pages/company.tsx
+++ b/artifacts/qleno/src/pages/company.tsx
@@ -1501,6 +1501,7 @@ function ClockInOutTab() {
     geofence_clockout_radius_ft: 1000,
     geofence_override_allowed: true,
     geofence_soft_mode: false,
+    flag_missing_gps: true,
   });
 
   useEffect(() => {
@@ -1514,6 +1515,7 @@ function ClockInOutTab() {
           geofence_clockout_radius_ft: d.geofence_clockout_radius_ft ?? 1000,
           geofence_override_allowed: d.geofence_override_allowed ?? true,
           geofence_soft_mode: d.geofence_soft_mode ?? false,
+          flag_missing_gps: d.flag_missing_gps ?? true,
         });
       })
       .catch(() => {})
@@ -1561,6 +1563,16 @@ function ClockInOutTab() {
             <p style={{ fontSize: 12, color: '#6B7280', margin: 0 }}>Employees must be within range of job address to clock in and out</p>
           </div>
           <ToggleSwitch checked={settings.geofence_enabled} onChange={v => setSettings(s => ({ ...s, geofence_enabled: v }))} />
+        </div>
+      </div>
+
+      <div style={CARD}>
+        <div style={ROW}>
+          <div>
+            <p style={{ fontSize: 14, fontWeight: 700, color: '#1A1917', margin: '0 0 3px' }}>Flag missing GPS on the board</p>
+            <p style={{ fontSize: 12, color: '#6B7280', margin: 0 }}>Show a "GPS unavailable" flag on a job when a tech clocked in with no location captured</p>
+          </div>
+          <ToggleSwitch checked={settings.flag_missing_gps} onChange={v => setSettings(s => ({ ...s, flag_missing_gps: v }))} />
         </div>
       </div>
 

--- a/lib/db/src/schema/companies.ts
+++ b/lib/db/src/schema/companies.ts
@@ -32,6 +32,9 @@ export const companiesTable = pgTable("companies", {
   geofence_clockout_radius_ft: integer("geofence_clockout_radius_ft").notNull().default(1000),
   geofence_override_allowed: boolean("geofence_override_allowed").notNull().default(true),
   geofence_soft_mode: boolean("geofence_soft_mode").notNull().default(false),
+  // [gps-flag] When true, the dispatch panel flags clock punches that captured
+  // no GPS coordinates ("GPS unavailable"). Office can turn it off here.
+  flag_missing_gps: boolean("flag_missing_gps").notNull().default(true),
   brand_color: text("brand_color").notNull().default("#00C9A7"),
   sms_on_my_way_enabled: boolean("sms_on_my_way_enabled").notNull().default(true),
   sms_arrived_enabled: boolean("sms_arrived_enabled").notNull().default(false),


### PR DESCRIPTION
**DRAFT — schema change, shown first.** Adds the on/off tenant toggle for the "GPS unavailable" flag you asked for.

## Schema (review) — 1 additive column on `companies`
```sql
ALTER TABLE companies ADD COLUMN IF NOT EXISTS flag_missing_gps BOOLEAN NOT NULL DEFAULT true;
```
Additive, idempotent. **Default `true`** preserves today's always-flag behavior. No enum, no new table, no DELETE+INSERT.

## Behavior
- **Settings → Clock In/Out** gets a new toggle: **"Flag missing GPS on the board."** Loads/saves through the existing `GET`/`PATCH /api/companies/me` (same path the geofence settings already use).
- Dispatch **ANDs** the toggle into the per-job `gps_missing` value — so when it's off, the "GPS unavailable" flag simply never appears. No panel-side change.

Files: `schema/companies.ts`, `phes-data-migration.ts`, `routes/companies.ts`, `routes/dispatch.ts`, `company.tsx`. tsc clean (API + FE).

**Approve the one column and I'll mark it Ready + merge.**

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_