### PR TITLE
Time Clock: surface /day diagnostics in the empty-state (find the real bug)

### DIFF
--- a/artifacts/api-server/src/routes/timeclock.ts
+++ b/artifacts/api-server/src/routes/timeclock.ts
@@ -774,10 +774,13 @@ router.get("/day", requireRole("owner", "admin", "office"), async (req, res) => 
       };
     }).sort((a, b) => a.name.localeCompare(b.name));
 
-    return res.json({ date, employees });
-  } catch (err) {
+    return res.json({ date, employees, diagnostics: { jobCount: jobs.length, techRows: techRows.length, clockRows: clockRows.length } });
+  } catch (err: any) {
+    // Surface the failure to the UI instead of a silent 500 → empty screen.
+    // The Time Clock empty-state renders this so we can diagnose without
+    // DevTools. 200 keeps the front-end from swallowing it.
     console.error("GET /timeclock/day error:", err);
-    return res.status(500).json({ error: "Internal Server Error" });
+    return res.status(200).json({ date: String(req.query.date || "").slice(0, 10), employees: [], diagnostics: { error: String(err?.message || err) } });
   }
 });
 

--- a/artifacts/qleno/src/pages/time-clock.tsx
+++ b/artifacts/qleno/src/pages/time-clock.tsx
@@ -207,7 +207,7 @@ function RowEditor({ emp, row, dateStr, onChanged, toastFn }: {
 export default function TimeClockPage() {
   const { toast } = useToast();
   const [date, setDate] = useState(new Date());
-  const [data, setData] = useState<{ date: string; employees: Emp[] } | null>(null);
+  const [data, setData] = useState<{ date: string; employees: Emp[]; diagnostics?: { jobCount?: number; techRows?: number; clockRows?: number; error?: string } } | null>(null);
   const [loading, setLoading] = useState(true);
   const dk = dateKey(date);
   const isToday = dk === dateKey(new Date());
@@ -273,6 +273,13 @@ export default function TimeClockPage() {
             <Clock size={30} color="#D0CEC9" style={{ marginBottom: 10 }} />
             <div style={{ fontSize: 14, fontWeight: 700, color: "#6B7280" }}>No jobs scheduled this day</div>
             <div style={{ fontSize: 12, color: "#9E9B94" }}>Pick another date to reconcile its clocks.</div>
+            {data?.diagnostics && (
+              <div style={{ marginTop: 12, fontSize: 11, fontFamily: "monospace", color: data.diagnostics.error ? "#B91C1C" : "#9E9B94" }}>
+                {data.diagnostics.error
+                  ? `server error: ${data.diagnostics.error}`
+                  : `diagnostics — jobs found: ${data.diagnostics.jobCount ?? "?"} · tech rows: ${data.diagnostics.techRows ?? "?"} · clock rows: ${data.diagnostics.clockRows ?? "?"}`}
+              </div>
+            )}
           </div>
         ) : (
           employees.map(emp => {


### PR DESCRIPTION
The Time Clock day is still empty even though Dispatch shows 14 jobs for June 1 — and I've been guessing at the cause. This makes `/day` **report what it actually sees** so we stop guessing.

- `/day` now returns `diagnostics: { jobCount, techRows, clockRows }` on success.
- On any error it returns **200 with `{ diagnostics: { error } }`** instead of a silent 500 (which the front-end was swallowing into an empty screen).
- The portal empty-state renders this line, so we can read — with no DevTools — whether the query found 0 jobs or the endpoint is throwing, and the exact error if so.

Once deployed, the empty Time Clock screen will show e.g. `diagnostics — jobs found: 14 · tech rows: … · clock rows: …` or `server error: <message>`, which pins down the real bug immediately.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_