### PR TITLE
feat(payroll): jurisdiction-aware overtime engine + premium estimate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -346,6 +346,36 @@ commission shop, and the word "Efficiency" meaning three different formulas.)*
   can't be padded into overtime. Captured idle/drive/efficiency data is the
   office's coaching radar, not a pay obligation.
 
+## Overtime — Jurisdiction-Aware (Locked)
+*(Source of truth: docs/OVERTIME_COMPLIANCE_DESIGN.md. Engine: `lib/overtime.ts`.
+Not legal advice — the engine ESTIMATES the premium for office review; it never
+files or pays it.)*
+
+- **Hours worked = job clock time (`timeclock`) + between-jobs drive
+  (`mileage_legs.minutes`).** The home↔job commute is NEVER counted — no clock
+  runs during it and the mileage engine already excludes the commute legs
+  (29 CFR 785.35/785.38). Idle/breaks excluded. **Allowed hours is NOT hours
+  worked** — it's a budget for efficiency + commercial commission only.
+  Overtime is always measured against ACTUAL clocked time.
+- **Threshold is per-tenant.** Federal + most states (incl. Illinois) =
+  weekly-40 only, 1.5×. Daily-OT states (CA/AK/CO/NV; OR manufacturing) are
+  opt-in via `STATE_OVERTIME_PRESETS`, seeded from `companies.state`. Rules
+  resolve via `resolveOvertimeRules()`: company `ot_*` columns → state preset →
+  federal default. **Never hardcode 40 or 1.5× at a call site** — go through
+  the engine. No-pyramiding (a daily-OT hour isn't re-counted weekly).
+- **Premium = the extra over commission.** Phes pays commission, not hourly, so
+  straight time is already in the commission; only the premium portion is owed.
+  regular rate = workweek commission ÷ hours worked (reuse
+  `computeCommissionRows`). OT hours owe `(otMult−1)×rate`, DT hours
+  `(dtMult−1)×rate`. **Mileage is EXCLUDED from the regular rate** (reimbursement,
+  not wages — 29 CFR 778.217).
+- **Office-only.** `/payroll/overtime-check` is role-gated to owner/admin/office;
+  techs NEVER see overtime, hours-worked totals, drive, or idle as pay lines.
+  A tech's view is dollars. (Decision 2026-06-04: leave the tech view as-is;
+  do not surface hours to techs.)
+- **No money moves automatically** — same philosophy as mileage. The banner
+  surfaces the estimate; the office pays it via the normal additional-pay flow.
+
 ## Hard Rules — Never Reverse
 - No QuickBooks bidirectional sync — QB is write-only (Qleno pushes to QB, never pulls)
 - Square is for existing Phes clients only — new bookings always use Stripe

--- a/artifacts/api-server/src/cutover-data-migration.ts
+++ b/artifacts/api-server/src/cutover-data-migration.ts
@@ -99,6 +99,14 @@ export async function runCutoverDataMigration(): Promise<void> {
       err,
     );
   }
+  try {
+    await addOvertimeColumns();
+  } catch (err) {
+    console.error(
+      "[cutover-migration] overtime columns failed (non-fatal):",
+      err,
+    );
+  }
 }
 
 /**
@@ -313,6 +321,55 @@ async function addCancellationTechPayColumns(): Promise<void> {
         WHERE table_schema='public' AND table_name='companies' AND column_name='cancellation_tech_pay_amount'
       ) THEN
         ALTER TABLE companies ADD COLUMN cancellation_tech_pay_amount numeric(10,4) NOT NULL DEFAULT 60.0000;
+      END IF;
+    END $$;
+  `),
+  );
+}
+
+/**
+ * Overtime (2026-06-04) — add the jurisdiction-aware overtime config columns
+ * to companies. Idempotent (every ADD is column-guarded).
+ *
+ * ot_rules_source is intentionally left NULL on add: a NULL source means "not
+ * yet configured", and resolveOvertimeRules() falls back to the preset for
+ * companies.state at read time. So a fresh column add immediately yields the
+ * correct per-state rules (federal/weekly-40 for IL and most states; daily OT
+ * for CA/AK/CO/NV) without seeding state-specific values into every row. The
+ * source flips to 'custom' only when an owner edits the settings.
+ */
+async function addOvertimeColumns(): Promise<void> {
+  await db.execute(
+    sql.raw(`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (SELECT 1 FROM information_schema.columns
+        WHERE table_schema='public' AND table_name='companies' AND column_name='ot_rules_source') THEN
+        ALTER TABLE companies ADD COLUMN ot_rules_source text;
+      END IF;
+      IF NOT EXISTS (SELECT 1 FROM information_schema.columns
+        WHERE table_schema='public' AND table_name='companies' AND column_name='ot_weekly_threshold_hours') THEN
+        ALTER TABLE companies ADD COLUMN ot_weekly_threshold_hours numeric(5,2) DEFAULT 40.00;
+      END IF;
+      IF NOT EXISTS (SELECT 1 FROM information_schema.columns
+        WHERE table_schema='public' AND table_name='companies' AND column_name='ot_daily_threshold_hours') THEN
+        ALTER TABLE companies ADD COLUMN ot_daily_threshold_hours numeric(5,2);
+      END IF;
+      IF NOT EXISTS (SELECT 1 FROM information_schema.columns
+        WHERE table_schema='public' AND table_name='companies' AND column_name='ot_daily_doubletime_hours') THEN
+        ALTER TABLE companies ADD COLUMN ot_daily_doubletime_hours numeric(5,2);
+      END IF;
+      IF NOT EXISTS (SELECT 1 FROM information_schema.columns
+        WHERE table_schema='public' AND table_name='companies' AND column_name='ot_seventh_day_rule') THEN
+        ALTER TABLE companies ADD COLUMN ot_seventh_day_rule boolean NOT NULL DEFAULT false;
+      END IF;
+      IF NOT EXISTS (SELECT 1 FROM information_schema.columns
+        WHERE table_schema='public' AND table_name='companies' AND column_name='ot_multiplier') THEN
+        ALTER TABLE companies ADD COLUMN ot_multiplier numeric(4,2) NOT NULL DEFAULT 1.50;
+      END IF;
+      IF NOT EXISTS (SELECT 1 FROM information_schema.columns
+        WHERE table_schema='public' AND table_name='companies' AND column_name='ot_doubletime_multiplier') THEN
+        ALTER TABLE companies ADD COLUMN ot_doubletime_multiplier numeric(4,2) NOT NULL DEFAULT 2.00;
       END IF;
     END $$;
   `),

--- a/artifacts/api-server/src/lib/overtime.ts
+++ b/artifacts/api-server/src/lib/overtime.ts
@@ -1,0 +1,323 @@
+/**
+ * Overtime engine — jurisdiction-aware "hours worked" → overtime premium.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * LEGAL BASIS (not legal advice — tenants must confirm with their own
+ * payroll provider / employment counsel; see docs/OVERTIME_COMPLIANCE_DESIGN.md):
+ *
+ *  • Hours worked. Only COMPENSABLE time counts toward overtime. For a tech
+ *    who drives between client homes, that is:
+ *      - time on the per-house clock (timeclock.clock_in_at..clock_out_at), and
+ *      - travel BETWEEN job sites during the workday (29 CFR 785.38).
+ *    The home→first-job and last-job→home commute is NOT compensable
+ *    (29 CFR 785.35) and never enters this engine — it is excluded upstream
+ *    by the mileage engine (skip_first_leg_of_day / skip_no_from_job) and by
+ *    the fact that no clock runs during the commute.
+ *
+ *  • Threshold. Federal FLSA + most states (incl. Illinois, 820 ILCS 105/4a):
+ *    time-and-a-half for hours worked over 40 in a workweek. No daily overtime.
+ *    A handful of states ALSO require daily overtime — see STATE_OVERTIME_PRESETS.
+ *
+ *  • Commission pay (Phes model). Commissions are part of the regular rate
+ *    (29 CFR 778.117). For an employee paid by commission (no hourly wage),
+ *    straight-time for every hour is already covered by the commission, so the
+ *    only money owed for overtime is the PREMIUM portion — an extra 0.5× the
+ *    regular rate for 1.5× hours, an extra 1.0× for double-time hours. The
+ *    regular rate = total workweek commission ÷ total hours worked that week.
+ *    Mileage reimbursement is a bona-fide expense reimbursement and is EXCLUDED
+ *    from the regular rate (29 CFR 778.217).
+ *
+ * DESIGN: this module is pure (no DB / no I/O). The route layer feeds it the
+ * resolved company rules + the hours/commission it has already queried, and
+ * surfaces the result for office review. Consistent with the rest of the
+ * payroll build, computed overtime is a REVIEW SIGNAL — it does not auto-move
+ * money.
+ * ─────────────────────────────────────────────────────────────────────────
+ */
+
+export interface OvertimeRules {
+  /** Weekly overtime threshold in hours. Federal/most states = 40. */
+  weeklyThresholdHours: number;
+  /** Daily overtime threshold; null = no daily overtime (the common case). */
+  dailyThresholdHours: number | null;
+  /** Daily double-time threshold; null = no double-time. */
+  dailyDoubleTimeHours: number | null;
+  /** Seventh-consecutive-workday rule (California). */
+  seventhConsecutiveDayRule: boolean;
+  /** Overtime multiplier (time-and-a-half = 1.5). */
+  otMultiplier: number;
+  /** Double-time multiplier (2.0). */
+  dtMultiplier: number;
+}
+
+export interface OvertimePreset extends OvertimeRules {
+  /** Where this rule set came from, for display/audit. */
+  label: string;
+  /** Optional caveat the office should read before relying on the preset. */
+  note?: string;
+}
+
+/**
+ * Federal / FLSA default — also correct for Illinois and the majority of
+ * states: weekly-40 only, time-and-a-half. This is what every tenant gets
+ * out of the box, so Qleno is compliant by default regardless of where the
+ * tenant operates; daily-overtime states are opt-in via the presets below.
+ */
+export const FEDERAL_DEFAULT_RULES: OvertimeRules = {
+  weeklyThresholdHours: 40,
+  dailyThresholdHours: null,
+  dailyDoubleTimeHours: null,
+  seventhConsecutiveDayRule: false,
+  otMultiplier: 1.5,
+  dtMultiplier: 2.0,
+};
+
+/**
+ * State presets. Only states whose rules differ from the federal weekly-40
+ * baseline get an entry; every other state resolves to FEDERAL_DEFAULT_RULES.
+ * Keyed by USPS two-letter code. These are STARTING POINTS the tenant confirms
+ * in settings — labor law changes and has industry carve-outs, so the office
+ * can always override any field.
+ */
+export const STATE_OVERTIME_PRESETS: Record<string, OvertimePreset> = {
+  CA: {
+    label: "California",
+    weeklyThresholdHours: 40,
+    dailyThresholdHours: 8,
+    dailyDoubleTimeHours: 12,
+    seventhConsecutiveDayRule: true,
+    otMultiplier: 1.5,
+    dtMultiplier: 2.0,
+    note: "Daily OT after 8h, double-time after 12h, plus 7th-consecutive-day rules.",
+  },
+  AK: {
+    label: "Alaska",
+    weeklyThresholdHours: 40,
+    dailyThresholdHours: 8,
+    dailyDoubleTimeHours: null,
+    seventhConsecutiveDayRule: false,
+    otMultiplier: 1.5,
+    dtMultiplier: 2.0,
+    note: "Daily OT after 8h (employers with 4+ employees). No double-time.",
+  },
+  CO: {
+    label: "Colorado",
+    weeklyThresholdHours: 40,
+    dailyThresholdHours: 12,
+    dailyDoubleTimeHours: null,
+    seventhConsecutiveDayRule: false,
+    otMultiplier: 1.5,
+    dtMultiplier: 2.0,
+    note: "OT after 12h/day OR 12 consecutive hours OR 40/week — whichever yields more. The consecutive-hours test isn't modeled; daily-12 is.",
+  },
+  NV: {
+    label: "Nevada",
+    weeklyThresholdHours: 40,
+    dailyThresholdHours: 8,
+    dailyDoubleTimeHours: null,
+    seventhConsecutiveDayRule: false,
+    otMultiplier: 1.5,
+    dtMultiplier: 2.0,
+    note: "Daily-8 OT applies ONLY to employees earning under 1.5× minimum wage. Turn the daily threshold off for higher earners.",
+  },
+  OR: {
+    // Oregon's daily overtime is manufacturing-only; for a cleaning business
+    // the weekly-40 federal baseline applies, so OR maps to the default but
+    // carries a note so a manufacturing tenant knows to configure it.
+    label: "Oregon",
+    ...FEDERAL_DEFAULT_RULES,
+    note: "Weekly-40 for most industries. Manufacturing has daily-10 OT — configure manually if applicable.",
+  },
+};
+
+/** USPS code ⇆ name normalization so companies.state can be "IL" or "Illinois". */
+const STATE_NAME_TO_CODE: Record<string, string> = {
+  alabama: "AL", alaska: "AK", arizona: "AZ", arkansas: "AR", california: "CA",
+  colorado: "CO", connecticut: "CT", delaware: "DE", florida: "FL", georgia: "GA",
+  hawaii: "HI", idaho: "ID", illinois: "IL", indiana: "IN", iowa: "IA",
+  kansas: "KS", kentucky: "KY", louisiana: "LA", maine: "ME", maryland: "MD",
+  massachusetts: "MA", michigan: "MI", minnesota: "MN", mississippi: "MS",
+  missouri: "MO", montana: "MT", nebraska: "NE", nevada: "NV",
+  "new hampshire": "NH", "new jersey": "NJ", "new mexico": "NM", "new york": "NY",
+  "north carolina": "NC", "north dakota": "ND", ohio: "OH", oklahoma: "OK",
+  oregon: "OR", pennsylvania: "PA", "rhode island": "RI", "south carolina": "SC",
+  "south dakota": "SD", tennessee: "TN", texas: "TX", utah: "UT", vermont: "VT",
+  virginia: "VA", washington: "WA", "west virginia": "WV", wisconsin: "WI",
+  wyoming: "WY", "district of columbia": "DC",
+};
+
+/** Normalize a free-text state value to a USPS code, or null if unknown. */
+export function normalizeStateCode(state?: string | null): string | null {
+  if (!state) return null;
+  const trimmed = state.trim();
+  if (trimmed.length === 2) return trimmed.toUpperCase();
+  return STATE_NAME_TO_CODE[trimmed.toLowerCase()] ?? null;
+}
+
+/** The preset for a state (federal default when the state has no special rule). */
+export function getPresetForState(state?: string | null): OvertimePreset {
+  const code = normalizeStateCode(state);
+  if (code && STATE_OVERTIME_PRESETS[code]) return STATE_OVERTIME_PRESETS[code];
+  return {
+    label: code ? `${code} (federal baseline)` : "Federal baseline",
+    ...FEDERAL_DEFAULT_RULES,
+  };
+}
+
+/**
+ * A company row's OT-config columns (all nullable — added via ALTER). When
+ * `ot_rules_source` is null the tenant hasn't been configured yet and the
+ * caller should fall back to the state preset.
+ */
+export interface CompanyOvertimeColumns {
+  state?: string | null;
+  ot_rules_source?: string | null;
+  ot_weekly_threshold_hours?: string | number | null;
+  ot_daily_threshold_hours?: string | number | null;
+  ot_daily_doubletime_hours?: string | number | null;
+  ot_seventh_day_rule?: boolean | null;
+  ot_multiplier?: string | number | null;
+  ot_doubletime_multiplier?: string | number | null;
+}
+
+function numOrNull(v: string | number | null | undefined): number | null {
+  if (v === null || v === undefined || v === "") return null;
+  const n = typeof v === "number" ? v : parseFloat(String(v));
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Resolve the rules a company actually runs under:
+ *   1. explicit per-tenant config columns (source = 'custom' or a state code), else
+ *   2. the preset for companies.state, else
+ *   3. the federal default.
+ * Returns the rules plus a human label + the state preset, so the settings
+ * UI can show "you're on California rules" and offer a reset-to-preset.
+ */
+export function resolveOvertimeRules(company: CompanyOvertimeColumns): {
+  rules: OvertimeRules;
+  source: string;
+  statePreset: OvertimePreset;
+} {
+  const statePreset = getPresetForState(company.state);
+
+  // Not yet configured → use the state preset (Qleno is compliant by default).
+  if (!company.ot_rules_source) {
+    return { rules: { ...statePreset }, source: `preset:${statePreset.label}`, statePreset };
+  }
+
+  // Configured → read the stored columns, defaulting any gap to the preset.
+  const rules: OvertimeRules = {
+    weeklyThresholdHours: numOrNull(company.ot_weekly_threshold_hours) ?? statePreset.weeklyThresholdHours,
+    dailyThresholdHours: numOrNull(company.ot_daily_threshold_hours),
+    dailyDoubleTimeHours: numOrNull(company.ot_daily_doubletime_hours),
+    seventhConsecutiveDayRule: company.ot_seventh_day_rule ?? statePreset.seventhConsecutiveDayRule,
+    otMultiplier: numOrNull(company.ot_multiplier) ?? 1.5,
+    dtMultiplier: numOrNull(company.ot_doubletime_multiplier) ?? 2.0,
+  };
+  return { rules, source: company.ot_rules_source, statePreset };
+}
+
+export interface WeekOvertimeResult {
+  /** Total hours worked in the week (job + between-jobs drive). */
+  totalHours: number;
+  /** Hours paid at straight time (already covered by commission). */
+  regularHours: number;
+  /** Hours at the OT multiplier (e.g. 1.5×). */
+  otHours: number;
+  /** Hours at the double-time multiplier (e.g. 2×). */
+  dtHours: number;
+}
+
+/**
+ * Compute the overtime breakdown for ONE workweek using the standard
+ * no-pyramiding method (an hour counted as daily OT is not counted again as
+ * weekly OT):
+ *
+ *   per day:  straight = min(dayHrs, dailyThreshold)
+ *             ot(1.5×) = clamp(dayHrs − dailyThreshold) up to the DT threshold
+ *             dt(2×)   = dayHrs over the DT threshold
+ *   weekly:   any straight-time hours beyond the weekly threshold become 1.5×.
+ *
+ * When the rules have no daily threshold (federal / Illinois / most states),
+ * every hour is "straight" per day and this degenerates exactly to
+ * "hours over 40 in the week are 1.5×" — i.e. the plain weekly-40 rule.
+ *
+ * @param dailyHours hours worked each calendar day of the workweek. For the
+ *   7th-day rule, pass them in worked order (the last nonzero entry is treated
+ *   as the latest day worked).
+ */
+export function computeWeekOvertime(dailyHours: number[], rules: OvertimeRules): WeekOvertimeResult {
+  const dailyT = rules.dailyThresholdHours ?? Infinity;
+  const dtT = rules.dailyDoubleTimeHours ?? Infinity;
+
+  let straightSum = 0;
+  let otHours = 0;
+  let dtHours = 0;
+
+  const daysWorked = dailyHours.filter((h) => h > 0).length;
+  // 7th-consecutive-day (California): every hour on the 7th worked day is
+  // premium — first 8 at 1.5×, the rest at 2×. Identify the last worked day.
+  const seventhDayActive = rules.seventhConsecutiveDayRule && daysWorked >= 7;
+  let lastWorkedIdx = -1;
+  if (seventhDayActive) {
+    for (let i = dailyHours.length - 1; i >= 0; i--) {
+      if (dailyHours[i] > 0) { lastWorkedIdx = i; break; }
+    }
+  }
+
+  dailyHours.forEach((h, idx) => {
+    if (h <= 0) return;
+    if (seventhDayActive && idx === lastWorkedIdx) {
+      // 7th day: first 8h @1.5×, remainder @2×. No straight-time hours.
+      otHours += Math.min(h, 8);
+      dtHours += Math.max(0, h - 8);
+      return;
+    }
+    const dayStraight = Math.min(h, dailyT);
+    const dayDt = Math.max(0, h - dtT);
+    const dayOt = Math.max(0, Math.min(h, dtT) - dailyT);
+    straightSum += dayStraight;
+    otHours += dayOt;
+    dtHours += dayDt;
+  });
+
+  // Weekly threshold applies to straight-time hours only (no pyramiding).
+  const weeklyOt = Math.max(0, straightSum - rules.weeklyThresholdHours);
+  otHours += weeklyOt;
+
+  const totalHours = dailyHours.reduce((s, h) => s + Math.max(0, h), 0);
+  const regularHours = round2(totalHours - otHours - dtHours);
+
+  return {
+    totalHours: round2(totalHours),
+    regularHours: regularHours < 0 ? 0 : regularHours,
+    otHours: round2(otHours),
+    dtHours: round2(dtHours),
+  };
+}
+
+/**
+ * Premium dollars owed on top of commission for one workweek. For a
+ * commission-paid (non-hourly) employee, straight time is already in the
+ * commission, so we owe only the EXTRA over straight: (mult − 1) × rate per
+ * premium hour. Mileage must already be excluded from `regularRate`.
+ *
+ * regularRate = workweek commission ÷ total hours worked that week.
+ */
+export function computeOvertimePremium(input: {
+  otHours: number;
+  dtHours: number;
+  regularRate: number;
+  rules: OvertimeRules;
+}): number {
+  const { otHours, dtHours, regularRate, rules } = input;
+  if (regularRate <= 0) return 0;
+  const otPremium = otHours * Math.max(0, rules.otMultiplier - 1) * regularRate;
+  const dtPremium = dtHours * Math.max(0, rules.dtMultiplier - 1) * regularRate;
+  return round2(otPremium + dtPremium);
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}

--- a/artifacts/api-server/src/routes/payroll.ts
+++ b/artifacts/api-server/src/routes/payroll.ts
@@ -4,6 +4,15 @@ import { usersTable, timeclockTable, additionalPayTable, jobsTable, clientsTable
 import { eq, and, gte, lte, sum, count, sql, inArray } from "drizzle-orm";
 import { requireAuth, requireRole } from "../lib/auth.js";
 import { parseResRatesRow, resolveResidentialPayPct } from "../lib/commission-rates.js";
+import { computeCommissionRows } from "../lib/commission-compute.js";
+import {
+  resolveOvertimeRules,
+  computeWeekOvertime,
+  computeOvertimePremium,
+  STATE_OVERTIME_PRESETS,
+  FEDERAL_DEFAULT_RULES,
+  type OvertimeRules,
+} from "../lib/overtime.js";
 
 const router = Router();
 
@@ -137,13 +146,24 @@ router.get("/summary", requireAuth, requireRole("owner", "admin", "office"), asy
   }
 });
 
-// ── Overtime check (>40 hrs/week) ─────────────────────────────────────────────
-// [ot-trigger 2026-06-04] Per CLAUDE.md "Time Clock — Workflow Model": a quiet
-// flag only when total hours cross 40 in a workweek — the one real OT exposure
-// for a commission shop. "Hours worked" = job clock time (timeclock) + drive
-// time between jobs (mileage_legs.minutes). Idle/breaks excluded. Buckets by
-// ISO week (Mon-start, date_trunc('week')) so a multi-week range is split into
-// proper workweeks. Pure read; surfaces in the office payroll view.
+// ── Overtime check ────────────────────────────────────────────────────────────
+// [overtime 2026-06-04] Jurisdiction-aware overtime review signal. Per
+// CLAUDE.md "Time Clock — Workflow Model" + docs/OVERTIME_COMPLIANCE_DESIGN.md.
+//
+// "Hours worked" = job clock time (timeclock) + drive time BETWEEN jobs
+// (mileage_legs.minutes). The home↔job commute never enters this — no clock
+// runs during it and the mileage engine excludes the commute legs (29 CFR
+// 785.35/785.38). Idle/breaks excluded.
+//
+// Threshold is per-tenant: federal/most states (incl. Illinois) = weekly-40
+// only; CA/AK/CO/NV add daily overtime. The rules resolve from the company's
+// OT config (falls back to the preset for companies.state, then federal).
+//
+// For a commission shop the only money owed on OT is the PREMIUM portion
+// (extra 0.5×/1.0× the regular rate) — straight time is already in commission.
+// regular rate = workweek commission ÷ hours worked; mileage excluded
+// (29 CFR 778.117/778.217). The premium is an ESTIMATE for office review — it
+// does not auto-move money. Pure read.
 router.get("/overtime-check", requireAuth, requireRole("owner", "admin", "office"), async (req, res) => {
   try {
     const { from, to } = req.query;
@@ -153,69 +173,253 @@ router.get("/overtime-check", requireAuth, requireRole("owner", "admin", "office
     const companyId = req.auth!.companyId;
     const toEnd = `${to} 23:59:59`;
 
-    // Job hours per (user, week) from the per-house clock.
+    // Resolve this tenant's overtime rules (state preset unless overridden).
+    let rules: OvertimeRules = { ...FEDERAL_DEFAULT_RULES };
+    let rulesSource = "preset:Federal baseline";
+    try {
+      const cRow = await db.execute(sql`
+        SELECT state, ot_rules_source, ot_weekly_threshold_hours, ot_daily_threshold_hours,
+               ot_daily_doubletime_hours, ot_seventh_day_rule, ot_multiplier, ot_doubletime_multiplier
+        FROM companies WHERE id = ${companyId} LIMIT 1`);
+      if (cRow.rows[0]) {
+        const resolved = resolveOvertimeRules(cRow.rows[0] as any);
+        rules = resolved.rules;
+        rulesSource = resolved.source;
+      }
+    } catch { /* OT columns absent pre-migration — keep federal default */ }
+
+    // Job hours per (user, week, day) from the per-house clock.
     const jobRows = await db.execute(sql`
       SELECT user_id,
              to_char(date_trunc('week', clock_in_at), 'YYYY-MM-DD') AS week_start,
+             to_char(date_trunc('day',  clock_in_at), 'YYYY-MM-DD') AS day,
              COALESCE(SUM(EXTRACT(EPOCH FROM (clock_out_at - clock_in_at)) / 3600), 0) AS job_hours
       FROM timeclock
       WHERE company_id = ${companyId}
         AND clock_out_at IS NOT NULL
         AND clock_in_at >= ${from} AND clock_in_at <= ${toEnd}
-      GROUP BY user_id, week_start
+      GROUP BY user_id, week_start, day
     `);
 
-    // Drive hours per (user, week) from the between-jobs mileage legs.
+    // Drive hours per (user, week, day) from the between-jobs mileage legs.
     const driveRows = await db.execute(sql`
       SELECT user_id,
              to_char(date_trunc('week', leg_date::timestamp), 'YYYY-MM-DD') AS week_start,
+             to_char(date_trunc('day',  leg_date::timestamp), 'YYYY-MM-DD') AS day,
              COALESCE(SUM(minutes) / 60.0, 0) AS drive_hours
       FROM mileage_legs
       WHERE company_id = ${companyId}
         AND status <> 'discarded'
         AND leg_date >= ${from} AND leg_date <= ${to}
-      GROUP BY user_id, week_start
+      GROUP BY user_id, week_start, day
     `);
 
-    type Bucket = { user_id: number; week_start: string; job: number; drive: number };
-    const map = new Map<string, Bucket>();
+    // Assemble per (user, week): a map of day → {job, drive} so we can feed the
+    // daily-hours array to the rules engine (needed for daily-OT states).
+    type WeekBucket = { user_id: number; week_start: string; days: Map<string, { job: number; drive: number }> };
+    const map = new Map<string, WeekBucket>();
     const key = (u: number, w: string) => `${u}|${w}`;
+    const touch = (u: number, w: string, d: string) => {
+      const k = key(u, w);
+      let b = map.get(k);
+      if (!b) { b = { user_id: u, week_start: w, days: new Map() }; map.set(k, b); }
+      let day = b.days.get(d);
+      if (!day) { day = { job: 0, drive: 0 }; b.days.set(d, day); }
+      return day;
+    };
     for (const r of jobRows.rows as any[]) {
-      const u = Number(r.user_id), w = String(r.week_start);
-      map.set(key(u, w), { user_id: u, week_start: w, job: Number(r.job_hours) || 0, drive: 0 });
+      touch(Number(r.user_id), String(r.week_start), String(r.day)).job += Number(r.job_hours) || 0;
     }
     for (const r of driveRows.rows as any[]) {
-      const u = Number(r.user_id), w = String(r.week_start);
-      const b = map.get(key(u, w)) ?? { user_id: u, week_start: w, job: 0, drive: 0 };
-      b.drive = Number(r.drive_hours) || 0;
-      map.set(key(u, w), b);
+      touch(Number(r.user_id), String(r.week_start), String(r.day)).drive += Number(r.drive_hours) || 0;
     }
 
-    const over = [...map.values()].filter(b => b.job + b.drive > 40);
-    const userIds = [...new Set(over.map(b => b.user_id))];
+    // Weekly commission per (user, week) → the regular rate for the OT premium.
+    // Reuse the canonical commission engine + per-job final_pay overrides so the
+    // rate matches what the office sees on the payroll detail screen.
+    const weeklyCommission = new Map<string, number>(); // user|mondayWeek → $
+    try {
+      let comp: any = { res_tech_pay_pct: 0.35, deep_clean_pay_pct: 0.32, move_in_out_pay_pct: 0.32, commercial_hourly_rate: 20, commercial_comp_mode: "allowed_hours" };
+      try {
+        const cr = await db.execute(sql`SELECT res_tech_pay_pct, deep_clean_pay_pct, move_in_out_pay_pct, commercial_hourly_rate, commercial_comp_mode FROM companies WHERE id = ${companyId} LIMIT 1`);
+        if (cr.rows[0]) comp = cr.rows[0];
+      } catch { /* keep defaults */ }
+      const resRates = parseResRatesRow(comp);
+
+      const cJobs = await db
+        .select({
+          id: jobsTable.id, assigned_user_id: jobsTable.assigned_user_id,
+          service_type: jobsTable.service_type, account_id: jobsTable.account_id,
+          base_fee: jobsTable.base_fee, billed_amount: jobsTable.billed_amount,
+          allowed_hours: jobsTable.allowed_hours, actual_hours: jobsTable.actual_hours,
+          branch_id: jobsTable.branch_id, scheduled_date: jobsTable.scheduled_date,
+        })
+        .from(jobsTable)
+        .where(and(
+          eq(jobsTable.company_id, companyId),
+          eq(jobsTable.status, "complete"),
+          gte(jobsTable.scheduled_date, from as string),
+          lte(jobsTable.scheduled_date, to as string),
+        ));
+
+      // Per-job final_pay overrides (one query for the whole range).
+      const overrides = new Map<string, number>();
+      const jobIds = cJobs.map(j => j.id);
+      if (jobIds.length) {
+        try {
+          const ov = await db.execute(sql`SELECT user_id, job_id, final_pay FROM job_technicians WHERE job_id = ANY(${jobIds}::int[]) AND final_pay IS NOT NULL`);
+          for (const r of ov.rows as any[]) overrides.set(`${r.user_id}:${r.job_id}`, parseFloat(String(r.final_pay)));
+        } catch { /* job_technicians may be absent */ }
+      }
+
+      const rows = computeCommissionRows({
+        jobs: cJobs as any,
+        resRates,
+        commercial: {
+          commercial_hourly_rate: parseFloat(String(comp.commercial_hourly_rate ?? 20)),
+          commercial_comp_mode: (String(comp.commercial_comp_mode ?? "allowed_hours") as any),
+        },
+        overrides,
+      });
+      for (const row of rows) {
+        const wk = mondayOf(row.scheduled_date);
+        const k = key(row.user_id, wk);
+        weeklyCommission.set(k, (weeklyCommission.get(k) || 0) + row.amount);
+      }
+    } catch (e) {
+      console.error("Overtime commission regular-rate calc failed (non-fatal):", e);
+    }
+
+    const round1 = (n: number) => Math.round(n * 10) / 10;
+    const round2 = (n: number) => Math.round(n * 100) / 100;
+
+    const weeks = [...map.values()].map(b => {
+      const dayEntries = [...b.days.entries()].sort((a, c) => a[0].localeCompare(c[0]));
+      const dailyHours = dayEntries.map(([, v]) => v.job + v.drive);
+      const job = dayEntries.reduce((s, [, v]) => s + v.job, 0);
+      const drive = dayEntries.reduce((s, [, v]) => s + v.drive, 0);
+
+      const ot = computeWeekOvertime(dailyHours, rules);
+      const commission = weeklyCommission.get(key(b.user_id, b.week_start)) || 0;
+      const regularRate = ot.totalHours > 0 ? commission / ot.totalHours : 0;
+      const premium = computeOvertimePremium({ otHours: ot.otHours, dtHours: ot.dtHours, regularRate, rules });
+
+      return {
+        user_id: b.user_id,
+        week_start: b.week_start,
+        job_hours: round1(job),
+        drive_hours: round1(drive),
+        total_hours: round1(ot.totalHours),
+        // overtime_hours = premium-bearing hours (1.5× + 2×). For weekly-40
+        // tenants this equals max(0, total − 40); daily-OT states may exceed it.
+        overtime_hours: round1(ot.otHours + ot.dtHours),
+        ot_hours: round1(ot.otHours),
+        dt_hours: round1(ot.dtHours),
+        weekly_commission: round2(commission),
+        regular_rate: round2(regularRate),
+        premium_estimate: round2(premium),
+      };
+    }).filter(w => w.ot_hours > 0 || w.dt_hours > 0);
+
+    const userIds = [...new Set(weeks.map(w => w.user_id))];
     const names = userIds.length
       ? await db.select({ id: usersTable.id, first_name: usersTable.first_name, last_name: usersTable.last_name })
           .from(usersTable).where(inArray(usersTable.id, userIds))
       : [];
     const nameById = new Map(names.map(n => [n.id, `${n.first_name ?? ""} ${n.last_name ?? ""}`.trim()]));
 
-    const round1 = (n: number) => Math.round(n * 10) / 10;
-    const weeks = over
-      .map(b => ({
-        user_id: b.user_id,
-        name: nameById.get(b.user_id) || `User ${b.user_id}`,
-        week_start: b.week_start,
-        job_hours: round1(b.job),
-        drive_hours: round1(b.drive),
-        total_hours: round1(b.job + b.drive),
-        overtime_hours: round1(b.job + b.drive - 40),
-      }))
+    const enriched = weeks
+      .map(w => ({ ...w, name: nameById.get(w.user_id) || `User ${w.user_id}` }))
       .sort((a, b) => b.total_hours - a.total_hours);
 
-    return res.json({ any_over_40: weeks.length > 0, count: weeks.length, weeks });
+    const totalPremium = round2(enriched.reduce((s, w) => s + w.premium_estimate, 0));
+
+    return res.json({
+      any_over_40: enriched.length > 0,
+      count: enriched.length,
+      weeks: enriched,
+      total_premium_estimate: totalPremium,
+      rules,
+      rules_source: rulesSource,
+      has_daily_overtime: rules.dailyThresholdHours != null,
+    });
   } catch (err) {
     console.error("Overtime check error:", err);
     return res.status(500).json({ error: "Internal Server Error", message: "Failed to run overtime check" });
+  }
+});
+
+// Monday-of-week (ISO, matches Postgres date_trunc('week')) for a YYYY-MM-DD
+// date string. TZ-independent because scheduled_date carries no time.
+function mondayOf(ymd: string): string {
+  const d = new Date(`${ymd}T00:00:00Z`);
+  const dow = d.getUTCDay(); // 0 Sun..6 Sat
+  d.setUTCDate(d.getUTCDate() + (dow === 0 ? -6 : 1 - dow));
+  return d.toISOString().slice(0, 10);
+}
+
+// ── Overtime rules config (read + save) ───────────────────────────────────────
+// Powers the Overtime section of company settings. GET returns the resolved
+// rules + the state preset + all presets for the picker; PUT persists owner
+// overrides onto the companies OT columns (source flips to 'custom').
+router.get("/overtime-rules", requireAuth, requireRole("owner", "admin", "office"), async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    const cRow = await db.execute(sql`
+      SELECT state, ot_rules_source, ot_weekly_threshold_hours, ot_daily_threshold_hours,
+             ot_daily_doubletime_hours, ot_seventh_day_rule, ot_multiplier, ot_doubletime_multiplier
+      FROM companies WHERE id = ${companyId} LIMIT 1`);
+    const company = (cRow.rows[0] as any) || {};
+    const resolved = resolveOvertimeRules(company);
+    return res.json({
+      state: company.state ?? null,
+      rules: resolved.rules,
+      source: resolved.source,
+      state_preset: resolved.statePreset,
+      is_custom: company.ot_rules_source === "custom",
+      presets: STATE_OVERTIME_PRESETS,
+    });
+  } catch (err) {
+    console.error("Get overtime rules error:", err);
+    return res.status(500).json({ error: "Internal Server Error", message: "Failed to get overtime rules" });
+  }
+});
+
+router.put("/overtime-rules", requireAuth, requireRole("owner", "admin"), async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    const b = req.body ?? {};
+
+    // "reset" clears overrides → source NULL → resolver falls back to the
+    // state preset again.
+    if (b.reset === true) {
+      await db.execute(sql`UPDATE companies SET ot_rules_source = NULL WHERE id = ${companyId}`);
+      return res.json({ ok: true, reset: true });
+    }
+
+    const numOrNull = (v: any) => (v === null || v === undefined || v === "" ? null : Number(v));
+    const weekly = numOrNull(b.weeklyThresholdHours) ?? 40;
+    const daily = numOrNull(b.dailyThresholdHours);
+    const dt = numOrNull(b.dailyDoubleTimeHours);
+    const seventh = b.seventhConsecutiveDayRule === true;
+    const otMult = numOrNull(b.otMultiplier) ?? 1.5;
+    const dtMult = numOrNull(b.dtMultiplier) ?? 2.0;
+
+    await db.execute(sql`
+      UPDATE companies SET
+        ot_rules_source = 'custom',
+        ot_weekly_threshold_hours = ${weekly},
+        ot_daily_threshold_hours = ${daily},
+        ot_daily_doubletime_hours = ${dt},
+        ot_seventh_day_rule = ${seventh},
+        ot_multiplier = ${otMult},
+        ot_doubletime_multiplier = ${dtMult}
+      WHERE id = ${companyId}`);
+
+    return res.json({ ok: true });
+  } catch (err) {
+    console.error("Save overtime rules error:", err);
+    return res.status(500).json({ error: "Internal Server Error", message: "Failed to save overtime rules" });
   }
 });
 

--- a/artifacts/api-server/src/routes/payroll.ts
+++ b/artifacts/api-server/src/routes/payroll.ts
@@ -425,11 +425,12 @@ router.put("/overtime-rules", requireAuth, requireRole("owner", "admin"), async 
 
 // ── Pre-payroll health check ──────────────────────────────────────────────────
 // [payroll-preflight 2026-06-04] The "fix before you run payroll" safety net —
-// a cleaner take on MaidCentral's "Uh oh! issues with your data" screen.
-// Surfaces what quietly breaks a payroll run: completed jobs with no clock
-// punch, completed jobs never invoiced, techs still clocked in, and tipped
-// invoices with no matching tip pay. Blocking issues vs soft warnings.
-// Office-only, pure read.
+// a cleaner take on MaidCentral's "Uh oh! issues with your data" screen, but
+// PAYROLL-only: it flags only things that affect what a tech is PAID. Invoicing
+// is deliberately excluded — billing the customer is A/R, not payroll, and the
+// tech is paid regardless of whether the invoice went out (Sal, 2026-06-04).
+// Checks: completed jobs with no clock punch, techs still clocked in (blocking),
+// and tipped invoices with no matching tip pay (warning). Office-only, pure read.
 router.get("/preflight", requireAuth, requireRole("owner", "admin", "office"), async (req, res) => {
   try {
     const { from, to } = req.query;
@@ -445,10 +446,6 @@ router.get("/preflight", requireAuth, requireRole("owner", "admin", "office"), a
              WHERE j.company_id = ${companyId} AND j.status = 'complete'
                AND j.scheduled_date BETWEEN ${f} AND ${t}
                AND NOT EXISTS (SELECT 1 FROM timeclock tc WHERE tc.job_id = j.id)) AS no_clocks,
-          (SELECT COUNT(*) FROM jobs j
-             WHERE j.company_id = ${companyId} AND j.status = 'complete'
-               AND j.scheduled_date BETWEEN ${f} AND ${t}
-               AND NOT EXISTS (SELECT 1 FROM invoices i WHERE i.job_id = j.id)) AS not_invoiced,
           (SELECT COUNT(DISTINCT tc.user_id) FROM timeclock tc
              WHERE tc.company_id = ${companyId} AND tc.clock_out_at IS NULL
                AND tc.clock_in_at::date BETWEEN ${f} AND ${t}) AS open_clocks,
@@ -471,7 +468,6 @@ router.get("/preflight", requireAuth, requireRole("owner", "admin", "office"), a
     const n = (v: any) => Number(v || 0);
     const issues = [
       { key: "jobs_without_clocks", severity: "block", count: n(row.no_clocks),    label: "completed job(s) with no clock punch", action: "Add a clock or cancel the job" },
-      { key: "jobs_not_invoiced",   severity: "block", count: n(row.not_invoiced),  label: "completed job(s) not invoiced",        action: "Invoice or cancel the job" },
       { key: "still_clocked_in",    severity: "block", count: n(row.open_clocks),   label: "employee(s) still clocked in",         action: "Review clock data" },
       { key: "missing_tips",        severity: "warn",  count: n(row.missing_tips),  label: "tipped invoice(s) with no tip pay",    action: "Review tips — won't block payroll" },
     ].filter(i => i.count > 0);

--- a/artifacts/api-server/src/routes/payroll.ts
+++ b/artifacts/api-server/src/routes/payroll.ts
@@ -423,6 +423,72 @@ router.put("/overtime-rules", requireAuth, requireRole("owner", "admin"), async 
   }
 });
 
+// ── Pre-payroll health check ──────────────────────────────────────────────────
+// [payroll-preflight 2026-06-04] The "fix before you run payroll" safety net —
+// a cleaner take on MaidCentral's "Uh oh! issues with your data" screen.
+// Surfaces what quietly breaks a payroll run: completed jobs with no clock
+// punch, completed jobs never invoiced, techs still clocked in, and tipped
+// invoices with no matching tip pay. Blocking issues vs soft warnings.
+// Office-only, pure read.
+router.get("/preflight", requireAuth, requireRole("owner", "admin", "office"), async (req, res) => {
+  try {
+    const { from, to } = req.query;
+    if (!from || !to) return res.status(400).json({ error: "Bad Request", message: "from and to are required (YYYY-MM-DD)" });
+    const companyId = req.auth!.companyId;
+    const f = String(from), t = String(to), tEnd = `${to} 23:59:59`;
+
+    let row: any = {};
+    try {
+      const r = await db.execute(sql`
+        SELECT
+          (SELECT COUNT(*) FROM jobs j
+             WHERE j.company_id = ${companyId} AND j.status = 'complete'
+               AND j.scheduled_date BETWEEN ${f} AND ${t}
+               AND NOT EXISTS (SELECT 1 FROM timeclock tc WHERE tc.job_id = j.id)) AS no_clocks,
+          (SELECT COUNT(*) FROM jobs j
+             WHERE j.company_id = ${companyId} AND j.status = 'complete'
+               AND j.scheduled_date BETWEEN ${f} AND ${t}
+               AND NOT EXISTS (SELECT 1 FROM invoices i WHERE i.job_id = j.id)) AS not_invoiced,
+          (SELECT COUNT(DISTINCT tc.user_id) FROM timeclock tc
+             WHERE tc.company_id = ${companyId} AND tc.clock_out_at IS NULL
+               AND tc.clock_in_at::date BETWEEN ${f} AND ${t}) AS open_clocks,
+          (SELECT COUNT(*) FROM invoices i
+             JOIN jobs j ON j.id = i.job_id
+             WHERE i.company_id = ${companyId} AND COALESCE(i.tips, 0) > 0
+               AND j.scheduled_date BETWEEN ${f} AND ${t}
+               AND j.assigned_user_id IS NOT NULL
+               AND NOT EXISTS (
+                 SELECT 1 FROM additional_pay ap
+                 WHERE ap.user_id = j.assigned_user_id AND ap.type = 'tips'
+                   AND ap.created_at BETWEEN ${f} AND ${tEnd})) AS missing_tips
+      `);
+      row = r.rows[0] || {};
+    } catch (e) {
+      console.error("Preflight query failed (non-fatal):", e);
+      return res.json({ ok: true, available: false, issues: [] });
+    }
+
+    const n = (v: any) => Number(v || 0);
+    const issues = [
+      { key: "jobs_without_clocks", severity: "block", count: n(row.no_clocks),    label: "completed job(s) with no clock punch", action: "Add a clock or cancel the job" },
+      { key: "jobs_not_invoiced",   severity: "block", count: n(row.not_invoiced),  label: "completed job(s) not invoiced",        action: "Invoice or cancel the job" },
+      { key: "still_clocked_in",    severity: "block", count: n(row.open_clocks),   label: "employee(s) still clocked in",         action: "Review clock data" },
+      { key: "missing_tips",        severity: "warn",  count: n(row.missing_tips),  label: "tipped invoice(s) with no tip pay",    action: "Review tips — won't block payroll" },
+    ].filter(i => i.count > 0);
+
+    const blocking = issues.filter(i => i.severity === "block");
+    return res.json({
+      ok: blocking.length === 0,
+      available: true,
+      total_blocking: blocking.reduce((s, i) => s + i.count, 0),
+      issues,
+    });
+  } catch (err) {
+    console.error("Preflight error:", err);
+    return res.status(500).json({ error: "Internal Server Error", message: "Failed to run payroll preflight" });
+  }
+});
+
 // ── Payroll Detail (per-job breakdown) ────────────────────────────────────────
 
 router.get("/detail", requireAuth, async (req, res) => {
@@ -528,6 +594,31 @@ router.get("/detail", requireAuth, async (req, res) => {
       .select({ user_id: additionalPayTable.user_id, type: additionalPayTable.type, amount: additionalPayTable.amount, notes: additionalPayTable.notes })
       .from(additionalPayTable)
       .where(and(...addlPayConditions));
+
+    // [payroll-summary 2026-06-04] pay_adjustments (the 2B mileage-reimbursement
+    // promotion + any office adjustments) never reached the payroll summary —
+    // /detail only read additional_pay, so applied mileage was invisible here.
+    // Pull them grouped per (user, adjustment_type) and fold into each
+    // employee's breakdown + grand total below. Filtered by created_at to match
+    // the additional_pay window. Raw SQL + try/catch so a tenant without the
+    // table degrades gracefully.
+    const adjByUser = new Map<number, Record<string, number>>();
+    try {
+      const adjRows = await db.execute(sql`
+        SELECT user_id, adjustment_type, COALESCE(SUM(amount), 0) AS total
+        FROM pay_adjustments
+        WHERE company_id = ${companyId}
+          AND created_at >= ${String(pay_period_start)}
+          AND created_at <= ${String(pay_period_end) + " 23:59:59"}
+          ${filterUserId ? sql`AND user_id = ${filterUserId}` : sql``}
+        GROUP BY user_id, adjustment_type
+      `);
+      for (const r of adjRows.rows as any[]) {
+        const uid = Number(r.user_id);
+        if (!adjByUser.has(uid)) adjByUser.set(uid, {});
+        adjByUser.get(uid)![String(r.adjustment_type)] = parseFloat(String(r.total || 0));
+      }
+    } catch { /* pay_adjustments absent for this tenant — skip */ }
 
     // Group jobs by user
     const byUser = new Map<number, typeof jobs>();
@@ -640,6 +731,11 @@ router.get("/detail", requireAuth, async (req, res) => {
       const addlByType: Record<string, number> = {};
       for (const p of userAddlPay) {
         addlByType[p.type] = (addlByType[p.type] || 0) + parseFloat(String(p.amount || 0));
+      }
+      // Fold pay_adjustments (e.g. mileage_reimbursement from the 2B apply gate)
+      // into the same breakdown so they show as a line AND land in grand_total.
+      for (const [adjType, amt] of Object.entries(adjByUser.get(uid) || {})) {
+        addlByType[adjType] = (addlByType[adjType] || 0) + amt;
       }
 
       const totalCommission = jobRows.reduce((s, j) => s + j.commission, 0);

--- a/artifacts/api-server/src/routes/payroll.ts
+++ b/artifacts/api-server/src/routes/payroll.ts
@@ -137,6 +137,88 @@ router.get("/summary", requireAuth, requireRole("owner", "admin", "office"), asy
   }
 });
 
+// ── Overtime check (>40 hrs/week) ─────────────────────────────────────────────
+// [ot-trigger 2026-06-04] Per CLAUDE.md "Time Clock — Workflow Model": a quiet
+// flag only when total hours cross 40 in a workweek — the one real OT exposure
+// for a commission shop. "Hours worked" = job clock time (timeclock) + drive
+// time between jobs (mileage_legs.minutes). Idle/breaks excluded. Buckets by
+// ISO week (Mon-start, date_trunc('week')) so a multi-week range is split into
+// proper workweeks. Pure read; surfaces in the office payroll view.
+router.get("/overtime-check", requireAuth, requireRole("owner", "admin", "office"), async (req, res) => {
+  try {
+    const { from, to } = req.query;
+    if (!from || !to) {
+      return res.status(400).json({ error: "Bad Request", message: "from and to are required (YYYY-MM-DD)" });
+    }
+    const companyId = req.auth!.companyId;
+    const toEnd = `${to} 23:59:59`;
+
+    // Job hours per (user, week) from the per-house clock.
+    const jobRows = await db.execute(sql`
+      SELECT user_id,
+             to_char(date_trunc('week', clock_in_at), 'YYYY-MM-DD') AS week_start,
+             COALESCE(SUM(EXTRACT(EPOCH FROM (clock_out_at - clock_in_at)) / 3600), 0) AS job_hours
+      FROM timeclock
+      WHERE company_id = ${companyId}
+        AND clock_out_at IS NOT NULL
+        AND clock_in_at >= ${from} AND clock_in_at <= ${toEnd}
+      GROUP BY user_id, week_start
+    `);
+
+    // Drive hours per (user, week) from the between-jobs mileage legs.
+    const driveRows = await db.execute(sql`
+      SELECT user_id,
+             to_char(date_trunc('week', leg_date::timestamp), 'YYYY-MM-DD') AS week_start,
+             COALESCE(SUM(minutes) / 60.0, 0) AS drive_hours
+      FROM mileage_legs
+      WHERE company_id = ${companyId}
+        AND status <> 'discarded'
+        AND leg_date >= ${from} AND leg_date <= ${to}
+      GROUP BY user_id, week_start
+    `);
+
+    type Bucket = { user_id: number; week_start: string; job: number; drive: number };
+    const map = new Map<string, Bucket>();
+    const key = (u: number, w: string) => `${u}|${w}`;
+    for (const r of jobRows.rows as any[]) {
+      const u = Number(r.user_id), w = String(r.week_start);
+      map.set(key(u, w), { user_id: u, week_start: w, job: Number(r.job_hours) || 0, drive: 0 });
+    }
+    for (const r of driveRows.rows as any[]) {
+      const u = Number(r.user_id), w = String(r.week_start);
+      const b = map.get(key(u, w)) ?? { user_id: u, week_start: w, job: 0, drive: 0 };
+      b.drive = Number(r.drive_hours) || 0;
+      map.set(key(u, w), b);
+    }
+
+    const over = [...map.values()].filter(b => b.job + b.drive > 40);
+    const userIds = [...new Set(over.map(b => b.user_id))];
+    const names = userIds.length
+      ? await db.select({ id: usersTable.id, first_name: usersTable.first_name, last_name: usersTable.last_name })
+          .from(usersTable).where(inArray(usersTable.id, userIds))
+      : [];
+    const nameById = new Map(names.map(n => [n.id, `${n.first_name ?? ""} ${n.last_name ?? ""}`.trim()]));
+
+    const round1 = (n: number) => Math.round(n * 10) / 10;
+    const weeks = over
+      .map(b => ({
+        user_id: b.user_id,
+        name: nameById.get(b.user_id) || `User ${b.user_id}`,
+        week_start: b.week_start,
+        job_hours: round1(b.job),
+        drive_hours: round1(b.drive),
+        total_hours: round1(b.job + b.drive),
+        overtime_hours: round1(b.job + b.drive - 40),
+      }))
+      .sort((a, b) => b.total_hours - a.total_hours);
+
+    return res.json({ any_over_40: weeks.length > 0, count: weeks.length, weeks });
+  } catch (err) {
+    console.error("Overtime check error:", err);
+    return res.status(500).json({ error: "Internal Server Error", message: "Failed to run overtime check" });
+  }
+});
+
 // ── Payroll Detail (per-job breakdown) ────────────────────────────────────────
 
 router.get("/detail", requireAuth, async (req, res) => {

--- a/artifacts/api-server/src/tests/overtime.test.ts
+++ b/artifacts/api-server/src/tests/overtime.test.ts
@@ -1,0 +1,116 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  computeWeekOvertime,
+  computeOvertimePremium,
+  resolveOvertimeRules,
+  normalizeStateCode,
+  getPresetForState,
+  FEDERAL_DEFAULT_RULES,
+  STATE_OVERTIME_PRESETS,
+} from "../lib/overtime.js";
+
+test("federal/IL: weekly-40 only, no daily overtime", () => {
+  // 5 days × 9h = 45h
+  const r = computeWeekOvertime([0, 9, 9, 9, 9, 9, 0], FEDERAL_DEFAULT_RULES);
+  assert.equal(r.totalHours, 45);
+  assert.equal(r.otHours, 5);
+  assert.equal(r.dtHours, 0);
+  assert.equal(r.regularHours, 40);
+});
+
+test("federal: under 40 → no overtime", () => {
+  const r = computeWeekOvertime([8, 8, 8, 8, 0, 0, 0], FEDERAL_DEFAULT_RULES);
+  assert.equal(r.otHours, 0);
+  assert.equal(r.dtHours, 0);
+});
+
+test("federal: a single 13h day is NOT overtime until the week passes 40", () => {
+  const r = computeWeekOvertime([13, 0, 0, 0, 0, 0, 0], FEDERAL_DEFAULT_RULES);
+  assert.equal(r.otHours, 0, "no daily OT federally");
+  assert.equal(r.dtHours, 0);
+});
+
+test("California: daily OT after 8h", () => {
+  const r = computeWeekOvertime([10, 0, 0, 0, 0, 0, 0], STATE_OVERTIME_PRESETS.CA);
+  assert.equal(r.otHours, 2); // hours 9-10
+  assert.equal(r.dtHours, 0);
+});
+
+test("California: double-time after 12h", () => {
+  const r = computeWeekOvertime([13, 0, 0, 0, 0, 0, 0], STATE_OVERTIME_PRESETS.CA);
+  assert.equal(r.otHours, 4); // hours 9-12
+  assert.equal(r.dtHours, 1); // hour 13
+});
+
+test("California: no pyramiding — daily OT hours aren't re-counted weekly", () => {
+  // 5 days × 10h = 50h. Each day: 8 straight + 2 OT → 40 straight, 10 daily OT.
+  // Straight (40) does not exceed weekly 40 → no extra weekly OT.
+  const r = computeWeekOvertime([0, 10, 10, 10, 10, 10, 0], STATE_OVERTIME_PRESETS.CA);
+  assert.equal(r.totalHours, 50);
+  assert.equal(r.otHours, 10);
+  assert.equal(r.dtHours, 0);
+});
+
+test("premium is only the extra over straight time (commission already paid)", () => {
+  // $900 commission / 45h = $20/hr regular rate. 5 OT hours × 0.5 × $20 = $50.
+  const premium = computeOvertimePremium({
+    otHours: 5, dtHours: 0, regularRate: 20, rules: FEDERAL_DEFAULT_RULES,
+  });
+  assert.equal(premium, 50);
+});
+
+test("premium: double-time hours owe a full extra rate", () => {
+  // 2 DT hours × (2-1) × $20 = $40; 4 OT hours × 0.5 × $20 = $40 → $80.
+  const premium = computeOvertimePremium({
+    otHours: 4, dtHours: 2, regularRate: 20, rules: STATE_OVERTIME_PRESETS.CA,
+  });
+  assert.equal(premium, 80);
+});
+
+test("zero regular rate (no commission recorded) → zero premium, never negative", () => {
+  assert.equal(computeOvertimePremium({ otHours: 5, dtHours: 0, regularRate: 0, rules: FEDERAL_DEFAULT_RULES }), 0);
+});
+
+test("normalizeStateCode handles codes and names", () => {
+  assert.equal(normalizeStateCode("IL"), "IL");
+  assert.equal(normalizeStateCode("il"), "IL");
+  assert.equal(normalizeStateCode("Illinois"), "IL");
+  assert.equal(normalizeStateCode("California"), "CA");
+  assert.equal(normalizeStateCode("  ca "), "CA");
+  assert.equal(normalizeStateCode(null), null);
+  assert.equal(normalizeStateCode("Narnia"), null);
+});
+
+test("getPresetForState: IL → federal baseline, CA → daily rules", () => {
+  const il = getPresetForState("Illinois");
+  assert.equal(il.dailyThresholdHours, null);
+  assert.equal(il.weeklyThresholdHours, 40);
+  const ca = getPresetForState("CA");
+  assert.equal(ca.dailyThresholdHours, 8);
+  assert.equal(ca.seventhConsecutiveDayRule, true);
+});
+
+test("resolveOvertimeRules: unconfigured tenant falls back to state preset", () => {
+  const il = resolveOvertimeRules({ state: "IL", ot_rules_source: null });
+  assert.equal(il.rules.dailyThresholdHours, null);
+  assert.match(il.source, /preset/);
+
+  const ca = resolveOvertimeRules({ state: "California", ot_rules_source: null });
+  assert.equal(ca.rules.dailyThresholdHours, 8);
+});
+
+test("resolveOvertimeRules: custom config wins over the state preset", () => {
+  const custom = resolveOvertimeRules({
+    state: "IL",
+    ot_rules_source: "custom",
+    ot_weekly_threshold_hours: "40.00",
+    ot_daily_threshold_hours: "10.00",
+    ot_daily_doubletime_hours: null,
+    ot_seventh_day_rule: false,
+    ot_multiplier: "1.50",
+    ot_doubletime_multiplier: "2.00",
+  });
+  assert.equal(custom.source, "custom");
+  assert.equal(custom.rules.dailyThresholdHours, 10);
+});

--- a/artifacts/qleno/src/pages/company.tsx
+++ b/artifacts/qleno/src/pages/company.tsx
@@ -861,6 +861,179 @@ function PlaceholderTab({ title, desc }: { title: string; desc: string }) {
   );
 }
 
+// [overtime 2026-06-04] Office settings for jurisdiction-aware overtime. Reads
+// the resolved rules from /payroll/overtime-rules (state preset unless the
+// owner has overridden), lets the owner tune the thresholds, and saves back
+// (source flips to 'custom'). "Reset to preset" clears the override so the
+// company falls back to its state's rule again. Self-contained — does not
+// touch the payroll_settings save flow.
+function OvertimeSettingsCard({ isOwner }: { isOwner: boolean }) {
+  const { toast } = useToast();
+  const BASE = import.meta.env.BASE_URL.replace(/\/$/, '');
+  const FF2 = "'Plus Jakarta Sans', sans-serif";
+  const fieldLabel = { fontSize: 11, fontWeight: 700, color: '#9E9B94', textTransform: 'uppercase' as const, letterSpacing: '0.06em', display: 'block', marginBottom: 5, fontFamily: FF2 };
+  const fieldInput: React.CSSProperties = { padding: '9px 12px', border: '1px solid #E5E2DC', borderRadius: 8, fontSize: 13, fontFamily: FF2, background: '#fff', color: '#1A1917', width: 90, outline: 'none' };
+  const sectionCard: React.CSSProperties = { background: '#fff', border: '1px solid #E5E2DC', borderRadius: 10, padding: '20px 24px' };
+
+  const [loaded, setLoaded] = useState(false);
+  const [stateName, setStateName] = useState<string | null>(null);
+  const [source, setSource] = useState<string>('');
+  const [presetLabel, setPresetLabel] = useState<string>('');
+  const [presetNote, setPresetNote] = useState<string>('');
+  const [weekly, setWeekly] = useState('40');
+  const [dailyEnabled, setDailyEnabled] = useState(false);
+  const [daily, setDaily] = useState('8');
+  const [dtEnabled, setDtEnabled] = useState(false);
+  const [dt, setDt] = useState('12');
+  const [seventh, setSeventh] = useState(false);
+  const [otMult, setOtMult] = useState('1.5');
+  const [dtMult, setDtMult] = useState('2.0');
+  const [saving, setSaving] = useState(false);
+
+  const load = () => {
+    fetch(`${BASE}/api/payroll/overtime-rules`, { headers: getAuthHeaders() })
+      .then(r => r.ok ? r.json() : null)
+      .then(d => {
+        if (!d) return;
+        const rules = d.rules || {};
+        setStateName(d.state ?? null);
+        setSource(d.source ?? '');
+        setPresetLabel(d.state_preset?.label ?? '');
+        setPresetNote(d.state_preset?.note ?? '');
+        setWeekly(String(rules.weeklyThresholdHours ?? 40));
+        setDailyEnabled(rules.dailyThresholdHours != null);
+        if (rules.dailyThresholdHours != null) setDaily(String(rules.dailyThresholdHours));
+        setDtEnabled(rules.dailyDoubleTimeHours != null);
+        if (rules.dailyDoubleTimeHours != null) setDt(String(rules.dailyDoubleTimeHours));
+        setSeventh(!!rules.seventhConsecutiveDayRule);
+        setOtMult(String(rules.otMultiplier ?? 1.5));
+        setDtMult(String(rules.dtMultiplier ?? 2.0));
+        setLoaded(true);
+      });
+  };
+  useEffect(load, []);
+
+  const save = async (reset = false) => {
+    setSaving(true);
+    try {
+      const body = reset ? { reset: true } : {
+        weeklyThresholdHours: parseFloat(weekly),
+        dailyThresholdHours: dailyEnabled ? parseFloat(daily) : null,
+        dailyDoubleTimeHours: dailyEnabled && dtEnabled ? parseFloat(dt) : null,
+        seventhConsecutiveDayRule: seventh,
+        otMultiplier: parseFloat(otMult),
+        dtMultiplier: parseFloat(dtMult),
+      };
+      const r = await fetch(`${BASE}/api/payroll/overtime-rules`, {
+        method: 'PUT',
+        headers: { ...getAuthHeaders(), 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (!r.ok) throw new Error('save failed');
+      toast({ title: reset ? 'Reset to state preset' : 'Overtime rules saved' });
+      load();
+    } catch {
+      toast({ title: 'Failed to save overtime rules', variant: 'destructive' });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const isCustom = source === 'custom';
+  const numInput = (v: string, set: (s: string) => void, props: any = {}) => (
+    <input type="number" value={v} onChange={e => set(e.target.value)} disabled={!isOwner}
+      style={isOwner ? fieldInput : { ...fieldInput, background: '#F9FAFB', color: '#9CA3AF', cursor: 'not-allowed' }} {...props} />
+  );
+
+  return (
+    <div style={sectionCard}>
+      <p style={{ fontSize: 14, fontWeight: 700, color: '#1A1917', margin: '0 0 4px', fontFamily: FF2 }}>Overtime Rules</p>
+      <p style={{ fontSize: 12, color: '#9E9B94', margin: '0 0 16px', fontFamily: FF2 }}>
+        Used only to flag and estimate the overtime premium for the office when a tech's weekly
+        hours (job clock + between-jobs drive) cross the limit. Techs never see this.
+      </p>
+
+      {loaded && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, background: '#F0FDF9', border: '1px solid #99E6D3', borderRadius: 8, padding: '8px 12px', marginBottom: 16 }}>
+          <span style={{ fontSize: 12, color: '#0A6E5A', fontFamily: FF2 }}>
+            Currently using: <strong>{isCustom ? 'Custom rules' : (presetLabel || 'Federal baseline')}</strong>
+            {stateName ? ` · business state ${stateName}` : ''}
+            {isCustom && presetLabel ? ` (state default: ${presetLabel})` : ''}
+          </span>
+        </div>
+      )}
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <label style={{ ...fieldLabel, width: 240, marginBottom: 0 }}>Weekly overtime after</label>
+          {numInput(weekly, setWeekly, { step: '1', min: '1' })}
+          <span style={{ fontSize: 13, color: '#6B7280', fontFamily: FF2 }}>hours/week (federal &amp; most states = 40)</span>
+        </div>
+
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <label style={{ ...fieldLabel, width: 240, marginBottom: 0 }}>Daily overtime</label>
+          <input type="checkbox" checked={dailyEnabled} disabled={!isOwner} onChange={e => setDailyEnabled(e.target.checked)} />
+          <span style={{ fontSize: 13, color: '#6B7280', fontFamily: FF2 }}>This state has daily overtime</span>
+        </div>
+        {dailyEnabled && (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 12, paddingLeft: 16, borderLeft: '2px solid #E5E2DC' }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+              <label style={{ ...fieldLabel, width: 224, marginBottom: 0 }}>OT after (per day)</label>
+              {numInput(daily, setDaily, { step: '1', min: '1' })}
+              <span style={{ fontSize: 13, color: '#6B7280', fontFamily: FF2 }}>hours/day (e.g. CA = 8)</span>
+            </div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+              <label style={{ ...fieldLabel, width: 224, marginBottom: 0 }}>Double-time</label>
+              <input type="checkbox" checked={dtEnabled} disabled={!isOwner} onChange={e => setDtEnabled(e.target.checked)} />
+              {dtEnabled && numInput(dt, setDt, { step: '1', min: '1' })}
+              <span style={{ fontSize: 13, color: '#6B7280', fontFamily: FF2 }}>{dtEnabled ? 'hours/day (e.g. CA = 12)' : 'pay double-time past a daily limit'}</span>
+            </div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+              <label style={{ ...fieldLabel, width: 224, marginBottom: 0 }}>7th-consecutive-day rule</label>
+              <input type="checkbox" checked={seventh} disabled={!isOwner} onChange={e => setSeventh(e.target.checked)} />
+              <span style={{ fontSize: 13, color: '#6B7280', fontFamily: FF2 }}>California-style</span>
+            </div>
+          </div>
+        )}
+
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <label style={{ ...fieldLabel, width: 240, marginBottom: 0 }}>Multipliers</label>
+          {numInput(otMult, setOtMult, { step: '0.1', min: '1' })}
+          <span style={{ fontSize: 13, color: '#6B7280', fontFamily: FF2 }}>× OT</span>
+          {numInput(dtMult, setDtMult, { step: '0.1', min: '1' })}
+          <span style={{ fontSize: 13, color: '#6B7280', fontFamily: FF2 }}>× double-time</span>
+        </div>
+      </div>
+
+      {presetNote && (
+        <p style={{ fontSize: 12, color: '#92400E', background: '#FFFBEB', border: '1px solid #FDE68A', borderRadius: 6, padding: '8px 10px', margin: '14px 0 0', fontFamily: FF2 }}>
+          {presetLabel}: {presetNote}
+        </p>
+      )}
+      <p style={{ fontSize: 11, color: '#9E9B94', margin: '12px 0 0', fontFamily: FF2, lineHeight: 1.5 }}>
+        Defaults follow your business state. Labor law has industry carve-outs and changes over time —
+        confirm these settings with your payroll provider or employment counsel. This estimates the
+        premium; it does not file or pay it.
+      </p>
+
+      {isOwner && (
+        <div style={{ display: 'flex', gap: 10, marginTop: 16 }}>
+          <button onClick={() => save(false)} disabled={saving}
+            style={{ padding: '9px 20px', background: 'var(--brand, #00C9A0)', color: '#fff', border: 'none', borderRadius: 8, fontWeight: 600, fontSize: 13, fontFamily: FF2, cursor: 'pointer' }}>
+            {saving ? 'Saving...' : 'Save Overtime Rules'}
+          </button>
+          {isCustom && (
+            <button onClick={() => save(true)} disabled={saving}
+              style={{ padding: '9px 20px', background: '#fff', color: '#6B7280', border: '1px solid #E5E2DC', borderRadius: 8, fontWeight: 600, fontSize: 13, fontFamily: FF2, cursor: 'pointer' }}>
+              Reset to {presetLabel || 'state'} preset
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
 function PayrollOptionsTab() {
   const { data: company } = useGetMyCompany({ request: { headers: getAuthHeaders() } });
   const updateCompany = useUpdateMyCompany({ request: { headers: getAuthHeaders() } });
@@ -1107,6 +1280,8 @@ function PayrollOptionsTab() {
           </div>
         </div>
       </div>
+
+      <OvertimeSettingsCard isOwner={isOwner} />
 
       {isOwner ? (
         <button

--- a/artifacts/qleno/src/pages/payroll.tsx
+++ b/artifacts/qleno/src/pages/payroll.tsx
@@ -4,7 +4,7 @@ import { useListUsers } from "@workspace/api-client-react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { getAuthHeaders, getTokenRole } from "@/lib/auth";
 import { useBranch } from "@/contexts/branch-context";
-import { Download, Calendar, Plus, X, Zap, Trash2, ChevronDown, ChevronRight } from "lucide-react";
+import { Download, Calendar, Plus, X, Zap, Trash2, ChevronDown, ChevronRight, AlertTriangle } from "lucide-react";
 
 const API = import.meta.env.BASE_URL.replace(/\/$/, "");
 async function apiFetch(path: string, opts?: RequestInit) {
@@ -210,6 +210,40 @@ function WeeklyDetailView() {
   );
 }
 
+// [ot-trigger 2026-06-04] Quiet overtime alert. Hits /payroll/overtime-check
+// (job clock hours + between-jobs drive hours, bucketed by workweek) and warns
+// only when a tech crosses 40 hrs in a week — so no one is underpaid on OT.
+// Renders nothing when everyone's under 40.
+function OvertimeBanner({ from, to }: { from: string; to: string }) {
+  const { data } = useQuery<any>({
+    queryKey: ['ot-check', from, to],
+    queryFn: () => apiFetch(`/payroll/overtime-check?from=${from}&to=${to}`),
+    enabled: !!from && !!to,
+  });
+  if (!data?.any_over_40) return null;
+  return (
+    <div style={{ background: '#FEF3C7', border: '1px solid #FCD34D', borderRadius: 10, padding: '12px 16px' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
+        <AlertTriangle size={15} color="#92400E" />
+        <span style={{ fontWeight: 800, color: '#92400E', fontSize: 13 }}>
+          Overtime check — {data.count} {data.count === 1 ? 'week' : 'weeks'} over 40 hours
+        </span>
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+        {data.weeks.map((w: any, i: number) => (
+          <div key={i} style={{ fontSize: 12, color: '#92400E' }}>
+            <b>{w.name}</b> · week of {w.week_start}: <b>{w.total_hours}h</b>{' '}
+            ({w.job_hours}h job + {w.drive_hours}h drive) — <b>{w.overtime_hours}h over</b>
+          </div>
+        ))}
+      </div>
+      <div style={{ fontSize: 11, color: '#92400E', opacity: 0.85, marginTop: 6 }}>
+        Hours worked = job time + between-jobs drive. Review these for overtime so no one is underpaid.
+      </div>
+    </div>
+  );
+}
+
 export default function PayrollPage() {
   const qc = useQueryClient();
   const { activeBranchId } = useBranch();
@@ -303,6 +337,7 @@ export default function PayrollPage() {
   return (
     <DashboardLayout>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
+        <OvertimeBanner from={payPeriod.start} to={payPeriod.end} />
         {/* View Toggle */}
         <div style={{ display: 'flex', gap: 4, background: '#F4F3F0', padding: 4, borderRadius: 8, width: 'fit-content' }}>
           {[{ key: 'overview', label: 'Overview' }, { key: 'weekly-detail', label: 'Weekly Detail' }].map(v => (

--- a/artifacts/qleno/src/pages/payroll.tsx
+++ b/artifacts/qleno/src/pages/payroll.tsx
@@ -28,13 +28,14 @@ function empRate(emp: any): number {
 }
 
 const PAY_TYPE_LABELS: Record<string, string> = {
-  bonus: 'Bonus', tips: 'Tips', mileage: 'Mileage',
+  bonus: 'Bonus', tips: 'Tips', mileage: 'Mileage', mileage_reimbursement: 'Mileage',
   sick_pay: 'Sick Pay', holiday_pay: 'Holiday Pay', vacation_pay: 'Vacation Pay',
   compliment: 'Compliment', amount_owed: 'Amount Owed',
 };
 
 const PAY_GROUPS = [
-  { label: 'Earnings',  types: ['bonus','tips','mileage'] },
+  { label: 'Earnings',  types: ['bonus','tips'] },
+  { label: 'Reimbursements', types: ['mileage','mileage_reimbursement'] },
   { label: 'Time Off',  types: ['sick_pay','holiday_pay','vacation_pay'] },
   { label: 'Other',     types: ['compliment','amount_owed'] },
 ];
@@ -96,6 +97,23 @@ function WeeklyDetailView() {
       {employees.map((emp: any) => {
         const isOpen = expanded.includes(emp.user_id);
         const addlEntries = Object.entries(emp.additional_pay || {}).filter(([, v]) => (v as number) !== 0);
+        // At-a-glance roll-up so the office sees each person's pay essentials
+        // inline — no horizontal scrolling (the MaidCentral pain).
+        const ap: Record<string, number> = emp.additional_pay || {};
+        const sumK = (...ks: string[]) => ks.reduce((s, k) => s + (Number(ap[k]) || 0), 0);
+        const tipsAmt = sumK('tips');
+        const mileageAmt = sumK('mileage', 'mileage_reimbursement');
+        const timeOffAmt = sumK('sick_pay', 'holiday_pay', 'vacation_pay');
+        const hoursWorked = Number(emp.totals?.hrs_worked ?? 0);
+        const money = (n: number) => `$${Number(n).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+        const rollup: any[] = [
+          { label: 'Hours', value: hoursWorked.toFixed(1) },
+          { label: 'Commission', value: money(emp.totals.commission), accent: true },
+          ...(tipsAmt > 0 ? [{ label: 'Tips', value: money(tipsAmt) }] : []),
+          ...(mileageAmt > 0 ? [{ label: 'Mileage', value: money(mileageAmt) }] : []),
+          ...(timeOffAmt > 0 ? [{ label: 'Time Off', value: money(timeOffAmt) }] : []),
+          { label: 'Total Pay', value: money(emp.totals.grand_total), strong: true },
+        ];
         return (
           <div key={emp.user_id} style={{ backgroundColor: '#fff', border: '1px solid #E5E2DC', borderRadius: 10, overflow: 'hidden' }}>
             <div
@@ -106,19 +124,13 @@ function WeeklyDetailView() {
                 <span style={{ fontSize: 14, fontWeight: 700, color: '#1A1917' }}>{emp.name}</span>
                 <span style={{ fontSize: 12, color: '#9E9B94' }}>{emp.totals.job_count} jobs</span>
               </div>
-              <div style={{ display: 'flex', gap: 24 }}>
-                <div style={{ textAlign: 'right' }}>
-                  <p style={{ fontSize: 10, color: '#9E9B94', margin: '0 0 1px', textTransform: 'uppercase', letterSpacing: '0.06em' }}>Job Total</p>
-                  <p style={{ fontSize: 14, fontWeight: 700, color: '#1A1917', margin: 0 }}>${emp.totals.job_total.toLocaleString('en-US', { minimumFractionDigits: 2 })}</p>
-                </div>
-                <div style={{ textAlign: 'right' }}>
-                  <p style={{ fontSize: 10, color: '#9E9B94', margin: '0 0 1px', textTransform: 'uppercase', letterSpacing: '0.06em' }}>Commission</p>
-                  <p style={{ fontSize: 14, fontWeight: 700, color: 'var(--brand)', margin: 0 }}>${emp.totals.commission.toLocaleString('en-US', { minimumFractionDigits: 2 })}</p>
-                </div>
-                <div style={{ textAlign: 'right' }}>
-                  <p style={{ fontSize: 10, color: '#9E9B94', margin: '0 0 1px', textTransform: 'uppercase', letterSpacing: '0.06em' }}>Grand Total</p>
-                  <p style={{ fontSize: 14, fontWeight: 700, color: '#1A1917', margin: 0 }}>${emp.totals.grand_total.toLocaleString('en-US', { minimumFractionDigits: 2 })}</p>
-                </div>
+              <div style={{ display: 'flex', gap: 22, flexWrap: 'wrap', justifyContent: 'flex-end' }}>
+                {rollup.map((s: any) => (
+                  <div key={s.label} style={{ textAlign: 'right', minWidth: 64 }}>
+                    <p style={{ fontSize: 10, color: '#9E9B94', margin: '0 0 1px', textTransform: 'uppercase', letterSpacing: '0.06em' }}>{s.label}</p>
+                    <p style={{ fontSize: 14, fontWeight: s.strong ? 800 : 700, color: s.accent ? 'var(--brand)' : '#1A1917', margin: 0 }}>{s.value}</p>
+                  </div>
+                ))}
               </div>
             </div>
 
@@ -256,6 +268,49 @@ function OvertimeBanner({ from, to }: { from: string; to: string }) {
   );
 }
 
+// [payroll-preflight 2026-06-04] Office-only "fix before you run payroll" banner.
+// Hits /payroll/preflight (jobs without clocks, not invoiced, still clocked in,
+// missing tips). Red when blocking issues exist, amber for warnings only, green
+// when clean. Role-gated server-side so it never reaches a technician.
+function PreflightBanner({ from, to }: { from: string; to: string }) {
+  const { data } = useQuery<any>({
+    queryKey: ['payroll-preflight', from, to],
+    queryFn: () => apiFetch(`/payroll/preflight?from=${from}&to=${to}`),
+    enabled: !!from && !!to,
+  });
+  if (!data || !data.available) return null;
+  const issues: any[] = data.issues || [];
+  if (issues.length === 0) {
+    return (
+      <div style={{ background: '#F0FDF9', border: '1px solid #99E6D3', borderRadius: 10, padding: '10px 16px', display: 'flex', alignItems: 'center', gap: 8 }}>
+        <span style={{ width: 8, height: 8, borderRadius: 2, background: '#00C9A0', display: 'inline-block' }} />
+        <span style={{ fontSize: 13, fontWeight: 700, color: '#0A6E5A' }}>Payroll looks clean — no issues to fix before you run it.</span>
+      </div>
+    );
+  }
+  const blocking = issues.filter(i => i.severity === 'block');
+  const hasBlock = blocking.length > 0;
+  return (
+    <div style={{ background: hasBlock ? '#FEF2F2' : '#FEF3C7', border: `1px solid ${hasBlock ? '#FCA5A5' : '#FCD34D'}`, borderRadius: 10, padding: '12px 16px' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
+        <AlertTriangle size={15} color={hasBlock ? '#B91C1C' : '#92400E'} />
+        <span style={{ fontWeight: 800, color: hasBlock ? '#B91C1C' : '#92400E', fontSize: 13 }}>
+          {hasBlock
+            ? `${blocking.length} thing${blocking.length > 1 ? 's' : ''} to fix before you run payroll`
+            : 'Heads up before you run payroll'}
+        </span>
+      </div>
+      <ul style={{ margin: 0, padding: '0 0 0 20px', display: 'flex', flexDirection: 'column', gap: 3 }}>
+        {issues.map((i, idx) => (
+          <li key={idx} style={{ fontSize: 12, color: i.severity === 'block' ? '#991B1B' : '#92400E' }}>
+            <b>{i.count}</b> {i.label} <span style={{ opacity: 0.8 }}>— {i.action}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
 export default function PayrollPage() {
   const qc = useQueryClient();
   const { activeBranchId } = useBranch();
@@ -349,6 +404,7 @@ export default function PayrollPage() {
   return (
     <DashboardLayout>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
+        <PreflightBanner from={payPeriod.start} to={payPeriod.end} />
         <OvertimeBanner from={payPeriod.start} to={payPeriod.end} />
         {/* View Toggle */}
         <div style={{ display: 'flex', gap: 4, background: '#F4F3F0', padding: 4, borderRadius: 8, width: 'fit-content' }}>

--- a/artifacts/qleno/src/pages/payroll.tsx
+++ b/artifacts/qleno/src/pages/payroll.tsx
@@ -210,10 +210,12 @@ function WeeklyDetailView() {
   );
 }
 
-// [ot-trigger 2026-06-04] Quiet overtime alert. Hits /payroll/overtime-check
-// (job clock hours + between-jobs drive hours, bucketed by workweek) and warns
-// only when a tech crosses 40 hrs in a week — so no one is underpaid on OT.
-// Renders nothing when everyone's under 40.
+// [overtime 2026-06-04] Office-only overtime review banner. Hits
+// /payroll/overtime-check (job clock hours + between-jobs drive hours, bucketed
+// by workweek under the tenant's jurisdiction rules) and surfaces both the
+// overtime HOURS and the estimated premium DOLLARS for any week that crosses
+// the limit — so the office can pay it. Endpoint is role-gated to office/admin/
+// owner, so this never reaches a technician. Renders nothing when all clear.
 function OvertimeBanner({ from, to }: { from: string; to: string }) {
   const { data } = useQuery<any>({
     queryKey: ['ot-check', from, to],
@@ -221,24 +223,34 @@ function OvertimeBanner({ from, to }: { from: string; to: string }) {
     enabled: !!from && !!to,
   });
   if (!data?.any_over_40) return null;
+  const money = (n: number) => `$${(n ?? 0).toFixed(2)}`;
+  const totalPremium = data.total_premium_estimate ?? 0;
   return (
     <div style={{ background: '#FEF3C7', border: '1px solid #FCD34D', borderRadius: 10, padding: '12px 16px' }}>
       <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
         <AlertTriangle size={15} color="#92400E" />
         <span style={{ fontWeight: 800, color: '#92400E', fontSize: 13 }}>
-          Overtime check — {data.count} {data.count === 1 ? 'week' : 'weeks'} over 40 hours
+          Overtime review — {data.count} {data.count === 1 ? 'week' : 'weeks'} over the limit
+          {totalPremium > 0 && <> · est. premium {money(totalPremium)}</>}
         </span>
       </div>
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
         {data.weeks.map((w: any, i: number) => (
           <div key={i} style={{ fontSize: 12, color: '#92400E' }}>
             <b>{w.name}</b> · week of {w.week_start}: <b>{w.total_hours}h</b>{' '}
-            ({w.job_hours}h job + {w.drive_hours}h drive) — <b>{w.overtime_hours}h over</b>
+            ({w.job_hours}h job + {w.drive_hours}h drive) —{' '}
+            <b>{w.ot_hours}h OT</b>{w.dt_hours > 0 ? <> + <b>{w.dt_hours}h double-time</b></> : null}
+            {w.premium_estimate > 0 && (
+              <> · est. premium <b>{money(w.premium_estimate)}</b>{w.regular_rate > 0 ? <> (reg. rate {money(w.regular_rate)}/h)</> : null}</>
+            )}
           </div>
         ))}
       </div>
-      <div style={{ fontSize: 11, color: '#92400E', opacity: 0.85, marginTop: 6 }}>
-        Hours worked = job time + between-jobs drive. Review these for overtime so no one is underpaid.
+      <div style={{ fontSize: 11, color: '#92400E', opacity: 0.85, marginTop: 6, lineHeight: 1.5 }}>
+        Hours worked = job clock time + between-jobs drive (home↔job commute excluded). Premium is the
+        extra owed over commission ({data.has_daily_overtime ? 'daily + weekly' : 'weekly'} rules
+        {data.rules_source ? ` · ${String(data.rules_source).replace(/^preset:/, '')}` : ''}).
+        Estimate for review — confirm with your payroll provider before paying. Configure thresholds in Settings → Payroll.
       </div>
     </div>
   );

--- a/docs/OVERTIME_COMPLIANCE_DESIGN.md
+++ b/docs/OVERTIME_COMPLIANCE_DESIGN.md
@@ -1,0 +1,96 @@
+# Overtime Compliance Design
+
+Source of truth for the overtime engine. Read before touching
+`lib/overtime.ts`, the `/payroll/overtime-check` / `/payroll/overtime-rules`
+endpoints, or the OT settings UI.
+
+> **Not legal advice.** This documents how Qleno *computes* an overtime
+> estimate so the office can review and pay it. Labor law has industry
+> carve-outs and changes over time. Every tenant must confirm thresholds with
+> their own payroll provider / employment counsel. The engine estimates the
+> premium — it does not file or pay it.
+
+## 1. What counts as "hours worked"
+
+Only **compensable** time counts toward overtime. For a cleaning tech who
+drives between client homes:
+
+| Segment | Clock runs? | Mileage tracked? | Counts as hours worked? |
+|---|---|---|---|
+| Home → first job ("On My Way", SMS) | No | No | **No** — commute (29 CFR 785.35) |
+| Inside a house (clocked in→out) | Yes | — | **Yes** — job time |
+| Job → job (between sites, during the day) | Yes | Yes | **Yes** — "all in a day's work" (29 CFR 785.38) |
+| Last job → home | No | No | **No** — commute |
+
+So hours worked = **job clock time (`timeclock`) + between-jobs drive
+(`mileage_legs.minutes`)**. The commute bookends never enter the math — no
+clock runs during them, and the mileage engine already excludes the commute
+legs (`skip_first_leg_of_day` / `skip_no_from_job`). Idle/breaks are excluded.
+
+**Allowed hours is NOT hours worked.** Allowed hours is a budget used for the
+efficiency score and (on commercial jobs) the commission basis. Overtime is
+always measured against *actual* clocked time, never allowed hours.
+
+## 2. Threshold — jurisdiction aware
+
+- **Federal FLSA + most states (incl. Illinois, 820 ILCS 105/4a):** time-and-a-half
+  for hours worked over **40 in a workweek**. No daily overtime. This is the
+  default every tenant gets, so Qleno is compliant out of the box regardless of
+  where the tenant operates.
+- **Daily-overtime states** (opt-in via the state preset, owner-overridable):
+  - **California** — daily OT after 8h, double-time after 12h, 7th-consecutive-day rules.
+  - **Alaska** — daily OT after 8h (4+ employees).
+  - **Colorado** — daily OT after 12h (the 12-consecutive-hours test isn't modeled).
+  - **Nevada** — daily OT after 8h, but only for employees under 1.5× minimum wage.
+  - **Oregon** — weekly-40 for most industries; manufacturing has daily-10 (configure manually).
+
+Rules resolve from the company's OT config columns; when unconfigured they fall
+back to the preset for `companies.state`, then to the federal default. See
+`STATE_OVERTIME_PRESETS` and `resolveOvertimeRules()` in `lib/overtime.ts`.
+
+The no-pyramiding method is used: an hour counted as daily OT is not counted
+again as weekly OT. With no daily threshold the math degenerates exactly to
+"hours over 40 in the week" — the plain weekly-40 rule.
+
+## 3. The premium — commission pay
+
+Phes (and most Qleno tenants) pay **commission + mileage**, not hourly.
+Commissions are part of the regular rate (29 CFR 778.117). For a
+commission-paid employee, straight time for every hour is *already* covered by
+the commission, so the only money owed on overtime is the **premium portion**:
+
+- regular rate = **workweek commission ÷ total hours worked that week**
+- OT hours owe an extra `(otMultiplier − 1) × rate` (i.e. +0.5× for 1.5×)
+- double-time hours owe an extra `(dtMultiplier − 1) × rate` (i.e. +1.0× for 2×)
+- **Mileage is excluded from the regular rate** — it's a bona-fide expense
+  reimbursement (29 CFR 778.217), not wages.
+
+The regular rate reuses the canonical commission engine (`computeCommissionRows`)
+so it matches the payroll detail screen, including per-job `final_pay` overrides.
+
+## 4. Visibility — office only
+
+- **Office** sees the full picture: which weeks crossed the limit, OT/DT hours,
+  the regular-rate math, and the estimated premium dollars. The
+  `/payroll/overtime-check` endpoint is role-gated to **owner / admin / office**.
+- **Technicians never see overtime, hours-worked totals, drive, or idle as pay
+  lines.** A tech's view is dollars (commission/earnings). The clock runs in the
+  background as the meter for commission/billing/efficiency — it is not surfaced
+  to the tech as "hours." This is a deliberate anti-confusion decision: the
+  moment a tech sees "hours," they assume hourly pay.
+
+## 5. No money moves automatically
+
+Consistent with the mileage engine, computed overtime is a **review signal**.
+The banner surfaces the estimate; the office decides and pays it through the
+normal additional-pay flow. The engine never writes a pay row on its own.
+
+## Files
+
+- `artifacts/api-server/src/lib/overtime.ts` — pure engine (presets, resolver, week math, premium).
+- `artifacts/api-server/src/tests/overtime.test.ts` — unit tests.
+- `artifacts/api-server/src/routes/payroll.ts` — `/overtime-check`, `/overtime-rules` (GET/PUT).
+- `lib/db/src/schema/companies.ts` — `ot_*` config columns.
+- `artifacts/api-server/src/cutover-data-migration.ts` — `addOvertimeColumns()` cold-start ALTER.
+- `artifacts/qleno/src/pages/payroll.tsx` — office `OvertimeBanner`.
+- `artifacts/qleno/src/pages/company.tsx` — `OvertimeSettingsCard` (Settings → Payroll).

--- a/docs/REPORTING_ANALYTICS_SPEC.md
+++ b/docs/REPORTING_ANALYTICS_SPEC.md
@@ -1,0 +1,82 @@
+# Qleno Reporting & Analytics — Working Spec
+
+Captured 2026-06-04 from Sal. The thing MaidCentral does poorly: slicing the
+same payroll/job data the many ways an owner actually needs. All of this is the
+SAME underlying data (jobs → assigned tech, service_type, commission, hours;
+mileage_legs; additional_pay) sliced by different filters. Build it once with
+shared filters (date range, tech, branch, service_type), expose each slice as a
+report + export.
+
+> Not yet built — roadmap. Overtime engine (PR #295) is the first piece.
+
+## 1. Time windows everywhere — MTD / YTD
+
+Add **This Period / Month-to-Date / Year-to-Date** toggles to:
+- **Tech** "My Earnings": their own commission, tips, mileage, job count, scope mix.
+- **Office** payroll + every report below.
+
+Decisions to lock:
+- **YTD = calendar year** (aligns to W-2 / ADP). MTD = calendar month.
+- Attribution date: be consistent. Commission/job reports key on `scheduled_date`
+  (when the work happened); payroll/ADP cares about pay date. Pick per report and label it.
+
+## 2. Per-technician reports ("how much did X make / drive")
+
+For any tech, any window:
+- **Commission earned** (e.g. "Maria, last month")
+- **Mileage paid out** — APPLIED legs only (count `mileage_legs` status=applied /
+  the pay_adjustment), shown separate from pending/computed so we never imply
+  unpaid miles were paid.
+- **Tips** (split cash vs CC — ADP has a CC Tips field)
+- **Job count + scope mix**: deep clean / standard / move-in-out / commercial
+- **Effective hourly rate** = commission ÷ hours worked (spots underpay vs minimum
+  wage; this is the same regular-rate the OT engine uses)
+
+## 3. Company-wide / cross-tech reports (distribution & fairness)
+
+This is the MaidCentral gap that drives tech complaints. One row per tech:
+- **Commission leaderboard** across the whole company, any window
+- **Job-distribution equity**: deep cleans per tech, commercial vs residential per
+  tech, total jobs, hours, efficiency
+- **The fairness fix is a RATE, not a raw count.** "Maria got 12 deep cleans, Ana
+  got 3" is misleading if Maria worked twice the weeks. Show deep cleans as a share
+  (per 100 jobs, or per week worked) so part-timers aren't unfairly compared. Raw
+  count + rate side by side.
+- **Reporting is OFFICE-ONLY (locked 2026-06-04).** Technicians do NOT see
+  distribution, fairness, leaderboards, or any "what's been dispatched to me"
+  analytics. A tech sees only their OWN paystub (My Earnings). The office decides
+  what, if anything, to share verbally. (Reverses an earlier "transparency to techs"
+  idea — Sal's call.)
+
+## 4. Things to not overlook (proactive)
+
+- **OT premium YTD** — cumulative OT cost for compliance + budgeting (office only).
+- **Revenue per tech vs commission earned** — margin/cost view (office only; never tech).
+- **Reclean / complaint count per tech** — pair the "deep cleans" fairness lens with
+  quality (we already track quality-probation data). Volume without quality is noise.
+- **Commercial vs residential mix doubles as a pay-equity lens** — the two have
+  different commission bases, so the mix explains pay differences.
+- **Every report exports (CSV/JSON)** — this is the bridge to the Claude Dispatch →
+  ADP workflow (see §5). Dispatch should pull a report, not scrape a screen.
+- **Branch filter on everything** (Oak Lawn vs Schaumburg) — rollups already exist.
+- **Permissions — reporting is OFFICE-ONLY.** Techs have NO access to reports,
+  distribution, fairness, or "what's been dispatched to me" analytics. A tech sees
+  only their OWN paystub (My Earnings). Everything else is owner/admin/office.
+
+## 5. Claude Dispatch → ADP handoff (the "make it easier" goal)
+
+Sal runs payroll by having Claude Dispatch read the payroll roll-up and enter each
+employee into ADP (Tips → CC Tips, commission → Salary Amount, holiday confirmed).
+To make that reliable:
+- **Per-employee payroll roll-up** (one row/employee) with ADP-ready columns:
+  `Employee | Reg Hours | Commission(→Salary Amt) | Tips(→CC Tips) | Holiday | PTO/Sick | Mileage | OT Premium* | Gross`
+  (*OT premium flagged, office-approved before entry — never auto-added.)
+- **One-click export (CSV + JSON)** matching those fields so Dispatch pulls exact
+  numbers — no MaidCentral scraping, no transcription error.
+
+## Build order (proposed)
+
+1. Per-employee payroll roll-up + ADP export (unblocks Dispatch immediately).
+2. MTD/YTD toggles on tech + office pay views.
+3. Reports hub: per-tech (commission, mileage, scope mix) + company distribution/fairness.
+4. Fairness transparency on the tech side.

--- a/docs/time-mileage-workflow.html
+++ b/docs/time-mileage-workflow.html
@@ -1,0 +1,201 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Qleno Time & Mileage Workflow</title>
+<style>
+  @page { size: letter; margin: 0; }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  html { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+  body { font-family: 'Plus Jakarta Sans', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif; color: #1A1917; background: #fff; font-size: 12px; line-height: 1.55; }
+  .page { width: 8.5in; min-height: 11in; padding: 0.7in 0.75in; page-break-after: always; position: relative; }
+  .page:last-child { page-break-after: avoid; }
+  h1 { font-size: 30px; font-weight: 800; letter-spacing: -0.02em; line-height: 1.1; }
+  h2 { font-size: 19px; font-weight: 800; color: #0A0E1A; margin: 26px 0 10px; letter-spacing: -0.01em; }
+  h3 { font-size: 14px; font-weight: 800; margin: 16px 0 6px; }
+  p { margin: 0 0 9px; color: #2b2a27; }
+  .muted { color: #6B6860; }
+  .mint { color: #2D9B83; }
+  .pill { display: inline-block; font-size: 10px; font-weight: 800; text-transform: uppercase; letter-spacing: 0.07em; padding: 3px 9px; border-radius: 20px; }
+  .pill-mint { background: #ECFDF5; color: #2D9B83; }
+  .pill-night { background: #0A0E1A; color: #fff; }
+  table { width: 100%; border-collapse: collapse; margin: 8px 0 14px; font-size: 11.5px; }
+  th { text-align: left; background: #0A0E1A; color: #fff; padding: 8px 10px; font-weight: 700; font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.04em; }
+  td { padding: 8px 10px; border-bottom: 1px solid #E5E2DC; vertical-align: top; }
+  tr:nth-child(even) td { background: #FAFAF8; }
+  .card { background: #fff; border: 1px solid #E5E2DC; border-radius: 12px; padding: 16px 18px; margin: 10px 0; }
+  .card-mint { border-left: 3px solid #2D9B83; }
+  .grid2 { display: flex; gap: 14px; }
+  .grid2 > * { flex: 1; }
+  .step { display: flex; gap: 12px; align-items: flex-start; margin: 10px 0; }
+  .stepnum { flex-shrink: 0; width: 26px; height: 26px; border-radius: 13px; background: #2D9B83; color: #fff; font-weight: 800; font-size: 13px; display: flex; align-items: center; justify-content: center; }
+  .footer { position: absolute; bottom: 0.4in; left: 0.75in; right: 0.75in; font-size: 9.5px; color: #9E9B94; border-top: 1px solid #E5E2DC; padding-top: 6px; display: flex; justify-content: space-between; }
+  .lead { background: #F7F6F3; border-radius: 10px; padding: 12px 14px; margin: 10px 0; }
+  ul { margin: 4px 0 12px 18px; } li { margin: 3px 0; }
+  .good { color: #15803D; font-weight: 700; }
+  .bad { color: #B91C1C; font-weight: 700; }
+  /* phone mock */
+  .phone { width: 250px; border: 9px solid #0A0E1A; border-radius: 30px; overflow: hidden; background: #F7F6F3; }
+  .phone .bar { background: #fff; padding: 9px 12px; display: flex; align-items: center; gap: 7px; border-bottom: 1px solid #eee; }
+  .phone .logo { width: 20px; height: 20px; border-radius: 6px; background: #2D9B83; color: #fff; font-weight: 800; font-size: 12px; display: flex; align-items: center; justify-content: center; }
+  .phone .body { padding: 12px; }
+  .jc { background: #fff; border: 1px solid #E5E2DC; border-left: 3px solid #2D9B83; border-radius: 11px; padding: 12px; }
+  .tile { background: #F7F6F3; border-radius: 9px; padding: 8px 10px; }
+  .btn { border-radius: 9px; padding: 9px; text-align: center; font-weight: 700; font-size: 12px; margin-top: 8px; }
+  .btn-out { border: 1px solid #2D9B83; color: #2D9B83; background: #ECFDF5; }
+  .btn-solid { background: #2D9B83; color: #fff; }
+  .anno { display: flex; gap: 9px; margin: 7px 0; font-size: 11.5px; }
+  .anno b { color: #0A0E1A; }
+  .dot { flex-shrink:0; width: 18px; height: 18px; border-radius: 9px; background: #0A0E1A; color: #fff; font-size: 10px; font-weight: 800; display: flex; align-items: center; justify-content: center; }
+</style>
+</head>
+<body>
+
+<!-- COVER -->
+<div class="page" style="display:flex;flex-direction:column;justify-content:center;background:#F7F6F3;">
+  <div style="width:64px;height:64px;border-radius:16px;background:#2D9B83;color:#fff;font-weight:800;font-size:38px;display:flex;align-items:center;justify-content:center;margin-bottom:28px;">Q</div>
+  <span class="pill pill-night" style="align-self:flex-start;margin-bottom:16px;">Internal Guideline</span>
+  <h1 style="font-size:40px;">Time &amp; Mileage<br>Workflow</h1>
+  <p style="font-size:16px;color:#6B6860;margin-top:14px;max-width:5in;">How the Qleno clock, drive, and pay model works — and how it improves on MaidCentral by removing the confusion.</p>
+  <div style="margin-top:40px;display:flex;gap:10px;">
+    <span class="pill pill-mint">One clock, at the house</span>
+    <span class="pill pill-mint">Automatic mileage</span>
+    <span class="pill pill-mint">Capture &ne; pay</span>
+  </div>
+  <div style="position:absolute;bottom:0.7in;left:0.75in;color:#9E9B94;font-size:11px;">Qleno · Phes · Prepared June 2026</div>
+</div>
+
+<!-- PAGE 1: Reading the My Jobs screen -->
+<div class="page">
+  <span class="pill pill-mint">Part 1</span>
+  <h2 style="margin-top:8px;">Reading the My Jobs screen</h2>
+  <p>This is what a cleaner sees for each job. Every element maps to a decision — here is what each one does.</p>
+  <div style="display:flex;gap:24px;margin-top:10px;">
+    <div class="phone">
+      <div class="bar"><div class="logo">Q</div><b style="font-size:13px;">My Jobs</b></div>
+      <div class="body">
+        <div class="jc">
+          <div style="display:flex;justify-content:space-between;align-items:center;">
+            <span class="pill" style="background:#EEF4FF;color:#3B6CC9;">Scheduled</span>
+            <span style="font-weight:800;font-size:13px;">$260.00 <span style="color:#3B6CC9;font-weight:600;">Change price</span></span>
+          </div>
+          <div style="font-size:17px;font-weight:800;margin:8px 0 1px;">Daryll Golladay <span class="pill" style="background:#F2F0EC;color:#6B6860;">PHES</span></div>
+          <div style="color:#3B6CC9;font-weight:700;font-size:11px;">STANDARD CLEAN</div>
+          <div style="color:#6B6860;font-size:12px;margin:3px 0;">9:00 AM</div>
+          <div style="color:#3B6CC9;font-size:11.5px;text-decoration:underline;">15060 West 95th Ave, IL 15060</div>
+          <span class="pill" style="background:#FEE2E2;color:#B91C1C;margin-top:6px;">8.0 mi away — drive to location</span>
+          <div class="btn" style="border:1px dashed #C9C6C0;color:#6B6860;">+ Add note</div>
+          <div style="font-size:11px;font-weight:700;margin-top:8px;">Before / After Photos</div>
+          <div class="btn btn-out">On My Way</div>
+          <div class="btn btn-solid">Clock In</div>
+        </div>
+      </div>
+    </div>
+    <div style="flex:1;">
+      <div class="anno"><div class="dot">1</div><div><b>Status + Price.</b> The job state and price. <b>Change price</b> lets the cleaner adjust with office permission (e.g. an add-on).</div></div>
+      <div class="anno"><div class="dot">2</div><div><b>Client &amp; service.</b> Who, what service, scheduled time, and the address (tap to navigate).</div></div>
+      <div class="anno"><div class="dot">3</div><div><b>"8.0 mi away."</b> Live distance from the cleaner's phone to the job — orientation only. <span class="muted">This is NOT the reimbursed mileage; that is computed job-to-job by the engine.</span></div></div>
+      <div class="anno"><div class="dot">4</div><div><b>Add note + Before/After photos.</b> Job documentation — proof of work and any issues.</div></div>
+      <div class="anno"><div class="dot">5</div><div><b>On My Way.</b> The departure tap. Sends the client an ETA text from GPS <i>and</i> records the drive leg from the previous job (the mileage hook).</div></div>
+      <div class="anno"><div class="dot">6</div><div><b>Clock In.</b> The check-in at the house — starts this job's time. (Clock Out appears when done.)</div></div>
+      <div class="lead" style="margin-top:14px;"><b>Notice what's missing:</b> no "Mileage" button (retired — it's automatic now) and no separate "start my day" clock. The day is figured out from the clocks themselves.</div>
+    </div>
+  </div>
+  <div class="footer"><span>Qleno — Time &amp; Mileage Workflow</span><span>1</span></div>
+</div>
+
+<!-- PAGE 2: The flow + Day complete -->
+<div class="page">
+  <span class="pill pill-mint">Part 2</span>
+  <h2 style="margin-top:8px;">The whole day — three taps per house</h2>
+  <p>One simple loop repeats at each home. There is no day clock to remember.</p>
+  <div class="step"><div class="stepnum">1</div><div><b>On My Way</b> — when leaving for the house. Texts the client a live ETA and starts the drive leg (job&nbsp;A&nbsp;→&nbsp;job&nbsp;B).</div></div>
+  <div class="step"><div class="stepnum">2</div><div><b>Clock In</b> — on arrival. Starts this job's time, with GPS to confirm they're on-site.</div></div>
+  <div class="step"><div class="stepnum">3</div><div><b>Clock Out</b> — when the house is done. Stamps the actual job time. Then drive to the next house and repeat.</div></div>
+  <div class="lead"><b>The day is derived, never a button.</b> "Paid day" = first Clock In → last Clock Out. Checking out of the <i>last</i> house ends the day automatically — because there's no more activity, not because a button was pressed. A surprise add-on just extends it. This is also what guarantees the drive home is never paid.</div>
+
+  <h3>What the cleaner sees when the last house is done</h3>
+  <div style="display:flex;gap:24px;align-items:flex-start;">
+    <div class="phone" style="width:230px;">
+      <div class="bar"><div class="logo">Q</div><b style="font-size:13px;">My Jobs</b></div>
+      <div class="body">
+        <div class="jc">
+          <div style="display:flex;align-items:center;gap:8px;">
+            <div style="width:28px;height:28px;border-radius:14px;background:#ECFDF5;color:#2D9B83;font-weight:800;display:flex;align-items:center;justify-content:center;">&#10003;</div>
+            <div><div style="font-size:15px;font-weight:800;">Day complete</div><div style="color:#9E9B94;font-size:11px;">Wed, Jun 4</div></div>
+          </div>
+          <div style="display:flex;gap:8px;margin-top:10px;">
+            <div class="tile" style="flex:1;"><div style="font-size:9px;font-weight:800;color:#9E9B94;text-transform:uppercase;">Jobs done</div><div style="font-size:19px;font-weight:800;">3</div></div>
+            <div class="tile" style="flex:1;"><div style="font-size:9px;font-weight:800;color:#9E9B94;text-transform:uppercase;">Job hours</div><div style="font-size:19px;font-weight:800;">6.4h</div></div>
+          </div>
+          <div style="font-size:10.5px;color:#6B6860;margin-top:9px;">Drive mileage between your jobs is calculated automatically. Pay and mileage finalize after office review.</div>
+        </div>
+      </div>
+    </div>
+    <div style="flex:1;">
+      <p>This is a <b>closure state, not a tap</b> — it appears on its own once every job is checked out. It gives the cleaner a clear "I'm finished" moment plus their day at a glance, without a clock-out button to forget.</p>
+      <p class="muted">"Start another job" is available only if a late add-on comes in — which simply extends the day.</p>
+      <p style="margin-top:8px;"><span class="pill pill-mint">Shipped</span> &nbsp;This card is live in the mobile app today.</p>
+    </div>
+  </div>
+  <div class="footer"><span>Qleno — Time &amp; Mileage Workflow</span><span>2</span></div>
+</div>
+
+<!-- PAGE 3: MaidCentral vs Qleno -->
+<div class="page">
+  <span class="pill pill-mint">Part 3</span>
+  <h2 style="margin-top:8px;">MaidCentral vs. Qleno</h2>
+  <p>Same rigor — half the friction, none of the "why is this on here?"</p>
+  <table>
+    <tr><th style="width:26%;">Area</th><th style="width:37%;">MaidCentral</th><th style="width:37%;">Qleno</th></tr>
+    <tr><td><b>Taps per house</b></td><td>Day Clock In/Out <i>and</i> per-job Check In/Out — two button pairs the tech mixes up</td><td class="good">One pair, at the house. Day is derived. One fewer tap.</td></tr>
+    <tr><td><b>Drive time on payroll</b></td><td>Auto-adds a paid "Drive &amp; Office Hours" line — confusing for a commission shop</td><td class="good">Drive hours are a record, never an auto-pay line. Pay = commission + mileage only.</td></tr>
+    <tr><td><b>Mileage entry</b></td><td>Captured, but bundled with auto drive-pay</td><td class="good">Automatic from the job sequence. No form. Route-proof point-to-point distance.</td></tr>
+    <tr><td><b>"Efficiency"</b></td><td>Three different formulas all called "Efficiency"</td><td class="good">One number, one name: Allowed ÷ Actual Job Hours.</td></tr>
+    <tr><td><b>Payroll screen</b></td><td>Hours-first; the drive-pay line draws the eye</td><td class="good">Dollars-first: Commission + Mileage = Total. Hours shown as a record.</td></tr>
+    <tr><td><b>Compliance</b></td><td>Captured</td><td class="good">Same record — plus a quiet flag only when a week crosses 40 hours.</td></tr>
+  </table>
+
+  <h2>Mileage — the rules, locked</h2>
+  <ul>
+    <li><b>Only the legs between jobs are paid.</b> House A → House B counts. Home → first job and last job → home are commute and are never reimbursed.</li>
+    <li><b>Distance is the mapping API's driving distance between the two client addresses</b> — not the cleaner's actual route. They cannot pad miles by driving around.</li>
+    <li><b>Dated rate table.</b> A past week computes at the rate that was in effect then, never today's rate.</li>
+    <li><b>No money until reviewed.</b> Computed mileage waits in a review gate; it only becomes pay when the office approves it. Every paid mile traces back to its leg.</li>
+  </ul>
+  <div class="footer"><span>Qleno — Time &amp; Mileage Workflow</span><span>3</span></div>
+</div>
+
+<!-- PAGE 4: Idle, capture vs pay, anti-gaming, reports -->
+<div class="page">
+  <span class="pill pill-mint">Part 4</span>
+  <h2 style="margin-top:8px;">Idle time, &amp; "what if they milk it?"</h2>
+  <div class="card card-mint"><b>The one rule that protects you both ways: capturing &ne; paying.</b><br>Qleno records every minute — job, drive, idle — for visibility and the rare overtime check. But the only dollars that move are <b>commission + mileage</b>. Idle is a number you <i>see</i>, not a line you <i>pay</i>.</div>
+  <p><b>Idle</b> = on-the-clock time that wasn't in a house and wasn't reimbursed driving (usually a lunch break). It is a record, not pay. Real meal breaks are excluded; on-duty waiting only matters in a 40+ hour week.</p>
+
+  <h3>Why milking the system earns nothing</h3>
+  <table>
+    <tr><th style="width:42%;">What they might try</th><th>Why it doesn't work</th></tr>
+    <tr><td>Dawdle inside a house</td><td>Pay is on commission / allowed hours — taking longer earns the <b>same money in more time</b>, lowering their effective rate and turning their efficiency score <span class="bad">red</span>.</td></tr>
+    <tr><td>Pad idle / linger between jobs</td><td>Idle isn't paid. Lingering earns <b>$0</b>.</td></tr>
+    <tr><td>Take the long way for more miles</td><td>Mileage is fixed point-to-point distance — <b>route-independent</b>.</td></tr>
+    <tr><td>Fake their location</td><td>GPS at check-in/out + a geofence flag catches off-site punches.</td></tr>
+    <tr><td>Linger into overtime</td><td>No day clock to pad — the day auto-ends at the last check-out.</td></tr>
+  </table>
+  <p class="muted">The captured idle / drive / efficiency data is the office's <b>coaching radar</b> — it tells you who to coach, not who to pay.</p>
+
+  <h2>Where each timestamp goes</h2>
+  <table>
+    <tr><th>Timestamp</th><th>Feeds</th><th>Drives</th></tr>
+    <tr><td>Clock In/Out (per house)</td><td>Job hours, allowed-vs-actual, billing</td><td>Pay, pricing, coaching</td></tr>
+    <tr><td>On My Way</td><td>Client ETA text + drive leg</td><td>Customer experience + mileage</td></tr>
+    <tr><td>Drive legs (between jobs)</td><td>Mileage reimbursement; hours record</td><td>Reimbursement; OT check</td></tr>
+    <tr><td>GPS at punch</td><td>On-site verification + geofence flag</td><td>Accountability / disputes</td></tr>
+    <tr><td>Derived day</td><td>Total paid hours record</td><td>Overtime compliance</td></tr>
+  </table>
+  <div class="lead"><b>Bottom line.</b> Qleno keeps MaidCentral's insight — separate meters for pay, job cost, and the drive/idle gap — but the cleaner only ever taps On My Way, Clock In, Clock Out. Everything else is derived, automatic, and milking-proof.</div>
+  <div class="footer"><span>Qleno — Time &amp; Mileage Workflow · Phes</span><span>4</span></div>
+</div>
+
+</body>
+</html>

--- a/lib/db/src/schema/companies.ts
+++ b/lib/db/src/schema/companies.ts
@@ -101,6 +101,23 @@ export const companiesTable = pgTable("companies", {
   // nobody worked.
   cancellation_tech_pay_mode: text("cancellation_tech_pay_mode").notNull().default("flat"),
   cancellation_tech_pay_amount: numeric("cancellation_tech_pay_amount", { precision: 10, scale: 4 }).notNull().default("60.0000"),
+  // [overtime 2026-06-04] Jurisdiction-aware overtime config. Out of the box
+  // every tenant runs the federal/most-state baseline (weekly-40, 1.5×), so
+  // Qleno is compliant by default no matter where they operate. Daily-overtime
+  // states (CA/AK/CO/NV…) are opt-in via the state preset seeded from
+  // companies.state on cold-start, and any field is owner-overridable here.
+  // null daily columns = "no daily overtime" (the common case). See
+  // lib/overtime.ts + docs/OVERTIME_COMPLIANCE_DESIGN.md. Computed overtime is
+  // a REVIEW SIGNAL — it never auto-moves money.
+  //   ot_rules_source: null = not yet configured → fall back to state preset;
+  //     'preset:<state>' = seeded from state; 'custom' = owner-edited.
+  ot_rules_source: text("ot_rules_source"),
+  ot_weekly_threshold_hours: numeric("ot_weekly_threshold_hours", { precision: 5, scale: 2 }).default("40.00"),
+  ot_daily_threshold_hours: numeric("ot_daily_threshold_hours", { precision: 5, scale: 2 }),
+  ot_daily_doubletime_hours: numeric("ot_daily_doubletime_hours", { precision: 5, scale: 2 }),
+  ot_seventh_day_rule: boolean("ot_seventh_day_rule").notNull().default(false),
+  ot_multiplier: numeric("ot_multiplier", { precision: 4, scale: 2 }).notNull().default("1.50"),
+  ot_doubletime_multiplier: numeric("ot_doubletime_multiplier", { precision: 4, scale: 2 }).notNull().default("2.00"),
   created_at: timestamp("created_at").notNull().defaultNow(),
 });
 


### PR DESCRIPTION
## What this does

Finishes the `>40hr` overtime trigger into a legally-complete, **multi-tenant** engine — so no one is underpaid, and Qleno is compliant **by default** wherever a tenant operates.

> Not legal advice. The engine *estimates* the overtime premium for office review; it never files or pays it. Tenants confirm thresholds with their own payroll provider / counsel.

### The three rules it enforces

1. **Hours worked = job clock time (`timeclock`) + between-jobs drive (`mileage_legs`).** The home↔job commute is excluded — no clock runs during it and the mileage engine already skips the commute legs (29 CFR 785.35 / 785.38). Idle/breaks excluded. **Allowed hours is never counted as worked time** (it's a budget for efficiency + commercial commission only).

2. **Threshold is per-tenant.** Federal + most states (incl. **Illinois**) = weekly-40 only, 1.5×. **California / Alaska / Colorado / Nevada / Oregon** daily-overtime presets are opt-in, seeded from `companies.state` and owner-overridable. No-pyramiding daily+weekly+7th-day math; with no daily threshold it degenerates exactly to plain weekly-40.

3. **Premium = the extra owed over commission.** Phes pays commission, not hourly, so straight time is already in the commission — only the premium portion is owed. regular rate = workweek commission ÷ hours worked; **mileage excluded** (29 CFR 778.117 / 778.217). Reuses `computeCommissionRows` so the rate matches the payroll detail screen.

### Visibility (locked decision)

- **Office-only.** `/payroll/overtime-check` is role-gated to owner/admin/office. Techs **never** see overtime, hours-worked totals, drive, or idle as pay lines — a tech's view stays dollars-only.
- **No money moves automatically** — same philosophy as mileage. The banner surfaces the estimate; the office pays it via the normal additional-pay flow.

## Changes

| Area | File |
|---|---|
| Pure engine (presets, resolver, week math, premium) | `artifacts/api-server/src/lib/overtime.ts` |
| Unit tests (13, all passing) | `artifacts/api-server/src/tests/overtime.test.ts` |
| Upgraded `/overtime-check`; new GET/PUT `/overtime-rules` | `artifacts/api-server/src/routes/payroll.ts` |
| `ot_*` config columns | `lib/db/src/schema/companies.ts` |
| Idempotent cold-start ALTER | `artifacts/api-server/src/cutover-data-migration.ts` |
| Office overtime banner (premium $ + rule basis) | `artifacts/qleno/src/pages/payroll.tsx` |
| Overtime settings card (Settings → Payroll) | `artifacts/qleno/src/pages/company.tsx` |
| Design doc + invariant | `docs/OVERTIME_COMPLIANCE_DESIGN.md`, `CLAUDE.md` |

## Testing

- `npx tsx --test src/tests/overtime.test.ts` → **13/13 pass** (federal/IL weekly-40, CA daily-OT + double-time, no-pyramiding, commission premium math, per-state resolver).
- Backend typecheck clean for changed files (sandbox lacks `@types/node`; frontend deps not installed here, so UI not type-verified in CI sandbox).

## Notes for reviewers

- Daily-OT presets (CA/AK/CO/NV/OR) carry caveats in `note` fields (e.g. NV's under-1.5×-min-wage condition, CO's consecutive-hours test not modeled). Confirm before relying on them.
- Workweek bucketing uses Postgres `date_trunc('week')` (Monday start); commission weeks use a matching `mondayOf()`. TZ edge cases are acceptable for a review signal.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_