### PR TITLE
Time Clock portal: show the day's jobs (drop the branch filter)

### DIFF
--- a/artifacts/api-server/src/routes/timeclock.ts
+++ b/artifacts/api-server/src/routes/timeclock.ts
@@ -549,8 +549,12 @@ router.get("/day", requireRole("owner", "admin", "office"), async (req, res) => 
     const companyId = req.auth!.companyId;
     const date = String(req.query.date || "").slice(0, 10);
     if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return res.status(400).json({ error: "date=YYYY-MM-DD required" });
-    const branchId = req.query.branch_id && req.query.branch_id !== "all" ? parseInt(String(req.query.branch_id)) : null;
-
+    // [timeclock-show-jobs 2026-06-05] Show EVERY job scheduled that day for the
+    // company — NO branch filter. The portal was filtering by the selected
+    // branch and hiding the day's jobs (today had 15 scheduled but the portal
+    // showed 0) because many jobs carry a null/mismatched branch_id from the MC
+    // import. Reconciliation is company-wide anyway; a branch filter can return
+    // once branch_id is reliably stamped on every job.
     const jobsRes = await db.execute(sql`
       SELECT j.id AS job_id, j.scheduled_time, j.assigned_user_id,
              j.service_type::text AS service_type, j.address_street,
@@ -561,7 +565,6 @@ router.get("/day", requireRole("owner", "admin", "office"), async (req, res) => 
       WHERE j.company_id = ${companyId}
         AND j.scheduled_date = ${date}
         AND j.status <> 'cancelled'
-        ${branchId !== null ? sql`AND j.branch_id = ${branchId}` : sql``}
       ORDER BY j.scheduled_time NULLS LAST, j.id
     `);
     const jobs = jobsRes.rows as any[];


### PR DESCRIPTION
**Priority fix — the Time Clock portal showed an empty day and looked non-functional.**

The portal calls `GET /api/timeclock/day` with the selected branch, and the endpoint filtered jobs by `j.branch_id`. Today has **15 scheduled jobs** (techs actively clocking in — confirmed against MaidCentral), but those jobs carry a **null/mismatched `branch_id`** from the MC import, so the branch filter excluded them → 0 jobs shown.

**Fix:** drop the branch filter on `/day` — show every non-cancelled job scheduled that date for the company. Reconciliation is company-wide anyway. Now the office sees each tech with their jobs and editable in/out times, which feed payroll hours + the actual-minutes commission split. A branch filter can return once `branch_id` is reliably stamped on every job.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_