### PR TITLE
fix(recurring): create_recurring cascade crashed on pg Date — no future jobs generated

### DIFF
--- a/artifacts/api-server/src/lib/recurring-cadences.ts
+++ b/artifacts/api-server/src/lib/recurring-cadences.ts
@@ -31,7 +31,20 @@ export function addMonths(date: Date, months: number): Date {
   return d;
 }
 
-export function parseDate(str: string): Date {
+export function parseDate(str: string | Date): Date {
+  // Accept a JS Date as well as a "YYYY-MM-DD" string. The cadence engine
+  // is fed schedule rows from two sources: Drizzle typed selects (the
+  // `date()` column codec yields a string) and raw `tx.execute`/`db.execute`
+  // SELECTs (node-postgres' default `date` parser yields a JS Date at local
+  // midnight). The create_recurring cascade uses the raw-execute path, so a
+  // Date object reaches here — `.split` then threw `str.split is not a
+  // function`, aborting the whole transaction and silently rolling back the
+  // schedule + its fan-out. Reading the local Y/M/D components (matches how
+  // pg parses a bare `date`) normalizes both forms to a clean local-midnight
+  // Date so downstream day-of-week math is stable.
+  if (str instanceof Date) {
+    return new Date(str.getFullYear(), str.getMonth(), str.getDate());
+  }
   const [y, m, d] = str.split("-").map(Number);
   return new Date(y, m - 1, d);
 }
@@ -83,8 +96,9 @@ export interface CadenceInput {
   days_of_week?: number[] | null;
   days_of_month?: number[] | null;
   custom_frequency_weeks?: number | null;
-  start_date: string;
-  end_date?: string | null;
+  // string from a Drizzle typed select; Date from a raw pg `date` column.
+  start_date: string | Date;
+  end_date?: string | Date | null;
 }
 
 export function generateCadenceDates(

--- a/artifacts/api-server/src/lib/recurring-jobs.ts
+++ b/artifacts/api-server/src/lib/recurring-jobs.ts
@@ -234,8 +234,8 @@ export function generateOccurrences(
     days_of_week?: number[] | null;
     days_of_month?: number[] | null;
     custom_frequency_weeks?: number | null;
-    start_date: string;
-    end_date?: string | null;
+    start_date: string | Date;
+    end_date?: string | Date | null;
   },
   fromDate: Date,
   toDate: Date
@@ -258,8 +258,9 @@ type ScheduleInput = {
   // 0 = "last day of month" — engine resolves per-month.
   days_of_month?: number[] | null;
   custom_frequency_weeks?: number | null;
-  start_date: string;
-  end_date?: string | null;
+  // string from a Drizzle typed select; Date from a raw pg `date` column.
+  start_date: string | Date;
+  end_date?: string | Date | null;
   assigned_employee_id: number | null;
   service_type: string | null;
   // Time-of-day for the recurring visit ("HH:MM:SS"). Stamped onto each

--- a/artifacts/api-server/src/routes/jobs.ts
+++ b/artifacts/api-server/src/routes/jobs.ts
@@ -1708,8 +1708,23 @@ router.patch("/:id", requireAuth, async (req, res) => {
         let cascadeInserted = 0;
         let cascadeSkippedLocked = 0;
 
+        // The anchor job IS the first occurrence — it already carries the
+        // schedule's settings and was linked above. The cadence window
+        // includes its date, so without this guard the loop would query
+        // existing jobs at that date EXCLUDING the anchor (`j.id != jobId`),
+        // see "no other job," and INSERT a duplicate of the anchor on the
+        // same day. Normalize the anchor's date (before.scheduled_date is a
+        // raw pg Date; scheduled_date from the payload is a string) and skip
+        // it so we never self-duplicate.
+        const anchorDateStr = scheduled_date !== undefined
+          ? String(scheduled_date)
+          : (before.scheduled_date instanceof Date
+              ? `${before.scheduled_date.getFullYear()}-${String(before.scheduled_date.getMonth() + 1).padStart(2, "0")}-${String(before.scheduled_date.getDate()).padStart(2, "0")}`
+              : String(before.scheduled_date));
+
         for (const row of candidateRows) {
           const dateStr = String(row.scheduled_date);
+          if (dateStr === anchorDateStr) continue;
           const date = new Date(`${dateStr}T00:00:00`);
 
           // Find existing jobs at this date for this client EXCEPT the

--- a/artifacts/api-server/src/tests/recurring-engine-cadences.test.ts
+++ b/artifacts/api-server/src/tests/recurring-engine-cadences.test.ts
@@ -284,3 +284,40 @@ describe("Recurring engine — start_date and end_date boundaries", () => {
     }
   });
 });
+
+describe("Recurring engine — Date-object start/end inputs (cascade path)", () => {
+  // The create_recurring cascade (PATCH /api/jobs/:id) reads the schedule via
+  // raw `tx.execute`, where node-postgres returns a `date` column as a JS Date
+  // object — not a "YYYY-MM-DD" string. parseDate() previously called
+  // `.split("-")` unconditionally and threw `str.split is not a function`,
+  // aborting the whole transaction so the schedule saved-then-rolled-back with
+  // zero future jobs and no visible error. These guard that regression.
+  it("accepts a Date object for start_date without throwing", () => {
+    const dates = generateOccurrences(
+      mkSchedule({ frequency: "weekly", day_of_week: "wednesday", start_date: new Date(2026, 5, 3) as any }),
+      WINDOW_START, WINDOW_END,
+    );
+    assert.ok(dates.length >= 12, `Expected ≥12 Wednesdays from a Date start_date, got ${dates.length}`);
+    for (const d of dates) assert.equal(dowOf(d), "Wed");
+  });
+
+  it("matches the string result when start_date is the equivalent Date object", () => {
+    const fromStr = generateOccurrences(
+      mkSchedule({ frequency: "weekly", day_of_week: "monday", start_date: "2026-06-15" }),
+      WINDOW_START, WINDOW_END,
+    ).map(isoOf);
+    const fromDate = generateOccurrences(
+      mkSchedule({ frequency: "weekly", day_of_week: "monday", start_date: new Date(2026, 5, 15) as any }),
+      WINDOW_START, WINDOW_END,
+    ).map(isoOf);
+    assert.deepEqual(fromDate, fromStr);
+  });
+
+  it("accepts a Date object for end_date", () => {
+    const dates = generateOccurrences(
+      mkSchedule({ frequency: "weekly", day_of_week: "monday", start_date: "2026-06-01", end_date: new Date(2026, 5, 30) as any }),
+      WINDOW_START, WINDOW_END,
+    );
+    for (const d of dates) assert.ok(d <= new Date(2026, 5, 30), `${isoOf(d)} is after end_date`);
+  });
+});

--- a/artifacts/qleno/src/components/edit-job-modal.tsx
+++ b/artifacts/qleno/src/components/edit-job-modal.tsx
@@ -1183,6 +1183,21 @@ export default function EditJobModal({
       if (d.cascade?.schedule_updated) summaryParts.push("Schedule updated.");
       const futureN = Number(d.cascade?.future_jobs_updated ?? 0);
       if (futureN > 0) summaryParts.push(`${futureN} future job${futureN === 1 ? "" : "s"} reflect new times.`);
+      // [recurring-fix] create_recurring path — the operator just converted a
+      // one-off into a recurring schedule. Make the fan-out result explicit so
+      // "I set a cadence and nothing happened" can never recur silently: report
+      // newly-scheduled visits, in-place updates of existing imported jobs, and
+      // any locked (paid/completed) occurrences that were left untouched.
+      if (d.cascade?.create_recurring) {
+        const cr = d.cascade.create_recurring;
+        const inserted = Number(cr.jobs_inserted ?? 0);
+        const overwritten = Number(cr.jobs_overwritten ?? 0);
+        const lockedSkipped = Number(cr.jobs_skipped_locked ?? 0);
+        if (inserted > 0) summaryParts.push(`Scheduled ${inserted} upcoming visit${inserted === 1 ? "" : "s"}.`);
+        if (overwritten > 0) summaryParts.push(`${overwritten} existing job${overwritten === 1 ? "" : "s"} updated to match.`);
+        if (inserted === 0 && overwritten === 0) summaryParts.push("Recurring schedule created.");
+        if (lockedSkipped > 0) summaryParts.push(`${lockedSkipped} paid/completed visit${lockedSkipped === 1 ? "" : "s"} left untouched.`);
+      }
       if (d.cascade?.anchor_protected) {
         const fields: string[] = Array.isArray(d.cascade?.anchor_skipped_fields) ? d.cascade.anchor_skipped_fields : [];
         const fieldList = fields.length > 0 ? ` (${fields.join(", ")} stayed frozen)` : "";


### PR DESCRIPTION
## The bug Maribel hit

Setting a recurring cadence on a one-off job (commercial **or** residential) saved the schedule but generated **no future jobs**, and showed **no error** — "I set the cadence and nothing happened."

## Root cause

The `create_recurring` cascade in `PATCH /api/jobs/:id` reads the just-inserted `recurring_schedules` row via a **raw `tx.execute` SELECT**. node-postgres returns a `date` column as a **JS `Date` object**, not a `"YYYY-MM-DD"` string. The cadence engine's `parseDate()` called `.split("-")` unconditionally and threw:

```
TypeError: str.split is not a function
```

Confirmed empirically against the real engine — a `Date` start_date throws, a string works. That throw aborted the entire transaction, **rolling back the schedule INSERT and its fan-out together**, which is exactly why the operator saw "saved, but no future jobs, no error" (the modal didn't surface the 500, and the schedule never actually persisted).

The nightly engine path was unaffected because it reads schedules via a Drizzle typed select (the `date()` codec yields a string).

## Fixes

- **`parseDate()` accepts `Date | string`** — normalizes a pg `Date` via its local Y/M/D components (matches how pg parses a bare `date`). Protects every cadence caller, not just this path. `CadenceInput` / `ScheduleInput` widened to `string | Date`.
- **Anchor-date guard** in the cascade loop. The anchor job *is* the first occurrence, but the existing-jobs query excludes it (`j.id != jobId`), so once the crash was fixed the loop would treat the anchor's date as an empty day and **INSERT a duplicate** of the anchor. Now we skip the anchor's date.
- **Surface the fan-out result** in the edit-job modal toast — "Scheduled N upcoming visits." / "N existing jobs updated to match." / paid-or-completed left-untouched count — so a silent zero-generation can never recur unnoticed.
- **Regression tests** added: `Date`-object `start_date`/`end_date` no longer throw and produce identical output to the string form. Full suite: 20/20 pass.

## Test

```
npx tsx --test src/tests/recurring-engine-cadences.test.ts
# tests 20 / pass 20 / fail 0
```

## Follow-up (not in this PR)

For clients who already have imported MaidCentral jobs occupying future dates, the cascade now overwrites those in place (0 new inserts) and the toast reports that honestly. If the desired behavior is to also backfill gaps beyond the imported horizon, that's a separate enhancement — flag if wanted.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_