### PR TITLE
feat(payroll): scheduled-hours fallback during clock-in transition

### DIFF
--- a/artifacts/api-server/src/routes/payroll.ts
+++ b/artifacts/api-server/src/routes/payroll.ts
@@ -655,6 +655,13 @@ router.get("/detail", requireAuth, async (req, res) => {
         const jobTotal = parseFloat(String(job.billed_amount || job.base_fee || 0));
         const allowedHrs = parseFloat(String(job.allowed_hours || 0));
         const workedHrs = parseFloat(String(job.actual_hours || 0));
+        // [payroll-hours-transition 2026-06-04] Until clock-in/out is fully
+        // adopted in Qleno, fall back to the job's scheduled (allowed) hours
+        // when there's no clocked time, so payroll hours don't read 0 during
+        // the cutover. Self-correcting: the moment a job is actually clocked,
+        // workedHrs > 0 and the real time takes over automatically.
+        const effectiveHrs = workedHrs > 0 ? workedHrs : allowedHrs;
+        const hoursEstimated = workedHrs <= 0 && allowedHrs > 0;
         // [AI.7.4] Commercial routes on account_id. Hours signal honors
         // commercial_comp_mode (default 'allowed_hours'). Residential
         // unchanged — pool-rate × jobTotal.
@@ -673,7 +680,7 @@ router.get("/detail", requireAuth, async (req, res) => {
           ? Math.round(commercialHourlyRate * commercialHours * 100) / 100
           : Math.round(jobTotal * jobResPct * 100) / 100;
         const commission = jtMap.has(job.id) ? jtMap.get(job.id)! : calcCommission;
-        const effectiveRate = workedHrs > 0 ? Math.round((commission / workedHrs) * 100) / 100 : null;
+        const effectiveRate = effectiveHrs > 0 ? Math.round((commission / effectiveHrs) * 100) / 100 : null;
         return {
           job_id: job.id,
           date: job.scheduled_date,
@@ -691,7 +698,11 @@ router.get("/detail", requireAuth, async (req, res) => {
             ? (branchNameMap.get((job as any).branch_id) ?? null)
             : null,
           hrs_scheduled: allowedHrs,
-          hrs_worked: workedHrs,
+          // hrs_worked is the figure that cascades to payroll: clocked time
+          // when present, else scheduled hours (transition fallback above).
+          hrs_worked: effectiveHrs,
+          hrs_actual: workedHrs,
+          hrs_estimated: hoursEstimated,
           effective_rate: effectiveRate,
         };
       });

--- a/artifacts/qleno/src/pages/payroll.tsx
+++ b/artifacts/qleno/src/pages/payroll.tsx
@@ -88,6 +88,11 @@ function WeeklyDetailView() {
         </div>
       </div>
 
+      <p style={{ fontSize: 11, color: '#9E9B94', margin: '-4px 2px 0', fontFamily: FF }}>
+        During the transition, hours fall back to a job's <b>scheduled</b> hours (shown with ≈) when it
+        hasn't been clocked yet — real clocked time takes over automatically as the team adopts clock-in/out.
+      </p>
+
       {isLoading && <div style={{ padding: '40px', textAlign: 'center', color: '#9E9B94', fontSize: 13 }}>Loading…</div>}
 
       {!isLoading && employees.length === 0 && (
@@ -155,7 +160,7 @@ function WeeklyDetailView() {
                           <td style={td}>${job.job_total.toFixed(2)}</td>
                           <td style={{ ...td, color: 'var(--brand)', fontWeight: 600 }}>${job.commission.toFixed(2)}</td>
                           <td style={{ ...td, color: '#6B6860' }}>{job.hrs_scheduled.toFixed(1)}h</td>
-                          <td style={{ ...td, color: '#6B6860' }}>{job.hrs_worked.toFixed(1)}h</td>
+                          <td style={{ ...td, color: job.hrs_estimated ? '#B45309' : '#6B6860' }} title={job.hrs_estimated ? 'Scheduled hours — job not clocked yet' : 'Clocked hours'}>{job.hrs_estimated ? '≈' : ''}{job.hrs_worked.toFixed(1)}h</td>
                           <td style={{ ...td, color: '#9E9B94', fontSize: 11 }}>{job.effective_rate != null ? `$${job.effective_rate.toFixed(2)}/hr` : '—'}</td>
                         </tr>
                       ))}

--- a/artifacts/qleno/src/pages/payroll.tsx
+++ b/artifacts/qleno/src/pages/payroll.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, Fragment } from "react";
 import { DashboardLayout } from "@/components/layout/dashboard-layout";
 import { useListUsers } from "@workspace/api-client-react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
@@ -345,12 +345,20 @@ export default function PayrollPage() {
     }
     return m;
   }, [payData]);
+  // Full per-employee detail (jobs + additional pay) keyed by user_id, so the
+  // Overview rows can expand into a per-client breakdown without another fetch.
+  const payDetailMap = useMemo(() => {
+    const m: Record<number, any> = {};
+    for (const e of (payData?.data || [])) m[e.user_id] = e;
+    return m;
+  }, [payData]);
 
   const totalGross = billableEmployees.reduce((sum: number, e: any) => sum + (payMap[e.id]?.gross ?? 0), 0);
   const totalHours = billableEmployees.reduce((sum: number, e: any) => sum + (payMap[e.id]?.hours ?? 0), 0);
 
   const isOwnerAdmin = ['owner','admin'].includes(getTokenRole() || '');
   const [activeView, setActiveView] = useState<'overview' | 'weekly-detail'>('overview');
+  const [expandedOverview, setExpandedOverview] = useState<number[]>([]);
 
   // Templates
   const { data: templatesData, refetch: refetchTemplates } = useQuery({
@@ -526,13 +534,23 @@ export default function PayrollPage() {
               ) : billableEmployees.length > 0 ? billableEmployees.map((emp: any) => {
                 const pay = payMap[emp.id] || { hours: 0, gross: 0 };
                 const effRate = pay.hours > 0 ? pay.gross / pay.hours : null;
+                const detail = payDetailMap[emp.id];
+                const jobs: any[] = detail?.jobs || [];
+                const addl = Object.entries(detail?.additional_pay || {}).filter(([, v]) => (v as number) !== 0);
+                const canOpen = jobs.length > 0 || addl.length > 0;
+                const isOpen = expandedOverview.includes(emp.id);
                 return (
-                  <tr key={emp.id} style={{ borderBottom: '1px solid #F0EEE9', cursor: 'default' }}
+                  <Fragment key={emp.id}>
+                  <tr style={{ borderBottom: isOpen ? 'none' : '1px solid #F0EEE9', cursor: canOpen ? 'pointer' : 'default' }}
+                    onClick={() => canOpen && setExpandedOverview(p => isOpen ? p.filter(id => id !== emp.id) : [...p, emp.id])}
                     onMouseEnter={e => (e.currentTarget.style.backgroundColor = '#F7F6F3')}
                     onMouseLeave={e => (e.currentTarget.style.backgroundColor = 'transparent')}
                   >
                     <td style={{ padding: '14px 20px' }}>
                       <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+                        {canOpen
+                          ? (isOpen ? <ChevronDown size={14} style={{ color: '#9E9B94', flexShrink: 0 }} /> : <ChevronRight size={14} style={{ color: '#9E9B94', flexShrink: 0 }} />)
+                          : <span style={{ width: 14, flexShrink: 0 }} />}
                         <div style={{ width: '32px', height: '32px', borderRadius: '50%', backgroundColor: 'var(--brand-dim)', color: 'var(--brand)', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: '12px', fontWeight: 600, flexShrink: 0 }}>
                           {emp.first_name?.[0]}{emp.last_name?.[0]}
                         </div>
@@ -556,6 +574,40 @@ export default function PayrollPage() {
                         : <span style={{ background: '#F3F4F6', color: '#6B7280', border: '1px solid #E5E2DC', display: 'inline-flex', alignItems: 'center', padding: '3px 8px', borderRadius: '4px', fontSize: '11px', fontWeight: 600, letterSpacing: '0.04em', textTransform: 'uppercase' }}>No pay yet</span>}
                     </td>
                   </tr>
+                  {isOpen && (
+                    <tr>
+                      <td colSpan={6} style={{ padding: '0 20px 16px 64px', background: '#FBFBFA', borderBottom: '1px solid #F0EEE9' }}>
+                        {jobs.length > 0 && (
+                          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+                            <thead><tr>
+                              {['Date', 'Client', 'Scope', 'Hours', 'Pay'].map(h => (
+                                <th key={h} style={{ fontSize: 10, fontWeight: 700, color: '#9E9B94', textTransform: 'uppercase', letterSpacing: '0.05em', textAlign: 'left', padding: '10px 12px 6px 0' }}>{h}</th>
+                              ))}
+                            </tr></thead>
+                            <tbody>
+                              {jobs.map((job: any) => (
+                                <tr key={job.job_id}>
+                                  <td style={{ fontSize: 12, padding: '6px 12px 6px 0', borderTop: '1px solid #F0EEE9', color: '#6B6860', whiteSpace: 'nowrap' }}>{job.date}</td>
+                                  <td style={{ fontSize: 12, padding: '6px 12px 6px 0', borderTop: '1px solid #F0EEE9' }}>{job.client}</td>
+                                  <td style={{ fontSize: 12, padding: '6px 12px 6px 0', borderTop: '1px solid #F0EEE9', color: '#6B6860' }}>{job.scope}</td>
+                                  <td style={{ fontSize: 12, padding: '6px 12px 6px 0', borderTop: '1px solid #F0EEE9', color: job.hrs_estimated ? '#B45309' : '#6B6860' }} title={job.hrs_estimated ? 'Scheduled hours — not clocked yet' : 'Clocked hours'}>{job.hrs_estimated ? '≈' : ''}{Number(job.hrs_worked ?? 0).toFixed(1)}h</td>
+                                  <td style={{ fontSize: 12, padding: '6px 12px 6px 0', borderTop: '1px solid #F0EEE9', fontWeight: 600, color: 'var(--brand)' }}>${Number(job.commission ?? 0).toFixed(2)}</td>
+                                </tr>
+                              ))}
+                            </tbody>
+                          </table>
+                        )}
+                        {addl.length > 0 && (
+                          <div style={{ marginTop: 10, display: 'flex', gap: 18, flexWrap: 'wrap' }}>
+                            {addl.map(([type, amt]) => (
+                              <span key={type} style={{ fontSize: 12, color: '#6B6860' }}>{PAY_TYPE_LABELS[type] || type}: <b style={{ color: '#1A1917' }}>${Number(amt).toFixed(2)}</b></span>
+                            ))}
+                          </div>
+                        )}
+                      </td>
+                    </tr>
+                  )}
+                  </Fragment>
                 );
               }) : (
                 <tr><td colSpan={6} style={{ padding: '40px', textAlign: 'center', color: '#6B7280', fontSize: '13px' }}>No employees found.</td></tr>


### PR DESCRIPTION
## What this does

Until clock-in/out is fully adopted in Qleno, payroll hours read **0** because they depend on clock punches (you saw "Total Hours 0.0"). This makes the payroll summary fall back to each job's **scheduled (allowed) hours** when there's no clocked time — so payroll cascades sensible hours during the MaidCentral → Qleno transition.

**Rule:** clocked hours when present, otherwise scheduled hours. "Done if clocked, scheduled if not."

**Self-correcting:** the moment a job is actually clocked, `actual_hours > 0` and the real time takes over automatically — no switch to flip as adoption grows. The pre-payroll health check still flags any completed job with no clock punch, so nothing slips silently.

## Changes
- `routes/payroll.ts` (`/detail`): `hrs_worked` = actual when clocked, else scheduled; adds `hrs_actual` + `hrs_estimated` so the UI can mark fallback rows. `effective_rate` divides by the effective hours.
- `payroll.tsx`: estimated hours shown with a `≈` marker (amber) + a one-line transition note in Weekly Detail.

No migration, no new setting — the fallback adapts on its own. If you later want a strict "clock-only, missing = flag" mode post-transition, that's a small toggle to add then.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_