### PR TITLE
feat(jobs): prompt how far an address change cascades to future jobs

### DIFF
--- a/artifacts/api-server/src/routes/jobs.ts
+++ b/artifacts/api-server/src/routes/jobs.ts
@@ -4035,9 +4035,19 @@ router.patch("/:id/address", requireAuth, async (req, res) => {
     const jobId = parseInt(req.params.id);
     const companyId = req.auth!.companyId!;
     const userId = req.auth!.userId!;
-    const { address, city, state, zip, mode: requestedMode } = (req.body ?? {}) as {
+    const { address, city, state, zip, mode: requestedMode, cascade_future, preview } = (req.body ?? {}) as {
       address?: string; city?: string; state?: string; zip?: string;
       mode?: "client" | "job";
+      // [address-cascade 2026-06-04] How far an "apply to all future" change
+      // reaches into jobs already on the calendar. The office picks this via a
+      // prompt (Sal's call). "all" = every upcoming job that carries its own
+      // saved address; "matching" = only those still at the OLD client address
+      // (leaves deliberate one-off sites alone); "none" = client record only,
+      // upcoming jobs without an override inherit it automatically.
+      cascade_future?: "none" | "matching" | "all";
+      // When true, don't write anything — return how many upcoming jobs would
+      // be affected so the frontend can render the cascade prompt.
+      preview?: boolean;
     };
 
     if (!address || !address.trim()) {
@@ -4058,6 +4068,40 @@ router.patch("/:id/address", requireAuth, async (req, res) => {
     `);
     if (!ctx.rows.length) return res.status(404).json({ error: "Job not found" });
     const r = ctx.rows[0] as any;
+
+    // [address-cascade 2026-06-04] Preview: count UPCOMING jobs for this client
+    // (excluding the one being edited) that carry their OWN saved address —
+    // those are the only ones a client-level change won't fix automatically.
+    // Split into "same" (still at the old client address — safe to move) vs
+    // "different" (a deliberate one-off site). Jobs without an override aren't
+    // counted: they inherit the client address the moment it changes.
+    if (preview === true) {
+      const counts = await db.execute(sql`
+        SELECT
+          COUNT(*) FILTER (WHERE has_override)                AS override_total,
+          COUNT(*) FILTER (WHERE has_override AND is_same)    AS same_count,
+          COUNT(*) FILTER (WHERE has_override AND NOT is_same) AS diff_count
+        FROM (
+          SELECT
+            (j.address_street IS NOT NULL AND btrim(j.address_street) <> '') AS has_override,
+            (lower(btrim(coalesce(j.address_street, ''))) = lower(btrim(coalesce(${r.c_addr ?? ""}, '')))
+             AND coalesce(j.address_zip, '') = coalesce(${r.c_zip ?? ""}, '')) AS is_same
+          FROM jobs j
+          WHERE j.company_id = ${companyId}
+            AND j.client_id = ${r.client_id}
+            AND j.id <> ${jobId}
+            AND j.scheduled_date >= CURRENT_DATE
+            AND j.status IN ('scheduled', 'in_progress')
+        ) t
+      `);
+      const c = (counts.rows[0] as any) ?? {};
+      return res.json({
+        preview: true,
+        future_override_total: Number(c.override_total ?? 0),
+        future_same: Number(c.same_count ?? 0),
+        future_different: Number(c.diff_count ?? 0),
+      });
+    }
 
     // Mode resolution. Frontend now sends an explicit mode (the popover's
     // "permanent change" checkbox controls it: unchecked = job, checked =
@@ -4108,6 +4152,14 @@ router.patch("/:id/address", requireAuth, async (req, res) => {
       });
     }
 
+    // Cascade scope only applies to a client-level change. Defaults to "none"
+    // (existing behavior) for any caller that doesn't send it.
+    const scope: "none" | "matching" | "all" =
+      (mode === "client" && (cascade_future === "all" || cascade_future === "matching"))
+        ? cascade_future
+        : "none";
+    let cascadedCount = 0;
+
     const before = {
       mode,
       address: r.j_addr ?? r.c_addr ?? null,
@@ -4150,6 +4202,38 @@ router.patch("/:id/address", requireAuth, async (req, res) => {
           UPDATE jobs SET zone_id = ${newZoneId}
           WHERE id = ${jobId} AND company_id = ${companyId}
         `);
+
+        // [address-cascade 2026-06-04] Rewrite the address on upcoming jobs
+        // that carry their OWN saved address, per the scope the office chose
+        // in the prompt. Jobs without an override already inherit the client
+        // change above, so they're untouched. "matching" leaves deliberate
+        // one-off sites (different from the old client address) alone.
+        if (scope === "all" || scope === "matching") {
+          const sameOnly = scope === "matching"
+            ? sql`AND lower(btrim(coalesce(address_street, ''))) = lower(btrim(coalesce(${r.c_addr ?? ""}, '')))
+                  AND coalesce(address_zip, '') = coalesce(${r.c_zip ?? ""}, '')`
+            : sql``;
+          const cascaded = await tx.execute(sql`
+            UPDATE jobs SET
+              address_street   = ${address},
+              address_city     = ${city ?? null},
+              address_state    = ${state ?? null},
+              address_zip      = ${zip ?? null},
+              address_lat      = ${String(coords.lat)},
+              address_lng      = ${String(coords.lng)},
+              address_verified = true,
+              zone_id          = ${newZoneId}
+            WHERE company_id = ${companyId}
+              AND client_id = ${r.client_id}
+              AND id <> ${jobId}
+              AND scheduled_date >= CURRENT_DATE
+              AND status IN ('scheduled', 'in_progress')
+              AND address_street IS NOT NULL AND btrim(address_street) <> ''
+              ${sameOnly}
+            RETURNING id
+          `);
+          cascadedCount = cascaded.rows.length;
+        }
       }
 
       // Audit row.
@@ -4164,6 +4248,8 @@ router.patch("/:id/address", requireAuth, async (req, res) => {
         address, city: city ?? null, state: state ?? null, zip: zip ?? null,
         zone_id: newZoneId,
         lat: String(coords.lat), lng: String(coords.lng),
+        cascade_future: scope,
+        cascaded_jobs: cascadedCount,
       };
       await tx.execute(sql`
         INSERT INTO job_audit_log
@@ -4184,6 +4270,8 @@ router.patch("/:id/address", requireAuth, async (req, res) => {
         address, city, state, zip,
         lat: coords.lat, lng: coords.lng,
         zone_id: newZoneId,
+        cascade_future: scope,
+        cascaded_jobs: cascadedCount,
       },
     });
   } catch (err) {

--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -517,6 +517,10 @@ function InlineAddressEdit({ job, onUpdate }: { job: DispatchJob; onUpdate: () =
     lat: number; lng: number; formatted: string;
   } | null>(null);
   const [permanent, setPermanent] = useState(false);
+  // [address-cascade 2026-06-04] When "apply to all future" is checked and the
+  // client has upcoming jobs with their own saved address, we ask how far to
+  // cascade instead of guessing. Null = no prompt showing.
+  const [cascadePrompt, setCascadePrompt] = useState<{ total: number; same: number; diff: number } | null>(null);
 
   const inputRef = useRef<HTMLInputElement | null>(null);
 
@@ -614,24 +618,51 @@ function InlineAddressEdit({ job, onUpdate }: { job: DispatchJob; onUpdate: () =
     setPickedAddress(null);
     setError(null);
     setPermanent(false);
+    setCascadePrompt(null);
     setEditing(true);
   }
   function cancel() {
     setPickedAddress(null);
     setError(null);
     setPermanent(false);
+    setCascadePrompt(null);
     setEditing(false);
   }
 
+  // Click "Save". For a one-time (job) change, just write it. For a permanent
+  // (client) change, first check how many upcoming jobs carry their own saved
+  // address — if any, ask how far to cascade before writing.
   async function save() {
     if (!pickedAddress) {
       setError("Pick an address from the suggestions.");
       return;
     }
-    // Resolve the effective mode. If the client has no address on file
-    // (NULL/empty), the server will auto-cascade to client mode regardless
-    // of this flag; we still send the user's intent so audit log is honest.
-    const requestedMode: "client" | "job" = permanent ? "client" : "job";
+    if (!permanent) { await doSave("job", "none"); return; }
+    setSaving(true);
+    setError(null);
+    try {
+      const r = await fetch(`${API}/api/jobs/${job.id}/address`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ address: pickedAddress.address, city: pickedAddress.city, state: pickedAddress.state, zip: pickedAddress.zip, mode: "client", preview: true }),
+      });
+      const body = await r.json().catch(() => ({} as any));
+      const total = Number(body?.future_override_total ?? 0);
+      if (total > 0) {
+        setSaving(false);
+        setCascadePrompt({ total, same: Number(body?.future_same ?? 0), diff: Number(body?.future_different ?? 0) });
+        return;
+      }
+      // No upcoming jobs with their own address — nothing to ask.
+      await doSave("client", "none");
+    } catch (e: any) {
+      setError(e.message || "Network error.");
+      setSaving(false);
+    }
+  }
+
+  async function doSave(mode: "client" | "job", cascade: "none" | "matching" | "all") {
+    if (!pickedAddress) return;
     setSaving(true);
     setError(null);
     try {
@@ -643,7 +674,8 @@ function InlineAddressEdit({ job, onUpdate }: { job: DispatchJob; onUpdate: () =
           city:    pickedAddress.city,
           state:   pickedAddress.state,
           zip:     pickedAddress.zip,
-          mode:    requestedMode,
+          mode,
+          cascade_future: cascade,
         }),
       });
       if (!r.ok) {
@@ -652,20 +684,21 @@ function InlineAddressEdit({ job, onUpdate }: { job: DispatchJob; onUpdate: () =
         setSaving(false);
         return;
       }
-      // Server may have upgraded our requested mode to "client" if the
-      // client had no address on file. Read the response to surface the
-      // accurate result in the toast.
       const body = await r.json().catch(() => ({} as any));
-      const effectiveMode = body?.data?.mode ?? requestedMode;
+      const effectiveMode = body?.data?.mode ?? mode;
+      const cascaded = Number(body?.data?.cascaded_jobs ?? 0);
       toast({
         title: "Address updated",
         description: effectiveMode === "client"
-          ? "Applied to this client and all future jobs."
+          ? (cascaded > 0
+              ? `Applied to this client and ${cascaded} upcoming job${cascaded === 1 ? "" : "s"}.`
+              : "Applied to this client and all future jobs.")
           : "Applied as a one-time override for this job only.",
       });
       setEditing(false);
       setPickedAddress(null);
       setPermanent(false);
+      setCascadePrompt(null);
       onUpdate();
     } catch (e: any) {
       setError(e.message || "Network error.");
@@ -770,31 +803,68 @@ function InlineAddressEdit({ job, onUpdate }: { job: DispatchJob; onUpdate: () =
             {error}
           </div>
         )}
-        <div style={{ display: "flex", gap: 8 }}>
-          <button
-            onClick={save}
-            disabled={saving || !pickedAddress}
-            style={{
-              fontSize: 12, fontWeight: 700, color: "#FFFFFF",
-              background: (saving || !pickedAddress) ? "#9CA3AF" : "#2D9B83",
-              border: "none", borderRadius: 6, padding: "6px 14px",
-              cursor: (saving || !pickedAddress) ? "not-allowed" : "pointer", fontFamily: FF,
-            }}
-          >
-            {saving ? "Saving…" : "Save"}
-          </button>
-          <button
-            onClick={cancel}
-            disabled={saving}
-            style={{
-              fontSize: 12, fontWeight: 600, color: "#6B6860",
-              background: "transparent", border: "1px solid #E5E2DC",
-              borderRadius: 6, padding: "6px 14px", cursor: "pointer", fontFamily: FF,
-            }}
-          >
-            Cancel
-          </button>
-        </div>
+        {cascadePrompt ? (
+          /* [address-cascade] Ask how far the permanent change reaches into
+             jobs already on the calendar. Jobs without their own saved
+             address inherit the client change automatically and aren't
+             counted here. */
+          <div style={{ background: "#F0FDF4", border: "1px solid #BBF7D0", borderRadius: 6, padding: "10px 12px", display: "flex", flexDirection: "column", gap: 4 }}>
+            <div style={{ fontSize: 12, fontWeight: 700, color: "#1A1917" }}>
+              {cascadePrompt.total} upcoming job{cascadePrompt.total === 1 ? "" : "s"} {cascadePrompt.total === 1 ? "has" : "have"} their own saved address.
+            </div>
+            <div style={{ fontSize: 11, color: "#4B5563", lineHeight: 1.4 }}>
+              {cascadePrompt.diff > 0
+                ? `${cascadePrompt.diff} ${cascadePrompt.diff === 1 ? "is" : "are"} at a different address than the current one. Update them to the new address too?`
+                : "Update those to the new address as well?"}
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 6, marginTop: 6 }}>
+              <button onClick={() => doSave("client", "all")} disabled={saving}
+                style={{ fontSize: 12, fontWeight: 700, color: "#FFFFFF", background: saving ? "#9CA3AF" : "#2D9B83", border: "none", borderRadius: 6, padding: "7px 12px", cursor: saving ? "not-allowed" : "pointer", fontFamily: FF, textAlign: "left" }}>
+                {saving ? "Saving…" : `Update all ${cascadePrompt.total} upcoming job${cascadePrompt.total === 1 ? "" : "s"}`}
+              </button>
+              {cascadePrompt.diff > 0 && cascadePrompt.same > 0 && (
+                <button onClick={() => doSave("client", "matching")} disabled={saving}
+                  style={{ fontSize: 12, fontWeight: 600, color: "#2D9B83", background: "#FFFFFF", border: "1px solid #A7F3D0", borderRadius: 6, padding: "7px 12px", cursor: saving ? "not-allowed" : "pointer", fontFamily: FF, textAlign: "left" }}>
+                  Update only the {cascadePrompt.same} at the old address (leave the {cascadePrompt.diff} different)
+                </button>
+              )}
+              <button onClick={() => doSave("client", "none")} disabled={saving}
+                style={{ fontSize: 12, fontWeight: 600, color: "#6B6860", background: "#FFFFFF", border: "1px solid #E5E2DC", borderRadius: 6, padding: "7px 12px", cursor: saving ? "not-allowed" : "pointer", fontFamily: FF, textAlign: "left" }}>
+                Just the client record — leave upcoming jobs as they are
+              </button>
+              <button onClick={() => setCascadePrompt(null)} disabled={saving}
+                style={{ fontSize: 11, fontWeight: 600, color: "#9E9B94", background: "transparent", border: "none", cursor: "pointer", fontFamily: FF, alignSelf: "flex-start", padding: "2px 0" }}>
+                ← Back
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div style={{ display: "flex", gap: 8 }}>
+            <button
+              onClick={save}
+              disabled={saving || !pickedAddress}
+              style={{
+                fontSize: 12, fontWeight: 700, color: "#FFFFFF",
+                background: (saving || !pickedAddress) ? "#9CA3AF" : "#2D9B83",
+                border: "none", borderRadius: 6, padding: "6px 14px",
+                cursor: (saving || !pickedAddress) ? "not-allowed" : "pointer", fontFamily: FF,
+              }}
+            >
+              {saving ? "Saving…" : "Save"}
+            </button>
+            <button
+              onClick={cancel}
+              disabled={saving}
+              style={{
+                fontSize: 12, fontWeight: 600, color: "#6B6860",
+                background: "transparent", border: "1px solid #E5E2DC",
+                borderRadius: 6, padding: "6px 14px", cursor: "pointer", fontFamily: FF,
+              }}
+            >
+              Cancel
+            </button>
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Context

Changing a booked job's address already worked (the **Edit** link next to the address — Google-verified, re-zones, audited). The "Save permanently for this client → apply to all future jobs" option updated the **client record**, but **upcoming jobs that carry their own saved address kept pointing at the old place** — so "apply to all future jobs" wasn't fully true.

You said a prompt should ask rather than bake in a rule. This does that.

## What changed

**Backend — `PATCH /api/jobs/:id/address`**
- New **`preview`** mode: counts upcoming jobs for the client that have their **own saved address**, split into **same** (still at the old client address) vs **different** (a deliberate one-off site). Jobs *without* their own address aren't counted — they inherit the client change automatically.
- New **`cascade_future`** scope on apply:
  - `all` — rewrite every upcoming job with its own address
  - `matching` — only the ones still at the old client address (leaves deliberate different-address visits alone)
  - `none` — client record only (existing behavior)
- The **audit row** now records the chosen scope and how many jobs were rewritten.

**Frontend — the address popover**
- Checking "apply to all future" now fetches the preview. If upcoming jobs would be affected, it shows a **prompt**:
  - *Update all N upcoming jobs*
  - *Update only the M at the old address (leave the K different)* — only when some differ
  - *Just the client record — leave upcoming jobs as they are*
- The success toast reports how many upcoming jobs were updated.

If there are no upcoming jobs with their own address, there's nothing to ask and it just saves (client + inheriting jobs), exactly as before.

## Scope notes
- Only the **dispatch panel** address editor gets the prompt; the customer-profile copy is untouched.
- Past/completed jobs are never changed. Matching is case/whitespace-insensitive on street + zip.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_