### PR TITLE
feat(tech): My Pay total rewards — effective rate, running avg, tips & mileage YTD

### DIFF
--- a/artifacts/api-server/src/routes/payroll.ts
+++ b/artifacts/api-server/src/routes/payroll.ts
@@ -616,6 +616,24 @@ router.get("/detail", requireAuth, async (req, res) => {
       }
     } catch { /* pay_adjustments absent for this tenant — skip */ }
 
+    // [tech-rewards 2026-06-04] Per-tech mileage accrued in the window (any
+    // non-discarded leg). Powers the tech's "total rewards" tracker. Reported
+    // separately as totals.mileage — display-only; applied mileage already
+    // counts in grand_total via pay_adjustments above, so this isn't re-added.
+    const mileageByUser = new Map<number, number>();
+    try {
+      const mRows = await db.execute(sql`
+        SELECT user_id, COALESCE(SUM(amount), 0) AS total
+        FROM mileage_legs
+        WHERE company_id = ${companyId}
+          AND status <> 'discarded'
+          AND leg_date >= ${String(pay_period_start)} AND leg_date <= ${String(pay_period_end)}
+          ${filterUserId ? sql`AND user_id = ${filterUserId}` : sql``}
+        GROUP BY user_id
+      `);
+      for (const r of mRows.rows as any[]) mileageByUser.set(Number(r.user_id), parseFloat(String(r.total || 0)));
+    } catch { /* mileage_legs absent — skip */ }
+
     // Group jobs by user
     const byUser = new Map<number, typeof jobs>();
     for (const job of jobs) {
@@ -766,6 +784,8 @@ router.get("/detail", requireAuth, async (req, res) => {
           commission: Math.round(totalCommission * 100) / 100,
           hrs_scheduled: Math.round(totalHrsScheduled * 100) / 100,
           hrs_worked: Math.round(totalHrsWorked * 100) / 100,
+          mileage: Math.round((mileageByUser.get(uid) || 0) * 100) / 100,
+          effective_rate: totalHrsWorked > 0 ? Math.round((totalCommission / totalHrsWorked) * 100) / 100 : null,
           grand_total: Math.round(grandTotal * 100) / 100,
         },
       });

--- a/artifacts/qleno/src/components/earnings-panel.tsx
+++ b/artifacts/qleno/src/components/earnings-panel.tsx
@@ -18,8 +18,23 @@ type JobRow = {
 type EmpEarnings = {
   user_id: number; name: string; jobs: JobRow[];
   additional_pay: Record<string, number>;
-  totals: { job_count: number; job_total: number; commission: number; hrs_scheduled: number; hrs_worked: number };
+  totals: { job_count: number; job_total: number; commission: number; hrs_scheduled: number; hrs_worked: number; mileage?: number; effective_rate?: number | null };
 };
+
+const MILEAGE_KEYS = ["mileage", "mileage_reimbursement"];
+type WindowSum = { commission: number; tips: number; mileage: number; hours: number };
+const EMPTY_SUM: WindowSum = { commission: 0, tips: 0, mileage: 0, hours: 0 };
+async function fetchWindowSum(start: string, end: string, uq: string): Promise<WindowSum> {
+  try {
+    const r = await fetch(`${API}/api/payroll/detail?pay_period_start=${start}&pay_period_end=${end}${uq}`, { headers: getAuthHeaders() });
+    if (!r.ok) return EMPTY_SUM;
+    const d = await r.json();
+    const e = d?.data?.[0];
+    if (!e) return EMPTY_SUM;
+    const tips = Object.entries(e.additional_pay || {}).filter(([k]) => !MILEAGE_KEYS.includes(k)).reduce((s, [, v]) => s + Number(v || 0), 0);
+    return { commission: e.totals?.commission || 0, tips, mileage: e.totals?.mileage || 0, hours: e.totals?.hrs_worked || 0 };
+  } catch { return EMPTY_SUM; }
+}
 
 function ymd(d: Date) { return d.toISOString().slice(0, 10); }
 function thisWeek() {
@@ -37,6 +52,10 @@ function lastWeek() {
 function thisMonth() {
   const t = new Date();
   return { start: ymd(new Date(t.getFullYear(), t.getMonth(), 1)), end: ymd(t) };
+}
+function ytd() {
+  const t = new Date();
+  return { start: ymd(new Date(t.getFullYear(), 0, 1)), end: ymd(t) };
 }
 const money = (n: number) => `$${(n || 0).toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
 const fmtScope = (s: string | null) => (s ? s.split("_").map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(" ") : "—");
@@ -60,10 +79,29 @@ export function EarningsPanel({ userId, title = "Earnings" }: { userId?: number;
     return () => { cancelled = true; };
   }, [userId, period.start, period.end]);
 
-  const tips = useMemo(() => Object.values(data?.additional_pay || {}).reduce((s, v) => s + v, 0), [data]);
+  // Fixed-window rollup (this week / this month / year-to-date) for the rewards
+  // tracker + running-average hourly rate. Independent of the selected period.
+  const [roll, setRoll] = useState<{ week: WindowSum; month: WindowSum; ytd: WindowSum } | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    const uq = userId ? `&user_id=${userId}` : "";
+    const w = thisWeek(), m = thisMonth(), y = ytd();
+    Promise.all([fetchWindowSum(w.start, w.end, uq), fetchWindowSum(m.start, m.end, uq), fetchWindowSum(y.start, y.end, uq)])
+      .then(([week, month, yr]) => { if (!cancelled) setRoll({ week, month, ytd: yr }); })
+      .catch(() => { if (!cancelled) setRoll(null); });
+    return () => { cancelled = true; };
+  }, [userId]);
+
+  // Tips exclude mileage keys (mileage is shown on its own card).
+  const tips = useMemo(() => Object.entries(data?.additional_pay || {}).filter(([k]) => !MILEAGE_KEYS.includes(k)).reduce((s, [, v]) => s + Number(v || 0), 0), [data]);
   const commission = data?.totals?.commission ?? 0;
-  const earned = commission + tips;
   const hours = data?.totals?.hrs_worked ?? 0;
+  const mileage = data?.totals?.mileage ?? 0;
+  const rewards = commission + tips + mileage;
+  const periodRate = data?.totals?.effective_rate ?? (hours > 0 ? commission / hours : null);
+  const runningRate = roll && roll.ytd.hours > 0 ? roll.ytd.commission / roll.ytd.hours : null;
+  const rTh: React.CSSProperties = { fontSize: 10, fontWeight: 700, color: "#9E9B94", textTransform: "uppercase", letterSpacing: "0.05em", textAlign: "left", padding: "0 0 6px" };
+  const rTd: React.CSSProperties = { fontSize: 13, color: "#1A1917", padding: "6px 0", borderTop: "1px solid #F4F3F0" };
 
   const byDay = useMemo(() => {
     const m: Record<string, JobRow[]> = {};
@@ -101,10 +139,54 @@ export function EarningsPanel({ userId, title = "Earnings" }: { userId?: number;
       {/* Summary */}
       <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(150px, 1fr))", gap: 10 }}>
         <SummaryCard icon={<TrendingUp size={14} />} label="Commission earned" value={money(commission)} accent />
+        <SummaryCard icon={<TrendingUp size={14} />} label="Effective rate"
+          value={periodRate != null ? `$${periodRate.toFixed(2)}/hr` : "—"}
+          sub={runningRate != null ? `avg $${runningRate.toFixed(2)}/hr` : undefined} accent />
         <SummaryCard icon={<Clock size={14} />} label="Hours worked" value={`${hours.toFixed(1)} hrs`} />
         <SummaryCard icon={<DollarSign size={14} />} label="Tips & extra" value={money(tips)} />
-        <SummaryCard icon={<DollarSign size={14} />} label="Total earned" value={money(earned)} strong />
+        <SummaryCard icon={<DollarSign size={14} />} label="Mileage" value={money(mileage)} />
+        <SummaryCard icon={<DollarSign size={14} />} label="Total rewards" value={money(rewards)} strong />
       </div>
+
+      {/* Total rewards tracker — this week / this month / year-to-date */}
+      {roll && (
+        <div style={{ background: "#fff", border: "1px solid #E5E2DC", borderRadius: 12, padding: "14px 16px" }}>
+          <div style={{ display: "flex", alignItems: "baseline", justifyContent: "space-between", flexWrap: "wrap", gap: 8, marginBottom: 8 }}>
+            <p style={{ fontSize: 11, fontWeight: 700, color: "#6B7280", textTransform: "uppercase", letterSpacing: "0.05em", margin: 0 }}>Your total rewards</p>
+            {runningRate != null && (
+              <span style={{ fontSize: 12, color: "#0A6E5A", fontWeight: 700 }}>Running average: ${runningRate.toFixed(2)}/hr</span>
+            )}
+          </div>
+          <table style={{ width: "100%", borderCollapse: "collapse" }}>
+            <thead><tr>
+              <th style={rTh}></th>
+              <th style={{ ...rTh, textAlign: "right" }}>This week</th>
+              <th style={{ ...rTh, textAlign: "right" }}>This month</th>
+              <th style={{ ...rTh, textAlign: "right" }}>Year to date</th>
+            </tr></thead>
+            <tbody>
+              {([
+                { k: "Commission", f: (w: WindowSum) => w.commission },
+                { k: "Tips", f: (w: WindowSum) => w.tips },
+                { k: "Mileage", f: (w: WindowSum) => w.mileage },
+              ]).map(row => (
+                <tr key={row.k}>
+                  <td style={rTd}>{row.k}</td>
+                  <td style={{ ...rTd, textAlign: "right" }}>{money(row.f(roll.week))}</td>
+                  <td style={{ ...rTd, textAlign: "right" }}>{money(row.f(roll.month))}</td>
+                  <td style={{ ...rTd, textAlign: "right" }}>{money(row.f(roll.ytd))}</td>
+                </tr>
+              ))}
+              <tr>
+                <td style={{ ...rTd, fontWeight: 800, borderTop: "2px solid #E5E2DC" }}>Total rewards</td>
+                {[roll.week, roll.month, roll.ytd].map((w, i) => (
+                  <td key={i} style={{ ...rTd, textAlign: "right", fontWeight: 800, color: "var(--brand, #00C9A0)", borderTop: "2px solid #E5E2DC" }}>{money(w.commission + w.tips + w.mileage)}</td>
+                ))}
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      )}
 
       {/* Additional pay broken out by type — tips, sick pay paid out, bonuses,
           holiday, employee-of-the-month, reimbursements, etc. */}
@@ -157,7 +239,7 @@ export function EarningsPanel({ userId, title = "Earnings" }: { userId?: number;
   );
 }
 
-function SummaryCard({ icon, label, value, accent, strong }: { icon: React.ReactNode; label: string; value: string; accent?: boolean; strong?: boolean }) {
+function SummaryCard({ icon, label, value, accent, strong, sub }: { icon: React.ReactNode; label: string; value: string; accent?: boolean; strong?: boolean; sub?: string }) {
   return (
     <div style={{ background: "#fff", border: `1px solid ${accent ? "#99E6D5" : "#E5E2DC"}`, borderRadius: 12, padding: "12px 14px" }}>
       <div style={{ display: "flex", alignItems: "center", gap: 6, color: accent ? "var(--brand, #00C9A0)" : "#6B7280", marginBottom: 6 }}>
@@ -165,6 +247,7 @@ function SummaryCard({ icon, label, value, accent, strong }: { icon: React.React
         <span style={{ fontSize: 10, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.05em" }}>{label}</span>
       </div>
       <p style={{ fontSize: strong ? 22 : 20, fontWeight: 700, color: "#1A1917", margin: 0, lineHeight: 1 }}>{value}</p>
+      {sub && <p style={{ fontSize: 11, fontWeight: 600, color: "#0A6E5A", margin: "4px 0 0", lineHeight: 1 }}>{sub}</p>}
     </div>
   );
 }


### PR DESCRIPTION
## What this does

Gives technicians their own **Total Rewards** picture in My Pay (`/my-jobs` → Pay) — a pride/motivation metric, distinct from the office-only reporting.

- **Effective $/hr** for the selected window, with a **running-average $/hr** (YTD commission ÷ hours) right beneath it — so they can see (and feel good about) their hourly wage.
- A **Mileage** card.
- A **"Your total rewards" tracker**: Commission / Tips / Mileage across **This week · This month · Year-to-date**, with a Total Rewards row.

### Backend
`/payroll/detail` now returns per-employee `totals.mileage` (sum of non-discarded `mileage_legs` in the window) and `totals.effective_rate`. The endpoint is already tech-scoped (a technician only ever sees their own data), so this stays private to each tech.

The panel reuses `/payroll/detail` for the three fixed windows — no new endpoint.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_