### PR TITLE
perf(translate): use Haiku instead of Opus for note translation

### DIFF
--- a/artifacts/api-server/src/routes/translate.ts
+++ b/artifacts/api-server/src/routes/translate.ts
@@ -51,7 +51,9 @@ router.post("/", requireAuth, requireRole("owner", "admin", "office"), async (re
       `Use cleaning-industry vocabulary that a Mexican-Spanish-speaking technician would understand naturally.`;
 
     const response = await client.messages.create({
-      model: "claude-opus-4-7",
+      // Haiku — note translation is a simple task; Haiku is far cheaper and
+      // faster than Opus with no quality loss for short job notes.
+      model: "claude-haiku-4-5",
       max_tokens: 4096,
       system,
       messages: [{ role: "user", content: text }],


### PR DESCRIPTION
Switches the note-translation model from **Opus** to **Haiku** (`claude-haiku-4-5`).

Note translation is a simple, high-frequency task — every "Translate to Spanish" tap is one API call. Haiku is roughly an order of magnitude cheaper and noticeably faster than Opus, with no meaningful quality loss on short job notes. The translation-specific system prompt (preserve names/numbers/addresses, Mexican-Spanish cleaning vocab) is unchanged.

One-line change in `routes/translate.ts`.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_