### PR TITLE
fix(quotes): add-on time flows into the booked job's allowed hours

### DIFF
--- a/artifacts/api-server/src/routes/quotes.ts
+++ b/artifacts/api-server/src/routes/quotes.ts
@@ -350,11 +350,16 @@ router.post("/:id/convert", requireAuth, requireRole("owner", "admin", "office")
     };
     const jobFreq = FREQ_MAP[freqRaw] || "on_demand";
 
+    // [addon-hours 2026-06-04] Carry the quote's estimated hours (which now
+    // include add-on time-adds) onto the job as BOTH allowed_hours and
+    // estimated_hours. Previously the convert wrote neither, so every
+    // quote-booked job landed with NULL allowed_hours — the dispatch Gantt
+    // rendered a flat default block and the add-on time never showed up.
     const jobResult = await db.execute(sql`
       INSERT INTO jobs (
         company_id, client_id, scheduled_date, scheduled_time,
         service_type, base_fee, status, assigned_user_id,
-        frequency, notes, created_at
+        frequency, notes, allowed_hours, estimated_hours, created_at
       ) VALUES (
         ${companyId},
         ${q.client_id || null},
@@ -366,6 +371,8 @@ router.post("/:id/convert", requireAuth, requireRole("owner", "admin", "office")
         ${assigned_user_id || null},
         ${sql.raw(`'${jobFreq}'::frequency`)},
         ${q.internal_memo || null},
+        ${q.estimated_hours || null},
+        ${q.estimated_hours || null},
         NOW()
       ) RETURNING id
     `);

--- a/artifacts/qleno/src/pages/quote-builder.tsx
+++ b/artifacts/qleno/src/pages/quote-builder.tsx
@@ -780,7 +780,11 @@ export default function QuoteBuilderPage() {
       addons_total: cr ? String(cr.addons_total) : "0",
       discount_amount: cr ? String(cr.discount_amount) : "0",
       total_price: quickBookPrice != null ? String(quickBookPrice) : (cr ? String(cr.final_total) : null),
-      estimated_hours: cr ? String(cr.base_hours) : primaryScopeState?.hours ? String(primaryScopeState.hours) : null,
+      // [addon-hours 2026-06-04] Persist TOTAL hours (base + add-on time-adds)
+      // so Hourly/Time-Add add-ons (Oven, Cabinets, Basement, etc.) flow into
+      // the booked job's allowed hours. Was base_hours, which silently dropped
+      // every add-on's time — the job came out under-budgeted on the schedule.
+      estimated_hours: cr ? String(cr.total_hours ?? cr.base_hours) : primaryScopeState?.hours ? String(primaryScopeState.hours) : null,
       hourly_rate: cr ? String(cr.hourly_rate) : null,
       notes: notes || null,
       internal_memo: internalMemo || null,


### PR DESCRIPTION
## What Maribel hit

In the quote builder, checking a time-add add-on (Oven, Cabinets, **Clean Basement**, etc.) didn't move the **allowed hours** on the booked job — so jobs came out under-budgeted on the schedule.

## Root cause — two gaps

1. **Quote save dropped add-on time.** The quote persisted `estimated_hours` from `base_hours`, ignoring the add-on time-adds — even though the calc engine already returns `total_hours = base + add-on minutes` and the summary's "Est. hours" line already displays it.
2. **Convert wrote no hours at all.** `POST /api/quotes/:id/convert` created the job without `allowed_hours` *or* `estimated_hours`, so every quote-booked job landed with **NULL allowed_hours** → the dispatch Gantt drew a flat default block and the add-on time never appeared.

## Fix

- Quote save now persists **`total_hours`** (base + add-on time).
- Convert now carries the quote's `estimated_hours` onto the job as **both `allowed_hours` and `estimated_hours`**.

Net: add-on time flows quote → job → schedule, and (for commercial) into the rate × hours revenue from #309.

## One caveat worth knowing

Some add-ons have their **"time add minutes" set to 0** on purpose — the `(Hourly)`-scope variants were intentionally zeroed (on an hourly scope you bill time directly, so the add-on shouldn't double-count it). Those add **no** time by design. If a *flat-scope* add-on (like Clean Basement on a Deep Clean) should extend hours but doesn't after this PR, its `time_add_minutes` is 0 in the add-on settings — tell me which add-on and I'll check/set it. I couldn't inspect the live add-on config from here.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_