### PR TITLE
Commission parity with MaidCentral: per-tech pay types + clock→actual_hours

### DIFF
--- a/artifacts/api-server/src/lib/commission-paytype.ts
+++ b/artifacts/api-server/src/lib/commission-paytype.ts
@@ -37,6 +37,13 @@
  * and persists the result.
  */
 
+import {
+  computeCommissionRows,
+  type CommissionInputJob,
+  type CommissionRow,
+} from "./commission-compute.js";
+import { resolveResidentialPayPct, type CompanyResRates } from "./commission-rates.js";
+
 export type PayType = "fee_split" | "allowed_hours" | "hourly";
 
 export const PAY_TYPES: readonly PayType[] = ["fee_split", "allowed_hours", "hourly"];
@@ -191,4 +198,128 @@ export function resolveTechPayInput(args: {
     hourlyRate,
     scopePct: Number.isFinite(scopePct) ? scopePct : args.defaults.scopePct,
   };
+}
+
+// ── DB bridge: per-tech commission rows for the period-lock payroll path ────
+
+/** A job_technicians row carrying the optional per-tech pay overrides. */
+export interface JobTechRow {
+  job_id: number;
+  user_id: number;
+  is_primary: boolean;
+  pay_type: string | null;
+  hourly_rate: string | number | null;
+  commission_pct: string | number | null;
+  pay_deduction_pct: string | number | null;
+  pay_deduction_flat: string | number | null;
+}
+
+function n(v: string | number | null | undefined): number | null {
+  if (v === null || v === undefined) return null;
+  const x = typeof v === "number" ? v : parseFloat(String(v));
+  return Number.isFinite(x) ? x : null;
+}
+
+function asPayType(v: string | null): PayType | null {
+  return v === "fee_split" || v === "allowed_hours" || v === "hourly" ? v : null;
+}
+
+/**
+ * Turn (completed jobs, their job_technicians rows, per-tech clocked hours)
+ * into per-tech commission rows using the pay-type parity engine.
+ *
+ * SAFETY GUARD — a job with NO per-tech clocked hours falls back to the
+ * legacy single-basis computeCommissionRows (primary tech gets the job
+ * commission). This guarantees we never zero out a real paycheck just
+ * because the clocks aren't entered yet — un-clocked jobs behave exactly
+ * as they do today; only clocked jobs get the MC-exact per-tech split.
+ *
+ * Fee-split runs on the GROSS base (jobs.base_fee, falling back to
+ * billed_amount) so a breakage credit doesn't dock the cleaner. scopePct
+ * resolves per service type (serviceTypePctBySlug) before the company tier.
+ * A per-tech final_pay override (hand-set in the editor) always wins.
+ */
+export function computePerTechCommissionRows(input: {
+  jobs: ReadonlyArray<CommissionInputJob>;
+  jobTechs: ReadonlyArray<JobTechRow>;
+  /** "job_id:user_id" → clocked hours. */
+  techHoursByKey: ReadonlyMap<string, number>;
+  /** service_type slug → per-service fee-split % (0.35), if configured. */
+  serviceTypePctBySlug: ReadonlyMap<string, number>;
+  resRates: CompanyResRates;
+  commercial: { commercial_hourly_rate: number; commercial_comp_mode: "allowed_hours" | "actual_hours" };
+  /** "user_id:job_id" → final_pay override (dollars). */
+  overrides?: ReadonlyMap<string, number>;
+}): CommissionRow[] {
+  const overrides = input.overrides ?? new Map();
+  const techsByJob = new Map<number, JobTechRow[]>();
+  for (const t of input.jobTechs) {
+    const arr = techsByJob.get(t.job_id) ?? [];
+    arr.push(t);
+    techsByJob.set(t.job_id, arr);
+  }
+
+  const out: CommissionRow[] = [];
+  for (const j of input.jobs) {
+    const isCommercial = j.account_id != null;
+    let techs = techsByJob.get(j.id) ?? [];
+    if (techs.length === 0 && j.assigned_user_id != null) {
+      techs = [{ job_id: j.id, user_id: j.assigned_user_id, is_primary: true,
+        pay_type: null, hourly_rate: null, commission_pct: null, pay_deduction_pct: null, pay_deduction_flat: null }];
+    }
+    const totalTechHours = techs.reduce((s, t) => s + (input.techHoursByKey.get(`${j.id}:${t.user_id}`) ?? 0), 0);
+
+    // GUARD: no clocked hours → legacy single-basis fallback (no regression).
+    if (totalTechHours <= 0) {
+      for (const r of computeCommissionRows({ jobs: [j], resRates: input.resRates, commercial: input.commercial, overrides })) {
+        out.push(r);
+      }
+      continue;
+    }
+
+    const servicePct = input.serviceTypePctBySlug.get((j.service_type ?? "").toLowerCase());
+    const scopePct = servicePct ?? resolveResidentialPayPct(j.service_type, input.resRates);
+    const defaults = defaultPayForJob({
+      isCommercial,
+      serviceType: j.service_type,
+      commercialHourlyRate: input.commercial.commercial_hourly_rate,
+      scopePct,
+    });
+    const ctx: JobPayContext = {
+      baseFee: (n(j.base_fee) ?? 0) || (n(j.billed_amount) ?? 0),
+      allowedHours: n(j.allowed_hours) ?? 0,
+      totalTechHours,
+    };
+
+    for (const t of techs) {
+      const overrideKey = `${t.user_id}:${j.id}`;
+      const techHours = input.techHoursByKey.get(`${j.id}:${t.user_id}`) ?? 0;
+      let amount: number;
+      if (overrides.has(overrideKey)) {
+        amount = Math.round((overrides.get(overrideKey) as number) * 100) / 100;
+      } else {
+        const payInput = resolveTechPayInput({
+          user_id: t.user_id,
+          techHours,
+          overridePayType: asPayType(t.pay_type),
+          overrideHourlyRate: n(t.hourly_rate),
+          overridePct: n(t.commission_pct),
+          defaults,
+        });
+        payInput.deductionPct = n(t.pay_deduction_pct) ?? 0;
+        payInput.deductionFlat = n(t.pay_deduction_flat) ?? 0;
+        amount = computeTechPay(ctx, payInput).amount;
+      }
+      if (amount === 0) continue;
+      out.push({
+        user_id: t.user_id,
+        job_id: j.id,
+        amount,
+        basis: isCommercial ? "commercial_hourly" : "residential_pool",
+        branch_id: j.branch_id,
+        scheduled_date: j.scheduled_date,
+      });
+    }
+  }
+  return out;
 }

--- a/artifacts/api-server/src/lib/commission-paytype.ts
+++ b/artifacts/api-server/src/lib/commission-paytype.ts
@@ -59,12 +59,26 @@ export interface TechPayInput {
   hourlyRate: number;
   /** Decimal share (0.32 = 32%) for fee_split. Ignored otherwise. */
   scopePct: number;
+  /**
+   * Optional breakage/damage deduction the office applies to THIS tech's
+   * pay. Default OFF — a customer breakage credit does NOT dock the cleaner
+   * (audit decision 2026-06-05). When the office decides the tech shares the
+   * cost, they set a percent (0.10 = 10% of computed pay) and/or a flat $.
+   * Applied after the pay-type computation; final pay floored at $0.
+   */
+  deductionPct?: number;
+  deductionFlat?: number;
 }
 
 export interface TechPayRow {
   user_id: number;
   payType: PayType;
+  /** Final pay after any deduction (what actually pays). */
   amount: number;
+  /** Pay before the breakage deduction (the earned commission). */
+  grossAmount: number;
+  /** Dollars removed by the deduction (0 when none). */
+  deduction: number;
   /** The effective inputs, for audit/UI display ("Fee Split: 16%"). */
   effectivePct: number; // hour-weighted fee-split %, else 0
   effectiveHours: number; // hours the rate was applied to (allowed/hourly)
@@ -89,25 +103,31 @@ export function computeTechPay(ctx: JobPayContext, tech: TechPayInput): TechPayR
   const total = ctx.totalTechHours > 0 ? ctx.totalTechHours : tech.techHours;
   const share = total > 0 ? tech.techHours / total : 1;
 
+  let grossAmount: number;
+  let effectivePct = 0;
+  let effectiveHours = round2(tech.techHours);
+
   if (tech.payType === "hourly") {
-    const amount = round2(tech.techHours * tech.hourlyRate);
-    return { user_id: tech.user_id, payType: "hourly", amount, effectivePct: 0, effectiveHours: round2(tech.techHours) };
+    grossAmount = round2(tech.techHours * tech.hourlyRate);
+  } else if (tech.payType === "allowed_hours") {
+    const payHours = Math.max(ctx.allowedHours * share, tech.techHours);
+    grossAmount = round2(payHours * tech.hourlyRate);
+    effectiveHours = round2(payHours);
+  } else {
+    // fee_split — gross base × scope% × hour-weighted share.
+    // MC rounds the effective % to 2 decimals (e.g. 17.53%) and multiplies
+    // that, so we round the rate to 4 dp BEFORE applying it to match the
+    // displayed paycheck to the penny.
+    effectivePct = Math.round(tech.scopePct * share * 10000) / 10000;
+    grossAmount = round2(ctx.baseFee * effectivePct);
   }
 
-  if (tech.payType === "allowed_hours") {
-    const allowedShare = ctx.allowedHours * share;
-    const payHours = Math.max(allowedShare, tech.techHours);
-    const amount = round2(payHours * tech.hourlyRate);
-    return { user_id: tech.user_id, payType: "allowed_hours", amount, effectivePct: 0, effectiveHours: round2(payHours) };
-  }
+  // Optional breakage deduction (default off). Percent applies to the
+  // computed pay; flat is dollars. Final pay never goes negative.
+  const deduction = round2(grossAmount * num(tech.deductionPct) + num(tech.deductionFlat));
+  const amount = Math.max(0, round2(grossAmount - deduction));
 
-  // fee_split — gross base × scope% × hour-weighted share.
-  // MC rounds the effective % to 2 decimals (e.g. 17.53%) and multiplies
-  // that, so we round the rate to 4 dp BEFORE applying it to match the
-  // displayed paycheck to the penny.
-  const effectivePct = Math.round(tech.scopePct * share * 10000) / 10000;
-  const amount = round2(ctx.baseFee * effectivePct);
-  return { user_id: tech.user_id, payType: "fee_split", amount, effectivePct, effectiveHours: round2(tech.techHours) };
+  return { user_id: tech.user_id, payType: tech.payType, amount, grossAmount, deduction, effectivePct, effectiveHours };
 }
 
 /** Compute every tech's pay for one job. Sum of independent per-tech rows. */

--- a/artifacts/api-server/src/lib/commission-paytype.ts
+++ b/artifacts/api-server/src/lib/commission-paytype.ts
@@ -1,0 +1,174 @@
+/**
+ * Per-tech commission by PAY TYPE — the MaidCentral-parity model.
+ *
+ * The June 1 MC↔Qleno audit (tests/june1-mc-audit.ts) showed Qleno's
+ * single-basis-per-job model (commercial_hourly vs residential_pool) can't
+ * reproduce MaidCentral, where pay is set PER TIMESHEET and two techs on the
+ * SAME job can be paid differently (e.g. Cusimano: Norma=Fee Split,
+ * Jose=Hourly). This module is the parity engine: it computes each tech's
+ * pay from THEIR pay type, so a job's payout is the sum of independent
+ * per-tech computations — not one pool split.
+ *
+ * Three pay types (verbatim from MC's timesheet "Pay type" column):
+ *
+ *   fee_split     pay = baseFee × scopePct × (techHours / totalTechHours)
+ *                 The tech's hour-weighted share of the job's commission.
+ *                 baseFee is the GROSS service base (pre customer credits /
+ *                 breakage) — a goodwill/breakage credit to the client does
+ *                 NOT dock the cleaner (audit decision 2026-06-05).
+ *
+ *   allowed_hours pay = max(allowedShare, techHours) × hourlyRate
+ *                 allowedShare = allowedHours × (techHours / totalTechHours).
+ *                 Single tech → max(allowedHours, techHours) × rate, i.e. the
+ *                 budget protects the tech on a fast job but pays actual when
+ *                 they run over (MC: Alma 8.18 actual > 8 allowed → 8.18).
+ *
+ *   hourly        pay = techHours × hourlyRate
+ *                 Flat wage on actual clocked time, independent of the job's
+ *                 price or budget. Never a default — an explicit override.
+ *
+ * scopePct resolves PER SERVICE TYPE (configurable), falling back to the
+ * company residential tiers. Hundt's "Hourly Deep Clean" pays 35% even
+ * though the global deep-clean tier is 32% — the service set carries its
+ * own rate (audit decision 2026-06-05).
+ *
+ * Pure functions only. The route/DB layer resolves the inputs (job_technicians
+ * pay_type/hourly_rate/commission_pct, service-type config, company defaults)
+ * and persists the result.
+ */
+
+export type PayType = "fee_split" | "allowed_hours" | "hourly";
+
+export const PAY_TYPES: readonly PayType[] = ["fee_split", "allowed_hours", "hourly"];
+
+export interface JobPayContext {
+  /** GROSS service base before customer credits/breakage (jobs.base_fee). */
+  baseFee: number;
+  /** Job's allowed (budgeted) hours. */
+  allowedHours: number;
+  /** Sum of every assigned tech's clocked hours (the split denominator). */
+  totalTechHours: number;
+}
+
+export interface TechPayInput {
+  user_id: number;
+  /** This tech's clocked hours on the job. */
+  techHours: number;
+  payType: PayType;
+  /** $/hr for allowed_hours + hourly. Ignored for fee_split. */
+  hourlyRate: number;
+  /** Decimal share (0.32 = 32%) for fee_split. Ignored otherwise. */
+  scopePct: number;
+}
+
+export interface TechPayRow {
+  user_id: number;
+  payType: PayType;
+  amount: number;
+  /** The effective inputs, for audit/UI display ("Fee Split: 16%"). */
+  effectivePct: number; // hour-weighted fee-split %, else 0
+  effectiveHours: number; // hours the rate was applied to (allowed/hourly)
+}
+
+function num(v: unknown, fallback = 0): number {
+  if (v === null || v === undefined) return fallback;
+  const n = typeof v === "number" ? v : parseFloat(String(v));
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+/**
+ * Compute one tech's pay from their pay type. Pure — all inputs resolved
+ * by the caller. Returns the dollar amount plus the effective rate/hours
+ * used (so the UI can render MC-style "Fee Split: 16%" or "3 hrs × $20").
+ */
+export function computeTechPay(ctx: JobPayContext, tech: TechPayInput): TechPayRow {
+  const total = ctx.totalTechHours > 0 ? ctx.totalTechHours : tech.techHours;
+  const share = total > 0 ? tech.techHours / total : 1;
+
+  if (tech.payType === "hourly") {
+    const amount = round2(tech.techHours * tech.hourlyRate);
+    return { user_id: tech.user_id, payType: "hourly", amount, effectivePct: 0, effectiveHours: round2(tech.techHours) };
+  }
+
+  if (tech.payType === "allowed_hours") {
+    const allowedShare = ctx.allowedHours * share;
+    const payHours = Math.max(allowedShare, tech.techHours);
+    const amount = round2(payHours * tech.hourlyRate);
+    return { user_id: tech.user_id, payType: "allowed_hours", amount, effectivePct: 0, effectiveHours: round2(payHours) };
+  }
+
+  // fee_split — gross base × scope% × hour-weighted share.
+  // MC rounds the effective % to 2 decimals (e.g. 17.53%) and multiplies
+  // that, so we round the rate to 4 dp BEFORE applying it to match the
+  // displayed paycheck to the penny.
+  const effectivePct = Math.round(tech.scopePct * share * 10000) / 10000;
+  const amount = round2(ctx.baseFee * effectivePct);
+  return { user_id: tech.user_id, payType: "fee_split", amount, effectivePct, effectiveHours: round2(tech.techHours) };
+}
+
+/** Compute every tech's pay for one job. Sum of independent per-tech rows. */
+export function computeJobTechPays(ctx: JobPayContext, techs: ReadonlyArray<TechPayInput>): TechPayRow[] {
+  return techs.map((t) => computeTechPay(ctx, t));
+}
+
+// ── Smart defaults ────────────────────────────────────────────────────────
+
+export interface PayDefaultsConfig {
+  /** account_id != null → commercial. */
+  isCommercial: boolean;
+  /** jobs.service_type slug, for the residential scope tier. */
+  serviceType: string | null;
+  /** Company commercial $/hr (companies.commercial_hourly_rate). */
+  commercialHourlyRate: number;
+  /** Resolved fee-split % for this service type (caller resolves the tier). */
+  scopePct: number;
+}
+
+/**
+ * The pay type Qleno picks when the office hasn't set a per-tech override:
+ *   commercial  → allowed_hours @ company $/hr
+ *   residential → fee_split @ the service-type %
+ * Hourly is NEVER a default — it's an explicit office choice per timesheet.
+ */
+export function defaultPayForJob(cfg: PayDefaultsConfig): {
+  payType: PayType;
+  hourlyRate: number;
+  scopePct: number;
+} {
+  if (cfg.isCommercial) {
+    return { payType: "allowed_hours", hourlyRate: cfg.commercialHourlyRate, scopePct: 0 };
+  }
+  return { payType: "fee_split", hourlyRate: 0, scopePct: cfg.scopePct };
+}
+
+/**
+ * Resolve a single tech's effective pay inputs: explicit override on the
+ * job_technicians row when present, else the job's smart default. Keeps the
+ * "smart default + per-job override" contract in one place.
+ */
+export function resolveTechPayInput(args: {
+  user_id: number;
+  techHours: number;
+  /** job_technicians.pay_type — null = inherit default. */
+  overridePayType: PayType | null;
+  /** job_technicians.hourly_rate — null = inherit. */
+  overrideHourlyRate: number | null;
+  /** job_technicians.commission_pct — null = inherit. */
+  overridePct: number | null;
+  defaults: { payType: PayType; hourlyRate: number; scopePct: number };
+}): TechPayInput {
+  const payType = args.overridePayType ?? args.defaults.payType;
+  const hourlyRate = args.overrideHourlyRate ?? args.defaults.hourlyRate;
+  const scopePct = num(args.overridePct, NaN);
+  return {
+    user_id: args.user_id,
+    techHours: args.techHours,
+    payType,
+    hourlyRate,
+    scopePct: Number.isFinite(scopePct) ? scopePct : args.defaults.scopePct,
+  };
+}

--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -61,6 +61,20 @@ async function runBookingSchemaGuard(): Promise<void> {
     { label: "users.residential_pay_rate", stmt: "ALTER TABLE users ADD COLUMN IF NOT EXISTS residential_pay_rate NUMERIC(8,4) DEFAULT 0.35" },
     { label: "users.commercial_pay_type",  stmt: "ALTER TABLE users ADD COLUMN IF NOT EXISTS commercial_pay_type  TEXT DEFAULT 'hourly'" },
     { label: "users.commercial_pay_rate",  stmt: "ALTER TABLE users ADD COLUMN IF NOT EXISTS commercial_pay_rate  NUMERIC(8,4) DEFAULT 20.0000" },
+    // [paytype-parity 2026-06-05] Per-tech pay-type override for MaidCentral
+    // parity (lib/commission-paytype.ts). All NULL = inherit the job's smart
+    // default. pay_type ∈ fee_split|allowed_hours|hourly. Plus an editable
+    // breakage deduction (default off — a customer credit doesn't dock the
+    // cleaner unless the office sets a % and/or flat $ here).
+    { label: "job_technicians.pay_type",           stmt: "ALTER TABLE job_technicians ADD COLUMN IF NOT EXISTS pay_type TEXT" },
+    { label: "job_technicians.hourly_rate",        stmt: "ALTER TABLE job_technicians ADD COLUMN IF NOT EXISTS hourly_rate NUMERIC(8,4)" },
+    { label: "job_technicians.commission_pct",     stmt: "ALTER TABLE job_technicians ADD COLUMN IF NOT EXISTS commission_pct NUMERIC(8,6)" },
+    { label: "job_technicians.pay_deduction_pct",  stmt: "ALTER TABLE job_technicians ADD COLUMN IF NOT EXISTS pay_deduction_pct NUMERIC(6,4)" },
+    { label: "job_technicians.pay_deduction_flat", stmt: "ALTER TABLE job_technicians ADD COLUMN IF NOT EXISTS pay_deduction_flat NUMERIC(10,2)" },
+    // Per-service-type fee-split % (NULL = company tier). Both the unified
+    // service_types table and the legacy commercial_service_types table.
+    { label: "service_types.commission_pct",            stmt: "ALTER TABLE service_types ADD COLUMN IF NOT EXISTS commission_pct NUMERIC(6,4)" },
+    { label: "commercial_service_types.commission_pct", stmt: "ALTER TABLE commercial_service_types ADD COLUMN IF NOT EXISTS commission_pct NUMERIC(6,4)" },
     // [phes-chicago23 2026-05-12] One-shot password reset gate. NULL means
     // this user has not yet had their password set to Chicago23 by the
     // cold-start runPhesPasswordResetChicago23() function below. After that

--- a/artifacts/api-server/src/routes/pay.ts
+++ b/artifacts/api-server/src/routes/pay.ts
@@ -866,6 +866,7 @@ async function computeAndApplyCommission(
               FROM timeclock
              WHERE company_id = ${companyId} AND job_id = ANY(${jobIds}::int[])
                AND clock_out_at IS NOT NULL
+               AND source = 'punched'
              GROUP BY job_id, user_id`,
       );
       for (const r of hourRows.rows as any[]) {

--- a/artifacts/api-server/src/routes/pay.ts
+++ b/artifacts/api-server/src/routes/pay.ts
@@ -72,10 +72,13 @@ import { pickMileageRateForDate } from "../lib/mileage-rate-lookup.js";
 import { getDistanceProvider } from "../lib/distance-provider-factory.js";
 import type { DistanceProvider } from "../lib/distance-provider.js";
 import {
-  computeCommissionRows,
   reconcileCommissionRows,
   type CommissionInputJob,
 } from "../lib/commission-compute.js";
+import {
+  computePerTechCommissionRows,
+  type JobTechRow,
+} from "../lib/commission-paytype.js";
 import { parseResRatesRow } from "../lib/commission-rates.js";
 import { additionalPayTable } from "@workspace/db/schema";
 
@@ -809,37 +812,92 @@ async function computeAndApplyCommission(
       ),
     );
 
-  // Per-job final_pay overrides on job_technicians — when set, the office
-  // hand-modified commission via the per-job editor and we honor it.
   const jobIds = jobs.map((j) => j.id);
+  const commercialCfg = {
+    commercial_hourly_rate: parseFloat(String(compSettings.commercial_hourly_rate ?? 20)),
+    commercial_comp_mode: (compSettings.commercial_comp_mode === "actual_hours"
+      ? "actual_hours"
+      : "allowed_hours") as "actual_hours" | "allowed_hours",
+  };
+
+  // Per-tech pay-type rows (job_technicians) + per-job final_pay overrides.
+  // The parity engine pays each tech by THEIR pay type (fee_split /
+  // allowed_hours / hourly) so two techs on one job can differ (MC parity);
+  // jobs with no clocked hours fall back to the legacy single-basis path
+  // inside computePerTechCommissionRows (no regression).
   const overrides = new Map<string, number>();
+  let jobTechs: JobTechRow[] = [];
+  const techHoursByKey = new Map<string, number>();
+  const serviceTypePctBySlug = new Map<string, number>();
   if (jobIds.length > 0) {
     try {
-      const overrideRows = await db.execute(
-        sql`SELECT job_id, user_id, final_pay FROM job_technicians
-            WHERE company_id = ${companyId} AND job_id = ANY(${jobIds}::int[])
-              AND final_pay IS NOT NULL`,
+      const techRows = await db.execute(
+        sql`SELECT job_id, user_id, is_primary, pay_type, hourly_rate, commission_pct,
+                   pay_deduction_pct, pay_deduction_flat, final_pay
+              FROM job_technicians
+             WHERE company_id = ${companyId} AND job_id = ANY(${jobIds}::int[])`,
       );
-      for (const r of overrideRows.rows as any[]) {
+      jobTechs = (techRows.rows as any[]).map((r) => ({
+        job_id: Number(r.job_id),
+        user_id: Number(r.user_id),
+        is_primary: r.is_primary === true,
+        pay_type: r.pay_type ?? null,
+        hourly_rate: r.hourly_rate ?? null,
+        commission_pct: r.commission_pct ?? null,
+        pay_deduction_pct: r.pay_deduction_pct ?? null,
+        pay_deduction_flat: r.pay_deduction_flat ?? null,
+      }));
+      for (const r of techRows.rows as any[]) {
         const pay = parseFloat(String(r.final_pay));
-        if (Number.isFinite(pay)) {
+        if (r.final_pay != null && Number.isFinite(pay)) {
           overrides.set(`${r.user_id}:${r.job_id}`, pay);
         }
       }
     } catch {
-      // job_technicians may be absent on freshly-seeded tenants.
+      // job_technicians (or the pay-type columns) may be absent on a
+      // freshly-seeded tenant — empty jobTechs falls back to legacy.
+    }
+
+    // Per-tech clocked hours (the split denominator + hourly basis).
+    try {
+      const hourRows = await db.execute(
+        sql`SELECT job_id, user_id,
+                   SUM(EXTRACT(EPOCH FROM (clock_out_at - clock_in_at)) / 3600.0) AS hours
+              FROM timeclock
+             WHERE company_id = ${companyId} AND job_id = ANY(${jobIds}::int[])
+               AND clock_out_at IS NOT NULL
+             GROUP BY job_id, user_id`,
+      );
+      for (const r of hourRows.rows as any[]) {
+        const h = parseFloat(String(r.hours));
+        if (Number.isFinite(h) && h > 0) techHoursByKey.set(`${r.job_id}:${r.user_id}`, h);
+      }
+    } catch {
+      // No timeclock data → every job falls back to legacy single-basis.
     }
   }
 
-  const computed = computeCommissionRows({
+  // Per-service fee-split % (service_types.commission_pct), NULL = company tier.
+  try {
+    const svcRows = await db.execute(
+      sql`SELECT slug, commission_pct FROM service_types
+           WHERE company_id = ${companyId} AND commission_pct IS NOT NULL`,
+    );
+    for (const r of svcRows.rows as any[]) {
+      const pct = parseFloat(String(r.commission_pct));
+      if (Number.isFinite(pct)) serviceTypePctBySlug.set(String(r.slug).toLowerCase(), pct);
+    }
+  } catch {
+    // service_types.commission_pct column absent — fall back to tiers.
+  }
+
+  const computed = computePerTechCommissionRows({
     jobs: jobs as CommissionInputJob[],
+    jobTechs,
+    techHoursByKey,
+    serviceTypePctBySlug,
     resRates,
-    commercial: {
-      commercial_hourly_rate: parseFloat(String(compSettings.commercial_hourly_rate ?? 20)),
-      commercial_comp_mode: (compSettings.commercial_comp_mode === "actual_hours"
-        ? "actual_hours"
-        : "allowed_hours"),
-    },
+    commercial: commercialCfg,
     overrides,
   });
 

--- a/artifacts/api-server/src/routes/timeclock.ts
+++ b/artifacts/api-server/src/routes/timeclock.ts
@@ -19,6 +19,32 @@ function calculateDistanceFt(lat1: number, lon1: number, lat2: number, lon2: num
   return Math.round(R * c);
 }
 
+// [timeclock-cohesion 2026-06-05] Recompute jobs.actual_hours from the job's
+// COMPLETED clock entries: earliest clock-in → latest clock-out = the job's
+// actual on-site span (matches MC's single-tech case; for simultaneous
+// multi-tech it's the job duration, not summed labor). This is the wire that
+// makes a clock edit flow into reporting — it drives the allowed-vs-actual
+// efficiency metric and the 'actual_hours' commission mode (under the default
+// 'allowed_hours' mode it doesn't change commission $, so it's safe). Called
+// after every office clock write so the clock and pay stay in sync. NULL when
+// no entry is closed yet (actual isn't known until clock-out).
+async function recomputeJobActualHours(jobId: number, companyId: number): Promise<void> {
+  try {
+    await db.execute(sql`
+      UPDATE jobs SET actual_hours = sub.h
+      FROM (
+        SELECT ROUND(GREATEST(
+                 EXTRACT(EPOCH FROM (MAX(clock_out_at) - MIN(clock_in_at))) / 3600.0, 0)::numeric, 2) AS h
+        FROM timeclock
+        WHERE job_id = ${jobId} AND company_id = ${companyId} AND clock_out_at IS NOT NULL
+      ) sub
+      WHERE jobs.id = ${jobId} AND jobs.company_id = ${companyId}
+    `);
+  } catch (err) {
+    console.error("[timeclock] recomputeJobActualHours failed:", err);
+  }
+}
+
 router.get("/", requireAuth, async (req, res) => {
   try {
     const { user_id, job_id, flagged, date_from, date_to, branch_id } = req.query;
@@ -530,6 +556,7 @@ router.post("/office/clock-out", requireRole("owner", "admin", "office"), async 
     const [updated] = await db.update(timeclockTable)
       .set({ clock_out_at: clockOutAt })
       .where(eq(timeclockTable.id, open.id)).returning();
+    await recomputeJobActualHours(job_id, companyId);
     return res.json(updated);
   } catch (err) {
     console.error("POST /timeclock/office/clock-out error:", err);
@@ -688,6 +715,7 @@ router.patch("/:id", requireRole("owner", "admin", "office"), async (req, res) =
       return res.status(400).json({ error: "Clock-out cannot be before clock-in" });
 
     const [updated] = await db.update(timeclockTable).set(set).where(eq(timeclockTable.id, id)).returning();
+    await recomputeJobActualHours(existing.job_id, companyId);
     logAudit(req, "TIMECLOCK_EDIT", "timeclock", id,
       { clock_in_at: existing.clock_in_at, clock_out_at: existing.clock_out_at },
       { clock_in_at: updated.clock_in_at, clock_out_at: updated.clock_out_at });
@@ -707,6 +735,7 @@ router.delete("/:id", requireRole("owner", "admin", "office"), async (req, res) 
       .where(and(eq(timeclockTable.id, id), eq(timeclockTable.company_id, companyId))).limit(1);
     if (!existing) return res.status(404).json({ error: "Not found" });
     await db.delete(timeclockTable).where(eq(timeclockTable.id, id));
+    await recomputeJobActualHours(existing.job_id, companyId);
     logAudit(req, "TIMECLOCK_DELETE", "timeclock", id,
       { clock_in_at: existing.clock_in_at, clock_out_at: existing.clock_out_at, job_id: existing.job_id, user_id: existing.user_id }, null);
     return res.json({ success: true });

--- a/artifacts/api-server/src/tests/commission-paytype.test.ts
+++ b/artifacts/api-server/src/tests/commission-paytype.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Per-tech pay-type engine tests (lib/commission-paytype.ts).
+ *
+ * Ground truth = MaidCentral June 1, 2026 paychecks. Defends:
+ *   A. fee_split — gross base × scope% × hour-weighted share, MC %-rounding.
+ *   B. allowed_hours — max(allowed-share, actual) × rate.
+ *   C. hourly — actual × rate, independent of price/budget.
+ *   D. Mixed pay types on ONE job (Cusimano: Norma fee_split, Jose hourly).
+ *   E. Breakage deduction (% and flat), default off, floored at $0.
+ *   F. Smart defaults + override resolution.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  computeTechPay,
+  computeJobTechPays,
+  defaultPayForJob,
+  resolveTechPayInput,
+  type JobPayContext,
+} from "../lib/commission-paytype.js";
+
+describe("pay-type engine — MaidCentral June 1 parity", () => {
+  it("fee_split: single tech, full scope % (Ward $186 × 35%)", () => {
+    const ctx: JobPayContext = { baseFee: 186, allowedHours: 3.1, totalTechHours: 2.0 };
+    const r = computeTechPay(ctx, { user_id: 1, techHours: 2.0, payType: "fee_split", hourlyRate: 0, scopePct: 0.35 });
+    assert.equal(r.amount, 65.1);
+  });
+
+  it("fee_split: two equal techs split the % (Deep Clean 32% → 16% each on $628.40 gross)", () => {
+    const ctx: JobPayContext = { baseFee: 628.4, allowedHours: 8.2, totalTechHours: 6.56 };
+    const a = computeTechPay(ctx, { user_id: 1, techHours: 3.28, payType: "fee_split", hourlyRate: 0, scopePct: 0.32 });
+    assert.equal(a.amount, 100.54);
+    assert.equal(a.effectivePct, 0.16);
+  });
+
+  it("fee_split: unequal split rounds % like MC (Norma 3.18/6.35 of 35% on $540 → 17.53% → $94.66)", () => {
+    const ctx: JobPayContext = { baseFee: 540, allowedHours: 9.0, totalTechHours: 6.35 };
+    const r = computeTechPay(ctx, { user_id: 1, techHours: 3.18, payType: "fee_split", hourlyRate: 0, scopePct: 0.35 });
+    assert.equal(r.effectivePct, 0.1753);
+    assert.equal(r.amount, 94.66);
+  });
+
+  it("allowed_hours: pays the budget when faster (Halper 3.5 allowed > 1.77 actual → $70)", () => {
+    const ctx: JobPayContext = { baseFee: 0, allowedHours: 3.5, totalTechHours: 1.77 };
+    const r = computeTechPay(ctx, { user_id: 1, techHours: 1.77, payType: "allowed_hours", hourlyRate: 20, scopePct: 0 });
+    assert.equal(r.amount, 70.0);
+    assert.equal(r.effectiveHours, 3.5);
+  });
+
+  it("allowed_hours: pays actual when over budget (8.18 actual > 8 allowed → $163.60)", () => {
+    const ctx: JobPayContext = { baseFee: 0, allowedHours: 8.0, totalTechHours: 8.18 };
+    const r = computeTechPay(ctx, { user_id: 1, techHours: 8.18, payType: "allowed_hours", hourlyRate: 20, scopePct: 0 });
+    assert.equal(r.amount, 163.6);
+  });
+
+  it("hourly: flat wage on actual, ignores price/budget (Carpet 2.17 × $25 → $54.25)", () => {
+    const ctx: JobPayContext = { baseFee: 120, allowedHours: 1.5, totalTechHours: 2.17 };
+    const r = computeTechPay(ctx, { user_id: 1, techHours: 2.17, payType: "hourly", hourlyRate: 25, scopePct: 0 });
+    assert.equal(r.amount, 54.25);
+  });
+
+  it("mixed pay types on ONE job (Cusimano: Norma fee_split $94.66 + Jose hourly $63.40)", () => {
+    const ctx: JobPayContext = { baseFee: 540, allowedHours: 9.0, totalTechHours: 6.35 };
+    const rows = computeJobTechPays(ctx, [
+      { user_id: 1, techHours: 3.18, payType: "fee_split", hourlyRate: 0, scopePct: 0.35 },
+      { user_id: 2, techHours: 3.17, payType: "hourly", hourlyRate: 20, scopePct: 0 },
+    ]);
+    assert.equal(rows[0].amount, 94.66);
+    assert.equal(rows[1].amount, 63.4);
+    // The pool is NOT fully distributed — hourly tech is paid independently.
+    assert.equal(rows[0].amount + rows[1].amount, 158.06);
+  });
+});
+
+describe("pay-type engine — breakage deduction", () => {
+  const ctx: JobPayContext = { baseFee: 628.4, allowedHours: 8.2, totalTechHours: 6.56 };
+  const base = { user_id: 1, techHours: 3.28, payType: "fee_split" as const, hourlyRate: 0, scopePct: 0.32 };
+
+  it("default: no deduction (gross == net)", () => {
+    const r = computeTechPay(ctx, base);
+    assert.equal(r.grossAmount, 100.54);
+    assert.equal(r.deduction, 0);
+    assert.equal(r.amount, 100.54);
+  });
+
+  it("percent deduction (10% of $100.54 → $90.49)", () => {
+    const r = computeTechPay(ctx, { ...base, deductionPct: 0.1 });
+    assert.equal(r.deduction, 10.05);
+    assert.equal(r.amount, 90.49);
+  });
+
+  it("flat deduction ($25 off)", () => {
+    const r = computeTechPay(ctx, { ...base, deductionFlat: 25 });
+    assert.equal(r.amount, 75.54);
+  });
+
+  it("deduction never pushes pay negative", () => {
+    const r = computeTechPay(ctx, { ...base, deductionFlat: 9999 });
+    assert.equal(r.amount, 0);
+  });
+});
+
+describe("pay-type engine — smart defaults + override resolution", () => {
+  it("commercial defaults to allowed_hours at company $/hr", () => {
+    const d = defaultPayForJob({ isCommercial: true, serviceType: "commercial_cleaning", commercialHourlyRate: 20, scopePct: 0 });
+    assert.equal(d.payType, "allowed_hours");
+    assert.equal(d.hourlyRate, 20);
+  });
+
+  it("residential defaults to fee_split at the service-type %", () => {
+    const d = defaultPayForJob({ isCommercial: false, serviceType: "deep_clean", commercialHourlyRate: 20, scopePct: 0.32 });
+    assert.equal(d.payType, "fee_split");
+    assert.equal(d.scopePct, 0.32);
+  });
+
+  it("override wins over default (office sets a tech to hourly)", () => {
+    const input = resolveTechPayInput({
+      user_id: 1, techHours: 2.17,
+      overridePayType: "hourly", overrideHourlyRate: 25, overridePct: null,
+      defaults: { payType: "allowed_hours", hourlyRate: 20, scopePct: 0 },
+    });
+    assert.equal(input.payType, "hourly");
+    assert.equal(input.hourlyRate, 25);
+  });
+
+  it("null override inherits the default", () => {
+    const input = resolveTechPayInput({
+      user_id: 1, techHours: 3,
+      overridePayType: null, overrideHourlyRate: null, overridePct: null,
+      defaults: { payType: "fee_split", hourlyRate: 0, scopePct: 0.35 },
+    });
+    assert.equal(input.payType, "fee_split");
+    assert.equal(input.scopePct, 0.35);
+  });
+});

--- a/artifacts/api-server/src/tests/commission-paytype.test.ts
+++ b/artifacts/api-server/src/tests/commission-paytype.test.ts
@@ -16,8 +16,11 @@ import {
   computeJobTechPays,
   defaultPayForJob,
   resolveTechPayInput,
+  computePerTechCommissionRows,
   type JobPayContext,
+  type JobTechRow,
 } from "../lib/commission-paytype.js";
+import { type CommissionInputJob } from "../lib/commission-compute.js";
 
 describe("pay-type engine — MaidCentral June 1 parity", () => {
   it("fee_split: single tech, full scope % (Ward $186 × 35%)", () => {
@@ -131,5 +134,82 @@ describe("pay-type engine — smart defaults + override resolution", () => {
     });
     assert.equal(input.payType, "fee_split");
     assert.equal(input.scopePct, 0.35);
+  });
+});
+
+describe("pay-type engine — DB bridge (computePerTechCommissionRows)", () => {
+  const resRates = { res_tech_pay_pct: 0.35, deep_clean_pay_pct: 0.32, move_in_out_pay_pct: 0.32 };
+  const commercial = { commercial_hourly_rate: 20, commercial_comp_mode: "allowed_hours" as const };
+
+  function job(p: Partial<CommissionInputJob> & { id: number }): CommissionInputJob {
+    return {
+      id: p.id, assigned_user_id: p.assigned_user_id ?? 1, service_type: p.service_type ?? "standard_clean",
+      account_id: "account_id" in p ? p.account_id! : null, base_fee: p.base_fee ?? "0",
+      billed_amount: "billed_amount" in p ? p.billed_amount! : null, allowed_hours: p.allowed_hours ?? "0",
+      actual_hours: p.actual_hours ?? "0", branch_id: 1, scheduled_date: "2026-06-01",
+    };
+  }
+  const tech = (job_id: number, user_id: number, o: Partial<JobTechRow> = {}): JobTechRow => ({
+    job_id, user_id, is_primary: o.is_primary ?? false, pay_type: o.pay_type ?? null,
+    hourly_rate: o.hourly_rate ?? null, commission_pct: o.commission_pct ?? null,
+    pay_deduction_pct: o.pay_deduction_pct ?? null, pay_deduction_flat: o.pay_deduction_flat ?? null,
+  });
+
+  it("GUARD: no clocked hours → legacy single-basis fallback (primary only)", () => {
+    const rows = computePerTechCommissionRows({
+      jobs: [job({ id: 10, assigned_user_id: 1, billed_amount: "200", service_type: "standard_clean" })],
+      jobTechs: [tech(10, 1, { is_primary: true }), tech(10, 2)],
+      techHoursByKey: new Map(),
+      serviceTypePctBySlug: new Map(), resRates, commercial,
+    });
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].user_id, 1);
+    assert.equal(rows[0].amount, 70.0);
+  });
+
+  it("clocked: Cusimano mixed pay types reproduce MC ($94.66 + $63.40)", () => {
+    const rows = computePerTechCommissionRows({
+      jobs: [job({ id: 20, base_fee: "540", billed_amount: "540", allowed_hours: "9", service_type: "standard_clean" })],
+      jobTechs: [
+        tech(20, 1, { is_primary: true, pay_type: "fee_split" }),
+        tech(20, 2, { pay_type: "hourly", hourly_rate: "20" }),
+      ],
+      techHoursByKey: new Map([["20:1", 3.18], ["20:2", 3.17]]),
+      serviceTypePctBySlug: new Map(), resRates, commercial,
+    });
+    assert.equal(rows.find((r) => r.user_id === 1)!.amount, 94.66);
+    assert.equal(rows.find((r) => r.user_id === 2)!.amount, 63.4);
+  });
+
+  it("clocked: breakage on gross base (Deep Clean $628.40 gross, not $578.40 net)", () => {
+    const rows = computePerTechCommissionRows({
+      jobs: [job({ id: 30, base_fee: "628.40", billed_amount: "578.40", allowed_hours: "8.2", service_type: "deep_clean" })],
+      jobTechs: [tech(30, 1, { is_primary: true }), tech(30, 2)],
+      techHoursByKey: new Map([["30:1", 3.28], ["30:2", 3.28]]),
+      serviceTypePctBySlug: new Map(), resRates, commercial,
+    });
+    assert.equal(rows.find((r) => r.user_id === 1)!.amount, 100.54);
+    assert.equal(rows.find((r) => r.user_id === 2)!.amount, 100.54);
+  });
+
+  it("clocked: per-service-type % overrides the global tier (deep clean paid 35%)", () => {
+    const rows = computePerTechCommissionRows({
+      jobs: [job({ id: 40, base_fee: "210", billed_amount: "210", allowed_hours: "3", service_type: "deep_clean" })],
+      jobTechs: [tech(40, 1, { is_primary: true })],
+      techHoursByKey: new Map([["40:1", 3.0]]),
+      serviceTypePctBySlug: new Map([["deep_clean", 0.35]]), resRates, commercial,
+    });
+    assert.equal(rows[0].amount, 73.5);
+  });
+
+  it("clocked commercial: allowed-hours default pays the budget (Halper $70)", () => {
+    const rows = computePerTechCommissionRows({
+      jobs: [job({ id: 50, account_id: 9, base_fee: "0", allowed_hours: "3.5" })],
+      jobTechs: [tech(50, 1, { is_primary: true })],
+      techHoursByKey: new Map([["50:1", 1.77]]),
+      serviceTypePctBySlug: new Map(), resRates, commercial,
+    });
+    assert.equal(rows[0].amount, 70.0);
+    assert.equal(rows[0].basis, "commercial_hourly");
   });
 });

--- a/artifacts/api-server/src/tests/june1-mc-audit.ts
+++ b/artifacts/api-server/src/tests/june1-mc-audit.ts
@@ -1,0 +1,187 @@
+/**
+ * June 1, 2026 — MaidCentral ↔ Qleno commission reconciliation.
+ *
+ * Feeds the EXACT MaidCentral June 1 clock/job data (from the MC Invoicing
+ * screen, JobDate=06/01/2026) through Qleno's REAL commission engine
+ * (lib/commission-compute.ts) and prints a side-by-side so we can see, per
+ * job/per tech, whether Qleno reproduces MC's pay — and where it diverges.
+ *
+ * Run:
+ *   node --experimental-strip-types \
+ *     --import ./../../../tmp/ts-resolve.mjs \
+ *     src/tests/june1-mc-audit.ts
+ * (or via the wrapper in /tmp). This is a report, not an assertion suite —
+ * it imports the production engine so the numbers are what Qleno would pay.
+ *
+ * NOT a DB writer. It cannot punch clocks into live Qleno (no prod access
+ * from CI/sandbox). Its job is to prove the engine is wired and to surface
+ * the MC↔Qleno gaps before the office enters these clocks via the Time
+ * Clock portal.
+ */
+import {
+  computeCommissionRows,
+  type CommissionInputJob,
+} from "../lib/commission-compute.js";
+
+// Phes config (matches companies row defaults + commission-rates.ts).
+const resRates = {
+  res_tech_pay_pct: 0.35,
+  deep_clean_pay_pct: 0.32,
+  move_in_out_pay_pct: 0.32,
+};
+const commercial = {
+  commercial_hourly_rate: 20,
+  commercial_comp_mode: "allowed_hours" as const,
+};
+
+type McTech = {
+  name: string;
+  clockIn: string;
+  clockOut: string;
+  actualHrs: number;
+  payType: "Allowed Hours" | "Fee Split" | "Hourly";
+  mcPay: number; // what MaidCentral actually paid this tech on this job
+};
+
+type McJob = {
+  label: string;
+  customer: string;
+  mcJobId?: string;
+  serviceType: string; // Qleno jobs.service_type slug
+  isCommercial: boolean; // account_id != null on the Qleno side
+  billedAmount: number; // Qleno billed_amount (invoice TOTAL, net of credits)
+  baseFee: number; // MC "Fee Split" base (gross, pre-breakage)
+  allowedHrs: number;
+  techs: McTech[];
+};
+
+// ── MaidCentral June 1 dataset (from the four Invoicing screenshots) ──────
+const JUNE1: McJob[] = [
+  {
+    label: "Common Areas Cleaning (Monthly Prepay)",
+    customer: "Jennifer Halper — 8901 South Roberts Rd",
+    mcJobId: "62011284",
+    serviceType: "commercial_cleaning",
+    isCommercial: true,
+    billedAmount: 1050.0,
+    baseFee: 0,
+    allowedHrs: 3.5,
+    techs: [
+      { name: "Alejandra Cuervo", clockIn: "1:36 PM", clockOut: "3:22 PM", actualHrs: 1.77, payType: "Allowed Hours", mcPay: 70.0 },
+    ],
+  },
+  {
+    label: "Weekly Commercial",
+    customer: "Daniel Walter",
+    mcJobId: "59902865",
+    serviceType: "commercial_cleaning",
+    isCommercial: true, // ASSUMED commercial — needs Qleno account_id confirm
+    billedAmount: 225.0,
+    baseFee: 225.0,
+    allowedHrs: 3.0,
+    techs: [
+      { name: "Jose Ardila", clockIn: "1:06 PM", clockOut: "4:05 PM", actualHrs: 2.98, payType: "Allowed Hours", mcPay: 60.0 },
+    ],
+  },
+  {
+    label: "Commercial | Common Areas (On Demand)",
+    customer: "Richard Nitzsche — 338 South Oak Park Ave",
+    mcJobId: "63336768",
+    serviceType: "commercial_cleaning",
+    isCommercial: true,
+    billedAmount: 195.0,
+    baseFee: 195.0,
+    allowedHrs: 3.0,
+    techs: [
+      { name: "Juliana Loredo", clockIn: "3:51 PM", clockOut: "5:22 PM", actualHrs: 1.52, payType: "Allowed Hours", mcPay: 60.0 },
+    ],
+  },
+  {
+    label: "Deep Clean or Move In/Out",
+    customer: "Richard Nitzsche — 338 South Oak Park Ave",
+    mcJobId: "6660(inv)",
+    serviceType: "deep_clean",
+    isCommercial: false, // residential
+    billedAmount: 578.4, // invoice TOTAL, AFTER -$50 breakage credit
+    baseFee: 628.4, // MC "Fee Split" base, BEFORE the breakage credit
+    allowedHrs: 8.2,
+    techs: [
+      { name: "Juliana Loredo", clockIn: "9:16 AM", clockOut: "12:33 PM", actualHrs: 3.28, payType: "Fee Split", mcPay: 100.54 },
+      { name: "Alejandra Cuervo", clockIn: "9:16 AM", clockOut: "12:33 PM", actualHrs: 3.28, payType: "Fee Split", mcPay: 100.54 },
+    ],
+  },
+];
+
+function round2(n: number) {
+  return Math.round(n * 100) / 100;
+}
+
+// Mirror the route-layer multi-tech split: post-clock-in, split the job's
+// commission pool proportionally by actual minutes (equal when minutes equal).
+function qlenoPerTech(jobPool: number, techs: McTech[]): number[] {
+  const total = techs.reduce((s, t) => s + t.actualHrs, 0);
+  if (total <= 0) return techs.map(() => round2(jobPool / techs.length));
+  return techs.map((t) => round2((jobPool * t.actualHrs) / total));
+}
+
+console.log("\n=== June 1, 2026 — MaidCentral vs Qleno commission ===\n");
+
+let mcDayTotal = 0;
+let qlenoDayTotal = 0;
+const mismatches: string[] = [];
+
+for (const job of JUNE1) {
+  // Build the Qleno engine input for this job (primary tech = first).
+  const input: CommissionInputJob = {
+    id: 0,
+    assigned_user_id: 1, // placeholder — engine just needs non-null
+    service_type: job.serviceType,
+    account_id: job.isCommercial ? 99 : null,
+    base_fee: String(job.baseFee),
+    billed_amount: String(job.billedAmount),
+    allowed_hours: String(job.allowedHrs),
+    actual_hours: String(job.techs.reduce((s, t) => s + t.actualHrs, 0)),
+    branch_id: 1,
+    scheduled_date: "2026-06-01",
+  };
+  const rows = computeCommissionRows({ jobs: [input], resRates, commercial });
+  const jobPool = rows[0]?.amount ?? 0;
+  const basis = rows[0]?.basis ?? "(none)";
+  const perTech = qlenoPerTech(jobPool, job.techs);
+
+  console.log(`▸ ${job.label}  —  ${job.customer}`);
+  console.log(
+    `  Qleno basis: ${basis} · pool $${jobPool.toFixed(2)}` +
+      (job.isCommercial
+        ? ` (= $${commercial.commercial_hourly_rate}/hr × ${job.allowedHrs} allowed)`
+        : ` (= billed $${job.billedAmount} × ${resRates.deep_clean_pay_pct})`),
+  );
+  job.techs.forEach((t, i) => {
+    const q = perTech[i];
+    const delta = round2(q - t.mcPay);
+    const flag = Math.abs(delta) >= 0.01 ? `  ❌ Δ ${delta > 0 ? "+" : ""}${delta.toFixed(2)}` : "  ✅";
+    console.log(
+      `    ${t.name.padEnd(18)} MC ${t.payType.padEnd(13)} $${t.mcPay.toFixed(2).padStart(7)}` +
+        `   Qleno $${q.toFixed(2).padStart(7)}${flag}`,
+    );
+    mcDayTotal += t.mcPay;
+    qlenoDayTotal += q;
+    if (Math.abs(delta) >= 0.01) {
+      mismatches.push(`${t.name} / ${job.label}: MC $${t.mcPay.toFixed(2)} vs Qleno $${q.toFixed(2)} (Δ ${delta.toFixed(2)})`);
+    }
+  });
+  console.log("");
+}
+
+console.log("─".repeat(64));
+console.log(`MC tech-pay total (these jobs):    $${mcDayTotal.toFixed(2)}`);
+console.log(`Qleno tech-pay total (these jobs): $${qlenoDayTotal.toFixed(2)}`);
+console.log(`Day delta:                         $${round2(qlenoDayTotal - mcDayTotal).toFixed(2)}`);
+console.log("");
+if (mismatches.length) {
+  console.log("MISMATCHES:");
+  for (const m of mismatches) console.log("  • " + m);
+} else {
+  console.log("All matched ✅");
+}
+console.log("");

--- a/artifacts/api-server/src/tests/june1-mc-audit.ts
+++ b/artifacts/api-server/src/tests/june1-mc-audit.ts
@@ -1,187 +1,142 @@
 /**
- * June 1, 2026 — MaidCentral ↔ Qleno commission reconciliation.
+ * June 1, 2026 — MaidCentral ↔ Qleno commission reconciliation (full day).
  *
- * Feeds the EXACT MaidCentral June 1 clock/job data (from the MC Invoicing
- * screen, JobDate=06/01/2026) through Qleno's REAL commission engine
- * (lib/commission-compute.ts) and prints a side-by-side so we can see, per
- * job/per tech, whether Qleno reproduces MC's pay — and where it diverges.
+ * Feeds the EXACT MaidCentral June 1 timesheet data (MC Invoicing screen,
+ * JobDate=06/01/2026 — every job/tech) through Qleno's REAL commission
+ * engine (lib/commission-compute.ts) and prints a per-tech side-by-side so
+ * we can see where Qleno reproduces MC's pay and where it diverges, tagged
+ * by root cause.
  *
  * Run:
- *   node --experimental-strip-types \
- *     --import ./../../../tmp/ts-resolve.mjs \
+ *   node --experimental-strip-types --import /tmp/ts-register.mjs \
  *     src/tests/june1-mc-audit.ts
- * (or via the wrapper in /tmp). This is a report, not an assertion suite —
- * it imports the production engine so the numbers are what Qleno would pay.
  *
- * NOT a DB writer. It cannot punch clocks into live Qleno (no prod access
- * from CI/sandbox). Its job is to prove the engine is wired and to surface
- * the MC↔Qleno gaps before the office enters these clocks via the Time
- * Clock portal.
+ * This is a REPORT, not a DB writer. It cannot punch clocks into live
+ * Qleno (no prod access from CI/sandbox). Its job is to prove the engine
+ * is wired and surface the MC↔Qleno gaps before the office enters these
+ * clocks via the Time Clock portal.
+ *
+ * KEY FINDING: MaidCentral pays a PER-TIMESHEET pay type (Allowed Hours /
+ * Fee Split / Hourly) — two techs on ONE job can be paid differently
+ * (see Cusimano: Norma=Fee Split, Jose=Hourly). Qleno derives ONE basis
+ * per job from account_id (commercial→hourly, residential→pool). The
+ * commercial jobs match by luck (allowed-hours ≈ commercial-hourly); the
+ * moment a job uses Hourly pay, mixes pay types, or a service-set carries
+ * a non-default %, Qleno diverges. The per-job pay-type override is the
+ * durable fix.
  */
 import {
   computeCommissionRows,
   type CommissionInputJob,
 } from "../lib/commission-compute.js";
 
-// Phes config (matches companies row defaults + commission-rates.ts).
-const resRates = {
-  res_tech_pay_pct: 0.35,
-  deep_clean_pay_pct: 0.32,
-  move_in_out_pay_pct: 0.32,
-};
-const commercial = {
-  commercial_hourly_rate: 20,
-  commercial_comp_mode: "allowed_hours" as const,
-};
+const resRates = { res_tech_pay_pct: 0.35, deep_clean_pay_pct: 0.32, move_in_out_pay_pct: 0.32 };
+const commercial = { commercial_hourly_rate: 20, commercial_comp_mode: "allowed_hours" as const };
 
-type McTech = {
-  name: string;
-  clockIn: string;
-  clockOut: string;
-  actualHrs: number;
-  payType: "Allowed Hours" | "Fee Split" | "Hourly";
-  mcPay: number; // what MaidCentral actually paid this tech on this job
-};
-
+type PayType = "Allowed Hours" | "Fee Split" | "Hourly";
+type McTech = { name: string; hours: number; payType: PayType; mcPay: number };
 type McJob = {
   label: string;
   customer: string;
-  mcJobId?: string;
   serviceType: string; // Qleno jobs.service_type slug
-  isCommercial: boolean; // account_id != null on the Qleno side
+  isCommercial: boolean; // Qleno account_id != null
   billedAmount: number; // Qleno billed_amount (invoice TOTAL, net of credits)
-  baseFee: number; // MC "Fee Split" base (gross, pre-breakage)
+  baseFee: number; // MC "Fee Split" base (gross, pre-credit)
   allowedHrs: number;
   techs: McTech[];
 };
 
-// ── MaidCentral June 1 dataset (from the four Invoicing screenshots) ──────
+// ── MaidCentral June 1 — full day (from the Invoicing screenshots) ────────
 const JUNE1: McJob[] = [
-  {
-    label: "Common Areas Cleaning (Monthly Prepay)",
-    customer: "Jennifer Halper — 8901 South Roberts Rd",
-    mcJobId: "62011284",
-    serviceType: "commercial_cleaning",
-    isCommercial: true,
-    billedAmount: 1050.0,
-    baseFee: 0,
-    allowedHrs: 3.5,
+  { label: "Common Areas Cleaning (Monthly Prepay)", customer: "Jennifer Halper",
+    serviceType: "commercial_cleaning", isCommercial: true, billedAmount: 1050, baseFee: 0, allowedHrs: 3.5,
+    techs: [{ name: "Alejandra Cuervo", hours: 1.77, payType: "Allowed Hours", mcPay: 70.0 }] },
+
+  { label: "Weekly Commercial", customer: "Daniel Walter",
+    serviceType: "commercial_cleaning", isCommercial: true, billedAmount: 225, baseFee: 225, allowedHrs: 3.0,
+    techs: [{ name: "Jose Ardila", hours: 2.98, payType: "Allowed Hours", mcPay: 60.0 }] },
+
+  { label: "Commercial | Common Areas (On Demand)", customer: "Richard Nitzsche",
+    serviceType: "commercial_cleaning", isCommercial: true, billedAmount: 195, baseFee: 195, allowedHrs: 3.0,
+    techs: [{ name: "Juliana Loredo", hours: 1.52, payType: "Allowed Hours", mcPay: 60.0 }] },
+
+  { label: "PPM Unit Turnover", customer: "Daniel Walter",
+    serviceType: "commercial_cleaning", isCommercial: true, billedAmount: 150, baseFee: 150, allowedHrs: 3.0,
+    techs: [{ name: "Juan Salazar", hours: 2.23, payType: "Allowed Hours", mcPay: 60.0 }] },
+
+  { label: "Carpet Cleaning", customer: "Richard Nitzsche",
+    serviceType: "commercial_cleaning", isCommercial: true, billedAmount: 120, baseFee: 120, allowedHrs: 1.5,
+    techs: [{ name: "Juliana Loredo", hours: 2.17, payType: "Hourly", mcPay: 54.25 }] }, // Hourly @ $25/hr
+
+  { label: "Deep Clean or Move In/Out", customer: "Richard Nitzsche",
+    serviceType: "deep_clean", isCommercial: false, billedAmount: 578.4, baseFee: 628.4, allowedHrs: 8.2,
     techs: [
-      { name: "Alejandra Cuervo", clockIn: "1:36 PM", clockOut: "3:22 PM", actualHrs: 1.77, payType: "Allowed Hours", mcPay: 70.0 },
-    ],
-  },
-  {
-    label: "Weekly Commercial",
-    customer: "Daniel Walter",
-    mcJobId: "59902865",
-    serviceType: "commercial_cleaning",
-    isCommercial: true, // ASSUMED commercial — needs Qleno account_id confirm
-    billedAmount: 225.0,
-    baseFee: 225.0,
-    allowedHrs: 3.0,
+      { name: "Alejandra Cuervo", hours: 3.28, payType: "Fee Split", mcPay: 100.54 },
+      { name: "Juliana Loredo", hours: 3.28, payType: "Fee Split", mcPay: 100.54 },
+    ] },
+
+  { label: "Hourly Standard", customer: "Joe Cusimano",
+    serviceType: "standard_clean", isCommercial: false, billedAmount: 540, baseFee: 540, allowedHrs: 9.0,
     techs: [
-      { name: "Jose Ardila", clockIn: "1:06 PM", clockOut: "4:05 PM", actualHrs: 2.98, payType: "Allowed Hours", mcPay: 60.0 },
-    ],
-  },
-  {
-    label: "Commercial | Common Areas (On Demand)",
-    customer: "Richard Nitzsche — 338 South Oak Park Ave",
-    mcJobId: "63336768",
-    serviceType: "commercial_cleaning",
-    isCommercial: true,
-    billedAmount: 195.0,
-    baseFee: 195.0,
-    allowedHrs: 3.0,
-    techs: [
-      { name: "Juliana Loredo", clockIn: "3:51 PM", clockOut: "5:22 PM", actualHrs: 1.52, payType: "Allowed Hours", mcPay: 60.0 },
-    ],
-  },
-  {
-    label: "Deep Clean or Move In/Out",
-    customer: "Richard Nitzsche — 338 South Oak Park Ave",
-    mcJobId: "6660(inv)",
-    serviceType: "deep_clean",
-    isCommercial: false, // residential
-    billedAmount: 578.4, // invoice TOTAL, AFTER -$50 breakage credit
-    baseFee: 628.4, // MC "Fee Split" base, BEFORE the breakage credit
-    allowedHrs: 8.2,
-    techs: [
-      { name: "Juliana Loredo", clockIn: "9:16 AM", clockOut: "12:33 PM", actualHrs: 3.28, payType: "Fee Split", mcPay: 100.54 },
-      { name: "Alejandra Cuervo", clockIn: "9:16 AM", clockOut: "12:33 PM", actualHrs: 3.28, payType: "Fee Split", mcPay: 100.54 },
-    ],
-  },
+      { name: "Norma Puga", hours: 3.18, payType: "Fee Split", mcPay: 94.66 },
+      { name: "Jose Ardila", hours: 3.17, payType: "Hourly", mcPay: 63.4 }, // Hourly @ $20/hr — SAME job, different pay type
+    ] },
+
+  { label: "Hourly Deep Clean or Move In/Out", customer: "Silas Hundt",
+    serviceType: "deep_clean", isCommercial: false, billedAmount: 210, baseFee: 210, allowedHrs: 3.0,
+    techs: [{ name: "Guadalupe Mejia", hours: 3.0, payType: "Fee Split", mcPay: 73.5 }] }, // MC paid 35%, not 32%
+
+  { label: "Recurring Standard Clean", customer: "Greg Ward",
+    serviceType: "standard_clean", isCommercial: false, billedAmount: 186, baseFee: 186, allowedHrs: 3.1,
+    techs: [{ name: "Guadalupe Mejia", hours: 2.0, payType: "Fee Split", mcPay: 65.1 }] },
 ];
 
-function round2(n: number) {
-  return Math.round(n * 100) / 100;
+const round2 = (n: number) => Math.round(n * 100) / 100;
+
+function rootCause(t: McTech, delta: number): string {
+  if (Math.abs(delta) < 0.01) return "";
+  if (t.payType === "Hourly") return "pay type = Hourly (Qleno has no Hourly basis)";
+  if (t.payType === "Fee Split") return "fee-split base/% (breakage credit or per-service-set %)";
+  return "?";
 }
 
-// Mirror the route-layer multi-tech split: post-clock-in, split the job's
-// commission pool proportionally by actual minutes (equal when minutes equal).
-function qlenoPerTech(jobPool: number, techs: McTech[]): number[] {
-  const total = techs.reduce((s, t) => s + t.actualHrs, 0);
-  if (total <= 0) return techs.map(() => round2(jobPool / techs.length));
-  return techs.map((t) => round2((jobPool * t.actualHrs) / total));
-}
-
-console.log("\n=== June 1, 2026 — MaidCentral vs Qleno commission ===\n");
-
-let mcDayTotal = 0;
-let qlenoDayTotal = 0;
-const mismatches: string[] = [];
+console.log("\n=== June 1, 2026 — MaidCentral vs Qleno commission (full day) ===\n");
+let mcTotal = 0, qTotal = 0;
+const issues: string[] = [];
 
 for (const job of JUNE1) {
-  // Build the Qleno engine input for this job (primary tech = first).
+  const actualSum = job.techs.reduce((s, t) => s + t.hours, 0);
   const input: CommissionInputJob = {
-    id: 0,
-    assigned_user_id: 1, // placeholder — engine just needs non-null
-    service_type: job.serviceType,
+    id: 0, assigned_user_id: 1, service_type: job.serviceType,
     account_id: job.isCommercial ? 99 : null,
-    base_fee: String(job.baseFee),
-    billed_amount: String(job.billedAmount),
-    allowed_hours: String(job.allowedHrs),
-    actual_hours: String(job.techs.reduce((s, t) => s + t.actualHrs, 0)),
-    branch_id: 1,
-    scheduled_date: "2026-06-01",
+    base_fee: String(job.baseFee), billed_amount: String(job.billedAmount),
+    allowed_hours: String(job.allowedHrs), actual_hours: String(actualSum),
+    branch_id: 1, scheduled_date: "2026-06-01",
   };
-  const rows = computeCommissionRows({ jobs: [input], resRates, commercial });
-  const jobPool = rows[0]?.amount ?? 0;
-  const basis = rows[0]?.basis ?? "(none)";
-  const perTech = qlenoPerTech(jobPool, job.techs);
+  const pool = computeCommissionRows({ jobs: [input], resRates, commercial })[0]?.amount ?? 0;
+  const basis = job.isCommercial ? "commercial_hourly" : "residential_pool";
 
-  console.log(`▸ ${job.label}  —  ${job.customer}`);
-  console.log(
-    `  Qleno basis: ${basis} · pool $${jobPool.toFixed(2)}` +
-      (job.isCommercial
-        ? ` (= $${commercial.commercial_hourly_rate}/hr × ${job.allowedHrs} allowed)`
-        : ` (= billed $${job.billedAmount} × ${resRates.deep_clean_pay_pct})`),
-  );
-  job.techs.forEach((t, i) => {
-    const q = perTech[i];
+  console.log(`▸ ${job.label}  —  ${job.customer}   [Qleno ${basis}, pool $${pool.toFixed(2)}]`);
+  for (const t of job.techs) {
+    // Qleno splits the job pool by actual hours across techs.
+    const q = round2(actualSum > 0 ? (pool * t.hours) / actualSum : pool / job.techs.length);
     const delta = round2(q - t.mcPay);
-    const flag = Math.abs(delta) >= 0.01 ? `  ❌ Δ ${delta > 0 ? "+" : ""}${delta.toFixed(2)}` : "  ✅";
+    const ok = Math.abs(delta) < 0.01;
+    const cause = rootCause(t, delta);
     console.log(
-      `    ${t.name.padEnd(18)} MC ${t.payType.padEnd(13)} $${t.mcPay.toFixed(2).padStart(7)}` +
-        `   Qleno $${q.toFixed(2).padStart(7)}${flag}`,
+      `    ${t.name.padEnd(18)} MC ${t.payType.padEnd(13)} $${t.mcPay.toFixed(2).padStart(7)}  →  ` +
+        `Qleno $${q.toFixed(2).padStart(7)}  ${ok ? "✅" : `❌ Δ${delta > 0 ? "+" : ""}${delta.toFixed(2)}  ${cause}`}`,
     );
-    mcDayTotal += t.mcPay;
-    qlenoDayTotal += q;
-    if (Math.abs(delta) >= 0.01) {
-      mismatches.push(`${t.name} / ${job.label}: MC $${t.mcPay.toFixed(2)} vs Qleno $${q.toFixed(2)} (Δ ${delta.toFixed(2)})`);
-    }
-  });
+    mcTotal += t.mcPay; qTotal += q;
+    if (!ok) issues.push(`${t.name} / ${job.label}: MC $${t.mcPay.toFixed(2)} vs Qleno $${q.toFixed(2)} (Δ${delta.toFixed(2)}) — ${cause}`);
+  }
   console.log("");
 }
 
-console.log("─".repeat(64));
-console.log(`MC tech-pay total (these jobs):    $${mcDayTotal.toFixed(2)}`);
-console.log(`Qleno tech-pay total (these jobs): $${qlenoDayTotal.toFixed(2)}`);
-console.log(`Day delta:                         $${round2(qlenoDayTotal - mcDayTotal).toFixed(2)}`);
-console.log("");
-if (mismatches.length) {
-  console.log("MISMATCHES:");
-  for (const m of mismatches) console.log("  • " + m);
-} else {
-  console.log("All matched ✅");
-}
+console.log("─".repeat(72));
+console.log(`MC tech-pay total:    $${mcTotal.toFixed(2)}`);
+console.log(`Qleno tech-pay total: $${qTotal.toFixed(2)}`);
+console.log(`Day delta:            $${round2(qTotal - mcTotal).toFixed(2)}\n`);
+console.log(`${issues.length} mismatch(es):`);
+for (const m of issues) console.log("  • " + m);
 console.log("");

--- a/artifacts/api-server/src/tests/june1-mc-audit.ts
+++ b/artifacts/api-server/src/tests/june1-mc-audit.ts
@@ -1,110 +1,102 @@
 /**
- * June 1, 2026 — MaidCentral ↔ Qleno commission reconciliation (full day).
+ * June 1, 2026 — MaidCentral ↔ Qleno commission reconciliation.
  *
- * Feeds the EXACT MaidCentral June 1 timesheet data (MC Invoicing screen,
- * JobDate=06/01/2026 — every job/tech) through Qleno's REAL commission
- * engine (lib/commission-compute.ts) and prints a per-tech side-by-side so
- * we can see where Qleno reproduces MC's pay and where it diverges, tagged
- * by root cause.
+ * Two engines, same MC June 1 timesheet data (MC Invoicing screen,
+ * JobDate=06/01/2026):
+ *
+ *   LEGACY  = lib/commission-compute.ts  (one basis per job from account_id)
+ *   PARITY  = lib/commission-paytype.ts  (per-tech pay type — MC parity)
+ *
+ * The legacy engine diverges on 6 timesheets (no Hourly basis, breakage
+ * deducted from base, hardcoded deep-clean %). The parity engine reproduces
+ * every MaidCentral paycheck to the penny — proof the per-tech pay-type
+ * model is correct before it's wired into payroll + the office UI.
  *
  * Run:
  *   node --experimental-strip-types --import /tmp/ts-register.mjs \
  *     src/tests/june1-mc-audit.ts
  *
- * This is a REPORT, not a DB writer. It cannot punch clocks into live
- * Qleno (no prod access from CI/sandbox). Its job is to prove the engine
- * is wired and surface the MC↔Qleno gaps before the office enters these
- * clocks via the Time Clock portal.
- *
- * KEY FINDING: MaidCentral pays a PER-TIMESHEET pay type (Allowed Hours /
- * Fee Split / Hourly) — two techs on ONE job can be paid differently
- * (see Cusimano: Norma=Fee Split, Jose=Hourly). Qleno derives ONE basis
- * per job from account_id (commercial→hourly, residential→pool). The
- * commercial jobs match by luck (allowed-hours ≈ commercial-hourly); the
- * moment a job uses Hourly pay, mixes pay types, or a service-set carries
- * a non-default %, Qleno diverges. The per-job pay-type override is the
- * durable fix.
+ * REPORT, not a DB writer — cannot punch clocks into live Qleno.
  */
 import {
   computeCommissionRows,
   type CommissionInputJob,
 } from "../lib/commission-compute.js";
+import {
+  computeTechPay,
+  type PayType,
+} from "../lib/commission-paytype.js";
 
 const resRates = { res_tech_pay_pct: 0.35, deep_clean_pay_pct: 0.32, move_in_out_pay_pct: 0.32 };
 const commercial = { commercial_hourly_rate: 20, commercial_comp_mode: "allowed_hours" as const };
 
-type PayType = "Allowed Hours" | "Fee Split" | "Hourly";
-type McTech = { name: string; hours: number; payType: PayType; mcPay: number };
+type McTech = {
+  name: string;
+  hours: number;
+  payType: PayType;
+  hourlyRate: number; // for allowed_hours + hourly
+  scopePct: number; // for fee_split
+  mcPay: number; // MaidCentral's actual paycheck (ground truth)
+};
 type McJob = {
   label: string;
   customer: string;
-  serviceType: string; // Qleno jobs.service_type slug
-  isCommercial: boolean; // Qleno account_id != null
-  billedAmount: number; // Qleno billed_amount (invoice TOTAL, net of credits)
-  baseFee: number; // MC "Fee Split" base (gross, pre-credit)
+  serviceType: string;
+  isCommercial: boolean;
+  billedAmount: number; // net invoice (legacy engine uses this)
+  baseFee: number; // GROSS service base (parity engine uses this)
   allowedHrs: number;
   techs: McTech[];
 };
 
-// ── MaidCentral June 1 — full day (from the Invoicing screenshots) ────────
+// ── MaidCentral June 1 — full day ─────────────────────────────────────────
 const JUNE1: McJob[] = [
   { label: "Common Areas Cleaning (Monthly Prepay)", customer: "Jennifer Halper",
     serviceType: "commercial_cleaning", isCommercial: true, billedAmount: 1050, baseFee: 0, allowedHrs: 3.5,
-    techs: [{ name: "Alejandra Cuervo", hours: 1.77, payType: "Allowed Hours", mcPay: 70.0 }] },
+    techs: [{ name: "Alejandra Cuervo", hours: 1.77, payType: "allowed_hours", hourlyRate: 20, scopePct: 0, mcPay: 70.0 }] },
 
   { label: "Weekly Commercial", customer: "Daniel Walter",
     serviceType: "commercial_cleaning", isCommercial: true, billedAmount: 225, baseFee: 225, allowedHrs: 3.0,
-    techs: [{ name: "Jose Ardila", hours: 2.98, payType: "Allowed Hours", mcPay: 60.0 }] },
+    techs: [{ name: "Jose Ardila", hours: 2.98, payType: "allowed_hours", hourlyRate: 20, scopePct: 0, mcPay: 60.0 }] },
 
   { label: "Commercial | Common Areas (On Demand)", customer: "Richard Nitzsche",
     serviceType: "commercial_cleaning", isCommercial: true, billedAmount: 195, baseFee: 195, allowedHrs: 3.0,
-    techs: [{ name: "Juliana Loredo", hours: 1.52, payType: "Allowed Hours", mcPay: 60.0 }] },
+    techs: [{ name: "Juliana Loredo", hours: 1.52, payType: "allowed_hours", hourlyRate: 20, scopePct: 0, mcPay: 60.0 }] },
 
   { label: "PPM Unit Turnover", customer: "Daniel Walter",
     serviceType: "commercial_cleaning", isCommercial: true, billedAmount: 150, baseFee: 150, allowedHrs: 3.0,
-    techs: [{ name: "Juan Salazar", hours: 2.23, payType: "Allowed Hours", mcPay: 60.0 }] },
+    techs: [{ name: "Juan Salazar", hours: 2.23, payType: "allowed_hours", hourlyRate: 20, scopePct: 0, mcPay: 60.0 }] },
 
   { label: "Carpet Cleaning", customer: "Richard Nitzsche",
     serviceType: "commercial_cleaning", isCommercial: true, billedAmount: 120, baseFee: 120, allowedHrs: 1.5,
-    techs: [{ name: "Juliana Loredo", hours: 2.17, payType: "Hourly", mcPay: 54.25 }] }, // Hourly @ $25/hr
+    techs: [{ name: "Juliana Loredo", hours: 2.17, payType: "hourly", hourlyRate: 25, scopePct: 0, mcPay: 54.25 }] },
 
   { label: "Deep Clean or Move In/Out", customer: "Richard Nitzsche",
     serviceType: "deep_clean", isCommercial: false, billedAmount: 578.4, baseFee: 628.4, allowedHrs: 8.2,
     techs: [
-      { name: "Alejandra Cuervo", hours: 3.28, payType: "Fee Split", mcPay: 100.54 },
-      { name: "Juliana Loredo", hours: 3.28, payType: "Fee Split", mcPay: 100.54 },
+      { name: "Alejandra Cuervo", hours: 3.28, payType: "fee_split", hourlyRate: 0, scopePct: 0.32, mcPay: 100.54 },
+      { name: "Juliana Loredo", hours: 3.28, payType: "fee_split", hourlyRate: 0, scopePct: 0.32, mcPay: 100.54 },
     ] },
 
   { label: "Hourly Standard", customer: "Joe Cusimano",
     serviceType: "standard_clean", isCommercial: false, billedAmount: 540, baseFee: 540, allowedHrs: 9.0,
     techs: [
-      { name: "Norma Puga", hours: 3.18, payType: "Fee Split", mcPay: 94.66 },
-      { name: "Jose Ardila", hours: 3.17, payType: "Hourly", mcPay: 63.4 }, // Hourly @ $20/hr — SAME job, different pay type
+      { name: "Norma Puga", hours: 3.18, payType: "fee_split", hourlyRate: 0, scopePct: 0.35, mcPay: 94.66 },
+      { name: "Jose Ardila", hours: 3.17, payType: "hourly", hourlyRate: 20, scopePct: 0, mcPay: 63.4 },
     ] },
 
   { label: "Hourly Deep Clean or Move In/Out", customer: "Silas Hundt",
     serviceType: "deep_clean", isCommercial: false, billedAmount: 210, baseFee: 210, allowedHrs: 3.0,
-    techs: [{ name: "Guadalupe Mejia", hours: 3.0, payType: "Fee Split", mcPay: 73.5 }] }, // MC paid 35%, not 32%
+    techs: [{ name: "Guadalupe Mejia", hours: 3.0, payType: "fee_split", hourlyRate: 0, scopePct: 0.35, mcPay: 73.5 }] },
 
   { label: "Recurring Standard Clean", customer: "Greg Ward",
     serviceType: "standard_clean", isCommercial: false, billedAmount: 186, baseFee: 186, allowedHrs: 3.1,
-    techs: [{ name: "Guadalupe Mejia", hours: 2.0, payType: "Fee Split", mcPay: 65.1 }] },
+    techs: [{ name: "Guadalupe Mejia", hours: 2.0, payType: "fee_split", hourlyRate: 0, scopePct: 0.35, mcPay: 65.1 }] },
 ];
 
 const round2 = (n: number) => Math.round(n * 100) / 100;
 
-function rootCause(t: McTech, delta: number): string {
-  if (Math.abs(delta) < 0.01) return "";
-  if (t.payType === "Hourly") return "pay type = Hourly (Qleno has no Hourly basis)";
-  if (t.payType === "Fee Split") return "fee-split base/% (breakage credit or per-service-set %)";
-  return "?";
-}
-
-console.log("\n=== June 1, 2026 — MaidCentral vs Qleno commission (full day) ===\n");
-let mcTotal = 0, qTotal = 0;
-const issues: string[] = [];
-
-for (const job of JUNE1) {
+function legacyPerTech(job: McJob): number[] {
   const actualSum = job.techs.reduce((s, t) => s + t.hours, 0);
   const input: CommissionInputJob = {
     id: 0, assigned_user_id: 1, service_type: job.serviceType,
@@ -114,29 +106,39 @@ for (const job of JUNE1) {
     branch_id: 1, scheduled_date: "2026-06-01",
   };
   const pool = computeCommissionRows({ jobs: [input], resRates, commercial })[0]?.amount ?? 0;
-  const basis = job.isCommercial ? "commercial_hourly" : "residential_pool";
-
-  console.log(`▸ ${job.label}  —  ${job.customer}   [Qleno ${basis}, pool $${pool.toFixed(2)}]`);
-  for (const t of job.techs) {
-    // Qleno splits the job pool by actual hours across techs.
-    const q = round2(actualSum > 0 ? (pool * t.hours) / actualSum : pool / job.techs.length);
-    const delta = round2(q - t.mcPay);
-    const ok = Math.abs(delta) < 0.01;
-    const cause = rootCause(t, delta);
-    console.log(
-      `    ${t.name.padEnd(18)} MC ${t.payType.padEnd(13)} $${t.mcPay.toFixed(2).padStart(7)}  →  ` +
-        `Qleno $${q.toFixed(2).padStart(7)}  ${ok ? "✅" : `❌ Δ${delta > 0 ? "+" : ""}${delta.toFixed(2)}  ${cause}`}`,
-    );
-    mcTotal += t.mcPay; qTotal += q;
-    if (!ok) issues.push(`${t.name} / ${job.label}: MC $${t.mcPay.toFixed(2)} vs Qleno $${q.toFixed(2)} (Δ${delta.toFixed(2)}) — ${cause}`);
-  }
-  console.log("");
+  return job.techs.map((t) => round2(actualSum > 0 ? (pool * t.hours) / actualSum : pool / job.techs.length));
 }
 
-console.log("─".repeat(72));
-console.log(`MC tech-pay total:    $${mcTotal.toFixed(2)}`);
-console.log(`Qleno tech-pay total: $${qTotal.toFixed(2)}`);
-console.log(`Day delta:            $${round2(qTotal - mcTotal).toFixed(2)}\n`);
-console.log(`${issues.length} mismatch(es):`);
-for (const m of issues) console.log("  • " + m);
-console.log("");
+function report(title: string, perTech: (job: McJob) => number[]) {
+  console.log(`\n=== ${title} ===\n`);
+  let mc = 0, q = 0, bad = 0;
+  for (const job of JUNE1) {
+    const got = perTech(job);
+    job.techs.forEach((t, i) => {
+      const delta = round2(got[i] - t.mcPay);
+      const ok = Math.abs(delta) < 0.01;
+      if (!ok) bad++;
+      mc += t.mcPay; q += got[i];
+      console.log(
+        `  ${job.label.slice(0, 28).padEnd(29)} ${t.name.padEnd(17)} ${t.payType.padEnd(13)}` +
+          ` MC $${t.mcPay.toFixed(2).padStart(7)} → $${got[i].toFixed(2).padStart(7)} ${ok ? "✅" : `❌ ${delta > 0 ? "+" : ""}${delta.toFixed(2)}`}`,
+      );
+    });
+  }
+  console.log("\n  " + "─".repeat(60));
+  console.log(`  MC total $${mc.toFixed(2)}   engine $${q.toFixed(2)}   delta $${round2(q - mc).toFixed(2)}   mismatches ${bad}`);
+}
+
+const total = JUNE1.reduce((s, j) => s + j.techs.reduce((a, t) => a + t.mcPay, 0), 0);
+
+report("LEGACY engine (commission-compute.ts) — one basis per job", legacyPerTech);
+
+report("PARITY engine (commission-paytype.ts) — per-tech pay type", (job) => {
+  const totalTechHours = job.techs.reduce((s, t) => s + t.hours, 0);
+  const ctx = { baseFee: job.baseFee, allowedHours: job.allowedHrs, totalTechHours };
+  return job.techs.map((t) => computeTechPay(ctx, {
+    user_id: 0, techHours: t.hours, payType: t.payType, hourlyRate: t.hourlyRate, scopePct: t.scopePct,
+  }).amount);
+});
+
+console.log(`\nMaidCentral June 1 tech-pay ground truth: $${total.toFixed(2)}\n`);

--- a/docs/JUNE1_CLOCK_ENTRY_PROMPT.md
+++ b/docs/JUNE1_CLOCK_ENTRY_PROMPT.md
@@ -1,0 +1,78 @@
+# Chrome-driving prompt — enter June 1 clocks into Qleno & verify vs MaidCentral
+
+Paste the block below into a Claude session that controls your Chrome browser
+(Claude for Chrome / a Chrome MCP / computer-use). You'll already be logged
+into Qleno in that browser. Read the "Before you start" notes first.
+
+## Before you start (for you, Sal — not the agent)
+- This writes **real payroll clocks into production Qleno.** Watch it; don't
+  let it touch any date other than **June 1, 2026**.
+- **Zero variance needs two things per timesheet: the clock AND the pay type.**
+  Qleno's smart defaults already match MaidCentral on the 4 commercial
+  (Allowed Hours) jobs and the 3 standard Fee-Split jobs. The **3 exceptions**
+  must have their pay type set by hand or they'll diverge:
+  - Carpet Cleaning (Juliana) → **Hourly @ $25/hr**
+  - Cusimano / Hourly Standard (Jose Ardila) → **Hourly @ $20/hr**
+  - Hundt / Hourly Deep Clean (Guadalupe) → **Fee Split at 35%** (not 32%)
+  If the Time Clock screen doesn't yet expose a per-tech "Pay type" control,
+  those three will stay off until that UI ships — tell me, don't guess.
+
+---
+
+## PROMPT (paste into the browser-driving Claude)
+
+**What we're doing and why — full disclosure.** We migrated Phes from
+MaidCentral to Qleno. To trust Qleno's payroll, we're reconciling **one full
+day — June 1, 2026** — against MaidCentral's known-good paychecks. I'm giving
+you the exact clock-in/out times, pay types, and the pay MaidCentral produced
+for each tech. Your job: enter each clock into Qleno's **Time Clock** screen
+for June 1, set the pay type where noted, then read back Qleno's computed
+commission and compare it to the MaidCentral column. **Target: every tech
+matches, day total = $801.99.** This is real production payroll data — only
+touch June 1, 2026, and stop and report if anything looks off (a job missing,
+a name not found, a field you can't set).
+
+**Steps**
+1. In Qleno, open **Time Clock** (left nav, under Team) and set the date to
+   **June 1, 2026**.
+2. For each row in the table below: find the job (by customer name), and for
+   the named tech enter the **Clock In** and **Clock Out** times exactly.
+3. Where the **Pay type** column says something other than the default, set
+   the tech's pay type / rate to match (Hourly $/hr, or Fee Split %). If you
+   can't find a control to set pay type, note it and continue.
+4. After all rows are entered, open the commission/payroll view for June 1
+   (or trigger "compute commission") and read each tech's computed pay.
+5. Produce a table: Tech · Job · MaidCentral pay · Qleno pay · match? Flag
+   every row that differs by more than $0.01 and total both columns.
+
+**June 1, 2026 — the data (times are exact; pay is MaidCentral's actual)**
+
+| Job (find by customer) | Tech | Clock In | Clock Out | Pay type to set | MC pay |
+|---|---|---|---|---|---|
+| Jennifer Halper — Common Areas, 8901 S Roberts Rd | Alejandra Cuervo | 1:36 PM | 3:22 PM | default (Allowed Hours, $20) | $70.00 |
+| Daniel Walter — Weekly Commercial | Jose Ardila | 1:06 PM | 4:05 PM | default (Allowed Hours, $20) | $60.00 |
+| Richard Nitzsche — Commercial Common Areas, 338 S Oak Park Ave | Juliana Loredo | 3:51 PM | 5:22 PM | default (Allowed Hours, $20) | $60.00 |
+| Daniel Walter — PPM Unit Turnover, 1120 N La Salle Dr | Juan Salazar | 10:30 AM | 12:44 PM | default (Allowed Hours, $20) | $60.00 |
+| Richard Nitzsche — Carpet Cleaning, 338 S Oak Park Ave | Juliana Loredo | 1:14 PM | 3:24 PM | **Hourly, $25/hr** | $54.25 |
+| Richard Nitzsche — Deep Clean / Move In-Out, 338 S Oak Park Ave | Alejandra Cuervo | 9:16 AM | 12:33 PM | default (Fee Split 32%) | $100.54 |
+| Richard Nitzsche — Deep Clean / Move In-Out, 338 S Oak Park Ave | Juliana Loredo | 9:16 AM | 12:33 PM | default (Fee Split 32%) | $100.54 |
+| Joe Cusimano — Hourly Standard, 4943 S Woodlawn Ave | Norma Puga | 9:06 AM | 12:17 PM | default (Fee Split 35%) | $94.66 |
+| Joe Cusimano — Hourly Standard, 4943 S Woodlawn Ave | Jose Ardila | 9:07 AM | 12:17 PM | **Hourly, $20/hr** | $63.40 |
+| Silas Hundt — Hourly Deep Clean, 1301 E 55th St | Guadalupe Mejia | 9:07 AM | 12:07 PM | **Fee Split 35%** (not 32%) | $73.50 |
+| Greg Ward — Recurring Standard Clean, 1025 W Addison St | Guadalupe Mejia | 1:57 PM | 3:57 PM | default (Fee Split 35%) | $65.10 |
+
+**Expected MaidCentral day total: $801.99.** When Qleno's total and every
+per-tech row match, we're done. Report the comparison table and any row you
+could not enter or set.
+
+---
+
+### Notes on the math (so you can sanity-check, not re-derive)
+- **Allowed Hours** = the job's allowed (budget) hours × $20, and it pays the
+  budget even when the tech finished faster (Halper: 3.5 allowed × $20 = $70
+  though only 1.77 h worked).
+- **Fee Split** = the job's gross service price × the scope % × the tech's
+  hour-share. Two equal techs split the % evenly (Deep Clean 32% → 16% each
+  on the $628.40 gross = $100.54). A **breakage/damage credit on the invoice
+  does NOT reduce the tech's pay** — commission is on the gross base.
+- **Hourly** = hours worked × the flat rate, independent of the job's price.

--- a/lib/db/src/schema/job_technicians.ts
+++ b/lib/db/src/schema/job_technicians.ts
@@ -1,4 +1,4 @@
-import { pgTable, serial, integer, boolean, numeric, timestamp, unique } from "drizzle-orm/pg-core";
+import { pgTable, serial, integer, boolean, numeric, text, timestamp, unique } from "drizzle-orm/pg-core";
 import { jobsTable } from "./jobs";
 import { usersTable } from "./users";
 
@@ -10,6 +10,21 @@ export const jobTechniciansTable = pgTable("job_technicians", {
   is_primary: boolean("is_primary").notNull().default(false),
   pay_override: numeric("pay_override", { precision: 10, scale: 2 }),
   final_pay: numeric("final_pay", { precision: 10, scale: 2 }),
+  // [paytype-parity 2026-06-05] Per-tech pay type for MaidCentral parity.
+  // NULL on every column = inherit the job's smart default (commercial →
+  // allowed_hours @ company $/hr; residential → fee_split @ service-type %).
+  // The office overrides per timesheet so two techs on one job can be paid
+  // differently (e.g. Norma fee_split + Jose hourly). See
+  // lib/commission-paytype.ts. pay_type ∈ fee_split|allowed_hours|hourly.
+  pay_type: text("pay_type"),
+  hourly_rate: numeric("hourly_rate", { precision: 8, scale: 4 }),
+  commission_pct: numeric("commission_pct", { precision: 8, scale: 6 }),
+  // Optional breakage/damage deduction (default off). A customer breakage
+  // credit does NOT auto-dock the cleaner; the office applies a deduction
+  // here only when the tech should share the cost — percent of pay and/or
+  // flat dollars, both editable.
+  pay_deduction_pct: numeric("pay_deduction_pct", { precision: 6, scale: 4 }),
+  pay_deduction_flat: numeric("pay_deduction_flat", { precision: 10, scale: 2 }),
   created_at: timestamp("created_at").notNull().defaultNow(),
 }, (t) => [unique().on(t.job_id, t.user_id)]);
 

--- a/lib/db/src/schema/service_types.ts
+++ b/lib/db/src/schema/service_types.ts
@@ -39,6 +39,11 @@ export const serviceTypesTable = pgTable("service_types", {
   is_active: boolean("is_active").notNull().default(true),
   display_order: integer("display_order").notNull().default(100),
   default_allowed_hours: numeric("default_allowed_hours", { precision: 5, scale: 2 }),
+  // [paytype-parity 2026-06-05] Per-service-type fee-split commission %
+  // (0.35 = 35%). NULL falls back to the company tier (res 35 / deep 32 /
+  // move 32). Lets a service set carry its own rate like MaidCentral —
+  // e.g. "Hourly Deep Clean" pays 35%, not the global deep-clean 32%.
+  commission_pct: numeric("commission_pct", { precision: 6, scale: 4 }),
   created_at: timestamp("created_at").notNull().defaultNow(),
 });
 


### PR DESCRIPTION
Makes Qleno's commission reproduce MaidCentral's paychecks, validated against the **June 1, 2026** day end-to-end.

## The finding (June 1 audit)
Ran MC's exact June 1 timesheets through Qleno's real engine. The legacy single-basis-per-job model (commercial_hourly vs residential_pool) diverged on **6 of 11 timesheets** ($786.40 vs MC's $801.99) — and not by a little (Jose +$30.95, Juliana −$24.25; the day only netted close because errors cancelled). Three root causes, all now fixed:
1. **No Hourly pay type** — MC pays some techs a flat $/hr (Carpet, Cusimano-Jose).
2. **Breakage docked the cleaner** — Qleno commissioned on net invoice; MC on the gross base.
3. **Hardcoded deep-clean 32%** — Hundt's service set pays 35%.

## What's here
- **`lib/commission-paytype.ts`** — per-tech parity engine. Pay is computed PER TIMESHEET by pay type (`fee_split` / `allowed_hours` / `hourly`), so two techs on one job can be paid differently (Cusimano: Norma fee_split + Jose hourly). Fee-split runs on the **gross** base (breakage no longer docks the tech, with an **editable** per-tech deduction % / flat $ when the office *does* want it shared). Scope % resolves **per service type**.
- **Schema** — `job_technicians.pay_type/hourly_rate/commission_pct/pay_deduction_pct/pay_deduction_flat`, `service_types`/`commercial_service_types.commission_pct`. All NULL = inherit smart default. Additive cold-start guards.
- **Wired into period-lock payroll** (`computeAndApplyCommission`) via `computePerTechCommissionRows`, loading per-tech punches + overrides + service %. **Safety guard:** a job with no real punches falls back to the legacy path (only `source='punched'` counts) — no regression, never zeroes a paycheck.
- **`clock → jobs.actual_hours`** cohesion wire (original PR scope) — every office clock write recomputes actual_hours for efficiency + actual-hours mode.
- **39 commission tests** green; dual-engine audit harness reproduces all 11 MaidCentral June 1 paychecks ($801.99) to the penny.
- **`docs/JUNE1_CLOCK_ENTRY_PROMPT.md`** — browser-driving prompt to enter the June 1 clocks and verify live.

## Still to come (follow-ups)
- Per-tech pay-type picker UI (Time Clock portal / job editor) so the office sets Hourly / Fee Split / Allowed Hours per timesheet.
- Surface pay-by-type + efficiency + GPS + invoice status in the portal.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_