### PR TITLE
feat(dashboard,quotes): drillable KPI cards + quotes commercial/residential/quoter breakdown

### DIFF
--- a/artifacts/api-server/src/routes/quotes.ts
+++ b/artifacts/api-server/src/routes/quotes.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import { db } from "@workspace/db";
-import { quotesTable, clientsTable, quoteScopesTable, recurringSchedulesTable } from "@workspace/db/schema";
+import { quotesTable, clientsTable, quoteScopesTable, recurringSchedulesTable, usersTable } from "@workspace/db/schema";
 import { eq, and, desc, count, sql } from "drizzle-orm";
 import { requireAuth, requireRole } from "../lib/auth.js";
 import { logAudit } from "../lib/audit.js";
@@ -124,10 +124,16 @@ router.get("/", requireAuth, async (req, res) => {
         client_last: clientsTable.last_name,
         client_email: clientsTable.email,
         scope_name: quoteScopesTable.name,
+        // [quote-breakdown 2026-06-08] who quoted + residential/commercial split.
+        created_by: quotesTable.created_by,
+        quoted_by_first: usersTable.first_name,
+        quoted_by_last: usersTable.last_name,
+        client_type: clientsTable.client_type,
       })
       .from(quotesTable)
       .leftJoin(clientsTable, eq(quotesTable.client_id, clientsTable.id))
       .leftJoin(quoteScopesTable, eq(quotesTable.scope_id, quoteScopesTable.id))
+      .leftJoin(usersTable, eq(quotesTable.created_by, usersTable.id))
       .where(and(...conditions))
       .orderBy(desc(quotesTable.created_at));
 

--- a/artifacts/qleno/src/components/mobile-dashboard.tsx
+++ b/artifacts/qleno/src/components/mobile-dashboard.tsx
@@ -2,7 +2,8 @@ import { useState, useEffect } from "react";
 import type { ReactNode, CSSProperties } from "react";
 import { getAuthHeaders, getTokenRole } from "@/lib/auth";
 import { useBranch } from "@/contexts/branch-context";
-import { Settings2, ArrowUp, ArrowDown, X, RotateCcw } from "lucide-react";
+import { useLocation } from "wouter";
+import { Settings2, ArrowUp, ArrowDown, X, RotateCcw, ChevronRight } from "lucide-react";
 
 // Role-based, user-customizable MOBILE dashboard. Each user picks which cards
 // to show and in what order; defaults differ by role but every card is in the
@@ -90,8 +91,23 @@ const OWNER_DEFAULT = ["daily_revenue", "jobs_today", "revenue_booked_today", "q
 const OFFICE_DEFAULT = ["jobs_scheduled_today", "late_clockins", "todays_status", "unassigned_jobs", "techs_today", "next_7_days"];
 const roleDefault = (role: string) => (role === "owner" ? OWNER_DEFAULT : OFFICE_DEFAULT);
 
+// Tap a metric card to open the underlying list/report it summarizes.
+const CARD_HREF: Record<string, string> = {
+  leads: "/leads",
+  quotes: "/quotes", closed_quotes: "/quotes", close_rate: "/quotes",
+  quotes_today: "/quotes", closed_quotes_today: "/quotes", close_rate_today: "/quotes",
+  daily_revenue: "/reports/revenue", revenue_booked_today: "/reports/revenue",
+  monthly_revenue: "/reports/revenue", avg_bill: "/reports/revenue", rate_trend: "/reports/revenue",
+  jobs_today: "/dispatch", jobs_scheduled_today: "/dispatch", unassigned_jobs: "/dispatch",
+  todays_status: "/dispatch", late_clockins: "/dispatch", techs_today: "/dispatch", next_7_days: "/dispatch",
+  active_clients: "/customers",
+  retention: "/reports/satisfaction",
+  payroll_pct: "/reports/payroll-to-revenue",
+};
+
 export default function MobileDashboard() {
   const { activeBranchId } = useBranch();
+  const [, setLocation] = useLocation();
   const role = getTokenRole() || "office";
 
   const [data, setData] = useState<CardData | null>(null);
@@ -209,10 +225,13 @@ export default function MobileDashboard() {
           const def = cardDef(k);
           if (!def || !data) return null;
           return (
-            <div key={k} style={{ ...CARD, padding: 16 }}>
+            <div key={k}
+              onClick={CARD_HREF[k] ? () => setLocation(CARD_HREF[k]) : undefined}
+              style={{ ...CARD, padding: 16, position: "relative", cursor: CARD_HREF[k] ? "pointer" : "default" }}>
               <div style={{ fontSize: 12, fontWeight: 700, color: MUTE, textTransform: "uppercase", letterSpacing: "0.06em" }}>{def.label}</div>
               <div style={{ marginTop: 6 }}>{def.render(data)}</div>
               {def.sub && <div style={{ fontSize: 11, color: "#9E9B94", marginTop: 4 }}>{def.sub}</div>}
+              {CARD_HREF[k] && <ChevronRight size={16} style={{ position: "absolute", top: 16, right: 14, color: "#C4C0B8" }} />}
             </div>
           );
         })

--- a/artifacts/qleno/src/pages/quotes.tsx
+++ b/artifacts/qleno/src/pages/quotes.tsx
@@ -56,6 +56,10 @@ interface Quote {
   client_last: string | null;
   client_email: string | null;
   scope_name: string | null;
+  created_by: number | null;
+  quoted_by_first: string | null;
+  quoted_by_last: string | null;
+  client_type: string | null;
 }
 
 interface Stats {
@@ -163,6 +167,24 @@ export default function QuotesPage() {
     );
   });
 
+  // [quote-breakdown 2026-06-08] Residential vs commercial + who quoted, over the
+  // currently-filtered set, so the office can see the mix at a glance.
+  const quoterName = (q: Quote) => `${q.quoted_by_first ?? ""} ${q.quoted_by_last ?? ""}`.trim() || "Unknown";
+  const breakdown = (() => {
+    let residential = 0, commercial = 0, other = 0;
+    const byQuoter: Record<string, number> = {};
+    for (const q of filtered) {
+      const t = (q.client_type || "").toLowerCase();
+      if (t === "commercial") commercial++;
+      else if (t === "residential") residential++;
+      else other++;
+      const n = quoterName(q);
+      byQuoter[n] = (byQuoter[n] || 0) + 1;
+    }
+    const quoters = Object.entries(byQuoter).sort((a, b) => b[1] - a[1]);
+    return { residential, commercial, other, quoters };
+  })();
+
   const statCards = [
     { label: "Total Quotes",          value: stats?.total ?? 0,                icon: FileText,    color: "text-[#5B9BD5]",    bg: "bg-[#5B9BD5]/10" },
     { label: "Awaiting Response",     value: stats?.pending ?? 0,              icon: Send,        color: "text-orange-500",   bg: "bg-orange-50" },
@@ -217,6 +239,31 @@ export default function QuotesPage() {
               </button>
             ))}
           </div>
+
+          {/* Breakdown: residential / commercial + who quoted */}
+          {!isLoading && filtered.length > 0 && (
+            <div style={{ padding: "12px 16px 0", display: "flex", flexDirection: "column", gap: 8 }}>
+              <div style={{ display: "flex", gap: 8 }}>
+                {[
+                  { label: "Residential", n: breakdown.residential },
+                  { label: "Commercial", n: breakdown.commercial },
+                  ...(breakdown.other > 0 ? [{ label: "Unspecified", n: breakdown.other }] : []),
+                ].map(c => (
+                  <div key={c.label} style={{ flex: 1, background: "#FFF", border: "1px solid #E5E2DC", borderRadius: 10, padding: "10px 12px" }}>
+                    <div style={{ fontSize: 11, color: "#9E9B94", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.05em", fontFamily: FF }}>{c.label}</div>
+                    <div style={{ fontSize: 20, fontWeight: 800, color: "#1A1917", fontFamily: FF }}>{c.n}</div>
+                  </div>
+                ))}
+              </div>
+              <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+                {breakdown.quoters.map(([name, n]) => (
+                  <span key={name} style={{ fontSize: 12, color: "#6B6860", background: "#F4F3F0", borderRadius: 999, padding: "4px 10px", fontFamily: FF }}>
+                    {name}: <b style={{ color: "#1A1917" }}>{n}</b>
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
 
           {/* Card list */}
           <div style={{ marginTop: 12, background: "#FFF", borderTop: "1px solid #E5E2DC", borderBottom: "1px solid #E5E2DC" }}>


### PR DESCRIPTION
## Make the dashboard numbers drillable + quotes breakdown

Addresses two things: the dashboard KPIs weren't clickable ("I can't click on anything and see the actual data"), and there was no commercial/residential/who-quoted view of quotes. The numbers were always **real** (Close Rate 44% = 4 closed ÷ 9 quotes) — this surfaces and links them.

### 1. Tappable dashboard cards (mobile)
Each metric card now opens the list/report it summarizes, with a chevron affordance:
- **Leads** → `/leads`
- **Quotes / Closed Quotes / Close Rate** (and the "today" variants) → `/quotes`
- **Daily/Monthly Revenue, Avg Bill, Rate Trend** → `/reports/revenue`
- **Jobs Today / Scheduled / Unassigned / Late Clock-ins / Techs / Next 7 Days** → `/dispatch`
- **Active Clients** → `/customers`, **Retention** → `/reports/satisfaction`, **Payroll %** → `/reports/payroll-to-revenue`

### 2. Quotes: commercial vs residential + who quoted
- The quotes list API now returns **`created_by` + quoter name** and the **client type**.
- The quotes page shows a **breakdown** over the currently-filtered set: **Residential** vs **Commercial** counts, plus a **per-quoter tally** (e.g. "Maribel: 6 · Sal: 3") — directly answering "how many quotes are commercial/residential, who quoted."

## Follow-ups (not in this PR)
- Same breakdown + clickable cards on the **desktop** dashboard/quotes views (this pass is mobile-first, where it was reported).
- Per-row Res/Comm + quoter on each quote card.

## Verification
- api-server typecheck: quotes.ts **20 → 20** (zero new); frontend: quotes.tsx **0**, mobile-dashboard **4 → 4** (pre-existing); `pnpm build` ✓ clean.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_