### PR TITLE
feat(assistant): bilingual voice assistant for field techs (v1)

### DIFF
--- a/artifacts/api-server/src/routes/assistant.ts
+++ b/artifacts/api-server/src/routes/assistant.ts
@@ -1,0 +1,164 @@
+import { Router } from "express";
+import { db } from "@workspace/db";
+import { jobsTable, clientsTable, accountsTable, accountPropertiesTable } from "@workspace/db/schema";
+import { eq, and, asc, sql } from "drizzle-orm";
+import Anthropic from "@anthropic-ai/sdk";
+import { requireAuth } from "../lib/auth.js";
+
+// [voice-assistant 2026-06-08] Field-tech voice assistant. The mobile app
+// transcribes the tech's spoken question (browser speech-to-text), POSTs it
+// here, and we answer using ONLY that tech's own jobs for the day via Claude.
+// Read-only + navigation; bilingual (English/Spanish). Reuses the same Anthropic
+// setup as routes/translate.ts (ANTHROPIC_API_KEY, claude-haiku-4-5 — cheap +
+// fast, ideal for short voice turns).
+//
+// PRIVACY: the query is hard-scoped to assigned_user_id = the authenticated
+// user. A tech can never see another tech's jobs through the assistant.
+
+const router = Router();
+
+const LANG_NAME: Record<string, string> = { en: "English", es: "Spanish" };
+
+function fmtAddr(street?: string | null, city?: string | null, state?: string | null, zip?: string | null): string {
+  const s = (v: any) => (v == null ? "" : String(v).trim());
+  const parts: string[] = [];
+  if (s(street)) parts.push(s(street));
+  if (s(city)) parts.push(s(city));
+  const sz = [s(state), s(zip)].filter(Boolean).join(" ");
+  if (sz) parts.push(sz);
+  return parts.join(", ");
+}
+
+router.post("/ask", requireAuth, async (req, res) => {
+  try {
+    const userId = req.auth!.userId as number;
+    const companyId = req.auth!.companyId as number;
+    const question = typeof req.body?.question === "string" ? req.body.question.trim() : "";
+    const language = req.body?.language === "es" ? "es" : "en";
+    const date = typeof req.body?.date === "string" && /^\d{4}-\d{2}-\d{2}$/.test(req.body.date)
+      ? req.body.date
+      : new Date().toISOString().slice(0, 10);
+
+    if (!question) { res.status(400).json({ error: "question required" }); return; }
+    if (question.length > 1000) { res.status(400).json({ error: "question too long" }); return; }
+
+    if (!process.env.ANTHROPIC_API_KEY) {
+      console.warn("[assistant] ANTHROPIC_API_KEY not set — assistant disabled");
+      res.status(503).json({ error: "Assistant is not configured — set ANTHROPIC_API_KEY in Railway" });
+      return;
+    }
+
+    // The tech's OWN jobs for the day (privacy: assigned_user_id = the caller).
+    // Address resolves account_property → client, mirroring routes/tech.ts.
+    const rows = await db
+      .select({
+        id: jobsTable.id,
+        client_first_name: clientsTable.first_name,
+        client_last_name: clientsTable.last_name,
+        client_company_name: clientsTable.company_name,
+        account_name: accountsTable.account_name,
+        property_name: accountPropertiesTable.property_name,
+        address_street: sql<string | null>`CASE WHEN ${jobsTable.account_property_id} IS NOT NULL THEN ${accountPropertiesTable.address} ELSE ${clientsTable.address} END`,
+        address_city: sql<string | null>`CASE WHEN ${jobsTable.account_property_id} IS NOT NULL THEN ${accountPropertiesTable.city} ELSE ${clientsTable.city} END`,
+        address_state: sql<string | null>`CASE WHEN ${jobsTable.account_property_id} IS NOT NULL THEN ${accountPropertiesTable.state} ELSE ${clientsTable.state} END`,
+        address_zip: sql<string | null>`CASE WHEN ${jobsTable.account_property_id} IS NOT NULL THEN ${accountPropertiesTable.zip} ELSE ${clientsTable.zip} END`,
+        service_type: jobsTable.service_type,
+        scheduled_time: jobsTable.scheduled_time,
+        allowed_hours: jobsTable.allowed_hours,
+        status: jobsTable.status,
+        frequency: jobsTable.frequency,
+        notes: jobsTable.notes,
+        office_notes: jobsTable.office_notes,
+      })
+      .from(jobsTable)
+      .leftJoin(clientsTable, eq(jobsTable.client_id, clientsTable.id))
+      .leftJoin(accountsTable, eq(jobsTable.account_id, accountsTable.id))
+      .leftJoin(accountPropertiesTable, eq(jobsTable.account_property_id, accountPropertiesTable.id))
+      .where(and(
+        eq(jobsTable.company_id, companyId),
+        eq(jobsTable.assigned_user_id, userId),
+        eq(jobsTable.scheduled_date, date),
+      ))
+      .orderBy(asc(jobsTable.scheduled_time), asc(jobsTable.id));
+
+    const jobs = rows.map((r, i) => {
+      const name = r.account_name || r.client_company_name
+        || `${r.client_first_name ?? ""} ${r.client_last_name ?? ""}`.trim() || "Unknown";
+      const address = fmtAddr(r.address_street, r.address_city, r.address_state, r.address_zip);
+      const notes = [r.office_notes, r.notes].filter(Boolean).join(" / ");
+      return {
+        n: i + 1,
+        client: r.property_name ? `${name} — ${r.property_name}` : name,
+        address: address || null,
+        time: r.scheduled_time ? String(r.scheduled_time).slice(0, 5) : null,
+        allowed_hours: r.allowed_hours != null ? Number(r.allowed_hours) : null,
+        service: String(r.service_type || "").replace(/_/g, " "),
+        status: r.status,
+        notes: notes || null,
+      };
+    });
+
+    const langName = LANG_NAME[language];
+    const system =
+      `You are a friendly, concise voice assistant for a house-cleaning technician using the Qleno app. ` +
+      `Today is ${date}. You are given ONLY this technician's own jobs for the day as JSON. ` +
+      `Answer the technician's question using ONLY that data — never invent jobs, addresses, times, or notes. ` +
+      `If the answer isn't in the data, say you don't have that information. ` +
+      `Reply in ${langName}. Keep it short and natural for reading aloud (1–3 sentences; for a full schedule give a brief list with time + client). ` +
+      `When the technician asks to navigate / get directions / go to a job, choose the intended job (by client name, or the next upcoming job if unspecified) and put its exact address string in "navigate_to". Otherwise "navigate_to" MUST be null. ` +
+      `Respond with ONLY a JSON object: {"answer": string, "navigate_to": string|null}. No other text.\n\n` +
+      `Technician's jobs for ${date}:\n${JSON.stringify(jobs)}`;
+
+    const client = new Anthropic();
+    const response = await client.messages.create({
+      model: "claude-haiku-4-5",
+      max_tokens: 1024,
+      system,
+      messages: [
+        { role: "user", content: question },
+        // Prefill an opening brace to force a clean JSON object back.
+        { role: "assistant", content: "{" },
+      ],
+    });
+
+    const raw = "{" + response.content
+      .filter((b): b is Anthropic.TextBlock => b.type === "text")
+      .map(b => b.text)
+      .join("");
+
+    let answer = "";
+    let navigateTo: string | null = null;
+    try {
+      const parsed = JSON.parse(raw);
+      answer = typeof parsed.answer === "string" ? parsed.answer : "";
+      navigateTo = typeof parsed.navigate_to === "string" && parsed.navigate_to.trim() ? parsed.navigate_to.trim() : null;
+    } catch {
+      answer = raw.replace(/^\{/, "").trim();
+    }
+    if (!answer) answer = language === "es" ? "No tengo esa información." : "I don't have that information.";
+
+    res.json({
+      answer,
+      language,
+      job_count: jobs.length,
+      navigate_to: navigateTo,
+      navigate_url: navigateTo ? `https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(navigateTo)}` : null,
+      input_tokens: response.usage.input_tokens,
+      output_tokens: response.usage.output_tokens,
+    });
+  } catch (e: any) {
+    if (e instanceof Anthropic.AuthenticationError) {
+      console.error("[assistant] Auth error:", e.message);
+      res.status(503).json({ error: "Assistant auth failed — check ANTHROPIC_API_KEY" });
+      return;
+    }
+    if (e instanceof Anthropic.RateLimitError) {
+      res.status(429).json({ error: "Assistant temporarily rate-limited — try again in a moment" });
+      return;
+    }
+    console.error("[assistant] Error:", e);
+    res.status(500).json({ error: "Assistant failed", message: e?.message });
+  }
+});
+
+export default router;

--- a/artifacts/api-server/src/routes/index.ts
+++ b/artifacts/api-server/src/routes/index.ts
@@ -92,6 +92,7 @@ import lmsSettingsRouter from "./lms-settings.js";
 import lmsAdminAuditRouter from "./lms-admin-audit.js";
 import lmsOnboardingIntakeRouter from "./lms-onboarding-intake.js";
 import translateRouter from "./translate.js";
+import assistantRouter from "./assistant.js";
 import devicesRouter from "./devices.js";
 
 const router: IRouter = Router();
@@ -124,6 +125,9 @@ router.use("/attachments", attachmentsRouter);
 // [translate-job-notes 2026-05-27] Office-only translation endpoint —
 // Claude API. POST /api/translate {text, target} → {translated}.
 router.use("/translate", translateRouter);
+// [voice-assistant 2026-06-08] Field-tech voice assistant — Claude API, scoped
+// to the caller's own jobs. POST /api/assistant/ask {question, language} → {answer, navigate_url}.
+router.use("/assistant", assistantRouter);
 router.use("/devices", devicesRouter);
 // [quote-attachments] The routers define full paths internally
 // (`:id/attachments`), so mount them at the resource root.

--- a/artifacts/qleno/src/components/voice-assistant.tsx
+++ b/artifacts/qleno/src/components/voice-assistant.tsx
@@ -1,0 +1,222 @@
+import { useState, useRef } from "react";
+import { getAuthHeaders } from "@/lib/auth";
+import { Mic, X, Navigation, Loader2, Volume2 } from "lucide-react";
+
+// [voice-assistant 2026-06-08] Push-to-talk field assistant for techs. Browser
+// speech-to-text captures the spoken question, POSTs it to /api/assistant/ask
+// (Claude, scoped to the tech's own jobs), then shows + speaks the answer.
+// Bilingual EN/ES (default English). Read + navigate only. Falls back to a text
+// box when the browser has no SpeechRecognition (e.g. some iOS versions).
+
+const API = import.meta.env.BASE_URL.replace(/\/$/, "");
+const FF = "'Plus Jakarta Sans', sans-serif";
+
+const SR: any = typeof window !== "undefined" ? ((window as any).SpeechRecognition || (window as any).webkitSpeechRecognition) : null;
+
+type Lang = "en" | "es";
+const T: Record<Lang, Record<string, string>> = {
+  en: {
+    title: "Assistant", listening: "Listening…", thinking: "Thinking…",
+    tap: "Tap the mic and ask", navigate: "Navigate", placeholder: "Or type your question…",
+    send: "Ask", unsupported: "Voice isn't available on this browser — type your question.",
+    error: "Something went wrong — try again.", examples: "Try: “What's my schedule today?” · “Navigate to my next job” · “What are the notes for this job?”",
+  },
+  es: {
+    title: "Asistente", listening: "Escuchando…", thinking: "Pensando…",
+    tap: "Toca el micrófono y pregunta", navigate: "Navegar", placeholder: "O escribe tu pregunta…",
+    send: "Preguntar", unsupported: "La voz no está disponible en este navegador — escribe tu pregunta.",
+    error: "Algo salió mal — inténtalo de nuevo.", examples: "Prueba: “¿Cuál es mi horario hoy?” · “Llévame a mi próximo trabajo” · “¿Cuáles son las notas de este trabajo?”",
+  },
+};
+
+export function VoiceAssistant() {
+  const [open, setOpen] = useState(false);
+  const [lang, setLang] = useState<Lang>("en");
+  const [listening, setListening] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [transcript, setTranscript] = useState("");
+  const [answer, setAnswer] = useState("");
+  const [navUrl, setNavUrl] = useState<string | null>(null);
+  const [typed, setTyped] = useState("");
+  const recRef = useRef<any>(null);
+  const t = T[lang];
+  const supported = !!SR;
+
+  function speak(text: string) {
+    try {
+      window.speechSynthesis.cancel();
+      const u = new SpeechSynthesisUtterance(text);
+      u.lang = lang === "es" ? "es-MX" : "en-US";
+      window.speechSynthesis.speak(u);
+    } catch { /* TTS unavailable — text answer still shows */ }
+  }
+
+  async function ask(q: string) {
+    if (!q.trim() || busy) return;
+    setBusy(true); setAnswer(""); setNavUrl(null); setTranscript(q);
+    try {
+      const r = await fetch(`${API}/api/assistant/ask`, {
+        method: "POST",
+        headers: { ...(getAuthHeaders() as Record<string, string>), "Content-Type": "application/json" },
+        body: JSON.stringify({ question: q, language: lang }),
+      });
+      const d = await r.json();
+      if (!r.ok) throw new Error(d?.error || "failed");
+      setAnswer(d.answer || "");
+      setNavUrl(d.navigate_url || null);
+      if (d.answer) speak(d.answer);
+    } catch {
+      setAnswer(t.error);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function startListening() {
+    if (!supported || listening || busy) return;
+    try {
+      const rec = new SR();
+      rec.lang = lang === "es" ? "es-MX" : "en-US";
+      rec.interimResults = false;
+      rec.maxAlternatives = 1;
+      rec.onresult = (ev: any) => {
+        const text = ev?.results?.[0]?.[0]?.transcript ?? "";
+        if (text) ask(text);
+      };
+      rec.onend = () => setListening(false);
+      rec.onerror = () => setListening(false);
+      recRef.current = rec;
+      setTranscript(""); setAnswer(""); setNavUrl(null);
+      setListening(true);
+      rec.start();
+    } catch { setListening(false); }
+  }
+
+  function stopListening() {
+    try { recRef.current?.stop(); } catch { /* noop */ }
+    setListening(false);
+  }
+
+  const close = () => {
+    stopListening();
+    try { window.speechSynthesis.cancel(); } catch { /* noop */ }
+    setOpen(false);
+  };
+
+  return (
+    <>
+      {/* Floating mic button */}
+      {!open && (
+        <button
+          onClick={() => setOpen(true)}
+          aria-label="Open assistant"
+          style={{
+            position: "fixed", right: 18, bottom: 86, zIndex: 200,
+            width: 56, height: 56, borderRadius: "50%", border: "none",
+            background: "var(--brand)", color: "#fff", cursor: "pointer",
+            boxShadow: "0 6px 20px rgba(0,0,0,0.22)", display: "flex",
+            alignItems: "center", justifyContent: "center", fontFamily: FF,
+          }}
+        >
+          <Mic size={24} />
+        </button>
+      )}
+
+      {/* Panel (bottom sheet) */}
+      {open && (
+        <>
+          <div onClick={close} style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,0.45)", zIndex: 210 }} />
+          <div style={{
+            position: "fixed", left: 0, right: 0, bottom: 0, zIndex: 220,
+            background: "#FFFFFF", borderRadius: "18px 18px 0 0",
+            padding: "16px 18px calc(20px + env(safe-area-inset-bottom))",
+            boxShadow: "0 -8px 28px rgba(0,0,0,0.18)", fontFamily: FF,
+            maxHeight: "82vh", display: "flex", flexDirection: "column", gap: 14,
+          }}>
+            {/* Header */}
+            <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+              <span style={{ fontSize: 16, fontWeight: 800, color: "#1A1917" }}>{t.title}</span>
+              <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+                <div style={{ display: "flex", background: "#F4F3F0", borderRadius: 8, padding: 3 }}>
+                  {(["en", "es"] as Lang[]).map(l => (
+                    <button key={l} onClick={() => setLang(l)}
+                      style={{ padding: "4px 12px", borderRadius: 6, border: "none", fontSize: 12, fontWeight: 700, cursor: "pointer", fontFamily: FF,
+                        background: lang === l ? "#fff" : "transparent", color: lang === l ? "#1A1917" : "#9E9B94",
+                        boxShadow: lang === l ? "0 1px 3px rgba(0,0,0,0.08)" : "none" }}>
+                      {l === "en" ? "EN" : "ES"}
+                    </button>
+                  ))}
+                </div>
+                <button onClick={close} aria-label="Close" style={{ background: "none", border: "none", cursor: "pointer", color: "#9E9B94", padding: 4, display: "flex" }}><X size={20} /></button>
+              </div>
+            </div>
+
+            {/* Mic */}
+            <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 8, padding: "6px 0 2px" }}>
+              <button
+                onClick={listening ? stopListening : startListening}
+                disabled={!supported || busy}
+                aria-label={listening ? "Stop" : "Speak"}
+                style={{
+                  width: 76, height: 76, borderRadius: "50%", border: "none", cursor: (!supported || busy) ? "default" : "pointer",
+                  background: listening ? "#DC2626" : "var(--brand)", color: "#fff",
+                  display: "flex", alignItems: "center", justifyContent: "center",
+                  boxShadow: listening ? "0 0 0 8px rgba(220,38,38,0.18)" : "0 4px 16px rgba(0,0,0,0.18)",
+                  opacity: (!supported || busy) ? 0.5 : 1, transition: "background 0.15s, box-shadow 0.15s",
+                }}
+              >
+                {busy ? <Loader2 size={28} className="animate-spin" /> : <Mic size={30} />}
+              </button>
+              <span style={{ fontSize: 13, color: "#6B6860", fontWeight: 600 }}>
+                {busy ? t.thinking : listening ? t.listening : t.tap}
+              </span>
+            </div>
+
+            {/* Transcript */}
+            {transcript && (
+              <div style={{ fontSize: 13, color: "#6B6860", fontStyle: "italic", textAlign: "center" }}>“{transcript}”</div>
+            )}
+
+            {/* Answer */}
+            {answer && (
+              <div style={{ background: "#F0FDF9", border: "1px solid #99E6D3", borderRadius: 12, padding: "14px 16px", display: "flex", gap: 10, alignItems: "flex-start" }}>
+                <Volume2 size={16} style={{ color: "#0A6E5A", flexShrink: 0, marginTop: 2, cursor: "pointer" }} onClick={() => speak(answer)} />
+                <div style={{ fontSize: 14, color: "#04241d", lineHeight: 1.45, flex: 1 }}>{answer}</div>
+              </div>
+            )}
+
+            {/* Navigate */}
+            {navUrl && (
+              <a href={navUrl} target="_blank" rel="noreferrer"
+                style={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 8, padding: "12px 0", background: "#1D4ED8", color: "#fff", borderRadius: 10, fontSize: 15, fontWeight: 700, textDecoration: "none" }}>
+                <Navigation size={18} /> {t.navigate}
+              </a>
+            )}
+
+            {/* Text fallback / typed input */}
+            <div style={{ display: "flex", gap: 8 }}>
+              <input
+                value={typed}
+                onChange={e => setTyped(e.target.value)}
+                onKeyDown={e => { if (e.key === "Enter" && typed.trim()) { ask(typed); setTyped(""); } }}
+                placeholder={t.placeholder}
+                style={{ flex: 1, height: 44, padding: "0 14px", border: "1px solid #E5E2DC", borderRadius: 10, fontSize: 14, color: "#1A1917", fontFamily: FF, outline: "none", boxSizing: "border-box" }}
+              />
+              <button onClick={() => { if (typed.trim()) { ask(typed); setTyped(""); } }} disabled={busy || !typed.trim()}
+                style={{ padding: "0 18px", height: 44, background: "var(--brand)", color: "#fff", border: "none", borderRadius: 10, fontSize: 14, fontWeight: 700, cursor: (busy || !typed.trim()) ? "default" : "pointer", fontFamily: FF, opacity: (busy || !typed.trim()) ? 0.5 : 1 }}>
+                {t.send}
+              </button>
+            </div>
+
+            {!supported && (
+              <div style={{ fontSize: 12, color: "#92400E", background: "#FEF3C7", border: "1px solid #FCD34D", borderRadius: 8, padding: "8px 12px" }}>{t.unsupported}</div>
+            )}
+            {!answer && !transcript && (
+              <div style={{ fontSize: 11, color: "#9E9B94", textAlign: "center", lineHeight: 1.5 }}>{t.examples}</div>
+            )}
+          </div>
+        </>
+      )}
+    </>
+  );
+}

--- a/artifacts/qleno/src/pages/my-jobs.tsx
+++ b/artifacts/qleno/src/pages/my-jobs.tsx
@@ -9,6 +9,7 @@ import { Link } from "wouter";
 import { useEmployeeView } from "@/contexts/employee-view-context";
 import { getJobVisualStatus, STATUS_VISUALS, ensureJobStatusStyles } from "@/lib/job-status";
 import { formatAddress, mapsDirectionsUrl } from "@/lib/format-address";
+import { VoiceAssistant } from "@/components/voice-assistant";
 import { QlenoMark } from "@/components/brand/QlenoMark";
 import { QuoteAttachments } from "@/components/quote-attachments";
 
@@ -956,6 +957,7 @@ export default function MyJobsPage() {
           )}
         </div>
       </div>
+      <VoiceAssistant />
     </div>
   );
 }


### PR DESCRIPTION
## Bilingual voice assistant for field techs (v1)

Maribel/Sal's ask: each cleaner presses a button and asks — in **English or Spanish** — things like *"What's my schedule today?"*, *"Navigate me to my next job"*, *"What are the notes for this job?"*

### How it works
- **Mic** on the tech's **My Jobs** page (floating button) → **browser speech-to-text** captures the question.
- **`POST /api/assistant/ask`** loads **only that tech's own jobs for the day** (`assigned_user_id` = the authenticated user — a tech can never see another tech's data) and asks **Claude** (`claude-haiku-4-5`, reusing the existing `routes/translate.ts` Anthropic setup) to answer **in the chosen language** using only that data. Returns `{answer, navigate_url}`.
- The answer is **shown and spoken** (speech synthesis), and for navigation it surfaces a **"Navigate"** button that opens **Google Maps directions**.
- **EN/ES toggle** (default English). **Typed-question fallback** when the browser has no `SpeechRecognition` (some iOS versions).

### Guardrails
- Read-only + navigate (no voice clock-in yet).
- Claude is instructed to answer **only** from the provided jobs and to say it doesn't have the info otherwise.
- 503s cleanly if `ANTHROPIC_API_KEY` isn't set.

### Verification
- api-server typecheck: assistant.ts + index.ts **0 errors**.
- frontend: voice-assistant.tsx + my-jobs.tsx **0 errors**; `pnpm build` ✓ clean.
- Live behavior depends on `ANTHROPIC_API_KEY` being set in Railway (same key the Job-Notes translation uses) and browser speech support.

### Follow-ups (not in v1)
Voice clock-in/out, "what's my next stop / drive time", wake-word, and a cloud STT option if iOS Safari needs to be rock-solid.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_