### PR TITLE
fix(dispatch): delete always works + client audit, inactive-tech→unassigned, revenue uses billed price

### DIFF
--- a/artifacts/api-server/src/lib/audit.ts
+++ b/artifacts/api-server/src/lib/audit.ts
@@ -33,3 +33,35 @@ export async function logAudit(
     console.error("[audit] Failed to write audit log:", err);
   }
 }
+
+// Per-client activity trail. Writes to client_audit_log (keyed by client_id) so
+// the office can audit ALL activity within a single client — job deletions,
+// rate changes, etc. — in one place. No-ops safely when there's no client
+// (e.g. account/commercial jobs) or no authenticated actor.
+export async function logClientActivity(
+  req: Request,
+  clientId: number | null | undefined,
+  fieldName: string,
+  oldValue?: Record<string, unknown> | null,
+  newValue?: Record<string, unknown> | null
+): Promise<void> {
+  const userId = req.auth?.userId ?? null;
+  const companyId = req.auth?.companyId ?? null;
+  if (clientId == null || userId == null || companyId == null) return;
+  try {
+    let name = "Unknown", email = "";
+    const u = await db.execute(sql`SELECT first_name, last_name, email FROM users WHERE id = ${userId} LIMIT 1`);
+    const row = (u.rows?.[0] as any) ?? null;
+    if (row) { name = `${row.first_name ?? ""} ${row.last_name ?? ""}`.trim() || "Unknown"; email = row.email ?? ""; }
+    await db.execute(sql`
+      INSERT INTO client_audit_log
+        (client_id, company_id, user_id, user_name, user_email, field_name, old_value, new_value, edited_at)
+      VALUES
+        (${clientId}, ${companyId}, ${userId}, ${name}, ${email}, ${fieldName},
+         ${oldValue ? JSON.stringify(oldValue) : null}::jsonb,
+         ${newValue ? JSON.stringify(newValue) : null}::jsonb, now())
+    `);
+  } catch (err) {
+    console.error("[audit] Failed to write client_audit_log:", err);
+  }
+}

--- a/artifacts/api-server/src/lib/job-revenue-sql.ts
+++ b/artifacts/api-server/src/lib/job-revenue-sql.ts
@@ -20,6 +20,6 @@ export function jobRevenueExpr(fallback: SQL, jobsAlias = "j", clientsAlias = "c
          AND ${j}.hourly_rate IS NOT NULL AND ${j}.allowed_hours IS NOT NULL
          AND CAST(${j}.hourly_rate AS NUMERIC) > 0 AND CAST(${j}.allowed_hours AS NUMERIC) > 0
     THEN CAST(${j}.hourly_rate AS NUMERIC) * CAST(${j}.allowed_hours AS NUMERIC)
-    ELSE ${fallback}
+    ELSE COALESCE(NULLIF(CAST(${j}.billed_amount AS NUMERIC), 0), ${fallback})
   END`;
 }

--- a/artifacts/api-server/src/routes/dispatch.ts
+++ b/artifacts/api-server/src/routes/dispatch.ts
@@ -711,6 +711,14 @@ router.get("/", requireAuth, async (req, res) => {
             const hrs = j.allowed_hours ? parseFloat(j.allowed_hours) : 0;
             if (rate > 0 && hrs > 0) return rate * hrs + mods + addOns;
           }
+          // [revenue-billed 2026-06-04] When the office set an explicit price
+          // (billed_amount — e.g. via "Change price"), THAT is what's actually
+          // billed and is the source of truth (matches MaidCentral and the
+          // commission engine, both of which use billed_amount || base_fee).
+          // Reconstruct from base_fee + add-ons only when no explicit price was
+          // set, so price changes stop under-counting daily revenue.
+          const billed = (j as any).billed_amount != null ? parseFloat(String((j as any).billed_amount)) : null;
+          if (billed != null && billed > 0) return billed;
           const base = j.base_fee ? parseFloat(j.base_fee) : 0;
           return base + mods + addOns;
         })(),
@@ -805,6 +813,11 @@ router.get("/", requireAuth, async (req, res) => {
 
     const jobsByEmployee = new Map<number, typeof mappedJobs>();
     const unassigned: typeof mappedJobs = [];
+    // [inactive-tech-unassigned 2026-06-04] A job assigned to a tech who is no
+    // longer active (deactivated/removed) must fall into Unassigned, not vanish.
+    // `employees` is already filtered to active techs, so any assigned user_id
+    // not in this set is treated as unassigned below.
+    const activeEmployeeIds = new Set(employees.map(e => e.id));
 
     // [hotfix iter 2] Two-level dedupe. The first level (seenIds) catches
     // the case where the same job.id appears twice via a JOIN fan-out.
@@ -865,12 +878,15 @@ router.get("/", requireAuth, async (req, res) => {
       // the full job value on the chip — that's what the operator wants
       // to see. assigned_user_id stays — still drives drag-and-drop and
       // the chip's tech name badge for the primary.
-      const techsArr: Array<{ user_id: number; is_primary?: boolean; calc_pay?: number }> =
+      const rawTechs: Array<{ user_id: number; is_primary?: boolean; calc_pay?: number }> =
         (Array.isArray((job as any).technicians) && (job as any).technicians.length > 0)
           ? (job as any).technicians
           : (job.assigned_user_id != null
               ? [{ user_id: Number(job.assigned_user_id), is_primary: true, calc_pay: Number((job as any).est_pay_per_tech) || 0 }]
               : []);
+      // Drop assignees who are no longer active techs (removed/deactivated) so
+      // their jobs surface under Unassigned instead of disappearing.
+      const techsArr = rawTechs.filter(t => activeEmployeeIds.has(Number(t.user_id)));
 
       if (techsArr.length === 0) {
         unassigned.push(job);

--- a/artifacts/api-server/src/routes/jobs.ts
+++ b/artifacts/api-server/src/routes/jobs.ts
@@ -4,7 +4,7 @@ import { jobsTable, clientsTable, usersTable, jobPhotosTable, timeclockTable, in
 import { eq, and, gte, lte, count, desc, sql, notExists, inArray, isNotNull, isNull } from "drizzle-orm";
 import { requireAuth } from "../lib/auth.js";
 import { notifyUserAsync } from "../lib/push.js";
-import { logAudit } from "../lib/audit.js";
+import { logAudit, logClientActivity } from "../lib/audit.js";
 import { generateJobCompletionPdf } from "../lib/generate-job-pdf.js";
 import { geocodeAddress } from "../lib/geocode.js";
 import { resolveZoneForZip } from "./zones.js";
@@ -4660,17 +4660,34 @@ router.delete("/:id", requireAuth, async (req, res) => {
       const detach: [string, string][] = [
         ["additional_pay", "job_id"], ["communication_log", "job_id"], ["contact_tickets", "job_id"],
         ["form_submissions", "job_id"], ["hr_logs", "job_id"], ["loyalty", "job_id"], ["invoices", "job_id"],
+        // [delete-always-works 2026-06-04] quotes.booked_job_id was the missing
+        // FK that made delete fail (409 "can't delete") for any job created from
+        // a converted quote. Detach it so delete always succeeds.
+        ["quotes", "booked_job_id"],
         ["mileage", "from_job_id"], ["mileage", "to_job_id"],
         ["mileage_requests", "from_job_id"], ["mileage_requests", "to_job_id"],
         ["cancellation_log", "rescheduled_to_job_id"],
       ];
-      for (const [t, c] of detach) await tx.execute(sql.raw(`UPDATE ${t} SET ${c} = NULL WHERE ${c} = ${jobId}`));
+      for (const [t, c] of detach) {
+        // Tolerate tables/columns that don't exist in a given tenant — a single
+        // missing detach target must never block the delete.
+        try { await tx.execute(sql.raw(`UPDATE ${t} SET ${c} = NULL WHERE ${c} = ${jobId}`)); }
+        catch (e) { console.error(`[delete-job] detach ${t}.${c} skipped:`, (e as any)?.message); }
+      }
       await tx.execute(sql.raw(`DELETE FROM jobs WHERE id = ${jobId}`));
     });
+    // Global audit trail.
     logAudit(req, "DELETE", "job", jobId, null, {
       client_id: job.client_id, scheduled_date: job.scheduled_date,
       service_type: job.service_type, base_fee: job.base_fee,
     });
+    // Cascade to the client's own audit trail so all activity within a client
+    // is auditable in one place.
+    logClientActivity(req, job.client_id, "job_deleted", {
+      job_id: jobId, scheduled_date: job.scheduled_date,
+      service_type: job.service_type, base_fee: job.base_fee,
+      billed_amount: job.billed_amount, status: job.status,
+    }, null);
     return res.json({ ok: true });
   } catch (err) {
     console.error("Delete job error:", err);

--- a/artifacts/api-server/src/routes/users.ts
+++ b/artifacts/api-server/src/routes/users.ts
@@ -481,6 +481,27 @@ router.delete("/:id", requireAuth, requireRole("owner", "admin"), async (req, re
       }
     }
 
+    // [inactive-tech-unassigned 2026-06-04] Release this tech's open (not-yet-
+    // completed) jobs so they fall to Unassigned on the dispatch board instead
+    // of disappearing with the deactivated user. Completed jobs keep their
+    // assignment (payroll/history). The dispatch board also guards defensively,
+    // but clearing the source here keeps the data clean (assignment-mirror
+    // invariant: jobs.assigned_user_id is the dispatch source of truth).
+    const released = await db.execute(sql`
+      UPDATE jobs SET assigned_user_id = NULL
+      WHERE assigned_user_id = ${userId}
+        AND company_id = ${req.auth!.companyId}
+        AND status <> 'complete'
+    `);
+    try {
+      await db.execute(sql`
+        DELETE FROM job_technicians jt
+        USING jobs j
+        WHERE jt.job_id = j.id AND jt.user_id = ${userId}
+          AND j.company_id = ${req.auth!.companyId} AND j.status <> 'complete'
+      `);
+    } catch (e) { console.error("[deactivate] job_technicians cleanup skipped:", (e as any)?.message); }
+
     await db
       .update(usersTable)
       .set({ is_active: false })
@@ -488,7 +509,9 @@ router.delete("/:id", requireAuth, requireRole("owner", "admin"), async (req, re
         eq(usersTable.id, userId),
         eq(usersTable.company_id, req.auth!.companyId)
       ));
-    logAudit(req, "DELETE_EMPLOYEE", "employee", userId, null, { is_active: false });
+    logAudit(req, "DELETE_EMPLOYEE", "employee", userId, null, {
+      is_active: false, jobs_released_to_unassigned: (released as any)?.rowCount ?? undefined,
+    });
     return res.json({ success: true, message: "User deactivated" });
   } catch (err) {
     console.error("Delete user error:", err);


### PR DESCRIPTION
## Three production fixes from the dispatch board

### 1. Delete always works + cascades to the client audit
- **Root cause of "can't delete":** `quotes.booked_job_id` was missing from the delete handler's detach list, so any job created from a converted quote hit an FK constraint → 409 "can't delete." Now detached (and every detach is `try/caught` so one bad table can never block a delete).
- **Audit:** delete already wrote `app_audit_log`; it now **also** writes `client_audit_log` (new `logClientActivity` helper) so the deletion shows in that **client's** own audit trail — "all activity within that client" in one place.
- Confirmation is already two-step in the job panel.

### 2. A removed/inactive tech's jobs go to Unassigned (not vanish)
- Dispatch grouping now drops assignees who aren't in the active-tech set → those jobs fall into **Unassigned** (fixes existing stale data like Ana Valdez's jobs / Michael Baffoe).
- Deactivating a user now **releases** their open (non-complete) jobs (`assigned_user_id = NULL` + clears `job_technicians`) so the source data stays clean per the assignment-mirror invariant. Completed jobs keep their assignment for payroll/history.

### 3. Revenue uses the actually-billed price
- Dispatch valued residential jobs by `base_fee`, **ignoring `billed_amount`** (the "Change price" value, e.g. Richard's $578.40). Commission/payroll already use `billed_amount || base_fee`, so dispatch was the odd one out and **under-counted** daily revenue vs MaidCentral.
- Now prefers `billed_amount` when set — in both the live dispatch `amount` and `jobRevenueExpr` (week-summary). This should close most/all of the June-1 variance ($4,369 → ~$4,444).
- Note: the daily total already summed exact (un-rounded) amounts, so the chip rounding wasn't the cause — the field was.

## Deferred (will do next, flagged to Sal)
- A **manual zone picker** on the job panel (set `jobs.zone_id`) so the office can fix any gray/zone-less tile directly — there's no such control today.
- **Multi-tech select** in the Create-Job wizard (backend `team_user_ids` already supports it; the picker is single-select).

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_