### PR TITLE
Employee write-paths + attachment 404 + assistant office-location/TTS

### DIFF
--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -1248,6 +1248,29 @@ async function runBookingSchemaGuard(): Promise<void> {
     ` },
     { label: "idx_scorecard_entries_emp",
       stmt: `CREATE INDEX IF NOT EXISTS idx_scorecard_entries_emp ON scorecard_entries(company_id, employee_id)` },
+
+    // ── hr-leave: company_leave_policy column drift (caused GET /balance 500) ──
+    // Drizzle schema declares these but prod was missing them, so
+    // `SELECT * FROM company_leave_policy` in routes/hr-leave.ts errored and
+    // every balance read 500'd. Idempotent backfill.
+    { label: "company_leave_policy.balance_ceiling_hours",
+      stmt: `ALTER TABLE company_leave_policy ADD COLUMN IF NOT EXISTS balance_ceiling_hours NUMERIC(8,2) DEFAULT '80'` },
+    { label: "company_leave_policy.use_it_or_lose_it_alert_lead_days",
+      stmt: `ALTER TABLE company_leave_policy ADD COLUMN IF NOT EXISTS use_it_or_lose_it_alert_lead_days INTEGER DEFAULT 60` },
+
+    // ── PTO / Sick balances (separate buckets, mirror MaidCentral) ──
+    { label: "users.pto_balance_hours",
+      stmt: `ALTER TABLE users ADD COLUMN IF NOT EXISTS pto_balance_hours NUMERIC(8,2) DEFAULT '0'` },
+    { label: "users.sick_balance_hours",
+      stmt: `ALTER TABLE users ADD COLUMN IF NOT EXISTS sick_balance_hours NUMERIC(8,2) DEFAULT '0'` },
+
+    // ── Property → sub-account grouping ──
+    // account_properties.client_id links a property to the client sub-account
+    // that owns it (Cucci PM account → CL-1358 / CL-1359). Nullable = unassigned.
+    { label: "account_properties.client_id",
+      stmt: `ALTER TABLE account_properties ADD COLUMN IF NOT EXISTS client_id INTEGER REFERENCES clients(id)` },
+    { label: "idx_account_properties_client",
+      stmt: `CREATE INDEX IF NOT EXISTS idx_account_properties_client ON account_properties(account_id, client_id)` },
   ];
 
   for (const { label, stmt } of guards) {

--- a/artifacts/api-server/src/routes/assistant.ts
+++ b/artifacts/api-server/src/routes/assistant.ts
@@ -179,9 +179,20 @@ router.post("/ask", requireAuth, async (req, res) => {
       const todayCommission = Math.round(todayJobs.reduce((s, j) => s + j.commission, 0) * 100) / 100;
       const truncated = jobs.length >= OFFICE_JOB_CAP;
 
+      // Office/HQ location so the assistant can answer proximity / "closest job
+      // to the office" questions. Pulled from the companies record.
+      let hqAddress: string | null = null;
+      try {
+        const hq = await db.execute(sql`SELECT address, city, state, zip FROM companies WHERE id = ${companyId} LIMIT 1`);
+        const h: any = hq.rows[0];
+        if (h) hqAddress = fmtAddr(h.address, h.city, h.state, h.zip) || null;
+      } catch { /* non-fatal — assistant still answers non-location questions */ }
+
       system =
         `You are an assistant for the OFFICE/OWNER (role: ${role}) of a residential & commercial cleaning company using Qleno. ` +
         `Today is ${date} (${weekdayOf(date)})${now ? `, current local time ${now}` : ""}. ` +
+        `The office / HQ location is: ${hqAddress || "not set"}. ` +
+        `When asked which job is closest/nearest to the office (optionally at a given time), compare each job's address against the office location and pick the nearest — reason by city and ZIP proximity when you can't compute exact distance — then name that job, its client, time, and address. If the office location is "not set" or you genuinely can't tell, say so. ` +
         `You have the company's scheduled jobs from ${fromDate} (${weekdayOf(fromDate)}) through ${toDate} (${weekdayOf(toDate)}) — about two weeks. Each job includes its "date" and "day" (weekday). ` +
         `Answer about ANY date or range in that window: "today", "tomorrow" (${addDaysYmd(date, 1)}), "this week", "next week" (the Mon–Sun after this one), or a specific date — by filtering jobs on their "date"/"day" and summing as needed. ` +
         `If asked about a date OUTSIDE ${fromDate}..${toDate}, say you only have the schedule through ${toDate}. ` +

--- a/artifacts/api-server/src/routes/attachments.ts
+++ b/artifacts/api-server/src/routes/attachments.ts
@@ -51,16 +51,17 @@ router.post("/", requireAuth, upload.single("file"), async (req, res) => {
     let file_type: string | undefined;
     let file_size: number | undefined;
     if (req.file) {
-      const fileBuffer = fs.readFileSync(req.file.path);
-      const base64 = fileBuffer.toString("base64");
-      file_url = `data:${req.file.mimetype};base64,${base64.substring(0, 100)}...stored`;
       file_type = req.file.mimetype;
       file_size = req.file.size;
-      const publicDir = path.join(process.cwd(), "public", "uploads");
-      fs.mkdirSync(publicDir, { recursive: true });
-      const destPath = path.join(publicDir, req.file.filename);
+      // Store under the dir the static handler serves (app.ts) and expose the
+      // canonical /api/uploads/ URL. The previous code wrote to public/uploads
+      // and stored a bare /uploads/ URL — neither served, so every download
+      // 404'd. Mirrors quote-attachments.ts.
+      const uploadsDir = process.env.UPLOADS_DIR ?? path.join(process.cwd(), "uploads");
+      fs.mkdirSync(uploadsDir, { recursive: true });
+      const destPath = path.join(uploadsDir, req.file.filename);
       fs.renameSync(req.file.path, destPath);
-      file_url = `/uploads/${req.file.filename}`;
+      file_url = `/api/uploads/${req.file.filename}`;
     }
     const [attachment] = await db.insert(clientAttachmentsTable).values({
       company_id: req.auth!.companyId,

--- a/artifacts/api-server/src/routes/hr-leave.ts
+++ b/artifacts/api-server/src/routes/hr-leave.ts
@@ -22,6 +22,8 @@ router.get("/balance/:employee_id", requireAuth, requireRole("owner", "admin", "
         leave_balance_hours: usersTable.leave_balance_hours,
         leave_balance_activated: usersTable.leave_balance_activated,
         benefit_year_start: usersTable.benefit_year_start,
+        pto_balance_hours: usersTable.pto_balance_hours,
+        sick_balance_hours: usersTable.sick_balance_hours,
       })
       .from(usersTable)
       .where(and(eq(usersTable.id, employeeId), eq(usersTable.company_id, companyId)))
@@ -51,6 +53,8 @@ router.get("/balance/:employee_id", requireAuth, requireRole("owner", "admin", "
       employee_id: employeeId,
       leave_balance_hours: employee.leave_balance_hours,
       leave_balance_activated: employee.leave_balance_activated,
+      pto_balance_hours: employee.pto_balance_hours,
+      sick_balance_hours: employee.sick_balance_hours,
       activation_date: activationDate,
       policy: policy ?? null,
       usage,
@@ -58,6 +62,41 @@ router.get("/balance/:employee_id", requireAuth, requireRole("owner", "admin", "
   } catch (err) {
     console.error("leave balance error:", err);
     return res.status(500).json({ error: "Failed to fetch leave balance" });
+  }
+});
+
+// Set an employee's PTO and/or Sick balance directly (admin "Update PTO" /
+// "Update Sick"). Absolute set, not a delta. Also the load path for the
+// reconciliation import of MaidCentral PTO/sick balances.
+router.put("/balance/:employee_id", requireAuth, requireRole("owner", "admin"), async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId!;
+    const employeeId = parseInt(req.params.employee_id);
+    if (isNaN(employeeId)) return res.status(400).json({ error: "Invalid employee_id" });
+
+    const updates: Record<string, string> = {};
+    if (req.body.pto_balance_hours !== undefined) updates.pto_balance_hours = String(parseFloat(req.body.pto_balance_hours) || 0);
+    if (req.body.sick_balance_hours !== undefined) updates.sick_balance_hours = String(parseFloat(req.body.sick_balance_hours) || 0);
+    if (req.body.leave_balance_hours !== undefined) updates.leave_balance_hours = String(parseFloat(req.body.leave_balance_hours) || 0);
+    if (Object.keys(updates).length === 0) {
+      return res.status(400).json({ error: "Provide pto_balance_hours, sick_balance_hours, or leave_balance_hours" });
+    }
+
+    const [row] = await db
+      .update(usersTable)
+      .set(updates)
+      .where(and(eq(usersTable.id, employeeId), eq(usersTable.company_id, companyId)))
+      .returning({
+        id: usersTable.id,
+        pto_balance_hours: usersTable.pto_balance_hours,
+        sick_balance_hours: usersTable.sick_balance_hours,
+        leave_balance_hours: usersTable.leave_balance_hours,
+      });
+    if (!row) return res.status(404).json({ error: "Employee not found" });
+    return res.json(row);
+  } catch (err) {
+    console.error("leave balance update error:", err);
+    return res.status(500).json({ error: "Failed to update leave balance" });
   }
 });
 

--- a/artifacts/api-server/src/routes/users.ts
+++ b/artifacts/api-server/src/routes/users.ts
@@ -235,7 +235,16 @@ router.post("/bulk-reset-password", requireAuth, requireRole("owner", "admin"), 
 
 router.post("/", requireAuth, requireRole("owner", "admin"), async (req, res) => {
   try {
-    const { email, first_name, last_name, role, pay_rate, pay_type, hire_date, phone } = req.body;
+    const {
+      email, first_name, last_name, role, pay_rate, pay_type, hire_date, phone,
+      personal_email, address, city, state, zip, skills,
+    } = req.body;
+
+    // Guard required fields — an undefined email previously threw on
+    // .toLowerCase() and surfaced as an opaque 500 / apparent hang.
+    if (!email || !first_name) {
+      return res.status(400).json({ error: "email and first_name are required" });
+    }
 
     const tempPassword = Math.random().toString(36).slice(-8);
     const password_hash = await bcrypt.hash(tempPassword, 10);
@@ -244,15 +253,22 @@ router.post("/", requireAuth, requireRole("owner", "admin"), async (req, res) =>
       .insert(usersTable)
       .values({
         company_id: req.auth!.companyId,
-        email: email.toLowerCase(),
+        email: String(email).toLowerCase(),
         password_hash,
         first_name,
         last_name,
-        role,
-        pay_rate,
-        pay_type,
-        hire_date,
-        phone,
+        role: role || "technician",
+        // Empty-string numerics would error on a NUMERIC column.
+        ...(pay_rate !== undefined && pay_rate !== "" && { pay_rate }),
+        ...(pay_type && { pay_type }),
+        ...(hire_date && { hire_date }),
+        ...(phone !== undefined && { phone }),
+        ...(personal_email !== undefined && { personal_email }),
+        ...(address !== undefined && { address }),
+        ...(city !== undefined && { city }),
+        ...(state !== undefined && { state }),
+        ...(zip !== undefined && { zip }),
+        ...(Array.isArray(skills) && { skills }),
       })
       .returning();
 
@@ -380,6 +396,12 @@ router.put("/:id", requireAuth, requireRole("owner", "admin", "office"), async (
       // [pay-matrix 2026-04-29] 4-cell pay matrix.
       residential_pay_type, residential_pay_rate,
       commercial_pay_type,  commercial_pay_rate,
+      // [2026-06-06] Information-tab fields the profile form sends but the
+      // route previously dropped silently (personal_email, address, …) —
+      // caused "Save Changes" to no-op. Only columns that exist on users.
+      personal_email, address, city, state, zip, dob, gender,
+      employment_type, bank_name, emergency_contact_name,
+      emergency_contact_phone, notes,
     } = req.body;
 
     // Only the OWNER may change a user's role (grant/revoke admin etc.).
@@ -421,10 +443,10 @@ router.put("/:id", requireAuth, requireRole("owner", "admin", "office"), async (
         ...(first_name && { first_name }),
         ...(last_name && { last_name }),
         ...(role && { role }),
-        ...(pay_rate !== undefined && { pay_rate }),
+        ...(pay_rate !== undefined && { pay_rate: pay_rate === "" ? null : pay_rate }),
         ...(pay_type && { pay_type }),
         ...(is_active !== undefined && { is_active }),
-        ...(hire_date !== undefined && { hire_date }),
+        ...(hire_date !== undefined && { hire_date: hire_date === "" ? null : hire_date }),
         ...(phone !== undefined && { phone }),
         ...(skills !== undefined && { skills }),
         ...(avatar_url !== undefined && { avatar_url }),
@@ -432,6 +454,19 @@ router.put("/:id", requireAuth, requireRole("owner", "admin", "office"), async (
         ...(residential_pay_rate !== undefined && { residential_pay_rate: String(residential_pay_rate) }),
         ...(commercial_pay_type  !== undefined && { commercial_pay_type }),
         ...(commercial_pay_rate  !== undefined && { commercial_pay_rate:  String(commercial_pay_rate) }),
+        // Information-tab fields (added 2026-06-06).
+        ...(personal_email !== undefined && { personal_email }),
+        ...(address !== undefined && { address }),
+        ...(city !== undefined && { city }),
+        ...(state !== undefined && { state }),
+        ...(zip !== undefined && { zip }),
+        ...(dob !== undefined && { dob: dob === "" ? null : dob }),
+        ...(gender !== undefined && { gender }),
+        ...(employment_type !== undefined && { employment_type }),
+        ...(bank_name !== undefined && { bank_name }),
+        ...(emergency_contact_name !== undefined && { emergency_contact_name }),
+        ...(emergency_contact_phone !== undefined && { emergency_contact_phone }),
+        ...(notes !== undefined && { notes }),
       })
       .where(and(
         eq(usersTable.id, userId),

--- a/artifacts/qleno/src/App.tsx
+++ b/artifacts/qleno/src/App.tsx
@@ -16,6 +16,8 @@ const EmployeeProfilePage = lazy(() => import("@/pages/employee-profile"));
 const AcceptInvitePage    = lazy(() => import("@/pages/accept-invite"));
 const CustomersPage       = lazy(() => import("@/pages/customers"));
 const CustomerProfilePage = lazy(() => import("@/pages/customer-profile"));
+const AddClientPage       = lazy(() => import("@/pages/add-client"));
+const AddEmployeePage     = lazy(() => import("@/pages/add-employee"));
 const InvoicesPage        = lazy(() => import("@/pages/invoices"));
 const CompanyPage         = lazy(() => import("@/pages/company"));
 const LoyaltyPage         = lazy(() => import("@/pages/loyalty"));
@@ -132,8 +134,10 @@ function Router() {
         <Route path="/reports/jobs" component={JobsListPage} />
         <Route path="/recurring" component={RecurringSchedulesPage} />
         <Route path="/employees/clocks" component={ClockMonitorPage} />
+        <Route path="/employees/new" component={AddEmployeePage} />
         <Route path="/employees/:id" component={EmployeeProfilePage} />
         <Route path="/employees" component={EmployeesPage} />
+        <Route path="/customers/new" component={AddClientPage} />
         <Route path="/customers/:id" component={CustomerProfilePage} />
         <Route path="/customers" component={CustomersPage} />
         <Route path="/invoices/:id" component={InvoiceDetailPage} />

--- a/artifacts/qleno/src/components/voice-assistant.tsx
+++ b/artifacts/qleno/src/components/voice-assistant.tsx
@@ -55,10 +55,34 @@ export function VoiceAssistant() {
 
   function speak(text: string) {
     try {
-      window.speechSynthesis.cancel();
-      const u = new SpeechSynthesisUtterance(text);
-      u.lang = lang === "es" ? "es-MX" : "en-US";
-      window.speechSynthesis.speak(u);
+      const synth = window.speechSynthesis;
+      if (!synth || !text) return;
+      const targetLang = lang === "es" ? "es-MX" : "en-US";
+      const prefix = lang === "es" ? "es" : "en";
+      let done = false;
+      const doSpeak = () => {
+        if (done) return;
+        done = true;
+        synth.cancel();
+        const u = new SpeechSynthesisUtterance(text);
+        u.lang = targetLang;
+        const voices = synth.getVoices();
+        const v = voices.find(vc => vc.lang === targetLang)
+          || voices.find(vc => vc.lang?.toLowerCase().startsWith(prefix));
+        if (v) u.voice = v;
+        try { synth.resume(); } catch { /* Chrome can leave synthesis paused */ }
+        synth.speak(u);
+      };
+      // First call after page load: Chrome's getVoices() is empty until the
+      // 'voiceschanged' event, and speaking before voices load silently no-ops
+      // ("doesn't talk back"). Wait for voices, with a timeout fallback.
+      if (synth.getVoices().length === 0) {
+        const handler = () => { synth.removeEventListener("voiceschanged", handler); doSpeak(); };
+        synth.addEventListener("voiceschanged", handler);
+        setTimeout(doSpeak, 300);
+      } else {
+        doSpeak();
+      }
     } catch { /* TTS unavailable — text answer still shows */ }
   }
 

--- a/artifacts/qleno/src/pages/add-client.tsx
+++ b/artifacts/qleno/src/pages/add-client.tsx
@@ -1,0 +1,141 @@
+import { useState } from "react";
+import { useLocation } from "wouter";
+import { DashboardLayout } from "@/components/layout/dashboard-layout";
+import { getAuthHeaders } from "@/lib/auth";
+import { toast } from "sonner";
+import { ArrowLeft, Loader2 } from "lucide-react";
+
+const API = import.meta.env.BASE_URL.replace(/\/$/, "");
+const FF = "'Plus Jakarta Sans', sans-serif";
+
+const FREQ_OPTIONS = [
+  { value: "", label: "—" },
+  { value: "weekly", label: "Weekly" },
+  { value: "biweekly", label: "Bi-weekly" },
+  { value: "monthly", label: "Monthly" },
+  { value: "on_demand", label: "On Demand" },
+];
+
+type Form = {
+  first_name: string; last_name: string; email: string; phone: string;
+  company_name: string; address: string; city: string; state: string;
+  zip: string; frequency: string; notes: string; send_welcome: boolean;
+};
+
+const EMPTY: Form = {
+  first_name: "", last_name: "", email: "", phone: "", company_name: "",
+  address: "", city: "", state: "IL", zip: "", frequency: "", notes: "",
+  send_welcome: false,
+};
+
+export default function AddClientPage() {
+  const [, navigate] = useLocation();
+  const [form, setForm] = useState<Form>(EMPTY);
+  const [saving, setSaving] = useState(false);
+  const set = <K extends keyof Form>(key: K, value: Form[K]) => setForm(prev => ({ ...prev, [key]: value }));
+  const canSave = form.first_name.trim().length > 0 && form.last_name.trim().length > 0 && !saving;
+
+  const handleSave = async () => {
+    if (!canSave) return;
+    setSaving(true);
+    try {
+      const res = await fetch(`${API}/api/clients`, {
+        method: "POST",
+        headers: { ...(getAuthHeaders() as Record<string, string>), "Content-Type": "application/json" },
+        body: JSON.stringify({
+          first_name: form.first_name.trim(),
+          last_name: form.last_name.trim(),
+          email: form.email.trim() || undefined,
+          phone: form.phone.trim() || undefined,
+          company_name: form.company_name.trim() || undefined,
+          address: form.address.trim() || undefined,
+          city: form.city.trim() || undefined,
+          state: form.state.trim() || undefined,
+          zip: form.zip.trim() || undefined,
+          frequency: form.frequency || undefined,
+          notes: form.notes.trim() || undefined,
+          send_welcome: form.send_welcome,
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.message || `Failed to create client (${res.status})`);
+      }
+      const created = await res.json();
+      toast.success(`${form.first_name} ${form.last_name} added`);
+      navigate(`/customers/${created.id}`);
+    } catch (e: any) {
+      toast.error(e.message || "Failed to create client");
+      setSaving(false);
+    }
+  };
+
+  const label: React.CSSProperties = {
+    display: "block", fontSize: "11px", fontWeight: 600, color: "#9E9B94",
+    textTransform: "uppercase", letterSpacing: "0.06em", marginBottom: "6px",
+  };
+  const input: React.CSSProperties = {
+    width: "100%", padding: "9px 12px", border: "1px solid #E5E2DC", borderRadius: "8px",
+    fontSize: "14px", color: "#1A1917", backgroundColor: "#FFFFFF", fontFamily: FF, boxSizing: "border-box",
+  };
+  const field = (key: keyof Form, lbl: string, opts?: { type?: string; required?: boolean; placeholder?: string }) => (
+    <div>
+      <label style={label}>{lbl}{opts?.required ? " *" : ""}</label>
+      <input style={input} type={opts?.type || "text"} placeholder={opts?.placeholder}
+        value={form[key] as string} onChange={e => set(key, e.target.value as any)} />
+    </div>
+  );
+
+  return (
+    <DashboardLayout>
+      <div style={{ maxWidth: "760px", margin: "0 auto", fontFamily: FF }}>
+        <button onClick={() => navigate("/customers")}
+          style={{ display: "flex", alignItems: "center", gap: "6px", background: "none", border: "none", color: "#9E9B94", fontSize: "13px", cursor: "pointer", padding: 0, marginBottom: "16px", fontFamily: FF }}>
+          <ArrowLeft size={14} strokeWidth={2} /> Clients
+        </button>
+        <h1 style={{ margin: "0 0 20px", fontSize: "22px", fontWeight: 700, color: "#1A1917" }}>Add Client</h1>
+        <div style={{ backgroundColor: "#FFFFFF", border: "1px solid #E5E2DC", borderRadius: "12px", padding: "24px", display: "flex", flexDirection: "column", gap: "18px" }}>
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "16px" }}>
+            {field("first_name", "First name", { required: true })}
+            {field("last_name", "Last name", { required: true })}
+            {field("email", "Email", { type: "email" })}
+            {field("phone", "Phone", { type: "tel" })}
+          </div>
+          {field("company_name", "Company name", { placeholder: "Optional — for commercial clients" })}
+          {field("address", "Street address")}
+          <div style={{ display: "grid", gridTemplateColumns: "2fr 1fr 1fr", gap: "16px" }}>
+            {field("city", "City")}
+            {field("state", "State")}
+            {field("zip", "Zip")}
+          </div>
+          <div>
+            <label style={label}>Frequency</label>
+            <select style={input} value={form.frequency} onChange={e => set("frequency", e.target.value)}>
+              {FREQ_OPTIONS.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+            </select>
+          </div>
+          <div>
+            <label style={label}>Notes</label>
+            <textarea style={{ ...input, minHeight: "80px", resize: "vertical" }}
+              value={form.notes} onChange={e => set("notes", e.target.value)} />
+          </div>
+          <label style={{ display: "flex", alignItems: "center", gap: "8px", fontSize: "13px", color: "#1A1917", cursor: "pointer" }}>
+            <input type="checkbox" checked={form.send_welcome} onChange={e => set("send_welcome", e.target.checked)} />
+            Send welcome message
+          </label>
+          <div style={{ display: "flex", justifyContent: "flex-end", gap: "10px", paddingTop: "4px" }}>
+            <button onClick={() => navigate("/customers")} disabled={saving}
+              style={{ padding: "9px 18px", border: "1px solid #E5E2DC", borderRadius: "8px", backgroundColor: "#FFFFFF", color: "#6B7280", fontSize: "13px", fontWeight: 600, cursor: saving ? "default" : "pointer", fontFamily: FF }}>
+              Cancel
+            </button>
+            <button onClick={handleSave} disabled={!canSave}
+              style={{ display: "flex", alignItems: "center", gap: "8px", padding: "9px 18px", border: "none", borderRadius: "8px", backgroundColor: canSave ? "var(--brand)" : "#9E9B94", color: "#FFFFFF", fontSize: "13px", fontWeight: 600, cursor: canSave ? "pointer" : "not-allowed", fontFamily: FF }}>
+              {saving && <Loader2 size={14} className="animate-spin" />}
+              {saving ? "Saving…" : "Create Client"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/artifacts/qleno/src/pages/add-employee.tsx
+++ b/artifacts/qleno/src/pages/add-employee.tsx
@@ -1,0 +1,145 @@
+import { useState } from "react";
+import { useLocation } from "wouter";
+import { DashboardLayout } from "@/components/layout/dashboard-layout";
+import { getAuthHeaders } from "@/lib/auth";
+import { toast } from "sonner";
+import { ArrowLeft, Loader2 } from "lucide-react";
+
+const API = import.meta.env.BASE_URL.replace(/\/$/, "");
+const FF = "'Plus Jakarta Sans', sans-serif";
+
+const ROLES = [
+  { value: "technician", label: "Technician" },
+  { value: "team_lead", label: "Team Lead" },
+  { value: "office", label: "Office" },
+  { value: "admin", label: "Admin" },
+  { value: "owner", label: "Owner" },
+];
+
+type Form = {
+  first_name: string; last_name: string; email: string; personal_email: string;
+  phone: string; role: string; address: string; city: string; state: string;
+  zip: string; hire_date: string; pay_type: string; pay_rate: string;
+};
+
+const EMPTY: Form = {
+  first_name: "", last_name: "", email: "", personal_email: "", phone: "",
+  role: "technician", address: "", city: "", state: "IL", zip: "",
+  hire_date: "", pay_type: "hourly", pay_rate: "",
+};
+
+export default function AddEmployeePage() {
+  const [, navigate] = useLocation();
+  const [form, setForm] = useState<Form>(EMPTY);
+  const [saving, setSaving] = useState(false);
+  const set = <K extends keyof Form>(k: K, v: Form[K]) => setForm(p => ({ ...p, [k]: v }));
+  const canSave = form.first_name.trim() && form.email.trim() && !saving;
+
+  async function handleSave() {
+    if (!canSave) return;
+    setSaving(true);
+    try {
+      const res = await fetch(`${API}/api/users`, {
+        method: "POST",
+        headers: { ...(getAuthHeaders() as Record<string, string>), "Content-Type": "application/json" },
+        body: JSON.stringify({
+          first_name: form.first_name.trim(),
+          last_name: form.last_name.trim(),
+          email: form.email.trim(),
+          personal_email: form.personal_email.trim() || undefined,
+          phone: form.phone.trim() || undefined,
+          role: form.role,
+          address: form.address.trim() || undefined,
+          city: form.city.trim() || undefined,
+          state: form.state.trim() || undefined,
+          zip: form.zip.trim() || undefined,
+          hire_date: form.hire_date || undefined,
+          pay_type: form.pay_type,
+          pay_rate: form.pay_rate.trim() || undefined,
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.message || body.error || `Failed to create employee (${res.status})`);
+      }
+      const created = await res.json();
+      toast.success(`${form.first_name} ${form.last_name} added`);
+      navigate(`/employees/${created.id}`);
+    } catch (e: any) {
+      toast.error(e.message || "Failed to create employee");
+      setSaving(false);
+    }
+  }
+
+  const label: React.CSSProperties = {
+    display: "block", fontSize: "11px", fontWeight: 600, color: "#9E9B94",
+    textTransform: "uppercase", letterSpacing: "0.06em", marginBottom: "6px",
+  };
+  const input: React.CSSProperties = {
+    width: "100%", padding: "9px 12px", border: "1px solid #E5E2DC", borderRadius: "8px",
+    fontSize: "14px", color: "#1A1917", backgroundColor: "#FFFFFF", fontFamily: FF, boxSizing: "border-box",
+  };
+  const field = (key: keyof Form, lbl: string, opts?: { type?: string; required?: boolean; placeholder?: string }) => (
+    <div>
+      <label style={label}>{lbl}{opts?.required ? " *" : ""}</label>
+      <input style={input} type={opts?.type || "text"} placeholder={opts?.placeholder}
+        value={form[key]} onChange={e => set(key, e.target.value as any)} />
+    </div>
+  );
+
+  return (
+    <DashboardLayout>
+      <div style={{ maxWidth: "760px", margin: "0 auto", fontFamily: FF }}>
+        <button onClick={() => navigate("/employees")}
+          style={{ display: "flex", alignItems: "center", gap: "6px", background: "none", border: "none", color: "#9E9B94", fontSize: "13px", cursor: "pointer", padding: 0, marginBottom: "16px", fontFamily: FF }}>
+          <ArrowLeft size={14} strokeWidth={2} /> Team
+        </button>
+        <h1 style={{ margin: "0 0 20px", fontSize: "22px", fontWeight: 700, color: "#1A1917" }}>Add Team Member</h1>
+        <div style={{ backgroundColor: "#FFFFFF", border: "1px solid #E5E2DC", borderRadius: "12px", padding: "24px", display: "flex", flexDirection: "column", gap: "18px" }}>
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "16px" }}>
+            {field("first_name", "First name", { required: true })}
+            {field("last_name", "Last name")}
+            {field("email", "Login email", { type: "email", required: true })}
+            {field("personal_email", "Personal email", { type: "email" })}
+            {field("phone", "Phone", { type: "tel" })}
+            <div>
+              <label style={label}>Role</label>
+              <select style={input} value={form.role} onChange={e => set("role", e.target.value)}>
+                {ROLES.map(r => <option key={r.value} value={r.value}>{r.label}</option>)}
+              </select>
+            </div>
+          </div>
+          {field("address", "Street address")}
+          <div style={{ display: "grid", gridTemplateColumns: "2fr 1fr 1fr", gap: "16px" }}>
+            {field("city", "City")}
+            {field("state", "State")}
+            {field("zip", "Zip")}
+          </div>
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: "16px" }}>
+            {field("hire_date", "Hire date", { type: "date" })}
+            <div>
+              <label style={label}>Pay type</label>
+              <select style={input} value={form.pay_type} onChange={e => set("pay_type", e.target.value)}>
+                <option value="hourly">Hourly</option>
+                <option value="fee_split">Fee Split</option>
+                <option value="per_job">Per Job</option>
+              </select>
+            </div>
+            {field("pay_rate", "Pay rate", { type: "number" })}
+          </div>
+          <div style={{ display: "flex", justifyContent: "flex-end", gap: "10px", paddingTop: "4px" }}>
+            <button onClick={() => navigate("/employees")} disabled={saving}
+              style={{ padding: "9px 18px", border: "1px solid #E5E2DC", borderRadius: "8px", backgroundColor: "#FFFFFF", color: "#6B7280", fontSize: "13px", fontWeight: 600, cursor: saving ? "default" : "pointer", fontFamily: FF }}>
+              Cancel
+            </button>
+            <button onClick={handleSave} disabled={!canSave}
+              style={{ display: "flex", alignItems: "center", gap: "8px", padding: "9px 18px", border: "none", borderRadius: "8px", backgroundColor: canSave ? "var(--brand)" : "#9E9B94", color: "#FFFFFF", fontSize: "13px", fontWeight: 600, cursor: canSave ? "pointer" : "not-allowed", fontFamily: FF }}>
+              {saving && <Loader2 size={14} className="animate-spin" />}
+              {saving ? "Saving…" : "Create Team Member"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/artifacts/qleno/src/pages/employees.tsx
+++ b/artifacts/qleno/src/pages/employees.tsx
@@ -130,7 +130,7 @@ export default function EmployeesPage() {
               <input type="checkbox" checked={showInactive} onChange={e => setShowInactive(e.target.checked)} style={{ cursor: 'pointer' }} />
               Show inactive
             </label>
-            <button onClick={() => setAddModal(true)}
+            <button onClick={() => navigate('/employees/new')}
               style={{ display: 'flex', alignItems: 'center', gap: '8px', padding: '8px 16px', backgroundColor: 'var(--brand)', color: '#FFFFFF', borderRadius: '8px', fontSize: '13px', fontWeight: 600, border: 'none', cursor: 'pointer' }}>
               <Plus size={14} strokeWidth={2} /> Add Team Member
             </button>

--- a/lib/db/src/schema/account_properties.ts
+++ b/lib/db/src/schema/account_properties.ts
@@ -3,6 +3,7 @@ import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod/v4";
 import { companiesTable } from "./companies";
 import { accountsTable } from "./accounts";
+import { clientsTable } from "./clients";
 
 export const propertyTypeEnum = pgEnum("property_type", [
   "apartment_building", "condo", "common_area", "office", "retail", "other",
@@ -12,6 +13,10 @@ export const accountPropertiesTable = pgTable("account_properties", {
   id: serial("id").primaryKey(),
   account_id: integer("account_id").references(() => accountsTable.id).notNull(),
   company_id: integer("company_id").references(() => companiesTable.id).notNull(),
+  // Sub-account that owns this property (nullable; null = unassigned). Lets a
+  // parent account (e.g. Cucci PM) group its properties under client
+  // sub-accounts (CL-1358 / CL-1359). See phes-data-migration guard.
+  client_id: integer("client_id").references(() => clientsTable.id),
   property_name: text("property_name"),
   address: text("address").notNull(),
   city: text("city"),

--- a/lib/db/src/schema/users.ts
+++ b/lib/db/src/schema/users.ts
@@ -75,6 +75,11 @@ export const usersTable = pgTable("users", {
   benefit_year_start: date("benefit_year_start"),
   leave_balance_hours: numeric("leave_balance_hours", { precision: 8, scale: 2 }).default("0"),
   leave_balance_activated: boolean("leave_balance_activated").default(false),
+  // PTO and Sick tracked separately (mirror MaidCentral). leave_balance_hours
+  // stays as the legacy single bucket; these two are the canonical balances
+  // shown in the employee Attendance tab and set via PUT /api/hr-leave/balance.
+  pto_balance_hours: numeric("pto_balance_hours", { precision: 8, scale: 2 }).default("0"),
+  sick_balance_hours: numeric("sick_balance_hours", { precision: 8, scale: 2 }).default("0"),
   invite_token: text("invite_token"),
   invite_sent_at: timestamp("invite_sent_at"),
   invite_accepted_at: timestamp("invite_accepted_at"),


### PR DESCRIPTION
Re-baselined onto current main; build-verified. P1 employee write-paths (hr-leave 500, PTO/Sick balances + GET/PUT, Save Changes allowlist, employee create + /employees/new, Add Client hang /customers/new), attachment 404 fix, assistant office/HQ location + TTS reliability, account_properties.client_id schema. Held: multi-tech split wiring, scorecard import, routing extension (waits for MC mapping), PTO/Sick in-UI buttons (next deploy). Generated with Claude Code.