### PR TITLE
Desktop office clock in/out (per tech, per job)

### DIFF
--- a/artifacts/api-server/src/routes/timeclock.ts
+++ b/artifacts/api-server/src/routes/timeclock.ts
@@ -462,4 +462,78 @@ router.patch("/:id/override", requireAuth, requireRole("owner", "admin", "office
   }
 });
 
+// ── Office-initiated clock in/out (desktop dispatch board) ───────────────────
+// The field-app tech clock locks to req.auth.userId, so it can't cover the
+// office clocking the team in/out on the tech's behalf from the board. These
+// role-gated endpoints stamp a SPECIFIC tech's clock pair on a job — no
+// GPS/geofence (office override), source stays 'punched' so payroll and the
+// proportional-by-minutes commission split treat it as real clocked time.
+// Writes the legacy timeclock table (the one payroll + commission read), not
+// the GPS job_clock_events model. from_job_id is NOT a timeclock column — the
+// mileage hook lives on on_my_way_events and is untouched here.
+router.post("/office/clock-in", requireRole("owner", "admin", "office"), async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    const job_id = parseInt(String(req.body?.job_id));
+    const user_id = parseInt(String(req.body?.user_id));
+    if (!job_id || !user_id) return res.status(400).json({ error: "job_id and user_id are required" });
+    const clockInAt = req.body?.clock_in_at ? new Date(req.body.clock_in_at) : new Date();
+    if (isNaN(clockInAt.getTime())) return res.status(400).json({ error: "Invalid clock_in_at" });
+
+    const [jobRow] = await db.select({ id: jobsTable.id, branch_id: jobsTable.branch_id })
+      .from(jobsTable).where(and(eq(jobsTable.id, job_id), eq(jobsTable.company_id, companyId))).limit(1);
+    if (!jobRow) return res.status(404).json({ error: "Job not found" });
+    const [techRow] = await db.select({ id: usersTable.id })
+      .from(usersTable).where(and(eq(usersTable.id, user_id), eq(usersTable.company_id, companyId))).limit(1);
+    if (!techRow) return res.status(404).json({ error: "Employee not found" });
+
+    // Idempotent: if this tech already has an OPEN entry on this job, return it
+    // instead of stacking a second open punch.
+    const [open] = await db.select().from(timeclockTable).where(and(
+      eq(timeclockTable.company_id, companyId), eq(timeclockTable.job_id, job_id),
+      eq(timeclockTable.user_id, user_id), sql`${timeclockTable.clock_out_at} IS NULL`
+    )).limit(1);
+    if (open) return res.json({ ...open, already_open: true });
+
+    const [entry] = await db.insert(timeclockTable).values({
+      job_id, user_id, company_id: companyId,
+      branch_id: jobRow.branch_id ?? 1,
+      clock_in_at: clockInAt,
+      override_approved: true,
+      source: "punched",
+    }).returning();
+    return res.json(entry);
+  } catch (err) {
+    console.error("POST /timeclock/office/clock-in error:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
+router.post("/office/clock-out", requireRole("owner", "admin", "office"), async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    const job_id = parseInt(String(req.body?.job_id));
+    const user_id = parseInt(String(req.body?.user_id));
+    if (!job_id || !user_id) return res.status(400).json({ error: "job_id and user_id are required" });
+    const clockOutAt = req.body?.clock_out_at ? new Date(req.body.clock_out_at) : new Date();
+    if (isNaN(clockOutAt.getTime())) return res.status(400).json({ error: "Invalid clock_out_at" });
+
+    const [open] = await db.select().from(timeclockTable).where(and(
+      eq(timeclockTable.company_id, companyId), eq(timeclockTable.job_id, job_id),
+      eq(timeclockTable.user_id, user_id), sql`${timeclockTable.clock_out_at} IS NULL`
+    )).orderBy(desc(timeclockTable.clock_in_at)).limit(1);
+    if (!open) return res.status(400).json({ error: "No open clock-in for this employee on this job" });
+    if (clockOutAt.getTime() < new Date(open.clock_in_at).getTime())
+      return res.status(400).json({ error: "Clock-out cannot be before clock-in" });
+
+    const [updated] = await db.update(timeclockTable)
+      .set({ clock_out_at: clockOutAt })
+      .where(eq(timeclockTable.id, open.id)).returning();
+    return res.json(updated);
+  } catch (err) {
+    console.error("POST /timeclock/office/clock-out error:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
 export default router;

--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -301,6 +301,10 @@ function fmtHour(h: number) { if (h === 12) return "12 PM"; if (h === 0) return 
 // [card-polish 2026-06-05] Minutes-since-midnight -> "9:00 AM" / "2:30 PM".
 // Used to render a job's full shift range (start–end) on the mobile card.
 function fmtMins(mins: number) { const h = Math.floor(mins / 60), m = ((mins % 60) + 60) % 60; const ampm = h % 24 < 12 ? "AM" : "PM"; const hr = h % 12 === 0 ? 12 : h % 12; return `${hr}:${String(m).padStart(2, "0")} ${ampm}`; }
+// [office-clock 2026-06-05] Format an ISO timestamp as wall-clock time and a
+// clock-in -> clock-out span, for the desktop Time Clock panel.
+function fmtClock(iso: string) { const d = new Date(iso); return isNaN(d.getTime()) ? "—" : d.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" }); }
+function clockDuration(a: string, b: string) { const ms = new Date(b).getTime() - new Date(a).getTime(); if (isNaN(ms) || ms < 0) return "—"; const mins = Math.round(ms / 60000); const h = Math.floor(mins / 60), m = mins % 60; return h > 0 ? `${h}h ${m}m` : `${m}m`; }
 function slotBg(count: number) { if (count === 0) return "#DCFCE7"; if (count <= 2) return "#FEF3C7"; return "#FEE2E2"; }
 function slotTxt(count: number) { if (count === 0) return "#15803D"; if (count <= 2) return "#92400E"; return "#991B1B"; }
 // Honest labels: the count is total jobs booked that hour across the whole
@@ -1237,6 +1241,50 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
   const canManageCommission = (userRole === "owner" || userRole === "admin" || userRole === "office");
   const canEditOfficeNotes  = (userRole === "owner" || userRole === "admin" || userRole === "office");
 
+  // [office-clock 2026-06-05] Desktop office clock in/out. The field-app tech
+  // clock isn't shipped, so the office clocks the team in/out from the board to
+  // start collecting real clocked minutes — which feed payroll hours and the
+  // proportional-by-minutes commission split (Sal: "starting today we clock the
+  // team in and out"). Per-tech clock state for THIS job loads from the legacy
+  // timeclock table; writes go through the role-gated office endpoints.
+  const canClock = (userRole === "owner" || userRole === "admin" || userRole === "office");
+  const [clockMap, setClockMap] = useState<Record<number, { id: number; clock_in_at: string; clock_out_at: string | null }>>({});
+  const [clockBusy, setClockBusy] = useState<number | null>(null);
+  const loadClocks = useCallback(async () => {
+    try {
+      const r = await fetch(`${_API3}/api/timeclock?job_id=${job.id}`, { headers: { Authorization: `Bearer ${token}` } });
+      if (!r.ok) return;
+      const d = await r.json();
+      // Rows come newest-first; keep the most recent entry per tech as their
+      // current state (open if clock_out_at is null, else completed).
+      const m: Record<number, { id: number; clock_in_at: string; clock_out_at: string | null }> = {};
+      for (const e of (d.data ?? [])) {
+        if (!m[e.user_id]) m[e.user_id] = { id: e.id, clock_in_at: e.clock_in_at, clock_out_at: e.clock_out_at };
+      }
+      setClockMap(m);
+    } catch {}
+  }, [job.id, token, _API3]);
+  useEffect(() => { if (canClock) loadClocks(); }, [canClock, loadClocks]);
+
+  async function handleOfficeClock(user_id: number, dir: "in" | "out") {
+    setClockBusy(user_id);
+    try {
+      const r = await fetch(`${_API3}/api/timeclock/office/clock-${dir}`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+        body: JSON.stringify({ job_id: job.id, user_id }),
+      });
+      const d = await r.json().catch(() => ({}));
+      if (!r.ok) throw new Error(d.error || "Clock action failed");
+      await loadClocks();
+      onUpdate();
+    } catch (err: any) {
+      toast({ title: err.message || "Clock action failed" });
+    } finally {
+      setClockBusy(null);
+    }
+  }
+
   // Header overflow (•••) menu — home for rare/destructive actions so they
   // stay out of the everyday content flow.
   const [menuOpen, setMenuOpen] = useState(false);
@@ -2172,6 +2220,56 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
               </button>
             </PS>
           )}
+
+          {/* [office-clock 2026-06-05] Time Clock — office clocks each assigned
+              tech in/out on this job. Real punches feed payroll hours and the
+              actual-minutes commission split. Owner/admin/office only. */}
+          {canClock && (() => {
+            const techList: { user_id: number; name: string }[] = commTechs.length > 0
+              ? commTechs.map(t => ({ user_id: t.user_id, name: t.name }))
+              : (job.assigned_user_id ? [{ user_id: job.assigned_user_id, name: assignedEmp?.name || job.assigned_user_name || "Tech" }] : []);
+            if (techList.length === 0) return null;
+            return (
+              <PS label="Time Clock">
+                {techList.map(t => {
+                  const entry = clockMap[t.user_id];
+                  const clockedIn = !!entry && !entry.clock_out_at;
+                  const done = !!entry && !!entry.clock_out_at;
+                  const busy = clockBusy === t.user_id;
+                  return (
+                    <div key={t.user_id} style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 8, marginBottom: 8 }}>
+                      <div style={{ minWidth: 0 }}>
+                        <div style={{ fontSize: 12, fontWeight: 600, color: "#1A1917", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{t.name}</div>
+                        <div style={{ fontSize: 11, color: clockedIn ? "#B5710C" : done ? "#16A34A" : "#9E9B94", fontWeight: clockedIn || done ? 600 : 400 }}>
+                          {clockedIn
+                            ? `On the clock since ${fmtClock(entry!.clock_in_at)}`
+                            : done
+                              ? `${fmtClock(entry!.clock_in_at)}–${fmtClock(entry!.clock_out_at!)} · ${clockDuration(entry!.clock_in_at, entry!.clock_out_at!)}`
+                              : "Not clocked in"}
+                        </div>
+                      </div>
+                      <button
+                        onClick={() => handleOfficeClock(t.user_id, clockedIn ? "out" : "in")}
+                        disabled={busy || done}
+                        title={done ? "Shift complete" : clockedIn ? "Clock out" : "Clock in"}
+                        style={{
+                          flexShrink: 0, display: "inline-flex", alignItems: "center", gap: 5, fontSize: 12, fontWeight: 700,
+                          padding: "6px 12px", borderRadius: 7, fontFamily: FF, border: "none", color: "#FFFFFF",
+                          cursor: busy || done ? "default" : "pointer", opacity: busy ? 0.6 : 1,
+                          background: done ? "#C4C0BB" : clockedIn ? "#D85A30" : "#2D9B83",
+                        }}>
+                        <Clock size={12} />
+                        {done ? "Done" : clockedIn ? "Clock Out" : "Clock In"}
+                      </button>
+                    </div>
+                  );
+                })}
+                <div style={{ fontSize: 10.5, color: "#9E9B94", marginTop: 2 }}>
+                  Office clock — feeds payroll hours and the actual-minutes commission split.
+                </div>
+              </PS>
+            );
+          })()}
 
           {/* Add Tech Modal */}
           {addTechOpen && (


### PR DESCRIPTION
Lets the office clock the team **in and out from the desktop dispatch board**, per tech per job — so we start collecting real clocked minutes that feed payroll hours and the **proportional-by-minutes commission split** (the accuracy check you're after).

### Why
The field-app tech clock isn't shipped yet, and the existing `/api/timeclock/clock-in` locks to the calling tech (a tech can only clock themselves). There was no way for the office to clock someone in. This adds that.

### Backend — two role-gated endpoints (owner/admin/office)
Write the **legacy `timeclock` table** (the one payroll + commission actually read):
- `POST /api/timeclock/office/clock-in` `{ job_id, user_id, clock_in_at? }`
- `POST /api/timeclock/office/clock-out` `{ job_id, user_id, clock_out_at? }`

No GPS/geofence (office `override_approved`), `source` stays `'punched'` so payroll treats it as real time. Idempotent: clock-in returns an existing open punch instead of stacking; clock-out targets the open entry and rejects a time before clock-in. `from_job_id` is **not** a `timeclock` column — the mileage hook on `on_my_way_events` is untouched, per the locked mileage design.

### Frontend — Time Clock section in the desktop JobPanel
Lists each assigned tech with a **Clock In / Clock Out** button and their live state ("On the clock since 9:04 AM" / "9:04 AM–1:58 PM · 4h 54m · Done"). Refreshes the board on change so the chip's active amber stripe reflects the punch. Multi-tech jobs show one row per tech (each runs their own pair, per the Time-Clock model).

### Honest limits (follow-ups if you want them)
- Once a tech is clocked out ("Done"), the row locks — **time corrections** (fix a wrong in/out) aren't in this first pass; that's the natural next add.
- Per-tech clock state loads via `GET /api/timeclock?job_id=X` when the panel opens (the dispatch payload only carries one clock_entry per job).

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_