### PR TITLE
fix(recurring): quote convert generates the whole series, not just the first job

### DIFF
--- a/artifacts/api-server/src/routes/quotes.ts
+++ b/artifacts/api-server/src/routes/quotes.ts
@@ -1,10 +1,11 @@
 import { Router } from "express";
 import { db } from "@workspace/db";
-import { quotesTable, clientsTable, quoteScopesTable } from "@workspace/db/schema";
+import { quotesTable, clientsTable, quoteScopesTable, recurringSchedulesTable } from "@workspace/db/schema";
 import { eq, and, desc, count, sql } from "drizzle-orm";
 import { requireAuth, requireRole } from "../lib/auth.js";
 import { logAudit } from "../lib/audit.js";
 import { getBranchByZip } from "../lib/branchRouter";
+import { generateJobsFromSchedule, DAYS_AHEAD } from "../lib/recurring-jobs.js";
 
 const router = Router();
 
@@ -349,6 +350,52 @@ router.post("/:id/convert", requireAuth, requireRole("owner", "admin", "office")
       "monthly": "monthly", "every_4_weeks": "monthly", "onetime": "on_demand", "one_time": "on_demand",
     };
     const jobFreq = FREQ_MAP[freqRaw] || "on_demand";
+
+    // [recurring-convert-fix 2026-06-05] A recurring quote must create a
+    // recurring_schedule and GENERATE THE SERIES — not a single job. The
+    // convert previously inserted one job with frequency='weekly' and stopped,
+    // so "scheduling a recurrence" only ever produced the first visit
+    // (Maribel's bug). When the quote is recurring and tied to a client, build
+    // the schedule and synchronously generate the next 90 days (first
+    // occurrence included). This calls generateJobsFromSchedule directly, so it
+    // works regardless of the RECURRING_ENGINE_ENABLED cron flag.
+    const isRecurring = jobFreq !== "on_demand";
+    if (isRecurring && q.client_id) {
+      const [sched] = await db.insert(recurringSchedulesTable).values({
+        company_id: companyId,
+        customer_id: q.client_id,
+        frequency: jobFreq,
+        day_of_week: null, // cadence anchors on start_date's weekday when null
+        start_date: jobDate,
+        end_date: null,
+        assigned_employee_id: assigned_user_id ? parseInt(String(assigned_user_id)) : null,
+        service_type: serviceType,
+        scheduled_time: scheduled_time || null,
+        duration_minutes: q.estimated_hours ? Math.round(parseFloat(String(q.estimated_hours)) * 60) : null,
+        base_fee: q.total_price != null ? String(q.total_price) : null,
+        notes: q.internal_memo || null,
+      }).returning();
+
+      let generated = { created: 0, skipped: 0 };
+      try {
+        const cl = await db.select({ zip: clientsTable.zip }).from(clientsTable).where(eq(clientsTable.id, q.client_id)).limit(1);
+        const clientZip = (cl[0]?.zip as any) ?? null;
+        const today = new Date();
+        const horizon = new Date(today.getTime() + DAYS_AHEAD * 24 * 60 * 60 * 1000);
+        generated = await generateJobsFromSchedule(sched as any, today, horizon, null, clientZip);
+      } catch (genErr: any) {
+        console.warn("[quote convert] recurring generation failed:", genErr?.message ?? genErr);
+      }
+
+      logAudit(req, "CONVERTED", "quote", id, null, { status: "booked", recurring_schedule_id: sched.id, jobs_generated: generated.created });
+      import("../services/followUpService.js").then(({ stopEnrollmentsForQuote }) => {
+        stopEnrollmentsForQuote(id, "booked").catch(() => {});
+      });
+      return res.json({
+        success: true, quote: q, recurring_schedule_id: sched.id, jobs_generated: generated.created,
+        message: `Quote converted — recurring schedule created with ${generated.created} visit${generated.created === 1 ? "" : "s"} over the next ${DAYS_AHEAD} days.`,
+      });
+    }
 
     // [addon-hours 2026-06-04] Carry the quote's estimated hours (which now
     // include add-on time-adds) onto the job as BOTH allowed_hours and


### PR DESCRIPTION
**Maribel:** *"I tried scheduling a recurrence but it only scheduled the first one."*

## Root cause
`POST /quotes/:id/convert` inserted **one** job with `frequency='weekly'` and stopped — it never created a `recurring_schedules` row and never generated future occurrences. So converting a recurring quote produced a single visit, not a series.

## Fix
When the quote is recurring (mapped freq ≠ on_demand) and tied to a client, convert now:
1. Creates the `recurring_schedules` row (frequency, start_date = scheduled date, tech, service type, time, duration, fee).
2. Synchronously generates the next **90 days** of occurrences (first visit included) via `generateJobsFromSchedule` — the same path Settings → Recurring uses.

Because it calls the generator **directly**, it works even with the `RECURRING_ENGINE_ENABLED` cron disabled. One-time/on-demand quotes keep the existing single-job path. Mapped to the `recurring_frequency` enum's valid values (weekly/biweekly/monthly), so the insert is safe.

## Note for the "23rd of each month" report
Separate symptom. `recurring_frequency` only has weekly/biweekly/monthly/custom, and monthly cadence anchors on the schedule's **day-of-month** (`start_date`'s day). A set landing on the 23rd is consistent with a **monthly schedule whose start date is the 23rd** — i.e. a data/anchor issue, not a cadence-math bug. Tracking that down separately with the office (need to know which client/schedule).

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_