### PR TITLE
Quote-convert fix, MC-parity rates, dashboard Recent Activity, mobile Schedule views

### DIFF
--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -3221,6 +3221,37 @@ export async function runPhesDataMigration(): Promise<void> {
       SET minimum_bill = 210.00
       WHERE company_id = ${PHES} AND name = 'Recurring Cleaning - Every 4 Weeks' AND minimum_bill != 210.00
     `);
+
+    // ── MaidCentral-parity base hourly rates (confirmed by Sal, 2026-06-05) ───
+    // The scope INSERTs above are insert-only (WHERE NOT EXISTS), so they never
+    // correct an existing row's rate. Production scopes seeded at the old
+    // defaults (Deep Clean $70, One-Time $60, Recurring $55/$60) stayed stale,
+    // so quotes priced BELOW MaidCentral — a hard problem when onboarding
+    // existing clients who must be quoted at the exact price they already pay
+    // in MC. These idempotent UPDATEs enforce the canonical MC rates:
+    //   Deep Clean / Move In-Out / Hourly Deep Clean ...... $80/hr
+    //   One-Time Standard / Hourly Standard ............... $65/hr
+    //   Recurring (Weekly / Every 2 Weeks / Every 4 Weeks)  $65/hr flat
+    // Recurring price still fluctuates by cadence — but that comes ENTIRELY
+    // from the per-cadence tier hours (already MC-matched above), NOT the rate,
+    // exactly like MC's single-rate recurring model. The `!= rate` guard makes
+    // this a no-op once correct.
+    const mcParityRates: Array<{ name: string; rate: string }> = [
+      { name: "Deep Clean",                          rate: "80.00" },
+      { name: "Move In / Move Out",                  rate: "80.00" },
+      { name: "Hourly Deep Clean",                   rate: "80.00" },
+      { name: "One-Time Standard Clean",             rate: "65.00" },
+      { name: "Hourly Standard Cleaning",            rate: "65.00" },
+      { name: "Recurring Cleaning - Weekly",         rate: "65.00" },
+      { name: "Recurring Cleaning - Every 2 Weeks",  rate: "65.00" },
+      { name: "Recurring Cleaning - Every 4 Weeks",  rate: "65.00" },
+    ];
+    for (const { name, rate } of mcParityRates) {
+      await db.execute(sql`
+        UPDATE pricing_scopes SET hourly_rate = ${rate}
+        WHERE company_id = ${PHES} AND name = ${name} AND hourly_rate != ${rate}
+      `);
+    }
     // These were seeded before scope_group existed, so they defaulted to
     // 'Residential' — which both hid them from commercial clients AND showed
     // commercial work to residential ones. Reclassify to 'Commercial'.

--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -3227,29 +3227,36 @@ export async function runPhesDataMigration(): Promise<void> {
     // correct an existing row's rate. Production scopes seeded at the old
     // defaults (Deep Clean $70, One-Time $60, Recurring $55/$60) stayed stale,
     // so quotes priced BELOW MaidCentral — a hard problem when onboarding
-    // existing clients who must be quoted at the exact price they already pay
-    // in MC. These idempotent UPDATEs enforce the canonical MC rates:
+    // existing clients who must be quoted at the exact price they already pay.
+    // Target MC rates:
     //   Deep Clean / Move In-Out / Hourly Deep Clean ...... $80/hr
     //   One-Time Standard / Hourly Standard ............... $65/hr
     //   Recurring (Weekly / Every 2 Weeks / Every 4 Weeks)  $65/hr flat
     // Recurring price still fluctuates by cadence — but that comes ENTIRELY
-    // from the per-cadence tier hours (already MC-matched above), NOT the rate,
-    // exactly like MC's single-rate recurring model. The `!= rate` guard makes
-    // this a no-op once correct.
-    const mcParityRates: Array<{ name: string; rate: string }> = [
-      { name: "Deep Clean",                          rate: "80.00" },
-      { name: "Move In / Move Out",                  rate: "80.00" },
-      { name: "Hourly Deep Clean",                   rate: "80.00" },
-      { name: "One-Time Standard Clean",             rate: "65.00" },
-      { name: "Hourly Standard Cleaning",            rate: "65.00" },
-      { name: "Recurring Cleaning - Weekly",         rate: "65.00" },
-      { name: "Recurring Cleaning - Every 2 Weeks",  rate: "65.00" },
-      { name: "Recurring Cleaning - Every 4 Weeks",  rate: "65.00" },
+    // from the per-cadence tier hours (already MC-matched above), NOT the rate.
+    //
+    // ONE-TIME correction, not perpetual enforcement: each UPDATE is guarded on
+    // the *old stale seed value* (`hourly_rate = <from>`), so it bumps a scope
+    // off the old default exactly once and then NEVER fires again. This is
+    // deliberate — base rate + minimum are owner-managed in Settings → Pricing
+    // (pricing.tsx), so the migration must not clobber a deliberate UI edit on
+    // the next cold-start. A scope already at the target (or any custom value)
+    // is left untouched.
+    const mcParityRates: Array<{ name: string; from: string; to: string }> = [
+      { name: "Deep Clean",                          from: "70.00", to: "80.00" },
+      { name: "Move In / Move Out",                  from: "70.00", to: "80.00" },
+      { name: "Hourly Deep Clean",                   from: "70.00", to: "80.00" },
+      { name: "One-Time Standard Clean",             from: "60.00", to: "65.00" },
+      { name: "Hourly Standard Cleaning",            from: "60.00", to: "65.00" },
+      { name: "Recurring Cleaning - Weekly",         from: "55.00", to: "65.00" },
+      { name: "Recurring Cleaning - Every 2 Weeks",  from: "60.00", to: "65.00" },
+      // Recurring Every 4 Weeks was already seeded at $65 — no correction.
     ];
-    for (const { name, rate } of mcParityRates) {
+    for (const { name, from, to } of mcParityRates) {
       await db.execute(sql`
-        UPDATE pricing_scopes SET hourly_rate = ${rate}
-        WHERE company_id = ${PHES} AND name = ${name} AND hourly_rate != ${rate}
+        UPDATE pricing_scopes SET hourly_rate = ${to}
+        WHERE company_id = ${PHES} AND name = ${name}
+          AND hourly_rate::numeric = ${from}::numeric
       `);
     }
     // These were seeded before scope_group existed, so they defaulted to

--- a/artifacts/api-server/src/routes/dashboard.ts
+++ b/artifacts/api-server/src/routes/dashboard.ts
@@ -1497,4 +1497,48 @@ router.delete("/card-prefs", requireAuth, async (req, res) => {
   }
 });
 
+// ── Recent activity feed (main dashboard, under the revenue forecast) ─────────
+// HCP-style stream of business events drawn from app_audit_log. Company-scoped,
+// business events only — auth/LMS/smoke-test noise is filtered out so the card
+// reads like "what happened to my jobs/quotes/invoices/clients lately", with a
+// link back to each record. Raw fields go to the client; the dashboard maps
+// them to a friendly label + route (the frontend owns the route table).
+router.get("/recent-activity", requireAuth, async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId!;
+    const limit = Math.min(parseInt(String(req.query.limit ?? "15")) || 15, 50);
+    const r = await db.execute(sql`
+      SELECT aal.id, aal.action, aal.target_type, aal.target_id,
+             aal.new_value, aal.performed_at,
+             NULLIF(TRIM(COALESCE(au.first_name,'') || ' ' || COALESCE(au.last_name,'')), '') AS user_name
+      FROM app_audit_log aal
+      LEFT JOIN users au ON aal.performed_by = au.id
+      WHERE aal.company_id = ${companyId}
+        AND aal.performed_at >= NOW() - INTERVAL '30 days'
+        AND aal.target_type IN ('job','quote','invoice','client','employee')
+        AND aal.action NOT LIKE 'lms_%'
+        AND aal.action NOT IN (
+          'login_success','login_failed','logout','password_changed',
+          'password_reset','company_switch','user_companies_grant',
+          'user_companies_revoke','SMOKE_TEST'
+        )
+      ORDER BY aal.performed_at DESC
+      LIMIT ${limit}
+    `);
+    const activities = (r.rows as any[]).map((x) => ({
+      id: Number(x.id),
+      action: String(x.action),
+      target_type: String(x.target_type),
+      target_id: x.target_id != null ? String(x.target_id) : null,
+      new_value: x.new_value ?? null,
+      performed_at: x.performed_at,
+      user_name: x.user_name ?? null,
+    }));
+    return res.json({ activities });
+  } catch (err) {
+    console.error("Recent activity error:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
 export default router;

--- a/artifacts/api-server/src/routes/quotes.ts
+++ b/artifacts/api-server/src/routes/quotes.ts
@@ -385,6 +385,23 @@ router.post("/:id/convert", requireAuth, requireRole("owner", "admin", "office")
       } catch { /* column may not exist */ }
     }
 
+    // [quote-convert-assignment-mirror] When the office assigns a tech on the
+    // Review step, the INSERT above already mirrors onto jobs.assigned_user_id,
+    // but the convert previously NEVER wrote job_technicians. That split-brain
+    // left the chip in the dispatch Unassigned row ("job needs assignment")
+    // even though a tech was chosen in the quote tool. Per the assignment-mirror
+    // invariant, every code path that assigns a tech MUST write both. Promote
+    // the chosen tech to primary (is_primary=true) so the dispatch grid and the
+    // per-tech fan-out recognize the assignment.
+    const assignedTechId = assigned_user_id ? parseInt(String(assigned_user_id)) : NaN;
+    if (jobId && !isNaN(assignedTechId)) {
+      await db.execute(sql`
+        INSERT INTO job_technicians (job_id, user_id, company_id, is_primary)
+        VALUES (${jobId}, ${assignedTechId}, ${companyId}, true)
+        ON CONFLICT (job_id, user_id) DO UPDATE SET is_primary = EXCLUDED.is_primary
+      `);
+    }
+
     logAudit(req, "CONVERTED", "quote", id, null, { status: "booked", total_price: q.total_price, job_id: jobId });
 
     // Stop quote_followup enrollment (non-blocking)

--- a/artifacts/qleno/src/pages/dashboard.tsx
+++ b/artifacts/qleno/src/pages/dashboard.tsx
@@ -149,6 +149,128 @@ function useWeeklyForecast() {
   return { data, loading, error };
 }
 
+// ── Recent Activity (HCP-style stream, under the revenue forecast) ────────────
+type ActivityRow = {
+  id: number; action: string; target_type: string; target_id: string | null;
+  new_value: any; performed_at: string; user_name: string | null;
+};
+
+function useRecentActivity() {
+  const [data, setData] = useState<ActivityRow[] | null>(null);
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const r = await apiFetch('/api/dashboard/recent-activity?limit=12');
+        if (r.ok) { const j = await r.json(); setData(j.activities || []); }
+      } catch {}
+    };
+    load();
+    const iv = setInterval(load, 60000);
+    return () => clearInterval(iv);
+  }, []);
+  return data;
+}
+
+function relTime(iso: string): string {
+  const then = new Date(iso).getTime();
+  if (isNaN(then)) return '';
+  const min = Math.floor((Date.now() - then) / 60000);
+  if (min < 1) return 'just now';
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const day = Math.floor(hr / 24);
+  if (day < 7) return `${day}d ago`;
+  return new Date(iso).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+function actMoney(v: any): string | null {
+  const n = parseFloat(String(v ?? ''));
+  return isNaN(n) ? null : `$${n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+// Map a raw audit row to a human label + in-app route. The frontend owns the
+// route table, so links stay correct if routes move.
+function describeActivity(a: ActivityRow): { label: string; link: string | null } {
+  const id = a.target_id;
+  const nv = a.new_value || {};
+  const amt = actMoney(nv.total_price ?? nv.amount ?? nv.total);
+  const verb = a.action.toLowerCase().replace(/_/g, ' ');
+  switch (a.target_type) {
+    case 'quote':
+      if (a.action === 'CONVERTED') return { label: `Quote #${id} converted to a job`, link: id ? `/quotes/${id}` : null };
+      if (a.action === 'CREATE') return { label: `Quote #${id} created${amt ? ` — ${amt}` : ''}`, link: id ? `/quotes/${id}` : null };
+      if (a.action === 'DELETE') return { label: `Quote #${id} deleted`, link: null };
+      return { label: `Quote #${id} ${verb}`, link: id ? `/quotes/${id}` : null };
+    case 'job':
+      if (a.action === 'CREATE') return { label: `New job created${amt ? ` — ${amt}` : ''}`, link: '/dispatch' };
+      if (a.action === 'UPDATE') return { label: `Job #${id} updated`, link: '/dispatch' };
+      if (a.action === 'DELETE') return { label: `Job #${id} deleted`, link: null };
+      if (a.action === 'SET_ZONE') return { label: `Job #${id} zone set`, link: '/dispatch' };
+      return { label: `Job #${id} ${verb}`, link: '/dispatch' };
+    case 'invoice':
+      if (a.action === 'PAYMENT_CHARGED') return { label: `Payment charged${amt ? ` — ${amt}` : ''}`, link: id ? `/invoices/${id}` : '/invoices' };
+      if (a.action === 'CREATE') return { label: `Invoice created${amt ? ` — ${amt}` : ''}`, link: id ? `/invoices/${id}` : '/invoices' };
+      return { label: `Invoice #${id} ${verb}`, link: id ? `/invoices/${id}` : '/invoices' };
+    case 'client':
+      if (a.action === 'CREATE') return { label: 'New client added', link: id ? `/customers/${id}` : '/customers' };
+      return { label: `Client ${verb}`, link: id ? `/customers/${id}` : '/customers' };
+    case 'employee': {
+      const map: Record<string, string> = {
+        CREATE: 'Employee added', CREATE_EMPLOYEE: 'Employee added',
+        DELETE: 'Employee removed', DELETE_EMPLOYEE: 'Employee removed',
+        ACTIVATE_EMPLOYEE: 'Employee activated', DEACTIVATE_EMPLOYEE: 'Employee deactivated',
+        UPDATE: 'Employee updated',
+      };
+      return { label: map[a.action] || `Employee ${verb}`, link: id ? `/employees/${id}` : '/employees' };
+    }
+    default:
+      return { label: `${a.target_type} ${verb}`, link: null };
+  }
+}
+
+function RecentActivitySection() {
+  const activities = useRecentActivity();
+  const [, setLocation] = useLocation();
+  return (
+    <div>
+      <p style={{ fontSize: 11, fontWeight: 500, color: '#4A4845', textTransform: 'uppercase', letterSpacing: '0.05em', margin: '0 0 10px', fontFamily: FF }}>Recent Activity</p>
+      <div style={{ ...CARD, padding: '6px 0' }}>
+        {activities == null ? (
+          <p style={{ fontSize: 13, color: '#9E9B94', fontFamily: FF, padding: '14px 24px', margin: 0 }}>Loading…</p>
+        ) : activities.length === 0 ? (
+          <p style={{ fontSize: 13, color: '#9E9B94', fontFamily: FF, padding: '14px 24px', margin: 0 }}>No recent activity in the last 30 days.</p>
+        ) : (
+          activities.map((a, i) => {
+            const { label, link } = describeActivity(a);
+            return (
+              <div
+                key={a.id}
+                onClick={() => link && setLocation(link)}
+                style={{
+                  display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12,
+                  padding: '11px 24px',
+                  borderTop: i === 0 ? 'none' : '0.5px solid #F0EEE9',
+                  cursor: link ? 'pointer' : 'default',
+                }}
+              >
+                <div style={{ minWidth: 0 }}>
+                  <p style={{ fontSize: 13, fontWeight: 500, color: '#1A1917', margin: 0, fontFamily: FF, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{label}</p>
+                  <p style={{ fontSize: 11, color: '#9E9B94', margin: '2px 0 0', fontFamily: FF }}>{a.user_name || 'System'}</p>
+                </div>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexShrink: 0 }}>
+                  <span style={{ fontSize: 11, color: '#9E9B94', fontFamily: FF }}>{relTime(a.performed_at)}</span>
+                  {link && <ChevronRight size={14} color="#C9C5BD" />}
+                </div>
+              </div>
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+}
+
 // ── WeeklyForecastSection component ──────────────────────────────────────────
 function fmtWF(n: number) {
   return '$' + Math.round(n).toLocaleString('en-US');
@@ -730,6 +852,9 @@ export default function Dashboard() {
 
         {/* ── Weekly Revenue Forecast ── */}
         <WeeklyForecastSection />
+
+        {/* ── Recent Activity (under the revenue forecast) ── */}
+        <RecentActivitySection />
 
         {/* ── Commercial Alerts ── */}
         {canAdmin && <CommercialAlertsBanner />}

--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -3247,14 +3247,6 @@ function MobileJobCard({ job, onClick }: { job: DispatchJob; onClick: () => void
   );
 }
 
-// [schedule-views 2026-06-05] Hour label for the mobile time-grid gutter.
-function fmtHour(h: number): string {
-  if (h >= 24) return "12 AM";
-  const ampm = h < 12 ? "AM" : "PM";
-  const hr = h % 12 === 0 ? 12 : h % 12;
-  return `${hr} ${ampm}`;
-}
-
 // [schedule-views 2026-06-05] MOBILE TIME-GRID (HCP-style). Renders the focal
 // day's jobs on an hour grid: vertical position = start time, height =
 // duration, concurrent jobs packed into PARALLEL COLUMNS. Column packing is

--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -3247,6 +3247,120 @@ function MobileJobCard({ job, onClick }: { job: DispatchJob; onClick: () => void
   );
 }
 
+// [schedule-views 2026-06-05] Hour label for the mobile time-grid gutter.
+function fmtHour(h: number): string {
+  if (h >= 24) return "12 AM";
+  const ampm = h < 12 ? "AM" : "PM";
+  const hr = h % 12 === 0 ? 12 : h % 12;
+  return `${hr} ${ampm}`;
+}
+
+// [schedule-views 2026-06-05] MOBILE TIME-GRID (HCP-style). Renders the focal
+// day's jobs on an hour grid: vertical position = start time, height =
+// duration, concurrent jobs packed into PARALLEL COLUMNS. Column packing is
+// per-overlap-cluster (a "connected component" of mutually overlapping jobs),
+// so a lone job stays full-width while a 9 AM pile-up splits into N columns —
+// same idea as the desktop Gantt's packLanes, rotated to a vertical grid.
+// Blocks fill with the job's zone color (matches desktop); text flips to dark
+// on light zones via luminance. Jobs with no scheduled time list below.
+function MobileTimeGrid({ jobs, onJobClick }: { jobs: DispatchJob[]; onJobClick: (j: DispatchJob) => void }) {
+  const PX_PER_MIN = 1.15;
+  const GUTTER = 46;
+  const dur = (j: DispatchJob) => Math.max(j.duration_minutes || 0, 30);
+  const timed = jobs.filter(j => timeToMins(j.scheduled_time) > 0);
+  const untimed = jobs.filter(j => timeToMins(j.scheduled_time) <= 0);
+
+  let body: React.ReactNode = null;
+  if (timed.length > 0) {
+    const minStart = Math.min(...timed.map(j => timeToMins(j.scheduled_time)));
+    const maxEnd = Math.max(...timed.map(j => timeToMins(j.scheduled_time) + dur(j)));
+    const startHour = Math.max(0, Math.min(8, Math.floor(minStart / 60)));
+    const endHour = Math.min(24, Math.max(18, Math.ceil(maxEnd / 60)));
+    const dayStart = startHour * 60;
+    const gridH = (endHour - startHour) * 60 * PX_PER_MIN;
+
+    // Per-cluster greedy column packing.
+    type Placed = { job: DispatchJob; col: number; cols: number; start: number; end: number };
+    const sorted = [...timed].sort((a, b) => timeToMins(a.scheduled_time) - timeToMins(b.scheduled_time) || a.id - b.id);
+    const placed: Placed[] = [];
+    let cluster: Placed[] = [];
+    let clusterEnd = -1;
+    let colEnds: number[] = [];
+    const flush = () => {
+      const cols = colEnds.length;
+      for (const p of cluster) p.cols = cols;
+      placed.push(...cluster);
+      cluster = []; colEnds = []; clusterEnd = -1;
+    };
+    for (const j of sorted) {
+      const s = timeToMins(j.scheduled_time), e = s + dur(j);
+      if (clusterEnd !== -1 && s >= clusterEnd) flush();
+      let col = colEnds.findIndex(end => end <= s);
+      if (col === -1) { col = colEnds.length; colEnds.push(e); } else colEnds[col] = e;
+      cluster.push({ job: j, col, cols: 0, start: s, end: e });
+      clusterEnd = Math.max(clusterEnd, e);
+    }
+    flush();
+
+    const hours: number[] = [];
+    for (let h = startHour; h <= endHour; h++) hours.push(h);
+
+    body = (
+      <div style={{ position: "relative", marginLeft: GUTTER, height: gridH, borderTop: "1px solid #F0EEE9" }}>
+        {hours.map(h => {
+          const top = (h * 60 - dayStart) * PX_PER_MIN;
+          return (
+            <div key={h} style={{ position: "absolute", left: -GUTTER, right: 0, top, borderTop: "1px solid #F2F0EB" }}>
+              <span style={{ position: "absolute", left: 0, top: -7, width: GUTTER - 8, textAlign: "right", fontSize: 10, color: "#9E9B94", fontWeight: 600 }}>{fmtHour(h)}</span>
+            </div>
+          );
+        })}
+        {placed.map(p => {
+          const j = p.job;
+          const visual = STATUS_VISUALS[getJobVisualStatus(j)];
+          const color = j.zone_color || "#9CA3AF";
+          const onDark = (zoneLuminance(color) / 255) < 0.62;
+          const top = (p.start - dayStart) * PX_PER_MIN;
+          const height = Math.max((p.end - p.start) * PX_PER_MIN, 36);
+          const widthPct = 100 / p.cols;
+          const leftPct = p.col * widthPct;
+          return (
+            <div key={j.id} onClick={() => onJobClick(j)} style={{
+              position: "absolute", top, left: `calc(${leftPct}% + 2px)`, width: `calc(${widthPct}% - 4px)`,
+              height: height - 3, backgroundColor: color, borderRadius: 8, padding: "5px 7px",
+              cursor: "pointer", overflow: "hidden", fontFamily: FF, boxSizing: "border-box",
+              color: onDark ? "#FFFFFF" : "#1A1917", opacity: visual.bodyOpacity,
+              filter: visual.desaturate ? "grayscale(1)" : "none",
+              boxShadow: visual.stripe ? `inset 0 0 0 2px rgba(255,255,255,0.55), 0 0 0 2px ${visual.stripe}` : "none",
+            }}>
+              <div style={{ fontSize: 11.5, fontWeight: 700, lineHeight: 1.15, textDecoration: visual.strikethrough ? "line-through" : "none", overflow: "hidden", whiteSpace: "nowrap", textOverflow: "ellipsis" }}>
+                {j.display_name ?? j.client_name}
+              </div>
+              {height >= 46 && (
+                <div style={{ fontSize: 9.5, opacity: 0.92, marginTop: 2, overflow: "hidden", whiteSpace: "nowrap", textOverflow: "ellipsis" }}>
+                  {fmtTime(j.scheduled_time)}{j.assigned_user_name ? ` · ${j.assigned_user_name}` : ""}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {body}
+      {untimed.length > 0 && (
+        <div style={{ marginTop: body ? 14 : 0 }}>
+          <div style={{ fontSize: 10, fontWeight: 700, color: "#9E9B94", textTransform: "uppercase", letterSpacing: "0.06em", margin: "0 2px 6px" }}>No time set</div>
+          {untimed.map(j => <MobileJobCard key={j.id} job={j} onClick={() => onJobClick(j)} />)}
+        </div>
+      )}
+    </div>
+  );
+}
+
 // [schedule-views 2026-06-05] Decorative, stable avatar color derived from a
 // tech's name. Job colors in this app are ZONE-based (not per-tech), so this is
 // purely to visually distinguish people in the By-Employee grouping. Hashing the
@@ -5755,6 +5869,8 @@ export default function JobsPage() {
                 <div style={{ fontSize: 14, fontWeight: 700, color: "#6B7280", marginBottom: 4 }}>No jobs {isToday ? "today" : "this day"}{selectedZoneFilter !== null ? " in this zone" : ""}</div>
                 <div style={{ fontSize: 12, color: "#9E9B94" }}>Tap "+ New Job" to schedule one</div>
               </div>
+            ) : mobileViewMode === "grid" ? (
+              <MobileTimeGrid jobs={allJobs} onJobClick={setSelectedJob} />
             ) : mobileViewMode === "team" ? (
               /* [schedule-views] BY EMPLOYEE — group the focal day's jobs under
                  each assigned tech (Unassigned floats to the top so nothing

--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -3247,6 +3247,21 @@ function MobileJobCard({ job, onClick }: { job: DispatchJob; onClick: () => void
   );
 }
 
+// [schedule-views 2026-06-05] Decorative, stable avatar color derived from a
+// tech's name. Job colors in this app are ZONE-based (not per-tech), so this is
+// purely to visually distinguish people in the By-Employee grouping. Hashing the
+// name keeps each tech on one color across renders. Tenant-generic.
+const TECH_AVATAR_COLORS = ["#0FA3A3", "#8B3FBF", "#2D6BE0", "#D2691E", "#2D9B83", "#C2410C", "#6D28D9", "#0E7490", "#B45309", "#9D174D"];
+function techAvatarColor(name: string): string {
+  let h = 0;
+  for (let i = 0; i < name.length; i++) h = (h * 31 + name.charCodeAt(i)) >>> 0;
+  return TECH_AVATAR_COLORS[h % TECH_AVATAR_COLORS.length];
+}
+function techInitials(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  return (((parts[0]?.[0] ?? "") + (parts.length > 1 ? parts[parts.length - 1][0] : "")).toUpperCase()) || "?";
+}
+
 // ─── MINI CALENDAR ─────────────────────────────────────────────────────────────
 function MiniCalendar({ value, onChange, jobDates }: { value: Date; onChange: (d: Date) => void; jobDates: Set<string> }) {
   const [month, setMonth] = useState(new Date(value.getFullYear(), value.getMonth(), 1));
@@ -5740,6 +5755,41 @@ export default function JobsPage() {
                 <div style={{ fontSize: 14, fontWeight: 700, color: "#6B7280", marginBottom: 4 }}>No jobs {isToday ? "today" : "this day"}{selectedZoneFilter !== null ? " in this zone" : ""}</div>
                 <div style={{ fontSize: 12, color: "#9E9B94" }}>Tap "+ New Job" to schedule one</div>
               </div>
+            ) : mobileViewMode === "team" ? (
+              /* [schedule-views] BY EMPLOYEE — group the focal day's jobs under
+                 each assigned tech (Unassigned floats to the top so nothing
+                 hides). Header shows the tech, their job count, and total job
+                 hours. Cards keep their zone color so they still match desktop. */
+              (() => {
+                const groups = new Map<string, DispatchJob[]>();
+                for (const j of allJobs) {
+                  const key = j.assigned_user_name || "Unassigned";
+                  if (!groups.has(key)) groups.set(key, []);
+                  groups.get(key)!.push(j);
+                }
+                const ordered = [...groups.entries()].sort((a, b) => {
+                  if (a[0] === "Unassigned") return -1;
+                  if (b[0] === "Unassigned") return 1;
+                  return a[0].localeCompare(b[0]);
+                });
+                return ordered.map(([name, jobs]) => {
+                  const mins = jobs.reduce((s, j) => s + (j.duration_minutes || 0), 0);
+                  const hrs = mins % 60 === 0 ? String(mins / 60) : (mins / 60).toFixed(1);
+                  const isUn = name === "Unassigned";
+                  return (
+                    <div key={name} style={{ marginBottom: 4 }}>
+                      <div style={{ display: "flex", alignItems: "center", gap: 9, margin: "12px 2px 8px" }}>
+                        <div style={{ width: 26, height: 26, borderRadius: "50%", flexShrink: 0, color: "#fff", fontSize: 11, fontWeight: 700, display: "flex", alignItems: "center", justifyContent: "center", backgroundColor: isUn ? "#9CA3AF" : techAvatarColor(name) }}>
+                          {isUn ? "?" : techInitials(name)}
+                        </div>
+                        <div style={{ fontSize: 14, fontWeight: 700, color: isUn ? "#B45309" : "#1A1917", flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{name}</div>
+                        <div style={{ fontSize: 11, color: "#9E9B94", fontWeight: 600, flexShrink: 0 }}>{jobs.length} {jobs.length !== 1 ? "jobs" : "job"} · {hrs}h</div>
+                      </div>
+                      {jobs.map(j => <MobileJobCard key={j.id} job={j} onClick={() => setSelectedJob(j)} />)}
+                    </div>
+                  );
+                });
+              })()
             ) : (
               <>
                 {allJobs.map(j => <MobileJobCard key={j.id} job={j} onClick={() => setSelectedJob(j)} />)}

--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -3099,7 +3099,12 @@ function MobileJobCard({ job, onClick }: { job: DispatchJob; onClick: () => void
     <div onClick={onClick} style={{
       backgroundColor: "#FFFFFF", border: "1px solid #E5E2DC", borderRadius: 12,
       padding: "14px 16px", marginBottom: 10, cursor: "pointer", position: "relative",
-      borderLeft: visual.stripe ? "none" : `4px solid ${visual.borderOverride ?? sc.dot}`,
+      // [schedule-views 2026-06-05] Left stripe = the job's ZONE color (same
+      // source the desktop Gantt chip fills with), not the status-blue sc.dot.
+      // This closes the desktop/mobile color variance — a job that's purple on
+      // the board is now purple on mobile. Special-state overrides (late red,
+      // unpaid amber, no-show dark-red) and the animated active stripe still win.
+      borderLeft: visual.stripe ? "none" : `4px solid ${visual.borderOverride ?? job.zone_color ?? sc.dot}`,
       fontFamily: FF, opacity: visual.bodyOpacity,
       filter: visual.desaturate ? "grayscale(1)" : "none", overflow: "hidden",
     }}>
@@ -5126,6 +5131,10 @@ export default function JobsPage() {
   const [expandedDays, setExpandedDays] = useState<Set<string>>(new Set());
   const [dayDataCache, setDayDataCache] = useState<Map<string, DispatchData>>(new Map());
   const [dayDataLoading, setDayDataLoading] = useState<Set<string>>(new Set());
+  // [schedule-views 2026-06-05] Mobile focal-day view mode: Time list / By
+  // Employee groups / Time-grid. Three selectable views so the office can try
+  // each and keep whichever earns its place. Generic — applies to every tenant.
+  const [mobileViewMode, setMobileViewMode] = useState<"time" | "team" | "grid">("time");
 
   const load = useCallback(async () => {
     const id = ++refreshRef.current;
@@ -5682,6 +5691,24 @@ export default function JobsPage() {
               <Info size={11} />
               Legend
             </button>
+          </div>
+
+          {/* [schedule-views 2026-06-05] Focal-day VIEW SWITCHER — Time list /
+              By Employee / Time-grid. Affects only the focal-day section below;
+              the week summary, risk strip, and Upcoming list are shared chrome. */}
+          <div style={{ backgroundColor: "#FFFFFF", borderBottom: "1px solid #EEECE7", padding: "8px 14px" }}>
+            <div style={{ display: "flex", background: "#F1EFEA", borderRadius: 9, padding: 3, gap: 3 }}>
+              {([["time", "Time"], ["team", "Team"], ["grid", "Grid"]] as const).map(([val, label]) => (
+                <button key={val} onClick={() => setMobileViewMode(val)} style={{
+                  flex: 1, textAlign: "center", border: "none", cursor: "pointer", fontFamily: FF,
+                  fontSize: 12, fontWeight: 700, padding: "7px 0", borderRadius: 7,
+                  backgroundColor: mobileViewMode === val ? "#FFFFFF" : "transparent",
+                  color: mobileViewMode === val ? "#1A1917" : "#6B7280",
+                  boxShadow: mobileViewMode === val ? "0 1px 2px rgba(0,0,0,0.08)" : "none",
+                  transition: "background 0.15s",
+                }}>{label}</button>
+              ))}
+            </div>
           </div>
 
           {/* [AI.7] FOCAL DAY (TODAY) — full job cards. Heading carries the

--- a/artifacts/qleno/src/pages/quote-builder.tsx
+++ b/artifacts/qleno/src/pages/quote-builder.tsx
@@ -2548,6 +2548,15 @@ export default function QuoteBuilderPage() {
                       <div style={{ display: "flex", justifyContent: "space-between", fontSize: 13, color: "#6B6860" }}>
                         <span>Base</span><span>${s.calc.base_price.toFixed(2)}</span>
                       </div>
+                      {/* [min-applied 2026-06-05] When hours × rate falls below the
+                          scope's Minimum Bill, the floor takes over and Base shows the
+                          minimum. Surface it so the office knows the price was floored
+                          (not mis-computed) — minimum applies regardless of sq ft. */}
+                      {s.calc.minimum_applied && (
+                        <div style={{ display: "flex", justifyContent: "space-between", fontSize: 11, color: "#9E9B94", fontFamily: FF, marginTop: -2 }}>
+                          <span>Minimum applied</span><span>${s.calc.minimum_bill.toFixed(2)} floor</span>
+                        </div>
+                      )}
                       {s.calc.addon_breakdown.map(a => (
                         <div key={a.id} style={{ display: "flex", justifyContent: "space-between", fontSize: 13, color: "#6B6860" }}>
                           <span>{a.name}</span><span>{a.amount < 0 ? `-$${Math.abs(a.amount).toFixed(2)}` : `+$${a.amount.toFixed(2)}`}</span>


### PR DESCRIPTION
Session work for the Phes office (2026-06-05).

## 1. Quote convert left jobs Unassigned
`POST /api/quotes/:id/convert` set `assigned_user_id` but never wrote a `job_technicians` row, so the chosen tech landed in dispatch **Unassigned**. Fix inserts the tech as primary (mirror invariant); also unlocks add-a-2nd-tech commission split.

## 2. MC-parity base hourly rates (one-time correction)
Insert-only seed never corrected stale rates, so quotes priced below MaidCentral. Guarded `UPDATE`s (only rows still at the old seed default → never clobbers Settings edits): Deep Clean/Move-In-Out/Hourly-Deep $70→**$80**, One-Time/Hourly-Standard $60→**$65**, Recurring **flat $65** across cadences. Cadence price difference stays in the per-cadence hours (already MC-matched).

## 3. "Minimum applied" note in quote builder
Price Preview shows "Minimum applied — $X floor" when a scope's Minimum Bill floors the price (applies regardless of sq ft).

## 4. Recent Activity feed on the main dashboard
HCP-style stream under the Weekly Revenue Forecast. `GET /api/dashboard/recent-activity` reads `app_audit_log` (company-scoped, 30 days, business events only). Clickable rows deep-link to each record.

## 5. Mobile Schedule — three switchable views (Time / Team / Grid)
Focal-day view switcher on the mobile Jobs page. Generic across all tenants (shared components, `company_id`-scoped data, nothing Phes-hardcoded).
- **View 1 — Time + color parity:** mobile card left stripe now uses `job.zone_color` (the same source the desktop Gantt fills with) instead of the status-blue palette — closes the desktop/mobile color variance. Already time-sorted.
- **View 2 — By Employee:** groups the day's jobs under each assigned tech (Unassigned on top), header shows count + total job hours. Cards keep zone color.
- **View 3 — Time-Grid (HCP-style):** hour grid, vertical = start time, height = duration, concurrent jobs packed into parallel columns (per-cluster, so lone jobs stay full width). Zone-colored blocks, luminance-based text, active amber ring, untimed jobs listed below.

Shipped as three commits so the views can be reviewed/tried as they land. Design note: list cards keep the white-card brand with a zone-color **stripe** (not a full fill) per the brand system; the Grid view uses full-color blocks since it's a calendar surface.

---
### Follow-ups (not in this PR)
- Recurring `Every 4 Weeks` $210 minimum over-prices tiny homes ~$9 vs MC — adjustable in Settings once MC's minimum is confirmed.
- Add-on "$377 vs $412" — needs the per-line breakdown from that quote to pin.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj