### PR TITLE
CRITICAL: stop overnight job deletion (commercial same-day jobs) + deleted recurring occurrences stay gone

### DIFF
--- a/artifacts/api-server/src/lib/recurring-jobs.ts
+++ b/artifacts/api-server/src/lib/recurring-jobs.ts
@@ -321,7 +321,18 @@ export async function computeOccurrencesForSchedule(
 
   const existingDates = new Set((existing.rows as any[]).map(r => String(r.occ)));
 
-  const toInsert = occurrences.filter(d => !existingDates.has(toDateStr(d)));
+  // [recurring-delete-skip 2026-06-05] Occurrence dates the office deleted on
+  // purpose. The generator must NOT regenerate them — otherwise a deleted
+  // recurring occurrence "keeps coming back". Stored as YYYY-MM-DD on the
+  // schedule; normalize to a date string and exclude from the insert set.
+  const skipSet = new Set(
+    (((schedule as any).skipped_dates ?? []) as (string | Date)[]).map(x => String(x).slice(0, 10))
+  );
+
+  const toInsert = occurrences.filter(d => {
+    const ds = toDateStr(d);
+    return !existingDates.has(ds) && !skipSet.has(ds);
+  });
   const skipped = occurrences.length - toInsert.length;
 
   if (!toInsert.length) return { rows: [], skipped };

--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -25,6 +25,9 @@ async function runBookingSchemaGuard(): Promise<void> {
   const guards: Array<{ label: string; stmt: string }> = [
     // ── jobs extra columns ──────────────────────────────────────────────────
     { label: "jobs.home_condition_rating", stmt: "ALTER TABLE jobs ADD COLUMN IF NOT EXISTS home_condition_rating INTEGER" },
+    // [recurring-delete-skip 2026-06-05] Deleted-occurrence tombstones so a
+    // recurring occurrence the office removed isn't regenerated next run.
+    { label: "recurring_schedules.skipped_dates", stmt: "ALTER TABLE recurring_schedules ADD COLUMN IF NOT EXISTS skipped_dates DATE[] DEFAULT '{}'" },
     // [recurring-reschedule 2026-06-05] Stable cadence-slot identity for the
     // recurrence dedup (see lib/recurring-jobs.ts). Column add then a one-time
     // backfill so existing recurring jobs get occurrence_date = scheduled_date
@@ -1388,47 +1391,24 @@ async function runScopeVisibility(): Promise<void> {
 //
 // Cancelled jobs can still coexist with active ones (cancel + rebook).
 async function runJobsDedupeAndConstraint(): Promise<void> {
-  // Step 1: dedupe. Partition collapses NULL scheduled_time into the
-  // sentinel '00:00:00' so two NULL-time rows for the same client/date
-  // are caught. Order by created_at DESC, id DESC to keep the latest
-  // row — operator edits land via PATCH which doesn't change `id` but
-  // does bump `updated_at` indirectly via the row itself; if both
-  // share created_at, lowest id wins as a stable tiebreak.
-  const deleted = await db.execute(sql`
-    WITH dupes AS (
-      SELECT id,
-             ROW_NUMBER() OVER (
-               PARTITION BY company_id, client_id, scheduled_date,
-                            COALESCE(scheduled_time::text, '00:00:00')
-               ORDER BY created_at DESC NULLS LAST, id DESC
-             ) AS rn
-      FROM jobs
-      WHERE status NOT IN ('cancelled')
-    )
-    DELETE FROM jobs
-    WHERE id IN (SELECT id FROM dupes WHERE rn > 1)
-    RETURNING id
-  `);
-  const removed = (deleted.rows ?? []).length;
-  // [iter 2 logging] Always log — distinguishes "ran, found nothing"
-  // from "didn't run at all" when staring at Railway logs.
-  console.log(`[jobs-dedupe] Migration ran. Removed ${removed} duplicate job row(s).`);
-
-  // Step 2: replace the old index with the COALESCE-keyed version.
-  // Drop-then-create is safe because the dedupe in step 1 just ran;
-  // no transient duplicates to trip the new index. IF EXISTS guards
-  // first-run when the old name was never created.
+  // [overnight-job-loss 2026-06-05] CRITICAL FIX. This used to DELETE every
+  // non-cancelled job that shared (company_id, client_id, scheduled_date,
+  // scheduled_time) with another — keeping one — and enforce a UNIQUE index on
+  // that key. That "no double-book" assumption is WRONG for commercial
+  // accounts: a single client legitimately has multiple jobs the same day at
+  // the same time (KMA's Office + Common Areas, Daniel Walter's multiple PPM
+  // turnovers, multi-unit common areas, etc.). Running on EVERY cold-start
+  // (every deploy/restart), the sweep silently deleted those real jobs and the
+  // index blocked re-creating them — the office's "we scheduled jobs, woke up
+  // and they're gone / revenue is wrong again" report, and the Tuesday
+  // MC-vs-Qleno shortfall (Hilda's 3 PPM jobs collapsed to 1).
+  //
+  // Fix: NEVER auto-delete jobs here, and DROP the bad index so multiple
+  // same-client / same-day / same-time jobs can coexist. True recurrence
+  // duplicates are prevented at generation time by the engine's occurrence_date
+  // dedup (lib/recurring-jobs.ts) — not by a destructive nightly DB sweep.
   await db.execute(sql`DROP INDEX IF EXISTS uq_jobs_no_double_book`);
-  await db.execute(sql`
-    CREATE UNIQUE INDEX IF NOT EXISTS uq_jobs_no_double_book
-      ON jobs (
-        company_id,
-        client_id,
-        scheduled_date,
-        (COALESCE(scheduled_time::text, '00:00:00'))
-      )
-      WHERE status NOT IN ('cancelled')
-  `);
+  console.log("[jobs-dedupe] Destructive same-day dedupe REMOVED; dropped uq_jobs_no_double_book (commercial clients legitimately have multiple same-day jobs).");
 }
 
 // [pay-matrix 2026-04-29] Backfill the per-employee pay matrix and

--- a/artifacts/api-server/src/routes/admin.ts
+++ b/artifacts/api-server/src/routes/admin.ts
@@ -501,39 +501,20 @@ router.post("/jobs-dedupe-run", ...isSuperAdmin, async (_req, res) => {
     `);
     const previewRows = preview.rows as any[];
 
-    const deleted = await db.execute(sql`
-      WITH dupes AS (
-        SELECT id,
-               ROW_NUMBER() OVER (
-                 PARTITION BY company_id, client_id, scheduled_date,
-                              COALESCE(scheduled_time::text, '00:00:00')
-                 ORDER BY created_at DESC NULLS LAST, id DESC
-               ) AS rn
-        FROM jobs
-        WHERE status NOT IN ('cancelled')
-      )
-      DELETE FROM jobs
-      WHERE id IN (SELECT id FROM dupes WHERE rn > 1)
-      RETURNING id
-    `);
-
+    // [overnight-job-loss 2026-06-05] DISABLED the destructive half. Commercial
+    // clients legitimately have multiple same-day / same-time jobs, so deleting
+    // "duplicates" by (client, date, time) and recreating the unique index
+    // wiped real jobs (same bug as phes-data-migration's runJobsDedupeAndConstraint).
+    // This endpoint now only DROPS the bad index and reports the rows the old
+    // logic WOULD have deleted — for inspection only. Nothing is deleted.
     await db.execute(sql`DROP INDEX IF EXISTS uq_jobs_no_double_book`);
-    await db.execute(sql`
-      CREATE UNIQUE INDEX IF NOT EXISTS uq_jobs_no_double_book
-        ON jobs (
-          company_id,
-          client_id,
-          scheduled_date,
-          (COALESCE(scheduled_time::text, '00:00:00'))
-        )
-        WHERE status NOT IN ('cancelled')
-    `);
 
     return res.json({
-      deleted_count: (deleted.rows ?? []).length,
-      deleted_ids: (deleted.rows as any[]).map(r => r.id),
+      deleted_count: 0,
+      deleted_ids: [],
       preview_rows: previewRows,
-      index: "uq_jobs_no_double_book recreated",
+      index: "uq_jobs_no_double_book dropped — destructive dedupe disabled",
+      note: "Destructive same-day dedupe is permanently disabled (commercial clients legitimately have multiple same-day jobs). No jobs were deleted.",
     });
   } catch (err: any) {
     console.error("[admin] jobs-dedupe-run error:", err);

--- a/artifacts/api-server/src/routes/jobs.ts
+++ b/artifacts/api-server/src/routes/jobs.ts
@@ -2804,6 +2804,30 @@ router.delete("/:id", requireAuth, async (req, res) => {
     const role = req.auth!.role;
     const force = req.query.force === "true";
 
+    // [recurring-delete-skip 2026-06-05] Capture the recurring linkage BEFORE
+    // deleting so we can tombstone the occurrence's cadence slot on the
+    // schedule. Without this, the generator regenerates the deleted occurrence
+    // next run and it "keeps coming back". Skip the cadence slot
+    // (occurrence_date, falling back to scheduled_date) — the same key the
+    // engine dedups on.
+    const recurInfo = ((await db.execute(sql`
+      SELECT recurring_schedule_id, occurrence_date::text AS occ, scheduled_date::text AS sched
+      FROM jobs WHERE id = ${jobId} AND company_id = ${companyId} LIMIT 1
+    `)).rows[0]) as any;
+    async function tombstoneOccurrence() {
+      const sid = recurInfo?.recurring_schedule_id;
+      const skipDate = recurInfo?.occ ?? recurInfo?.sched;
+      if (sid != null && skipDate) {
+        await db.execute(sql`
+          UPDATE recurring_schedules
+          SET skipped_dates = ARRAY(
+            SELECT DISTINCT unnest(COALESCE(skipped_dates, '{}'::date[]) || ARRAY[${skipDate}::date])
+          )
+          WHERE id = ${sid} AND company_id = ${companyId}
+        `);
+      }
+    }
+
     // Force-delete branch: admin/owner can wipe a completed job's clock entries
     // and then delete the job in a single transaction.
     if (force) {
@@ -2866,6 +2890,7 @@ router.delete("/:id", requireAuth, async (req, res) => {
           .delete(jobsTable)
           .where(and(eq(jobsTable.id, jobId), eq(jobsTable.company_id, companyId)));
       });
+      await tombstoneOccurrence();
       logAudit(req, "DELETE", "job", jobId, null, { force: true });
       return res.json({ success: true, message: "Job and dependent records cleaned up" });
     }
@@ -2876,6 +2901,7 @@ router.delete("/:id", requireAuth, async (req, res) => {
         eq(jobsTable.id, jobId),
         eq(jobsTable.company_id, companyId)
       ));
+    await tombstoneOccurrence();
     logAudit(req, "DELETE", "job", jobId, null, null);
     return res.json({ success: true, message: "Job deleted" });
   } catch (err) {

--- a/lib/db/src/schema/recurring_schedules.ts
+++ b/lib/db/src/schema/recurring_schedules.ts
@@ -55,6 +55,11 @@ export const recurringSchedulesTable = pgTable("recurring_schedules", {
   // PATCH endpoint enforces exclusivity; engine warns and prefers
   // days_of_week if both end up populated.
   days_of_week: integer("days_of_week").array(),
+  // [recurring-delete-skip 2026-06-05] Occurrence dates the office deleted on
+  // purpose. The generator skips these so a deleted occurrence stays gone
+  // instead of being regenerated next run (the series otherwise keeps going).
+  // YYYY-MM-DD entries, matched against each occurrence's cadence slot.
+  skipped_dates: date("skipped_dates").array(),
   // [PR #58] Anchor days for monthly + semi_monthly cadences. Stored as an
   // INTEGER[] of day-of-month values (1..31 plus a sentinel 0 for "last day
   // of month" — engine resolves 0 to the actual last day per month).


### PR DESCRIPTION
## 🚨 Critical: overnight job loss + "revenue is wrong again"

**Root cause:** `runJobsDedupeAndConstraint()` runs on **every cold-start** (every deploy/restart) and **DELETES** every non-cancelled job that shares `(company_id, client_id, scheduled_date, scheduled_time)` with another — keeping one — and enforces a UNIQUE index on that key.

That "no double-book" rule is **wrong for commercial accounts**: one client legitimately has multiple jobs the same day at the same time — KMA's **Office + Common Areas**, Daniel Walter's multiple **PPM turnovers**, multi-unit common areas. So the sweep silently **deleted real jobs**, and the index **blocked recreating them**.

This single bug explains all three reports:
- **"We scheduled jobs, woke up and they're gone"** — deleted on the next cold-start.
- **"Revenue is wrong again"** — fewer jobs after the sweep.
- **Tuesday MC-vs-Qleno shortfall** — Hilda's 3 PPM jobs collapsed to 1; Qleno 14 vs MC 17.

**Fix:** never auto-delete jobs there, and **DROP** the bad index so same-day jobs coexist. True recurrence duplicates are already prevented at generation time by the `occurrence_date` dedup (merged earlier), so the destructive nightly sweep is not needed.

## Also: deleted recurring occurrences now stay gone
Your other report — *"this job keeps coming back no matter how much I delete it."* The generator regenerates any empty slot, and a delete left no record that it was intentional.
- New `recurring_schedules.skipped_dates` (DATE[]) — occurrences the office deleted on purpose.
- `DELETE /api/jobs/:id` tombstones the deleted occurrence's cadence slot (normal + force paths).
- The generator excludes skipped dates → a deleted recurring occurrence isn't regenerated.

## ⚠️ Note on already-lost data
This **stops future loss**. Jobs already deleted by prior cold-starts are gone and need re-adding (or restoring from MC). Once this deploys, the bad index is dropped and manual same-day jobs will persist.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_