### PR TITLE
fix(commission): commercial client → Allowed Hours $20 + rate field defaults to 20

### DIFF
--- a/artifacts/api-server/src/lib/commission-compute.ts
+++ b/artifacts/api-server/src/lib/commission-compute.ts
@@ -38,6 +38,11 @@ export interface CommissionInputJob {
   actual_hours: string | number | null;
   branch_id: number | null;
   scheduled_date: string;
+  // [commercial-client 2026-06-06] client_type='commercial' marks a commercial
+  // client even when the job's service_type reads residential (e.g. a condo's
+  // "Deep Clean"). Optional so existing callers compile; commercial routing
+  // treats it the same as an account link.
+  client_type?: string | null;
 }
 
 export interface CompanyCommercialConfig {

--- a/artifacts/api-server/src/lib/commission-paytype.ts
+++ b/artifacts/api-server/src/lib/commission-paytype.ts
@@ -61,8 +61,13 @@ const COMMERCIAL_KEYWORDS = [
   "commercial", "ppm", "common_area", "office", "janitor", "facility",
   "post_construction", "turnover", "build_out", "buildout",
 ];
-export function isCommercialJob(account_id: number | string | null | undefined, service_type: string | null | undefined): boolean {
+export function isCommercialJob(
+  account_id: number | string | null | undefined,
+  service_type: string | null | undefined,
+  client_type?: string | null | undefined,
+): boolean {
   if (account_id != null) return true;
+  if ((client_type ?? "").toLowerCase() === "commercial") return true;
   const s = (service_type ?? "").toLowerCase();
   return COMMERCIAL_KEYWORDS.some(k => s.includes(k));
 }
@@ -280,7 +285,7 @@ export function computePerTechCommissionRows(input: {
 
   const out: CommissionRow[] = [];
   for (const j of input.jobs) {
-    const isCommercial = isCommercialJob(j.account_id, j.service_type);
+    const isCommercial = isCommercialJob(j.account_id, j.service_type, j.client_type);
     let techs = techsByJob.get(j.id) ?? [];
     if (techs.length === 0 && j.assigned_user_id != null) {
       techs = [{ job_id: j.id, user_id: j.assigned_user_id, is_primary: true,

--- a/artifacts/api-server/src/routes/pay.ts
+++ b/artifacts/api-server/src/routes/pay.ts
@@ -801,8 +801,13 @@ async function computeAndApplyCommission(
       actual_hours: jobsTable.actual_hours,
       branch_id: jobsTable.branch_id,
       scheduled_date: jobsTable.scheduled_date,
+      // [commercial-client 2026-06-06] commercial routing also honors a
+      // commercial client_type even when the job's service_type reads
+      // residential (e.g. a condo's Deep Clean).
+      client_type: clientsTable.client_type,
     })
     .from(jobsTable)
+    .leftJoin(clientsTable, eq(jobsTable.client_id, clientsTable.id))
     .where(
       and(
         eq(jobsTable.company_id, companyId),

--- a/artifacts/api-server/src/routes/timeclock.ts
+++ b/artifacts/api-server/src/routes/timeclock.ts
@@ -650,6 +650,7 @@ router.get("/day", requireAuth, requireRole("owner", "admin", "office"), async (
       SELECT j.id AS job_id, j.scheduled_time, j.assigned_user_id,
              j.service_type::text AS service_type, j.address_street,
              j.account_id, j.base_fee, j.billed_amount, j.allowed_hours, j.branch_id, j.scheduled_date::text AS scheduled_date,
+             c.client_type,
              COALESCE(NULLIF(TRIM(COALESCE(c.first_name,'') || ' ' || COALESCE(c.last_name,'')), ''),
                       c.company_name, 'Client') AS client_name
       FROM jobs j
@@ -753,7 +754,7 @@ router.get("/day", requireAuth, requireRole("owner", "admin", "office"), async (
         id: Number(j.job_id), assigned_user_id: j.assigned_user_id != null ? Number(j.assigned_user_id) : null,
         service_type: j.service_type ?? null, account_id: j.account_id ?? null, base_fee: j.base_fee ?? null,
         billed_amount: j.billed_amount ?? null, allowed_hours: j.allowed_hours ?? null, actual_hours: null,
-        branch_id: j.branch_id ?? null, scheduled_date: j.scheduled_date ?? date,
+        branch_id: j.branch_id ?? null, scheduled_date: j.scheduled_date ?? date, client_type: j.client_type ?? null,
       })) as CommissionInputJob[];
       for (const r of computePerTechCommissionRows({ jobs: jobsForCalc, jobTechs: jobTechsForCalc, techHoursByKey, serviceTypePctBySlug, resRates, commercial })) {
         payByKey.set(`${r.job_id}:${r.user_id}`, r.amount);

--- a/artifacts/api-server/src/tests/commission-paytype.test.ts
+++ b/artifacts/api-server/src/tests/commission-paytype.test.ts
@@ -261,3 +261,23 @@ describe("pay-type engine — gross guard + commercial-by-service-type", () => {
     assert.equal(rows[0].basis, "commercial_hourly");
   });
 });
+
+describe("pay-type engine — commercial CLIENT routing", () => {
+  const resRates = { res_tech_pay_pct: 0.35, deep_clean_pay_pct: 0.32, move_in_out_pay_pct: 0.32 };
+  const commercial = { commercial_hourly_rate: 20, commercial_comp_mode: "allowed_hours" as const };
+
+  it("commercial client_type with residential service_type → Allowed Hours $20, not fee split (Heritage)", () => {
+    const rows = computePerTechCommissionRows({
+      jobs: [{
+        id: 1, assigned_user_id: 1, service_type: "deep_clean", account_id: null,
+        base_fee: "300", billed_amount: "300", allowed_hours: "2", actual_hours: "0",
+        branch_id: 1, scheduled_date: "2026-06-01", client_type: "commercial",
+      }],
+      jobTechs: [{ job_id: 1, user_id: 1, is_primary: true, pay_type: null, hourly_rate: null, commission_pct: null, pay_deduction_pct: null, pay_deduction_flat: null }],
+      techHoursByKey: new Map([["1:1", 1.45]]),
+      serviceTypePctBySlug: new Map(), resRates, commercial,
+    });
+    assert.equal(rows[0].basis, "commercial_hourly");
+    assert.equal(rows[0].amount, 40.0); // 2h allowed × $20
+  });
+});

--- a/artifacts/qleno/src/pages/time-clock.tsx
+++ b/artifacts/qleno/src/pages/time-clock.tsx
@@ -133,7 +133,14 @@ function PayEditor({ emp, row, onChanged, toastFn }: {
   return (
     <div style={{ display: "flex", alignItems: "center", gap: 8, padding: "0 14px 9px 14px", flexWrap: "wrap" }}>
       <span style={{ fontSize: 10, color: "#9E9B94", fontWeight: 700, minWidth: 28 }}>PAY</span>
-      <select value={payType} onChange={e => setPayType(e.target.value)}
+      <select value={payType} onChange={e => {
+          const v = e.target.value;
+          setPayType(v);
+          // Commercial pay is $20/hr — pre-fill the rate so the office doesn't
+          // type it every time (still editable). Only when switching to a
+          // $/hr type with no rate yet; fee_split keeps its % handling.
+          if ((v === "allowed_hours" || v === "hourly") && !rate.trim()) setRate("20");
+        }}
         style={{ height: 28, border: "1px solid #E5E2DC", borderRadius: 6, fontSize: 12, fontFamily: FF, color: "#1A1917", background: "#fff", padding: "0 6px" }}>
         <option value="">Default</option>
         <option value="fee_split">Fee Split</option>


### PR DESCRIPTION
From Sal's note: *"Heritage Condominium is a commercial job. For commercial jobs all are $20, no exception. I had to manually plug the number in — it should default to $20 (editable)."*

Heritage is a **commercial client** whose job has a **"Deep Clean"** service type and **no account link**, so it defaulted to a residential fee split — forcing a manual Hourly $20 override. Two fixes:

1. **Commercial *client* now routes commercial.** `isCommercialJob()` also returns true when `client_type='commercial'` (in addition to account link + commercial service keywords). So a commercial client's job defaults to **Allowed Hours @ company $20/hr** automatically — no manual switch. Plumbed through both **`/day`** (Time Clock) and the **period-lock** (`pay.ts`) so they agree.
2. **Rate field pre-fills 20.** Picking Allowed Hours / Hourly in the PAY control now defaults the rate to **20** (still fully editable) — no more typing it each time.

24 engine tests (added: commercial client_type → $20 Allowed Hours); June 1 stays penny-exact at $801.99.

Note: this only auto-detects if the client is actually marked `client_type='commercial'` in Qleno. If a commercial client isn't flagged, the office can still override per job — but the right long-term fix is to mark the client commercial.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_