### PR TITLE
fix(assistant): mic permission feedback + navigate-on-command + next-job time accuracy

### DIFF
--- a/artifacts/api-server/src/routes/assistant.ts
+++ b/artifacts/api-server/src/routes/assistant.ts
@@ -35,9 +35,15 @@ router.post("/ask", requireAuth, async (req, res) => {
     const companyId = req.auth!.companyId as number;
     const question = typeof req.body?.question === "string" ? req.body.question.trim() : "";
     const language = req.body?.language === "es" ? "es" : "en";
+    // Prefer the client's LOCAL date so an evening tech (UTC rollover) still
+    // gets today's jobs, not tomorrow's.
     const date = typeof req.body?.date === "string" && /^\d{4}-\d{2}-\d{2}$/.test(req.body.date)
       ? req.body.date
       : new Date().toISOString().slice(0, 10);
+    // Client's local time (HH:MM) so "my next job" resolves against now.
+    const now = typeof req.body?.now === "string" && /^\d{1,2}:\d{2}/.test(req.body.now)
+      ? req.body.now.slice(0, 5)
+      : null;
 
     if (!question) { res.status(400).json({ error: "question required" }); return; }
     if (question.length > 1000) { res.status(400).json({ error: "question too long" }); return; }
@@ -101,7 +107,7 @@ router.post("/ask", requireAuth, async (req, res) => {
     const langName = LANG_NAME[language];
     const system =
       `You are a friendly, concise voice assistant for a house-cleaning technician using the Qleno app. ` +
-      `Today is ${date}. You are given ONLY this technician's own jobs for the day as JSON. ` +
+      `Today is ${date}.${now ? ` The current local time is ${now}; "my next job" / "next stop" means the earliest job scheduled at or after ${now} (or the first job today if none remain).` : ""} You are given ONLY this technician's own jobs for the day as JSON. ` +
       `Answer the technician's question using ONLY that data — never invent jobs, addresses, times, or notes. ` +
       `If the answer isn't in the data, say you don't have that information. ` +
       // [assistant-guardrail 2026-06-08] Defense-in-depth: pay/commission and

--- a/artifacts/qleno/src/components/voice-assistant.tsx
+++ b/artifacts/qleno/src/components/voice-assistant.tsx
@@ -20,12 +20,20 @@ const T: Record<Lang, Record<string, string>> = {
     tap: "Tap the mic and ask", navigate: "Navigate", placeholder: "Or type your question…",
     send: "Ask", unsupported: "Voice isn't available on this browser — type your question.",
     error: "Something went wrong — try again.", examples: "Try: “What's my schedule today?” · “Navigate to my next job” · “What are the notes for this job?”",
+    micBlocked: "Microphone is blocked. Allow mic access for this site in your browser settings, then try again.",
+    noSpeech: "Didn't catch that — tap the mic and speak right after, or type below.",
+    noMic: "No microphone found on this device — type your question instead.",
+    netErr: "Couldn't reach the speech service — check your connection or type your question.",
   },
   es: {
     title: "Asistente", listening: "Escuchando…", thinking: "Pensando…",
     tap: "Toca el micrófono y pregunta", navigate: "Navegar", placeholder: "O escribe tu pregunta…",
     send: "Preguntar", unsupported: "La voz no está disponible en este navegador — escribe tu pregunta.",
     error: "Algo salió mal — inténtalo de nuevo.", examples: "Prueba: “¿Cuál es mi horario hoy?” · “Llévame a mi próximo trabajo” · “¿Cuáles son las notas de este trabajo?”",
+    micBlocked: "El micrófono está bloqueado. Permite el acceso al micrófono para este sitio y vuelve a intentar.",
+    noSpeech: "No escuché nada — toca el micrófono y habla, o escribe abajo.",
+    noMic: "No se encontró micrófono en este dispositivo — escribe tu pregunta.",
+    netErr: "No se pudo conectar al servicio de voz — revisa tu conexión o escribe tu pregunta.",
   },
 };
 
@@ -38,7 +46,10 @@ export function VoiceAssistant() {
   const [answer, setAnswer] = useState("");
   const [navUrl, setNavUrl] = useState<string | null>(null);
   const [typed, setTyped] = useState("");
+  const [status, setStatus] = useState("");
   const recRef = useRef<any>(null);
+  const gotResultRef = useRef(false);
+  const hadErrorRef = useRef(false);
   const t = T[lang];
   const supported = !!SR;
 
@@ -58,13 +69,29 @@ export function VoiceAssistant() {
       const r = await fetch(`${API}/api/assistant/ask`, {
         method: "POST",
         headers: { ...(getAuthHeaders() as Record<string, string>), "Content-Type": "application/json" },
-        body: JSON.stringify({ question: q, language: lang }),
+        body: JSON.stringify({
+          question: q,
+          language: lang,
+          // Tech's LOCAL date + time so "today" and "my next job" are correct
+          // regardless of server timezone.
+          date: new Date().toLocaleDateString("en-CA"),
+          now: new Date().toLocaleTimeString("en-GB", { hour: "2-digit", minute: "2-digit" }),
+        }),
       });
       const d = await r.json();
       if (!r.ok) throw new Error(d?.error || "failed");
       setAnswer(d.answer || "");
       setNavUrl(d.navigate_url || null);
       if (d.answer) speak(d.answer);
+      // Navigate on command: when the assistant resolved a destination (e.g.
+      // "take me to my next job"), launch Google Maps directions automatically.
+      // Prefer a new tab; fall back to same-tab nav if the browser blocks it
+      // (keeps the Maps hand-off reliable on mobile). The Navigate button stays
+      // as a manual fallback.
+      if (d.navigate_url) {
+        const w = window.open(d.navigate_url, "_blank");
+        if (!w) window.location.href = d.navigate_url;
+      }
     } catch {
       setAnswer(t.error);
     } finally {
@@ -72,24 +99,52 @@ export function VoiceAssistant() {
     }
   }
 
-  function startListening() {
+  async function startListening() {
     if (!supported || listening || busy) return;
+    setStatus(""); setTranscript(""); setAnswer(""); setNavUrl(null);
+    // Pre-flight the microphone permission so a denial gives a clear message
+    // instead of a silent no-op (the #1 reason "the mic does nothing").
+    try {
+      if (navigator.mediaDevices?.getUserMedia) {
+        const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        stream.getTracks().forEach(tr => tr.stop());
+      }
+    } catch {
+      setStatus(t.micBlocked);
+      return;
+    }
     try {
       const rec = new SR();
       rec.lang = lang === "es" ? "es-MX" : "en-US";
       rec.interimResults = false;
       rec.maxAlternatives = 1;
+      gotResultRef.current = false;
+      hadErrorRef.current = false;
       rec.onresult = (ev: any) => {
         const text = ev?.results?.[0]?.[0]?.transcript ?? "";
-        if (text) ask(text);
+        if (text) { gotResultRef.current = true; ask(text); }
       };
-      rec.onend = () => setListening(false);
-      rec.onerror = () => setListening(false);
+      rec.onerror = (ev: any) => {
+        setListening(false);
+        hadErrorRef.current = true;
+        const code = ev?.error;
+        if (code === "not-allowed" || code === "service-not-allowed") setStatus(t.micBlocked);
+        else if (code === "no-speech") setStatus(t.noSpeech);
+        else if (code === "audio-capture") setStatus(t.noMic);
+        else if (code === "network") setStatus(t.netErr);
+        else if (code !== "aborted") setStatus(t.error);
+      };
+      rec.onend = () => {
+        setListening(false);
+        if (!gotResultRef.current && !hadErrorRef.current) setStatus(t.noSpeech);
+      };
       recRef.current = rec;
-      setTranscript(""); setAnswer(""); setNavUrl(null);
       setListening(true);
       rec.start();
-    } catch { setListening(false); }
+    } catch {
+      setListening(false);
+      setStatus(t.error);
+    }
   }
 
   function stopListening() {
@@ -208,6 +263,9 @@ export function VoiceAssistant() {
               </button>
             </div>
 
+            {status && (
+              <div style={{ fontSize: 12, color: "#92400E", background: "#FEF3C7", border: "1px solid #FCD34D", borderRadius: 8, padding: "8px 12px" }}>{status}</div>
+            )}
             {!supported && (
               <div style={{ fontSize: 12, color: "#92400E", background: "#FEF3C7", border: "1px solid #FCD34D", borderRadius: 8, padding: "8px 12px" }}>{t.unsupported}</div>
             )}


### PR DESCRIPTION
## Fixes the "mic does nothing" + adds navigate-on-command

### Why the mic wasn't picking anything up
The browser `SpeechRecognition` errors — **mic permission denied**, **no-speech**, **unsupported browser** — were caught and **silently swallowed** (`onerror`/`onend` just stopped listening). So you tapped, spoke, and saw nothing.

**Fixes:**
- **Mic permission pre-flight** (`getUserMedia`) before starting, so the OS/browser permission prompt reliably appears and a denial is caught.
- **Clear status messages** surfaced in the panel (EN + ES): "Microphone is blocked…", "Didn't catch that…", "No microphone found…", "Couldn't reach the speech service…". No more dead button.

### Navigate on command
When the assistant resolves a destination (e.g. *"take me to my next job"*), it now **auto-opens Google Maps directions** (new tab, same-tab fallback for reliability on mobile) — not just a button.

### "Next job" accuracy
The app now sends the tech's **local date + time**; the prompt uses the time so *"my next job / next stop"* = the earliest job at/after now. Also fixes a UTC-rollover off-by-one that could show an evening tech tomorrow's jobs.

## Heads-up on iOS
If a tech is on **iPhone (Safari or Chrome)**, the browser doesn't implement speech recognition at all — they'll now see a clear "Voice isn't available — type your question" instead of silence. If you need rock-solid iPhone voice, the follow-up is a cloud STT (record audio → transcribe); say the word.

## Verification
- api-server typecheck: assistant.ts **0 errors**; frontend: voice-assistant.tsx **0 errors**; `pnpm build` ✓ clean.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_