### PR TITLE
diag: always-on [TC-DAY] server logging to find why /day is empty

### DIFF
--- a/artifacts/api-server/src/routes/timeclock.ts
+++ b/artifacts/api-server/src/routes/timeclock.ts
@@ -656,6 +656,7 @@ router.get("/day", requireRole("owner", "admin", "office"), async (req, res) => 
       ORDER BY j.scheduled_time NULLS LAST, j.id
     `);
     const jobs = jobsRes.rows as any[];
+    console.log(`[TC-DAY] company=${companyId} date=${date} jobsRes=${jobs.length} auth_user=${req.auth?.userId ?? "?"} auth_role=${req.auth?.role ?? "?"}`);
     const jobIds = jobs.map(j => Number(j.job_id)).filter(n => Number.isFinite(n));
     const inList = jobIds.length ? sql.raw(jobIds.join(",")) : null;
 
@@ -774,6 +775,7 @@ router.get("/day", requireRole("owner", "admin", "office"), async (req, res) => 
       };
     }).sort((a, b) => a.name.localeCompare(b.name));
 
+    console.log(`[TC-DAY] company=${companyId} date=${date} RESULT jobs=${jobs.length} techRows=${techRows.length} clockRows=${clockRows.length} employees=${employees.length}`);
     return res.json({ date, employees, diagnostics: { jobCount: jobs.length, techRows: techRows.length, clockRows: clockRows.length } });
   } catch (err: any) {
     // Surface the failure to the UI instead of a silent 500 → empty screen.


### PR DESCRIPTION
Diagnostic only. `/day` returns empty for days that Dispatch shows have jobs, and it isn't throwing (no error log) — so it's silently returning 0. The frontend diagnostic line lags (served on a different cadence), so this logs to the server instead.

Adds two always-on `[TC-DAY]` log lines: right after the jobs query (`jobsRes` count + auth company/user/role) and before the response (final `employees` count). Filtering the Railway deploy logs for `TC-DAY` will show exactly whether the query returns 0 jobs (data/scoping) or the grouping drops them.

Revert after we have the answer.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_