### PR TITLE
fix(my-jobs): zone border, hide price in preview, actionable preview clock, expected end time

### DIFF
--- a/artifacts/api-server/src/routes/timeclock.ts
+++ b/artifacts/api-server/src/routes/timeclock.ts
@@ -180,7 +180,29 @@ router.get("/attempts", requireAuth, requireRole("owner", "admin", "office"), as
 
 router.post("/clock-in", requireAuth, async (req, res) => {
   try {
-    const { job_id, lat, lng, accuracy, override_token } = req.body;
+    const { job_id, lat, lng, accuracy, override_token, acting_for_user_id } = req.body;
+
+    // [acting-for 2026-06-10] The office can clock a tech in on their behalf —
+    // testing via "view as", or a tech whose phone died on site. Only
+    // owner/admin/office/super_admin may act for someone else, the target must
+    // belong to the same company, and a remote (office-acted) clock skips the
+    // hard geofence block because the office isn't standing at the job site.
+    let effectiveUserId = req.auth!.userId;
+    let actingForOther = false;
+    if (acting_for_user_id != null && Number(acting_for_user_id) !== req.auth!.userId) {
+      const role = req.auth!.role || "";
+      if (!["owner", "admin", "office", "super_admin"].includes(role)) {
+        return res.status(403).json({ error: "Forbidden", message: "Not allowed to clock in another user" });
+      }
+      const target = await db.select({ id: usersTable.id }).from(usersTable)
+        .where(and(eq(usersTable.id, Number(acting_for_user_id)), eq(usersTable.company_id, req.auth!.companyId)))
+        .limit(1);
+      if (!target[0]) {
+        return res.status(404).json({ error: "Not Found", message: "Target employee not found in this company" });
+      }
+      effectiveUserId = Number(acting_for_user_id);
+      actingForOther = true;
+    }
 
     const job = await db
       .select()
@@ -230,12 +252,12 @@ router.post("/clock-in", requireAuth, async (req, res) => {
 
     if (geofenceEnabled && distanceFt !== null) {
       outsideGeofence = distanceFt > clockInRadius;
-      flagged = outsideGeofence && !softMode;
+      flagged = outsideGeofence && !softMode && !actingForOther;
     }
 
     const isOverride = override_token === "approved";
 
-    if (geofenceEnabled && outsideGeofence && !softMode && !isOverride) {
+    if (geofenceEnabled && outsideGeofence && !softMode && !isOverride && !actingForOther) {
       await db.insert(clockInAttemptsTable).values({
         company_id: req.auth!.companyId,
         user_id: req.auth!.userId,
@@ -270,7 +292,7 @@ router.post("/clock-in", requireAuth, async (req, res) => {
       .insert(timeclockTable)
       .values({
         job_id,
-        user_id: req.auth!.userId,
+        user_id: effectiveUserId,
         company_id: req.auth!.companyId,
         branch_id: stampedBranchId,
         clock_in_lat: empLat !== null ? String(empLat) : null,
@@ -286,7 +308,7 @@ router.post("/clock-in", requireAuth, async (req, res) => {
 
     await db.insert(clockInAttemptsTable).values({
       company_id: req.auth!.companyId,
-      user_id: req.auth!.userId,
+      user_id: effectiveUserId,
       job_id,
       employee_lat: empLat !== null ? String(empLat) : null,
       employee_lng: empLng !== null ? String(empLng) : null,
@@ -307,14 +329,14 @@ router.post("/clock-in", requireAuth, async (req, res) => {
         const lateThreshold = new Date(scheduledStart.getTime() + 20 * 60 * 1000);
         if (new Date() > lateThreshold) {
           const techRow = await db.select({ first_name: usersTable.first_name, last_name: usersTable.last_name })
-            .from(usersTable).where(eq(usersTable.id, req.auth!.userId)).limit(1);
+            .from(usersTable).where(eq(usersTable.id, effectiveUserId)).limit(1);
           const techName = techRow[0] ? `${techRow[0].first_name} ${techRow[0].last_name}` : "A technician";
           const clientName = job[0].clients ? `${(job[0].clients as any).first_name} ${(job[0].clients as any).last_name}` : "a client";
           const notifTitle = `Late Clock-In — ${techName}`;
           const notifBody = `${techName} clocked in late for ${clientName}'s job (scheduled ${arrivalWindow}).`;
           await db.execute(
             sql`INSERT INTO notifications (company_id, type, title, body, link, meta)
-              VALUES (${req.auth!.companyId}, 'late_clockin', ${notifTitle}, ${notifBody}, ${`/dispatch`}, ${JSON.stringify({ job_id, user_id: req.auth!.userId, tech_name: techName })}::jsonb)`
+              VALUES (${req.auth!.companyId}, 'late_clockin', ${notifTitle}, ${notifBody}, ${`/dispatch`}, ${JSON.stringify({ job_id, user_id: effectiveUserId, tech_name: techName })}::jsonb)`
           );
         }
       }

--- a/artifacts/qleno/src/pages/my-jobs.tsx
+++ b/artifacts/qleno/src/pages/my-jobs.tsx
@@ -497,9 +497,12 @@ function JobCard({ job, empPos, onRefresh, isPreviewMode, prevJobId, requireAfte
 
   return (
     <div style={{
-      backgroundColor: "#FFFFFF", border: "1px solid #E5E2DC",
+      backgroundColor: "#FFFFFF",
+      // Outline the whole card in the zone color so the tech sees their area at
+      // a glance; status overrides (active/unpaid/no-show/unassigned) win when
+      // present, mirroring the dispatch chip's border behavior.
+      border: `2px solid ${visual.borderOverride || job.zone_color || "#E5E2DC"}`,
       borderRadius: 12, padding: 18, margin: "0 0 12px 0",
-      borderLeft: visual.stripe ? "none" : `3px solid var(--brand)`,
       position: "relative", overflow: "hidden",
       opacity: visual.bodyOpacity * (job.status === "cancelled" ? 1 : 1),
       filter: visual.desaturate ? "grayscale(1)" : "none",
@@ -524,7 +527,9 @@ function JobCard({ job, empPos, onRefresh, isPreviewMode, prevJobId, requireAfte
         <span style={{ fontSize: 11, fontWeight: 600, padding: "2px 8px", borderRadius: 20, backgroundColor: sc.bg, color: sc.color, textTransform: "capitalize", textDecoration: visual.strikethrough ? "line-through" : "none" }}>
           {job.status.replace("_", " ")}
         </span>
-        {["owner", "admin", "office"].includes(getTokenRole() || "")
+        {/* Techs never edit price. Also suppressed in office "view-as" preview
+            so the preview faithfully shows what the cleaner actually sees. */}
+        {!isPreviewMode && ["owner", "admin", "office"].includes(getTokenRole() || "")
           ? <InlinePriceEdit jobId={job.id} price={job.base_fee} canEdit onUpdated={onRefresh} />
           : <span style={{ fontSize: 20, fontWeight: 700, color: "#1A1917" }}>${job.base_fee.toFixed(2)}</span>}
       </div>

--- a/artifacts/qleno/src/pages/my-jobs.tsx
+++ b/artifacts/qleno/src/pages/my-jobs.tsx
@@ -34,6 +34,18 @@ function formatServiceType(s: string) {
   return s.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
 }
 
+// Expected finish = scheduled start + allowed hours, so the tech sees their
+// target end time on the card (e.g. "9:00 AM · 3.0 hrs allowed · ends ~12:00 PM").
+function addHoursToTime(t: string, hours: number): string {
+  const [h, m] = t.split(":").map(Number);
+  const total = (h || 0) * 60 + (m || 0) + Math.round(hours * 60);
+  const hh = Math.floor(total / 60) % 24;
+  const mm = ((total % 60) + 60) % 60;
+  const ampm = hh >= 12 ? "PM" : "AM";
+  const h12 = hh > 12 ? hh - 12 : hh || 12;
+  return `${h12}:${String(mm).padStart(2, "0")} ${ampm}`;
+}
+
 function formatDuration(ms: number) {
   const total = Math.floor(ms / 1000);
   const h = Math.floor(total / 3600);
@@ -306,7 +318,7 @@ function AddNote({ jobId, onSaved }: { jobId: number; onSaved: () => void }) {
   );
 }
 
-function JobCard({ job, empPos, onRefresh, isPreviewMode, prevJobId, requireAfterPhoto }: { job: Job; empPos: { lat: number; lng: number } | null; onRefresh: () => void; isPreviewMode?: boolean; prevJobId?: number | null; requireAfterPhoto?: boolean }) {
+function JobCard({ job, empPos, onRefresh, isPreviewMode, actingForUserId, prevJobId, requireAfterPhoto }: { job: Job; empPos: { lat: number; lng: number } | null; onRefresh: () => void; isPreviewMode?: boolean; actingForUserId?: number | null; prevJobId?: number | null; requireAfterPhoto?: boolean }) {
   const { toast } = useToast();
   const qc = useQueryClient();
   const [geoLoading, setGeoLoading] = useState(false);
@@ -337,7 +349,9 @@ function JobCard({ job, empPos, onRefresh, isPreviewMode, prevJobId, requireAfte
     mutationFn: async ({ lat, lng, accuracy, override_token }: { lat: number; lng: number; accuracy?: number; override_token?: string }) => {
       const res = await apiFetch("/timeclock/clock-in", {
         method: "POST",
-        body: JSON.stringify({ job_id: job.id, lat, lng, accuracy, override_token }),
+        // In office "view-as" preview the API call carries the office user's
+        // token; acting_for_user_id attributes the clock to the viewed tech.
+        body: JSON.stringify({ job_id: job.id, lat, lng, accuracy, override_token, acting_for_user_id: actingForUserId ?? undefined }),
       });
       const data = await res.json();
       if (!res.ok) throw { status: res.status, ...data };
@@ -584,7 +598,9 @@ function JobCard({ job, empPos, onRefresh, isPreviewMode, prevJobId, requireAfte
               <p style={{ fontSize: 12, color: "#6B6860", margin: "0 0 2px" }}>
                 {formatTime(job.scheduled_time)}
                 {hrs != null && hrs > 0 && (
-                  <span style={{ marginLeft: 8, color: "#9E9B94" }}>· {hrs.toFixed(1)} {label}</span>
+                  <span style={{ marginLeft: 8, color: "#9E9B94" }}>
+                    · {hrs.toFixed(1)} {label} · ends ~{addHoursToTime(job.scheduled_time, hrs)}
+                  </span>
                 )}
               </p>
             )}
@@ -691,7 +707,7 @@ function JobCard({ job, empPos, onRefresh, isPreviewMode, prevJobId, requireAfte
           <p style={{ fontSize: 12, color: "#7F1D1D", margin: "0 0 12px", lineHeight: 1.5 }}>
             You are {geofenceError.distanceFt} ft from this job. Must be within {geofenceError.radiusFt} ft to clock in. Please drive to the job address and try again.
           </p>
-          {geofenceError.overrideAllowed && !isPreviewMode && (
+          {geofenceError.overrideAllowed && (
             <button
               onClick={() => {
                 setGeofenceError(null);
@@ -731,15 +747,13 @@ function JobCard({ job, empPos, onRefresh, isPreviewMode, prevJobId, requireAfte
             </div>
             <p style={{ fontSize: 11, color: "#9E9B94", margin: "0 0 12px" }}>Time on job</p>
             <button
-              onClick={() => !isPreviewMode && smsMutation.mutate(paused ? "resumed" : "paused")}
-              disabled={smsMutation.isPending || isPreviewMode}
-              title={isPreviewMode ? "Actions disabled in preview mode" : undefined}
+              onClick={() => smsMutation.mutate(paused ? "resumed" : "paused")}
+              disabled={smsMutation.isPending}
               style={{
                 width: "100%", height: 42, borderRadius: 10, border: `1px solid ${paused ? "#10B981" : "#F59E0B"}`,
-                fontSize: 14, fontWeight: 600, cursor: isPreviewMode ? "not-allowed" : "pointer", marginBottom: 10,
+                fontSize: 14, fontWeight: 600, cursor: "pointer", marginBottom: 10,
                 backgroundColor: paused ? "#DCFCE7" : "#FEF3C7",
                 color: paused ? "#166534" : "#92400E",
-                opacity: isPreviewMode ? 0.6 : 1,
                 fontFamily: "'Plus Jakarta Sans', sans-serif",
               }}
             >
@@ -747,22 +761,19 @@ function JobCard({ job, empPos, onRefresh, isPreviewMode, prevJobId, requireAfte
             </button>
             <button
               onClick={() => {
-                if (isPreviewMode) return;
                 if (photoGate) {
                   toast({ variant: "destructive", title: "After photo required", description: "Upload at least 1 after photo first" });
                   return;
                 }
                 getLocation((lat, lng) => clockOutMutation.mutate({ lat, lng }));
               }}
-              disabled={clockOutMutation.isPending || geoLoading || isPreviewMode}
-              title={isPreviewMode ? "Actions disabled in preview mode" : undefined}
+              disabled={clockOutMutation.isPending || geoLoading}
               style={{
                 width: "100%", height: 48, borderRadius: 10, border: "none",
                 fontSize: 15, fontWeight: 600,
-                cursor: (isPreviewMode || photoGate) ? "not-allowed" : "pointer",
-                backgroundColor: (isPreviewMode || photoGate) ? "#F3F4F6" : "#166534",
-                color: (isPreviewMode || photoGate) ? "#9E9B94" : "#FFFFFF",
-                opacity: isPreviewMode ? 0.6 : 1,
+                cursor: photoGate ? "not-allowed" : "pointer",
+                backgroundColor: photoGate ? "#F3F4F6" : "#166534",
+                color: photoGate ? "#9E9B94" : "#FFFFFF",
                 transition: "opacity 0.15s",
                 fontFamily: "'Plus Jakarta Sans', sans-serif",
               }}
@@ -774,13 +785,12 @@ function JobCard({ job, empPos, onRefresh, isPreviewMode, prevJobId, requireAfte
           <div>
             <button
               onClick={fireOnMyWay}
-              disabled={omwBusy || omwMutation.isPending || isPreviewMode}
-              title={isPreviewMode ? "Actions disabled in preview mode" : undefined}
+              disabled={omwBusy || omwMutation.isPending}
               style={{
                 width: "100%", height: 42, borderRadius: 10, border: "1px solid var(--brand)",
-                fontSize: 14, fontWeight: 600, cursor: isPreviewMode ? "not-allowed" : "pointer", marginBottom: 10,
+                fontSize: 14, fontWeight: 600, cursor: "pointer", marginBottom: 10,
                 backgroundColor: "var(--brand-soft)", color: "var(--brand)",
-                opacity: (isPreviewMode || omwBusy) ? 0.6 : 1,
+                opacity: omwBusy ? 0.6 : 1,
                 fontFamily: "'Plus Jakarta Sans', sans-serif",
               }}
             >
@@ -788,17 +798,15 @@ function JobCard({ job, empPos, onRefresh, isPreviewMode, prevJobId, requireAfte
             </button>
             <button
               onClick={() => {
-                if (isPreviewMode) return;
                 setGeofenceError(null);
                 setSoftWarning(null);
                 getLocation((lat, lng, accuracy) => clockInMutation.mutate({ lat, lng, accuracy }));
               }}
-              disabled={clockInMutation.isPending || geoLoading || isPreviewMode}
-              title={isPreviewMode ? "Actions disabled in preview mode" : undefined}
+              disabled={clockInMutation.isPending || geoLoading}
               style={{
-                width: "100%", height: 48, backgroundColor: isPreviewMode ? "#E5E7EB" : "var(--brand)", color: isPreviewMode ? "#9E9B94" : "#FFFFFF",
+                width: "100%", height: 48, backgroundColor: "var(--brand)", color: "#FFFFFF",
                 borderRadius: 10, border: "none", fontSize: 15, fontWeight: 600,
-                cursor: isPreviewMode ? "not-allowed" : "pointer",
+                cursor: "pointer",
                 opacity: (clockInMutation.isPending || geoLoading) ? 0.7 : 1,
                 fontFamily: "'Plus Jakarta Sans', sans-serif",
               }}
@@ -1002,6 +1010,7 @@ export default function MyJobsPage() {
               )}
               {activeJobs.map((job, i) => (
                 <JobCard key={job.id} job={job} empPos={empPos} onRefresh={refetch} isPreviewMode={!!employeeView}
+                  actingForUserId={employeeView ? employeeView.employeeId : null}
                   prevJobId={i > 0 ? activeJobs[i - 1].id : null} requireAfterPhoto={requireAfterPhoto} />
               ))}
               {upcomingJobs.length > 0 && (


### PR DESCRIPTION
## Field-testing fixes on the tech job card

From Sal testing as Juliana. Five issues addressed:

1. **Full zone-color border** — the card is now outlined all around in its zone color (e.g., South Suburbs red). Status overrides (active / unpaid / no-show / unassigned) still win, mirroring the dispatch chip.
2. **Price edit hidden in preview** — the inline price editor no longer renders in office "view-as" mode, so preview shows what the cleaner actually sees. (Real techs never had edit rights via the role gate.)
3. **Actionable preview clock** — Clock In/Out, Pause, On My Way are now **live in view-as preview** (were disabled). The clock-in call passes `acting_for_user_id` so the entry is attributed to the **viewed tech**, not the office user holding the token.
   - Backend `/timeclock/clock-in` accepts `acting_for_user_id`: only owner/admin/office/super_admin may act for someone, the target must be in the same company, and a remote (office-acted) clock **skips the hard geofence block** since the office isn't at the job site. Clock-out already keyed off entry id, so it worked for the office already.
4. **Expected end time** — card now shows `9:00 AM · 3.0 hrs allowed · ends ~12:00 PM` so the tech knows their target finish.

## Not code — for Sal
- **"Pictures don't save"** is the server flag `PHOTOS_ENABLED` (returns 503 unless `"true"` in Railway env), not a bug.

## Still open (next PR)
- **Tapping a job card → detail screen** (Sal chose "open a detail screen") — building next as its own change.

## Verification
api-server esbuild bundle + Vite frontend build both pass.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj