### PR TITLE
fix(dispatch): show dispatch dollars to the cent, not rounded

### DIFF
--- a/artifacts/qleno/src/lib/price-delta.test.ts
+++ b/artifacts/qleno/src/lib/price-delta.test.ts
@@ -14,7 +14,7 @@ test("Case A: billed_amount is null → no delta, price shows base_fee", () => {
     billingMethod: null,
   });
   assert.equal(r.deltaAmount, null);
-  assert.equal(r.display, "$250");
+  assert.equal(r.display, "$250.00");
 });
 
 test("Case A (undefined billed): no delta, price shows base_fee", () => {
@@ -25,7 +25,7 @@ test("Case A (undefined billed): no delta, price shows base_fee", () => {
     billingMethod: null,
   });
   assert.equal(r.deltaAmount, null);
-  assert.equal(r.display, "$180");
+  assert.equal(r.display, "$180.00");
 });
 
 test("Case B: billed_amount === base_fee → no delta, price shows base_fee", () => {
@@ -36,7 +36,7 @@ test("Case B: billed_amount === base_fee → no delta, price shows base_fee", ()
     billingMethod: null,
   });
   assert.equal(r.deltaAmount, null);
-  assert.equal(r.display, "$200");
+  assert.equal(r.display, "$200.00");
 });
 
 test("Case B (within epsilon): tiny float drift → no delta", () => {
@@ -48,7 +48,7 @@ test("Case B (within epsilon): tiny float drift → no delta", () => {
     billingMethod: null,
   });
   assert.equal(r.deltaAmount, null);
-  assert.equal(r.display, "$200");
+  assert.equal(r.display, "$200.00");
 });
 
 test("Case C (positive): billed > base_fee → delta renders, price shows billed", () => {
@@ -59,7 +59,7 @@ test("Case C (positive): billed > base_fee → delta renders, price shows billed
     billingMethod: null,
   });
   assert.equal(r.deltaAmount, 45);
-  assert.equal(r.display, "$245");
+  assert.equal(r.display, "$245.00");
 });
 
 test("Case C (negative): billed < base_fee → delta renders negative, price shows billed", () => {
@@ -70,7 +70,7 @@ test("Case C (negative): billed < base_fee → delta renders negative, price sho
     billingMethod: null,
   });
   assert.equal(r.deltaAmount, -20);
-  assert.equal(r.display, "$230");
+  assert.equal(r.display, "$230.00");
 });
 
 test("Case C: half-dollar threshold — $0.50 difference renders delta", () => {
@@ -113,7 +113,7 @@ test("Edge: base_fee 0, billed null → no delta, $0 display", () => {
     billingMethod: null,
   });
   assert.equal(r.deltaAmount, null);
-  assert.equal(r.display, "$0");
+  assert.equal(r.display, "$0.00");
 });
 
 test("Edge: base_fee 0 with billed set — delta suppressed (no original to compare against)", () => {
@@ -126,5 +126,5 @@ test("Edge: base_fee 0 with billed set — delta suppressed (no original to comp
     billingMethod: null,
   });
   assert.equal(r.deltaAmount, null);
-  assert.equal(r.display, "$150"); // shows billed when present
+  assert.equal(r.display, "$150.00"); // shows billed when present
 });

--- a/artifacts/qleno/src/lib/price-delta.ts
+++ b/artifacts/qleno/src/lib/price-delta.ts
@@ -61,7 +61,11 @@ export function computePriceDelta(input: PriceDeltaInput): PriceDelta {
   // current even when delta is suppressed (e.g. base=0).
   const displayValue = billed != null ? billed : baseFee;
   return {
-    display: `$${Math.round(displayValue)}`,
+    // [penny-exact 2026-06-04] Render full cents + thousands separators
+    // ($1,339.20 — not $1339). Dispatch dollars are reconciled against
+    // MaidCentral/ADP payroll to the cent, so rounding the chip drops the
+    // exact figure the office is matching against.
+    display: displayValue.toLocaleString("en-US", { style: "currency", currency: "USD" }),
     deltaAmount: delta,
     isHourly: false,
   };

--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -56,6 +56,14 @@ function refreshTimeline() {
 }
 refreshTimeline();
 
+// [penny-exact 2026-06-04] Dispatch dollar figures are reconciled against
+// MaidCentral/ADP payroll to the cent, so money MUST render with full cents
+// and thousands separators ($1,339.20 — never $1339 or $1.3k). Use this for
+// every revenue / pay / billed amount on the board. `formatRev` (the $1.3k
+// compact form) is for the mobile week-summary chart only, not reconciliation.
+const fmtUSD = (n: number | null | undefined) =>
+  Number(n ?? 0).toLocaleString("en-US", { style: "currency", currency: "USD" });
+
 const STATUS: Record<string, { bg: string; border: string; text: string; dot: string }> = {
   scheduled:   { bg: "#DBEAFE", border: "#93C5FD", text: "#1D4ED8", dot: "#3B82F6" },
   in_progress: { bg: "#FEF3C7", border: "#FCD34D", text: "#92400E", dot: "#F59E0B" },
@@ -1773,8 +1781,8 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
             );
             return (
               <div style={{ display: "flex", gap: 8, marginBottom: 16 }}>
-                <Tile label="Billed" value={`$${Math.round(billed).toLocaleString()}`} />
-                <Tile label="Commission" value={hasComm ? `$${Math.round(commTotal).toLocaleString()}` : "—"} color="#2D9B83" />
+                <Tile label="Billed" value={fmtUSD(billed)} />
+                <Tile label="Commission" value={hasComm ? fmtUSD(commTotal) : "—"} color="#2D9B83" />
                 <Tile label="Hours" value={allowed != null ? `${allowed.toFixed(1)}h` : "—"} sub="allowed" />
               </div>
             );
@@ -4069,7 +4077,7 @@ function JobChipBody({
                 backgroundColor: deltaAmount > 0 ? "rgba(34,197,94,0.85)" : "rgba(239,68,68,0.85)",
                 color: "#FFFFFF", lineHeight: 1.2, whiteSpace: "nowrap",
               }}>
-                {deltaAmount > 0 ? "↑" : "↓"} ${Math.abs(Math.round(deltaAmount))}
+                {deltaAmount > 0 ? "↑" : "↓"} {fmtUSD(Math.abs(deltaAmount))}
               </span>
             )}
           </div>
@@ -4272,7 +4280,7 @@ function EmployeeRow({ employee, onChipClick, nowLine }: { employee: Employee; o
           </div>
           <div style={{ fontSize: 9, color: "#9E9B94", textTransform: "uppercase", fontWeight: 700, letterSpacing: "0.05em" }}>{employee.role}</div>
           <div style={{ fontSize: 10, color: "#6B6860", marginTop: 1 }}>
-            {employee.jobs.length}j · {Math.floor(totalMins / 60)}h · ${revenue.toFixed(0)} · ${pay != null ? pay.toFixed(0) : "0"}
+            {employee.jobs.length}j · {(totalMins / 60).toFixed(1)}h · {fmtUSD(revenue)} · {fmtUSD(pay)}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## The issue

Reconciling the dispatch board against MaidCentral for payroll, the dollars didn't match to the penny. For Alejandra Cuervo on June 1:

| | Qleno (before) | MaidCentral |
|---|---|---|
| Row total | `7h · $1339` | `7.6h · $1,339.20` |
| Richard Nitzsche chip | `$578` | `$578.40` |
| Jennifer Halper chip | `$1050` | `$1,050.00` |

The underlying numbers were right — the board was just **rounding/truncating cents** in the display, and the tech-row hours were floored to a whole number.

## Fix

Added a shared **`fmtUSD()`** penny-exact formatter (full cents + thousands separators) and routed the rounding spots through it:

- **Tech-row summary** — hours now show one decimal (`7.6h`); revenue and pay via `fmtUSD` → `$1,339.20`.
- **Job chip price** (`lib/price-delta.ts`) — full cents instead of `Math.round` → `$578.40`, `$1,050.00`.
- **Chip price-change pill** and **JobPanel Billed/Commission tiles** — `fmtUSD`.
- Updated `price-delta` unit tests for the cent-precise strings (all 11 pass).

The top-strip **Revenue Today** tile and the **"rev"** pill already formatted to two decimals, so they're unchanged. The compact `$1.3k` form stays only on the mobile week-summary chart (a glanceable chart, not a reconciliation surface).

## Note
Chips are a touch wider now that they carry `.00`, but penny-exactness is the requirement for payroll reconciliation. If any chip feels cramped at the narrowest widths, I can right-trim trailing `.00` only when the value is a whole dollar — say the word.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_