### PR TITLE
Show bundle discount in quote total + add-ons on the job bar

### DIFF
--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -4431,16 +4431,26 @@ function JobChipBody({
                 {Math.round((allowedMin / 60) * 10) / 10}h
               </span>
             )}
-            {addOnCount > 0 && isWide && (
-              <span style={{
-                flexShrink: 0, fontSize: 9, fontWeight: 700,
-                padding: "1px 5px", borderRadius: 4,
-                backgroundColor: tokens.pillBg, color: tokens.primary,
-                lineHeight: 1.2, whiteSpace: "nowrap",
-              }}>
-                +{addOnCount}
-              </span>
-            )}
+            {/* [addons-on-bar 2026-06-05] Show the add-ons on the chip itself
+                (Sal: "add-on emblems or text need to show on the job bar so we
+                have full scope"). Wide chips render the names (truncated, full
+                list in the tooltip); medium chips show "+N add-ons"; narrow
+                chips drop it (the panel still lists them). */}
+            {addOnCount > 0 && !isNarrow && (() => {
+              const names = (job.add_ons ?? []).map(a => a.name).filter(Boolean).join(", ");
+              return (
+                <span title={names || `${addOnCount} add-on${addOnCount > 1 ? "s" : ""}`} style={{
+                  flexShrink: 0, fontSize: 9, fontWeight: 700,
+                  padding: "1px 5px", borderRadius: 4,
+                  backgroundColor: tokens.pillBg, color: tokens.primary,
+                  lineHeight: 1.2, whiteSpace: "nowrap",
+                  overflow: "hidden", textOverflow: "ellipsis",
+                  maxWidth: isWide ? 150 : 78,
+                }}>
+                  {isWide && names ? `+ ${names}` : `+${addOnCount} add-on${addOnCount > 1 ? "s" : ""}`}
+                </span>
+              );
+            })()}
           </div>
         </>
       )}

--- a/artifacts/qleno/src/pages/quote-builder.tsx
+++ b/artifacts/qleno/src/pages/quote-builder.tsx
@@ -2562,6 +2562,16 @@ export default function QuoteBuilderPage() {
                           <span>{a.name}</span><span>{a.amount < 0 ? `-$${Math.abs(a.amount).toFixed(2)}` : `+$${a.amount.toFixed(2)}`}</span>
                         </div>
                       ))}
+                      {/* [bundle-display 2026-06-05] Bundle discounts are subtracted from
+                          the total in the calc but were never shown here — so the line
+                          items summed to MORE than the Total and it looked like broken
+                          addition (Maribel's "the issue is the addition" — a hidden $35).
+                          Render each matched bundle so Base + add-ons − bundle = Total. */}
+                      {(s.calc.bundle_breakdown ?? []).map((b, i) => (
+                        <div key={`bundle-${i}`} style={{ display: "flex", justifyContent: "space-between", fontSize: 13, color: "#16A34A" }}>
+                          <span>{b.name || "Bundle discount"}</span><span>-${b.discount.toFixed(2)}</span>
+                        </div>
+                      ))}
                       {s.calc.discount_amount > 0 && (
                         <div style={{ display: "flex", justifyContent: "space-between", fontSize: 13, color: "#16A34A" }}>
                           <span>Discount</span><span>-${s.calc.discount_amount.toFixed(2)}</span>


### PR DESCRIPTION
Two transparency fixes from the office, plus a full pricing-math audit.

## 1. The "$35 math error" — a hidden bundle discount
Maribel: *"the amounts are correct, the issue is the addition."* She's right. For the Deep Clean quote: Base $672 + Oven $50 + Fridge $50 + Windows $100.80 + Basement $100.80 = **$973.60**, but the Total showed **$938.60** — off by exactly **$35**.

That $35 is a configured `addon_bundles` discount the calc subtracts from the total, but **the Price Preview never rendered it** — so the line items summed to more than the Total and looked like broken addition. Fix: render each matched bundle as its own line, so **Base + add-ons − bundle = Total** reconciles.

**Full audit** (both calc paths, `pricing.ts` quote calc + `public.ts` booking calc): the hidden `bundle_discount` was the **only** total component missing from the display. Other differences between the two are by-design (quote builder supports qty/manual-adjustment/hourly-override; the widget doesn't) or sub-cent rounding. Per-scope (sqft / hourly / commercial / flat) all run the same base → minimum → add-ons → bundle → discount pipeline.

> Note: if Phes doesn't actually want that $35 bundle, it's a row in `addon_bundles` — tell me and I'll help locate/disable it. This PR just makes it **visible** so the math stops looking wrong.

## 2. Add-ons on the job bar
Maribel: *"no salen los add ons either."* The Gantt chip only showed a "+N" count, and only on wide chips. Now:
- **Wide chips** show the add-on **names** (truncated; full list in the hover tooltip).
- **Medium chips** show "+N add-ons".
- **Narrow chips** defer to the panel (which already lists them).

So the office sees a job's full add-on scope right on the board.

Frontend-only; typechecks clean.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_