### PR TITLE
fix(commission): gross guard (add-ons in, credits never dock) + commercial-by-service-type

### DIFF
--- a/artifacts/api-server/src/lib/commission-paytype.ts
+++ b/artifacts/api-server/src/lib/commission-paytype.ts
@@ -48,6 +48,21 @@ export type PayType = "fee_split" | "allowed_hours" | "hourly";
 
 export const PAY_TYPES: readonly PayType[] = ["fee_split", "allowed_hours", "hourly"];
 
+// A job is commercial when it's tied to an account OR its service type is one
+// of the commercial scopes. Some commercial jobs (e.g. a one-off "Common
+// Areas") aren't linked to an account, but they're still paid Allowed Hours,
+// not a residential fee split. Without this they'd default to fee_split and
+// pay the wrong way (the Nitzsche Common Areas $68.25-vs-$60 mismatch).
+const COMMERCIAL_SERVICE_SLUGS = new Set([
+  "office_cleaning", "common_areas", "ppm_turnover", "commercial_cleaning",
+  "commercial", "post_construction", "janitorial",
+]);
+export function isCommercialJob(account_id: number | string | null | undefined, service_type: string | null | undefined): boolean {
+  if (account_id != null) return true;
+  const s = (service_type ?? "").toLowerCase();
+  return COMMERCIAL_SERVICE_SLUGS.has(s);
+}
+
 export interface JobPayContext {
   /** GROSS service base before customer credits/breakage (jobs.base_fee). */
   baseFee: number;
@@ -261,7 +276,7 @@ export function computePerTechCommissionRows(input: {
 
   const out: CommissionRow[] = [];
   for (const j of input.jobs) {
-    const isCommercial = j.account_id != null;
+    const isCommercial = isCommercialJob(j.account_id, j.service_type);
     let techs = techsByJob.get(j.id) ?? [];
     if (techs.length === 0 && j.assigned_user_id != null) {
       techs = [{ job_id: j.id, user_id: j.assigned_user_id, is_primary: true,
@@ -285,8 +300,14 @@ export function computePerTechCommissionRows(input: {
       commercialHourlyRate: input.commercial.commercial_hourly_rate,
       scopePct,
     });
+    // Commission base = max(base_fee, billed_amount). billed_amount =
+    // base_fee + SUM(job mods), so add-ons RAISE it (they're commissionable —
+    // MC pays on the add-on-inclusive total) while a customer credit/discount
+    // LOWERS billed below base, and max() ignores it so the credit never docks
+    // the tech (locked rule). For a plain job base==billed → unchanged, so
+    // every job that already matched stays matched.
     const ctx: JobPayContext = {
-      baseFee: (n(j.base_fee) ?? 0) || (n(j.billed_amount) ?? 0),
+      baseFee: Math.max(n(j.base_fee) ?? 0, n(j.billed_amount) ?? 0),
       allowedHours: n(j.allowed_hours) ?? 0,
       totalTechHours,
     };

--- a/artifacts/api-server/src/tests/commission-paytype.test.ts
+++ b/artifacts/api-server/src/tests/commission-paytype.test.ts
@@ -213,3 +213,51 @@ describe("pay-type engine — DB bridge (computePerTechCommissionRows)", () => {
     assert.equal(rows[0].basis, "commercial_hourly");
   });
 });
+
+describe("pay-type engine — gross guard + commercial-by-service-type", () => {
+  const resRates = { res_tech_pay_pct: 0.35, deep_clean_pay_pct: 0.32, move_in_out_pay_pct: 0.32 };
+  const commercial = { commercial_hourly_rate: 20, commercial_comp_mode: "allowed_hours" as const };
+  const job = (p: any): CommissionInputJob => ({
+    id: p.id, assigned_user_id: p.assigned_user_id ?? 1, service_type: p.service_type ?? "standard_clean",
+    account_id: "account_id" in p ? p.account_id : null, base_fee: p.base_fee ?? "0",
+    billed_amount: "billed_amount" in p ? p.billed_amount : null, allowed_hours: p.allowed_hours ?? "0",
+    actual_hours: "0", branch_id: 1, scheduled_date: "2026-06-01",
+  });
+  const tech = (job_id: number, user_id: number, o: Partial<JobTechRow> = {}): JobTechRow => ({
+    job_id, user_id, is_primary: o.is_primary ?? false, pay_type: o.pay_type ?? null,
+    hourly_rate: o.hourly_rate ?? null, commission_pct: o.commission_pct ?? null,
+    pay_deduction_pct: o.pay_deduction_pct ?? null, pay_deduction_flat: o.pay_deduction_flat ?? null,
+  });
+
+  it("ADD-ON raises the base: base 578.40 + $50 add-on (billed 628.40) → $100.54/tech, not $92.54", () => {
+    const rows = computePerTechCommissionRows({
+      jobs: [job({ id: 1, base_fee: "578.40", billed_amount: "628.40", allowed_hours: "8.2", service_type: "deep_clean" })],
+      jobTechs: [tech(1, 1, { is_primary: true }), tech(1, 2)],
+      techHoursByKey: new Map([["1:1", 3.28], ["1:2", 3.28]]),
+      serviceTypePctBySlug: new Map(), resRates, commercial,
+    });
+    assert.equal(rows.find(r => r.user_id === 1)!.amount, 100.54);
+    assert.equal(rows.find(r => r.user_id === 2)!.amount, 100.54);
+  });
+
+  it("CREDIT never docks: base 628.40, $50 credit (billed 578.40) → still $100.54 (max ignores the lower billed)", () => {
+    const rows = computePerTechCommissionRows({
+      jobs: [job({ id: 2, base_fee: "628.40", billed_amount: "578.40", allowed_hours: "8.2", service_type: "deep_clean" })],
+      jobTechs: [tech(2, 1, { is_primary: true }), tech(2, 2)],
+      techHoursByKey: new Map([["2:1", 3.28], ["2:2", 3.28]]),
+      serviceTypePctBySlug: new Map(), resRates, commercial,
+    });
+    assert.equal(rows.find(r => r.user_id === 1)!.amount, 100.54);
+  });
+
+  it("commercial by SERVICE TYPE with no account → Allowed Hours, not fee split (Common Areas $60)", () => {
+    const rows = computePerTechCommissionRows({
+      jobs: [job({ id: 3, account_id: null, service_type: "common_areas", base_fee: "195", allowed_hours: "3" })],
+      jobTechs: [tech(3, 1, { is_primary: true })],
+      techHoursByKey: new Map([["3:1", 1.52]]),
+      serviceTypePctBySlug: new Map(), resRates, commercial,
+    });
+    assert.equal(rows[0].amount, 60.0);
+    assert.equal(rows[0].basis, "commercial_hourly");
+  });
+});


### PR DESCRIPTION
The June 1 parallel run surfaced two real mismatches. Both are now fixed **in the engine** (so they apply to every job and every day — no per-job data corrections needed), and neither changes any job that already matched.

## 1. Commission on gross — add-ons in, credits never dock
`billed_amount = base_fee + SUM(job mods)`. The engine used `base_fee` alone, so a **+$50 add-on** on Nitzsche Deep Clean was left out → $92.54/tech instead of MC's **$100.54**.

Fix: commission base = **`max(base_fee, billed_amount)`**.
- **Add-on** → billed > base → counted (matches MC's add-on-inclusive total). ✅ $100.54
- **Customer credit/breakage** → billed < base → `max` ignores it, so it **never docks the tech** (the locked rule). ✅
- Plain job → base == billed → unchanged, so everything that matched stays matched.

## 2. Commercial-by-service-type
Nitzsche **Common Areas** had no account link, so it defaulted to a residential fee split → $68.25 instead of MC's Allowed-Hours **$60**. New `isCommercialJob(account_id, service_type)` treats commercial scopes (`common_areas`, `office_cleaning`, `ppm_turnover`, …) as commercial even without an account, so they default to Allowed Hours.

23 engine tests (added: add-on raises base, credit never docks, commercial-by-service); the June 1 dual-engine audit stays **penny-exact at $801.99**.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_