### PR TITLE
docs: bilingual (EN/ES) field-app team guide (pre-written copy)

### DIFF
--- a/docs/FIELD_APP_GUIDE.md
+++ b/docs/FIELD_APP_GUIDE.md
@@ -1,0 +1,215 @@
+# Qleno Field App — Team Guide / Guía del Equipo
+
+> **Status:** Copy pre-written (2026-06-10). Screenshot slots marked `[[SHOT n]]`
+> are placeholders for fresh post-deploy captures. Once the images are dropped in,
+> this exports to a bilingual PDF (English pages first, Spanish pages second).
+>
+> **Audience:** Cleaning technicians (field staff).
+> **Covers:** logging in, reading your job card (zone, hours, team), getting
+> directions, before/after photos, and the clock — Clock In → Pause → Clock Out.
+>
+> **Design note — the clock model (do not reword):** there is ONE clock pair,
+> used at each house: **Clock In → (Pause/Resume) → Clock Out.** There is no
+> separate "Check In / Check Out." Your paid day is figured out automatically
+> from your first Clock In to your last Clock Out — there is no "start day" or
+> "end day" button.
+
+---
+
+# ENGLISH
+
+## 1. Opening the app & signing in
+`[[SHOT 1: login screen]]`
+
+1. Open the Qleno app on your phone (or the link your office sent — add it to your home screen so it opens like an app).
+2. Enter your phone number or email and your password, then tap **Sign In**.
+3. You land on **My Jobs** — your schedule for the day.
+
+> Tip: If the app looks out of date or a button is missing, fully close the tab and reopen it (or pull down to refresh). That loads the newest version.
+
+## 2. Finding the right day
+`[[SHOT 2: My Jobs header with the day strip]]`
+
+- The bar under the title shows the day. Tap **‹** or **›** to move to the day before or after.
+- Tap the date in the middle to jump back to **Today**.
+- **Today** shows your full job cards. Other days show a shorter list — tap a job to open it.
+
+## 3. Reading your job card
+`[[SHOT 3: a full job card with zone chip, hours, and team]]`
+
+Each card tells you everything you need before you go:
+
+- **Status** (top left): Scheduled, In Progress, Complete, etc.
+- **Price** (top right): the job total.
+- **Client name** and any tags — **Commercial**, the business (Phes), and the **Zone** (a colored dot + zone name so you know which area you're headed to).
+- **Service type** (e.g., Standard Clean) and the **start time**.
+- **Allowed hours** — the time budgeted for this job (shown as "X hrs allowed"). This is your target.
+- **Team** — if another cleaner is assigned, you'll see **"Team: …"** with their names, so you know who else is going.
+- **Address** — tap it to open directions (see next step).
+- **Phone** — tap to call the client.
+- **Building Access / Client Notes** — gate codes, where to park, pets, special requests. Read these first.
+
+> If a job has no zone color or no address, tell the office — that's missing data they can fix.
+
+## 4. Getting directions
+`[[SHOT 4: tapping the address]]`
+
+1. Tap the **address** (underlined, with the arrow icon) on the job card.
+2. Your phone's maps app opens with the route already set.
+3. Drive to the house. (Home-to-first-job and last-job-to-home driving is not paid — only client-to-client drive time counts.)
+
+## 5. Before photos
+`[[SHOT 5: Before Photos box]]`
+
+1. On the job card, find **Before Photos**.
+2. Tap the **+** box.
+3. Take the photo (or choose one). It uploads automatically.
+4. Add as many as you need to show the starting condition.
+
+> Before photos protect you — they show the condition of the home when you arrived.
+
+## 6. Clock In (at the house)
+`[[SHOT 6: Clock In button]]`
+
+1. When you arrive **at the house and are ready to start**, tap **Clock In**.
+2. The timer starts counting your time on the job.
+3. Allow location when asked — clocking in confirms you're at the right address.
+
+> Clock in **at the house**, not in the car or at home. Your location is checked.
+
+## 7. Pause and resume
+`[[SHOT 7: Pause Job button + running timer]]`
+
+- Taking a real, fully-off break (like a 30-minute lunch)? Tap **Pause Job**.
+- When you start working again, tap **Resume**.
+- Short waits while you keep working do not need a pause.
+
+## 8. After photos
+`[[SHOT 8: After Photos box]]`
+
+1. When the work is done, find **After Photos**.
+2. Tap **+** and capture the finished result — the same areas as your before photos.
+3. After photos show your great work and help with any questions later.
+
+## 9. Clock Out
+`[[SHOT 9: Clock Out button]]`
+
+1. When the job is finished and your after photos are added, tap **Clock Out**.
+2. The timer stops and the job moves to **Complete**.
+3. That's it for this house — no separate "check out."
+
+> The **Clock Out** button is grayed out when the office is *viewing as you* (preview mode). On your own phone, signed in as yourself, it works normally.
+
+## 10. Your day ends by itself
+`[[SHOT 10: end-of-day summary]]`
+
+- Your **paid day** runs from your **first Clock In** to your **last Clock Out** — automatically. There is no "end my day" button.
+- If a surprise job gets added after your "last" one, just Clock In there too — your day simply extends to the new last Clock Out.
+- After your last house, you'll see a short summary of the day (jobs, hours, miles).
+
+## Quick reminders
+- One clock per house: **Clock In → Clock Out**. No separate check-in.
+- Clock in **at the house** — your location is checked.
+- **Allowed hours** on the card is your time target.
+- Read **Building Access / Notes** before you start.
+- App looks old or a button is missing? Close and reopen to update.
+
+---
+
+# ESPAÑOL
+
+## 1. Abrir la aplicación e iniciar sesión
+`[[SHOT 1: pantalla de inicio de sesión]]`
+
+1. Abre la aplicación de Qleno en tu teléfono (o el enlace que te envió la oficina — agrégalo a tu pantalla de inicio para que se abra como una app).
+2. Escribe tu número de teléfono o correo y tu contraseña, y toca **Iniciar sesión**.
+3. Llegarás a **Mis Trabajos** (My Jobs) — tu agenda del día.
+
+> Consejo: Si la app se ve desactualizada o falta un botón, cierra la pestaña por completo y vuelve a abrirla (o desliza hacia abajo para actualizar). Así se carga la versión más nueva.
+
+## 2. Encontrar el día correcto
+`[[SHOT 2: encabezado de Mis Trabajos con la barra de días]]`
+
+- La barra debajo del título muestra el día. Toca **‹** o **›** para ir al día anterior o siguiente.
+- Toca la fecha en el centro para regresar a **Hoy**.
+- **Hoy** muestra las tarjetas completas de tus trabajos. Los otros días muestran una lista más corta — toca un trabajo para abrirlo.
+
+## 3. Leer la tarjeta de tu trabajo
+`[[SHOT 3: una tarjeta completa con la zona, las horas y el equipo]]`
+
+Cada tarjeta te dice todo lo que necesitas antes de salir:
+
+- **Estado** (arriba a la izquierda): Programado, En Progreso, Completado, etc.
+- **Precio** (arriba a la derecha): el total del trabajo.
+- **Nombre del cliente** y las etiquetas — **Comercial**, el negocio (Phes) y la **Zona** (un punto de color + el nombre de la zona, para que sepas a qué área vas).
+- **Tipo de servicio** (por ejemplo, Limpieza Estándar) y la **hora de inicio**.
+- **Horas asignadas** (allowed hours) — el tiempo presupuestado para este trabajo (aparece como "X hrs allowed"). Esta es tu meta.
+- **Equipo** — si hay otro/a limpiador/a asignado/a, verás **"Team: …"** con sus nombres, para que sepas quién más va.
+- **Dirección** — tócala para abrir las indicaciones (ver el siguiente paso).
+- **Teléfono** — tócalo para llamar al cliente.
+- **Acceso al edificio / Notas del cliente** — códigos de puerta, dónde estacionarse, mascotas, peticiones especiales. Lee esto primero.
+
+> Si un trabajo no tiene color de zona o no tiene dirección, avísale a la oficina — son datos que faltan y que ellos pueden corregir.
+
+## 4. Obtener las indicaciones para llegar
+`[[SHOT 4: tocando la dirección]]`
+
+1. Toca la **dirección** (subrayada, con el ícono de flecha) en la tarjeta.
+2. Se abre la app de mapas de tu teléfono con la ruta ya marcada.
+3. Maneja hasta la casa. (El manejo de tu casa al primer trabajo y del último trabajo a tu casa no se paga — solo cuenta el tiempo de manejo de un cliente a otro.)
+
+## 5. Fotos "antes" (Before)
+`[[SHOT 5: cuadro de Fotos Antes]]`
+
+1. En la tarjeta, busca **Before Photos** (Fotos Antes).
+2. Toca el cuadro con el **+**.
+3. Toma la foto (o elige una). Se sube automáticamente.
+4. Toma todas las que necesites para mostrar cómo estaba al llegar.
+
+> Las fotos "antes" te protegen — muestran las condiciones de la casa cuando llegaste.
+
+## 6. Marcar entrada / Clock In (en la casa)
+`[[SHOT 6: botón Clock In]]`
+
+1. Cuando llegues **a la casa y estés listo/a para empezar**, toca **Clock In**.
+2. El cronómetro empieza a contar tu tiempo en el trabajo.
+3. Permite el acceso a la ubicación cuando te lo pida — marcar entrada confirma que estás en la dirección correcta.
+
+> Marca entrada **en la casa**, no en el carro ni en tu hogar. Se verifica tu ubicación.
+
+## 7. Pausar y reanudar
+`[[SHOT 7: botón Pause Job + cronómetro corriendo]]`
+
+- ¿Vas a tomar un descanso real y completo (como un almuerzo de 30 minutos)? Toca **Pause Job** (Pausar).
+- Cuando vuelvas a trabajar, toca **Resume** (Reanudar).
+- Las esperas cortas mientras sigues trabajando no necesitan pausa.
+
+## 8. Fotos "después" (After)
+`[[SHOT 8: cuadro de Fotos Después]]`
+
+1. Cuando termines el trabajo, busca **After Photos** (Fotos Después).
+2. Toca el **+** y toma el resultado final — las mismas áreas que en tus fotos "antes".
+3. Las fotos "después" muestran tu buen trabajo y ayudan si hay preguntas más adelante.
+
+## 9. Marcar salida / Clock Out
+`[[SHOT 9: botón Clock Out]]`
+
+1. Cuando el trabajo esté terminado y tus fotos "después" estén agregadas, toca **Clock Out**.
+2. El cronómetro se detiene y el trabajo pasa a **Completado**.
+3. Eso es todo para esta casa — no hay una "salida" aparte.
+
+> El botón **Clock Out** aparece gris cuando la oficina te está *viendo como tú* (modo de vista previa). En tu propio teléfono, con tu sesión iniciada, funciona normal.
+
+## 10. Tu día termina solo
+`[[SHOT 10: resumen de fin de día]]`
+
+- Tu **día pagado** va desde tu **primer Clock In** hasta tu **último Clock Out** — automáticamente. No hay un botón de "terminar mi día".
+- Si te agregan un trabajo sorpresa después del "último", solo marca entrada (Clock In) ahí también — tu día simplemente se extiende hasta el nuevo último Clock Out.
+- Después de tu última casa, verás un resumen corto del día (trabajos, horas, millas).
+
+## Recordatorios rápidos
+- Un reloj por casa: **Clock In → Clock Out**. No hay entrada aparte.
+- Marca entrada **en la casa** — se verifica tu ubicación.
+- Las **horas asignadas** (allowed hours) en la tarjeta son tu meta de tiempo.
+- Lee el **Acceso al edificio / Notas** antes de empezar.
+- ¿La app se ve vieja o falta un botón? Ciérrala y ábrela de nuevo para actualizar.


### PR DESCRIPTION
## Bilingual (EN/ES) field-app team guide — pre-written copy

Pre-write step toward the training PDF. Full field-app guide for cleaning techs, in **English and Spanish**, covering:

1. Signing in
2. Day navigation (the ‹ Today › strip)
3. Reading the job card — **zone, allowed hours, team**, notes, building access
4. Getting directions
5. Before photos
6. **Clock In** (at the house)
7. Pause / Resume
8. After photos
9. **Clock Out**
10. The derived day (no "end day" button)

Plus a quick-reminders box per language.

### Screenshot slots
Ten `[[SHOT n]]` placeholders mark where fresh post-deploy captures drop in. Once Sal sends the new screenshots (showing the deployed zone chip / allowed hours / day strip), this exports straight to the bilingual PDF.

### Locked language
The clock-model copy matches the Time Clock design exactly: **one clock pair per house, no separate check-in, day derived from first Clock In → last Clock Out.** The guide also explains why Clock Out looks grayed in office "view-as" preview mode.

Docs-only — no code paths touched.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_