### PR TITLE
feat(clients): per-client Activity log — audit all activity within a client

### DIFF
--- a/artifacts/api-server/src/routes/clients.ts
+++ b/artifacts/api-server/src/routes/clients.ts
@@ -1086,6 +1086,83 @@ router.post("/geocode-all", requireAuth, requireRole("owner", "admin"), async (r
   return res.json({ geocoded: updated, total: clients.length });
 });
 
+// ─── CLIENT ACTIVITY FEED ────────────────────────────────────────────────────
+// [client-activity 2026-06-04] One chronological audit feed of ALL activity for
+// a client — job created/edited/rescheduled/cancelled/deleted, price changes,
+// tech reassignments, client field edits, and communications. Aggregates the
+// audit tables Qleno already writes (so it shows history retroactively) rather
+// than dual-writing everywhere. Each source is independently try/caught so a
+// missing table never blanks the feed. Office-only; scoped to client + company.
+router.get("/:id/activity", requireAuth, requireRole("owner", "admin", "office"), async (req, res) => {
+  const clientId = parseInt(req.params.id);
+  if (isNaN(clientId)) return res.status(400).json({ error: "Invalid id" });
+  const companyId = req.auth!.companyId;
+  const limit = Math.min(parseInt(String(req.query.limit ?? "200")) || 200, 500);
+
+  type Ev = { event_type: string; occurred_at: string; user_name: string | null; field_name: string | null; old_value: any; new_value: any; related_job_id: number | null; action: string | null };
+  const events: Ev[] = [];
+
+  // 1. Per-field job edits (price changes, reschedule-by-edit, reassignments…)
+  try {
+    const r = await db.execute(sql`
+      SELECT jal.edited_at, jal.user_name, jal.field_name, jal.old_value, jal.new_value, jal.job_id, jal.cascade_scope
+      FROM job_audit_log jal JOIN jobs j ON jal.job_id = j.id
+      WHERE j.client_id = ${clientId} AND jal.company_id = ${companyId}
+      ORDER BY jal.edited_at DESC LIMIT ${limit}`);
+    for (const x of r.rows as any[]) events.push({ event_type: "job_edit", occurred_at: x.edited_at, user_name: x.user_name, field_name: x.field_name, old_value: x.old_value, new_value: x.new_value, related_job_id: x.job_id != null ? Number(x.job_id) : null, action: x.cascade_scope ?? null });
+  } catch (e) { console.error("[client-activity] job_audit_log:", (e as any)?.message); }
+
+  // 2. Client field edits + job deletions (delete writes here via logClientActivity)
+  try {
+    const r = await db.execute(sql`
+      SELECT edited_at, user_name, field_name, old_value, new_value
+      FROM client_audit_log
+      WHERE client_id = ${clientId} AND company_id = ${companyId}
+      ORDER BY edited_at DESC LIMIT ${limit}`);
+    for (const x of r.rows as any[]) events.push({ event_type: x.field_name === "job_deleted" ? "job_deleted" : "client_edit", occurred_at: x.edited_at, user_name: x.user_name, field_name: x.field_name, old_value: x.old_value, new_value: x.new_value, related_job_id: x.old_value?.job_id ?? null, action: null });
+  } catch (e) { console.error("[client-activity] client_audit_log:", (e as any)?.message); }
+
+  // 3. Cancellations / reschedules / lockouts
+  try {
+    const r = await db.execute(sql`
+      SELECT cl.cancelled_at, cl.cancel_action, cl.cancel_reason, cl.customer_charge_amount, cl.notes, cl.job_id,
+             NULLIF(TRIM(COALESCE(u.first_name,'') || ' ' || COALESCE(u.last_name,'')), '') AS user_name
+      FROM cancellation_log cl LEFT JOIN users u ON cl.cancelled_by = u.id
+      WHERE cl.customer_id = ${clientId} AND cl.company_id = ${companyId}
+      ORDER BY cl.cancelled_at DESC LIMIT ${limit}`);
+    for (const x of r.rows as any[]) events.push({ event_type: (x.cancel_action === "move" || x.cancel_action === "bump") ? "job_rescheduled" : "job_cancelled", occurred_at: x.cancelled_at, user_name: x.user_name, field_name: x.cancel_action, old_value: null, new_value: { reason: x.cancel_reason, charge: x.customer_charge_amount, notes: x.notes }, related_job_id: x.job_id != null ? Number(x.job_id) : null, action: x.cancel_action });
+  } catch (e) { console.error("[client-activity] cancellation_log:", (e as any)?.message); }
+
+  // 4. Communications (SMS / email / calls / notes)
+  try {
+    const r = await db.execute(sql`
+      SELECT com.logged_at, com.channel, com.direction, com.summary, com.subject, com.job_id,
+             NULLIF(TRIM(COALESCE(u.first_name,'') || ' ' || COALESCE(u.last_name,'')), '') AS user_name
+      FROM communication_log com LEFT JOIN users u ON com.logged_by = u.id
+      WHERE com.customer_id = ${clientId} AND com.company_id = ${companyId}
+      ORDER BY com.logged_at DESC LIMIT ${limit}`);
+    for (const x of r.rows as any[]) events.push({ event_type: "communication", occurred_at: x.logged_at, user_name: x.user_name, field_name: x.channel, old_value: null, new_value: { direction: x.direction, summary: x.summary, subject: x.subject }, related_job_id: x.job_id != null ? Number(x.job_id) : null, action: x.direction });
+  } catch (e) { console.error("[client-activity] communication_log:", (e as any)?.message); }
+
+  // 5. Creations (job + client) from the global audit log
+  try {
+    const r = await db.execute(sql`
+      SELECT aal.performed_at, aal.action, aal.target_type, aal.target_id, aal.new_value,
+             NULLIF(TRIM(COALESCE(au.first_name,'') || ' ' || COALESCE(au.last_name,'')), '') AS user_name
+      FROM app_audit_log aal
+      LEFT JOIN users au ON aal.performed_by = au.id
+      LEFT JOIN jobs jj ON aal.target_type = 'job' AND aal.target_id ~ '^[0-9]+$' AND aal.target_id::int = jj.id
+      WHERE aal.company_id = ${companyId} AND aal.action = 'CREATE'
+        AND ((aal.target_type = 'client' AND aal.target_id = ${String(clientId)})
+          OR (aal.target_type = 'job' AND jj.client_id = ${clientId}))
+      ORDER BY aal.performed_at DESC LIMIT ${limit}`);
+    for (const x of r.rows as any[]) events.push({ event_type: x.target_type === "job" ? "job_created" : "client_created", occurred_at: x.performed_at, user_name: x.user_name, field_name: null, old_value: null, new_value: x.new_value, related_job_id: x.target_type === "job" ? Number(x.target_id) : null, action: x.action });
+  } catch (e) { console.error("[client-activity] app_audit_log:", (e as any)?.message); }
+
+  events.sort((a, b) => new Date(b.occurred_at).getTime() - new Date(a.occurred_at).getTime());
+  return res.json({ events: events.slice(0, limit) });
+});
+
 // ─── GET JOB HISTORY (from job_history table, mc_import + future sources) ─────
 router.get("/:id/job-history", requireAuth, async (req, res) => {
   try {

--- a/artifacts/qleno/src/pages/customer-profile.tsx
+++ b/artifacts/qleno/src/pages/customer-profile.tsx
@@ -5210,11 +5210,81 @@ function JobCalendar({ clientId, clientName, onScheduleOnDate }: { clientId: num
 }
 
 // ─── Main Profile Page ─────────────────────────────────────────────────────────
+// [client-activity 2026-06-04] One chronological audit feed for the client —
+// every recorded action (job created/edited/rescheduled/cancelled/deleted,
+// price changes, tech reassignments, client edits, messages) with who + when.
+// Reads the aggregated GET /api/clients/:id/activity endpoint.
+function ActivityTab({ clientId }: { clientId: number }) {
+  const { data, isLoading } = useQuery<any>({
+    queryKey: ["client-activity", clientId],
+    queryFn: () => apiFetch(`/api/clients/${clientId}/activity?limit=200`),
+  });
+  const events: any[] = data?.events || [];
+  const FF2 = "'Plus Jakarta Sans', sans-serif";
+  const fmtWhen = (s: string) => (s ? new Date(s).toLocaleString("en-US", { month: "short", day: "numeric", year: "numeric", hour: "numeric", minute: "2-digit" }) : "—");
+  const META: Record<string, { label: string; color: string; bg: string }> = {
+    job_created:     { label: "Job created",    color: "#0A6E5A", bg: "#E6F8F2" },
+    job_edit:        { label: "Job edited",     color: "#1D4ED8", bg: "#EAF0FE" },
+    job_rescheduled: { label: "Rescheduled",    color: "#92400E", bg: "#FEF3C7" },
+    job_cancelled:   { label: "Cancelled",      color: "#B91C1C", bg: "#FEECEC" },
+    job_deleted:     { label: "Deleted",        color: "#7C2D12", bg: "#FBE8E0" },
+    client_edit:     { label: "Client edited",  color: "#5B21B6", bg: "#F1ECFD" },
+    client_created:  { label: "Client created", color: "#0A6E5A", bg: "#E6F8F2" },
+    communication:   { label: "Message",        color: "#374151", bg: "#F3F4F6" },
+  };
+  const label = (f: string | null) => (f ? f.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase()) : "");
+  const fmtVal = (v: any) => (v == null ? "—" : typeof v === "object" ? JSON.stringify(v) : String(v));
+  const describe = (e: any): string => {
+    const nv = e.new_value || {}, ov = e.old_value || {};
+    switch (e.event_type) {
+      case "job_edit":        return `${label(e.field_name)}: ${fmtVal(ov?.value ?? ov)} → ${fmtVal(nv?.value ?? nv)}`;
+      case "job_rescheduled": return `${label(e.field_name)}${nv.reason ? ` · ${nv.reason}` : ""}`;
+      case "job_cancelled":   return `${label(e.field_name) || "Cancelled"}${nv.reason ? ` · ${nv.reason}` : ""}${nv.charge ? ` · charged $${Number(nv.charge).toFixed(2)}` : ""}`;
+      case "job_deleted":     return `Job #${ov.job_id ?? ""}${ov.service_type ? ` · ${label(ov.service_type)}` : ""}${ov.scheduled_date ? ` · ${ov.scheduled_date}` : ""}`;
+      case "communication":   return `${nv.direction === "inbound" ? "Received" : "Sent"} ${e.field_name || ""}${nv.summary ? ` · ${nv.summary}` : nv.subject ? ` · ${nv.subject}` : ""}`;
+      case "client_edit":     return `${label(e.field_name)}: ${fmtVal(ov)} → ${fmtVal(nv)}`;
+      case "job_created":     return `Job #${e.related_job_id ?? ""} created`;
+      case "client_created":  return "Client created";
+      default:                return label(e.field_name);
+    }
+  };
+  return (
+    <div>
+      <div style={{ fontSize: 13, color: "#6B6860", marginBottom: 14, fontFamily: FF2 }}>
+        Every recorded action on this client — jobs, reschedules, cancellations, price changes, messages — with who and when.
+      </div>
+      {isLoading ? (
+        <div style={{ padding: 30, textAlign: "center", color: "#9E9B94", fontSize: 13 }}>Loading…</div>
+      ) : events.length === 0 ? (
+        <div style={{ padding: 30, textAlign: "center", color: "#9E9B94", fontSize: 13 }}>No recorded activity yet.</div>
+      ) : (
+        <div>
+          {events.map((e, i) => {
+            const m = META[e.event_type] || { label: e.event_type, color: "#374151", bg: "#F3F4F6" };
+            return (
+              <div key={i} style={{ display: "flex", gap: 12, padding: "12px 2px", borderTop: i === 0 ? "none" : "1px solid #F0EEE9" }}>
+                <span style={{ flexShrink: 0, alignSelf: "flex-start", fontSize: 11, fontWeight: 700, color: m.color, background: m.bg, borderRadius: 6, padding: "3px 9px", fontFamily: FF2, whiteSpace: "nowrap" }}>{m.label}</span>
+                <div style={{ minWidth: 0, flex: 1 }}>
+                  <div style={{ fontSize: 13, color: "#1A1917", fontFamily: FF2, wordBreak: "break-word" }}>{describe(e)}</div>
+                  <div style={{ fontSize: 11, color: "#9E9B94", marginTop: 2, fontFamily: FF2 }}>
+                    {fmtWhen(e.occurred_at)}{e.user_name ? ` · ${e.user_name}` : ""}{e.related_job_id ? ` · Job #${e.related_job_id}` : ""}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
 const PROFILE_TABS = [
   { id: "client",        label: "Client"        },
   { id: "property",      label: "Property"      },
   { id: "jobs",          label: "Jobs"          },
   { id: "admin",         label: "Admin"         },
+  { id: "activity",      label: "Activity"      },
   { id: "profitability", label: "Profitability" },
 ] as const;
 type ProfileTab = typeof PROFILE_TABS[number]["id"];
@@ -5818,6 +5888,11 @@ export default function CustomerProfilePage() {
       {/* ══════════════════════════════════════════════
           TAB 5: PROFITABILITY — owner/office only
          ══════════════════════════════════════════════ */}
+      {activeTab === "activity" && (
+        <div style={{ padding: "24px 0" }}>
+          <ActivityTab clientId={clientId} />
+        </div>
+      )}
       {activeTab === "profitability" && (
         <div style={{ padding: "24px 0" }}>
           <ProfitabilityTab clientId={clientId} />
@@ -5975,6 +6050,9 @@ export default function CustomerProfilePage() {
               <CollapsibleSection title="Portal"><PortalTab clientId={clientId} client={profile} onPortalInvite={() => apiFetch(`/api/clients/${clientId}/portal-invite`, { method: "POST" })} refetch={refetchProfile} /></CollapsibleSection>
               <CollapsibleSection title="Tech Preferences"><TechPrefsTab clientId={clientId} prefs={profile.tech_preferences || []} refetch={refetchProfile} /></CollapsibleSection>
             </>)}
+            {activeTab === "activity" && (
+              <ActivityTab clientId={clientId} />
+            )}
             {activeTab === "profitability" && (
               <ProfitabilityTab clientId={clientId} />
             )}


### PR DESCRIPTION
## Per-client Activity log — "audit all the activity within that client"

Adds an **Activity** tab on every client profile that shows **one chronological feed of all activity for that client**, each with **who did it and when**:

- Job **created / edited / rescheduled / cancelled / deleted**
- **Price changes** and **tech reassignments** (per-field, with before → after)
- **Client field edits**
- **Messages** (SMS / email / calls / notes)

### How it works
Backend `GET /api/clients/:id/activity` **aggregates the audit tables Qleno already writes** into one sorted feed — so it surfaces **historical** activity too, not just from today:

| Source | Captures |
|---|---|
| `job_audit_log` (via job → client) | per-field job edits, price changes, tech assign/remove |
| `client_audit_log` | client field edits + **job deletions** (from PR #300's `logClientActivity`) |
| `cancellation_log` | cancellations, reschedules, lockouts (+ reason/charge) |
| `communication_log` | SMS / email / calls / notes |
| `app_audit_log` (creates) | job + client creation |

Each source is independently `try/caught` (a missing table never blanks the feed), office-only, and scoped to the client + company.

### Frontend
`ActivityTab` on `customer-profile.tsx` (desktop + mobile) — color-coded event chips with before→after detail, who, when, and the related job.

This builds on the delete→client-audit cascade already merged in #300, generalizing it to a complete per-client audit trail.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_