### PR TITLE
feat(jobs): duplicate job to a new date + payroll % of revenue metric

### DIFF
--- a/artifacts/api-server/src/routes/jobs.ts
+++ b/artifacts/api-server/src/routes/jobs.ts
@@ -73,6 +73,84 @@ async function persistJobAddOns(exec: any, jobId: number, companyId: number, add
   }
 }
 
+// [duplicate-job 2026-06-08] Maribel's HouseCall-Pro-style "duplicate this job
+// to a new date, same service" flow (mobile-first). Copies the source job's
+// DEFINITION — client/account, service, fee, allowed hours, tech team, add-ons,
+// address, zone — into a NEW job on the requested date, and RESETS all
+// operational state (status, clock, billing, completion, no-show) so the copy
+// is a clean scheduled visit. The duplicate is standalone: frequency on_demand,
+// no recurring_schedule_id/occurrence_date — it's a single extra visit, not a
+// series (recurring lives on recurring_schedules). Same company scope enforced.
+router.post("/:id/duplicate", requireAuth, async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId as number;
+    const srcId = parseInt(String(req.params.id));
+    const { scheduled_date, scheduled_time } = req.body;
+    if (!scheduled_date) return res.status(400).json({ error: "scheduled_date required" });
+
+    const srcConds: any[] = [eq(jobsTable.id, srcId), eq(jobsTable.company_id, companyId)];
+    const [src] = await db.select().from(jobsTable).where(and(...srcConds));
+    if (!src) return res.status(404).json({ error: "Job not found" });
+
+    // Copy every definition column, then override date + reset instance state.
+    const { id: _omitId, created_at: _omitCreated, ...rest } = src as any;
+    const [dup] = await db
+      .insert(jobsTable)
+      .values({
+        ...rest,
+        scheduled_date,
+        scheduled_time: scheduled_time ?? src.scheduled_time,
+        status: "scheduled",
+        frequency: "on_demand",
+        recurring_schedule_id: null,
+        occurrence_date: null,
+        // reset all operational / clock / billing / completion / no-show state
+        billed_hours: null,
+        billed_amount: null,
+        actual_hours: null,
+        actual_end_time: null,
+        locked_at: null,
+        completed_by_user_id: null,
+        completion_pdf_url: null,
+        completion_pdf_sent_at: null,
+        charge_attempted_at: null,
+        charge_succeeded_at: null,
+        charge_failed_at: null,
+        charge_failure_reason: null,
+        no_show_marked_by_tech: null,
+        no_show_marked_by_user_id: null,
+        flagged: false,
+      } as any)
+      .returning();
+
+    const newId = dup.id;
+    logAudit(req, "CREATE", "job", newId, null, dup);
+
+    // Carry the tech team over (same per-job assignment + primary).
+    try {
+      await db.execute(sql`
+        INSERT INTO job_technicians (job_id, user_id, company_id, is_primary)
+        SELECT ${newId}, user_id, company_id, is_primary FROM job_technicians WHERE job_id = ${srcId}
+        ON CONFLICT (job_id, user_id) DO NOTHING
+      `);
+    } catch (e) { console.error("duplicate job_technicians copy failed for", newId, e); }
+
+    // Carry the add-ons over (Parking Fee, etc.).
+    try {
+      await db.execute(sql`
+        INSERT INTO job_add_ons (job_id, add_on_id, quantity, unit_price, subtotal, pricing_addon_id)
+        SELECT ${newId}, add_on_id, quantity, unit_price, subtotal, pricing_addon_id FROM job_add_ons WHERE job_id = ${srcId}
+        ON CONFLICT (job_id, add_on_id) DO NOTHING
+      `);
+    } catch (e) { console.error("duplicate job_add_ons copy failed for", newId, e); }
+
+    return res.status(201).json(dup);
+  } catch (err) {
+    console.error("[jobs duplicate]", err);
+    return res.status(500).json({ error: "Failed to duplicate job" });
+  }
+});
+
 router.get("/", requireAuth, async (req, res) => {
   try {
     // [BUG-7 / 2026-06-01] Added `date` as a single-day filter alongside the

--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -1265,6 +1265,12 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
   const [rescheduleBusy, setRescheduleBusy] = useState(false);
   const [rescheduleSuccess, setRescheduleSuccess] = useState("");
   const [rescheduleCount, setRescheduleCount] = useState<number | null>(null);
+  // [duplicate-job 2026-06-08] HCP-style "copy this job to a new date, same
+  // service" (Maribel). Works the same on mobile + desktop via this shared panel.
+  const [duplicateOpen, setDuplicateOpen] = useState(false);
+  const [duplicateDate, setDuplicateDate] = useState("");
+  const [duplicateTime, setDuplicateTime] = useState("");
+  const [duplicateBusy, setDuplicateBusy] = useState(false);
   const [smsOpen, setSmsOpen] = useState(false);
   const [smsMessage, setSmsMessage] = useState("");
   const [smsBusy, setSmsBusy] = useState(false);
@@ -2560,6 +2566,17 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
             Edit
           </button>
           <button
+            onClick={() => {
+              const base = job.scheduled_date ? new Date(`${job.scheduled_date}T12:00:00`) : new Date();
+              base.setDate(base.getDate() + 7);
+              setDuplicateDate(base.toISOString().slice(0, 10));
+              setDuplicateTime(job.scheduled_time || "");
+              setDuplicateOpen(true);
+            }}
+            style={{ padding: "10px 12px", border: "1px solid #DDD6FE", borderRadius: 8, backgroundColor: "#F5F3FF", color: "#6D28D9", fontSize: 13, fontWeight: 600, cursor: "pointer", fontFamily: FF }}>
+            Duplicate
+          </button>
+          <button
             disabled={isLocked}
             onClick={() => {
               if (isLocked) return;
@@ -2578,6 +2595,58 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
           )}
         </div>
       </div>
+
+      {/* Duplicate Job Modal */}
+      {duplicateOpen && (
+        <>
+          <div style={{ position: "fixed", inset: 0, backgroundColor: "rgba(0,0,0,0.5)", zIndex: 299 }} onClick={() => !duplicateBusy && setDuplicateOpen(false)} />
+          <div style={mobile
+            ? { position: "fixed", bottom: 0, left: 0, right: 0, zIndex: 300, backgroundColor: "#FFFFFF", borderRadius: "16px 16px 0 0", padding: "20px 20px 28px", fontFamily: FF }
+            : { position: "fixed", top: "50%", left: "50%", transform: "translate(-50%,-50%)", zIndex: 300, backgroundColor: "#FFFFFF", borderRadius: 16, width: "100%", maxWidth: 420, padding: 24, boxShadow: "0 24px 64px rgba(0,0,0,0.25)", fontFamily: FF }
+          }>
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 4 }}>
+              <span style={{ fontSize: 16, fontWeight: 700, color: "#1A1917" }}>Duplicate Job</span>
+              <button onClick={() => !duplicateBusy && setDuplicateOpen(false)} style={{ background: "none", border: "none", cursor: "pointer", padding: 6, display: "flex" }} type="button"><X size={18} /></button>
+            </div>
+            <p style={{ margin: "0 0 16px", fontSize: 12, color: "#6B7280" }}>
+              Creates a new job with the same service, price, tech, and add-ons — just pick the new date.
+            </p>
+            <label style={{ fontSize: 11, fontWeight: 700, color: "#9E9B94", textTransform: "uppercase", letterSpacing: "0.06em", display: "block", marginBottom: 6 }}>New date</label>
+            <input type="date" value={duplicateDate} onChange={e => setDuplicateDate(e.target.value)}
+              style={{ width: "100%", height: 42, padding: "0 12px", border: "1px solid #E5E2DC", borderRadius: 8, fontSize: 14, color: "#1A1917", fontFamily: FF, marginBottom: 14, boxSizing: "border-box" }} />
+            <label style={{ fontSize: 11, fontWeight: 700, color: "#9E9B94", textTransform: "uppercase", letterSpacing: "0.06em", display: "block", marginBottom: 6 }}>Time (optional)</label>
+            <input type="time" value={duplicateTime ? duplicateTime.slice(0, 5) : ""} onChange={e => setDuplicateTime(e.target.value ? `${e.target.value}:00` : "")}
+              style={{ width: "100%", height: 42, padding: "0 12px", border: "1px solid #E5E2DC", borderRadius: 8, fontSize: 14, color: "#1A1917", fontFamily: FF, marginBottom: 18, boxSizing: "border-box" }} />
+            <div style={{ display: "flex", gap: 10, justifyContent: "flex-end" }}>
+              <button type="button" onClick={() => setDuplicateOpen(false)} disabled={duplicateBusy}
+                style={{ padding: "10px 16px", border: "1px solid #E5E2DC", borderRadius: 8, backgroundColor: "#FFFFFF", color: "#6B7280", fontSize: 13, fontWeight: 600, cursor: "pointer", fontFamily: FF }}>Cancel</button>
+              <button type="button" disabled={!duplicateDate || duplicateBusy}
+                onClick={async () => {
+                  if (!duplicateDate) return;
+                  setDuplicateBusy(true);
+                  try {
+                    const r = await fetch(`${_API2}/api/jobs/${job.id}/duplicate`, {
+                      method: "POST",
+                      headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+                      body: JSON.stringify({ scheduled_date: duplicateDate, scheduled_time: duplicateTime || job.scheduled_time || null }),
+                    });
+                    if (!r.ok) throw new Error(await r.text());
+                    const fmtNew = new Date(duplicateDate + "T12:00").toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric" });
+                    toast({ title: "Job duplicated", description: `Copied to ${fmtNew}` });
+                    setDuplicateOpen(false);
+                    onUpdate();
+                    onClose();
+                  } catch {
+                    toast({ title: "Error", description: "Could not duplicate job", variant: "destructive" });
+                  } finally { setDuplicateBusy(false); }
+                }}
+                style={{ padding: "10px 18px", border: "none", borderRadius: 8, backgroundColor: "var(--brand)", color: "#fff", fontSize: 13, fontWeight: 700, cursor: (!duplicateDate || duplicateBusy) ? "not-allowed" : "pointer", fontFamily: FF, opacity: (!duplicateDate || duplicateBusy) ? 0.6 : 1 }}>
+                {duplicateBusy ? "Duplicating…" : "Duplicate"}
+              </button>
+            </div>
+          </div>
+        </>
+      )}
 
       {/* Charge Confirmation Modal */}
       {chargeOpen && (

--- a/artifacts/qleno/src/pages/payroll.tsx
+++ b/artifacts/qleno/src/pages/payroll.tsx
@@ -98,14 +98,20 @@ function WeeklyDetailView() {
   const dayTotals = employees.reduce((a: any, e: any) => ({
     revenue: a.revenue + Number(e.totals?.job_total || 0),
     commission: a.commission + Number(e.totals?.commission || 0),
+    // Total pay (commission + tips + mileage + additional) for the labor-cost ratio.
+    payroll: a.payroll + Number(e.totals?.grand_total ?? e.totals?.commission ?? 0),
     allowed: a.allowed + Number(e.totals?.hrs_scheduled || 0),
     worked: a.worked + Number(e.totals?.hrs_worked || 0),
-  }), { revenue: 0, commission: 0, allowed: 0, worked: 0 });
+  }), { revenue: 0, commission: 0, payroll: 0, allowed: 0, worked: 0 });
   // Company-wide customer-quality avg across every rated job in the period.
   const allQ = employees.flatMap((e: any) => (e.jobs || []).map((j: any) => j.quality_score).filter((v: any) => v != null));
   const avgQuality = allQ.length ? allQ.reduce((a: number, b: number) => a + b, 0) / allQ.length : null;
   const money2 = (n: number) => `$${Number(n).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
   const isSingleDay = period.start === period.end;
+  // Payroll as % of revenue — the labor-cost target to "stay under" (MC parity).
+  // <40% healthy (mint), 40–50% watch (amber), >50% hot (red).
+  const payrollPct = dayTotals.revenue > 0 ? Math.round((dayTotals.payroll / dayTotals.revenue) * 1000) / 10 : null;
+  const payrollPctColor = payrollPct == null ? '#9E9B94' : payrollPct < 40 ? '#16A34A' : payrollPct <= 50 ? '#D97706' : '#DC2626';
 
   const inputStyle: React.CSSProperties = { height: 34, padding: '0 10px', border: '1px solid #E5E2DC', borderRadius: 6, fontSize: 13, color: '#1A1917', background: '#fff', outline: 'none', fontFamily: FF };
   const th: React.CSSProperties = { fontSize: 11, fontWeight: 700, color: '#9E9B94', textTransform: 'uppercase', letterSpacing: '0.06em', padding: '0 10px 8px 0', textAlign: 'left', whiteSpace: 'nowrap' };
@@ -138,6 +144,7 @@ function WeeklyDetailView() {
           {[
             { k: isSingleDay ? 'Revenue · this day' : 'Revenue', v: money2(dayTotals.revenue), accent: true },
             { k: 'Commission', v: money2(dayTotals.commission), accent: true },
+            { k: 'Payroll % of rev', v: payrollPct != null ? `${payrollPct}%` : '—', color: payrollPctColor },
             { k: 'Allowed hrs', v: dayTotals.allowed.toFixed(1) },
             { k: 'Worked hrs', v: dayTotals.worked.toFixed(1) },
             { k: 'Avg Quality', v: avgQuality != null ? `${avgQuality.toFixed(1)}/4` : '—', quality: avgQuality },
@@ -145,7 +152,7 @@ function WeeklyDetailView() {
           ].map((s: any) => (
             <div key={s.k} style={{ minWidth: 104 }}>
               <div style={{ fontSize: 10, color: '#9E9B94', textTransform: 'uppercase', letterSpacing: '0.05em', fontFamily: FF }}>{s.k}</div>
-              <div style={{ fontSize: 18, fontWeight: 800, color: 'quality' in s ? qualityColor(s.quality) : s.accent ? 'var(--brand)' : '#1A1917', fontFamily: FF }}>{s.v}</div>
+              <div style={{ fontSize: 18, fontWeight: 800, color: s.color ?? ('quality' in s ? qualityColor(s.quality) : s.accent ? 'var(--brand)' : '#1A1917'), fontFamily: FF }}>{s.v}</div>
             </div>
           ))}
         </div>


### PR DESCRIPTION
## 1. Duplicate Job (Maribel's HouseCall-Pro flow, mobile-first)
"Click a job, duplicate it, change the date — same service."

- **Backend:** `POST /api/jobs/:id/duplicate` copies the source job's *definition* — client/account, service type, fee, allowed hours, **tech team** (`job_technicians`), **add-ons** (`job_add_ons`), address, zone — into a **new** job on the requested date. Resets all operational state (status → scheduled, clock, billing, completion, no-show). The copy is **standalone** (`frequency: on_demand`, no `recurring_schedule_id`) — a single extra visit, not a series. Company-scoped.
- **Frontend:** a **"Duplicate"** button + a responsive date/time modal in the shared **JobPanel**, so it behaves identically on **mobile and desktop**. Defaults the new date to +7 days; on success it refreshes the board and toasts "Copied to <date>".

*Design note:* duplicate creates a one-off visit (matches HCP). If you'd rather it preserve the recurring cadence, that's a quick toggle — let me know.

## 2. Payroll % of revenue metric
Added **"Payroll % of rev"** to the payroll By-Employee summary bar (total pay ÷ revenue), color-banded so the office can watch the labor-cost target — MaidCentral parity:
- **< 40%** mint · **40–50%** amber · **> 50%** red.

## Verification
- api-server typecheck: jobs.ts **71 → 71** (zero new errors).
- frontend: jobs.tsx **0 → 0**, payroll.tsx no new errors; `pnpm build` ✓ clean.
- Not verified against live data (no DB in sandbox).

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_