### PR TITLE
fix(commission): round clocked hours to 2 decimals like MaidCentral (kills $0.07 gaps)

### DIFF
--- a/artifacts/api-server/src/lib/commission-paytype.ts
+++ b/artifacts/api-server/src/lib/commission-paytype.ts
@@ -291,7 +291,12 @@ export function computePerTechCommissionRows(input: {
       techs = [{ job_id: j.id, user_id: j.assigned_user_id, is_primary: true,
         pay_type: null, hourly_rate: null, commission_pct: null, pay_deduction_pct: null, pay_deduction_flat: null }];
     }
-    const totalTechHours = techs.reduce((s, t) => s + (input.techHoursByKey.get(`${j.id}:${t.user_id}`) ?? 0), 0);
+    // MaidCentral rounds each timesheet's clocked hours to 2 decimals BEFORE
+    // multiplying by the rate (3h10m → 3.17 → ×$20 = $63.40, not 3.1667 →
+    // $63.33). Round per-tech hours here so hourly pay, allowed-actual, and the
+    // fee-split hour-shares all tie to MC to the penny.
+    const hoursOf = (uid: number) => round2(input.techHoursByKey.get(`${j.id}:${uid}`) ?? 0);
+    const totalTechHours = techs.reduce((s, t) => s + hoursOf(t.user_id), 0);
 
     // GUARD: no clocked hours → legacy single-basis fallback (no regression).
     if (totalTechHours <= 0) {
@@ -323,7 +328,7 @@ export function computePerTechCommissionRows(input: {
 
     for (const t of techs) {
       const overrideKey = `${t.user_id}:${j.id}`;
-      const techHours = input.techHoursByKey.get(`${j.id}:${t.user_id}`) ?? 0;
+      const techHours = hoursOf(t.user_id);
       let amount: number;
       if (overrides.has(overrideKey)) {
         amount = Math.round((overrides.get(overrideKey) as number) * 100) / 100;

--- a/artifacts/api-server/src/tests/commission-paytype.test.ts
+++ b/artifacts/api-server/src/tests/commission-paytype.test.ts
@@ -281,3 +281,22 @@ describe("pay-type engine — commercial CLIENT routing", () => {
     assert.equal(rows[0].amount, 40.0); // 2h allowed × $20
   });
 });
+
+describe("pay-type engine — MC 2-decimal hours rounding", () => {
+  const resRates = { res_tech_pay_pct: 0.35, deep_clean_pay_pct: 0.32, move_in_out_pay_pct: 0.32 };
+  const commercial = { commercial_hourly_rate: 20, commercial_comp_mode: "allowed_hours" as const };
+
+  it("hourly: 3h10m exact (3.1667) rounds to 3.17 → $63.40, matching MC (not $63.33)", () => {
+    const rows = computePerTechCommissionRows({
+      jobs: [{
+        id: 1, assigned_user_id: 1, service_type: "standard_clean", account_id: null,
+        base_fee: "540", billed_amount: "540", allowed_hours: "4.49", actual_hours: "0",
+        branch_id: 1, scheduled_date: "2026-06-01",
+      }],
+      jobTechs: [{ job_id: 1, user_id: 1, is_primary: true, pay_type: "hourly", hourly_rate: "20", commission_pct: null, pay_deduction_pct: null, pay_deduction_flat: null }],
+      techHoursByKey: new Map([["1:1", 190 / 60]]), // 3h10m = 3.16667
+      serviceTypePctBySlug: new Map(), resRates, commercial,
+    });
+    assert.equal(rows[0].amount, 63.40);
+  });
+});


### PR DESCRIPTION
First real audit delta on Jose, June 1: Qleno **$123.33** vs MC **$123.40** — the whole $0.07 is the Cusimano hourly line.

- **MC:** rounds the clock to 2 decimals first → 3h10m = **3.17** × $20 = **$63.40**
- **Qleno:** used exact minutes → 3.1667 × $20 = **$63.33**

The engine math is right; MaidCentral just rounds hours to 2 decimals before multiplying and Qleno didn't. This rounds each tech's clocked hours to 2 dp before the pay math (hourly, allowed-actual, and the fee-split hour-shares), so Qleno ties to MC penny-for-penny. After this, Jose 6/1 reads **$123.40**.

25 engine tests (added: 3h10m exact → $63.40); June 1 audit stays penny-exact at $801.99.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_