### PR TITLE
feat(my-jobs): zone color + allowed hours + assigned team on the tech card

### DIFF
--- a/artifacts/api-server/src/routes/jobs.ts
+++ b/artifacts/api-server/src/routes/jobs.ts
@@ -484,6 +484,25 @@ router.get("/my-jobs", requireAuth, async (req, res) => {
         property_name: accountPropertiesTable.property_name,
         access_notes: accountPropertiesTable.access_notes,
         estimated_hours: jobsTable.estimated_hours,
+        // [tech-card-data 2026-06-09] Allowed hours is the load-bearing budget
+        // the tech needs (estimated_hours is the stale creation stamp). Zone
+        // (name + color) resolves zone_id first, then any zip source — a
+        // gray/zoneless tile is a data error per the zone-resolution invariant.
+        // Team = every assigned tech so the cleaner knows who else is going.
+        allowed_hours: jobsTable.allowed_hours,
+        zone_name: sql<string | null>`COALESCE(
+          (SELECT z.name FROM service_zones z WHERE z.id = ${jobsTable.zone_id}),
+          (SELECT z.name FROM service_zones z WHERE z.company_id = ${jobsTable.company_id} AND z.is_active = true
+             AND COALESCE(${jobsTable.address_zip}, CASE WHEN ${jobsTable.account_property_id} IS NOT NULL THEN ${accountPropertiesTable.zip} ELSE ${clientsTable.zip} END) = ANY(z.zip_codes) LIMIT 1)
+        )`,
+        zone_color: sql<string | null>`COALESCE(
+          (SELECT z.color FROM service_zones z WHERE z.id = ${jobsTable.zone_id}),
+          (SELECT z.color FROM service_zones z WHERE z.company_id = ${jobsTable.company_id} AND z.is_active = true
+             AND COALESCE(${jobsTable.address_zip}, CASE WHEN ${jobsTable.account_property_id} IS NOT NULL THEN ${accountPropertiesTable.zip} ELSE ${clientsTable.zip} END) = ANY(z.zip_codes) LIMIT 1)
+        )`,
+        team: sql<string | null>`(SELECT string_agg(u.first_name, ', ' ORDER BY jt.is_primary DESC, u.first_name)
+          FROM job_technicians jt JOIN users u ON u.id = jt.user_id WHERE jt.job_id = ${jobsTable.id})`,
+        team_count: sql<number>`(SELECT COUNT(*)::int FROM job_technicians jt WHERE jt.job_id = ${jobsTable.id})`,
         // Surface BOTH the tenant (the business that owns the job) and the
         // branch (Phes-internal location, if set). For cross-tenant techs
         // the company_name distinguishes "Phes Oak Lawn" from "PHES
@@ -550,6 +569,7 @@ router.get("/my-jobs", requireAuth, async (req, res) => {
         job_lng: j.job_lng ? parseFloat(j.job_lng) : null,
         base_fee: j.base_fee ? parseFloat(j.base_fee) : 0,
         estimated_hours: j.estimated_hours ? parseFloat(j.estimated_hours) : null,
+        allowed_hours: j.allowed_hours != null ? parseFloat(j.allowed_hours as any) : null,
         before_photo_count: photoMap.get(j.id)?.before || 0,
         after_photo_count: photoMap.get(j.id)?.after || 0,
         time_clock_entry: clockMap.get(j.id) || null,

--- a/artifacts/qleno/src/pages/my-jobs.tsx
+++ b/artifacts/qleno/src/pages/my-jobs.tsx
@@ -4,7 +4,7 @@ import { useAuthStore, getTokenRole } from "@/lib/auth";
 import { InlinePriceEdit } from "@/components/inline-price-edit";
 import { EarningsPanel } from "@/components/earnings-panel";
 import { useToast } from "@/hooks/use-toast";
-import { Check, Eye, Navigation, Phone, GraduationCap, DollarSign } from "lucide-react";
+import { Check, Eye, Navigation, Phone, GraduationCap, DollarSign, Users } from "lucide-react";
 import { Link } from "wouter";
 import { useEmployeeView } from "@/contexts/employee-view-context";
 import { getJobVisualStatus, STATUS_VISUALS, ensureJobStatusStyles } from "@/lib/job-status";
@@ -97,6 +97,11 @@ type Job = {
   access_notes: string | null;
   base_fee: number;
   estimated_hours: number | null;
+  allowed_hours: number | null;
+  zone_name: string | null;
+  zone_color: string | null;
+  team: string | null;
+  team_count: number;
   before_photo_count: number;
   after_photo_count: number;
   time_clock_entry: TimeclockEntry | null;
@@ -551,20 +556,44 @@ function JobCard({ job, empPos, onRefresh, isPreviewMode, prevJobId, requireAfte
             {job.branch_name}
           </span>
         ) : null}
+        {/* Zone chip — color dot + name so the tech knows which area they're
+            headed to. A zoneless job is a data error (see zone-resolution rule). */}
+        {job.zone_name && (
+          <span style={{ display: "inline-flex", alignItems: "center", gap: 5, fontSize: 10, fontWeight: 700, padding: "2px 8px", borderRadius: 20, background: "#F4F3F0", color: "#1A1917", letterSpacing: "0.02em" }}>
+            <span style={{ width: 9, height: 9, borderRadius: "50%", background: job.zone_color || "#9E9B94", display: "inline-block", flexShrink: 0 }} />
+            {job.zone_name}
+          </span>
+        )}
       </div>
       <p style={{ fontSize: 11, fontWeight: 600, color: "var(--brand)", textTransform: "uppercase", letterSpacing: "0.05em", margin: "0 0 4px" }}>
         {formatServiceType(job.service_type)}
       </p>
-      {job.scheduled_time && (
-        <p style={{ fontSize: 12, color: "#6B6860", margin: "0 0 2px" }}>
-          {formatTime(job.scheduled_time)}
-          {job.estimated_hours != null && job.estimated_hours > 0 && (
-            <span style={{ marginLeft: 8, color: "#9E9B94" }}>· ~{job.estimated_hours.toFixed(1)} hrs</span>
-          )}
+      {(() => {
+        // Allowed hours is the budget the tech needs; estimated_hours is the
+        // stale creation stamp and only a fallback.
+        const hrs = job.allowed_hours ?? job.estimated_hours;
+        const label = job.allowed_hours != null ? "hrs allowed" : "hrs est.";
+        return (
+          <>
+            {job.scheduled_time && (
+              <p style={{ fontSize: 12, color: "#6B6860", margin: "0 0 2px" }}>
+                {formatTime(job.scheduled_time)}
+                {hrs != null && hrs > 0 && (
+                  <span style={{ marginLeft: 8, color: "#9E9B94" }}>· {hrs.toFixed(1)} {label}</span>
+                )}
+              </p>
+            )}
+            {!job.scheduled_time && hrs != null && hrs > 0 && (
+              <p style={{ fontSize: 12, color: "#9E9B94", margin: "0 0 2px" }}>{hrs.toFixed(1)} {label}</p>
+            )}
+          </>
+        );
+      })()}
+      {job.team && job.team_count > 1 && (
+        <p style={{ fontSize: 12, color: "#6B6860", margin: "4px 0 0", display: "inline-flex", alignItems: "center", gap: 5 }}>
+          <Users size={13} aria-hidden="true" style={{ color: "#9E9B94", flexShrink: 0 }} />
+          Team: {job.team}
         </p>
-      )}
-      {!job.scheduled_time && job.estimated_hours != null && job.estimated_hours > 0 && (
-        <p style={{ fontSize: 12, color: "#9E9B94", margin: "0 0 2px" }}>Est. {job.estimated_hours.toFixed(1)} hrs</p>
       )}
       {job.address && (
         <a


### PR DESCRIPTION
## Wiring real job data onto the tech card

A tech opening a job card couldn't see which **zone** they were headed to, how many **hours** were budgeted, or whether **another team member** was going. This adds all three to `/my-jobs`.

- **Zone (color + name):** `/jobs/my-jobs` resolves the zone via `zone_id` first, then any zip source (`address_zip` → property/client zip) per the zone-resolution invariant. The card shows a color-dot zone chip next to the business chip.
- **Allowed hours:** the card now leads with `allowed_hours` (the budget that drives the efficiency math) instead of the stale `estimated_hours` creation stamp; estimated remains a clearly-labeled fallback (`hrs est.` vs `hrs allowed`).
- **Team:** aggregates every assigned tech's first name; the card shows `Team: …` when more than one tech is on the job.

## Verification
api-server esbuild bundle + Vite frontend build both pass.

## Note
This is independent of the day-navigation strip (shipped in #364) and the clock-in/out flow — both already behave as designed; see the chat for the clock-in/out + preview-mode explanation.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_