### PR TITLE
feat(address): tap address to navigate in Google Maps (panel + tech views)

### DIFF
--- a/artifacts/qleno/src/lib/format-address.ts
+++ b/artifacts/qleno/src/lib/format-address.ts
@@ -66,3 +66,17 @@ export function appendZipIfMissing(addressLine: string | null | undefined, zip?:
   if (a.includes(z)) return a;
   return `${a} ${z}`;
 }
+
+/**
+ * Google Maps turn-by-turn NAVIGATION url for an address. Uses the directions
+ * endpoint (`dir/?api=1&destination=…`) so tapping it launches the Google Maps
+ * app in navigation mode on mobile (and maps.google.com on desktop) — not just
+ * a dropped pin. Single source of truth so "tap the address to navigate"
+ * behaves identically on the dispatch panel and the tech My Day / My Jobs views.
+ * Returns null for an empty address so callers can skip the link.
+ */
+export function mapsDirectionsUrl(address: string | null | undefined): string | null {
+  const a = (address ?? "").trim();
+  if (!a) return null;
+  return `https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(a)}`;
+}

--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -4,6 +4,7 @@ import { DashboardLayout } from "@/components/layout/dashboard-layout";
 import { getAuthHeaders, useAuthStore } from "@/lib/auth";
 import { useBranch } from "@/contexts/branch-context";
 import { useToast } from "@/hooks/use-toast";
+import { mapsDirectionsUrl } from "@/lib/format-address";
 import { JobWizard } from "@/components/job-wizard";
 import EditJobModal from "@/components/edit-job-modal";
 import {
@@ -3819,9 +3820,18 @@ function JobHoverCard({ job, assignedName }: { job: DispatchJob; assignedName?: 
           </span>
         </div>
         {job.address && (
-          <div style={{ fontSize: 15, fontWeight: 500, color: "#1A1917", lineHeight: 1.35, marginBottom: 8 }}>
-            {job.address}
-          </div>
+          mapsDirectionsUrl(job.address) ? (
+            <a href={mapsDirectionsUrl(job.address)!} target="_blank" rel="noreferrer"
+              title="Tap to navigate in Google Maps"
+              style={{ display: "inline-flex", alignItems: "center", gap: 6, fontSize: 15, fontWeight: 500, color: "#1D4ED8", lineHeight: 1.35, marginBottom: 8, textDecoration: "none" }}>
+              <MapPin size={14} style={{ flexShrink: 0 }} />
+              <span style={{ textDecoration: "underline" }}>{job.address}</span>
+            </a>
+          ) : (
+            <div style={{ fontSize: 15, fontWeight: 500, color: "#1A1917", lineHeight: 1.35, marginBottom: 8 }}>
+              {job.address}
+            </div>
+          )
         )}
         {job.client_phone && (
           <a

--- a/artifacts/qleno/src/pages/my-day.tsx
+++ b/artifacts/qleno/src/pages/my-day.tsx
@@ -21,7 +21,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useAuthStore } from "@/lib/auth";
-import { formatAddress } from "@/lib/format-address";
+import { formatAddress, mapsDirectionsUrl } from "@/lib/format-address";
 import { ChevronLeft, ChevronRight, Check, AlertTriangle, MapPin } from "lucide-react";
 
 const BASE = import.meta.env.BASE_URL.replace(/\/$/, "");
@@ -125,7 +125,7 @@ function mapsHref(item: TodayItem): string | null {
     item.address_zip,
   );
   if (!addr) return null;
-  return `https://maps.google.com/?q=${encodeURIComponent(addr)}`;
+  return mapsDirectionsUrl(addr);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/artifacts/qleno/src/pages/my-jobs.tsx
+++ b/artifacts/qleno/src/pages/my-jobs.tsx
@@ -8,7 +8,7 @@ import { Check, Eye, Navigation, Phone, GraduationCap, DollarSign } from "lucide
 import { Link } from "wouter";
 import { useEmployeeView } from "@/contexts/employee-view-context";
 import { getJobVisualStatus, STATUS_VISUALS, ensureJobStatusStyles } from "@/lib/job-status";
-import { formatAddress } from "@/lib/format-address";
+import { formatAddress, mapsDirectionsUrl } from "@/lib/format-address";
 import { QlenoMark } from "@/components/brand/QlenoMark";
 import { QuoteAttachments } from "@/components/quote-attachments";
 
@@ -565,7 +565,7 @@ function JobCard({ job, empPos, onRefresh, isPreviewMode, prevJobId }: { job: Jo
       )}
       {job.address && (
         <a
-          href={`https://maps.apple.com/?address=${encodeURIComponent(formatAddress(job.address, job.city, job.state, job.zip))}`}
+          href={mapsDirectionsUrl(formatAddress(job.address, job.city, job.state, job.zip)) ?? "#"}
           target="_blank"
           rel="noreferrer"
           style={{


### PR DESCRIPTION
## Tap an address → Google Maps navigation

The job address wasn't a navigation link where you expected it, and the surfaces that *did* link were inconsistent (one used Apple Maps, another dropped a pin instead of starting directions). Fixed with one shared helper.

- **New `mapsDirectionsUrl()`** in `lib/format-address.ts` — builds the Google Maps **directions** URL (`dir/?api=1&destination=…`), which launches turn-by-turn **navigation** in the Google Maps app on mobile (maps.google.com on desktop). Single source of truth.
- **Dispatch job panel:** address was plain text → now a tappable nav link (📍 underlined, opens in a new tab).
- **Tech "My Jobs":** was **Apple** Maps (search) → now Google Maps navigation.
- **Tech "My Day":** was Google `?q=` (a pin) → now Google directions/navigation.

So a cleaner — or the office — can tap any job address and get routed straight there.

## Verification
- `pnpm --filter @workspace/qleno run build` ✓ clean; 0 type errors in the 4 changed files.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_