### PR TITLE
fix(reschedule): clearer availability + conflict labeling

### DIFF
--- a/artifacts/api-server/src/lib/push.ts
+++ b/artifacts/api-server/src/lib/push.ts
@@ -1,0 +1,253 @@
+// Push notifications (Capacitor native app)
+// ---------------------------------------------------------------------------
+// Sends to a user's registered devices via APNs (iOS) and FCM (Android). The
+// device tokens are persisted by routes/devices.ts into the device_tokens
+// table. Everything here is:
+//   - gated by COMMS_ENABLED (mirrors the SMS/email discipline — nothing fires
+//     until the env var is "true"), and
+//   - a no-op when the platform's credentials are absent, so this is safe to
+//     ship before the APNs/FCM keys exist; it "switches on" the moment they're
+//     added to Railway env vars.
+//
+// No new dependency: APNs (ES256) and the FCM OAuth assertion (RS256) are both
+// signed with the existing `jsonwebtoken`. APNs uses node's built-in HTTP/2.
+//
+// Required env vars to go live:
+//   iOS  — APNS_KEY_P8 (the .p8 contents), APNS_KEY_ID, APNS_TEAM_ID,
+//          APNS_BUNDLE_ID (default io.phes.qleno), APNS_PRODUCTION ("true"|"false")
+//   Andr — FCM_PROJECT_ID, FCM_CLIENT_EMAIL, FCM_PRIVATE_KEY
+
+import http2 from "node:http2";
+import jwt from "jsonwebtoken";
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+export type PushPayload = {
+  title: string;
+  body: string;
+  // Arbitrary deep-link data, e.g. { type: "job", jobId: "123" }. Values are
+  // coerced to strings (FCM data values must be strings).
+  data?: Record<string, string | number>;
+};
+
+type DeviceRow = { id: number; token: string; platform: string };
+
+// ── Token persistence ──────────────────────────────────────────────────────
+
+export async function upsertDeviceToken(opts: {
+  companyId: number;
+  userId: number;
+  token: string;
+  platform: string;
+}): Promise<void> {
+  const platform = ["ios", "android", "web"].includes(opts.platform) ? opts.platform : "unknown";
+  // A token is globally unique (one per app install). If it reappears for a
+  // different user (shared device, re-login), repoint it and refresh last_seen.
+  await db.execute(sql`
+    INSERT INTO device_tokens (company_id, user_id, token, platform, last_seen_at)
+    VALUES (${opts.companyId}, ${opts.userId}, ${opts.token}, ${platform}, NOW())
+    ON CONFLICT (token) DO UPDATE
+      SET company_id = EXCLUDED.company_id,
+          user_id    = EXCLUDED.user_id,
+          platform   = EXCLUDED.platform,
+          last_seen_at = NOW()
+  `);
+}
+
+export async function deleteDeviceToken(token: string): Promise<void> {
+  await db.execute(sql`DELETE FROM device_tokens WHERE token = ${token}`);
+}
+
+async function tokensForUser(companyId: number, userId: number): Promise<DeviceRow[]> {
+  const r = await db.execute(sql`
+    SELECT id, token, platform FROM device_tokens
+    WHERE company_id = ${companyId} AND user_id = ${userId}
+  `);
+  return (r.rows as any[]).map((row) => ({ id: Number(row.id), token: String(row.token), platform: String(row.platform) }));
+}
+
+// ── APNs (iOS) ───────────────────────────────────────────────────────────────
+
+let apnsJwt: { token: string; iat: number } | null = null;
+
+function apnsConfigured(): boolean {
+  return !!(process.env.APNS_KEY_P8 && process.env.APNS_KEY_ID && process.env.APNS_TEAM_ID);
+}
+
+function apnsAuthToken(): string {
+  // APNs JWTs are valid up to 1h; refresh every ~50 minutes.
+  const now = Math.floor(Date.now() / 1000);
+  if (apnsJwt && now - apnsJwt.iat < 3000) return apnsJwt.token;
+  const key = (process.env.APNS_KEY_P8 || "").replace(/\\n/g, "\n");
+  const token = jwt.sign({ iss: process.env.APNS_TEAM_ID, iat: now }, key, {
+    algorithm: "ES256",
+    header: { alg: "ES256", kid: process.env.APNS_KEY_ID! },
+  });
+  apnsJwt = { token, iat: now };
+  return token;
+}
+
+// Returns the set of tokens APNs reported as permanently invalid (to prune).
+async function sendApns(tokens: string[], payload: PushPayload): Promise<string[]> {
+  if (!tokens.length || !apnsConfigured()) return [];
+  const host = process.env.APNS_PRODUCTION === "true"
+    ? "https://api.push.apple.com"
+    : "https://api.sandbox.push.apple.com";
+  const topic = process.env.APNS_BUNDLE_ID || "io.phes.qleno";
+  const auth = apnsAuthToken();
+  const body = JSON.stringify({
+    aps: { alert: { title: payload.title, body: payload.body }, sound: "default" },
+    ...Object.fromEntries(Object.entries(payload.data ?? {}).map(([k, v]) => [k, String(v)])),
+  });
+
+  const dead: string[] = [];
+  const client = http2.connect(host);
+  try {
+    await Promise.all(tokens.map((deviceToken) => new Promise<void>((resolve) => {
+      const req = client.request({
+        ":method": "POST",
+        ":path": `/3/device/${deviceToken}`,
+        authorization: `bearer ${auth}`,
+        "apns-topic": topic,
+        "apns-push-type": "alert",
+        "content-type": "application/json",
+      });
+      let status = 0;
+      let respBody = "";
+      req.on("response", (h) => { status = Number(h[":status"]); });
+      req.on("data", (c) => { respBody += c; });
+      req.on("end", () => {
+        // 410 = device no longer registered; 400 BadDeviceToken = invalid.
+        if (status === 410 || (status === 400 && /BadDeviceToken|Unregistered/i.test(respBody))) {
+          dead.push(deviceToken);
+        } else if (status !== 200) {
+          console.warn(`[push:apns] status ${status} ${respBody.slice(0, 120)}`);
+        }
+        resolve();
+      });
+      req.on("error", (e) => { console.warn("[push:apns] req error", e.message); resolve(); });
+      req.setTimeout(8000, () => { req.close(); resolve(); });
+      req.end(body);
+    })));
+  } finally {
+    client.close();
+  }
+  return dead;
+}
+
+// ── FCM (Android) ─────────────────────────────────────────────────────────────
+
+let fcmAccess: { token: string; exp: number } | null = null;
+
+function fcmConfigured(): boolean {
+  return !!(process.env.FCM_PROJECT_ID && process.env.FCM_CLIENT_EMAIL && process.env.FCM_PRIVATE_KEY);
+}
+
+async function fcmAccessToken(): Promise<string | null> {
+  const now = Math.floor(Date.now() / 1000);
+  if (fcmAccess && fcmAccess.exp - now > 60) return fcmAccess.token;
+  const key = (process.env.FCM_PRIVATE_KEY || "").replace(/\\n/g, "\n");
+  const assertion = jwt.sign(
+    {
+      iss: process.env.FCM_CLIENT_EMAIL,
+      scope: "https://www.googleapis.com/auth/firebase.messaging",
+      aud: "https://oauth2.googleapis.com/token",
+      iat: now,
+      exp: now + 3600,
+    },
+    key,
+    { algorithm: "RS256" },
+  );
+  const res = await fetch("https://oauth2.googleapis.com/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+      assertion,
+    }).toString(),
+  });
+  if (!res.ok) {
+    console.warn(`[push:fcm] token exchange failed ${res.status}`);
+    return null;
+  }
+  const j = (await res.json()) as { access_token: string; expires_in: number };
+  fcmAccess = { token: j.access_token, exp: now + (j.expires_in || 3600) };
+  return j.access_token;
+}
+
+async function sendFcm(tokens: string[], payload: PushPayload): Promise<string[]> {
+  if (!tokens.length || !fcmConfigured()) return [];
+  const access = await fcmAccessToken();
+  if (!access) return [];
+  const url = `https://fcm.googleapis.com/v1/projects/${process.env.FCM_PROJECT_ID}/messages:send`;
+  const data = Object.fromEntries(Object.entries(payload.data ?? {}).map(([k, v]) => [k, String(v)]));
+
+  const dead: string[] = [];
+  await Promise.all(tokens.map(async (deviceToken) => {
+    try {
+      const res = await fetch(url, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${access}`, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          message: { token: deviceToken, notification: { title: payload.title, body: payload.body }, data },
+        }),
+      });
+      if (res.status === 404) {
+        dead.push(deviceToken); // UNREGISTERED
+      } else if (!res.ok) {
+        const t = await res.text().catch(() => "");
+        if (/UNREGISTERED|INVALID_ARGUMENT/i.test(t)) dead.push(deviceToken);
+        else console.warn(`[push:fcm] status ${res.status} ${t.slice(0, 120)}`);
+      }
+    } catch (e: any) {
+      console.warn("[push:fcm] send error", e?.message);
+    }
+  }));
+  return dead;
+}
+
+// ── Public API ─────────────────────────────────────────────────────────────
+
+export type PushResult =
+  | { status: "sent"; devices: number }
+  | { status: "no_devices" }
+  | { status: "suppressed_comms_disabled" }
+  | { status: "not_configured" };
+
+/**
+ * Send a push to every device a user has registered. Fire-and-forget friendly:
+ * never throws, returns a structured result. Dead tokens are pruned.
+ */
+export async function notifyUser(
+  userId: number,
+  companyId: number,
+  payload: PushPayload,
+): Promise<PushResult> {
+  if (process.env.COMMS_ENABLED !== "true") {
+    console.log("[COMMS BLOCKED] push suppressed — COMMS_ENABLED!=true", { userId, title: payload.title });
+    return { status: "suppressed_comms_disabled" };
+  }
+  if (!apnsConfigured() && !fcmConfigured()) return { status: "not_configured" };
+
+  const devices = await tokensForUser(companyId, userId);
+  if (!devices.length) return { status: "no_devices" };
+
+  const ios = devices.filter((d) => d.platform === "ios").map((d) => d.token);
+  const android = devices.filter((d) => d.platform !== "ios").map((d) => d.token);
+
+  const [deadIos, deadAndroid] = await Promise.all([
+    sendApns(ios, payload).catch((e) => { console.warn("[push:apns] batch error", e?.message); return [] as string[]; }),
+    sendFcm(android, payload).catch((e) => { console.warn("[push:fcm] batch error", e?.message); return [] as string[]; }),
+  ]);
+
+  const dead = [...deadIos, ...deadAndroid];
+  if (dead.length) {
+    await db.execute(sql`DELETE FROM device_tokens WHERE token = ANY(${dead})`).catch(() => {});
+  }
+  return { status: "sent", devices: devices.length - dead.length };
+}
+
+/** Convenience wrapper for callers that don't care about the result. */
+export function notifyUserAsync(userId: number, companyId: number, payload: PushPayload): void {
+  void notifyUser(userId, companyId, payload).catch((e) => console.warn("[push] notifyUser error", e?.message));
+}

--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -1070,6 +1070,22 @@ async function runBookingSchemaGuard(): Promise<void> {
     ` },
     { label: "idx_job_rate_mods_job",
       stmt: `CREATE INDEX IF NOT EXISTS idx_job_rate_mods_job ON job_rate_mods(company_id, job_id)` },
+    // ── device_tokens (Capacitor push notifications) ────────────────────────
+    { label: "CREATE device_tokens", stmt: `
+      CREATE TABLE IF NOT EXISTS device_tokens (
+        id           SERIAL PRIMARY KEY,
+        company_id   INTEGER NOT NULL,
+        user_id      INTEGER NOT NULL,
+        token        TEXT NOT NULL,
+        platform     TEXT NOT NULL DEFAULT 'unknown',
+        last_seen_at TIMESTAMP NOT NULL DEFAULT NOW(),
+        created_at   TIMESTAMP NOT NULL DEFAULT NOW()
+      )
+    ` },
+    { label: "device_tokens_token_key",
+      stmt: `CREATE UNIQUE INDEX IF NOT EXISTS device_tokens_token_key ON device_tokens(token)` },
+    { label: "idx_device_tokens_user",
+      stmt: `CREATE INDEX IF NOT EXISTS idx_device_tokens_user ON device_tokens(company_id, user_id)` },
   ];
 
   for (const { label, stmt } of guards) {

--- a/artifacts/api-server/src/routes/dashboard.ts
+++ b/artifacts/api-server/src/routes/dashboard.ts
@@ -1306,6 +1306,7 @@ router.get("/mobile-cards", requireAuth, async (req, res) => {
     // "Today" / month boundaries in Central time (Phes), not UTC.
     const today = sql`(now() AT TIME ZONE 'America/Chicago')::date`;
     const monthStart = sql`date_trunc('month', (now() AT TIME ZONE 'America/Chicago'))`;
+    const todayStart = sql`date_trunc('day', (now() AT TIME ZONE 'America/Chicago'))`;
     // Revenue: completed/booked use base_fee; rollups use billed_amount fallback.
     const exprBase = jobRevenueExpr(sql`CAST(j.base_fee AS NUMERIC)`, "j", "c");
     const exprBilled = jobRevenueExpr(sql`COALESCE(CAST(j.billed_amount AS NUMERIC), CAST(j.base_fee AS NUMERIC), 0)`, "j", "c");
@@ -1370,10 +1371,14 @@ router.get("/mobile-cards", requireAuth, async (req, res) => {
         SELECT COUNT(*)::int AS v FROM leads
         WHERE company_id = ${companyId} AND created_at >= ${monthStart}
       `),
-      // Quotes + closed (won) this month (company-wide). Closed = booked / converted.
+      // Quotes + closed (won) this month AND today (company-wide). Closed =
+      // booked / converted. Today's cohort mirrors the monthly one: quotes
+      // created today, and of those how many are closed.
       db.execute(sql`
         SELECT COUNT(*)::int AS total,
-               COUNT(*) FILTER (WHERE status = 'booked' OR booked_job_id IS NOT NULL)::int AS closed
+               COUNT(*) FILTER (WHERE status = 'booked' OR booked_job_id IS NOT NULL)::int AS closed,
+               COUNT(*) FILTER (WHERE created_at >= ${todayStart})::int AS total_today,
+               COUNT(*) FILTER (WHERE (status = 'booked' OR booked_job_id IS NOT NULL) AND created_at >= ${todayStart})::int AS closed_today
         FROM quotes WHERE company_id = ${companyId} AND created_at >= ${monthStart}
       `),
       // Active clients (branch-aware)
@@ -1389,6 +1394,8 @@ router.get("/mobile-cards", requireAuth, async (req, res) => {
     const q: any = (quotesRows as any).rows[0] ?? {};
     const quotesTotal = Number(q.total ?? 0);
     const quotesClosed = Number(q.closed ?? 0);
+    const quotesTotalToday = Number(q.total_today ?? 0);
+    const quotesClosedToday = Number(q.closed_today ?? 0);
     const num = (v: any) => Math.round(Number(v ?? 0) * 100) / 100;
 
     return res.json({
@@ -1413,6 +1420,9 @@ router.get("/mobile-cards", requireAuth, async (req, res) => {
       quotes: quotesTotal,
       closed_quotes: quotesClosed,
       close_rate: quotesTotal > 0 ? Math.round((quotesClosed / quotesTotal) * 100) : 0,
+      quotes_today: quotesTotalToday,
+      closed_quotes_today: quotesClosedToday,
+      close_rate_today: quotesTotalToday > 0 ? Math.round((quotesClosedToday / quotesTotalToday) * 100) : 0,
       monthly_revenue: num((monthRev as any).rows[0]?.v),
       // Avg bill, rate trend, retention from the shared job_history calc.
       avg_bill: bh.avg_bill_12mo,

--- a/artifacts/api-server/src/routes/devices.ts
+++ b/artifacts/api-server/src/routes/devices.ts
@@ -1,0 +1,39 @@
+// Device-token registration for native push notifications.
+// The Capacitor app (src/lib/native-push.ts) calls POST /api/devices/register
+// after APNs/FCM issues a token, and DELETE on logout.
+import { Router } from "express";
+import { requireAuth } from "../lib/auth.js";
+import { upsertDeviceToken, deleteDeviceToken } from "../lib/push.js";
+
+const router = Router();
+
+// POST /api/devices/register  { token, platform }
+router.post("/register", requireAuth, async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId!;
+    const userId = req.auth!.userId!;
+    const token = typeof req.body?.token === "string" ? req.body.token.trim() : "";
+    const platform = typeof req.body?.platform === "string" ? req.body.platform : "unknown";
+    if (!token) return res.status(400).json({ error: "token required" });
+
+    await upsertDeviceToken({ companyId, userId, token, platform });
+    return res.json({ ok: true });
+  } catch (err) {
+    console.error("POST /devices/register error:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
+// DELETE /api/devices/register  { token }  — called on logout / opt-out.
+router.delete("/register", requireAuth, async (req, res) => {
+  try {
+    const token = typeof req.body?.token === "string" ? req.body.token.trim() : "";
+    if (token) await deleteDeviceToken(token);
+    return res.json({ ok: true });
+  } catch (err) {
+    console.error("DELETE /devices/register error:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
+export default router;

--- a/artifacts/api-server/src/routes/index.ts
+++ b/artifacts/api-server/src/routes/index.ts
@@ -92,6 +92,7 @@ import lmsSettingsRouter from "./lms-settings.js";
 import lmsAdminAuditRouter from "./lms-admin-audit.js";
 import lmsOnboardingIntakeRouter from "./lms-onboarding-intake.js";
 import translateRouter from "./translate.js";
+import devicesRouter from "./devices.js";
 
 const router: IRouter = Router();
 
@@ -123,6 +124,7 @@ router.use("/attachments", attachmentsRouter);
 // [translate-job-notes 2026-05-27] Office-only translation endpoint —
 // Claude API. POST /api/translate {text, target} → {translated}.
 router.use("/translate", translateRouter);
+router.use("/devices", devicesRouter);
 // [quote-attachments] The routers define full paths internally
 // (`:id/attachments`), so mount them at the resource root.
 router.use("/quotes", quoteAttachmentsRouter);

--- a/artifacts/api-server/src/routes/jobs.ts
+++ b/artifacts/api-server/src/routes/jobs.ts
@@ -3,6 +3,7 @@ import { db } from "@workspace/db";
 import { jobsTable, clientsTable, usersTable, jobPhotosTable, timeclockTable, invoicesTable, scorecardsTable, serviceZonesTable, serviceZoneEmployeesTable, companiesTable, accountsTable, accountRateCardsTable, accountPropertiesTable, paymentsTable, recurringSchedulesTable, branchesTable, userCompaniesTable } from "@workspace/db/schema";
 import { eq, and, gte, lte, count, desc, sql, notExists, inArray, isNotNull, isNull } from "drizzle-orm";
 import { requireAuth } from "../lib/auth.js";
+import { notifyUserAsync } from "../lib/push.js";
 import { logAudit } from "../lib/audit.js";
 import { generateJobCompletionPdf } from "../lib/generate-job-pdf.js";
 import { geocodeAddress } from "../lib/geocode.js";
@@ -891,6 +892,23 @@ router.put("/:id", requireAuth, async (req, res) => {
     }
 
     logAudit(req, "UPDATE", "job", jobId, null, updated[0]);
+
+    // [push 2026-06-03] Schedule-change push to the assigned tech. Strictly
+    // gated on a date/time change so office-notes / status-only saves don't
+    // fire it. Fire-and-forget; no-op unless COMMS_ENABLED + a device exists.
+    const schedChanged = scheduled_date !== undefined || scheduled_time !== undefined;
+    const assignedTech = (updated[0] as any).assigned_user_id as number | null;
+    if (schedChanged && assignedTech && assignedTech !== req.auth!.userId) {
+      const dStr = (updated[0] as any).scheduled_date
+        ? new Date(`${(updated[0] as any).scheduled_date}T12:00:00`).toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric" })
+        : "";
+      notifyUserAsync(assignedTech, req.auth!.companyId!, {
+        title: "Schedule updated",
+        body: dStr ? `A job on your schedule was moved to ${dStr}.` : "A job time on your schedule was updated.",
+        data: { type: "job", jobId: String(jobId) },
+      });
+    }
+
     return res.json({
       ...updated[0],
       client_name: "",
@@ -3620,6 +3638,32 @@ router.post("/:id/technicians", requireAuth, async (req, res) => {
     });
 
     const result = await calculateTechPay(jobId, companyId);
+
+    // [push 2026-06-03] Notify the assigned tech (fire-and-forget, no-op unless
+    // COMMS_ENABLED and a device is registered). Don't block the response.
+    if (Number(user_id) !== userId) {
+      try {
+        const info = await db.execute(sql`
+          SELECT COALESCE(NULLIF(TRIM(COALESCE(c.first_name,'')||' '||COALESCE(c.last_name,'')),''),
+                          c.company_name, a.account_name, 'A job') AS who,
+                 j.scheduled_date::text AS scheduled_date
+          FROM jobs j
+          LEFT JOIN clients c ON c.id = j.client_id
+          LEFT JOIN accounts a ON a.id = j.account_id
+          WHERE j.id = ${jobId} LIMIT 1
+        `);
+        const row = info.rows[0] as any;
+        const when = row?.scheduled_date
+          ? new Date(`${row.scheduled_date}T12:00:00`).toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric" })
+          : "";
+        notifyUserAsync(Number(user_id), companyId, {
+          title: "New job assigned",
+          body: `${row?.who ?? "A job"}${when ? ` · ${when}` : ""}`,
+          data: { type: "job", jobId: String(jobId) },
+        });
+      } catch (e: any) { console.warn("[push] assign notify skipped", e?.message); }
+    }
+
     return res.json({ data: result, primary: willBePrimary });
   } catch (err) {
     console.error("POST /jobs/:id/technicians error:", err);

--- a/artifacts/api-server/src/routes/leave.ts
+++ b/artifacts/api-server/src/routes/leave.ts
@@ -55,6 +55,7 @@ import {
 } from "@workspace/db/schema";
 import { and, asc, desc, eq, gte, inArray, isNotNull, lte, sql } from "drizzle-orm";
 import { requireAuth, requireRole } from "../lib/auth.js";
+import { notifyUserAsync } from "../lib/push.js";
 import {
   computeCurrentBalance,
   isPastWaitingPeriod,
@@ -841,6 +842,17 @@ router.post("/requests/:id/approve", adminWriteGate, async (req, res) => {
     })
     .where(eq(leaveRequestsTable.id, id));
   void notifyEmployeeOfDecisionSilent(id, "approved");
+  // [push 2026-06-03] Push the employee (fire-and-forget, gated by COMMS_ENABLED).
+  {
+    const when = reqRow.start_date
+      ? new Date(`${String(reqRow.start_date)}T12:00:00`).toLocaleDateString("en-US", { month: "short", day: "numeric" })
+      : "";
+    notifyUserAsync(reqRow.user_id, companyId, {
+      title: "Time off approved",
+      body: `Your request${when ? ` for ${when}` : ""} was approved.`,
+      data: { type: "leave", requestId: String(id) },
+    });
+  }
   return res.json({ data: { id, status: "approved" } });
 });
 

--- a/artifacts/qleno/src/components/mobile-dashboard.tsx
+++ b/artifacts/qleno/src/components/mobile-dashboard.tsx
@@ -25,6 +25,7 @@ interface CardData {
   todays_status: { in_progress: number; scheduled: number; complete: number; flagged: number; unassigned: number };
   unassigned_jobs: number; techs_today: number; next_7_days_jobs: number; next_7_days_revenue: number;
   leads: number; quotes: number; closed_quotes: number; close_rate: number; monthly_revenue: number;
+  quotes_today: number; closed_quotes_today: number; close_rate_today: number;
   avg_bill: number; active_clients: number; rate_trend: number; avg_bill_12mo: number; retention: number;
   payroll_pct: number; payroll_window: string;
 }
@@ -67,6 +68,9 @@ const LIBRARY: LibCard[] = [
         <span style={{ fontSize: 13, color: MUTE, fontFamily: FF }}>{d.next_7_days_jobs} jobs</span>
       </div>
     ) },
+  { key: "quotes_today",         label: "Quotes Today",         sub: "created today",          render: d => <Big t={String(d.quotes_today)} /> },
+  { key: "closed_quotes_today",  label: "Closed Today",         sub: "won, of today's quotes", render: d => <Big t={String(d.closed_quotes_today)} /> },
+  { key: "close_rate_today",     label: "Close Rate Today",     sub: "closed / total, today",  render: d => <Big t={`${d.close_rate_today}%`} c={MINT} /> },
   { key: "leads",                label: "Leads",                sub: "this month",             render: d => <Big t={String(d.leads)} /> },
   { key: "quotes",               label: "Quotes",               sub: "this month",             render: d => <Big t={String(d.quotes)} /> },
   { key: "closed_quotes",        label: "Closed Quotes",        sub: "won this month",         render: d => <Big t={String(d.closed_quotes)} /> },
@@ -82,7 +86,7 @@ const LIB_KEYS = LIBRARY.map(l => l.key);
 const cardDef = (k: string) => LIBRARY.find(l => l.key === k);
 
 // Default sets shown before any customization.
-const OWNER_DEFAULT = ["daily_revenue", "jobs_today", "revenue_booked_today", "leads", "quotes", "closed_quotes", "close_rate"];
+const OWNER_DEFAULT = ["daily_revenue", "jobs_today", "revenue_booked_today", "quotes_today", "closed_quotes_today", "close_rate_today", "leads", "quotes", "closed_quotes", "close_rate"];
 const OFFICE_DEFAULT = ["jobs_scheduled_today", "late_clockins", "todays_status", "unassigned_jobs", "techs_today", "next_7_days"];
 const roleDefault = (role: string) => (role === "owner" ? OWNER_DEFAULT : OFFICE_DEFAULT);
 

--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback, useLayoutEffect } from "react";
+import { useSearch, useLocation } from "wouter";
 import { DashboardLayout } from "@/components/layout/dashboard-layout";
 import { getAuthHeaders, useAuthStore } from "@/lib/auth";
 import { useBranch } from "@/contexts/branch-context";
@@ -4848,20 +4849,26 @@ export default function JobsPage() {
       window.history.replaceState(null, "", url.toString());
     }
   }, [selectedDate]);
-  // Open the New Job wizard when arrived via the global "New → Job" menu (?new=1).
-  // The dispatch toolbar's own New Job button was removed, so this is how the
-  // header create menu reaches the scheduler.
+  // Open the New Job wizard when arrived via the global "New → Job" menu
+  // (?new=1). Keyed on wouter's reactive search string (not mount) so it fires
+  // from EVERY screen — including when the user is already on the dispatch page
+  // and the URL just gains ?new=1, which wouldn't remount this component.
+  const routeSearch = useSearch();
+  const [, navigate] = useLocation();
   useEffect(() => {
+    // Read the live URL (routeSearch is only the reactive trigger) so we keep
+    // any ?date= the date-sync effect just wrote.
     const sp = new URLSearchParams(window.location.search);
     if (sp.get("new") === "1") {
       setShowWizard(true);
+      // Strip ?new=1 via wouter's navigate (keeps wouter's reactive search in
+      // sync, so clicking New → Job again re-fires) while preserving ?date=.
       sp.delete("new");
-      const url = new URL(window.location.href);
-      url.search = sp.toString();
-      window.history.replaceState(null, "", url.toString());
+      const rest = sp.toString();
+      navigate(`${window.location.pathname}${rest ? `?${rest}` : ""}`, { replace: true });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [routeSearch]);
   const [data, setData] = useState<DispatchData | null>(null);
   const [loading, setLoading] = useState(true);
   const [selectedJob, setSelectedJob] = useState<DispatchJob | null>(null);

--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -291,7 +291,10 @@ function useIsMobile() { const [m, setM] = useState(window.innerWidth < 1024); u
 function fmtHour(h: number) { if (h === 12) return "12 PM"; if (h === 0) return "12 AM"; return h < 12 ? `${h} AM` : `${h - 12} PM`; }
 function slotBg(count: number) { if (count === 0) return "#DCFCE7"; if (count <= 2) return "#FEF3C7"; return "#FEE2E2"; }
 function slotTxt(count: number) { if (count === 0) return "#15803D"; if (count <= 2) return "#92400E"; return "#991B1B"; }
-function slotLbl(count: number) { if (count === 0) return "Open"; if (count <= 2) return `${count} job${count === 1 ? "" : "s"}`; return `Full (${count})`; }
+// Honest labels: the count is total jobs booked that hour across the whole
+// team — NOT a hard capacity. "Full" wrongly implied the slot was blocked, so
+// we show the real count and let colour carry the busy signal.
+function slotLbl(count: number) { if (count === 0) return "Open"; return `${count} job${count === 1 ? "" : "s"}`; }
 
 async function patchJob(id: number, patch: object, token: string) {
   const API = import.meta.env.BASE_URL.replace(/\/$/, "");
@@ -2473,6 +2476,17 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
                             {availLoading ? "Loading availability..." : "Tap a time slot to select"}
                           </span>
                           {!availLoading && (
+                            <div style={{ display: "flex", flexWrap: "wrap", alignItems: "center", gap: "4px 12px", marginBottom: 10 }}>
+                              {([["#16A34A", "Open"], ["#92400E", "1–2 jobs"], ["#991B1B", "3+ jobs (busy)"]] as [string, string][]).map(([c, l]) => (
+                                <span key={l} style={{ display: "inline-flex", alignItems: "center", gap: 5, fontSize: 11, color: "#6B6860" }}>
+                                  <span style={{ width: 9, height: 9, borderRadius: 3, backgroundColor: slotBg(l === "Open" ? 0 : l.startsWith("1") ? 1 : 3), border: `1px solid ${c}33` }} />
+                                  {l}
+                                </span>
+                              ))}
+                              <span style={{ fontSize: 11, color: "#9E9B94", width: "100%" }}>Counts are jobs already booked that hour across your team — you can still pick a busy slot.</span>
+                            </div>
+                          )}
+                          {!availLoading && (
                             <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
                               {availSlots.map(slot => {
                                 const isSelected = rescheduleHour === slot.hour;
@@ -2493,7 +2507,10 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
                     {/* Section 4 — Team Assignment */}
                     {rescheduleHour !== null && (
                       <div style={{ margin: "14px 20px 0", backgroundColor: "#FFFFFF", borderRadius: 12, border: "1px solid #E5E2DC", padding: "14px 16px" }}>
-                        <span style={{ fontSize: 10, fontWeight: 700, color: "#9E9B94", textTransform: "uppercase", letterSpacing: "0.07em", display: "block", marginBottom: 10 }}>Team Assignment</span>
+                        <span style={{ fontSize: 10, fontWeight: 700, color: "#9E9B94", textTransform: "uppercase", letterSpacing: "0.07em", display: "block", marginBottom: 6 }}>Team Assignment</span>
+                        <span style={{ fontSize: 11, color: "#9E9B94", display: "block", marginBottom: 10 }}>
+                          "<span style={{ color: "#991B1B", fontWeight: 600 }}>Conflict</span>" means the tech already has a job overlapping {fmtHour(rescheduleHour)}. You can still assign them.
+                        </span>
                         {techLoading ? (
                           <p style={{ fontSize: 13, color: "#6B6860", margin: 0 }}>Loading team availability...</p>
                         ) : techList.length === 0 ? (
@@ -2522,6 +2539,14 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
                                 </button>
                               );
                             })}
+                          </div>
+                        )}
+                        {selectedTechId !== null && techList.find(t => t.id === selectedTechId)?.has_conflict && (
+                          <div style={{ marginTop: 10, padding: "8px 12px", borderRadius: 8, backgroundColor: "#FEF3C7", border: "1px solid #FCD34D", display: "flex", alignItems: "flex-start", gap: 6 }}>
+                            <AlertTriangle size={13} color="#92400E" style={{ flexShrink: 0, marginTop: 1 }} />
+                            <span style={{ fontSize: 12, color: "#92400E", lineHeight: 1.4 }}>
+                              {techList.find(t => t.id === selectedTechId)?.name?.split(" ")[0]} already has a job at this time. Confirming will double-book them.
+                            </span>
                           </div>
                         )}
                       </div>

--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -1104,13 +1104,17 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
   // Header overflow (•••) menu — home for rare/destructive actions so they
   // stay out of the everyday content flow.
   const [menuOpen, setMenuOpen] = useState(false);
+  // [delete-confirm 2026-06-03] Two-step inline confirm so a stray click on
+  // "Delete job" can't wipe a job. First click arms; second click (the red
+  // "Confirm delete") actually deletes. Sal: "needs a confirmation after
+  // pressing delete in case by accident."
+  const [confirmDelete, setConfirmDelete] = useState(false);
 
   // Delete a job. A completed job (or one with clock-in / add-on / billing
   // history) can't be removed by a plain delete — child rows block it and the
   // server returns an error. The server's force path cleans those up first;
   // owner/admin can escalate after a second, clearer confirm.
   async function handleDeleteJob() {
-    if (!window.confirm("Delete this job? It's removed from the schedule and recorded in the audit log.")) return;
     try {
       let r = await fetch(`${_API3}/api/jobs/${job.id}`, { method: "DELETE", headers: { Authorization: `Bearer ${token}` } });
       let d = await r.json().catch(() => ({}));
@@ -1353,6 +1357,29 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
     } finally { setAddTechBusy(false); }
   }
 
+  // [team-edit 2026-06-03] Remove a tech from the job. The server promotes the
+  // next remaining tech to primary + mirrors jobs.assigned_user_id (or NULLs it
+  // when none remain) and returns the recalculated team via { data }. We update
+  // commTechs from the response so the panel reflects the removal immediately —
+  // no reopen needed (Sal: "you cannot remove a tech" / list "not sticky").
+  const [removeTechBusy, setRemoveTechBusy] = useState<number | null>(null);
+  async function removeTechFromJob(techId: number) {
+    setRemoveTechBusy(techId);
+    try {
+      const r = await fetch(`${_API3}/api/jobs/${job.id}/technicians/${techId}`, {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const d = await r.json().catch(() => ({}));
+      if (!r.ok) throw new Error(d.message || d.error || `HTTP ${r.status}`);
+      if (d.data) setCommTechs(d.data);
+      toast({ title: "Team member removed" });
+      onUpdate();
+    } catch (e: any) {
+      toast({ title: "Couldn't remove", description: e?.message ?? "Network error", variant: "destructive" });
+    } finally { setRemoveTechBusy(null); }
+  }
+
   // [AF] Supply-logging state removed — drawer section pulled per cleanup.
   // /api/supplies/log endpoint and supplies table remain in place so the
   // feature can return later without schema churn.
@@ -1576,23 +1603,45 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
             {canEditOfficeNotes && (
               <div style={{ position: "relative" }}>
                 <button
-                  onClick={() => setMenuOpen(o => !o)}
+                  onClick={() => { setMenuOpen(o => !o); setConfirmDelete(false); }}
                   aria-label="More actions"
                   style={{ border: "none", background: menuOpen ? "#F3F1EC" : "none", cursor: "pointer", color: "#9E9B94", padding: 4, borderRadius: 6 }}
                 ><MoreVertical size={18} /></button>
                 {menuOpen && (
                   <>
                     {/* Click-away layer */}
-                    <div onClick={() => setMenuOpen(false)} style={{ position: "fixed", inset: 0, zIndex: 50 }} />
-                    <div style={{ position: "absolute", top: "calc(100% + 4px)", right: 0, zIndex: 51, minWidth: 170, background: "#fff", border: "1px solid #E5E2DC", borderRadius: 10, boxShadow: "0 8px 24px rgba(10,14,26,0.12)", padding: 4, overflow: "hidden" }}>
-                      <button
-                        onClick={() => { setMenuOpen(false); handleDeleteJob(); }}
-                        style={{ display: "flex", alignItems: "center", gap: 8, width: "100%", textAlign: "left", border: "none", background: "none", cursor: "pointer", color: "#DC2626", fontSize: 13, fontWeight: 600, fontFamily: FF, padding: "9px 10px", borderRadius: 6 }}
-                        onMouseEnter={e => (e.currentTarget.style.background = "#FEF2F2")}
-                        onMouseLeave={e => (e.currentTarget.style.background = "none")}
-                      >
-                        <Trash2 size={14} /> Delete job
-                      </button>
+                    <div onClick={() => { setMenuOpen(false); setConfirmDelete(false); }} style={{ position: "fixed", inset: 0, zIndex: 50 }} />
+                    <div style={{ position: "absolute", top: "calc(100% + 4px)", right: 0, zIndex: 51, minWidth: 200, background: "#fff", border: "1px solid #E5E2DC", borderRadius: 10, boxShadow: "0 8px 24px rgba(10,14,26,0.12)", padding: 4, overflow: "hidden" }}>
+                      {!confirmDelete ? (
+                        <button
+                          onClick={() => setConfirmDelete(true)}
+                          style={{ display: "flex", alignItems: "center", gap: 8, width: "100%", textAlign: "left", border: "none", background: "none", cursor: "pointer", color: "#DC2626", fontSize: 13, fontWeight: 600, fontFamily: FF, padding: "9px 10px", borderRadius: 6 }}
+                          onMouseEnter={e => (e.currentTarget.style.background = "#FEF2F2")}
+                          onMouseLeave={e => (e.currentTarget.style.background = "none")}
+                        >
+                          <Trash2 size={14} /> Delete job
+                        </button>
+                      ) : (
+                        <div style={{ padding: "6px 8px 8px" }}>
+                          <p style={{ margin: "2px 2px 8px", fontSize: 12, color: "#6B6860", fontFamily: FF, lineHeight: 1.4 }}>
+                            Delete this job? It's removed from the schedule and recorded in the audit log.
+                          </p>
+                          <div style={{ display: "flex", gap: 6 }}>
+                            <button
+                              onClick={() => { setConfirmDelete(false); setMenuOpen(false); handleDeleteJob(); }}
+                              style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", gap: 6, border: "none", background: "#DC2626", cursor: "pointer", color: "#fff", fontSize: 12, fontWeight: 700, fontFamily: FF, padding: "8px 10px", borderRadius: 6 }}
+                            >
+                              <Trash2 size={13} /> Confirm delete
+                            </button>
+                            <button
+                              onClick={() => setConfirmDelete(false)}
+                              style={{ border: "1px solid #E5E2DC", background: "#fff", cursor: "pointer", color: "#6B6860", fontSize: 12, fontWeight: 600, fontFamily: FF, padding: "8px 12px", borderRadius: 6 }}
+                            >
+                              Cancel
+                            </button>
+                          </div>
+                        </div>
+                      )}
                     </div>
                   </>
                 )}
@@ -1807,44 +1856,44 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
             </div>
           )}
 
-          {job.clock_entry && (
-            <PS label="Clock Data">
-              {job.clock_entry.clock_in_at && <KV label="Clock in" value={new Date(job.clock_entry.clock_in_at).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })} />}
-              {job.clock_entry.clock_out_at && <KV label="Clock out" value={new Date(job.clock_entry.clock_out_at).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })} />}
-              {(job.clock_entry.clock_in_distance_ft ?? job.clock_entry.distance_from_job_ft) !== null && (job.clock_entry.clock_in_distance_ft ?? job.clock_entry.distance_from_job_ft) !== undefined && (
-                <KV label="Distance at clock-in" value={`${Math.round((job.clock_entry.clock_in_distance_ft ?? job.clock_entry.distance_from_job_ft)!)} ft${job.clock_entry.clock_in_outside_geofence ? " (outside)" : ""}`} color={job.clock_entry.clock_in_outside_geofence ? "#D97706" : undefined} />
-              )}
-              {job.clock_entry.clock_out_distance_ft != null && (
-                <KV label="Distance at clock-out" value={`${Math.round(job.clock_entry.clock_out_distance_ft)} ft${job.clock_entry.clock_out_outside_geofence ? " (outside)" : ""}`} color={job.clock_entry.clock_out_outside_geofence ? "#D97706" : undefined} />
-              )}
-              {job.clock_entry.gps_missing && (
-                <KV label="GPS" value="Unavailable — location not captured" color="#DC2626" />
-              )}
-            </PS>
-          )}
-
-          {/* [panel-revamp 2026-06-03] Allowed vs actual hours + variance.
-              Allowed = the real allowed_hours from the payload (not the stale
-              estimated_hours stamp, per CLAUDE.md); accessed via cast since
-              it's not on the FE type. Actual prefers actual_hours/billed_hours,
+          {/* [panel-revamp 2026-06-03 · hours-merge] One section so allowed
+              hours sit right next to the time-clock (actual) hours — Sal:
+              "you still put allowed hours separate from time clock hours, they
+              are not near each other." Order: Allowed → Actual → Variance →
+              the clock in/out times + distances. Allowed = the real
+              allowed_hours from the payload (not the stale estimated_hours
+              stamp, per CLAUDE.md). Actual prefers actual_hours/billed_hours,
               falls back to clock in/out duration. */}
           {(() => {
+            const ce = job.clock_entry;
             const allowed = (job as any).allowed_hours != null ? Number((job as any).allowed_hours) : null;
             let actual: number | null = job.actual_hours != null ? Number(job.actual_hours)
               : (job.billed_hours != null ? Number(job.billed_hours) : null);
-            if (actual == null && job.clock_entry?.clock_in_at && job.clock_entry?.clock_out_at) {
-              actual = (new Date(job.clock_entry.clock_out_at).getTime() - new Date(job.clock_entry.clock_in_at).getTime()) / 3600000;
+            if (actual == null && ce?.clock_in_at && ce?.clock_out_at) {
+              actual = (new Date(ce.clock_out_at).getTime() - new Date(ce.clock_in_at).getTime()) / 3600000;
             }
-            if (allowed == null && actual == null) return null;
+            if (allowed == null && actual == null && !ce) return null;
             const variance = (allowed != null && actual != null) ? actual - allowed : null;
+            const inDist = ce ? (ce.clock_in_distance_ft ?? ce.distance_from_job_ft) : null;
             return (
-              <PS label="Hours">
+              <PS label="Hours & Time Clock">
                 {allowed != null && <KV label="Allowed" value={`${allowed.toFixed(1)}h`} />}
                 {actual != null && <KV label="Actual" value={`${actual.toFixed(1)}h`} />}
                 {variance != null && (
                   <KV label="Variance"
                     value={`${variance > 0 ? "+" : ""}${variance.toFixed(1)}h`}
                     color={variance > 0.25 ? "#D97706" : variance < -0.25 ? "#16A34A" : undefined} />
+                )}
+                {ce?.clock_in_at && <KV label="Clock in" value={new Date(ce.clock_in_at).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })} />}
+                {ce?.clock_out_at && <KV label="Clock out" value={new Date(ce.clock_out_at).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })} />}
+                {ce && inDist != null && (
+                  <KV label="Distance at clock-in" value={`${Math.round(inDist)} ft${ce.clock_in_outside_geofence ? " (outside)" : ""}`} color={ce.clock_in_outside_geofence ? "#D97706" : undefined} />
+                )}
+                {ce?.clock_out_distance_ft != null && (
+                  <KV label="Distance at clock-out" value={`${Math.round(ce.clock_out_distance_ft)} ft${ce.clock_out_outside_geofence ? " (outside)" : ""}`} color={ce.clock_out_outside_geofence ? "#D97706" : undefined} />
+                )}
+                {ce?.gps_missing && (
+                  <KV label="GPS" value="Unavailable — location not captured" color="#DC2626" />
                 )}
               </PS>
             );
@@ -1881,6 +1930,17 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
                           {overrideOpen[t.user_id] ? "Cancel" : "Override"}
                         </button>
                       ) : null}
+                      {!isLocked && (
+                        <button
+                          onClick={() => removeTechFromJob(t.user_id)}
+                          disabled={removeTechBusy === t.user_id}
+                          title="Remove from job"
+                          aria-label={`Remove ${t.name}`}
+                          style={{ display: "inline-flex", alignItems: "center", justifyContent: "center", width: 22, height: 22, color: "#B91C1C", border: "1px solid #F3D2D2", background: "#FEF2F2", borderRadius: 5, cursor: removeTechBusy === t.user_id ? "wait" : "pointer", flexShrink: 0, opacity: removeTechBusy === t.user_id ? 0.6 : 1 }}
+                        >
+                          <X size={13} />
+                        </button>
+                      )}
                     </div>
                   </div>
                   <div style={{ fontSize: 11, color: "#9E9B94" }}>
@@ -2028,13 +2088,38 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
             </>
           )}
 
-          {/* Add Team Member — fallback for jobs without commission display */}
+          {/* Team — fallback for jobs without the commission display. Drives
+              off commTechs (live state updated on add/remove) so the list stays
+              sticky without reopening the panel. */}
           {(!canManageCommission || (job.estimated_hours ?? 0) === 0) && (
             <PS label="Team">
-              <div style={{ fontSize: 12, color: "#1A1917", marginBottom: 8 }}>
-                {assignedEmp?.name || job.assigned_user_name || "Unassigned"}
-                {commTechs.length > 1 && ` + ${commTechs.length - 1} more`}
-              </div>
+              {commTechs.length > 0 ? (
+                <div style={{ display: "flex", flexDirection: "column", gap: 6, marginBottom: 8 }}>
+                  {commTechs.map(t => (
+                    <div key={t.user_id} style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8 }}>
+                      <span style={{ fontSize: 12, color: "#1A1917", display: "inline-flex", alignItems: "center", gap: 6, minWidth: 0 }}>
+                        <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{t.name}</span>
+                        {t.is_primary && commTechs.length > 1 && <span style={{ flexShrink: 0, fontSize: 9, fontWeight: 800, color: "#2D9B83", background: "rgba(45,155,131,0.1)", padding: "2px 6px", borderRadius: 10, letterSpacing: "0.04em" }}>PRIMARY</span>}
+                      </span>
+                      {canManageCommission && !isLocked && (
+                        <button
+                          onClick={() => removeTechFromJob(t.user_id)}
+                          disabled={removeTechBusy === t.user_id}
+                          title="Remove from job"
+                          aria-label={`Remove ${t.name}`}
+                          style={{ display: "inline-flex", alignItems: "center", justifyContent: "center", width: 22, height: 22, color: "#B91C1C", border: "1px solid #F3D2D2", background: "#FEF2F2", borderRadius: 5, cursor: removeTechBusy === t.user_id ? "wait" : "pointer", flexShrink: 0, opacity: removeTechBusy === t.user_id ? 0.6 : 1 }}
+                        >
+                          <X size={13} />
+                        </button>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div style={{ fontSize: 12, color: "#9E9B94", marginBottom: 8 }}>
+                  {job.assigned_user_name || "Unassigned"}
+                </div>
+              )}
               <button onClick={() => !isLocked && setAddTechOpen(true)}
                 disabled={isLocked}
                 style={{ width: "100%", height: 32, display: "flex", alignItems: "center", justifyContent: "center", gap: 6, fontSize: 12, fontWeight: 600, color: isLocked ? "#9E9B94" : "#2D9B83", border: `1px dashed ${isLocked ? "#D1D5DB" : "#2D9B83"}`, borderRadius: 8, background: "transparent", cursor: isLocked ? "not-allowed" : "pointer", fontFamily: FF, opacity: isLocked ? 0.6 : 1 }}>

--- a/docs/NATIVE_APP_SETUP.md
+++ b/docs/NATIVE_APP_SETUP.md
@@ -77,15 +77,33 @@ pnpm run cap:android        # opens Android Studio → Build > Generate Signed B
 3. Distribute App → App Store Connect → Upload.
 4. The build appears in TestFlight after processing; add internal testers.
 
-## Push notifications (Phase 2)
+## Push notifications (Phase 2 — server side BUILT)
 
-`native-push.ts` already registers and posts the token to
-`POST /api/devices/register` (built next). To finish:
+The server side is now in place and inert until credentials exist:
 
-1. **iOS:** APNs key (.p8) in the Apple Developer portal; enable the Push
-   Notifications capability in Xcode.
-2. **Android:** Firebase project, `google-services.json` into `android/app`.
-3. **Server:** build `POST /api/devices/register` (persist `{token, platform}`
-   per user) and a sender that pushes on new-job / schedule-change /
-   PTO-approved, routed through `getBranchByZip` like every other comm and
-   gated by `COMMS_ENABLED`.
+- **`device_tokens` table** (migration guard `CREATE device_tokens`) — one user → many devices.
+- **`POST /api/devices/register`** / **`DELETE /api/devices/register`** (`routes/devices.ts`) — the app's `native-push.ts` already calls register on launch.
+- **`lib/push.ts` → `notifyUser(userId, companyId, {title, body, data})`** — sends via APNs (iOS, HTTP/2 + ES256) and FCM (Android, HTTP v1). Gated by `COMMS_ENABLED`; a **no-op when creds are absent**; prunes dead tokens on 410/UNREGISTERED.
+- **Triggers wired** (all fire-and-forget): new job assigned (`POST /jobs/:id/technicians`), schedule changed (`PUT /jobs/:id`), PTO approved (`POST /leave/requests/:id/approve`).
+
+### To switch it on — set these Railway env vars
+
+iOS (APNs):
+```
+APNS_KEY_P8        # contents of the .p8 auth key (newlines as \n is fine)
+APNS_KEY_ID        # 10-char key id
+APNS_TEAM_ID       # Apple developer team id
+APNS_BUNDLE_ID     # io.phes.qleno  (default)
+APNS_PRODUCTION    # "true" for App Store / TestFlight builds, else sandbox
+```
+Android (FCM HTTP v1, from a Firebase service-account JSON):
+```
+FCM_PROJECT_ID
+FCM_CLIENT_EMAIL
+FCM_PRIVATE_KEY    # the service account private key (\n escaped)
+```
+And of course `COMMS_ENABLED=true` (currently false — nothing sends until you flip it).
+
+### Native enablement still required (on a Mac)
+1. **iOS:** add the Push Notifications + Background Modes (remote notifications) capabilities in Xcode; the APNs key above is uploaded once to Apple.
+2. **Android:** create the Firebase project, drop `google-services.json` into `android/app`.

--- a/lib/db/src/schema/device_tokens.ts
+++ b/lib/db/src/schema/device_tokens.ts
@@ -1,0 +1,24 @@
+import { pgTable, serial, text, integer, timestamp, uniqueIndex } from "drizzle-orm/pg-core";
+import { createInsertSchema } from "drizzle-zod";
+import { z } from "zod/v4";
+import { companiesTable } from "./companies";
+import { usersTable } from "./users";
+
+// Push-notification device tokens. One user can have several devices (phone +
+// tablet); a token is globally unique (APNs/FCM mint one per app install). On
+// logout or when APNs/FCM reports a token invalid, the row is removed.
+export const deviceTokensTable = pgTable("device_tokens", {
+  id: serial("id").primaryKey(),
+  company_id: integer("company_id").references(() => companiesTable.id).notNull(),
+  user_id: integer("user_id").references(() => usersTable.id).notNull(),
+  token: text("token").notNull(),
+  platform: text("platform").notNull().default("unknown"), // ios | android | web | unknown
+  last_seen_at: timestamp("last_seen_at").notNull().defaultNow(),
+  created_at: timestamp("created_at").notNull().defaultNow(),
+}, (t) => ({
+  tokenUnique: uniqueIndex("device_tokens_token_key").on(t.token),
+}));
+
+export const insertDeviceTokenSchema = createInsertSchema(deviceTokensTable).omit({ id: true, created_at: true, last_seen_at: true });
+export type InsertDeviceToken = z.infer<typeof insertDeviceTokenSchema>;
+export type DeviceToken = typeof deviceTokensTable.$inferSelect;

--- a/lib/db/src/schema/index.ts
+++ b/lib/db/src/schema/index.ts
@@ -143,3 +143,7 @@ export * from "./user_companies";
 // missing_clockout). Pending rows become employee_attendance_log rows
 // via the confirm flow (which drives the 3A unexcused-hours ladder).
 export * from "./attendance_proposals";
+
+// Push-notification device tokens (Capacitor native app). One user → many
+// devices; sender lives in api-server/src/lib/push.ts, gated by COMMS_ENABLED.
+export * from "./device_tokens";


### PR DESCRIPTION
**First — to answer "is everything plugged in?": yes, it all is.** The reschedule modal pulls real data and the confirm actually works:

- **Time slots** → `GET /api/jobs/availability` counts real non-cancelled jobs per hour (7 AM–5 PM).
- **Team list** → `GET /api/users/available` returns each active tech's real `jobs_today` and a real time-overlap **conflict** check (job start → start + allowed hours).
- **Confirm** → patches date/time/tech, logs the reschedule + reason, and churn-flags clients who reschedule 3+ times.

Nothing is stubbed. This PR is **clarity only**:

## Changes

1. **Dropped the misleading "Full (N)" label.** The number is just *total team jobs booked that hour* — not a capacity cap — and the slot was always still selectable. Now it shows the honest count ("6 jobs"); the green→amber→red colour carries the busy signal.
2. **Added a legend** (Open / 1–2 / 3+ busy) plus a line: *"Counts are jobs already booked that hour across your team — you can still pick a busy slot."*
3. **Explained the "Conflict" badge** under Team Assignment (*"already has a job overlapping 9 AM — you can still assign them"*) and added a warning when a conflicting tech is actually selected (*"Confirming will double-book them"*), without blocking it.

## Possible follow-up (not in this PR)

The hourly slot counts are **company-wide**, not branch-filtered. If you'd want the Oak Lawn vs Schaumburg counts separated in the reschedule view, that's a small follow-up — say the word.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_