### PR TITLE
Let the office delete any job (unify child-row cleanup)

### DIFF
--- a/artifacts/api-server/src/routes/jobs.ts
+++ b/artifacts/api-server/src/routes/jobs.ts
@@ -2802,7 +2802,6 @@ router.delete("/:id", requireAuth, async (req, res) => {
     const jobId = parseInt(req.params.id);
     const companyId = req.auth!.companyId;
     const role = req.auth!.role;
-    const force = req.query.force === "true";
 
     // [recurring-delete-skip 2026-06-05] Capture the recurring linkage BEFORE
     // deleting so we can tombstone the occurrence's cadence slot on the
@@ -2828,81 +2827,61 @@ router.delete("/:id", requireAuth, async (req, res) => {
       }
     }
 
-    // Force-delete branch: admin/owner can wipe a completed job's clock entries
-    // and then delete the job in a single transaction.
-    if (force) {
-      if (role !== "owner" && role !== "admin") {
-        return res.status(403).json({
-          error: "Forbidden",
-          message: "Only owner or admin can force-delete a job",
-        });
-      }
-      const [existing] = await db
-        .select({ id: jobsTable.id, status: jobsTable.status })
-        .from(jobsTable)
-        .where(and(eq(jobsTable.id, jobId), eq(jobsTable.company_id, companyId)))
-        .limit(1);
-      if (!existing) {
-        return res.status(404).json({ error: "Not Found", message: "Job not found" });
-      }
-      // Allow on any non-active status. in_progress jobs have a tech actively
-      // on-site (clock-in in flight); deleting under them produces UI ghosts
-      // and confused techs — that one stays gated.
-      if (existing.status === "in_progress") {
-        return res.status(409).json({
-          error: "Conflict",
-          message: "force=true is not allowed on in-progress jobs",
-        });
-      }
-      await db.transaction(async (tx) => {
-        // Cascade child rows that FK to jobs.id with ON DELETE NO ACTION.
-        // Tables with ON DELETE CASCADE (job_audit_log, job_rate_mods,
-        // job_technicians) drop automatically with the parent row.
-        //
-        // Per-job ephemeral / replaceable data → DELETE child rows.
-        // (All of these have job_id NOT NULL so NULL-out isn't an option.)
-        await tx.execute(sql`DELETE FROM timeclock WHERE job_id = ${jobId} AND company_id = ${companyId}`);
-        await tx.execute(sql`DELETE FROM job_add_ons WHERE job_id = ${jobId}`);
-        await tx.execute(sql`DELETE FROM clock_in_attempts WHERE job_id = ${jobId}`);
-        await tx.execute(sql`DELETE FROM job_status_logs WHERE job_id = ${jobId}`);
-        await tx.execute(sql`DELETE FROM job_photos WHERE job_id = ${jobId}`);
-        await tx.execute(sql`DELETE FROM job_supplies WHERE job_id = ${jobId}`);
-        await tx.execute(sql`DELETE FROM scorecards WHERE job_id = ${jobId}`);
-        await tx.execute(sql`DELETE FROM client_ratings WHERE job_id = ${jobId}`);
-        await tx.execute(sql`DELETE FROM satisfaction_surveys WHERE job_id = ${jobId}`);
-        await tx.execute(sql`DELETE FROM cancellation_log WHERE job_id = ${jobId}`);
-        //
-        // Financial / legal / cross-entity records → NULL the back-reference.
-        // The parent row stays intact for billing, accounting, loyalty, and
-        // reporting purposes; only the link to the deleted job is severed.
-        await tx.execute(sql`UPDATE quotes SET booked_job_id = NULL WHERE booked_job_id = ${jobId}`);
-        await tx.execute(sql`UPDATE invoices SET job_id = NULL WHERE job_id = ${jobId}`);
-        await tx.execute(sql`UPDATE additional_pay SET job_id = NULL WHERE job_id = ${jobId}`);
-        await tx.execute(sql`UPDATE loyalty_points_log SET job_id = NULL WHERE job_id = ${jobId}`);
-        await tx.execute(sql`UPDATE communication_log SET job_id = NULL WHERE job_id = ${jobId}`);
-        await tx.execute(sql`UPDATE contact_tickets SET job_id = NULL WHERE job_id = ${jobId}`);
-        await tx.execute(sql`UPDATE form_submissions SET job_id = NULL WHERE job_id = ${jobId}`);
-        await tx.execute(sql`UPDATE quality_complaints SET job_id = NULL WHERE job_id = ${jobId}`);
-        await tx.execute(sql`UPDATE mileage_requests SET from_job_id = NULL WHERE from_job_id = ${jobId}`);
-        await tx.execute(sql`UPDATE mileage_requests SET to_job_id = NULL WHERE to_job_id = ${jobId}`);
-        await tx.execute(sql`UPDATE cancellation_log SET rescheduled_to_job_id = NULL WHERE rescheduled_to_job_id = ${jobId}`);
-        await tx
-          .delete(jobsTable)
-          .where(and(eq(jobsTable.id, jobId), eq(jobsTable.company_id, companyId)));
-      });
-      await tombstoneOccurrence();
-      logAudit(req, "DELETE", "job", jobId, null, { force: true });
-      return res.json({ success: true, message: "Job and dependent records cleaned up" });
+    // [delete-any-job 2026-06-05] Unified delete. Previously the plain path
+    // FK-failed on any job that had add-ons / photos / clock rows, and only
+    // owner/admin could "force" the cleanup — so the office literally could not
+    // delete those jobs (Sal: "we have to make sure we can delete any job").
+    // Now ONE path cleans up the child rows that FK to jobs and NULLs the
+    // financial back-refs, then deletes — for owner/admin/office. The only hard
+    // block is in_progress: a tech is clocked in on-site and deleting under them
+    // creates UI ghosts — clock them out first. The ?force flag is now a no-op
+    // (cleanup always runs); kept accepted for backward compatibility.
+    if (role !== "owner" && role !== "admin" && role !== "office") {
+      return res.status(403).json({ error: "Forbidden", message: "You don't have permission to delete jobs" });
     }
-
-    await db
-      .delete(jobsTable)
-      .where(and(
-        eq(jobsTable.id, jobId),
-        eq(jobsTable.company_id, companyId)
-      ));
+    const [existing] = await db
+      .select({ id: jobsTable.id, status: jobsTable.status })
+      .from(jobsTable)
+      .where(and(eq(jobsTable.id, jobId), eq(jobsTable.company_id, companyId)))
+      .limit(1);
+    if (!existing) {
+      return res.status(404).json({ error: "Not Found", message: "Job not found" });
+    }
+    if (existing.status === "in_progress") {
+      return res.status(409).json({
+        error: "Conflict",
+        message: "This job has a tech clocked in. Clock them out before deleting it.",
+      });
+    }
+    await db.transaction(async (tx) => {
+      // Per-job ephemeral / replaceable data → DELETE child rows (job_id NOT NULL).
+      await tx.execute(sql`DELETE FROM timeclock WHERE job_id = ${jobId} AND company_id = ${companyId}`);
+      await tx.execute(sql`DELETE FROM job_add_ons WHERE job_id = ${jobId}`);
+      await tx.execute(sql`DELETE FROM clock_in_attempts WHERE job_id = ${jobId}`);
+      await tx.execute(sql`DELETE FROM job_status_logs WHERE job_id = ${jobId}`);
+      await tx.execute(sql`DELETE FROM job_photos WHERE job_id = ${jobId}`);
+      await tx.execute(sql`DELETE FROM job_supplies WHERE job_id = ${jobId}`);
+      await tx.execute(sql`DELETE FROM scorecards WHERE job_id = ${jobId}`);
+      await tx.execute(sql`DELETE FROM client_ratings WHERE job_id = ${jobId}`);
+      await tx.execute(sql`DELETE FROM satisfaction_surveys WHERE job_id = ${jobId}`);
+      await tx.execute(sql`DELETE FROM cancellation_log WHERE job_id = ${jobId}`);
+      // Financial / legal / cross-entity records → NULL the back-reference; the
+      // parent row stays intact for billing/accounting/reporting.
+      await tx.execute(sql`UPDATE quotes SET booked_job_id = NULL WHERE booked_job_id = ${jobId}`);
+      await tx.execute(sql`UPDATE invoices SET job_id = NULL WHERE job_id = ${jobId}`);
+      await tx.execute(sql`UPDATE additional_pay SET job_id = NULL WHERE job_id = ${jobId}`);
+      await tx.execute(sql`UPDATE loyalty_points_log SET job_id = NULL WHERE job_id = ${jobId}`);
+      await tx.execute(sql`UPDATE communication_log SET job_id = NULL WHERE job_id = ${jobId}`);
+      await tx.execute(sql`UPDATE contact_tickets SET job_id = NULL WHERE job_id = ${jobId}`);
+      await tx.execute(sql`UPDATE form_submissions SET job_id = NULL WHERE job_id = ${jobId}`);
+      await tx.execute(sql`UPDATE quality_complaints SET job_id = NULL WHERE job_id = ${jobId}`);
+      await tx.execute(sql`UPDATE mileage_requests SET from_job_id = NULL WHERE from_job_id = ${jobId}`);
+      await tx.execute(sql`UPDATE mileage_requests SET to_job_id = NULL WHERE to_job_id = ${jobId}`);
+      await tx.execute(sql`UPDATE cancellation_log SET rescheduled_to_job_id = NULL WHERE rescheduled_to_job_id = ${jobId}`);
+      await tx.delete(jobsTable).where(and(eq(jobsTable.id, jobId), eq(jobsTable.company_id, companyId)));
+    });
     await tombstoneOccurrence();
-    logAudit(req, "DELETE", "job", jobId, null, null);
+    logAudit(req, "DELETE", "job", jobId, null, { status: existing.status });
     return res.json({ success: true, message: "Job deleted" });
   } catch (err) {
     console.error("Delete job error:", err);


### PR DESCRIPTION
Maribel: *"won't let me delete those jobs"* / *"we have to make sure we can delete any job."*

**Cause:** jobs that have **add-ons** (or photos / clock rows / etc.) couldn't be deleted by the office. The plain `DELETE /api/jobs/:id` FK-failed on those child rows, and only **owner/admin** could run the "force" cleanup path — so an office user trying to delete a job-with-add-ons just got a silent failure.

**Fix:** unify the delete into one path that always cleans up the child rows that FK to `jobs` (add-ons, photos, status logs, clock entries, supplies, scorecards, ratings, surveys, cancellation log) and **NULLs** the financial back-refs (invoices/quotes/additional-pay/etc. are *preserved*, just unlinked), then deletes — in a single transaction, for **owner/admin/office**.

- Only hard block: **in_progress** (a tech is clocked in on-site; deleting under them creates UI ghosts — clock out first). Clear 409 message.
- The `?force` flag is now a no-op (cleanup always runs); still accepted for back-compat.
- The recurring **tombstone** (deleted occurrence won't regenerate) and the audit log are preserved.

Net: the office can now delete **any** job except one a tech is actively clocked into — including the converted-from-quote jobs with add-ons that were stuck.

Also confirmed from the field: the recurring **move-from-Monday** fix and **add-on editing** are both working now.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_