### PR TITLE
feat(time-clock): Revenue + Labor % + Efficiency in the day summary, stable layout

### DIFF
--- a/artifacts/api-server/src/routes/timeclock.ts
+++ b/artifacts/api-server/src/routes/timeclock.ts
@@ -830,8 +830,14 @@ router.get("/day", requireAuth, requireRole("owner", "admin", "office"), async (
       };
     }).sort((a, b) => a.name.localeCompare(b.name));
 
+    // Day-level business metrics for the summary bar. Revenue is summed per
+    // UNIQUE job (not per tech-row, which would double-count multi-tech jobs).
+    const pf = (v: any) => { const n = parseFloat(String(v)); return Number.isFinite(n) ? n : 0; };
+    const revenue = Math.round(jobs.reduce((s, j: any) => s + (pf(j.billed_amount) || pf(j.base_fee)), 0) * 100) / 100;
+    const allowedHoursTotal = Math.round(jobs.reduce((s, j: any) => s + pf(j.allowed_hours), 0) * 100) / 100;
+
     console.log(`[TC-DAY] company=${companyId} date=${date} RESULT jobs=${jobs.length} techRows=${techRows.length} clockRows=${clockRows.length} employees=${employees.length}`);
-    return res.json({ date, employees, diagnostics: { jobCount: jobs.length, techRows: techRows.length, clockRows: clockRows.length } });
+    return res.json({ date, employees, revenue, allowed_hours_total: allowedHoursTotal, diagnostics: { jobCount: jobs.length, techRows: techRows.length, clockRows: clockRows.length } });
   } catch (err: any) {
     // Surface the failure to the UI instead of a silent 500 → empty screen.
     // The Time Clock empty-state renders this so we can diagnose without

--- a/artifacts/qleno/src/pages/time-clock.tsx
+++ b/artifacts/qleno/src/pages/time-clock.tsx
@@ -268,7 +268,7 @@ function RowEditor({ emp, row, dateStr, onChanged, toastFn }: {
 export default function TimeClockPage() {
   const { toast } = useToast();
   const [date, setDate] = useState(new Date());
-  const [data, setData] = useState<{ date: string; employees: Emp[]; diagnostics?: { jobCount?: number; techRows?: number; clockRows?: number; error?: string } } | null>(null);
+  const [data, setData] = useState<{ date: string; employees: Emp[]; revenue?: number; allowed_hours_total?: number; diagnostics?: { jobCount?: number; techRows?: number; clockRows?: number; error?: string } } | null>(null);
   const [loading, setLoading] = useState(true);
   const dk = dateKey(date);
   const isToday = dk === dateKey(new Date());
@@ -290,6 +290,15 @@ export default function TimeClockPage() {
   const totalPunches = employees.reduce((s, e) => s + e.rows.filter(r => r.source === "punched").length, 0);
   const totalRows = employees.reduce((s, e) => s + e.rows.length, 0);
   const totalPay = employees.reduce((s, e) => s + (e.pay_total ?? 0), 0);
+  // Business metrics for the summary bar. Revenue + allowed hours come from the
+  // API (summed per unique job). Labor % = commission ÷ revenue (the number a
+  // service business lives on). Efficiency = allowed ÷ actual hours (>100% =
+  // under budget = good — the canonical comp-model metric).
+  const revenue = data?.revenue ?? 0;
+  const laborPct = revenue > 0 ? (totalPay / revenue) * 100 : null;
+  const actualHours = totalWorked / 60;
+  const allowedTotal = data?.allowed_hours_total ?? 0;
+  const efficiency = actualHours > 0 ? (allowedTotal / actualHours) * 100 : null;
 
   return (
     <DashboardLayout>
@@ -321,12 +330,17 @@ export default function TimeClockPage() {
         </div>
 
         {/* Day summary */}
-        <div style={{ display: "flex", gap: 18, padding: "12px 16px", background: "#FFFFFF", border: "0.5px solid #E5E2DC", borderRadius: 12, marginBottom: 14 }}>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: "14px 24px", padding: "12px 16px", background: "#FFFFFF", border: "0.5px solid #E5E2DC", borderRadius: 12, marginBottom: 14 }}>
           <Stat label="People" value={String(employees.length)} />
           <Stat label="Jobs" value={String(totalRows)} />
           <Stat label="Punched" value={`${totalPunches}/${totalRows}`} accent={totalPunches < totalRows ? "#B45309" : "#16A34A"} />
           <Stat label="Worked hours" value={fmtHrs(totalWorked)} />
+          <Stat label="Revenue" value={`$${revenue.toFixed(2)}`} />
           <Stat label="Commission" value={`$${totalPay.toFixed(2)}`} accent="#0A7C66" />
+          <Stat label="Labor %" value={laborPct != null ? `${laborPct.toFixed(1)}%` : "—"}
+            accent={laborPct == null ? undefined : laborPct <= 40 ? "#16A34A" : laborPct <= 50 ? "#B45309" : "#B91C1C"} />
+          <Stat label="Efficiency" value={efficiency != null ? `${efficiency.toFixed(0)}%` : "—"}
+            accent={efficiency == null ? undefined : efficiency >= 100 ? "#16A34A" : efficiency >= 85 ? "#B45309" : "#B91C1C"} />
         </div>
 
         {loading && !data ? (
@@ -375,10 +389,12 @@ export default function TimeClockPage() {
 }
 
 function Stat({ label, value, accent }: { label: string; value: string; accent?: string }) {
+  // Fixed min-width so each metric holds its own column — the bar no longer
+  // reflows/shifts as dollar values change width from day to day.
   return (
-    <div>
-      <div style={{ fontSize: 10, fontWeight: 700, color: "#9E9B94", textTransform: "uppercase", letterSpacing: "0.05em" }}>{label}</div>
-      <div style={{ fontSize: 18, fontWeight: 800, color: accent ?? "#1A1917", marginTop: 2 }}>{value}</div>
+    <div style={{ minWidth: 92 }}>
+      <div style={{ fontSize: 10, fontWeight: 700, color: "#9E9B94", textTransform: "uppercase", letterSpacing: "0.05em", whiteSpace: "nowrap" }}>{label}</div>
+      <div style={{ fontSize: 18, fontWeight: 800, color: accent ?? "#1A1917", marginTop: 2, whiteSpace: "nowrap" }}>{value}</div>
     </div>
   );
 }


### PR DESCRIPTION
From Sal: the day summary bar shifted day to day, and it should carry the metrics a service provider actually uses (labor-to-revenue, etc.).

**Layout fix:** stats now have fixed min-widths + the row wraps, so the bar holds its columns instead of reflowing as dollar widths change. (Note: the *vertical* shift in some screenshots was the "Claude is debugging" / comms banners pushing the page down — that's external, not the bar.)

**New metrics in the bar** (alongside People / Jobs / Punched / Worked Hours):
- **Revenue** — the day's billed revenue (summed per unique job, not per tech-row, so multi-tech jobs don't double-count).
- **Commission** — labor $ (existing).
- **Labor %** — commission ÷ revenue, the headline service-business number. Color-coded green ≤40% / amber ≤50% / red >50%.
- **Efficiency** — allowed ÷ actual hours (the canonical comp-model metric). Green ≥100% (under budget) / amber ≥85% / red below.

Both ends typecheck clean.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_