### PR TITLE
feat(dispatch): show address (incl. unit/suite/apt) on the job bar

### DIFF
--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -4075,6 +4075,18 @@ function JobChipBody({
           </div>
         </>
       )}
+      {/* [address-on-bar 2026-06-04] Address (incl. any unit/suite/apt embedded
+          in the street) on every chip — narrow + wide — so dispatch reads the
+          location off the bar. Truncates with ellipsis; full address in the
+          panel/hover. */}
+      {job.address && (
+        <div style={{ display: "flex", alignItems: "center", gap: 3, minWidth: 0 }}>
+          <MapPin size={9} style={{ color: tokens.icon, flexShrink: 0 }} />
+          <span style={{ fontSize: 9, fontWeight: 500, color: tokens.secondary, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis", flex: 1, minWidth: 0 }}>
+            {job.address}
+          </span>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Address (incl. unit/suite/apt) on the job bar

Adds the address line to **every** dispatch chip — narrow and wide — so the office reads the location right off the bar instead of opening the panel. Includes any **unit/suite/apt** that's part of the street address, and the zip (uses the canonical formatted `address` already in the dispatch payload). Truncates with ellipsis on short bars; the full address stays in the panel/hover.

Note: there's no separate unit field in Qleno today — units show when they're part of the address text. If you want a dedicated Unit/Suite field (so it always shows even when not in the street line), that's a small follow-up.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_