### PR TITLE
feat: dispatch count accuracy + voice assistant (main-screen + guardrails)

### DIFF
--- a/artifacts/api-server/src/lib/recurring-jobs.ts
+++ b/artifacts/api-server/src/lib/recurring-jobs.ts
@@ -284,6 +284,17 @@ type ScheduleInput = {
   parking_fee_days?: number[] | null;
 };
 
+// [zero-fee-commercial 2026-06-08] Commercial visits are legitimately $0 when
+// the office bills the amount on a sibling job / monthly contract (Sal's
+// split-billing). The engine GENERATES those so they appear on the board +
+// count. Residential $0 stays blocked — that's the misconfigured "phantom $0
+// job" guard (744 cleaned up in Session 1). Detection is by service_type.
+const COMMERCIAL_SERVICE_TYPES = new Set([
+  "office_cleaning", "common_areas", "retail_store", "medical_office",
+  "ppm_turnover", "post_event", "ppm_common_areas",
+  "commercial_cleaning", "recurring_commercial_cleaning",
+]);
+
 // Pure compute: produces insert-ready rows after the dedupe check, but does NOT
 // insert. Returned rows can be handed to db.insert() directly (live run) or
 // serialized into a dry-run response.
@@ -666,8 +677,12 @@ export async function generateRecurringJobs(
       }
 
       const feeNum = parseFloat(feeTrimmed);
-      if (!Number.isFinite(feeNum) || feeNum === 0) {
-        console.warn(`[recurring-engine] SKIP schedule id=${schedule.id} client=${clientId} — base_fee is 0`);
+      // [zero-fee-commercial 2026-06-08] $0 is legitimate for COMMERCIAL
+      // schedules (split-billed / contract visits). Generate those; keep
+      // skipping non-numeric fees and $0 on RESIDENTIAL schedules (phantom guard).
+      const isCommercialSchedule = COMMERCIAL_SERVICE_TYPES.has(String(schedule.service_type || "").toLowerCase());
+      if (!Number.isFinite(feeNum) || (feeNum === 0 && !isCommercialSchedule)) {
+        console.warn(`[recurring-engine] SKIP schedule id=${schedule.id} client=${clientId} — base_fee is 0 (residential/unusable)`);
         skippedZeroFee++;
         if (skippedSchedules.length < SKIPPED_SCHEDULES_CAP) {
           skippedSchedules.push({

--- a/artifacts/api-server/src/routes/assistant.ts
+++ b/artifacts/api-server/src/routes/assistant.ts
@@ -104,6 +104,12 @@ router.post("/ask", requireAuth, async (req, res) => {
       `Today is ${date}. You are given ONLY this technician's own jobs for the day as JSON. ` +
       `Answer the technician's question using ONLY that data — never invent jobs, addresses, times, or notes. ` +
       `If the answer isn't in the data, say you don't have that information. ` +
+      // [assistant-guardrail 2026-06-08] Defense-in-depth: pay/commission and
+      // other employees' data are NEVER placed in this context, so they can't
+      // leak — but instruct an explicit, friendly refusal so a tech who asks
+      // "what's my coworker's pay/schedule?" or "is her commission higher?"
+      // gets a clean "can't help with that" instead of a guess.
+      `You ONLY have this technician's own job schedule for today — nothing else. You do NOT have pay, wages, commission, hours-as-money, or ANY other person's schedule or information. If asked about pay, commission, earnings, or anyone other than themselves, politely decline in one short sentence (e.g. "I can only help with your own schedule and job details") and set navigate_to to null. Never guess or fabricate such information. ` +
       `Reply in ${langName}. Keep it short and natural for reading aloud (1–3 sentences; for a full schedule give a brief list with time + client). ` +
       `When the technician asks to navigate / get directions / go to a job, choose the intended job (by client name, or the next upcoming job if unspecified) and put its exact address string in "navigate_to". Otherwise "navigate_to" MUST be null. ` +
       `Respond with ONLY a JSON object: {"answer": string, "navigate_to": string|null}. No other text.\n\n` +

--- a/artifacts/api-server/src/routes/dispatch.ts
+++ b/artifacts/api-server/src/routes/dispatch.ts
@@ -92,6 +92,9 @@ router.get("/", requireAuth, async (req, res) => {
         assigned_user_id: jobsTable.assigned_user_id,
         service_type: jobsTable.service_type,
         status: jobsTable.status,
+        // [count-rule 2026-06-08] job_kind distinguishes real visits ('cleaning')
+        // from office events/meetings so the FE can exclude events from the count.
+        job_kind: jobsTable.job_kind,
         scheduled_date: jobsTable.scheduled_date,
         scheduled_time: jobsTable.scheduled_time,
         frequency: jobsTable.frequency,
@@ -694,6 +697,7 @@ router.get("/", requireAuth, async (req, res) => {
         assigned_user_id: j.assigned_user_id,
         service_type: j.service_type,
         status: j.status,
+        job_kind: (j as any).job_kind ?? "cleaning",
         scheduled_date: j.scheduled_date,
         scheduled_time: j.scheduled_time,
         frequency: j.frequency,

--- a/artifacts/qleno/src/components/layout/dashboard-layout.tsx
+++ b/artifacts/qleno/src/components/layout/dashboard-layout.tsx
@@ -7,6 +7,7 @@ import { useGetMe } from "@workspace/api-client-react";
 import { getAuthHeaders } from "@/lib/auth";
 import { useTenantBrand } from "@/lib/tenant-brand";
 import { useIsMobile } from "@/hooks/use-mobile";
+import { VoiceAssistant } from "@/components/voice-assistant";
 import { GlobalSearch } from "@/components/global-search";
 import { ChatPanel } from "@/components/chat-panel";
 import { KeyboardShortcutsOverlay, useKeyboardShortcuts } from "@/components/keyboard-shortcuts";
@@ -813,6 +814,7 @@ export function DashboardLayout({ children, title, fullBleed, onNewJob }: Dashbo
             {(isMoreActive || moreOpen) && <div style={{ width: 4, height: 4, borderRadius: 2, backgroundColor: 'var(--brand)', marginTop: -1 }} />}
           </button>
         </nav>
+        <VoiceAssistant />
       </div>
     );
   }
@@ -1081,6 +1083,7 @@ export function DashboardLayout({ children, title, fullBleed, onNewJob }: Dashbo
           </main>
         )}
       </div>
+      <VoiceAssistant />
     </div>
   );
 }

--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -5763,7 +5763,9 @@ export default function JobsPage() {
   })() : [];
 
   const stats = {
-    total: allJobs.length,
+    // [count-rule 2026-06-08] Every job on the board counts EXCEPT office
+    // events / meetings (job_kind). $0 jobs are real jobs and still count.
+    total: allJobs.filter(j => (j as any).job_kind !== "office_event" && (j as any).job_kind !== "meeting").length,
     complete: allJobs.filter(j => j.status === "complete").length,
     inProgress: allJobs.filter(j => j.status === "in_progress").length,
     revenue: allJobs.reduce((s, j) => s + (j.amount || 0), 0),

--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -6439,6 +6439,10 @@ export default function JobsPage() {
             const techsWorking = filteredData?.employees?.filter(e => e.jobs?.length > 0).length ?? 0;
             const totalTechs = filteredData?.employees?.length ?? 0;
             const scheduledHrs = allJobs.reduce((s, j) => s + (j.duration_minutes || 120) / 60, 0);
+            // [labor-hours 2026-06-08] Total scheduled labor for the day (MC's
+            // "59.2h"). jobs.allowed_hours is team-aggregated, so a plain sum
+            // across the day's jobs = total labor hours across all techs.
+            const laborHrs = allJobs.reduce((s, j: any) => s + (j.allowed_hours != null ? Number(j.allowed_hours) : 0), 0);
             const availableHrs = totalTechs * ((DAY_END - DAY_START) / 60);
             const utilization = availableHrs > 0 ? Math.round((scheduledHrs / availableHrs) * 100) : 0;
             const now = new Date();
@@ -6470,15 +6474,16 @@ export default function JobsPage() {
 
             return (
               <>
-                <div style={{ display: "grid", gridTemplateColumns: "repeat(5, 1fr)", gap: 0, borderBottom: "1px solid #E5E2DC", backgroundColor: "#FFFFFF" }}>
+                <div style={{ display: "grid", gridTemplateColumns: "repeat(6, 1fr)", gap: 0, borderBottom: "1px solid #E5E2DC", backgroundColor: "#FFFFFF" }}>
                   {[
                     { label: "JOBS TODAY", value: stats.total },
                     { label: "REVENUE TODAY", value: `$${stats.revenue.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}` },
+                    { label: "LABOR HRS", value: `${laborHrs.toFixed(1)}h` },
                     { label: "UNASSIGNED", value: stats.unassigned },
                     { label: "TECHS WORKING", value: techsWorking },
                     { label: "AVG UTILIZATION", value: `${utilization}%` },
                   ].map((card, i) => (
-                    <div key={i} style={{ padding: "14px 20px", borderRight: i < 4 ? "1px solid #E5E2DC" : "none" }}>
+                    <div key={i} style={{ padding: "14px 20px", borderRight: i < 5 ? "1px solid #E5E2DC" : "none" }}>
                       <div style={{ fontSize: 26, fontWeight: 600, color: "#1A1917", fontFamily: FF, fontVariantNumeric: "tabular-nums", lineHeight: 1.1 }}>{card.value}</div>
                       <div style={{ fontSize: 11, fontWeight: 500, color: "#6B6860", textTransform: "uppercase", letterSpacing: "0.02em", marginTop: 4 }}>{card.label}</div>
                     </div>


### PR DESCRIPTION
## Dispatch count accuracy + voice assistant (main-screen + guardrails)

Bundled end-of-day work:

### Dispatch count
- **Labor Hrs** KPI card (sums team-aggregated `allowed_hours`) — MC's "… | 59.2h" parity.
- **Count rule:** "Jobs Today" counts every board job **except** office events/meetings (`job_kind`); $0 jobs still count. `job_kind` added to the dispatch payload.
- **$0 commercial visits now generate:** the recurring engine skipped *all* $0-fee schedules (the post-"744 phantom" guard). It now **generates $0-fee occurrences for COMMERCIAL schedules** (your split-billed visits) while keeping residential/null-fee skipped — so visits like 1641 N Lamon stop going missing, without reopening the phantom incident.

### Voice assistant
- **Surfaced on the main screen:** mounted in `DashboardLayout` (above the mobile bottom nav), so the mic is on the dashboard + across the app, not just My Jobs.
- **Cross-employee guardrail:** the endpoint already scopes context to the caller's own jobs and never includes pay/commission/other employees, so that data can't leak; added an explicit system-prompt refusal so coworker-pay/commission questions get a clean "I can only help with your own schedule."

## Verification
- api-server typecheck: changed routes/libs **no new errors** (stash-compared).
- frontend: changed files 0 new errors; `pnpm build` ✓ clean.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj