### PR TITLE
fix(dispatch): restore full MaidCentral zone colors on completed jobs

### DIFF
--- a/artifacts/qleno/src/lib/job-status.ts
+++ b/artifacts/qleno/src/lib/job-status.ts
@@ -292,10 +292,12 @@ export const STATUS_VISUALS: Record<JobVisualStatus, StatusVisual> = {
     description: "Job finished and payment is in.",
     swatch: "#A78BFA",
     stripe: null,
-    // [2026-06-04] No body dimming — keep the card readable. Completion
-    // reads from the muted bar fill + green checkmark instead.
+    // [2026-06-04] No body dimming — keep the card readable. Completion reads
+    // from the green checkmark. fillMuted is OFF: draining the fill washed out
+    // the MaidCentral-matched zone colors (every job on a finished day looked
+    // grey/recolored). Zone hue stays exact; the checkmark is the done signal.
     bodyOpacity: 1,
-    fillMuted: true,
+    fillMuted: false,
     showCheckmark: true,
     showNoShowBadge: false,
     strikethrough: false,
@@ -309,7 +311,7 @@ export const STATUS_VISUALS: Record<JobVisualStatus, StatusVisual> = {
     swatch: "#BA7517",
     stripe: null,
     bodyOpacity: 1,
-    fillMuted: true,
+    fillMuted: false,
     showCheckmark: true,
     showNoShowBadge: false,
     strikethrough: false,


### PR DESCRIPTION
## Restore the MaidCentral zone colors on the board

In #315 I added a fill-desaturation to completed jobs (you'd asked for the bar to "lose color" on completion). But since **every job on June 1 is done**, every bar got drained at once — making the whole board look grey/recolored, as if the MaidCentral-synced zone colors had changed.

They hadn't — the zone color **values** were never touched. This turns the muting **off** so completed bars render their **exact zone color again** (vibrant purple / salmon / green / magenta, matching MaidCentral). Completion is still signaled by the green checkmark, and the card stays readable (no body dim — that part of #315 stays).

Net: `fillMuted` → `false` for `completed` and `completed_unpaid`.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_