### PR TITLE
fix(time-clock): JOBS count counts distinct jobs, not tech-rows

### DIFF
--- a/artifacts/api-server/src/routes/timeclock.ts
+++ b/artifacts/api-server/src/routes/timeclock.ts
@@ -830,8 +830,14 @@ router.get("/day", requireAuth, requireRole("owner", "admin", "office"), async (
       };
     }).sort((a, b) => a.name.localeCompare(b.name));
 
+    // Day-level business metrics for the summary bar. Revenue is summed per
+    // UNIQUE job (not per tech-row, which would double-count multi-tech jobs).
+    const pf = (v: any) => { const n = parseFloat(String(v)); return Number.isFinite(n) ? n : 0; };
+    const revenue = Math.round(jobs.reduce((s, j: any) => s + (pf(j.billed_amount) || pf(j.base_fee)), 0) * 100) / 100;
+    const allowedHoursTotal = Math.round(jobs.reduce((s, j: any) => s + pf(j.allowed_hours), 0) * 100) / 100;
+
     console.log(`[TC-DAY] company=${companyId} date=${date} RESULT jobs=${jobs.length} techRows=${techRows.length} clockRows=${clockRows.length} employees=${employees.length}`);
-    return res.json({ date, employees, diagnostics: { jobCount: jobs.length, techRows: techRows.length, clockRows: clockRows.length } });
+    return res.json({ date, employees, revenue, allowed_hours_total: allowedHoursTotal, diagnostics: { jobCount: jobs.length, techRows: techRows.length, clockRows: clockRows.length } });
   } catch (err: any) {
     // Surface the failure to the UI instead of a silent 500 → empty screen.
     // The Time Clock empty-state renders this so we can diagnose without

--- a/artifacts/qleno/src/pages/time-clock.tsx
+++ b/artifacts/qleno/src/pages/time-clock.tsx
@@ -268,7 +268,7 @@ function RowEditor({ emp, row, dateStr, onChanged, toastFn }: {
 export default function TimeClockPage() {
   const { toast } = useToast();
   const [date, setDate] = useState(new Date());
-  const [data, setData] = useState<{ date: string; employees: Emp[]; diagnostics?: { jobCount?: number; techRows?: number; clockRows?: number; error?: string } } | null>(null);
+  const [data, setData] = useState<{ date: string; employees: Emp[]; revenue?: number; allowed_hours_total?: number; diagnostics?: { jobCount?: number; techRows?: number; clockRows?: number; error?: string } } | null>(null);
   const [loading, setLoading] = useState(true);
   const dk = dateKey(date);
   const isToday = dk === dateKey(new Date());
@@ -290,6 +290,15 @@ export default function TimeClockPage() {
   const totalPunches = employees.reduce((s, e) => s + e.rows.filter(r => r.source === "punched").length, 0);
   const totalRows = employees.reduce((s, e) => s + e.rows.length, 0);
   const totalPay = employees.reduce((s, e) => s + (e.pay_total ?? 0), 0);
+  // Business metrics for the summary bar. Revenue + allowed hours come from the
+  // API (summed per unique job). Labor % = commission ÷ revenue (the number a
+  // service business lives on). Efficiency = allowed ÷ actual hours (>100% =
+  // under budget = good — the canonical comp-model metric).
+  const revenue = data?.revenue ?? 0;
+  const laborPct = revenue > 0 ? (totalPay / revenue) * 100 : null;
+  const actualHours = totalWorked / 60;
+  const allowedTotal = data?.allowed_hours_total ?? 0;
+  const efficiency = actualHours > 0 ? (allowedTotal / actualHours) * 100 : null;
 
   return (
     <DashboardLayout>
@@ -321,12 +330,17 @@ export default function TimeClockPage() {
         </div>
 
         {/* Day summary */}
-        <div style={{ display: "flex", gap: 18, padding: "12px 16px", background: "#FFFFFF", border: "0.5px solid #E5E2DC", borderRadius: 12, marginBottom: 14 }}>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: "14px 24px", padding: "12px 16px", background: "#FFFFFF", border: "0.5px solid #E5E2DC", borderRadius: 12, marginBottom: 14 }}>
           <Stat label="People" value={String(employees.length)} />
           <Stat label="Jobs" value={String(totalRows)} />
           <Stat label="Punched" value={`${totalPunches}/${totalRows}`} accent={totalPunches < totalRows ? "#B45309" : "#16A34A"} />
           <Stat label="Worked hours" value={fmtHrs(totalWorked)} />
+          <Stat label="Revenue" value={`$${revenue.toFixed(2)}`} />
           <Stat label="Commission" value={`$${totalPay.toFixed(2)}`} accent="#0A7C66" />
+          <Stat label="Labor %" value={laborPct != null ? `${laborPct.toFixed(1)}%` : "—"}
+            accent={laborPct == null ? undefined : laborPct <= 40 ? "#16A34A" : laborPct <= 50 ? "#B45309" : "#B91C1C"} />
+          <Stat label="Efficiency" value={efficiency != null ? `${efficiency.toFixed(0)}%` : "—"}
+            accent={efficiency == null ? undefined : efficiency >= 100 ? "#16A34A" : efficiency >= 85 ? "#B45309" : "#B91C1C"} />
         </div>
 
         {loading && !data ? (
@@ -375,10 +389,12 @@ export default function TimeClockPage() {
 }
 
 function Stat({ label, value, accent }: { label: string; value: string; accent?: string }) {
+  // Fixed min-width so each metric holds its own column — the bar no longer
+  // reflows/shifts as dollar values change width from day to day.
   return (
-    <div>
-      <div style={{ fontSize: 10, fontWeight: 700, color: "#9E9B94", textTransform: "uppercase", letterSpacing: "0.05em" }}>{label}</div>
-      <div style={{ fontSize: 18, fontWeight: 800, color: accent ?? "#1A1917", marginTop: 2 }}>{value}</div>
+    <div style={{ minWidth: 92 }}>
+      <div style={{ fontSize: 10, fontWeight: 700, color: "#9E9B94", textTransform: "uppercase", letterSpacing: "0.05em", whiteSpace: "nowrap" }}>{label}</div>
+      <div style={{ fontSize: 18, fontWeight: 800, color: accent ?? "#1A1917", marginTop: 2, whiteSpace: "nowrap" }}>{value}</div>
     </div>
   );
 }

--- a/artifacts/qleno/src/pages/time-clock.tsx
+++ b/artifacts/qleno/src/pages/time-clock.tsx
@@ -340,8 +340,13 @@ export default function TimeClockPage() {
           </div>
         </div>
 
-        {/* Day summary */}
-        <div style={{ display: "flex", flexWrap: "wrap", gap: "14px 24px", padding: "12px 16px", background: "#FFFFFF", border: "0.5px solid #E5E2DC", borderRadius: 12, marginBottom: 14 }}>
+        {/* Day summary — CSS grid with fixed-size columns so every stat sits in
+            an identical cell regardless of its value. A flex row with per-stat
+            minWidth still let a stat grow past the floor to fit a wider value
+            ($4793.60 vs $2044.00, 50h 24m vs 0m), shoving every following stat
+            and shifting columns day to day. Grid tracks are content-independent,
+            so placement is static across days at a given width. */}
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(104px, 1fr))", gap: "14px 20px", padding: "12px 16px", background: "#FFFFFF", border: "0.5px solid #E5E2DC", borderRadius: 12, marginBottom: 14 }}>
           <Stat label="People" value={String(employees.length)} />
           <Stat label="Jobs" value={String(jobCount)} />
           <Stat label="Punched" value={`${totalPunches}/${totalRows}`} accent={totalPunches < totalRows ? "#B45309" : "#16A34A"} />
@@ -400,10 +405,11 @@ export default function TimeClockPage() {
 }
 
 function Stat({ label, value, accent }: { label: string; value: string; accent?: string }) {
-  // Fixed min-width so each metric holds its own column — the bar no longer
-  // reflows/shifts as dollar values change width from day to day.
+  // The parent grid owns the column width (fixed, content-independent), so each
+  // metric always lands in the same place day to day. minWidth:0 lets the cell
+  // be governed by the grid track rather than the stat's own content width.
   return (
-    <div style={{ minWidth: 92 }}>
+    <div style={{ minWidth: 0 }}>
       <div style={{ fontSize: 10, fontWeight: 700, color: "#9E9B94", textTransform: "uppercase", letterSpacing: "0.05em", whiteSpace: "nowrap" }}>{label}</div>
       <div style={{ fontSize: 18, fontWeight: 800, color: accent ?? "#1A1917", marginTop: 2, whiteSpace: "nowrap" }}>{value}</div>
     </div>

--- a/artifacts/qleno/src/pages/time-clock.tsx
+++ b/artifacts/qleno/src/pages/time-clock.tsx
@@ -332,7 +332,11 @@ export default function TimeClockPage() {
                 style={{ position: "absolute", inset: 0, width: "100%", height: "100%", opacity: 0, cursor: "pointer" }} />
             </label>
             <button onClick={() => setDate(d => addDays(d, 1))} aria-label="Next day" style={{ border: "1px solid #E5E2DC", background: "#fff", borderRadius: 8, padding: "7px 9px", cursor: "pointer", color: "#6B7280" }}><ChevronRight size={16} /></button>
-            {!isToday && <button onClick={() => setDate(new Date())} style={{ border: "1px solid #E5E2DC", background: "#fff", borderRadius: 8, padding: "7px 12px", cursor: "pointer", color: "#1A1917", fontSize: 12, fontWeight: 700, fontFamily: FF }}>Today</button>}
+            {/* Always render the Today button so its slot is reserved — when
+                isToday it's hidden but still occupies width, so the date box +
+                chevrons don't slide sideways switching today ↔ any other day. */}
+            <button onClick={() => setDate(new Date())} aria-hidden={isToday} tabIndex={isToday ? -1 : 0}
+              style={{ border: "1px solid #E5E2DC", background: "#fff", borderRadius: 8, padding: "7px 12px", cursor: isToday ? "default" : "pointer", color: "#1A1917", fontSize: 12, fontWeight: 700, fontFamily: FF, visibility: isToday ? "hidden" : "visible" }}>Today</button>
           </div>
         </div>
 

--- a/artifacts/qleno/src/pages/time-clock.tsx
+++ b/artifacts/qleno/src/pages/time-clock.tsx
@@ -289,6 +289,13 @@ export default function TimeClockPage() {
   const totalWorked = employees.reduce((s, e) => s + e.worked_minutes, 0);
   const totalPunches = employees.reduce((s, e) => s + e.rows.filter(r => r.source === "punched").length, 0);
   const totalRows = employees.reduce((s, e) => s + e.rows.length, 0);
+  // JOBS counts DISTINCT jobs — NOT tech-rows. A 2-tech job produces 2 rows
+  // but is still 1 job, so totalRows over-counts multi-tech jobs (14 jobs
+  // rendered as 16). Use the server's per-unique-job count (the same `jobs`
+  // array it sums revenue over, so JOBS and REVENUE stay reconciled with the
+  // dispatch day). Fall back to distinct job_ids from the rows if absent.
+  const jobCount = data?.diagnostics?.jobCount
+    ?? new Set(employees.flatMap(e => e.rows.map(r => r.job_id))).size;
   const totalPay = employees.reduce((s, e) => s + (e.pay_total ?? 0), 0);
   // Business metrics for the summary bar. Revenue + allowed hours come from the
   // API (summed per unique job). Labor % = commission ÷ revenue (the number a
@@ -332,7 +339,7 @@ export default function TimeClockPage() {
         {/* Day summary */}
         <div style={{ display: "flex", flexWrap: "wrap", gap: "14px 24px", padding: "12px 16px", background: "#FFFFFF", border: "0.5px solid #E5E2DC", borderRadius: 12, marginBottom: 14 }}>
           <Stat label="People" value={String(employees.length)} />
-          <Stat label="Jobs" value={String(totalRows)} />
+          <Stat label="Jobs" value={String(jobCount)} />
           <Stat label="Punched" value={`${totalPunches}/${totalRows}`} accent={totalPunches < totalRows ? "#B45309" : "#16A34A"} />
           <Stat label="Worked hours" value={fmtHrs(totalWorked)} />
           <Stat label="Revenue" value={`$${revenue.toFixed(2)}`} />


### PR DESCRIPTION
From Sal: found a disconnect on the Time Clock day summary — revenue matched the day but the **JOBS count did not**, throwing off reconciliation against the dispatch/MaidCentral day (MC showed **14 jobs**, Qleno showed **JOBS 16**).

**Root cause:** the JOBS stat used `totalRows` — the count of tech-rows across all employees. A 2-tech job produces 2 rows but is still 1 job, so multi-tech jobs were double-counted (14 distinct jobs rendered as 16).

**Fix:** JOBS now uses the server's per-unique-job count (`diagnostics.jobCount` — the same `jobs` array REVENUE is summed over), so JOBS and REVENUE stay reconciled with the dispatch day. Falls back to distinct `job_id`s from the rows if the field is absent.

**Left intentionally unchanged:** PUNCHED stays on `totalRows` (`16/16`) — it tracks per-tech clock pairs (each tech punches in/out per job), which is a deliberately different meter from job count.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_