### PR TITLE
Fix recurring occurrence regenerating on its old day after a reschedule

### DIFF
--- a/artifacts/api-server/src/lib/recurring-jobs.ts
+++ b/artifacts/api-server/src/lib/recurring-jobs.ts
@@ -195,6 +195,11 @@ export async function insertJobFromSchedule(
       service_type: mapServiceType(schedule.service_type) as any,
       status: "scheduled" as const,
       scheduled_date: toDateStr(date),
+      // [recurring-reschedule 2026-06-05] Stamp the cadence slot. scheduled_date
+      // and occurrence_date start equal; the office can later move
+      // scheduled_date, but occurrence_date stays so dedup still sees this slot
+      // as filled and the cron won't regenerate it.
+      occurrence_date: toDateStr(date) as any,
       scheduled_time: (schedule.scheduled_time ?? null) as any,
       frequency: mapFrequency(schedule.frequency) as any,
       base_fee: schedule.base_fee ? String(parseFloat(schedule.base_fee).toFixed(2)) : "0.00",
@@ -295,19 +300,26 @@ export async function computeOccurrencesForSchedule(
   const fromStr = toDateStr(fromDate);
   const toStr = toDateStr(toDate);
 
-  const existingRows = await db
-    .select({ scheduled_date: jobsTable.scheduled_date })
-    .from(jobsTable)
-    .where(
-      and(
-        eq(jobsTable.company_id, schedule.company_id),
-        eq((jobsTable as any).recurring_schedule_id, schedule.id),
-        gte(jobsTable.scheduled_date, fromStr),
-        lte(jobsTable.scheduled_date, toStr)
-      )
-    );
+  // [recurring-reschedule 2026-06-05] Dedup on the job's OCCURRENCE date (the
+  // cadence slot it was born from), not its scheduled_date. When the office
+  // moves a recurring occurrence off its day, scheduled_date changes but
+  // occurrence_date does not — so the slot still reads as filled and this run
+  // won't regenerate a duplicate on the original day (the "appears again on
+  // Monday 8th" bug). COALESCE falls back to scheduled_date for legacy rows
+  // generated before occurrence_date existed (backfilled on migration, but the
+  // fallback keeps a fresh deploy correct before the backfill lands). Matching
+  // on the coalesced occurrence date also catches a job that was moved OUT of
+  // the [from,to] window — its slot is still inside the window and stays filled.
+  const existing = await db.execute(sql`
+    SELECT COALESCE(occurrence_date, scheduled_date)::text AS occ
+    FROM jobs
+    WHERE company_id = ${schedule.company_id}
+      AND recurring_schedule_id = ${schedule.id}
+      AND COALESCE(occurrence_date, scheduled_date) >= ${fromStr}
+      AND COALESCE(occurrence_date, scheduled_date) <= ${toStr}
+  `);
 
-  const existingDates = new Set(existingRows.map(r => String(r.scheduled_date)));
+  const existingDates = new Set((existing.rows as any[]).map(r => String(r.occ)));
 
   const toInsert = occurrences.filter(d => !existingDates.has(toDateStr(d)));
   const skipped = occurrences.length - toInsert.length;
@@ -331,6 +343,7 @@ export async function computeOccurrencesForSchedule(
       service_type: mapServiceType(schedule.service_type) as any,
       status: "scheduled" as const,
       scheduled_date: toDateStr(d),
+      occurrence_date: toDateStr(d),
       scheduled_time: (schedule.scheduled_time ?? null) as any,
       frequency: mapFrequency(schedule.frequency) as any,
       base_fee: schedule.base_fee ? String(parseFloat(schedule.base_fee).toFixed(2)) : "0.00",

--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -25,6 +25,12 @@ async function runBookingSchemaGuard(): Promise<void> {
   const guards: Array<{ label: string; stmt: string }> = [
     // ── jobs extra columns ──────────────────────────────────────────────────
     { label: "jobs.home_condition_rating", stmt: "ALTER TABLE jobs ADD COLUMN IF NOT EXISTS home_condition_rating INTEGER" },
+    // [recurring-reschedule 2026-06-05] Stable cadence-slot identity for the
+    // recurrence dedup (see lib/recurring-jobs.ts). Column add then a one-time
+    // backfill so existing recurring jobs get occurrence_date = scheduled_date
+    // (their slot before any move). Idempotent: the UPDATE only fills NULLs.
+    { label: "jobs.occurrence_date", stmt: "ALTER TABLE jobs ADD COLUMN IF NOT EXISTS occurrence_date DATE" },
+    { label: "jobs.occurrence_date backfill", stmt: "UPDATE jobs SET occurrence_date = scheduled_date WHERE recurring_schedule_id IS NOT NULL AND occurrence_date IS NULL" },
     { label: "jobs.condition_multiplier",  stmt: "ALTER TABLE jobs ADD COLUMN IF NOT EXISTS condition_multiplier NUMERIC(5,3)" },
     { label: "jobs.applied_bundle_id",     stmt: "ALTER TABLE jobs ADD COLUMN IF NOT EXISTS applied_bundle_id INTEGER" },
     { label: "jobs.bundle_discount_total", stmt: "ALTER TABLE jobs ADD COLUMN IF NOT EXISTS bundle_discount_total NUMERIC(10,2)" },

--- a/lib/db/src/schema/jobs.ts
+++ b/lib/db/src/schema/jobs.ts
@@ -84,6 +84,13 @@ export const jobsTable = pgTable("jobs", {
   zone_id: integer("zone_id"),
   branch_id: integer("branch_id").references(() => branchesTable.id),
   recurring_schedule_id: integer("recurring_schedule_id"),
+  // [recurring-reschedule 2026-06-05] The cadence slot this job was generated
+  // from — a stable identity for dedup, separate from scheduled_date (which the
+  // office can move). The recurrence engine dedups on occurrence_date so moving
+  // a recurring occurrence off its day never frees the original slot for the
+  // nightly cron to regenerate (the "appears again on Monday" duplicate bug).
+  // NULL for one-off (non-recurring) jobs.
+  occurrence_date: date("occurrence_date"),
   supply_cost: numeric("supply_cost", { precision: 8, scale: 2 }).default("0.00"),
   created_at: timestamp("created_at").notNull().defaultNow(),
   // ── Booking widget extra fields ─────────────────────────────────────────────


### PR DESCRIPTION
Fixes the office report (Maribel, 6/5): *"every time I move a service from Monday, it stays in the new reschedule but it appears again on Monday 8th — as if it's forced to have those services those days."*

### Root cause
The recurrence engine deduped on **`jobs.scheduled_date`** — "do I already have a job for this Monday?" When you drag a recurring occurrence off Monday, only `scheduled_date` changes (to the new day); the job stays linked to the series via `recurring_schedule_id`. So the nightly cron no longer sees a job *on Monday*, decides Monday is empty, and **regenerates it** → duplicate. There was no concept of "this occurrence was moved."

### Fix
Give each generated job a stable **`occurrence_date`** (the cadence slot it was born from), separate from `scheduled_date` (where it currently sits). Dedup on `occurrence_date`, so moving a job never frees its original slot.

- **`jobs.occurrence_date`** — new `DATE` column; `NULL` for one-off jobs.
- **`insertJobFromSchedule`** stamps `occurrence_date = scheduled_date` at birth. It's the single insert path, so this covers both the **nightly cron** and the **PATCH cascade** (which reuses it).
- **`computeOccurrencesForSchedule`** dedups on `COALESCE(occurrence_date, scheduled_date)` within the generation window — the `COALESCE` keeps legacy rows correct before the backfill, and matching on the slot date also catches a job moved *out* of the window (its slot is still inside it).
- **Migration**: adds the column + a one-time backfill (`occurrence_date = scheduled_date` for existing recurring jobs).

**No reschedule endpoints changed** — moving a job only touches `scheduled_date`; `occurrence_date` persists, so the slot stays "filled."

### Behavior after fix
- Move a Monday recurring job to Tuesday → it sits on Tuesday, and the cron sees Monday's slot still filled (by the moved job's `occurrence_date`) → **no duplicate**.
- Cancelled/edited occurrences still hold their slot (unchanged from today's behavior).
- Deleting a moved occurrence frees the slot → it regenerates next run (same as deleting any occurrence today).

### Note on existing duplicates
This stops *new* duplicates. Any duplicate jobs already created on Mondays before this deploy are existing data — say the word and I'll write a one-time cleanup to remove the regenerated Monday copies where the office already moved the occurrence.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_