### PR TITLE
feat(my-jobs): photo album access, optional after-photo clock-out gate (default off), day navigation

### DIFF
--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -40,6 +40,7 @@ async function runBookingSchemaGuard(): Promise<void> {
     { label: "jobs.office_notes_updated_by", stmt: "ALTER TABLE jobs ADD COLUMN IF NOT EXISTS office_notes_updated_by INTEGER" },
     { label: "jobs.office_notes_updated_at", stmt: "ALTER TABLE jobs ADD COLUMN IF NOT EXISTS office_notes_updated_at TIMESTAMP" },
     { label: "companies.flag_missing_gps", stmt: "ALTER TABLE companies ADD COLUMN IF NOT EXISTS flag_missing_gps BOOLEAN NOT NULL DEFAULT true" },
+    { label: "companies.require_after_photo_for_clockout", stmt: "ALTER TABLE companies ADD COLUMN IF NOT EXISTS require_after_photo_for_clockout BOOLEAN NOT NULL DEFAULT false" },
     { label: "jobs.last_cleaned_response", stmt: "ALTER TABLE jobs ADD COLUMN IF NOT EXISTS last_cleaned_response TEXT" },
     { label: "jobs.last_cleaned_flag",     stmt: "ALTER TABLE jobs ADD COLUMN IF NOT EXISTS last_cleaned_flag TEXT" },
     { label: "jobs.overage_disclaimer_acknowledged", stmt: "ALTER TABLE jobs ADD COLUMN IF NOT EXISTS overage_disclaimer_acknowledged BOOLEAN DEFAULT false" },

--- a/artifacts/api-server/src/routes/companies.ts
+++ b/artifacts/api-server/src/routes/companies.ts
@@ -106,6 +106,7 @@ router.patch("/me", requireAuth, async (req, res) => {
       sms_complete_enabled, twilio_from_number,
       geofence_enabled, geofence_clockin_radius_ft, geofence_clockout_radius_ft,
       geofence_override_allowed, geofence_soft_mode, flag_missing_gps,
+      require_after_photo_for_clockout,
     } = req.body;
 
     const patch: Record<string, unknown> = {};
@@ -125,6 +126,7 @@ router.patch("/me", requireAuth, async (req, res) => {
     if (geofence_override_allowed !== undefined) patch.geofence_override_allowed = geofence_override_allowed;
     if (geofence_soft_mode !== undefined) patch.geofence_soft_mode = geofence_soft_mode;
     if (flag_missing_gps !== undefined) patch.flag_missing_gps = flag_missing_gps;
+    if (require_after_photo_for_clockout !== undefined) patch.require_after_photo_for_clockout = require_after_photo_for_clockout;
     const {
       default_payment_terms_residential, default_payment_terms_commercial,
       default_invoice_notes_residential, default_invoice_notes_commercial,

--- a/artifacts/api-server/src/routes/jobs.ts
+++ b/artifacts/api-server/src/routes/jobs.ts
@@ -419,6 +419,9 @@ router.post("/", requireAuth, async (req, res) => {
 router.get("/my-jobs", requireAuth, async (req, res) => {
   try {
     const today = new Date().toISOString().split("T")[0];
+    // Day navigation: the tech view can page to other days. Default = today.
+    const reqDate = typeof req.query.date === "string" && /^\d{4}-\d{2}-\d{2}$/.test(req.query.date)
+      ? req.query.date : today;
     let userId = req.auth!.userId;
     if (req.auth!.role === "owner" && req.query.employee_id) {
       userId = parseInt(req.query.employee_id as string);
@@ -440,6 +443,17 @@ router.get("/my-jobs", requireAuth, async (req, res) => {
       // users with NULL company_id and no user_companies rows.
       return res.json({ data: [] });
     }
+
+    // After-photo-before-clock-out gate is a per-tenant owner setting (default
+    // off). Surface it so the tech UI can show/hide the requirement banner +
+    // disabled clock-out button. Read from the tech's auth company — the same
+    // company the clock-out route enforces against.
+    const companyCfg = await db
+      .select({ require_after_photo_for_clockout: companiesTable.require_after_photo_for_clockout })
+      .from(companiesTable)
+      .where(eq(companiesTable.id, req.auth!.companyId))
+      .limit(1);
+    const requireAfterPhoto = companyCfg[0]?.require_after_photo_for_clockout ?? false;
 
     const jobs = await db
       .select({
@@ -488,11 +502,11 @@ router.get("/my-jobs", requireAuth, async (req, res) => {
       .where(and(
         inArray(jobsTable.company_id, tenantIds),
         eq(jobsTable.assigned_user_id, userId),
-        eq(jobsTable.scheduled_date, today),
+        eq(jobsTable.scheduled_date, reqDate),
       ))
       .orderBy(jobsTable.scheduled_time);
 
-    if (jobs.length === 0) return res.json({ data: [] });
+    if (jobs.length === 0) return res.json({ data: [], require_after_photo_for_clockout: requireAfterPhoto });
 
     const jobIds = jobs.map(j => j.id);
 
@@ -540,6 +554,7 @@ router.get("/my-jobs", requireAuth, async (req, res) => {
         after_photo_count: photoMap.get(j.id)?.after || 0,
         time_clock_entry: clockMap.get(j.id) || null,
       })),
+      require_after_photo_for_clockout: requireAfterPhoto,
     });
   } catch (err) {
     console.error("My jobs error:", err);

--- a/artifacts/api-server/src/routes/timeclock.ts
+++ b/artifacts/api-server/src/routes/timeclock.ts
@@ -368,8 +368,8 @@ router.post("/:id/clock-out", requireAuth, async (req, res) => {
       .groupBy(jobsTable.id)
       .limit(1);
 
-    if (!jobData[0] || jobData[0].after_count === 0) {
-      return res.status(400).json({ error: "PHOTOS_REQUIRED", message: "At least 1 after photo required before clock out" });
+    if (!jobData[0]) {
+      return res.status(404).json({ error: "Not Found", message: "Job not found for this clock entry" });
     }
 
     const company = await db
@@ -377,6 +377,7 @@ router.post("/:id/clock-out", requireAuth, async (req, res) => {
         geofence_enabled: companiesTable.geofence_enabled,
         geofence_clockout_radius_ft: companiesTable.geofence_clockout_radius_ft,
         geofence_soft_mode: companiesTable.geofence_soft_mode,
+        require_after_photo_for_clockout: companiesTable.require_after_photo_for_clockout,
       })
       .from(companiesTable)
       .where(eq(companiesTable.id, req.auth!.companyId))
@@ -386,6 +387,12 @@ router.post("/:id/clock-out", requireAuth, async (req, res) => {
     const geofenceEnabled = cfg?.geofence_enabled ?? true;
     const clockOutRadius = cfg?.geofence_clockout_radius_ft ?? 1000;
     const softMode = cfg?.geofence_soft_mode ?? false;
+
+    // After-photo gate is OPT-IN (default off). Only block clock-out on a
+    // missing "after" photo when the owner enabled it in Clock In/Out settings.
+    if ((cfg?.require_after_photo_for_clockout ?? false) && jobData[0].after_count === 0) {
+      return res.status(400).json({ error: "PHOTOS_REQUIRED", message: "At least 1 after photo required before clock out" });
+    }
 
     const jobLat = jobData[0].job_lat ? parseFloat(jobData[0].job_lat) : null;
     const jobLng = jobData[0].job_lng ? parseFloat(jobData[0].job_lng) : null;

--- a/artifacts/qleno/src/pages/company.tsx
+++ b/artifacts/qleno/src/pages/company.tsx
@@ -1677,6 +1677,7 @@ function ClockInOutTab() {
     geofence_override_allowed: true,
     geofence_soft_mode: false,
     flag_missing_gps: true,
+    require_after_photo_for_clockout: false,
   });
 
   useEffect(() => {
@@ -1691,6 +1692,7 @@ function ClockInOutTab() {
           geofence_override_allowed: d.geofence_override_allowed ?? true,
           geofence_soft_mode: d.geofence_soft_mode ?? false,
           flag_missing_gps: d.flag_missing_gps ?? true,
+          require_after_photo_for_clockout: d.require_after_photo_for_clockout ?? false,
         });
       })
       .catch(() => {})
@@ -1748,6 +1750,16 @@ function ClockInOutTab() {
             <p style={{ fontSize: 12, color: '#6B7280', margin: 0 }}>Show a "GPS unavailable" flag on a job when a tech clocked in with no location captured</p>
           </div>
           <ToggleSwitch checked={settings.flag_missing_gps} onChange={v => setSettings(s => ({ ...s, flag_missing_gps: v }))} />
+        </div>
+      </div>
+
+      <div style={CARD}>
+        <div style={ROW}>
+          <div>
+            <p style={{ fontSize: 14, fontWeight: 700, color: '#1A1917', margin: '0 0 3px' }}>Require after photo before clock-out</p>
+            <p style={{ fontSize: 12, color: '#6B7280', margin: 0 }}>Block a tech from clocking out of a job until at least one "after" photo is uploaded. Off by default.</p>
+          </div>
+          <ToggleSwitch checked={settings.require_after_photo_for_clockout} onChange={v => setSettings(s => ({ ...s, require_after_photo_for_clockout: v }))} />
         </div>
       </div>
 

--- a/artifacts/qleno/src/pages/my-jobs.tsx
+++ b/artifacts/qleno/src/pages/my-jobs.tsx
@@ -165,7 +165,7 @@ function PhotoGrid({ jobId, type, photos, onUploaded }: {
         >
           {uploading ? "…" : "+"}
         </button>
-        <input ref={inputRef} type="file" accept="image/*" capture="environment" style={{ display: "none" }} onChange={handleFile} />
+        <input ref={inputRef} type="file" accept="image/*" style={{ display: "none" }} onChange={handleFile} />
       </div>
     </div>
   );
@@ -301,7 +301,7 @@ function AddNote({ jobId, onSaved }: { jobId: number; onSaved: () => void }) {
   );
 }
 
-function JobCard({ job, empPos, onRefresh, isPreviewMode, prevJobId }: { job: Job; empPos: { lat: number; lng: number } | null; onRefresh: () => void; isPreviewMode?: boolean; prevJobId?: number | null }) {
+function JobCard({ job, empPos, onRefresh, isPreviewMode, prevJobId, requireAfterPhoto }: { job: Job; empPos: { lat: number; lng: number } | null; onRefresh: () => void; isPreviewMode?: boolean; prevJobId?: number | null; requireAfterPhoto?: boolean }) {
   const { toast } = useToast();
   const qc = useQueryClient();
   const [geoLoading, setGeoLoading] = useState(false);
@@ -314,6 +314,8 @@ function JobCard({ job, empPos, onRefresh, isPreviewMode, prevJobId }: { job: Jo
   const entry = job.time_clock_entry;
   const isClockedIn = entry && !entry.clock_out_at;
   const isComplete = job.status === "complete" || (entry && entry.clock_out_at);
+  // After-photo gate only applies when the owner enabled it (default off).
+  const photoGate = !!requireAfterPhoto && photosAfter.length === 0;
 
   const loadPhotos = useCallback(async () => {
     const res = await apiFetch(`/jobs/${job.id}/photos`);
@@ -636,7 +638,7 @@ function JobCard({ job, empPos, onRefresh, isPreviewMode, prevJobId }: { job: Jo
       <PhotoGrid jobId={job.id} type="before" photos={photosBefore} onUploaded={loadPhotos} />
       <PhotoGrid jobId={job.id} type="after" photos={photosAfter} onUploaded={loadPhotos} />
 
-      {isClockedIn && photosAfter.length === 0 && (
+      {isClockedIn && photoGate && (
         <div style={{ backgroundColor: "#FEF3C7", borderLeft: "3px solid #F59E0B", borderRadius: "0 6px 6px 0", padding: "10px 12px", marginTop: 12 }}>
           <p style={{ fontSize: 12, color: "#92400E", margin: 0 }}>After photos required before clock-out</p>
         </div>
@@ -712,7 +714,7 @@ function JobCard({ job, empPos, onRefresh, isPreviewMode, prevJobId }: { job: Jo
             <button
               onClick={() => {
                 if (isPreviewMode) return;
-                if (photosAfter.length === 0) {
+                if (photoGate) {
                   toast({ variant: "destructive", title: "After photo required", description: "Upload at least 1 after photo first" });
                   return;
                 }
@@ -723,15 +725,15 @@ function JobCard({ job, empPos, onRefresh, isPreviewMode, prevJobId }: { job: Jo
               style={{
                 width: "100%", height: 48, borderRadius: 10, border: "none",
                 fontSize: 15, fontWeight: 600,
-                cursor: (isPreviewMode || photosAfter.length === 0) ? "not-allowed" : "pointer",
-                backgroundColor: (isPreviewMode || photosAfter.length === 0) ? "#F3F4F6" : "#166534",
-                color: (isPreviewMode || photosAfter.length === 0) ? "#9E9B94" : "#FFFFFF",
+                cursor: (isPreviewMode || photoGate) ? "not-allowed" : "pointer",
+                backgroundColor: (isPreviewMode || photoGate) ? "#F3F4F6" : "#166534",
+                color: (isPreviewMode || photoGate) ? "#9E9B94" : "#FFFFFF",
                 opacity: isPreviewMode ? 0.6 : 1,
                 transition: "opacity 0.15s",
                 fontFamily: "'Plus Jakarta Sans', sans-serif",
               }}
             >
-              {clockOutMutation.isPending || geoLoading ? "Getting location…" : photosAfter.length === 0 ? "Clock Out — add after photo first" : "Clock Out"}
+              {clockOutMutation.isPending || geoLoading ? "Getting location…" : photoGate ? "Clock Out — add after photo first" : "Clock Out"}
             </button>
           </div>
         ) : (
@@ -778,6 +780,11 @@ function JobCard({ job, empPos, onRefresh, isPreviewMode, prevJobId }: { job: Jo
   );
 }
 
+// Local YYYY-MM-DD (not UTC) so the day the tech sees matches their wall clock.
+function ymd(d: Date) {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
 export default function MyJobsPage() {
   const { employeeView, exitView } = useEmployeeView();
   const token = useAuthStore(state => state.token);
@@ -794,7 +801,18 @@ export default function MyJobsPage() {
   }
   const initials = userInfo ? `${userInfo.firstName[0] || ""}${userInfo.lastName[0] || ""}`.toUpperCase() : "?";
 
-  const today = new Date().toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric" });
+  // Day navigation: tech can page to other days; defaults to today.
+  const todayYmd = ymd(new Date());
+  const [selectedDate, setSelectedDate] = useState(todayYmd);
+  const isToday = selectedDate === todayYmd;
+  const selectedLabel = (() => {
+    const [y, m, d] = selectedDate.split("-").map(Number);
+    return new Date(y, m - 1, d).toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric" });
+  })();
+  const shiftDay = (delta: number) => {
+    const [y, m, d] = selectedDate.split("-").map(Number);
+    setSelectedDate(ymd(new Date(y, m - 1, d + delta)));
+  };
 
   useEffect(() => {
     let watchId: number | null = null;
@@ -817,10 +835,11 @@ export default function MyJobsPage() {
   }, []);
 
   const { data, isLoading, refetch } = useQuery({
-    queryKey: ["my-jobs", employeeView?.employeeId],
+    queryKey: ["my-jobs", employeeView?.employeeId, selectedDate],
     queryFn: async () => {
-      const url = employeeView ? `/jobs/my-jobs?employee_id=${employeeView.employeeId}` : "/jobs/my-jobs";
-      const res = await apiFetch(url);
+      const params = new URLSearchParams({ date: selectedDate });
+      if (employeeView) params.set("employee_id", String(employeeView.employeeId));
+      const res = await apiFetch(`/jobs/my-jobs?${params.toString()}`);
       if (!res.ok) throw new Error("Failed");
       return res.json();
     },
@@ -828,6 +847,7 @@ export default function MyJobsPage() {
   });
 
   const jobs: Job[] = data?.data || [];
+  const requireAfterPhoto: boolean = data?.require_after_photo_for_clockout ?? false;
   const activeJobs = jobs.filter(j => j.status !== "cancelled" && (!j.time_clock_entry || !j.time_clock_entry.clock_out_at || j.status !== "complete"));
   const upcomingJobs = jobs.filter(j => j.status === "scheduled" && !j.time_clock_entry);
   // [day-complete 2026-06-04] The day is DERIVED, never a button: it's done
@@ -871,6 +891,26 @@ export default function MyJobsPage() {
           </div>
         </div>
 
+        {/* Day navigation — page to other days; tap the date to jump back to today. */}
+        <div style={{
+          display: "flex", alignItems: "center", justifyContent: "space-between",
+          padding: "8px 12px", background: "#FFFFFF", borderBottom: "1px solid #E5E2DC",
+        }}>
+          <button type="button" onClick={() => shiftDay(-1)} aria-label="Previous day"
+            style={{ width: 36, height: 36, borderRadius: 8, border: "1px solid #E5E2DC", background: "#FFFFFF", color: "#1A1917", fontSize: 18, fontWeight: 700, cursor: "pointer", lineHeight: 1, fontFamily: "inherit" }}>
+            ‹
+          </button>
+          <button type="button" onClick={() => setSelectedDate(todayYmd)}
+            style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 1, background: "none", border: "none", cursor: "pointer", fontFamily: "inherit" }}>
+            <span style={{ fontSize: 14, fontWeight: 700, color: "#1A1917" }}>{isToday ? "Today" : selectedLabel}</span>
+            <span style={{ fontSize: 11, color: "#9E9B94" }}>{isToday ? selectedLabel : "Tap for today"}</span>
+          </button>
+          <button type="button" onClick={() => shiftDay(1)} aria-label="Next day"
+            style={{ width: 36, height: 36, borderRadius: 8, border: "1px solid #E5E2DC", background: "#FFFFFF", color: "#1A1917", fontSize: 18, fontWeight: 700, cursor: "pointer", lineHeight: 1, fontFamily: "inherit" }}>
+            ›
+          </button>
+        </div>
+
         {employeeView && (
           <div style={{ background: "var(--brand, #00C9A0)", padding: "10px 18px", display: "flex", alignItems: "center", gap: 10, flexShrink: 0 }}>
             <Eye size={14} color="#fff" />
@@ -895,7 +935,7 @@ export default function MyJobsPage() {
             <div style={{ textAlign: "center", padding: 40, color: "#9E9B94", fontSize: 14 }}>Loading your jobs…</div>
           ) : jobs.length === 0 ? (
             <div style={{ textAlign: "center", padding: 40 }}>
-              <p style={{ fontSize: 16, fontWeight: 600, color: "#1A1917", margin: "0 0 6px" }}>No jobs today</p>
+              <p style={{ fontSize: 16, fontWeight: 600, color: "#1A1917", margin: "0 0 6px" }}>{isToday ? "No jobs today" : `No jobs on ${selectedLabel}`}</p>
               <p style={{ fontSize: 13, color: "#9E9B94", margin: 0 }}>Check back or contact your manager</p>
             </div>
           ) : (
@@ -908,7 +948,7 @@ export default function MyJobsPage() {
                     </div>
                     <div>
                       <p style={{ fontSize: 16, fontWeight: 800, color: "#1A1917", margin: 0 }}>Day complete</p>
-                      <p style={{ fontSize: 12, color: "#9E9B94", margin: 0 }}>{today}</p>
+                      <p style={{ fontSize: 12, color: "#9E9B94", margin: 0 }}>{selectedLabel}</p>
                     </div>
                   </div>
                   <div style={{ display: "flex", gap: 10 }}>
@@ -928,7 +968,7 @@ export default function MyJobsPage() {
               )}
               {activeJobs.map((job, i) => (
                 <JobCard key={job.id} job={job} empPos={empPos} onRefresh={refetch} isPreviewMode={!!employeeView}
-                  prevJobId={i > 0 ? activeJobs[i - 1].id : null} />
+                  prevJobId={i > 0 ? activeJobs[i - 1].id : null} requireAfterPhoto={requireAfterPhoto} />
               ))}
               {upcomingJobs.length > 0 && (
                 <div style={{ marginTop: 20 }}>

--- a/lib/db/src/schema/companies.ts
+++ b/lib/db/src/schema/companies.ts
@@ -32,6 +32,11 @@ export const companiesTable = pgTable("companies", {
   geofence_clockout_radius_ft: integer("geofence_clockout_radius_ft").notNull().default(1000),
   geofence_override_allowed: boolean("geofence_override_allowed").notNull().default(true),
   geofence_soft_mode: boolean("geofence_soft_mode").notNull().default(false),
+  // [after-photo-gate 2026-06-09] When true, a tech cannot clock out of a job
+  // until at least one "after" photo is uploaded. Default OFF — most shops
+  // don't want to block clock-out on photos. Owner toggles in Clock In/Out
+  // settings; enforced both client-side (my-jobs) and server-side (clock-out).
+  require_after_photo_for_clockout: boolean("require_after_photo_for_clockout").notNull().default(false),
   // [gps-flag] When true, the dispatch panel flags clock punches that captured
   // no GPS coordinates ("GPS unavailable"). Office can turn it off here.
   flag_missing_gps: boolean("flag_missing_gps").notNull().default(true),


### PR DESCRIPTION
## Three field issues from Juliana using **My Jobs**

### 1. Photo picker wouldn't open the album
The "after"/"before" photo input had `capture="environment"`, which forces the camera on mobile and hides the photo library. Removed it — the OS picker now offers **Photo Library / Take Photo / Choose File**, so she can upload an existing picture or take a new one.

### 2. Clock-out was blocked until an after-photo was uploaded — now an opt-in setting (default OFF)
This was hard-enforced for everyone (the amber "After photos required before clock-out" banner + disabled button). Now it's a per-tenant owner setting, **off by default**:
- New column `companies.require_after_photo_for_clockout` (bool, default `false`) + idempotent cold-start `ALTER` in `phes-data-migration`.
- Server `clock-out` route only returns `PHOTOS_REQUIRED` when the flag is on.
- `/jobs/my-jobs` returns the flag; the tech UI shows the banner / disabled clock-out button **only when enabled**.
- Owner toggle added under **Settings → Clock In/Out**: "Require after photo before clock-out".

### 3. No day shown, today-only — added day navigation
My Jobs was a today-only list with no date. Added a **day-navigation strip** (‹ / ›, tap the date to jump back to Today) and a `?date=YYYY-MM-DD` param on `/jobs/my-jobs`, so a tech can review another day's schedule. Empty + "Day complete" states are now date-aware.

## Verification
- Frontend build passes.
- CI's gating checks (`typecheck:libs`, esbuild api-server build, vite frontend build) all apply; the new `companies` column compiles in `lib/db` and resolves at runtime via `tsx` reading source.

## Default behavior unchanged for existing tenants
Because the new flag defaults `false`, **Phes techs will no longer be blocked** at clock-out until the owner explicitly turns the setting on — which is the requested behavior.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_