### PR TITLE
fix(assistant): speak answers on iOS + answer "which job right now" from schedule

### DIFF
--- a/artifacts/api-server/src/routes/assistant.ts
+++ b/artifacts/api-server/src/routes/assistant.ts
@@ -156,6 +156,7 @@ router.post("/ask", requireAuth, async (req, res) => {
         `You can answer about the WHOLE company's day using ONLY the provided data: total revenue, total commission, each technician's schedule, and per-technician commission. ` +
         `Use ONLY this data — never invent numbers, jobs, names, or addresses; if it isn't here, say you don't have it. ` +
         `For a specific technician's commission or schedule, match jobs by that tech's name (case-insensitive) and sum their commission. All money is USD. ` +
+        `When asked which job a technician is on "right now" / "currently" / "at the moment", DO answer from the schedule and the current local time — do not refuse for lack of GPS. The current job is the latest one whose scheduled start time is at or before ${now || "now"}; name that client and time, and mention the next upcoming job if one remains. Add a brief caveat that this is based on the schedule, not live tracking. If the tech's first job today is still in the future, say they haven't started yet and give the first job's time. ` +
         `Reply in ${langName}, concise and natural for reading aloud (a few sentences; brief lists for schedules). ` +
         `When asked to navigate / get directions to a job, put that job's exact address in "navigate_to"; otherwise null. ` +
         `Respond with ONLY a JSON object: {"answer": string, "navigate_to": string|null}. No other text.\n\n` +

--- a/artifacts/qleno/src/components/voice-assistant.tsx
+++ b/artifacts/qleno/src/components/voice-assistant.tsx
@@ -62,8 +62,23 @@ export function VoiceAssistant() {
     } catch { /* TTS unavailable — text answer still shows */ }
   }
 
+  // iOS Safari only lets speechSynthesis play if it was first invoked inside a
+  // user gesture (the tap). Our real speak() runs after an await fetch, by
+  // which point the gesture is gone — so on iPhone the answer never spoke.
+  // Prime the engine with a silent utterance on the tap to unlock it; the
+  // later speak() then plays. No-op on browsers that don't need it.
+  function primeSpeech() {
+    try {
+      const u = new SpeechSynthesisUtterance("");
+      u.volume = 0;
+      window.speechSynthesis.speak(u);
+    } catch { /* noop */ }
+  }
+
   async function ask(q: string) {
     if (!q.trim() || busy) return;
+    // Unlock iOS TTS while we're still in the tap/submit gesture (typed path).
+    primeSpeech();
     setBusy(true); setAnswer(""); setNavUrl(null); setTranscript(q);
     try {
       const r = await fetch(`${API}/api/assistant/ask`, {
@@ -107,6 +122,9 @@ export function VoiceAssistant() {
 
   async function startListening() {
     if (!supported || listening || busy) return;
+    // Unlock iOS TTS now, while we're inside the mic-tap gesture — the spoken
+    // answer fires later from an async callback that iOS won't let speak cold.
+    primeSpeech();
     setStatus(""); setTranscript(""); setAnswer(""); setNavUrl(null);
     // Pre-flight the microphone permission so a denial gives a clear message
     // instead of a silent no-op (the #1 reason "the mic does nothing").


### PR DESCRIPTION
## Two field issues

From the owner using the voice assistant on iPhone:
1. **It doesn't speak the answer** — only shows text.
2. **It refuses "what job is X on right now"** — says it needs live tracking, instead of using the schedule it already has.

## Fixes

**Voice output on iOS** (`voice-assistant.tsx`)
TTS was already coded (`speak()`), but it's called *after* the `await fetch`. iOS Safari only allows `speechSynthesis` to play when first invoked inside a user gesture — and by the time the answer comes back, the tap gesture is gone, so iOS silently dropped it. Fix: prime the speech engine with a silent utterance during the actual gesture (the mic tap and the Ask submit). Once unlocked, the later spoken answer plays. No-op on browsers that don't need it.

**"Right now" reasoning** (`assistant.ts`)
The owner prompt included the current local time but never told the model to use it, so it punted. Now it's instructed to infer the current job from the schedule — the latest job whose start time is at/before now — name that client + time, mention the next upcoming job, and add a brief "based on the schedule, not live tracking" caveat instead of refusing.

## Verification
- Frontend build passes; `assistant.ts` typechecks clean (no new errors).

## Note
Both still require `ANTHROPIC_API_KEY` set in Railway for the assistant to answer at all — unchanged.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_