### PR TITLE
fix(dispatch): keep completed jobs readable + label the per-tech pay figure

### DIFF
--- a/artifacts/qleno/src/components/legend-popover.tsx
+++ b/artifacts/qleno/src/components/legend-popover.tsx
@@ -7,7 +7,7 @@
  */
 import { useEffect, useRef } from "react";
 import { X, Check, AlertTriangle } from "lucide-react";
-import { JobVisualStatus, STATUS_VISUALS, ensureJobStatusStyles } from "@/lib/job-status";
+import { JobVisualStatus, STATUS_VISUALS, ensureJobStatusStyles, mutedFill } from "@/lib/job-status";
 
 const FF = "'Plus Jakarta Sans', sans-serif";
 
@@ -32,7 +32,7 @@ function ExampleTile({ status }: { status: JobVisualStatus }) {
     <div style={{
       display: "flex", alignItems: "stretch", gap: 6, width: 96, height: 44,
       borderRadius: 6, padding: 4, position: "relative",
-      backgroundColor: v.swatch, opacity: v.bodyOpacity,
+      backgroundColor: v.fillMuted ? mutedFill(v.swatch) : v.swatch, opacity: v.bodyOpacity,
       filter: v.desaturate ? "grayscale(1)" : "none",
       border: v.borderOverride ? `1.5px solid ${v.borderOverride}` : "1px solid rgba(0,0,0,0.08)",
       flexShrink: 0,

--- a/artifacts/qleno/src/lib/job-status.ts
+++ b/artifacts/qleno/src/lib/job-status.ts
@@ -111,6 +111,27 @@ export const LATE_THRESHOLD_MINUTES = 20;
 // decides whether to enable the No Show button on the tech's screen.
 export const NO_SHOW_WAIT_MINUTES = 20;
 
+// [2026-06-04] Drain most of the color out of a chip fill while preserving
+// its luminance, so a completed job's bar reads as "done" (washed out) but the
+// light/dark text-token choice (which keys off the original luminance) still
+// contrasts. Blends each channel toward the color's own grey at MUTE_MIX
+// (0 = untouched, 1 = full grey). Kept short of full grey so a completed bar
+// stays distinct from a cancelled one (which greyscales the whole card).
+// Lives here next to STATUS_VISUALS so every surface mutes identically.
+export const MUTE_MIX = 0.8;
+export function mutedFill(hex: string | null | undefined): string {
+  if (!hex) return "#D6D3CD";
+  const h = hex.replace("#", "");
+  if (h.length !== 6) return hex;
+  const r = parseInt(h.slice(0, 2), 16);
+  const g = parseInt(h.slice(2, 4), 16);
+  const b = parseInt(h.slice(4, 6), 16);
+  if ([r, g, b].some(v => Number.isNaN(v))) return hex;
+  const grey = 0.299 * r + 0.587 * g + 0.114 * b;
+  const mix = (c: number) => Math.round(c * (1 - MUTE_MIX) + grey * MUTE_MIX);
+  return `#${[mix(r), mix(g), mix(b)].map(v => v.toString(16).padStart(2, "0")).join("")}`;
+}
+
 function timeToMins(t: string | null | undefined): number {
   if (!t) return 0;
   const m = String(t).match(/^(\d{1,2}):(\d{2})/);
@@ -193,8 +214,16 @@ export interface StatusVisual {
   swatch: string;
   /** Stripe color when active (amber); null for non-active states. */
   stripe: string | null;
-  /** Body opacity multiplier (1.0 default; 0.6 for completed; 0.5 cancelled). */
+  /** Body opacity multiplier (1.0 default; 0.5 cancelled). [2026-06-04]
+   *  Completed jobs no longer dim — Sal's call: dimming the whole card made
+   *  the text hard to read. Completion now reads from `fillMuted` (the bar
+   *  loses its color) + the green checkmark, while text/badges stay crisp. */
   bodyOpacity: number;
+  /** [2026-06-04] Desaturate ONLY the bar's fill color (not the text or
+   *  badges), so a completed job's bar drains of color while staying fully
+   *  legible. Distinct from `desaturate`, which greyscales the whole card
+   *  (text included) for cancelled. Optional — defaults to false. */
+  fillMuted?: boolean;
   /** Whether to render a green checkmark badge top-right (completed). */
   showCheckmark: boolean;
   /** Whether to render a "NO SHOW" text badge. */
@@ -263,7 +292,10 @@ export const STATUS_VISUALS: Record<JobVisualStatus, StatusVisual> = {
     description: "Job finished and payment is in.",
     swatch: "#A78BFA",
     stripe: null,
-    bodyOpacity: 0.6,
+    // [2026-06-04] No body dimming — keep the card readable. Completion
+    // reads from the muted bar fill + green checkmark instead.
+    bodyOpacity: 1,
+    fillMuted: true,
     showCheckmark: true,
     showNoShowBadge: false,
     strikethrough: false,
@@ -276,7 +308,8 @@ export const STATUS_VISUALS: Record<JobVisualStatus, StatusVisual> = {
     description: "Job is done but the payment hasn't gone through yet.",
     swatch: "#BA7517",
     stripe: null,
-    bodyOpacity: 0.6,
+    bodyOpacity: 1,
+    fillMuted: true,
     showCheckmark: true,
     showNoShowBadge: false,
     strikethrough: false,

--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -16,7 +16,7 @@ import {
   Building2, AlertTriangle, Repeat, Phone, MessageSquare, Send, Check, Info, Trash2, MoreVertical,
   Languages,
 } from "lucide-react";
-import { getJobVisualStatus, STATUS_VISUALS, ensureJobStatusStyles, LIVE_OPS } from "@/lib/job-status";
+import { getJobVisualStatus, STATUS_VISUALS, ensureJobStatusStyles, LIVE_OPS, mutedFill } from "@/lib/job-status";
 import { computePriceDelta } from "@/lib/price-delta";
 import { InlinePriceEdit } from "@/components/inline-price-edit";
 import LegendPopover from "@/components/legend-popover";
@@ -3744,6 +3744,10 @@ function JobChip({
   const ZONE_FALLBACK = "#9CA3AF";
   const bgColor = job.zone_color || ZONE_FALLBACK;
   const isLightZone = zoneLuminance(job.zone_color) > 0.65;
+  // [2026-06-04] Completed bars drain their color (fillMuted) but keep the
+  // border + text-token choice from the original zone color, so the chip
+  // stays legible. bgColor stays the source for token/border decisions.
+  const chipBg = visual.fillMuted ? mutedFill(bgColor) : bgColor;
   const borderColor = visual.borderOverride ?? bgColor;
 
   // Color tokens depend on background. Timeline + drag sit on the
@@ -3884,7 +3888,7 @@ function JobChip({
           border: `1.5px solid ${visual.borderOverride ?? "#E5E2DC"}`,
           borderLeft: visual.stripe
             ? "1.5px solid #E5E2DC"
-            : `4px solid ${visual.borderOverride ?? bgColor}`,
+            : `4px solid ${visual.borderOverride ?? chipBg}`,
           borderRadius: 10, padding: "12px 14px", cursor: "pointer",
           position: "relative", overflow: "hidden",
           opacity: visual.bodyOpacity,
@@ -3944,7 +3948,7 @@ function JobChip({
     return (
       <div style={{
         width: timelineWidth, height: ROW_H - 20,
-        borderRadius: 8, backgroundColor: bgColor,
+        borderRadius: 8, backgroundColor: chipBg,
         border: `2px solid ${borderColor}`,
         boxSizing: "border-box", overflow: "visible",
         opacity: 0.92,
@@ -3976,7 +3980,7 @@ function JobChip({
       {...(isComplete ? {} : { ...dnd.listeners, ...dnd.attributes })}
       style={{
         position: "absolute", top, left: timelineLeft, width: timelineWidth, height: ROW_H - 20,
-        borderRadius: 8, backgroundColor: bgColor,
+        borderRadius: 8, backgroundColor: chipBg,
         border: `2px solid ${borderColor}`,
         boxSizing: "border-box", overflow: "visible",
         cursor: isComplete ? "default" : dnd.isDragging ? "grabbing" : "grab",
@@ -4349,8 +4353,16 @@ function EmployeeRow({ employee, onChipClick, nowLine }: { employee: Employee; o
             {employee.zone && <div style={{ width: 7, height: 7, borderRadius: "50%", backgroundColor: employee.zone.zone_color, flexShrink: 0 }} title={employee.zone.zone_name} />}
           </div>
           <div style={{ fontSize: 9, color: "#9E9B94", textTransform: "uppercase", fontWeight: 700, letterSpacing: "0.05em" }}>{employee.role}</div>
-          <div style={{ fontSize: 10, color: "#6B6860", marginTop: 1 }}>
-            {employee.jobs.length}j · {(totalMins / 60).toFixed(1)}h · {fmtUSD(revenue)} · {fmtUSD(pay)}
+          {/* [2026-06-04] Two lines so the two dollar figures don't read as
+              one number. Line 1 = the work (jobs · hours · revenue billed).
+              Line 2 = what the TECH earns that day (commission/pay), mint +
+              labeled so it's never confused with the billed revenue. */}
+          <div style={{ fontSize: 10, color: "#6B6860", marginTop: 1, whiteSpace: "nowrap" }}>
+            {employee.jobs.length}j · {(totalMins / 60).toFixed(1)}h · {fmtUSD(revenue)}
+          </div>
+          <div style={{ fontSize: 10, color: "#2D9B83", fontWeight: 700, marginTop: 1, display: "flex", alignItems: "baseline", gap: 4 }}>
+            {fmtUSD(pay)}
+            <span style={{ fontSize: 8, fontWeight: 800, color: "#9E9B94", textTransform: "uppercase", letterSpacing: "0.05em" }}>pay</span>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Two dispatch-readability fixes (the quick wins)

### 1. Completed jobs stay readable
Completed jobs were dimmed to 60% body opacity, which washed out the text. Now the card stays full-strength and **only the bar's fill color drains**:
- New `fillMuted` flag on `STATUS_VISUALS` desaturates **just the background** (luminance-preserving, so the existing light/dark text-token choice still contrasts).
- Text, amount, and the green checkmark stay crisp.
- Shared `mutedFill()` lives in `job-status.ts` so every surface (Gantt chip, list, drag overlay, mobile card, Legend) mutes identically.
- `completed` and `completed_unpaid` both switch to `bodyOpacity: 1`.

### 2. Per-tech pay figure is now labeled
The sidebar row showed two bare dollar amounts (`$1,339.20 · $152.00`) that read as one number. The `$152.00` is the tech's **pay/commission for the day** — for commercial jobs it's `$20/hr × hours` (Alma `$20 × 8.0h = $160`, Alejandra `$20 × 7.6h = $152`), not revenue. Split onto two lines:

```
Alejandra Cuervo
TECHNICIAN
2j · 7.6h · $1,339.20        ← the work (jobs · hours · revenue billed)
$152.00 PAY                  ← mint-colored, labeled — what the tech earns
```

So billed revenue and tech pay can't be confused.

## Next
Rebuilding the hover card so it smart-positions to keep the whole card visible (separate PR, per our discussion).

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_