### PR TITLE
Time Clock: show all of a day's jobs (branch filter bug) + calendar date picker

### DIFF
--- a/artifacts/api-server/src/routes/timeclock.ts
+++ b/artifacts/api-server/src/routes/timeclock.ts
@@ -659,14 +659,32 @@ router.get("/day", requireRole("owner", "admin", "office"), async (req, res) => 
     const jobIds = jobs.map(j => Number(j.job_id)).filter(n => Number.isFinite(n));
     const inList = jobIds.length ? sql.raw(jobIds.join(",")) : null;
 
-    const techRows = inList ? ((await db.execute(sql`
-      SELECT jt.job_id, jt.user_id, jt.is_primary,
-             jt.pay_type, jt.hourly_rate, jt.commission_pct,
-             jt.pay_deduction_pct, jt.pay_deduction_flat,
-             TRIM(COALESCE(u.first_name,'') || ' ' || COALESCE(u.last_name,'')) AS name
-      FROM job_technicians jt JOIN users u ON u.id = jt.user_id
-      WHERE jt.job_id IN (${inList})
-    `)).rows as any[]) : [];
+    // Pay-type columns are newer than the rest of job_technicians. If the
+    // cold-start migration that adds them hasn't applied on this DB yet,
+    // selecting them throws and would 500 the WHOLE day (hiding every job).
+    // Try the full SELECT, fall back to base columns so the day always loads.
+    let techRows: any[] = [];
+    if (inList) {
+      try {
+        techRows = (await db.execute(sql`
+          SELECT jt.job_id, jt.user_id, jt.is_primary,
+                 jt.pay_type, jt.hourly_rate, jt.commission_pct,
+                 jt.pay_deduction_pct, jt.pay_deduction_flat,
+                 TRIM(COALESCE(u.first_name,'') || ' ' || COALESCE(u.last_name,'')) AS name
+          FROM job_technicians jt JOIN users u ON u.id = jt.user_id
+          WHERE jt.job_id IN (${inList})
+        `)).rows as any[];
+      } catch {
+        techRows = (await db.execute(sql`
+          SELECT jt.job_id, jt.user_id, jt.is_primary,
+                 NULL::text AS pay_type, NULL::numeric AS hourly_rate, NULL::numeric AS commission_pct,
+                 NULL::numeric AS pay_deduction_pct, NULL::numeric AS pay_deduction_flat,
+                 TRIM(COALESCE(u.first_name,'') || ' ' || COALESCE(u.last_name,'')) AS name
+          FROM job_technicians jt JOIN users u ON u.id = jt.user_id
+          WHERE jt.job_id IN (${inList})
+        `)).rows as any[];
+      }
+    }
     const payByJobUser = new Map<string, any>();
     for (const t of techRows) payByJobUser.set(`${Number(t.job_id)}:${Number(t.user_id)}`, t);
 

--- a/artifacts/api-server/src/routes/timeclock.ts
+++ b/artifacts/api-server/src/routes/timeclock.ts
@@ -651,8 +651,8 @@ router.get("/day", requireRole("owner", "admin", "office"), async (req, res) => 
       FROM jobs j
       LEFT JOIN clients c ON c.id = j.client_id
       WHERE j.company_id = ${companyId}
-        AND j.scheduled_date = ${date}
-        AND j.status <> 'cancelled'
+        AND j.scheduled_date::date = ${date}::date
+        AND j.status IS DISTINCT FROM 'cancelled'
       ORDER BY j.scheduled_time NULLS LAST, j.id
     `);
     const jobs = jobsRes.rows as any[];

--- a/artifacts/qleno/src/pages/time-clock.tsx
+++ b/artifacts/qleno/src/pages/time-clock.tsx
@@ -2,8 +2,7 @@ import { useState, useEffect, useCallback } from "react";
 import { DashboardLayout } from "@/components/layout/dashboard-layout";
 import { getAuthHeaders } from "@/lib/auth";
 import { useToast } from "@/hooks/use-toast";
-import { useBranch } from "@/contexts/branch-context";
-import { ChevronLeft, ChevronRight, Clock, Trash2, AlertTriangle, Check } from "lucide-react";
+import { ChevronLeft, ChevronRight, Clock, Trash2, AlertTriangle, Check, CalendarDays } from "lucide-react";
 
 // [time-clock-portal 2026-06-05] Office Time Clock portal. The office reconciles
 // Qleno's per-job clock times against MaidCentral so commission (proportional by
@@ -207,7 +206,6 @@ function RowEditor({ emp, row, dateStr, onChanged, toastFn }: {
 
 export default function TimeClockPage() {
   const { toast } = useToast();
-  const { activeBranchId } = useBranch();
   const [date, setDate] = useState(new Date());
   const [data, setData] = useState<{ date: string; employees: Emp[] } | null>(null);
   const [loading, setLoading] = useState(true);
@@ -217,12 +215,13 @@ export default function TimeClockPage() {
   const load = useCallback(async () => {
     setLoading(true);
     try {
-      const qs = `?date=${dk}` + (activeBranchId && activeBranchId !== "all" ? `&branch_id=${activeBranchId}` : "");
-      const r = await api(`/api/timeclock/day${qs}`);
+      // Reconciliation is company-wide — no branch filter (a job's branch_id
+      // is often null/mismatched on MC imports, which would hide it).
+      const r = await api(`/api/timeclock/day?date=${dk}`);
       setData(r.ok ? await r.json() : { date: dk, employees: [] });
     } catch { setData({ date: dk, employees: [] }); }
     setLoading(false);
-  }, [dk, activeBranchId]);
+  }, [dk]);
   useEffect(() => { load(); }, [load]);
 
   const employees = data?.employees ?? [];
@@ -242,12 +241,19 @@ export default function TimeClockPage() {
             </p>
           </div>
           <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-            <button onClick={() => setDate(d => addDays(d, -1))} style={{ border: "1px solid #E5E2DC", background: "#fff", borderRadius: 8, padding: "7px 9px", cursor: "pointer", color: "#6B7280" }}><ChevronLeft size={16} /></button>
-            <div style={{ textAlign: "center", minWidth: 150 }}>
-              <div style={{ fontSize: 14, fontWeight: 800, color: "#1A1917" }}>{isToday ? "Today" : date.toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric" })}</div>
-              <div style={{ fontSize: 11, color: "#9E9B94" }}>{date.toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric" })}</div>
-            </div>
-            <button onClick={() => setDate(d => addDays(d, 1))} style={{ border: "1px solid #E5E2DC", background: "#fff", borderRadius: 8, padding: "7px 9px", cursor: "pointer", color: "#6B7280" }}><ChevronRight size={16} /></button>
+            <button onClick={() => setDate(d => addDays(d, -1))} aria-label="Previous day" style={{ border: "1px solid #E5E2DC", background: "#fff", borderRadius: 8, padding: "7px 9px", cursor: "pointer", color: "#6B7280" }}><ChevronLeft size={16} /></button>
+            {/* Calendar jump — native date picker layered over the date label */}
+            <label style={{ position: "relative", display: "inline-flex", alignItems: "center", gap: 8, minWidth: 168, justifyContent: "center", border: "1px solid #E5E2DC", background: "#fff", borderRadius: 8, padding: "5px 12px", cursor: "pointer" }}>
+              <CalendarDays size={15} color="#6B7280" />
+              <div style={{ textAlign: "center" }}>
+                <div style={{ fontSize: 14, fontWeight: 800, color: "#1A1917", lineHeight: 1.15 }}>{isToday ? "Today" : date.toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric" })}</div>
+                <div style={{ fontSize: 11, color: "#9E9B94" }}>{date.toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric" })}</div>
+              </div>
+              <input type="date" value={dk}
+                onChange={e => { if (e.target.value) setDate(new Date(`${e.target.value}T00:00:00`)); }}
+                style={{ position: "absolute", inset: 0, width: "100%", height: "100%", opacity: 0, cursor: "pointer" }} />
+            </label>
+            <button onClick={() => setDate(d => addDays(d, 1))} aria-label="Next day" style={{ border: "1px solid #E5E2DC", background: "#fff", borderRadius: 8, padding: "7px 9px", cursor: "pointer", color: "#6B7280" }}><ChevronRight size={16} /></button>
             {!isToday && <button onClick={() => setDate(new Date())} style={{ border: "1px solid #E5E2DC", background: "#fff", borderRadius: 8, padding: "7px 12px", cursor: "pointer", color: "#1A1917", fontSize: 12, fontWeight: 700, fontFamily: FF }}>Today</button>}
           </div>
         </div>


### PR DESCRIPTION
Two issues surfaced while reconciling June 1: the Time Clock portal showed **0 jobs** for a day that Dispatch clearly had, and there was no way to jump to a date.

## Root cause — jobs hidden by a branch filter
The portal's `/day` request appended `&branch_id=<selected branch>`. Most June 1 jobs are Chicago addresses that route to Schaumburg or carry a NULL `branch_id`, so with **Oak Lawn** selected they were filtered out — Time Clock showed 0 while Dispatch (company-wide) showed them. Fixes:
- **Front-end:** drop `branch_id` from the `/day` request — reconciliation is company-wide.
- **Query:** `status IS DISTINCT FROM 'cancelled'` (NULL-status MC imports were silently excluded by `<> 'cancelled'`) + `scheduled_date::date` cast for type safety.

## UX — calendar date picker
Added a native date picker (calendar icon over the date label) to jump straight to any day; prev/next + Today retained.

After deploy, June 1 lists all 9 jobs and each row exposes the IN/OUT + PAY controls for the reconciliation.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_