### PR TITLE
fix(revenue): billed price wins for commercial too + exact day total

### DIFF
--- a/artifacts/api-server/src/lib/job-revenue-sql.ts
+++ b/artifacts/api-server/src/lib/job-revenue-sql.ts
@@ -16,10 +16,12 @@ export function jobRevenueExpr(fallback: SQL, jobsAlias = "j", clientsAlias = "c
   const j = sql.raw(jobsAlias);
   const c = sql.raw(clientsAlias);
   return sql`CASE
+    WHEN ${j}.billed_amount IS NOT NULL AND CAST(${j}.billed_amount AS NUMERIC) > 0
+    THEN CAST(${j}.billed_amount AS NUMERIC)
     WHEN (${j}.account_id IS NOT NULL OR ${c}.client_type = 'commercial')
          AND ${j}.hourly_rate IS NOT NULL AND ${j}.allowed_hours IS NOT NULL
          AND CAST(${j}.hourly_rate AS NUMERIC) > 0 AND CAST(${j}.allowed_hours AS NUMERIC) > 0
     THEN CAST(${j}.hourly_rate AS NUMERIC) * CAST(${j}.allowed_hours AS NUMERIC)
-    ELSE COALESCE(NULLIF(CAST(${j}.billed_amount AS NUMERIC), 0), ${fallback})
+    ELSE ${fallback}
   END`;
 }

--- a/artifacts/api-server/src/routes/dispatch.ts
+++ b/artifacts/api-server/src/routes/dispatch.ts
@@ -698,27 +698,24 @@ router.get("/", requireAuth, async (req, res) => {
         amount: (() => {
           const mods = rateModSumByJob.get(j.id) ?? 0;
           const addOns = (addOnsByJob.get(j.id) ?? []).reduce((s, a) => s + (a.subtotal ?? 0), 0);
-          // [revenue-reconciliation 2026-06-03] Commercial work bills
-          // hourly_rate × allowed_hours (matching MaidCentral), NOT a flat
-          // base_fee. allowed_hours is team-aggregated — the same total MC
-          // invoices against. This closes the variance where an imported
-          // commercial job carried a flat base_fee that didn't equal the
-          // contracted rate × hours. Fall back to base_fee only when the
-          // hourly inputs are missing (un-migrated commercial job), so
-          // nothing regresses to $0. Residential is unchanged.
+          // [revenue-billed 2026-06-04] An explicit billed price (e.g. via
+          // "Change price") is what's ACTUALLY charged and is the source of
+          // truth for EVERY job type — commercial AND residential — matching
+          // MaidCentral + the commission engine. It wins over the rate×hours /
+          // base_fee reconstructions below, so a price change on a commercial
+          // job (billed $578.40 instead of rate×hours) stops under-counting
+          // daily revenue.
+          const billed = (j as any).billed_amount != null ? parseFloat(String((j as any).billed_amount)) : null;
+          if (billed != null && billed > 0) return billed;
+          // [revenue-reconciliation 2026-06-03] No explicit billed price:
+          // commercial work bills hourly_rate × allowed_hours (matching MC),
+          // NOT a flat base_fee; fall back to base_fee only when the hourly
+          // inputs are missing. Residential uses base_fee + add-ons.
           if (isCommercialPay) {
             const rate = j.hourly_rate ? parseFloat(j.hourly_rate) : 0;
             const hrs = j.allowed_hours ? parseFloat(j.allowed_hours) : 0;
             if (rate > 0 && hrs > 0) return rate * hrs + mods + addOns;
           }
-          // [revenue-billed 2026-06-04] When the office set an explicit price
-          // (billed_amount — e.g. via "Change price"), THAT is what's actually
-          // billed and is the source of truth (matches MaidCentral and the
-          // commission engine, both of which use billed_amount || base_fee).
-          // Reconstruct from base_fee + add-ons only when no explicit price was
-          // set, so price changes stop under-counting daily revenue.
-          const billed = (j as any).billed_amount != null ? parseFloat(String((j as any).billed_amount)) : null;
-          if (billed != null && billed > 0) return billed;
           const base = j.base_fee ? parseFloat(j.base_fee) : 0;
           return base + mods + addOns;
         })(),

--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -5786,7 +5786,7 @@ export default function JobsPage() {
                 { label: `${stats.total} jobs`, color: "#1A1917", bg: "#F7F6F3" },
                 { label: `${stats.complete} done`, color: "#16A34A", bg: "#DCFCE7" },
                 ...(stats.inProgress > 0 ? [{ label: `${stats.inProgress} active`, color: "#D97706", bg: "#FEF3C7" }] : []),
-                { label: `$${stats.revenue.toFixed(0)} rev`, color: "var(--brand)", bg: "var(--brand-dim)" },
+                { label: `$${stats.revenue.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })} rev`, color: "var(--brand)", bg: "var(--brand-dim)" },
                 ...(stats.unassigned > 0 ? [{ label: `${stats.unassigned} unassigned`, color: "#DC2626", bg: "#FEE2E2" }] : []),
               ].map(s => (
                 <span key={s.label} style={{ fontSize: 11, fontWeight: 700, color: s.color, backgroundColor: s.bg, padding: "3px 8px", borderRadius: 20, whiteSpace: "nowrap" }}>{s.label}</span>
@@ -5922,7 +5922,7 @@ export default function JobsPage() {
                 <div style={{ display: "grid", gridTemplateColumns: "repeat(5, 1fr)", gap: 0, borderBottom: "1px solid #E5E2DC", backgroundColor: "#FFFFFF" }}>
                   {[
                     { label: "JOBS TODAY", value: stats.total },
-                    { label: "REVENUE TODAY", value: `$${stats.revenue.toFixed(0)}` },
+                    { label: "REVENUE TODAY", value: `$${stats.revenue.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}` },
                     { label: "UNASSIGNED", value: stats.unassigned },
                     { label: "TECHS WORKING", value: techsWorking },
                     { label: "AVG UTILIZATION", value: `${utilization}%` },


### PR DESCRIPTION
## Revenue: billed price wins for commercial too + exact day total

Your diagnosis was right. The remaining June-1 gap ($4,444.40 MC vs $4,369 Qleno = **$75.40**) came from **Richard Nitzsche — a *commercial* job**. The earlier billed-price fix only applied to *residential*; commercial revenue was computed as `hourly_rate × allowed_hours` and **ignored `billed_amount`** (his "Change price" of $578.40). So a price change didn't "connect" to revenue — exactly as you suspected.

**Fix:** the explicit **`billed_amount` now wins for *every* job type** (commercial + residential), before the rate×hours / base_fee reconstructions — in both the live dispatch `amount` and `jobRevenueExpr` (week-summary). It's the actually-charged amount and matches MaidCentral + the commission engine. `rate × hours` / `base_fee` stay as the fallback only when no billed price is set.

**Plus:** **REVENUE TODAY** and the "rev" pill now show **exact cents** ($4,444.40), so the day total matches MC precisely. Individual tiles can still round for display — that part was fine, as you said.

After deploy + hard-refresh, June-1 REVENUE TODAY should read **$4,444.40** and tie out to MaidCentral.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_