### PR TITLE
fix(dispatch): New → Job menu opens the scheduler

### DIFF
--- a/artifacts/qleno/src/components/layout/dashboard-layout.tsx
+++ b/artifacts/qleno/src/components/layout/dashboard-layout.tsx
@@ -711,7 +711,7 @@ export function DashboardLayout({ children, title, fullBleed, onNewJob }: Dashbo
                   <div style={{ fontSize: 10, fontWeight: 700, color: '#9E9B94', textTransform: 'uppercase', letterSpacing: '0.07em', padding: '7px 10px 5px', fontFamily: "'Plus Jakarta Sans', sans-serif" }}>Create new</div>
                   {([
                     { label: 'Quote',  desc: 'Build a price quote', Icon: Receipt,   href: '/quotes/new' },
-                    { label: 'Job',    desc: 'Schedule a job',      Icon: Briefcase, href: '/dispatch' },
+                    { label: 'Job',    desc: 'Schedule a job',      Icon: Briefcase, href: '/dispatch?new=1' },
                     { label: 'Client', desc: 'Add a customer',      Icon: UserPlus,  href: '/customers' },
                   ] as const).map((item) => (
                     <button
@@ -888,7 +888,7 @@ export function DashboardLayout({ children, title, fullBleed, onNewJob }: Dashbo
                   <div style={{ fontSize: 10, fontWeight: 700, color: '#9E9B94', textTransform: 'uppercase', letterSpacing: '0.07em', padding: '7px 10px 5px', fontFamily: "'Plus Jakarta Sans', sans-serif" }}>Create new</div>
                   {([
                     { label: 'Quote',  desc: 'Build a price quote', Icon: Receipt,   href: '/quotes/new' },
-                    { label: 'Job',    desc: 'Schedule a job',      Icon: Briefcase, href: '/dispatch' },
+                    { label: 'Job',    desc: 'Schedule a job',      Icon: Briefcase, href: '/dispatch?new=1' },
                     { label: 'Client', desc: 'Add a customer',      Icon: UserPlus,  href: '/customers' },
                   ] as const).map((item) => (
                     <button

--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -4763,6 +4763,20 @@ export default function JobsPage() {
       window.history.replaceState(null, "", url.toString());
     }
   }, [selectedDate]);
+  // Open the New Job wizard when arrived via the global "New → Job" menu (?new=1).
+  // The dispatch toolbar's own New Job button was removed, so this is how the
+  // header create menu reaches the scheduler.
+  useEffect(() => {
+    const sp = new URLSearchParams(window.location.search);
+    if (sp.get("new") === "1") {
+      setShowWizard(true);
+      sp.delete("new");
+      const url = new URL(window.location.href);
+      url.search = sp.toString();
+      window.history.replaceState(null, "", url.toString());
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
   const [data, setData] = useState<DispatchData | null>(null);
   const [loading, setLoading] = useState(true);
   const [selectedJob, setSelectedJob] = useState<DispatchJob | null>(null);


### PR DESCRIPTION
## Problem

"I hit new job and nothing happens." The header **New → Job** menu item navigated to `/dispatch`, but the dispatch toolbar's own New Job button was removed in #270 — so nothing actually opened the scheduler. Job creation from the global create menu was dead.

## Fix

- `dashboard-layout.tsx` (mobile + desktop create menus): the **Job** item now routes to `/dispatch?new=1`.
- `jobs.tsx`: on mount, if `?new=1` is present, open the New Job wizard and strip the param from the URL via `history.replaceState` so a refresh/back doesn't re-trigger it.

## Test

- Header → New → Job → dispatch loads with the New Job wizard open.
- URL is cleaned to `/dispatch` after the wizard opens.
- Direct `/dispatch` navigation is unchanged (no wizard).

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_