### PR TITLE
feat(estimates): commercial estimate builder + line items + templates (Phase 1a)

### DIFF
--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -187,6 +187,89 @@ async function runBookingSchemaGuard(): Promise<void> {
         created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
       )
     ` },
+    // ── commercial estimate tool ─────────────────────────────────────────────
+    // [commercial-estimate-tool 2026-06-09] Estimates + line items + reusable
+    // templates. Idempotent CREATE IF NOT EXISTS (matches the leads pattern —
+    // no FK constraints in the raw DDL; company_id scoping enforced in routes).
+    { label: "CREATE estimates", stmt: `
+      CREATE TABLE IF NOT EXISTS estimates (
+        id                  SERIAL PRIMARY KEY,
+        company_id          INTEGER NOT NULL,
+        branch_id           INTEGER,
+        account_id          INTEGER,
+        account_property_id INTEGER,
+        client_id           INTEGER,
+        contact_name        TEXT,
+        contact_email       TEXT,
+        contact_phone       TEXT,
+        property_name       TEXT,
+        service_address     TEXT,
+        estimate_number     TEXT,
+        title               TEXT,
+        intro_note          TEXT,
+        terms               TEXT,
+        internal_notes      TEXT,
+        status              TEXT NOT NULL DEFAULT 'draft',
+        subtotal            NUMERIC(12,2) NOT NULL DEFAULT 0,
+        discount_amount     NUMERIC(12,2) NOT NULL DEFAULT 0,
+        total               NUMERIC(12,2) NOT NULL DEFAULT 0,
+        valid_until         TIMESTAMPTZ,
+        public_token        TEXT,
+        sent_at             TIMESTAMPTZ,
+        viewed_at           TIMESTAMPTZ,
+        accepted_at         TIMESTAMPTZ,
+        declined_at         TIMESTAMPTZ,
+        accepted_name       TEXT,
+        ghl_synced_at       TIMESTAMPTZ,
+        created_by          INTEGER,
+        created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      )
+    ` },
+    { label: "CREATE estimate_line_items", stmt: `
+      CREATE TABLE IF NOT EXISTS estimate_line_items (
+        id           SERIAL PRIMARY KEY,
+        estimate_id  INTEGER NOT NULL,
+        company_id   INTEGER NOT NULL,
+        sort_order   INTEGER NOT NULL DEFAULT 0,
+        name         TEXT,
+        description  TEXT,
+        pricing_type TEXT NOT NULL DEFAULT 'flat',
+        frequency    TEXT,
+        quantity     NUMERIC(10,2) NOT NULL DEFAULT 1,
+        unit_rate    NUMERIC(12,2) NOT NULL DEFAULT 0,
+        amount       NUMERIC(12,2) NOT NULL DEFAULT 0,
+        created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      )
+    ` },
+    { label: "CREATE estimate_templates", stmt: `
+      CREATE TABLE IF NOT EXISTS estimate_templates (
+        id          SERIAL PRIMARY KEY,
+        company_id  INTEGER NOT NULL,
+        name        TEXT NOT NULL,
+        title       TEXT,
+        intro_note  TEXT,
+        terms       TEXT,
+        created_by  INTEGER,
+        created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      )
+    ` },
+    { label: "CREATE estimate_template_items", stmt: `
+      CREATE TABLE IF NOT EXISTS estimate_template_items (
+        id           SERIAL PRIMARY KEY,
+        template_id  INTEGER NOT NULL,
+        company_id   INTEGER NOT NULL,
+        sort_order   INTEGER NOT NULL DEFAULT 0,
+        name         TEXT,
+        description  TEXT,
+        pricing_type TEXT NOT NULL DEFAULT 'flat',
+        frequency    TEXT,
+        quantity     NUMERIC(10,2) NOT NULL DEFAULT 1,
+        unit_rate    NUMERIC(12,2) NOT NULL DEFAULT 0,
+        amount       NUMERIC(12,2) NOT NULL DEFAULT 0,
+        created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      )
+    ` },
     // ── follow_up_sequences table ────────────────────────────────────────────
     { label: "CREATE follow_up_sequences", stmt: `
       CREATE TABLE IF NOT EXISTS follow_up_sequences (

--- a/artifacts/api-server/src/routes/estimates.ts
+++ b/artifacts/api-server/src/routes/estimates.ts
@@ -1,0 +1,382 @@
+import { Router } from "express";
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+import { randomUUID } from "crypto";
+import { requireAuth } from "../lib/auth.js";
+
+// [commercial-estimate-tool 2026-06-09] Commercial / common-area estimates.
+// Raw SQL (db.execute) on purpose: the estimate tables are brand-new and the
+// api-server reads the db package's compiled .d.ts, which lags the source by a
+// build — raw SQL sidesteps that while the runtime (tsx) reads the live schema.
+// Every query is company-scoped via req.auth!.companyId. Line items are stored
+// in estimate_line_items; PATCH/create replace the full set (mirrors the
+// job_add_ons pattern). Totals are always recomputed server-side.
+
+const router = Router();
+
+const PRICING_TYPES = new Set(["flat", "hourly", "one_time"]);
+
+type NormalizedItem = {
+  sort_order: number;
+  name: string | null;
+  description: string | null;
+  pricing_type: string;
+  frequency: string | null;
+  quantity: number;
+  unit_rate: number;
+  amount: number;
+};
+
+function normalizeItems(raw: unknown): NormalizedItem[] {
+  const arr = Array.isArray(raw) ? raw : [];
+  return arr.map((it: any, i: number) => {
+    const pricing_type = PRICING_TYPES.has(it?.pricing_type) ? it.pricing_type : "flat";
+    const quantity = Math.max(0, Number(it?.quantity ?? 1) || 0);
+    const unit_rate = Math.max(0, Number(it?.unit_rate ?? 0) || 0);
+    const amount = Math.round(quantity * unit_rate * 100) / 100;
+    const name = (it?.name ?? "").toString().trim().slice(0, 300);
+    const description = (it?.description ?? "").toString().trim();
+    const frequency = (it?.frequency ?? "").toString().trim().slice(0, 80);
+    return {
+      sort_order: i,
+      name: name || null,
+      description: description || null,
+      pricing_type,
+      frequency: frequency || null,
+      quantity,
+      unit_rate,
+      amount,
+    };
+  });
+}
+
+function computeTotals(items: NormalizedItem[], discountRaw: unknown) {
+  const subtotal = Math.round(items.reduce((s, it) => s + it.amount, 0) * 100) / 100;
+  const discount = Math.max(0, Number(discountRaw ?? 0) || 0);
+  const total = Math.round(Math.max(0, subtotal - discount) * 100) / 100;
+  return { subtotal, discount, total };
+}
+
+function str(v: unknown, max = 2000): string | null {
+  if (v === undefined || v === null) return null;
+  const s = v.toString().trim();
+  return s ? s.slice(0, max) : null;
+}
+
+function intOrNull(v: unknown): number | null {
+  if (v === undefined || v === null || v === "") return null;
+  const n = parseInt(v.toString(), 10);
+  return Number.isFinite(n) ? n : null;
+}
+
+async function insertLineItems(estimateId: number, companyId: number, items: NormalizedItem[]) {
+  for (const it of items) {
+    await db.execute(sql`
+      INSERT INTO estimate_line_items
+        (estimate_id, company_id, sort_order, name, description, pricing_type, frequency, quantity, unit_rate, amount)
+      VALUES
+        (${estimateId}, ${companyId}, ${it.sort_order}, ${it.name}, ${it.description},
+         ${it.pricing_type}, ${it.frequency}, ${it.quantity}, ${it.unit_rate}, ${it.amount})
+    `);
+  }
+}
+
+// ─── Stats ───────────────────────────────────────────────────────────────────
+router.get("/stats", requireAuth, async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    const rows = await db.execute(sql`
+      SELECT
+        COUNT(*)::int AS total,
+        COUNT(*) FILTER (WHERE status = 'draft')::int AS draft,
+        COUNT(*) FILTER (WHERE status IN ('sent','viewed'))::int AS outstanding,
+        COUNT(*) FILTER (WHERE status = 'accepted')::int AS accepted,
+        COALESCE(SUM(total) FILTER (WHERE status = 'accepted'
+          AND accepted_at >= date_trunc('month', now())), 0)::numeric AS accepted_value_month
+      FROM estimates WHERE company_id = ${companyId}
+    `);
+    return res.json((rows as any).rows[0] ?? {});
+  } catch (err) {
+    console.error("Estimate stats error:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
+// ─── Templates ───────────────────────────────────────────────────────────────
+router.get("/templates", requireAuth, async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    const rows = await db.execute(sql`
+      SELECT t.*,
+        (SELECT COUNT(*)::int FROM estimate_template_items i WHERE i.template_id = t.id) AS item_count
+      FROM estimate_templates t
+      WHERE t.company_id = ${companyId}
+      ORDER BY t.created_at DESC
+    `);
+    return res.json({ data: (rows as any).rows });
+  } catch (err) {
+    console.error("List estimate templates error:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
+router.get("/templates/:id", requireAuth, async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    const id = parseInt(req.params.id, 10);
+    const t = await db.execute(sql`SELECT * FROM estimate_templates WHERE id = ${id} AND company_id = ${companyId} LIMIT 1`);
+    const tpl = (t as any).rows[0];
+    if (!tpl) return res.status(404).json({ error: "Not Found" });
+    const items = await db.execute(sql`
+      SELECT * FROM estimate_template_items WHERE template_id = ${id} AND company_id = ${companyId} ORDER BY sort_order
+    `);
+    return res.json({ ...tpl, items: (items as any).rows });
+  } catch (err) {
+    console.error("Get estimate template error:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
+router.post("/templates", requireAuth, async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    const name = str(req.body?.name, 200);
+    if (!name) return res.status(400).json({ error: "Bad Request", message: "Template name is required" });
+    const items = normalizeItems(req.body?.items);
+    const inserted = await db.execute(sql`
+      INSERT INTO estimate_templates (company_id, name, title, intro_note, terms, created_by)
+      VALUES (${companyId}, ${name}, ${str(req.body?.title, 300)}, ${str(req.body?.intro_note)}, ${str(req.body?.terms)}, ${req.auth!.userId})
+      RETURNING id
+    `);
+    const templateId = (inserted as any).rows[0].id;
+    for (const it of items) {
+      await db.execute(sql`
+        INSERT INTO estimate_template_items
+          (template_id, company_id, sort_order, name, description, pricing_type, frequency, quantity, unit_rate, amount)
+        VALUES
+          (${templateId}, ${companyId}, ${it.sort_order}, ${it.name}, ${it.description},
+           ${it.pricing_type}, ${it.frequency}, ${it.quantity}, ${it.unit_rate}, ${it.amount})
+      `);
+    }
+    return res.status(201).json({ id: templateId });
+  } catch (err) {
+    console.error("Create estimate template error:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
+router.delete("/templates/:id", requireAuth, async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    const id = parseInt(req.params.id, 10);
+    await db.execute(sql`DELETE FROM estimate_template_items WHERE template_id = ${id} AND company_id = ${companyId}`);
+    await db.execute(sql`DELETE FROM estimate_templates WHERE id = ${id} AND company_id = ${companyId}`);
+    return res.json({ ok: true });
+  } catch (err) {
+    console.error("Delete estimate template error:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
+// ─── List estimates ──────────────────────────────────────────────────────────
+router.get("/", requireAuth, async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    const status = str(req.query?.status, 40);
+    const search = str(req.query?.search, 120);
+    const rows = await db.execute(sql`
+      SELECT e.id, e.estimate_number, e.status, e.title, e.total, e.subtotal,
+             e.contact_name, e.property_name, e.service_address,
+             e.sent_at, e.viewed_at, e.accepted_at, e.valid_until, e.created_at,
+             a.account_name,
+             COALESCE(NULLIF(e.property_name, ''), p.property_name) AS resolved_property,
+             COALESCE(a.account_name, e.contact_name, p.property_name, 'Untitled') AS recipient
+      FROM estimates e
+      LEFT JOIN accounts a ON a.id = e.account_id
+      LEFT JOIN account_properties p ON p.id = e.account_property_id
+      WHERE e.company_id = ${companyId}
+        ${status ? sql`AND e.status = ${status}` : sql``}
+        ${search ? sql`AND (a.account_name ILIKE ${"%" + search + "%"} OR e.contact_name ILIKE ${"%" + search + "%"} OR e.property_name ILIKE ${"%" + search + "%"} OR e.estimate_number ILIKE ${"%" + search + "%"})` : sql``}
+      ORDER BY e.created_at DESC
+      LIMIT 300
+    `);
+    return res.json({ data: (rows as any).rows });
+  } catch (err) {
+    console.error("List estimates error:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
+// ─── Get one estimate (with line items) ──────────────────────────────────────
+router.get("/:id", requireAuth, async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    const id = parseInt(req.params.id, 10);
+    const e = await db.execute(sql`
+      SELECT e.*, a.account_name, p.property_name AS account_property_name
+      FROM estimates e
+      LEFT JOIN accounts a ON a.id = e.account_id
+      LEFT JOIN account_properties p ON p.id = e.account_property_id
+      WHERE e.id = ${id} AND e.company_id = ${companyId} LIMIT 1
+    `);
+    const est = (e as any).rows[0];
+    if (!est) return res.status(404).json({ error: "Not Found" });
+    const items = await db.execute(sql`
+      SELECT * FROM estimate_line_items WHERE estimate_id = ${id} AND company_id = ${companyId} ORDER BY sort_order
+    `);
+    return res.json({ ...est, items: (items as any).rows });
+  } catch (err) {
+    console.error("Get estimate error:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
+// ─── Create estimate ─────────────────────────────────────────────────────────
+router.post("/", requireAuth, async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    const b = req.body ?? {};
+
+    // Optionally seed line items from a saved template.
+    let items = normalizeItems(b.items);
+    const fromTemplate = intOrNull(b.from_template_id);
+    if (fromTemplate && items.length === 0) {
+      const ti = await db.execute(sql`
+        SELECT name, description, pricing_type, frequency, quantity, unit_rate
+        FROM estimate_template_items WHERE template_id = ${fromTemplate} AND company_id = ${companyId} ORDER BY sort_order
+      `);
+      items = normalizeItems((ti as any).rows);
+    }
+    const { subtotal, discount, total } = computeTotals(items, b.discount_amount);
+
+    const inserted = await db.execute(sql`
+      INSERT INTO estimates
+        (company_id, branch_id, account_id, account_property_id, client_id,
+         contact_name, contact_email, contact_phone, property_name, service_address,
+         title, intro_note, terms, internal_notes, status,
+         subtotal, discount_amount, total, valid_until, created_by, updated_at)
+      VALUES
+        (${companyId}, ${intOrNull(b.branch_id)}, ${intOrNull(b.account_id)}, ${intOrNull(b.account_property_id)}, ${intOrNull(b.client_id)},
+         ${str(b.contact_name, 200)}, ${str(b.contact_email, 200)}, ${str(b.contact_phone, 40)}, ${str(b.property_name, 300)}, ${str(b.service_address, 400)},
+         ${str(b.title, 300)}, ${str(b.intro_note)}, ${str(b.terms)}, ${str(b.internal_notes)}, 'draft',
+         ${subtotal}, ${discount}, ${total}, ${b.valid_until ? new Date(b.valid_until) : null}, ${req.auth!.userId}, now())
+      RETURNING id
+    `);
+    const id = (inserted as any).rows[0].id;
+    await db.execute(sql`UPDATE estimates SET estimate_number = ${"EST-" + String(1000 + id)} WHERE id = ${id}`);
+    await insertLineItems(id, companyId, items);
+    return res.status(201).json({ id });
+  } catch (err) {
+    console.error("Create estimate error:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
+// ─── Update estimate (replaces line items) ───────────────────────────────────
+router.patch("/:id", requireAuth, async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    const id = parseInt(req.params.id, 10);
+    const exists = await db.execute(sql`SELECT id FROM estimates WHERE id = ${id} AND company_id = ${companyId} LIMIT 1`);
+    if (!(exists as any).rows[0]) return res.status(404).json({ error: "Not Found" });
+
+    const b = req.body ?? {};
+    const items = normalizeItems(b.items);
+    const { subtotal, discount, total } = computeTotals(items, b.discount_amount);
+
+    await db.execute(sql`
+      UPDATE estimates SET
+        account_id = ${intOrNull(b.account_id)},
+        account_property_id = ${intOrNull(b.account_property_id)},
+        client_id = ${intOrNull(b.client_id)},
+        contact_name = ${str(b.contact_name, 200)},
+        contact_email = ${str(b.contact_email, 200)},
+        contact_phone = ${str(b.contact_phone, 40)},
+        property_name = ${str(b.property_name, 300)},
+        service_address = ${str(b.service_address, 400)},
+        title = ${str(b.title, 300)},
+        intro_note = ${str(b.intro_note)},
+        terms = ${str(b.terms)},
+        internal_notes = ${str(b.internal_notes)},
+        subtotal = ${subtotal},
+        discount_amount = ${discount},
+        total = ${total},
+        valid_until = ${b.valid_until ? new Date(b.valid_until) : null},
+        updated_at = now()
+      WHERE id = ${id} AND company_id = ${companyId}
+    `);
+    await db.execute(sql`DELETE FROM estimate_line_items WHERE estimate_id = ${id} AND company_id = ${companyId}`);
+    await insertLineItems(id, companyId, items);
+    return res.json({ id });
+  } catch (err) {
+    console.error("Update estimate error:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
+// ─── Save an estimate's line items as a reusable template ─────────────────────
+router.post("/:id/save-as-template", requireAuth, async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    const id = parseInt(req.params.id, 10);
+    const name = str(req.body?.name, 200);
+    if (!name) return res.status(400).json({ error: "Bad Request", message: "Template name is required" });
+    const e = await db.execute(sql`SELECT title, intro_note, terms FROM estimates WHERE id = ${id} AND company_id = ${companyId} LIMIT 1`);
+    const est = (e as any).rows[0];
+    if (!est) return res.status(404).json({ error: "Not Found" });
+    const inserted = await db.execute(sql`
+      INSERT INTO estimate_templates (company_id, name, title, intro_note, terms, created_by)
+      VALUES (${companyId}, ${name}, ${est.title}, ${est.intro_note}, ${est.terms}, ${req.auth!.userId})
+      RETURNING id
+    `);
+    const templateId = (inserted as any).rows[0].id;
+    await db.execute(sql`
+      INSERT INTO estimate_template_items
+        (template_id, company_id, sort_order, name, description, pricing_type, frequency, quantity, unit_rate, amount)
+      SELECT ${templateId}, ${companyId}, sort_order, name, description, pricing_type, frequency, quantity, unit_rate, amount
+      FROM estimate_line_items WHERE estimate_id = ${id} AND company_id = ${companyId}
+    `);
+    return res.status(201).json({ id: templateId });
+  } catch (err) {
+    console.error("Save estimate as template error:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
+// ─── Send: mark sent + mint the public token (hosted view + GHL come next) ────
+router.post("/:id/send", requireAuth, async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    const id = parseInt(req.params.id, 10);
+    const e = await db.execute(sql`SELECT public_token, valid_until FROM estimates WHERE id = ${id} AND company_id = ${companyId} LIMIT 1`);
+    const est = (e as any).rows[0];
+    if (!est) return res.status(404).json({ error: "Not Found" });
+    const token = est.public_token || randomUUID();
+    // Default a 30-day validity window if none was set.
+    const validUntil = est.valid_until || new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+    await db.execute(sql`
+      UPDATE estimates
+      SET status = 'sent', sent_at = COALESCE(sent_at, now()), public_token = ${token}, valid_until = ${validUntil}, updated_at = now()
+      WHERE id = ${id} AND company_id = ${companyId}
+    `);
+    return res.json({ id, public_token: token });
+  } catch (err) {
+    console.error("Send estimate error:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
+router.delete("/:id", requireAuth, async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    const id = parseInt(req.params.id, 10);
+    await db.execute(sql`DELETE FROM estimate_line_items WHERE estimate_id = ${id} AND company_id = ${companyId}`);
+    await db.execute(sql`DELETE FROM estimates WHERE id = ${id} AND company_id = ${companyId}`);
+    return res.json({ ok: true });
+  } catch (err) {
+    console.error("Delete estimate error:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
+export default router;

--- a/artifacts/api-server/src/routes/index.ts
+++ b/artifacts/api-server/src/routes/index.ts
@@ -24,6 +24,7 @@ import reportsRouter from "./reports.js";
 import notificationsRouter from "./notifications.js";
 import jobSmsRouter from "./job-sms.js";
 import quotesRouter from "./quotes.js";
+import estimatesRouter from "./estimates.js";
 import paymentsRouter from "./payments.js";
 import attachmentsRouter from "./attachments.js";
 import { quoteAttachmentsRouter, jobAttachmentsRouter } from "./quote-attachments.js";
@@ -120,6 +121,7 @@ router.use("/messages", messagesRouter);
 router.use("/reports", reportsRouter);
 router.use("/notifications", notificationsRouter);
 router.use("/quotes", quotesRouter);
+router.use("/estimates", estimatesRouter);
 router.use("/payments", paymentsRouter);
 router.use("/attachments", attachmentsRouter);
 // [translate-job-notes 2026-05-27] Office-only translation endpoint —

--- a/artifacts/qleno/src/App.tsx
+++ b/artifacts/qleno/src/App.tsx
@@ -55,6 +55,8 @@ const FormsPage           = lazy(() => import("@/pages/forms"));
 const SignPage             = lazy(() => import("@/pages/sign"));
 const QuotesPage          = lazy(() => import("@/pages/quotes"));
 const QuoteBuilderPage    = lazy(() => import("@/pages/quote-builder"));
+const EstimatesPage       = lazy(() => import("@/pages/estimates"));
+const EstimateBuilderPage = lazy(() => import("@/pages/estimate-builder"));
 const QuoteDetailPage     = lazy(() => import("@/pages/quote-detail"));
 const QuotingPage         = lazy(() => import("@/pages/quoting"));
 const InvoiceDetailPage   = lazy(() => import("@/pages/invoice-detail"));
@@ -193,6 +195,10 @@ function Router() {
         <Route path="/quotes/:id/edit" component={QuoteBuilderPage} />
         <Route path="/quotes/:id" component={QuoteDetailPage} />
         <Route path="/quotes" component={QuotesPage} />
+
+        <Route path="/estimates/new" component={EstimateBuilderPage} />
+        <Route path="/estimates/:id" component={EstimateBuilderPage} />
+        <Route path="/estimates" component={EstimatesPage} />
 
         <Route path="/book/:slug" component={BookPage} />
         <Route path="/pay/:token" component={PayPage} />

--- a/artifacts/qleno/src/components/layout/app-sidebar.tsx
+++ b/artifacts/qleno/src/components/layout/app-sidebar.tsx
@@ -3,7 +3,7 @@ import {
   Briefcase, Users, UserCheck, FileText, DollarSign,
   BarChart2, TrendingUp, FileText as FileTextIcon,
   BookOpen, Settings, AlertTriangle, HeartPulse, Building2,
-  UserPlus, GraduationCap, Clock,
+  UserPlus, GraduationCap, Clock, Calculator,
 } from "lucide-react";
 import { Link, useLocation } from "wouter";
 import { useAuthStore } from "@/lib/auth";
@@ -64,6 +64,7 @@ const NAV_SECTIONS = [
     items: [
       { title: "Leads",  url: "/leads",  icon: UserPlus,   roles: ["owner", "admin", "office"], badge: "needs_contacted" },
       { title: "Quotes", url: "/quotes", icon: FileTextIcon, roles: ["owner", "admin", "office"] },
+      { title: "Estimates", url: "/estimates", icon: Calculator, roles: ["owner", "admin", "office"] },
     ],
   },
   {

--- a/artifacts/qleno/src/pages/estimate-builder.tsx
+++ b/artifacts/qleno/src/pages/estimate-builder.tsx
@@ -1,0 +1,315 @@
+import { useEffect, useMemo, useState } from "react";
+import { useLocation, useRoute } from "wouter";
+import { getAuthHeaders } from "@/lib/auth";
+import { DashboardLayout } from "@/components/layout/dashboard-layout";
+import { Plus, Trash2, ArrowLeft, Save, Send, LayoutTemplate, GripVertical } from "lucide-react";
+import { toast } from "sonner";
+
+const FF = "'Plus Jakarta Sans', sans-serif";
+const API = import.meta.env.BASE_URL.replace(/\/$/, "");
+const INK = "#1A1917";
+const MUTE = "#6B7280";
+const BORDER = "#E5E2DC";
+const MINT = "#00C9A0";
+
+async function apiFetch(path: string, opts: { method?: string; body?: any } = {}) {
+  const { body, ...rest } = opts;
+  const r = await fetch(`${API}${path}`, {
+    headers: { ...getAuthHeaders(), "Content-Type": "application/json" },
+    ...rest,
+    ...(body !== undefined && { body: JSON.stringify(body) }),
+  });
+  if (!r.ok) throw new Error(await r.text());
+  return r.json();
+}
+
+const money = (n: number) => `$${n.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+
+type PricingType = "flat" | "hourly" | "one_time";
+interface Item {
+  name: string;
+  pricing_type: PricingType;
+  frequency: string;
+  quantity: string;
+  unit_rate: string;
+}
+
+const TYPE_LABELS: Record<PricingType, { type: string; qty: string; rate: string }> = {
+  flat: { type: "Flat / recurring", qty: "Qty", rate: "Price" },
+  hourly: { type: "Hourly", qty: "Hours", rate: "$/hr" },
+  one_time: { type: "One-time", qty: "Qty", rate: "Price" },
+};
+const FREQUENCY_OPTIONS = ["Daily", "5x/week", "3x/week", "2x/week", "Weekly", "Bi-weekly", "Monthly", "One-time"];
+
+const blankItem = (): Item => ({ name: "", pricing_type: "flat", frequency: "Monthly", quantity: "1", unit_rate: "" });
+
+function lineAmount(it: Item): number {
+  return Math.round((Number(it.quantity) || 0) * (Number(it.unit_rate) || 0) * 100) / 100;
+}
+
+export default function EstimateBuilderPage() {
+  const [, navigate] = useLocation();
+  const [, params] = useRoute("/estimates/:id");
+  const routeId = params?.id ?? "new";
+  const isNew = routeId === "new";
+  const estimateId = isNew ? null : parseInt(routeId, 10);
+
+  const [loading, setLoading] = useState(!isNew);
+  const [saving, setSaving] = useState(false);
+  const [id, setId] = useState<number | null>(estimateId);
+  const [status, setStatus] = useState("draft");
+  const [estimateNumber, setEstimateNumber] = useState<string>("");
+
+  const [contactName, setContactName] = useState("");
+  const [contactEmail, setContactEmail] = useState("");
+  const [contactPhone, setContactPhone] = useState("");
+  const [propertyName, setPropertyName] = useState("");
+  const [serviceAddress, setServiceAddress] = useState("");
+  const [title, setTitle] = useState("");
+  const [introNote, setIntroNote] = useState("");
+  const [terms, setTerms] = useState("");
+  const [internalNotes, setInternalNotes] = useState("");
+  const [discount, setDiscount] = useState("0");
+  const [validUntil, setValidUntil] = useState("");
+  const [items, setItems] = useState<Item[]>([blankItem()]);
+
+  // Load existing estimate, or seed a new one from a template (?template=id).
+  useEffect(() => {
+    (async () => {
+      try {
+        if (!isNew && estimateId) {
+          const e = await apiFetch(`/api/estimates/${estimateId}`);
+          setStatus(e.status); setEstimateNumber(e.estimate_number || "");
+          setContactName(e.contact_name || ""); setContactEmail(e.contact_email || ""); setContactPhone(e.contact_phone || "");
+          setPropertyName(e.property_name || ""); setServiceAddress(e.service_address || "");
+          setTitle(e.title || ""); setIntroNote(e.intro_note || ""); setTerms(e.terms || ""); setInternalNotes(e.internal_notes || "");
+          setDiscount(String(e.discount_amount ?? "0"));
+          setValidUntil(e.valid_until ? String(e.valid_until).slice(0, 10) : "");
+          setItems((e.items || []).length ? e.items.map(mapRow) : [blankItem()]);
+        } else {
+          const templateId = new URLSearchParams(window.location.search).get("template");
+          if (templateId) {
+            const t = await apiFetch(`/api/estimates/templates/${templateId}`);
+            setTitle(t.title || ""); setIntroNote(t.intro_note || ""); setTerms(t.terms || "");
+            setItems((t.items || []).length ? t.items.map(mapRow) : [blankItem()]);
+          }
+        }
+      } catch {
+        toast.error("Failed to load estimate");
+      } finally {
+        setLoading(false);
+      }
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const subtotal = useMemo(() => items.reduce((s, it) => s + lineAmount(it), 0), [items]);
+  const total = Math.max(0, subtotal - (Number(discount) || 0));
+
+  const body = () => ({
+    contact_name: contactName, contact_email: contactEmail, contact_phone: contactPhone,
+    property_name: propertyName, service_address: serviceAddress,
+    title, intro_note: introNote, terms, internal_notes: internalNotes,
+    discount_amount: Number(discount) || 0,
+    valid_until: validUntil || null,
+    items: items.filter(it => it.name.trim() || Number(it.unit_rate) > 0).map(it => ({
+      name: it.name, pricing_type: it.pricing_type, frequency: it.frequency,
+      quantity: Number(it.quantity) || 0, unit_rate: Number(it.unit_rate) || 0,
+    })),
+  });
+
+  async function save(): Promise<number | null> {
+    setSaving(true);
+    try {
+      if (id) {
+        await apiFetch(`/api/estimates/${id}`, { method: "PATCH", body: body() });
+        toast.success("Estimate saved");
+        return id;
+      } else {
+        const r = await apiFetch("/api/estimates", { method: "POST", body: body() });
+        setId(r.id);
+        window.history.replaceState(null, "", `${API}/estimates/${r.id}`);
+        toast.success("Estimate created");
+        return r.id;
+      }
+    } catch {
+      toast.error("Failed to save");
+      return null;
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function saveAsTemplate() {
+    const savedId = id || (await save());
+    if (!savedId) return;
+    const name = prompt("Template name (e.g. 'Condo common areas — 2x/week'):");
+    if (!name) return;
+    try {
+      await apiFetch(`/api/estimates/${savedId}/save-as-template`, { method: "POST", body: { name } });
+      toast.success("Saved as template");
+    } catch {
+      toast.error("Failed to save template");
+    }
+  }
+
+  async function markSent() {
+    const savedId = id || (await save());
+    if (!savedId) return;
+    try {
+      await apiFetch(`/api/estimates/${savedId}/send`, { method: "POST" });
+      setStatus("sent");
+      toast.success("Marked as sent — hosted link, PDF & GoHighLevel follow-up land in the next update.");
+    } catch {
+      toast.error("Failed to mark sent");
+    }
+  }
+
+  const updateItem = (i: number, patch: Partial<Item>) =>
+    setItems(its => its.map((it, idx) => (idx === i ? { ...it, ...patch } : it)));
+
+  if (loading) {
+    return <DashboardLayout><div style={{ padding: 60, textAlign: "center", color: MUTE, fontFamily: FF }}>Loading…</div></DashboardLayout>;
+  }
+
+  return (
+    <DashboardLayout>
+      <div style={{ fontFamily: FF, maxWidth: 860, margin: "0 auto", padding: "8px 4px 120px" }}>
+        <button onClick={() => navigate("/estimates")} style={{ display: "inline-flex", alignItems: "center", gap: 5, background: "none", border: "none", color: MUTE, fontSize: 13, fontWeight: 600, cursor: "pointer", fontFamily: FF, padding: 0, marginBottom: 12 }}>
+          <ArrowLeft size={15} /> Estimates
+        </button>
+
+        <div style={{ display: "flex", alignItems: "baseline", justifyContent: "space-between", flexWrap: "wrap", gap: 8, marginBottom: 18 }}>
+          <h1 style={{ fontSize: 23, fontWeight: 800, color: INK, margin: 0 }}>{isNew && !id ? "New Estimate" : (estimateNumber || "Estimate")}</h1>
+          <span style={{ fontSize: 12, fontWeight: 700, color: MUTE, textTransform: "uppercase", letterSpacing: "0.05em" }}>{status}</span>
+        </div>
+
+        <Section title="Who it's for">
+          <Grid>
+            <Field label="Contact name"><input style={inp} value={contactName} onChange={e => setContactName(e.target.value)} placeholder="Property manager" /></Field>
+            <Field label="Property / building"><input style={inp} value={propertyName} onChange={e => setPropertyName(e.target.value)} placeholder="e.g. 5721 W 103rd St Condos" /></Field>
+            <Field label="Email"><input style={inp} value={contactEmail} onChange={e => setContactEmail(e.target.value)} placeholder="name@email.com" /></Field>
+            <Field label="Phone"><input style={inp} value={contactPhone} onChange={e => setContactPhone(e.target.value)} placeholder="(773) 555-0123" /></Field>
+          </Grid>
+          <Field label="Service address"><input style={inp} value={serviceAddress} onChange={e => setServiceAddress(e.target.value)} placeholder="Street, City, State ZIP" /></Field>
+        </Section>
+
+        <Section title="Estimate details">
+          <Field label="Title"><input style={inp} value={title} onChange={e => setTitle(e.target.value)} placeholder="Common Area Cleaning — Monthly Service" /></Field>
+          <Field label="Intro note (shown to the client)"><textarea style={{ ...inp, minHeight: 64, resize: "vertical" }} value={introNote} onChange={e => setIntroNote(e.target.value)} placeholder="Thank you for the opportunity to quote your common-area cleaning…" /></Field>
+        </Section>
+
+        <Section title="Line items" right={
+          <button onClick={() => setItems(its => [...its, blankItem()])} style={addBtn}><Plus size={15} /> Add line</button>
+        }>
+          {items.map((it, i) => {
+            const L = TYPE_LABELS[it.pricing_type];
+            return (
+              <div key={i} style={{ border: `1px solid ${BORDER}`, borderRadius: 12, padding: 14, marginBottom: 10, background: "#FCFCFB" }}>
+                <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 10 }}>
+                  <GripVertical size={15} style={{ color: "#C9C6BF", flexShrink: 0 }} />
+                  <input style={{ ...inp, fontWeight: 700 }} value={it.name} onChange={e => updateItem(i, { name: e.target.value })} placeholder="Lobby & common hallways" />
+                  <button title="Remove" onClick={() => setItems(its => its.length > 1 ? its.filter((_, idx) => idx !== i) : its)} style={{ ...iconBtn, flexShrink: 0 }}><Trash2 size={15} /></button>
+                </div>
+                <div style={{ display: "grid", gridTemplateColumns: "1.2fr 1fr", gap: 8, marginBottom: 8 }}>
+                  <Field label="Type">
+                    <select style={inp} value={it.pricing_type} onChange={e => updateItem(i, { pricing_type: e.target.value as PricingType })}>
+                      <option value="flat">Flat / recurring</option>
+                      <option value="hourly">Hourly</option>
+                      <option value="one_time">One-time</option>
+                    </select>
+                  </Field>
+                  <Field label="Frequency">
+                    <input style={inp} list="freq-options" value={it.frequency} onChange={e => updateItem(i, { frequency: e.target.value })} placeholder="Monthly" />
+                  </Field>
+                </div>
+                <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: 8, alignItems: "end" }}>
+                  <Field label={L.qty}><input style={inp} type="number" min="0" step="0.25" value={it.quantity} onChange={e => updateItem(i, { quantity: e.target.value })} /></Field>
+                  <Field label={L.rate}><input style={inp} type="number" min="0" step="0.01" value={it.unit_rate} onChange={e => updateItem(i, { unit_rate: e.target.value })} placeholder="0.00" /></Field>
+                  <Field label="Amount"><div style={{ ...inp, background: "#F3F4F6", fontWeight: 700, color: INK }}>{money(lineAmount(it))}</div></Field>
+                </div>
+              </div>
+            );
+          })}
+          <datalist id="freq-options">{FREQUENCY_OPTIONS.map(f => <option key={f} value={f} />)}</datalist>
+        </Section>
+
+        {/* Totals */}
+        <div style={{ background: "#fff", border: `1px solid ${BORDER}`, borderRadius: 12, padding: "16px 18px", marginBottom: 16 }}>
+          <Row label="Subtotal" value={money(subtotal)} />
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", margin: "8px 0" }}>
+            <span style={{ fontSize: 14, color: MUTE }}>Discount</span>
+            <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
+              <span style={{ color: MUTE }}>$</span>
+              <input style={{ ...inp, width: 100, textAlign: "right" }} type="number" min="0" step="0.01" value={discount} onChange={e => setDiscount(e.target.value)} />
+            </div>
+          </div>
+          <div style={{ borderTop: `1px solid ${BORDER}`, marginTop: 8, paddingTop: 12, display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+            <span style={{ fontSize: 16, fontWeight: 800, color: INK }}>Total</span>
+            <span style={{ fontSize: 22, fontWeight: 800, color: INK }}>{money(total)}</span>
+          </div>
+        </div>
+
+        <Section title="Terms & internal notes">
+          <Grid>
+            <Field label="Valid until"><input style={inp} type="date" value={validUntil} onChange={e => setValidUntil(e.target.value)} /></Field>
+            <div />
+          </Grid>
+          <Field label="Terms (shown to the client)"><textarea style={{ ...inp, minHeight: 56, resize: "vertical" }} value={terms} onChange={e => setTerms(e.target.value)} placeholder="50% on first service, net-15 thereafter. Estimate valid 30 days." /></Field>
+          <Field label="Internal notes (office only)"><textarea style={{ ...inp, minHeight: 44, resize: "vertical" }} value={internalNotes} onChange={e => setInternalNotes(e.target.value)} placeholder="Walkthrough notes, access details…" /></Field>
+        </Section>
+      </div>
+
+      {/* Sticky action bar */}
+      <div style={{ position: "fixed", bottom: 0, left: 0, right: 0, background: "#fff", borderTop: `1px solid ${BORDER}`, padding: "12px 16px", display: "flex", justifyContent: "center", gap: 10, zIndex: 20 }}>
+        <div style={{ display: "flex", gap: 10, width: "100%", maxWidth: 860 }}>
+          <button onClick={saveAsTemplate} style={ghostBtn}><LayoutTemplate size={15} /> Save as template</button>
+          <div style={{ flex: 1 }} />
+          <button onClick={save} disabled={saving} style={ghostBtn}><Save size={15} /> {saving ? "Saving…" : "Save"}</button>
+          <button onClick={markSent} style={primaryBtn}><Send size={15} /> Mark sent</button>
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+}
+
+function mapRow(r: any): Item {
+  return {
+    name: r.name || "",
+    pricing_type: (["flat", "hourly", "one_time"].includes(r.pricing_type) ? r.pricing_type : "flat") as PricingType,
+    frequency: r.frequency || "",
+    quantity: String(r.quantity ?? "1"),
+    unit_rate: String(r.unit_rate ?? ""),
+  };
+}
+
+const Section = ({ title, right, children }: { title: string; right?: React.ReactNode; children: React.ReactNode }) => (
+  <div style={{ marginBottom: 22 }}>
+    <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 10 }}>
+      <h2 style={{ fontSize: 13, fontWeight: 800, color: INK, textTransform: "uppercase", letterSpacing: "0.05em", margin: 0 }}>{title}</h2>
+      {right}
+    </div>
+    {children}
+  </div>
+);
+const Grid = ({ children }: { children: React.ReactNode }) => (
+  <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10, marginBottom: 10 }}>{children}</div>
+);
+const Field = ({ label, children }: { label: string; children: React.ReactNode }) => (
+  <label style={{ display: "block", marginBottom: 10 }}>
+    <span style={{ display: "block", fontSize: 11, fontWeight: 700, color: MUTE, textTransform: "uppercase", letterSpacing: "0.04em", marginBottom: 5 }}>{label}</span>
+    {children}
+  </label>
+);
+const Row = ({ label, value }: { label: string; value: string }) => (
+  <div style={{ display: "flex", justifyContent: "space-between", fontSize: 14, color: INK }}><span style={{ color: MUTE }}>{label}</span><span style={{ fontWeight: 600 }}>{value}</span></div>
+);
+
+const inp: React.CSSProperties = {
+  width: "100%", padding: "9px 11px", border: `1px solid ${BORDER}`, borderRadius: 9,
+  fontSize: 14, fontFamily: FF, background: "#fff", boxSizing: "border-box", color: INK,
+};
+const iconBtn: React.CSSProperties = { width: 34, height: 34, display: "inline-flex", alignItems: "center", justifyContent: "center", background: "#fff", border: `1px solid ${BORDER}`, borderRadius: 8, color: MUTE, cursor: "pointer" };
+const addBtn: React.CSSProperties = { display: "inline-flex", alignItems: "center", gap: 5, background: "#fff", border: `1px solid ${BORDER}`, borderRadius: 9, padding: "7px 12px", fontSize: 13, fontWeight: 700, color: INK, cursor: "pointer", fontFamily: FF };
+const ghostBtn: React.CSSProperties = { display: "inline-flex", alignItems: "center", gap: 6, background: "#fff", border: `1px solid ${BORDER}`, borderRadius: 10, padding: "10px 16px", fontSize: 14, fontWeight: 700, color: INK, cursor: "pointer", fontFamily: FF };
+const primaryBtn: React.CSSProperties = { display: "inline-flex", alignItems: "center", gap: 6, background: INK, color: "#fff", border: "none", borderRadius: 10, padding: "10px 18px", fontSize: 14, fontWeight: 700, cursor: "pointer", fontFamily: FF };

--- a/artifacts/qleno/src/pages/estimates.tsx
+++ b/artifacts/qleno/src/pages/estimates.tsx
@@ -1,0 +1,196 @@
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useLocation } from "wouter";
+import { getAuthHeaders } from "@/lib/auth";
+import { DashboardLayout } from "@/components/layout/dashboard-layout";
+import { Plus, FileText, Send, CheckCircle, Clock, Trash2, Pencil, LayoutTemplate, Search } from "lucide-react";
+import { toast } from "sonner";
+
+const FF = "'Plus Jakarta Sans', sans-serif";
+const API = import.meta.env.BASE_URL.replace(/\/$/, "");
+const INK = "#1A1917";
+const MUTE = "#6B7280";
+const BORDER = "#E5E2DC";
+const MINT = "#00C9A0";
+
+async function apiFetch(path: string, opts: { method?: string; body?: any } = {}) {
+  const { body, ...rest } = opts;
+  const r = await fetch(`${API}${path}`, {
+    headers: { ...getAuthHeaders(), "Content-Type": "application/json" },
+    ...rest,
+    ...(body !== undefined && { body: JSON.stringify(body) }),
+  });
+  if (!r.ok) throw new Error(await r.text());
+  return r.json();
+}
+
+const money = (n: any) => `$${Number(n || 0).toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+
+const STATUS_STYLE: Record<string, { bg: string; fg: string; label: string; icon: any }> = {
+  draft:    { bg: "#F3F4F6", fg: "#6B7280", label: "Draft",    icon: FileText },
+  sent:     { bg: "#EFF6FF", fg: "#1D4ED8", label: "Sent",     icon: Send },
+  viewed:   { bg: "#FEF3C7", fg: "#92400E", label: "Viewed",   icon: Clock },
+  accepted: { bg: "#ECFDF5", fg: "#047857", label: "Accepted", icon: CheckCircle },
+  declined: { bg: "#FEF2F2", fg: "#991B1B", label: "Declined", icon: Trash2 },
+  expired:  { bg: "#F3F4F6", fg: "#6B7280", label: "Expired",  icon: Clock },
+};
+
+function StatusChip({ status }: { status: string }) {
+  const s = STATUS_STYLE[status] ?? STATUS_STYLE.draft;
+  const Icon = s.icon;
+  return (
+    <span style={{ display: "inline-flex", alignItems: "center", gap: 5, padding: "3px 9px", borderRadius: 999, background: s.bg, color: s.fg, fontSize: 12, fontWeight: 700 }}>
+      <Icon size={12} /> {s.label}
+    </span>
+  );
+}
+
+export default function EstimatesPage() {
+  const [, navigate] = useLocation();
+  const qc = useQueryClient();
+  const [search, setSearch] = useState("");
+  const [tab, setTab] = useState<"estimates" | "templates">("estimates");
+
+  const { data: statsData } = useQuery({ queryKey: ["estimate-stats"], queryFn: () => apiFetch("/api/estimates/stats") });
+  const { data: listData, isLoading } = useQuery({
+    queryKey: ["estimates", search],
+    queryFn: () => apiFetch(`/api/estimates${search ? `?search=${encodeURIComponent(search)}` : ""}`),
+  });
+  const { data: templatesData } = useQuery({ queryKey: ["estimate-templates"], queryFn: () => apiFetch("/api/estimates/templates") });
+
+  const estimates: any[] = listData?.data ?? [];
+  const templates: any[] = templatesData?.data ?? [];
+  const stats = statsData ?? {};
+
+  const del = useMutation({
+    mutationFn: (id: number) => apiFetch(`/api/estimates/${id}`, { method: "DELETE" }),
+    onSuccess: () => { qc.invalidateQueries({ queryKey: ["estimates"] }); qc.invalidateQueries({ queryKey: ["estimate-stats"] }); toast.success("Estimate deleted"); },
+    onError: () => toast.error("Failed to delete"),
+  });
+  const delTemplate = useMutation({
+    mutationFn: (id: number) => apiFetch(`/api/estimates/templates/${id}`, { method: "DELETE" }),
+    onSuccess: () => { qc.invalidateQueries({ queryKey: ["estimate-templates"] }); toast.success("Template deleted"); },
+    onError: () => toast.error("Failed to delete template"),
+  });
+
+  const statCards = [
+    { label: "Outstanding", value: stats.outstanding ?? 0, sub: "sent / viewed" },
+    { label: "Accepted", value: stats.accepted ?? 0, sub: "all time" },
+    { label: "Won this month", value: money(stats.accepted_value_month), sub: "accepted value" },
+    { label: "Drafts", value: stats.draft ?? 0, sub: "not yet sent" },
+  ];
+
+  return (
+    <DashboardLayout>
+      <div style={{ fontFamily: FF, maxWidth: 1100, margin: "0 auto", padding: "8px 4px 60px" }}>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12, marginBottom: 6 }}>
+          <div>
+            <h1 style={{ fontSize: 24, fontWeight: 800, color: INK, margin: 0 }}>Estimates</h1>
+            <p style={{ fontSize: 13, color: MUTE, margin: "4px 0 0" }}>Build, send, and track commercial &amp; common-area estimates.</p>
+          </div>
+          <button onClick={() => navigate("/estimates/new")}
+            style={{ display: "inline-flex", alignItems: "center", gap: 6, background: INK, color: "#fff", border: "none", borderRadius: 10, padding: "10px 16px", fontSize: 14, fontWeight: 700, cursor: "pointer", fontFamily: FF }}>
+            <Plus size={16} /> New Estimate
+          </button>
+        </div>
+
+        {/* Stat strip */}
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))", gap: 12, margin: "18px 0" }}>
+          {statCards.map(c => (
+            <div key={c.label} style={{ background: "#fff", border: `1px solid ${BORDER}`, borderRadius: 12, padding: "14px 16px" }}>
+              <p style={{ fontSize: 11, fontWeight: 700, color: MUTE, textTransform: "uppercase", letterSpacing: "0.05em", margin: "0 0 6px" }}>{c.label}</p>
+              <p style={{ fontSize: 24, fontWeight: 800, color: INK, margin: 0, lineHeight: 1 }}>{c.value}</p>
+              <p style={{ fontSize: 11, color: MUTE, margin: "5px 0 0" }}>{c.sub}</p>
+            </div>
+          ))}
+        </div>
+
+        {/* Tabs */}
+        <div style={{ display: "flex", gap: 6, borderBottom: `1px solid ${BORDER}`, marginBottom: 16 }}>
+          {([["estimates", "Estimates"], ["templates", "Templates"]] as const).map(([key, label]) => (
+            <button key={key} onClick={() => setTab(key)}
+              style={{ background: "none", border: "none", borderBottom: tab === key ? `2px solid ${INK}` : "2px solid transparent", color: tab === key ? INK : MUTE, fontWeight: 700, fontSize: 14, padding: "8px 12px", cursor: "pointer", fontFamily: FF, marginBottom: -1 }}>
+              {label}
+            </button>
+          ))}
+        </div>
+
+        {tab === "estimates" ? (
+          <>
+            <div style={{ position: "relative", maxWidth: 340, marginBottom: 14 }}>
+              <Search size={15} style={{ position: "absolute", left: 11, top: 11, color: MUTE }} />
+              <input value={search} onChange={e => setSearch(e.target.value)} placeholder="Search estimates…"
+                style={{ width: "100%", padding: "9px 12px 9px 32px", border: `1px solid ${BORDER}`, borderRadius: 9, fontSize: 14, fontFamily: FF, background: "#fff", boxSizing: "border-box" }} />
+            </div>
+
+            <div style={{ background: "#fff", border: `1px solid ${BORDER}`, borderRadius: 12, overflow: "hidden" }}>
+              {isLoading ? (
+                <div style={{ padding: 40, textAlign: "center", color: MUTE, fontSize: 14 }}>Loading…</div>
+              ) : estimates.length === 0 ? (
+                <div style={{ padding: "48px 20px", textAlign: "center" }}>
+                  <FileText size={28} style={{ color: "#C9C6BF", margin: "0 auto 10px" }} />
+                  <p style={{ fontSize: 15, fontWeight: 700, color: INK, margin: "0 0 4px" }}>No estimates yet</p>
+                  <p style={{ fontSize: 13, color: MUTE, margin: "0 0 16px" }}>Create your first commercial estimate.</p>
+                  <button onClick={() => navigate("/estimates/new")} style={{ background: MINT, color: "#063", border: "none", borderRadius: 9, padding: "9px 16px", fontSize: 13, fontWeight: 700, cursor: "pointer", fontFamily: FF }}>New Estimate</button>
+                </div>
+              ) : (
+                estimates.map((e, i) => {
+                  const recipient = e.recipient || e.account_name || e.contact_name || "Untitled";
+                  return (
+                    <div key={e.id} onClick={() => navigate(`/estimates/${e.id}`)}
+                      style={{ display: "flex", alignItems: "center", gap: 14, padding: "14px 16px", borderTop: i === 0 ? "none" : `1px solid ${BORDER}`, cursor: "pointer" }}>
+                      <div style={{ flex: 1, minWidth: 0 }}>
+                        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                          <span style={{ fontSize: 14, fontWeight: 700, color: INK, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{recipient}</span>
+                          <StatusChip status={e.status} />
+                        </div>
+                        <p style={{ fontSize: 12, color: MUTE, margin: "3px 0 0", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+                          {e.estimate_number || "—"}{e.title ? ` · ${e.title}` : ""}{e.service_address ? ` · ${e.service_address}` : ""}
+                        </p>
+                      </div>
+                      <div style={{ textAlign: "right" }}>
+                        <p style={{ fontSize: 15, fontWeight: 800, color: INK, margin: 0 }}>{money(e.total)}</p>
+                        <p style={{ fontSize: 11, color: MUTE, margin: "2px 0 0" }}>{e.created_at ? new Date(e.created_at).toLocaleDateString("en-US", { month: "short", day: "numeric" }) : ""}</p>
+                      </div>
+                      <div style={{ display: "flex", gap: 4 }} onClick={ev => ev.stopPropagation()}>
+                        <button title="Edit" onClick={() => navigate(`/estimates/${e.id}`)} style={iconBtn}><Pencil size={15} /></button>
+                        <button title="Delete" onClick={() => { if (confirm("Delete this estimate?")) del.mutate(e.id); }} style={iconBtn}><Trash2 size={15} /></button>
+                      </div>
+                    </div>
+                  );
+                })
+              )}
+            </div>
+          </>
+        ) : (
+          <div style={{ background: "#fff", border: `1px solid ${BORDER}`, borderRadius: 12, overflow: "hidden" }}>
+            {templates.length === 0 ? (
+              <div style={{ padding: "48px 20px", textAlign: "center" }}>
+                <LayoutTemplate size={28} style={{ color: "#C9C6BF", margin: "0 auto 10px" }} />
+                <p style={{ fontSize: 15, fontWeight: 700, color: INK, margin: "0 0 4px" }}>No templates yet</p>
+                <p style={{ fontSize: 13, color: MUTE, margin: 0 }}>Build an estimate, then "Save as template" to reuse it on your next walkthrough.</p>
+              </div>
+            ) : (
+              templates.map((t, i) => (
+                <div key={t.id} style={{ display: "flex", alignItems: "center", gap: 14, padding: "14px 16px", borderTop: i === 0 ? "none" : `1px solid ${BORDER}` }}>
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <p style={{ fontSize: 14, fontWeight: 700, color: INK, margin: 0 }}>{t.name}</p>
+                    <p style={{ fontSize: 12, color: MUTE, margin: "3px 0 0" }}>{t.item_count} line item{t.item_count === 1 ? "" : "s"}{t.title ? ` · ${t.title}` : ""}</p>
+                  </div>
+                  <button onClick={() => navigate(`/estimates/new?template=${t.id}`)}
+                    style={{ background: MINT, color: "#063", border: "none", borderRadius: 9, padding: "8px 14px", fontSize: 13, fontWeight: 700, cursor: "pointer", fontFamily: FF }}>Use template</button>
+                  <button title="Delete" onClick={() => { if (confirm("Delete this template?")) delTemplate.mutate(t.id); }} style={iconBtn}><Trash2 size={15} /></button>
+                </div>
+              ))
+            )}
+          </div>
+        )}
+      </div>
+    </DashboardLayout>
+  );
+}
+
+const iconBtn: React.CSSProperties = {
+  width: 32, height: 32, display: "inline-flex", alignItems: "center", justifyContent: "center",
+  background: "#fff", border: `1px solid ${BORDER}`, borderRadius: 8, color: MUTE, cursor: "pointer",
+};

--- a/lib/db/src/schema/estimates.ts
+++ b/lib/db/src/schema/estimates.ts
@@ -1,0 +1,102 @@
+import { pgTable, serial, text, integer, timestamp, numeric } from "drizzle-orm/pg-core";
+import { createInsertSchema } from "drizzle-zod";
+import { z } from "zod/v4";
+import { companiesTable } from "./companies";
+import { usersTable } from "./users";
+import { accountsTable } from "./accounts";
+import { accountPropertiesTable } from "./account_properties";
+import { clientsTable } from "./clients";
+
+// [commercial-estimate-tool 2026-06-09] Dedicated estimate model, kept SEPARATE
+// from the residential `quotes` builder (beds/baths/sqft/pets) so neither
+// regresses the other. An estimate is a line-item document for commercial /
+// common-area work: pick an account + property (or type a contact), add line
+// items (flat / hourly / one-time), send via a hosted link + PDF, and follow up
+// through GoHighLevel. Line items live in their own table; reusable templates
+// mirror the same shape so an on-site walkthrough can start from a saved set.
+export const estimatesTable = pgTable("estimates", {
+  id: serial("id").primaryKey(),
+  company_id: integer("company_id").references(() => companiesTable.id).notNull(),
+  branch_id: integer("branch_id"),
+  // Recipient — a commercial account/property, an existing client, or a
+  // free-typed contact (the property manager you met on a walkthrough).
+  account_id: integer("account_id").references(() => accountsTable.id),
+  account_property_id: integer("account_property_id").references(() => accountPropertiesTable.id),
+  client_id: integer("client_id").references(() => clientsTable.id),
+  contact_name: text("contact_name"),
+  contact_email: text("contact_email"),
+  contact_phone: text("contact_phone"),
+  property_name: text("property_name"),
+  service_address: text("service_address"),
+  // Document body
+  estimate_number: text("estimate_number"),
+  title: text("title"),
+  intro_note: text("intro_note"),
+  terms: text("terms"),
+  internal_notes: text("internal_notes"),
+  status: text("status").notNull().default("draft"), // draft|sent|viewed|accepted|declined|expired
+  subtotal: numeric("subtotal", { precision: 12, scale: 2 }).notNull().default("0"),
+  discount_amount: numeric("discount_amount", { precision: 12, scale: 2 }).notNull().default("0"),
+  total: numeric("total", { precision: 12, scale: 2 }).notNull().default("0"),
+  valid_until: timestamp("valid_until"),
+  // Public hosted view (tokenized, no login) + lifecycle stamps
+  public_token: text("public_token"),
+  sent_at: timestamp("sent_at"),
+  viewed_at: timestamp("viewed_at"),
+  accepted_at: timestamp("accepted_at"),
+  declined_at: timestamp("declined_at"),
+  accepted_name: text("accepted_name"),
+  // GoHighLevel sync bookkeeping (Phase 3)
+  ghl_synced_at: timestamp("ghl_synced_at"),
+  created_by: integer("created_by").references(() => usersTable.id),
+  created_at: timestamp("created_at").notNull().defaultNow(),
+  updated_at: timestamp("updated_at").notNull().defaultNow(),
+});
+
+export const estimateLineItemsTable = pgTable("estimate_line_items", {
+  id: serial("id").primaryKey(),
+  estimate_id: integer("estimate_id").references(() => estimatesTable.id).notNull(),
+  company_id: integer("company_id").references(() => companiesTable.id).notNull(),
+  sort_order: integer("sort_order").notNull().default(0),
+  name: text("name"),
+  description: text("description"),
+  pricing_type: text("pricing_type").notNull().default("flat"), // flat|hourly|one_time
+  frequency: text("frequency"), // "2x/week", "Monthly", "One-time", ...
+  // quantity = hours when pricing_type='hourly', else a plain quantity (default 1)
+  quantity: numeric("quantity", { precision: 10, scale: 2 }).notNull().default("1"),
+  unit_rate: numeric("unit_rate", { precision: 12, scale: 2 }).notNull().default("0"),
+  amount: numeric("amount", { precision: 12, scale: 2 }).notNull().default("0"),
+  created_at: timestamp("created_at").notNull().defaultNow(),
+});
+
+export const estimateTemplatesTable = pgTable("estimate_templates", {
+  id: serial("id").primaryKey(),
+  company_id: integer("company_id").references(() => companiesTable.id).notNull(),
+  name: text("name").notNull(),
+  title: text("title"),
+  intro_note: text("intro_note"),
+  terms: text("terms"),
+  created_by: integer("created_by").references(() => usersTable.id),
+  created_at: timestamp("created_at").notNull().defaultNow(),
+});
+
+export const estimateTemplateItemsTable = pgTable("estimate_template_items", {
+  id: serial("id").primaryKey(),
+  template_id: integer("template_id").references(() => estimateTemplatesTable.id).notNull(),
+  company_id: integer("company_id").references(() => companiesTable.id).notNull(),
+  sort_order: integer("sort_order").notNull().default(0),
+  name: text("name"),
+  description: text("description"),
+  pricing_type: text("pricing_type").notNull().default("flat"),
+  frequency: text("frequency"),
+  quantity: numeric("quantity", { precision: 10, scale: 2 }).notNull().default("1"),
+  unit_rate: numeric("unit_rate", { precision: 12, scale: 2 }).notNull().default("0"),
+  amount: numeric("amount", { precision: 12, scale: 2 }).notNull().default("0"),
+  created_at: timestamp("created_at").notNull().defaultNow(),
+});
+
+export const insertEstimateSchema = createInsertSchema(estimatesTable).omit({ id: true, created_at: true, updated_at: true });
+export type InsertEstimate = z.infer<typeof insertEstimateSchema>;
+export type Estimate = typeof estimatesTable.$inferSelect;
+export type EstimateLineItem = typeof estimateLineItemsTable.$inferSelect;
+export type EstimateTemplate = typeof estimateTemplatesTable.$inferSelect;

--- a/lib/db/src/schema/index.ts
+++ b/lib/db/src/schema/index.ts
@@ -147,3 +147,8 @@ export * from "./attendance_proposals";
 // Push-notification device tokens (Capacitor native app). One user → many
 // devices; sender lives in api-server/src/lib/push.ts, gated by COMMS_ENABLED.
 export * from "./device_tokens";
+
+// [commercial-estimate-tool 2026-06-09] Commercial / common-area estimate
+// builder: estimates + line items + reusable templates. Separate from the
+// residential quotes builder.
+export * from "./estimates";


### PR DESCRIPTION
## Commercial / common-area Estimate tool — Phase 1a

Foundation for the estimate tool you asked for: build clean, line-item estimates for commercial & common-area work (condo/HOA walkthroughs), save reusable templates, and track them. Built as a **dedicated `estimates` model**, separate from the residential quotes builder so neither regresses the other.

### What's in this PR (Phase 1a)
**Data model** (new tables, idempotent cold-start `CREATE TABLE IF NOT EXISTS`):
- `estimates` — recipient (account/property or free-typed contact), title/intro/terms, status lifecycle (`draft → sent → viewed → accepted → declined → expired`), totals, `public_token` + sent/viewed/accepted stamps, and `ghl_synced_at` reserved for the GHL phase.
- `estimate_line_items` — **flat / hourly / one-time** lines (qty × rate → amount).
- `estimate_templates` + `estimate_template_items` — reusable line-item sets.

**Backend** (`routes/estimates.ts`, raw SQL, company-scoped): CRUD + stats + search; totals always recomputed server-side; template list/create/delete, create-from-template, and save-an-estimate-as-template; `/:id/send` mints the public token + marks sent.

**Frontend**:
- `/estimates` list — stat strip (outstanding / accepted / won this month / drafts), status chips, search, and a **Templates** tab.
- `/estimates/new` & `/estimates/:id` builder — recipient, line-item editor (type · frequency · qty · rate · live amount), running totals + discount, terms, **Save**, **Save as template**, **Start from template**, and **Mark sent**. New sidebar **Estimates** entry under Sales.

### Deliberately NOT in this PR (next increments)
- **Hosted public estimate page + Accept** (the customer-facing link).
- **PDF** download/attach.
- **GoHighLevel bridge** — on send, POST the contact + estimate link to a GHL inbound-webhook so GHL runs the SMS follow-up drip from your office line; on accept, fire a stop webhook. "Mark sent" today only sets status + token.

### Verification
All three CI gates pass locally: `typecheck:libs` (new schema compiles), api-server esbuild bundle, and the Vite frontend build.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_