### PR TITLE
fix(jobs): inline time edit recomputes commercial price + unfreezes completed visit

### DIFF
--- a/artifacts/api-server/src/routes/jobs.ts
+++ b/artifacts/api-server/src/routes/jobs.ts
@@ -1418,10 +1418,15 @@ router.patch("/:id", requireAuth, async (req, res) => {
       // 4 future jobs reflect new times.").
       const anchorSkippedFields: string[] = [];
       if (skipAnchorLockedFields) {
+        // [2026-06-04] Price + rate are NO LONGER frozen on the completed
+        // anchor. Sal needs completed visits price-editable for MaidCentral
+        // reconciliation (correct hours/parking/rate on a finished job and
+        // have THIS visit's billed amount follow). The series identity —
+        // frequency + service_type — stays frozen on the anchor; the cascade
+        // below still propagates those to the template + future visits. Every
+        // change is captured by pushChange's audit rows above.
         if ("frequency" in setParts) { delete setParts.frequency; anchorSkippedFields.push("frequency"); }
         if ("service_type" in setParts) { delete setParts.service_type; anchorSkippedFields.push("service_type"); }
-        if ("base_fee" in setParts) { delete setParts.base_fee; anchorSkippedFields.push("base_fee"); }
-        if ("hourly_rate" in setParts) { delete setParts.hourly_rate; anchorSkippedFields.push("hourly_rate"); }
       }
       (req as any)._anchorSkippedFields = anchorSkippedFields;
 

--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -971,6 +971,22 @@ function InlineTimeEdit({ job, onUpdate }: { job: DispatchJob; onUpdate: () => v
         allowed_hours: String(durationH.toFixed(2)),
         cascade_scope: scope,
       };
+      // [time-edit price recompute 2026-06-04] Keep the commercial price in
+      // step with the hours.
+      //   • Rate-driven jobs (manual_rate_override = false) already bill
+      //     hourly_rate × allowed_hours LIVE, so updating allowed_hours above
+      //     is enough — we must NOT send base_fee (that would flip the job to a
+      //     pinned price and break the live billing).
+      //   • Pinned jobs (manual_rate_override = true) DON'T follow hours on
+      //     their own — that's Diana's PPM stuck at $170 when 4.5h should read
+      //     $245. Re-pin them using the same formula the Edit modal uses:
+      //     base_fee = hourly_rate × allowed_hours + add-ons (parking).
+      const isCommercialJob = job.account_id != null || job.client_type === "commercial";
+      const hourly = job.hourly_rate != null ? Number(job.hourly_rate) : 0;
+      if (isCommercialJob && job.manual_rate_override && hourly > 0) {
+        const addonSum = (job.add_ons ?? []).reduce((s, a) => s + Number((a as any).subtotal ?? 0), 0);
+        payload.base_fee = (Math.round((hourly * durationH + addonSum) * 100) / 100).toFixed(2);
+      }
       // Only pass the schedule's day_of_week field when actually
       // cascading to the schedule template (this_and_future / all).
       // 'this_job' / 'remove_this' don't touch the schedule.


### PR DESCRIPTION
## What this fixes
Editing a **completed** commercial job's time via the inline pencil said "saved" but the billed price never moved — Diana's PPM stayed at $170 when 4.5h should read **$245** ($50/hr × 4.5h + $20 parking).

Two compounding causes:
1. **Inline editor only sent `allowed_hours`.** Rate-driven commercial jobs bill `hourly_rate × allowed_hours` live, so that's enough for them — but a **pinned** price (`manual_rate_override`) doesn't follow hours. Now, for pinned commercial jobs, the editor re-pins `base_fee = hourly_rate × allowed_hours + add-ons` (the exact formula the full Edit modal already uses). Rate-driven jobs are deliberately left untouched so we never flip them to a pinned price and break their live billing.
2. **Completed visits froze their price.** On a completed recurring job, an edit that cascades to the schedule froze `base_fee`/`hourly_rate` on the anchor, so corrections couldn't land on the finished visit. Per your call, completed visits are now **price-editable** — the series identity (`frequency`/`service_type`) stays frozen, and every change is still audit-logged.

## Verify
You already got $245 to land (via the Edit modal). This makes the **inline time pencil** do the same thing. Worth a quick check on the live board that editing hours on a pinned commercial job lands the right price; if a job has no `hourly_rate` on file the editor leaves the price alone (no risk of zeroing it).

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_