### PR TITLE
Time Clock: fix +5h timezone shift + count only verified clocks (Payroll parity)

### DIFF
--- a/artifacts/api-server/src/routes/timeclock.ts
+++ b/artifacts/api-server/src/routes/timeclock.ts
@@ -694,7 +694,7 @@ router.get("/day", requireAuth, requireRole("owner", "admin", "office"), async (
     for (const t of techRows) payByJobUser.set(`${Number(t.job_id)}:${Number(t.user_id)}`, t);
 
     const clockRows = inList ? ((await db.execute(sql`
-      SELECT t.id, t.job_id, t.user_id, t.clock_in_at, t.clock_out_at, t.flagged,
+      SELECT t.id, t.job_id, t.user_id, t.clock_in_at, t.clock_out_at, t.flagged, t.source,
              TRIM(COALESCE(u.first_name,'') || ' ' || COALESCE(u.last_name,'')) AS name
       FROM timeclock t JOIN users u ON u.id = t.user_id
       WHERE t.company_id = ${companyId} AND t.job_id IN (${inList})
@@ -734,9 +734,13 @@ router.get("/day", requireAuth, requireRole("owner", "admin", "office"), async (
         const svc = await db.execute(sql`SELECT slug, commission_pct FROM service_types WHERE company_id = ${companyId} AND commission_pct IS NOT NULL`);
         for (const r of svc.rows as any[]) { const p = parseFloat(String(r.commission_pct)); if (Number.isFinite(p)) serviceTypePctBySlug.set(String(r.slug).toLowerCase(), p); }
       } catch { /* per-service column absent */ }
+      // Only REAL punches drive pay — exactly what the Payroll period-lock
+      // counts (source='punched'). Synthetic 'estimated' pre-seeds show as a
+      // row but contribute $0 until the office enters/verifies a real time
+      // (which flips them to punched via PATCH).
       const techHoursByKey = new Map<string, number>();
       for (const e of clockRows) {
-        if (!e.clock_out_at || !e.clock_in_at) continue;
+        if (e.source !== "punched" || !e.clock_out_at || !e.clock_in_at) continue;
         const h = (new Date(e.clock_out_at).getTime() - new Date(e.clock_in_at).getTime()) / 3600000;
         if (h > 0) techHoursByKey.set(`${e.job_id}:${e.user_id}`, (techHoursByKey.get(`${e.job_id}:${e.user_id}`) ?? 0) + h);
       }
@@ -760,7 +764,8 @@ router.get("/day", requireAuth, requireRole("owner", "admin", "office"), async (
                  entry_id: number | null; clock_in_at: string | null; clock_out_at: string | null;
                  flagged: boolean; minutes: number | null;
                  pay_type: string | null; hourly_rate: string | null; commission_pct: string | null;
-                 pay_deduction_pct: string | null; pay_deduction_flat: string | null; pay: number | null };
+                 pay_deduction_pct: string | null; pay_deduction_flat: string | null; pay: number | null;
+                 source: string | null };
     const payOf = (jid: number, uid: number) => {
       const p = payByJobUser.get(`${jid}:${uid}`);
       return {
@@ -792,7 +797,7 @@ router.get("/day", requireAuth, requireRole("owner", "admin", "office"), async (
           job_id: jid, client_name: j.client_name, service_type: j.service_type, scheduled_time: j.scheduled_time ?? null,
           entry_id: e ? Number(e.id) : null, clock_in_at: e?.clock_in_at ?? null, clock_out_at: e?.clock_out_at ?? null,
           flagged: !!e?.flagged, minutes: e ? minutesOf(e.clock_in_at, e.clock_out_at) : null,
-          ...payOf(jid, t.user_id), pay: payByKey.get(`${jid}:${t.user_id}`) ?? null,
+          ...payOf(jid, t.user_id), pay: payByKey.get(`${jid}:${t.user_id}`) ?? null, source: e?.source ?? null,
         });
       }
     }
@@ -804,7 +809,7 @@ router.get("/day", requireAuth, requireRole("owner", "admin", "office"), async (
         job_id: Number(e.job_id), client_name: j?.client_name ?? "Client", service_type: j?.service_type ?? "",
         scheduled_time: j?.scheduled_time ?? null, entry_id: Number(e.id), clock_in_at: e.clock_in_at ?? null,
         clock_out_at: e.clock_out_at ?? null, flagged: !!e.flagged, minutes: minutesOf(e.clock_in_at, e.clock_out_at),
-        ...payOf(Number(e.job_id), Number(e.user_id)), pay: payByKey.get(`${e.job_id}:${e.user_id}`) ?? null,
+        ...payOf(Number(e.job_id), Number(e.user_id)), pay: payByKey.get(`${e.job_id}:${e.user_id}`) ?? null, source: e.source ?? null,
       });
     }
 
@@ -864,6 +869,11 @@ router.patch("/:id", requireAuth, requireRole("owner", "admin", "office"), async
     const outAt = set.clock_out_at !== undefined ? set.clock_out_at : existing.clock_out_at;
     if (inAt && outAt && new Date(outAt).getTime() < new Date(inAt).getTime())
       return res.status(400).json({ error: "Clock-out cannot be before clock-in" });
+
+    // An office edit is a verified real time — promote a synthetic 'estimated'
+    // punch to 'punched' so it counts in payroll (period-lock uses punched
+    // only) and matches what the portal shows.
+    set.source = "punched";
 
     const [updated] = await db.update(timeclockTable).set(set).where(eq(timeclockTable.id, id)).returning();
     await recomputeJobActualHours(existing.job_id, companyId);

--- a/artifacts/qleno/src/pages/time-clock.tsx
+++ b/artifacts/qleno/src/pages/time-clock.tsx
@@ -24,12 +24,19 @@ function dateKey(d: Date) {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
 }
 function addDays(d: Date, n: number) { const x = new Date(d); x.setDate(x.getDate() + n); return x; }
+// Clock times are WALL-CLOCK, treated as plain strings end-to-end — never run
+// through Date()/toISOString()/getHours(), which silently shift by the browser
+// or server UTC offset (the +5h bug). isoToHHMM slices "HH:MM" straight out of
+// whatever timestamp string the API returns ("...T09:16:00", "...Z", or
+// "... 09:16:00"); hhmmToISO sends back a naive local datetime (no Z) so the
+// server stores exactly what was typed. What you type == what's stored == what
+// shows, in any timezone.
 function isoToHHMM(iso: string | null): string {
   if (!iso) return "";
-  const d = new Date(iso);
-  return isNaN(d.getTime()) ? "" : `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+  const m = String(iso).match(/[T ](\d{2}):(\d{2})/);
+  return m ? `${m[1]}:${m[2]}` : "";
 }
-function hhmmToISO(dateStr: string, hhmm: string): string { return new Date(`${dateStr}T${hhmm}:00`).toISOString(); }
+function hhmmToISO(dateStr: string, hhmm: string): string { return `${dateStr}T${hhmm}:00`; }
 // Typed-time parsing so the field is a plain text box ("9:16 AM") instead of
 // the native time-wheel — reliable to type for humans and trivial for an
 // automation agent to fill. Accepts "9:16 AM", "9:16am", "13:05", "09:16".
@@ -61,9 +68,8 @@ function hh24ToDisplay(hhmm: string): string {
 function isoToDisplay(iso: string | null): string { return hh24ToDisplay(isoToHHMM(iso)); }
 function fmtHrs(min: number) { const h = Math.floor(min / 60), m = min % 60; return h > 0 ? `${h}h ${m}m` : `${m}m`; }
 function fmtClock(iso: string | null) {
-  if (!iso) return "—";
-  const d = new Date(iso);
-  return isNaN(d.getTime()) ? "—" : d.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
+  const hhmm = isoToHHMM(iso);
+  return hhmm ? hh24ToDisplay(hhmm) : "—";
 }
 function fmtSvc(s: string) { return (s || "").replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase()); }
 function fmtSchedTime(t: string | null) {
@@ -78,7 +84,7 @@ type Row = {
   entry_id: number | null; clock_in_at: string | null; clock_out_at: string | null; flagged: boolean; minutes: number | null;
   pay_type: string | null; hourly_rate: string | null; commission_pct: string | null;
   pay_deduction_pct: string | null; pay_deduction_flat: string | null;
-  pay?: number | null;
+  pay?: number | null; source?: string | null;
 };
 type Emp = {
   user_id: number; name: string; rows: Row[]; worked_minutes: number;
@@ -215,6 +221,7 @@ function RowEditor({ emp, row, dateStr, onChanged, toastFn }: {
         <div style={{ fontSize: 13, fontWeight: 600, color: "#1A1917", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{row.client_name}</div>
         <div style={{ fontSize: 11, color: "#9E9B94" }}>
           {fmtSvc(row.service_type)}{row.scheduled_time ? ` · sched ${fmtSchedTime(row.scheduled_time)}` : ""}
+          {row.entry_id && row.source !== "punched" && <span style={{ color: "#B45309", marginLeft: 6, fontWeight: 700 }}>· estimated — verify</span>}
           {row.flagged && <span style={{ color: "#B45309", marginLeft: 6, fontWeight: 700 }}>· flagged</span>}
         </div>
       </div>
@@ -273,7 +280,7 @@ export default function TimeClockPage() {
 
   const employees = data?.employees ?? [];
   const totalWorked = employees.reduce((s, e) => s + e.worked_minutes, 0);
-  const totalPunches = employees.reduce((s, e) => s + e.rows.filter(r => r.entry_id).length, 0);
+  const totalPunches = employees.reduce((s, e) => s + e.rows.filter(r => r.source === "punched").length, 0);
   const totalRows = employees.reduce((s, e) => s + e.rows.length, 0);
   const totalPay = employees.reduce((s, e) => s + (e.pay_total ?? 0), 0);
 
@@ -332,7 +339,7 @@ export default function TimeClockPage() {
           </div>
         ) : (
           employees.map(emp => {
-            const punched = emp.rows.filter(r => r.entry_id).length;
+            const punched = emp.rows.filter(r => r.source === "punched").length;
             return (
               <div key={emp.user_id} style={{ background: "#fff", border: "0.5px solid #E5E2DC", borderRadius: 12, marginBottom: 12, overflow: "hidden" }}>
                 <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", padding: "11px 16px", background: "#FAFAF8", borderBottom: "1px solid #EEECE7" }}>


### PR DESCRIPTION
The browser agent's June 1 calibration (10/11 entered, verified, matching) surfaced two real bugs. Fixing both before the June 2–5 run.

## 1. +5h timezone shift (the blocker)
Clock times were round-tripped through `Date()` / `toISOString()` / `getHours()`, so a value typed in one offset and read in another shifted by the UTC delta (CDT = +5h). The agent was hand-compensating −5h, which would make Payroll disagree with the screen.

Fix: treat clock times as **wall-clock strings end to end.** `hhmmToISO` sends a naive local datetime (no `Z`); `isoToHHMM`/`fmtClock` slice `HH:MM` straight out of whatever string the API returns. No `Date()` math anywhere. **What you type == what's stored == what shows, in any timezone** (browser or server). Removes the need for the agent's hack — **June 1 should be re-entered with the real MC times** (no −5h).

## 2. Estimated pre-seeds polluting pay + the punched count
Completed jobs carry synthetic `source='estimated'` clock pairs (= scheduled window). Those were counting as "punched" and feeding portal pay that the Payroll period-lock (punched-only, #332) ignores — a portal↔Payroll mismatch.

Fix:
- `/day` pay now counts `source='punched'` **only** → matches Payroll exactly.
- The **punched count** reflects real verification (estimated rows don't count).
- Estimated rows show **"· estimated — verify"** so the office knows to confirm.
- An office **edit promotes the entry to `punched`**, so a verified time counts in the portal *and* Payroll at once.

39 commission tests green; both ends typecheck clean.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_