### PR TITLE
fix(auth): hard-wire Juliana Loredo access on cold start

### DIFF
--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -1929,6 +1929,111 @@ async function runDianaVasquezAccessRepair(): Promise<void> {
 }
 
 /**
+ * Juliana Loredo access repair (2026-06-09, ad-hoc).
+ *
+ * Same pattern as the Diana Vasquez repair from yesterday — office could
+ * not get Juliana into the app via the LMS Admin bulk-reset flow; she
+ * tried `chicago23` and got "Invalid email or password." Two known
+ * failure modes here:
+ *   - password isn't actually `chicago23` (e.g. the bulk reset never
+ *     reached her row), or
+ *   - her stored email has mixed case and the auth route's
+ *     `WHERE email = LOWER(?)` lookup misses (auth.ts:25).
+ *
+ * Unlike Diana, we don't know Juliana's intended email — Sal was typing
+ * "Loredo_juliana@yahoo.com" but the stored value could be anything.
+ * So we DO NOT overwrite her email. Instead we:
+ *   1. Resolve her by name in company_id=1 (Phes only).
+ *   2. Lowercase the stored email if it isn't already (defensive fix
+ *      for the auth lookup).
+ *   3. Ensure password_hash = bcrypt('chicago23').
+ *   4. Ensure is_active = true and archived_at = NULL.
+ *   5. Stamp password_reset_to_chicago23_at = NOW().
+ *
+ * The console.log line prints her actual stored email so Sal can copy
+ * the canonical address out of the Railway deploy log and send it to
+ * Juliana exactly. No-op once everything is in target state — the
+ * bcrypt.compare + string-equality guards make every subsequent boot
+ * one cheap SELECT + compare.
+ */
+async function runJulianaLoredoAccessRepair(): Promise<void> {
+  const PHES = 1;
+  const FIRST = "Juliana";
+  const LAST = "Loredo";
+  const TARGET_PASSWORD = "chicago23";
+
+  const rows = await db.execute<{
+    id: number;
+    email: string;
+    password_hash: string;
+    is_active: boolean;
+    archived_at: Date | null;
+  }>(sql`
+    SELECT id, email, password_hash, is_active, archived_at
+    FROM users
+    WHERE company_id = ${PHES}
+      AND LOWER(first_name) = LOWER(${FIRST})
+      AND LOWER(last_name) = LOWER(${LAST})
+      AND role != 'owner'
+    ORDER BY id ASC
+    LIMIT 1
+  `);
+  const row = ((rows as any).rows ?? rows)[0] as
+    | {
+        id: number;
+        email: string;
+        password_hash: string;
+        is_active: boolean;
+        archived_at: Date | null;
+      }
+    | undefined;
+
+  if (!row) {
+    console.log(
+      `[juliana-loredo-access-repair] no Juliana Loredo row in company_id=${PHES}; skipping`,
+    );
+    return;
+  }
+
+  const lowercasedEmail = row.email.trim().toLowerCase();
+  const emailNeedsNormalize = lowercasedEmail !== row.email;
+
+  const hashMatches = await bcrypt
+    .compare(TARGET_PASSWORD, row.password_hash)
+    .catch(() => false);
+  const activeOk = row.is_active === true;
+  const unarchivedOk = row.archived_at === null;
+
+  if (hashMatches && !emailNeedsNormalize && activeOk && unarchivedOk) {
+    console.log(
+      `[juliana-loredo-access-repair] user_id=${row.id} email=${lowercasedEmail} already in target state; no-op`,
+    );
+    return;
+  }
+
+  const newHash = hashMatches
+    ? row.password_hash
+    : await bcrypt.hash(TARGET_PASSWORD, 10);
+
+  await db.execute(sql`
+    UPDATE users
+    SET
+      email = ${lowercasedEmail},
+      password_hash = ${newHash},
+      is_active = true,
+      archived_at = NULL,
+      password_reset_to_chicago23_at = NOW()
+    WHERE id = ${row.id}
+  `);
+
+  console.log(
+    `[juliana-loredo-access-repair] user_id=${row.id} email=${lowercasedEmail} updated: ` +
+      `email_normalized=${emailNeedsNormalize} hash_rewritten=${!hashMatches} ` +
+      `reactivated=${!activeOk} unarchived=${!unarchivedOk}`,
+  );
+}
+
+/**
  * QA sandbox account repurpose (2026-05-15 sprint, pre-sprint task).
  *
  * Dispatch created an audit fixture user during Phase 6 — repurpose it
@@ -2668,6 +2773,12 @@ export async function runPhesDataMigration(): Promise<void> {
     await runDianaVasquezAccessRepair();
   } catch (err: any) {
     console.warn("[phes-migration] diana-vasquez-access-repair — non-fatal:", err?.message ?? err);
+  }
+
+  try {
+    await runJulianaLoredoAccessRepair();
+  } catch (err: any) {
+    console.warn("[phes-migration] juliana-loredo-access-repair — non-fatal:", err?.message ?? err);
   }
 
   try {


### PR DESCRIPTION
## Problem

Juliana Loredo cannot log in. Sal tried `chicago23` against the email he believed was hers (`Loredo_juliana@yahoo.com`) and got `Invalid email or password`.

Same class of issue as Diana yesterday (#351). Two failure modes possible:
1. **Wrong password** — the LMS Admin bulk-reset flow didn't actually land on her row
2. **Email case mismatch** — the `/login` handler at `routes/auth.ts:25` does `WHERE email = LOWER(?)`, so if her stored email is mixed-case (e.g. `Loredo_juliana@yahoo.com` with uppercase `L`), the lookup misses even when the password is right

## What this does

Adds `runJulianaLoredoAccessRepair()` to the `runPhesDataMigration()` chain. On every cold start (idempotent, scoped to `company_id = 1`):

1. Resolve Juliana Loredo by `LOWER(first_name) = 'juliana' AND LOWER(last_name) = 'loredo'`
2. **Lowercase the stored email** if it isn't already (defensive fix for the case-sensitive lookup) — does NOT change the address itself
3. Ensure `password_hash = bcrypt('chicago23', 10)` — `bcrypt.compare` guards against rewrites
4. Ensure `is_active = true` and `archived_at = NULL`
5. Stamp `password_reset_to_chicago23_at = NOW()`

**Key difference from #351:** we do NOT overwrite her email (Sal wasn't sure what it actually was). Instead the function logs her actual stored email so we can read it from the Railway deploy:

```
[juliana-loredo-access-repair] user_id=X email=<canonical> updated: email_normalized=... hash_rewritten=... reactivated=... unarchived=...
```

After merge, copy that email out of the boot log and send it to Juliana along with the password `chicago23`.

## Scope / safety

- One file changed: `artifacts/api-server/src/phes-data-migration.ts`
- Scoped to `company_id = 1`
- Idempotent: bcrypt-compare + string-equality guards make subsequent boots a no-op
- Typecheck: **849 errors — matches baseline, zero new**
- Non-fatal `try/catch` wrap so failure can't block deploy

https://claude.ai/code/session_013rJ4N4vgqZWB986x8D6Ahh

---
_Generated by [Claude Code](https://claude.ai/code/session_013rJ4N4vgqZWB986x8D6Ahh)_