### PR TITLE
fix(layout): reserve scrollbar gutter so pages don't shift sideways between days

### DIFF
--- a/artifacts/qleno/src/components/layout/dashboard-layout.tsx
+++ b/artifacts/qleno/src/components/layout/dashboard-layout.tsx
@@ -1075,7 +1075,7 @@ export function DashboardLayout({ children, title, fullBleed, onNewJob }: Dashbo
             {children}
           </div>
         ) : (
-          <main style={{ flex: 1, overflowY: 'auto', backgroundColor: '#F7F6F3', display: 'flex', flexDirection: 'column' }}>
+          <main style={{ flex: 1, overflowY: 'auto', scrollbarGutter: 'stable', backgroundColor: '#F7F6F3', display: 'flex', flexDirection: 'column' }}>
             <CommsPausedBanner />
             <div style={{ padding: '28px 28px', maxWidth: 1400, margin: '0 auto', width: '100%' }}>{children}</div>
           </main>


### PR DESCRIPTION
Follow-up to #346. Sal reported the Time Clock still shifts horizontally when stepping Friday → today, even after the column/date-nav fixes.

**Root cause:** the dashboard `<main>` scroll container (`overflowY: auto`) shows its scrollbar on tall days (more employee rows) and hides it on short days. Because page content is centered (`margin: 0 auto`), the scrollbar appearing/disappearing changes the usable width and slides everything sideways each time the content height changes.

**Fix:** `scrollbar-gutter: stable` on the `<main>` always reserves the scrollbar's space, so usable width is constant whether or not the scrollbar is present. The layout stays put across days — and this stabilizes every desktop page, not just Time Clock.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_