### PR TITLE
fix(commission): Allowed Hours is a hard cap at the budget (Phes policy)

### DIFF
--- a/artifacts/api-server/src/lib/commission-paytype.ts
+++ b/artifacts/api-server/src/lib/commission-paytype.ts
@@ -17,11 +17,13 @@
  *                 breakage) — a goodwill/breakage credit to the client does
  *                 NOT dock the cleaner (audit decision 2026-06-05).
  *
- *   allowed_hours pay = max(allowedShare, techHours) × hourlyRate
+ *   allowed_hours pay = allowedShare × hourlyRate  (HARD CAP at budget)
  *                 allowedShare = allowedHours × (techHours / totalTechHours).
- *                 Single tech → max(allowedHours, techHours) × rate, i.e. the
- *                 budget protects the tech on a fast job but pays actual when
- *                 they run over (MC: Alma 8.18 actual > 8 allowed → 8.18).
+ *                 Single tech → allowedHours × rate. The budget is paid whether
+ *                 the tech is faster OR slower — going over does NOT increase
+ *                 pay (the efficiency incentive). To pay actual on an overage,
+ *                 use Hourly. (Phes policy 2026-06-06 — diverges from MC, which
+ *                 paid actual when over.)
  *
  *   hourly        pay = techHours × hourlyRate
  *                 Flat wage on actual clocked time, independent of the job's
@@ -141,7 +143,13 @@ export function computeTechPay(ctx: JobPayContext, tech: TechPayInput): TechPayR
   if (tech.payType === "hourly") {
     grossAmount = round2(tech.techHours * tech.hourlyRate);
   } else if (tech.payType === "allowed_hours") {
-    const payHours = Math.max(ctx.allowedHours * share, tech.techHours);
+    // HARD CAP at the budget (Phes policy 2026-06-06): a commission job on
+    // Allowed Hours pays the allowed hours whether the tech is faster OR
+    // slower than the budget. Going over does NOT increase pay — that's the
+    // efficiency incentive. To pay actual time on an overage, use the Hourly
+    // pay type (or an hourly job). NOTE: this intentionally diverges from
+    // MaidCentral, which paid actual when over.
+    const payHours = ctx.allowedHours * share;
     grossAmount = round2(payHours * tech.hourlyRate);
     effectiveHours = round2(payHours);
   } else {

--- a/artifacts/api-server/src/tests/commission-paytype.test.ts
+++ b/artifacts/api-server/src/tests/commission-paytype.test.ts
@@ -50,10 +50,10 @@ describe("pay-type engine — MaidCentral June 1 parity", () => {
     assert.equal(r.effectiveHours, 3.5);
   });
 
-  it("allowed_hours: pays actual when over budget (8.18 actual > 8 allowed → $163.60)", () => {
+  it("allowed_hours: HARD CAP at budget even when over (8.18 actual, 8 allowed → $160, not $163.60)", () => {
     const ctx: JobPayContext = { baseFee: 0, allowedHours: 8.0, totalTechHours: 8.18 };
     const r = computeTechPay(ctx, { user_id: 1, techHours: 8.18, payType: "allowed_hours", hourlyRate: 20, scopePct: 0 });
-    assert.equal(r.amount, 163.6);
+    assert.equal(r.amount, 160.0);
   });
 
   it("hourly: flat wage on actual, ignores price/budget (Carpet 2.17 × $25 → $54.25)", () => {


### PR DESCRIPTION
Policy correction from Sal: **Allowed Hours is a hard cap at the budget.** A commission job on Allowed Hours pays the **allowed** hours whether the tech is faster *or* slower — going over the budget does **not** increase pay (that's the efficiency incentive). To pay actual time on an overage, the office picks **Hourly** (or it's an hourly job).

Change: drop `max(allowed, actual)` → pay `allowedShare` always.

- Faster than budget → pays budget (unchanged).
- **Over budget → now pays budget, not actual** (e.g. 8.18h on an 8h job → **$160**, was $163.60).

This **intentionally diverges from MaidCentral** (MC paid actual when over). June 1 is unaffected — every commercial job that day was under budget — so the audit stays **penny-exact at $801.99**. 25 tests (updated the over-budget case to assert the cap).

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_