### PR TITLE
fix(dispatch): converted quote jobs no longer vanish under a location filter

### DIFF
--- a/artifacts/api-server/src/routes/dispatch.ts
+++ b/artifacts/api-server/src/routes/dispatch.ts
@@ -228,7 +228,14 @@ router.get("/", requireAuth, async (req, res) => {
         eq(jobsTable.company_id, companyId),
         eq(jobsTable.scheduled_date, date),
         sql`${jobsTable.status} != 'cancelled'`,
-        ...(branch_id && branch_id !== "all" ? [eq(jobsTable.branch_id, parseInt(branch_id))] : [])
+        // [quote-convert-branch 2026-06-08] Untagged (NULL-branch) jobs must NOT
+        // vanish under a location filter. Quote→job convert never set branch_id,
+        // so converted jobs "didn't stick" on the board when the office viewed a
+        // specific branch (Oak Lawn). Treat NULL branch as "shows under any
+        // branch" — same fix as the techs-disappearing-under-Oak-Lawn case.
+        ...(branch_id && branch_id !== "all"
+          ? [sql`(${jobsTable.branch_id} = ${parseInt(branch_id)} OR ${jobsTable.branch_id} IS NULL)`]
+          : [])
       ))
       .orderBy(jobsTable.scheduled_time);
 
@@ -1001,7 +1008,7 @@ router.get("/week-summary", requireAuth, async (req, res) => {
     const toStr = (req.query.to as string) || fmt(defaultTo);
 
     const branchCond = branch_id && branch_id !== "all"
-      ? sql`AND j.branch_id = ${parseInt(branch_id)}`
+      ? sql`AND (j.branch_id = ${parseInt(branch_id)} OR j.branch_id IS NULL)`
       : sql``;
 
     // Per-day aggregate. Excludes cancelled. Unassigned = no assigned_user_id


### PR DESCRIPTION
## Priority: jobs scheduled from a quote don't "stick" on the board

### Root cause
The quote→job **convert** endpoint creates the job correctly (status `scheduled`, right date) but **never sets `jobs.branch_id`** — so every converted job is **NULL-branch**. The dispatch board filters `branch_id = <selected location>`, which **excludes NULL-branch jobs**. So whenever the office is viewing a specific location (e.g. **Oak Lawn**), the freshly-scheduled job is filtered out and appears to "not stick." (Normal wizard-created jobs carry a branch, which is why those stick and quote-jobs didn't.)

### Fix
Treat **NULL branch as "shows under any location"** in both the dispatch day query and the week-summary aggregate:
```
branch_id = X  →  (branch_id = X OR branch_id IS NULL)
```
This is the exact pattern already used for the techs-vanishing-under-Oak-Lawn case (`users.ts`). NULL-branch jobs now appear under any selected location; **nothing is ever hidden**. Converted quote-jobs stick immediately.

### Follow-up (not in this PR)
Set `jobs.branch_id` on convert from the client's zip (`getBranchByZip` → branch id) so converted jobs are *tagged* to the right location, not just visible everywhere. Low-risk add; this PR is the immediate unblock.

## Verification
- api-server typecheck: dispatch.ts **5 → 5** (zero new errors).
- Pure read-query change; no schema or write-path changes.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_