### PR TITLE
feat(timeclock): lock workflow model + Day Complete closure card (mobile)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -291,6 +291,61 @@ Honor this so the clocks stay consistent with how mileage reads from them.)*
   events MUST preserve `from_job_id`** — it's the hook the whole mileage
   chain hangs on. (Field-app "On My Way" wiring that sets this: #291.)
 
+## Time Clock — Workflow Model (Locked)
+*(Canonical design for the clock/payroll build. Goal: keep MaidCentral's
+insight — separate meters for pay, job cost, and the drive/idle gap — while
+removing its confusion: too many buttons, an auto-added drive-pay line on a
+commission shop, and the word "Efficiency" meaning three different formulas.)*
+
+- **ONE clock pair, at the house.** The tech checks in / out at **each
+  house** (the existing per-job `timeclock` clock-in/out). This is the
+  load-bearing meter — it feeds commission, allowed-vs-actual, billing, and
+  the multi-tech split (each tech runs their own pair per house, so labor
+  splits by actual minutes). **There is NO separate day/shift clock.** Do
+  NOT introduce a second "Check In/Out" pair or a day clock — one pair, one
+  name, used at the house. The MaidCentral two-pair muddle (Clock In *and*
+  Check In at the first house) is explicitly designed out.
+- **The day is DERIVED, never a button.** "Paid day" = first check-in →
+  last check-out. Checking out of the last house ends the day automatically
+  because there's no more clock activity — not because checkout fires a
+  clock-out. A surprise add-on after the "last" job just self-extends the
+  day to the new last check-out. This also *enforces* the mileage rule:
+  nothing after the last check-out counts, so last-job→home commute can
+  never be paid (a manual day clock-out would invite clocking out at home).
+- **"Day complete" is a closure STATE, not a tap.** After the last
+  check-out, show a derived end-of-day summary (jobs, job hours, miles) with
+  a "Start another job" affordance that just extends the day. Never a
+  required clock-out button.
+- **Idle = record, not pay.** Idle/gap = (day span) − job time − drive time.
+  It's a *visibility* number, not a pay line. Bona-fide meal breaks (30+
+  min, fully relieved) are excluded; on-duty waiting counts as hours worked
+  but only matters for the rare >40hr OT week.
+- **capturing ≠ paying (the rule that protects both ways).** Record every
+  minute (job, drive, idle) for visibility + the OT check, but the only
+  dollars that move are **commission + mileage reimbursement**. Phes pays
+  commission + mileage, NOT hourly and NOT drive-time-as-hours. Therefore:
+  **`pay_drive_time` defaults OFF** — drive *hours* show as a record, never
+  as an auto-added pay line (the MaidCentral annoyance). The drive *expense*
+  is covered by the mileage engine (2A/2B) only.
+- **Payroll summary is dollars-first.** Lead with Commission $ + Mileage $ =
+  Total Pay. Show hours (job / drive / idle / total-on-clock) underneath,
+  clearly labeled "for records — not paid hourly," plus a quiet flag only
+  when total hours cross 40 in a week (the one real OT exposure).
+- **ONE canonical efficiency definition.** Primary metric =
+  **`Allowed Hours ÷ Actual Job Hours`** (>100% = under budget = good). If a
+  day-level utilization metric is ever shown (job time ÷ paid time), it gets
+  its OWN distinct name ("Utilization") — the word "Efficiency" maps to
+  exactly one formula everywhere. Never repeat MaidCentral's three-denominator
+  confusion.
+- **Anti-gaming is structural, not punitive.** The comp model removes the
+  incentive to milk: commission/allowed-hours means slow = *less* effective
+  pay + a red efficiency score, not more money; idle/drive aren't paid so
+  inflating them earns $0; mileage is the mapping API's fixed point-to-point
+  distance (route-independent, can't be padded by driving around); GPS at
+  check-in/out + the geofence flag catches off-site punches; the derived day
+  can't be padded into overtime. Captured idle/drive/efficiency data is the
+  office's coaching radar, not a pay obligation.
+
 ## Hard Rules — Never Reverse
 - No QuickBooks bidirectional sync — QB is write-only (Qleno pushes to QB, never pulls)
 - Square is for existing Phes clients only — new bookings always use Stripe

--- a/artifacts/qleno/src/pages/my-jobs.tsx
+++ b/artifacts/qleno/src/pages/my-jobs.tsx
@@ -829,6 +829,18 @@ export default function MyJobsPage() {
   const jobs: Job[] = data?.data || [];
   const activeJobs = jobs.filter(j => j.status !== "cancelled" && (!j.time_clock_entry || !j.time_clock_entry.clock_out_at || j.status !== "complete"));
   const upcomingJobs = jobs.filter(j => j.status === "scheduled" && !j.time_clock_entry);
+  // [day-complete 2026-06-04] The day is DERIVED, never a button: it's done
+  // when every non-cancelled job today is checked out. No clock-out tap — this
+  // is a closure STATE. Job hours come from the tech's own check-in/out spans.
+  const completedToday = jobs.filter(j => j.status !== "cancelled" && (j.status === "complete" || !!j.time_clock_entry?.clock_out_at));
+  const dayComplete = jobs.length > 0 && activeJobs.length === 0 && completedToday.length > 0;
+  const dayJobHours = completedToday.reduce((sum, j) => {
+    const e = j.time_clock_entry;
+    if (e?.clock_in_at && e?.clock_out_at) {
+      return sum + Math.max(0, (new Date(e.clock_out_at).getTime() - new Date(e.clock_in_at).getTime()) / 3600000);
+    }
+    return sum + (j.estimated_hours ?? 0);
+  }, 0);
 
   return (
     <div style={{ minHeight: "100vh", backgroundColor: "#F7F6F3", fontFamily: "'Plus Jakarta Sans', sans-serif" }}>
@@ -887,6 +899,32 @@ export default function MyJobsPage() {
             </div>
           ) : (
             <>
+              {dayComplete && (
+                <div style={{ backgroundColor: "#FFFFFF", border: "1px solid #E5E2DC", borderLeft: "3px solid var(--brand, #2D9B83)", borderRadius: 12, padding: 18, marginBottom: 14 }}>
+                  <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8 }}>
+                    <div style={{ width: 30, height: 30, borderRadius: 15, background: "var(--brand-dim, #ECFDF5)", display: "flex", alignItems: "center", justifyContent: "center" }}>
+                      <Check size={17} color="var(--brand, #2D9B83)" />
+                    </div>
+                    <div>
+                      <p style={{ fontSize: 16, fontWeight: 800, color: "#1A1917", margin: 0 }}>Day complete</p>
+                      <p style={{ fontSize: 12, color: "#9E9B94", margin: 0 }}>{today}</p>
+                    </div>
+                  </div>
+                  <div style={{ display: "flex", gap: 10 }}>
+                    <div style={{ flex: 1, background: "#F7F6F3", borderRadius: 10, padding: "10px 12px" }}>
+                      <p style={{ fontSize: 11, fontWeight: 700, color: "#9E9B94", textTransform: "uppercase", letterSpacing: "0.05em", margin: "0 0 2px" }}>Jobs done</p>
+                      <p style={{ fontSize: 20, fontWeight: 800, color: "#1A1917", margin: 0 }}>{completedToday.length}</p>
+                    </div>
+                    <div style={{ flex: 1, background: "#F7F6F3", borderRadius: 10, padding: "10px 12px" }}>
+                      <p style={{ fontSize: 11, fontWeight: 700, color: "#9E9B94", textTransform: "uppercase", letterSpacing: "0.05em", margin: "0 0 2px" }}>Job hours</p>
+                      <p style={{ fontSize: 20, fontWeight: 800, color: "#1A1917", margin: 0 }}>{dayJobHours.toFixed(1)}h</p>
+                    </div>
+                  </div>
+                  <p style={{ fontSize: 12, color: "#6B6860", margin: "10px 0 0", lineHeight: 1.5 }}>
+                    Drive mileage between your jobs is calculated automatically. Pay and mileage finalize after office review.
+                  </p>
+                </div>
+              )}
               {activeJobs.map((job, i) => (
                 <JobCard key={job.id} job={job} empPos={empPos} onRefresh={refetch} isPreviewMode={!!employeeView}
                   prevJobId={i > 0 ? activeJobs[i - 1].id : null} />


### PR DESCRIPTION
Locks the time-clock workflow model and ships the first tech-facing piece.

## Design locked in `CLAUDE.md` — "Time Clock — Workflow Model (Locked)"
The full model we settled on, so the build can't reintroduce MaidCentral's confusion:
- **One clock pair, at the house** (the existing per-job clock-in/out); **no separate day clock**
- **The day is derived** (first check-in → last check-out); checkout of the last house ends it automatically; self-extends on a surprise add-on; this also enforces the "last-job→home commute isn't paid" rule
- **Idle = record, not pay**; **capturing ≠ paying** — only commission + mileage move dollars; **`pay_drive_time` defaults OFF**
- **Dollars-first payroll summary** + a quiet >40hr OT flag
- **One canonical efficiency definition** (`Allowed ÷ Actual Job Hours`); utilization gets its own name
- **Structural anti-gaming** (commission/allowed-hours makes slow pay *less*; route-proof point-to-point mileage; GPS geofence; un-paddable derived day)

## Built (mobile): "Day complete" closure card
On My Jobs, once every job today is checked out, a derived summary appears — **Jobs done + Job hours** — with no clock-out button (it's a *state*, not a tap). Notes that mileage/pay finalize after office review.

Most of the engine (per-job clock, On My Way → `from_job_id` → mileage, 2A/2B, allowed-hours, GPS) is already built and merged; this connects the model + the closure UX. The **office-facing reporting surfaces** (dollars-first payroll view, efficiency view, mileage review UI) are the next build phase, now fully specced in `CLAUDE.md`.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_