### PR TITLE
fix(timeclock): stamp estimated clock entries in Central time, not UTC

### DIFF
--- a/artifacts/api-server/src/routes/jobs.ts
+++ b/artifacts/api-server/src/routes/jobs.ts
@@ -2989,7 +2989,17 @@ router.post("/:id/complete", requireAuth, async (req, res) => {
     // activity (typical for MaidCentral imports and one-tap "Mark complete"
     // workflows where the operator never ran the field-app timer), stamp
     // an estimated clock pair for each assigned tech so the payroll
-    // report has hours to sum. Real punches always win — this only fires
+    // report has hours to sum.
+    //
+    // [PRODUCT INTENT 2026-06-04] FOR NOW — until Phes manages all clocks
+    // inside Qleno — the daily clocks are meant to MATCH the assigned job
+    // times. That's exactly what this estimate does (clock_in = scheduled
+    // start, clock_out = scheduled start + allowed_hours, in Central time),
+    // so it is deliberate, not a stopgap to rip out. Do NOT remove this
+    // fallback or decouple it from the scheduled time until real field-app
+    // punches are the source of truth for the whole fleet.
+    //
+    // Real punches always win — this only fires
     // when ZERO timeclock rows exist for this job; future real punches
     // would just create new rows that the payroll engine prefers via
     // ORDER BY source='punched' DESC if/when we add the tiebreaker.

--- a/artifacts/api-server/src/routes/jobs.ts
+++ b/artifacts/api-server/src/routes/jobs.ts
@@ -3026,6 +3026,15 @@ router.post("/:id/complete", requireAuth, async (req, res) => {
             (completedJob.allowed_hours != null && parseFloat(String(completedJob.allowed_hours)) > 0)
               ? Math.round(parseFloat(String(completedJob.allowed_hours)) * 60)
               : 120;
+          // [BUG 2026-06-04] scheduled_time is a Central (America/Chicago) wall
+          // time. Building the stamp as a naive `date + time` and letting it
+          // land in a `timestamp` column treats that wall time as UTC, so the
+          // round-trip renders it shifted by the Chicago offset (a 6:00 AM job
+          // showed a 1:00 AM clock-in). Anchor the wall time to Chicago, then
+          // express it in UTC for storage — session-timezone independent and
+          // consistent with the AT TIME ZONE pattern used elsewhere. Single-tz
+          // tenant (Phes); multi-tenant later should derive the zone per branch.
+          const clockIn = sql`(((${schedDate}::date + ${schedTime}::time) AT TIME ZONE 'America/Chicago') AT TIME ZONE 'UTC')`;
           for (const uid of techIds) {
             await db.execute(sql`
               INSERT INTO timeclock (
@@ -3034,8 +3043,8 @@ router.post("/:id/complete", requireAuth, async (req, res) => {
               ) VALUES (
                 ${jobId}, ${uid}, ${req.auth!.companyId},
                 ${completedJob.branch_id ?? null},
-                (${schedDate}::date + ${schedTime}::time),
-                (${schedDate}::date + ${schedTime}::time) + (${durationMinutes} || ' minutes')::interval,
+                ${clockIn},
+                ${clockIn} + (${durationMinutes} || ' minutes')::interval,
                 'estimated', false
               )
             `);


### PR DESCRIPTION
## Intent (per Sal, 2026-06-04)

**FOR NOW — until Phes manages all clocks inside Qleno — the daily clocks should MATCH the assigned job times.** This PR makes that true: the estimated clock is stamped as **scheduled start → scheduled start + allowed_hours, in Central time**, so the clock mirrors the job's assigned block (Jaira: 6:00 AM – 2:00 PM). A code comment now records this as deliberate so a future change doesn't decouple the estimate from the schedule before real field-app punches take over fleet-wide.

## The bug (Jaira Estrada, National Able Network, June 1)

The panel showed **Clock in 1:00 AM / Clock out 9:00 AM** for a commercial cleaning — and `Actual 8.0h` was *derived* from that bad span (so it happened to match `Allowed 8.0h`, variance 0). The Gantt bar correctly sits at **6:00 AM**, but the clock didn't match it.

### Root cause
That job had no real field-app punches (commercial, completed via one-tap), so the **synthetic-clock fallback** stamped an estimated entry. It built the timestamp as:

```sql
(scheduled_date::date + scheduled_time::time)   -- naive timestamp
```

`scheduled_time` is an **America/Chicago wall time** (6:00 AM). But:
- the column is `timestamp without time zone` (Drizzle default), and
- the Railway Node process runs in **UTC** (no `TZ` set, no pg type-parser override),

so a naive `06:00` round-trips as if it were `06:00Z`, then renders in Central as **1:00 AM** (−5h). Clock-out = +8h allowed → 2 PM UTC → **9:00 AM** Central. That's exactly the 1 AM → 9 AM you saw.

### Fix
Anchor the wall time to Chicago, then store it as the correct UTC instant — session-timezone independent and matching the `AT TIME ZONE 'America/Chicago'` pattern already used in `dashboard.ts`:

```sql
((scheduled_date::date + scheduled_time::time) AT TIME ZONE 'America/Chicago') AT TIME ZONE 'UTC'
```

Going forward, a 6:00 AM job stamps a **6:00 AM – 2:00 PM** estimated clock — matching the assigned job time.

## Historical rows
Per Sal: **leave existing estimated rows as-is.** Fix applies to new completions only. (A scoped, idempotent corrective UPDATE is available if that changes — touches only `source='estimated'` rows, never real punches.)

## Scope notes
- Only the synthetic/estimated fallback is affected — real field-app punches store a true instant and are correct.
- Display code renders in the viewer's local timezone; left as-is (all-Central Phes staff), per Sal.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj