### PR TITLE
Confirm step before a series-wide recurring edit

### DIFF
--- a/artifacts/qleno/src/components/edit-job-modal.tsx
+++ b/artifacts/qleno/src/components/edit-job-modal.tsx
@@ -377,6 +377,11 @@ export default function EditJobModal({
   type CascadeChoice = "this_job" | "this_and_future" | "all" | "remove_this" | "create_recurring";
   const [cascadePromptOpen, setCascadePromptOpen] = useState(false);
   const [cascadeChoice, setCascadeChoice] = useState<CascadeChoice>("this_job");
+  // [cascade-confirm 2026-06-05] Second-step confirm before a series-wide apply
+  // (this_and_future / all). These scopes can REMOVE future occurrences (when
+  // the day pattern changed) and recreate them — Sal asked for an explicit
+  // "are you sure" so a broad edit can't surprise anyone.
+  const [cascadeConfirm, setCascadeConfirm] = useState(false);
   // [PR / 2026-04-30] Set true when onSaveClick detected a mixed edit
   // (BOTH template + occurrence fields changed). Renders a footnote in
   // the cascade prompt explaining what "Just this visit" will and
@@ -2242,7 +2247,7 @@ export default function EditJobModal({
                     const sel = cascadeChoice === opt.v;
                     return (
                       <div key={opt.v}>
-                        <button type="button" onClick={() => setCascadeChoice(opt.v)}
+                        <button type="button" onClick={() => { setCascadeChoice(opt.v); setCascadeConfirm(false); }}
                           style={{
                             width: "100%",
                             textAlign: "left", padding: "12px 14px", borderRadius: 10,
@@ -2290,16 +2295,42 @@ export default function EditJobModal({
                 </div>
               );
             })()}
-            <div style={{ display: "flex", gap: 8 }}>
-              <button onClick={() => { setCascadePromptOpen(false); setMixedEditWarning(null); }} disabled={saving}
-                style={{ flex: 1, padding: "10px", borderRadius: 8, border: "1px solid #E5E2DC", background: "#FFFFFF", color: "#6B7280", fontSize: 13, fontWeight: 600, cursor: "pointer", fontFamily: FF }}>
-                Cancel
-              </button>
-              <button onClick={() => submit(cascadeChoice)} disabled={saving}
-                style={{ flex: 2, padding: "10px", borderRadius: 8, border: "none", background: "var(--brand, #00C9A0)", color: "#FFFFFF", fontSize: 13, fontWeight: 700, cursor: saving ? "wait" : "pointer", fontFamily: FF }}>
-                {saving ? "Applying…" : "Apply changes"}
-              </button>
-            </div>
+            {(() => {
+              const isSeriesWide = cascadeChoice === "this_and_future" || cascadeChoice === "all";
+              return (
+                <>
+                  {isSeriesWide && cascadeConfirm && (
+                    <div style={{ display: "flex", gap: 8, alignItems: "flex-start", padding: "10px 12px", background: "#FEF2F2", border: "1px solid #FCA5A5", borderRadius: 8, marginBottom: 10 }}>
+                      <AlertTriangle size={16} color="#B91C1C" style={{ flexShrink: 0, marginTop: 1 }} />
+                      <span style={{ fontSize: 12, color: "#991B1B", lineHeight: 1.4 }}>
+                        This applies to <strong>{cascadeChoice === "all" ? "every visit (past + future)" : "every future visit"}</strong> of this recurring job. If you changed the day, occurrences that no longer match are <strong>removed</strong> and recreated on the new day. Make sure that's intended.
+                      </span>
+                    </div>
+                  )}
+                  <div style={{ display: "flex", gap: 8 }}>
+                    <button
+                      onClick={() => {
+                        if (isSeriesWide && cascadeConfirm) { setCascadeConfirm(false); return; }
+                        setCascadePromptOpen(false); setMixedEditWarning(null); setCascadeConfirm(false);
+                      }}
+                      disabled={saving}
+                      style={{ flex: 1, padding: "10px", borderRadius: 8, border: "1px solid #E5E2DC", background: "#FFFFFF", color: "#6B7280", fontSize: 13, fontWeight: 600, cursor: "pointer", fontFamily: FF }}>
+                      {isSeriesWide && cascadeConfirm ? "Back" : "Cancel"}
+                    </button>
+                    <button
+                      onClick={() => {
+                        // First click on a series-wide scope arms the confirm; second click commits.
+                        if (isSeriesWide && !cascadeConfirm) { setCascadeConfirm(true); return; }
+                        submit(cascadeChoice);
+                      }}
+                      disabled={saving}
+                      style={{ flex: 2, padding: "10px", borderRadius: 8, border: "none", background: (isSeriesWide && cascadeConfirm) ? "#DC2626" : "var(--brand, #00C9A0)", color: "#FFFFFF", fontSize: 13, fontWeight: 700, cursor: saving ? "wait" : "pointer", fontFamily: FF }}>
+                      {saving ? "Applying…" : (isSeriesWide && cascadeConfirm) ? "Yes, apply to the series" : "Apply changes"}
+                    </button>
+                  </div>
+                </>
+              );
+            })()}
           </div>
         </>
       )}

--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -916,6 +916,9 @@ function InlineTimeEdit({ job, onUpdate }: { job: DispatchJob; onUpdate: () => v
   const [editing, setEditing] = useState(false);
   const [saving, setSaving] = useState(false);
   const [cascadePrompt, setCascadePrompt] = useState<null | "open">(null);
+  // [cascade-confirm 2026-06-05] Series-wide scopes (this_and_future / all) can
+  // remove + recreate future occurrences; require an explicit confirm step.
+  const [pendingScope, setPendingScope] = useState<null | "this_and_future" | "all">(null);
   const [error, setError] = useState<string | null>(null);
   const [start, setStart] = useState(startH24);
   const [durationH, setDurationH] = useState<number>(initialDurationH);
@@ -1106,6 +1109,24 @@ function InlineTimeEdit({ job, onUpdate }: { job: DispatchJob; onUpdate: () => v
           }}>
             <div style={{ fontSize: 16, fontWeight: 800, color: "#1A1917", marginBottom: 6 }}>Apply this change to:</div>
             <div style={{ fontSize: 12, color: "#6B6860", marginBottom: 14 }}>This is a recurring job. Pick how broadly the time change should apply.</div>
+            {pendingScope && (
+              <div style={{ display: "flex", gap: 8, alignItems: "flex-start", padding: "10px 12px", background: "#FEF2F2", border: "1px solid #FCA5A5", borderRadius: 8, marginBottom: 12 }}>
+                <AlertTriangle size={16} color="#B91C1C" style={{ flexShrink: 0, marginTop: 1 }} />
+                <span style={{ fontSize: 12, color: "#991B1B", lineHeight: 1.4 }}>
+                  This applies to <strong>{pendingScope === "all" ? "every visit (past + future)" : "every future visit"}</strong> of this recurring job. If you changed the day, occurrences that no longer match are <strong>removed</strong> and recreated. Continue?
+                </span>
+              </div>
+            )}
+            {pendingScope ? (
+              <div style={{ display: "flex", gap: 8, marginBottom: 4 }}>
+                <button type="button" onClick={() => setPendingScope(null)} disabled={saving}
+                  style={{ flex: 1, padding: "10px", borderRadius: 8, border: "1px solid #E5E2DC", background: "#FFFFFF", color: "#6B7280", fontSize: 13, fontWeight: 600, cursor: "pointer", fontFamily: FF }}>Back</button>
+                <button type="button" onClick={() => submit(pendingScope)} disabled={saving}
+                  style={{ flex: 2, padding: "10px", borderRadius: 8, border: "none", background: "#DC2626", color: "#FFFFFF", fontSize: 13, fontWeight: 700, cursor: saving ? "wait" : "pointer", fontFamily: FF }}>
+                  {saving ? "Applying…" : "Yes, apply to the series"}
+                </button>
+              </div>
+            ) : (
             <div style={{ display: "flex", flexDirection: "column", gap: 8, marginBottom: 16 }}>
               {([
                 { v: "this_job",        label: "Just this visit",                  sub: "Default. Updates this occurrence; other visits unchanged." },
@@ -1113,7 +1134,9 @@ function InlineTimeEdit({ job, onUpdate }: { job: DispatchJob; onUpdate: () => v
                 { v: "all",             label: "All visits in the series",         sub: "Backfills past + future. Paid past jobs are skipped." },
                 { v: "remove_this",     label: "Skip this visit only",             sub: "Mark this visit as one-off; schedule template stays intact." },
               ] as const).map(opt => (
-                <button key={opt.v} type="button" onClick={() => submit(opt.v)} disabled={saving}
+                <button key={opt.v} type="button"
+                  onClick={() => { if (opt.v === "this_and_future" || opt.v === "all") setPendingScope(opt.v); else submit(opt.v); }}
+                  disabled={saving}
                   style={{
                     textAlign: "left", padding: "12px 14px", borderRadius: 10,
                     border: "1.5px solid #E5E2DC", background: "#F7F6F3",
@@ -1124,7 +1147,8 @@ function InlineTimeEdit({ job, onUpdate }: { job: DispatchJob; onUpdate: () => v
                 </button>
               ))}
             </div>
-            <button onClick={() => setCascadePrompt(null)} disabled={saving}
+            )}
+            <button onClick={() => { setPendingScope(null); setCascadePrompt(null); }} disabled={saving}
               style={{ width: "100%", padding: "8px", borderRadius: 8, border: "1px solid #E5E2DC", background: "#FFFFFF", color: "#6B7280", fontSize: 12, fontWeight: 600, cursor: "pointer", fontFamily: FF }}>
               Cancel
             </button>


### PR DESCRIPTION
Adds an explicit "are you sure" before a **series-wide** recurring edit, so the one remaining user-triggered way a save can remove jobs can't surprise anyone.

Context: after the job-loss fix (#324), nothing auto-deletes jobs. The only way an *edit* removes occurrences is choosing **"This and all future"** or **"All visits"** while changing the recurrence day — the server then removes occurrences that no longer fall on the new day(s) and recreates them. This adds a confirm gate to that.

- **EditJobModal** (main edit path): selecting a series-wide scope arms a red warning banner explaining it affects every (future/past+future) visit and may remove + recreate occurrences. The primary button becomes **"Yes, apply to the series"** (red) and must be clicked again to commit; Cancel becomes **Back**.
- **Inline quick-time editor** (dispatch panel): same gate — "This and future" / "All visits" shows the warning + confirm before submitting.
- **Single-visit edits** (Just this visit / Skip this visit) are unchanged — no extra click, they only touch the one occurrence.

Frontend-only; typechecks clean.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_