### PR TITLE
feat(my-jobs): enable photos + surface field-tech essentials (add-ons, pets, entry code, visit context)

### DIFF
--- a/artifacts/api-server/src/routes/jobs.ts
+++ b/artifacts/api-server/src/routes/jobs.ts
@@ -503,6 +503,21 @@ router.get("/my-jobs", requireAuth, async (req, res) => {
         team: sql<string | null>`(SELECT string_agg(u.first_name, ', ' ORDER BY jt.is_primary DESC, u.first_name)
           FROM job_technicians jt JOIN users u ON u.id = jt.user_id WHERE jt.job_id = ${jobsTable.id})`,
         team_count: sql<number>`(SELECT COUNT(*)::int FROM job_technicians jt WHERE jt.job_id = ${jobsTable.id})`,
+        // [field-tech-audit 2026-06-10] The pertinent things a cleaner needs that
+        // weren't surfaced: the EXTRAS sold for this visit (so they actually do
+        // them), pets (safety/allergy), the entry/alarm code (to get in), the
+        // per-job instructions, and whether this is a recurring client + which
+        // visit number (calibrates expectations vs a first-time deep clean).
+        add_ons: sql<string | null>`(SELECT string_agg(CASE WHEN jao.quantity > 1 THEN ao.name || ' ×' || jao.quantity ELSE ao.name END, ', ' ORDER BY ao.name)
+          FROM job_add_ons jao JOIN add_ons ao ON ao.id = jao.add_on_id WHERE jao.job_id = ${jobsTable.id})`,
+        pets: clientsTable.pets,
+        alarm_code: clientsTable.alarm_code,
+        job_notes: jobsTable.notes,
+        is_recurring: sql<boolean>`${jobsTable.recurring_schedule_id} IS NOT NULL`,
+        visit_number: sql<number | null>`CASE WHEN ${jobsTable.client_id} IS NOT NULL THEN (
+          SELECT COUNT(*)::int FROM jobs j2 WHERE j2.client_id = ${jobsTable.client_id} AND j2.company_id = ${jobsTable.company_id}
+            AND (j2.scheduled_date < ${jobsTable.scheduled_date} OR (j2.scheduled_date = ${jobsTable.scheduled_date} AND j2.id <= ${jobsTable.id})))
+          ELSE NULL END`,
         // Surface BOTH the tenant (the business that owns the job) and the
         // branch (Phes-internal location, if set). For cross-tenant techs
         // the company_name distinguishes "Phes Oak Lawn" from "PHES
@@ -3475,10 +3490,10 @@ router.get("/:id/photos", requireAuth, async (req, res) => {
 });
 
 router.post("/:id/photos", requireAuth, async (req, res) => {
-  // [AF] PHOTOS_ENABLED feature gate — blocks new photo uploads while the
-  // before/after workflow is paused. GETs + existing photo rows stay intact.
-  if (process.env.PHOTOS_ENABLED !== "true") {
-    return res.status(503).json({ error: "feature_disabled", message: "Photo uploads are temporarily disabled (PHOTOS_ENABLED=false)." });
+  // [AF] PHOTOS_ENABLED is now an explicit kill switch — photo uploads are
+  // ENABLED by default and only blocked when PHOTOS_ENABLED="false".
+  if (process.env.PHOTOS_ENABLED === "false") {
+    return res.status(503).json({ error: "feature_disabled", message: "Photo uploads are disabled (PHOTOS_ENABLED=false)." });
   }
   try {
     const jobId = parseInt(req.params.id);

--- a/artifacts/api-server/src/routes/photos.ts
+++ b/artifacts/api-server/src/routes/photos.ts
@@ -5,10 +5,10 @@ import { requireAuth } from "../lib/auth.js";
 const router = Router();
 const storage = new ObjectStorageService();
 
-// [AF] PHOTOS_ENABLED feature flag — disables upload ingest while before/after
-// photo workflow is paused. GET /objects/:path stays live so previously-uploaded
-// photos remain viewable; only new uploads are blocked.
-const photosEnabled = () => process.env.PHOTOS_ENABLED === "true";
+// [AF] PHOTOS_ENABLED feature flag. Photos are ENABLED by default (field techs
+// rely on before/after photos); the flag is now an explicit kill switch —
+// uploads are only blocked when PHOTOS_ENABLED is set to "false".
+const photosEnabled = () => process.env.PHOTOS_ENABLED !== "false";
 
 router.post("/request-url", requireAuth, async (req: Request, res: Response) => {
   if (!photosEnabled()) {

--- a/artifacts/qleno/src/pages/my-jobs.tsx
+++ b/artifacts/qleno/src/pages/my-jobs.tsx
@@ -114,6 +114,12 @@ type Job = {
   zone_color: string | null;
   team: string | null;
   team_count: number;
+  add_ons: string | null;
+  pets: string | null;
+  alarm_code: string | null;
+  job_notes: string | null;
+  is_recurring: boolean;
+  visit_number: number | null;
   before_photo_count: number;
   after_photo_count: number;
   time_clock_entry: TimeclockEntry | null;
@@ -583,6 +589,14 @@ function JobCard({ job, empPos, onRefresh, isPreviewMode, actingForUserId, prevJ
             {job.zone_name}
           </span>
         )}
+        {/* Visit context — a first visit needs more care than a routine repeat. */}
+        {job.visit_number === 1 ? (
+          <span style={{ fontSize: 10, fontWeight: 700, padding: "2px 8px", borderRadius: 20, background: "#FEF3C7", color: "#92400E", letterSpacing: "0.02em" }}>First visit</span>
+        ) : job.is_recurring ? (
+          <span style={{ fontSize: 10, fontWeight: 700, padding: "2px 8px", borderRadius: 20, background: "#EEF2FF", color: "#3730A3", letterSpacing: "0.02em" }}>
+            Recurring{job.visit_number ? ` · Visit #${job.visit_number}` : ""}
+          </span>
+        ) : null}
       </div>
       <p style={{ fontSize: 11, fontWeight: 600, color: "var(--brand)", textTransform: "uppercase", letterSpacing: "0.05em", margin: "0 0 4px" }}>
         {formatServiceType(job.service_type)}
@@ -664,6 +678,33 @@ function JobCard({ job, empPos, onRefresh, isPreviewMode, actingForUserId, prevJ
         </p>
       )}
 
+      {/* What to do this visit — the EXTRAS that were sold. A tech who doesn't
+          see these skips paid work and the customer is unhappy. */}
+      {job.add_ons && (
+        <div style={{ backgroundColor: "#ECFDF8", border: "1px solid #99E9D3", borderRadius: 8, padding: "10px 12px", marginTop: 12 }}>
+          <p style={{ fontSize: 10, fontWeight: 700, color: "#047857", textTransform: "uppercase", letterSpacing: "0.06em", margin: "0 0 4px" }}>Services this visit</p>
+          <p style={{ fontSize: 13, color: "#065F46", margin: 0, lineHeight: 1.5, fontWeight: 600 }}>
+            {formatServiceType(job.service_type)} · {job.add_ons}
+          </p>
+        </div>
+      )}
+
+      {/* Pets — safety + allergy info the cleaner needs before entering. */}
+      {job.pets && (
+        <div style={{ display: "flex", alignItems: "flex-start", gap: 6, marginTop: 10, fontSize: 12, color: "#92400E", backgroundColor: "#FFFBEB", border: "1px solid #FDE68A", borderRadius: 8, padding: "8px 12px" }}>
+          <span style={{ fontWeight: 700, flexShrink: 0 }}>Pets:</span>
+          <span>{job.pets}</span>
+        </div>
+      )}
+
+      {/* Entry / alarm code — the assigned tech needs this to get in & disarm. */}
+      {job.alarm_code && (
+        <div style={{ backgroundColor: "#EEF2FF", border: "1px solid #C7D2FE", borderRadius: 8, padding: "10px 12px", marginTop: 10 }}>
+          <p style={{ fontSize: 10, fontWeight: 700, color: "#3730A3", textTransform: "uppercase", letterSpacing: "0.06em", margin: "0 0 4px" }}>Entry / Alarm Code</p>
+          <p style={{ fontSize: 14, color: "#1E1B4B", margin: 0, fontWeight: 700, letterSpacing: "0.04em" }}>{job.alarm_code}</p>
+        </div>
+      )}
+
       {job.access_notes && (
         <div style={{ backgroundColor: "#FFFBEB", border: "1px solid #FDE68A", borderRadius: 8, padding: "10px 12px", marginTop: 12 }}>
           <p style={{ fontSize: 10, fontWeight: 700, color: "#92400E", textTransform: "uppercase", letterSpacing: "0.06em", margin: "0 0 4px" }}>Building Access</p>
@@ -675,6 +716,14 @@ function JobCard({ job, empPos, onRefresh, isPreviewMode, actingForUserId, prevJ
         <div style={{ backgroundColor: "#F7F6F3", borderRadius: 8, padding: "10px 12px", marginTop: 12 }}>
           <p style={{ fontSize: 10, fontWeight: 600, color: "#9E9B94", textTransform: "uppercase", letterSpacing: "0.06em", margin: "0 0 4px" }}>Client Notes</p>
           <p style={{ fontSize: 12, color: "#1A1917", margin: 0 }}>{job.client_notes}</p>
+        </div>
+      )}
+
+      {/* Per-job instructions (distinct from the standing client notes). */}
+      {job.job_notes && (
+        <div style={{ backgroundColor: "#F7F6F3", borderRadius: 8, padding: "10px 12px", marginTop: 10 }}>
+          <p style={{ fontSize: 10, fontWeight: 600, color: "#9E9B94", textTransform: "uppercase", letterSpacing: "0.06em", margin: "0 0 4px" }}>Job Instructions</p>
+          <p style={{ fontSize: 12, color: "#1A1917", margin: 0, lineHeight: 1.5 }}>{job.job_notes}</p>
         </div>
       )}
 


### PR DESCRIPTION
## Enable photos + field-tech card audit

### Photos enabled
`PHOTOS_ENABLED` flipped from opt-in to an explicit **kill switch**: uploads work by default now and are only blocked when `PHOTOS_ENABLED=false` (covers `routes/photos.ts` request-url and `routes/jobs.ts` `POST /:id/photos`). The after-photo clock-out hard-block is left opt-in (unchanged), so clock-out isn't suddenly gated.

### Field-tech audit — the essentials a cleaner needs, now on the card
Enterprise field-service apps orient a tech around **what to do, how to get in, what to watch for, and context.** All of this already existed in the DB but wasn't surfaced:

- **Services this visit** — the add-ons sold for the job (`job_add_ons → add_ons`). The #1 gap: a tech who can't see the sold extras skips paid work and the customer is unhappy.
- **Pets** — `clients.pets` callout (safety / allergy before entering).
- **Entry / Alarm code** — `clients.alarm_code`, so the assigned tech can actually get in and disarm.
- **Job instructions** — the per-job `jobs.notes`, distinct from the standing client notes.
- **Visit context** — a `First visit` badge (visit #1) or `Recurring · Visit #N`, derived from `recurring_schedule_id` + a per-client visit count, so a tech calibrates a first-time deep clean vs a routine repeat.

### Verification
api-server esbuild bundle + Vite frontend build both pass.

### Note
Still queued from earlier: tapping a card → full detail screen.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_