### PR TITLE
copy: drop "match MaidCentral" framing from Time Clock + Payroll UI

### DIFF
--- a/artifacts/qleno/src/pages/payroll.tsx
+++ b/artifacts/qleno/src/pages/payroll.tsx
@@ -104,7 +104,7 @@ function WeeklyDetailView() {
       <p style={{ fontSize: 11, color: '#9E9B94', margin: '-4px 2px 0', fontFamily: FF }}>
         During the transition, hours fall back to a job's <b>scheduled</b> hours (shown with ≈) when it
         hasn't been clocked yet — real clocked time takes over automatically as the team adopts clock-in/out.
-        Set both dates to the same day to reconcile that day against MaidCentral.
+        Set both dates to the same day to reconcile a single day's pay.
       </p>
 
       {employees.length > 0 && (

--- a/artifacts/qleno/src/pages/time-clock.tsx
+++ b/artifacts/qleno/src/pages/time-clock.tsx
@@ -237,7 +237,7 @@ export default function TimeClockPage() {
           <div>
             <h1 style={{ fontSize: 22, fontWeight: 800, color: "#1A1917", margin: 0 }}>Time Clock</h1>
             <p style={{ fontSize: 13, color: "#6B6860", margin: "4px 0 0" }}>
-              Edit each tech's in/out to match MaidCentral — feeds payroll hours and the actual-minutes commission split.
+              Reconcile each tech's in/out — feeds payroll hours and the actual-minutes commission split.
             </p>
           </div>
           <div style={{ display: "flex", alignItems: "center", gap: 8 }}>


### PR DESCRIPTION
Qleno should stand on its own, not frame itself as matching MaidCentral.

- **Time Clock** subtitle: "Edit each tech's in/out to match MaidCentral — …" → "Reconcile each tech's in/out — feeds payroll hours and the actual-minutes commission split."
- **Payroll**: "…reconcile that day against MaidCentral." → "…reconcile a single day's pay."

Intentionally left alone (different purpose, not aspirational product copy):
- The **employee training curriculum**, which deliberately teaches the live MaidCentral workflow during the migration window.
- Factual **"imported from MaidCentral"** data-provenance labels on employee payroll history.
- Code comments.

Happy to scrub those too if you want — just say the word.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_