### PR TITLE
feat(my-jobs): tap-through job detail screen with visit history

### DIFF
--- a/artifacts/api-server/src/routes/jobs.ts
+++ b/artifacts/api-server/src/routes/jobs.ts
@@ -597,6 +597,54 @@ router.get("/my-jobs", requireAuth, async (req, res) => {
   }
 });
 
+// ─── GET /api/jobs/my-jobs/:id/history ───────────────────────────────────────
+// [job-detail 2026-06-10] Prior visits at the same client (residential) or
+// same property (commercial) for the tech's job-detail screen: when we were
+// last there, what was done, who went, how long it took, and any technician
+// notes left behind ("gate code changed", "cat hides under the bed"). Tech-
+// accessible — requireAuth + company scope only, no office role gate.
+router.get("/my-jobs/:id/history", requireAuth, async (req, res) => {
+  try {
+    const jobId = parseInt(req.params.id);
+    const companyId = req.auth!.companyId;
+    const base = await db.execute(sql`
+      SELECT client_id, account_property_id, scheduled_date
+      FROM jobs WHERE id = ${jobId} AND company_id = ${companyId} LIMIT 1
+    `);
+    const baseJob = (base as any).rows?.[0];
+    if (!baseJob) return res.status(404).json({ error: "Not Found", message: "Job not found" });
+    if (!baseJob.client_id && !baseJob.account_property_id) return res.json({ data: [] });
+
+    const rows = await db.execute(sql`
+      SELECT j2.id, j2.scheduled_date, j2.service_type,
+        (SELECT ROUND(GREATEST(EXTRACT(EPOCH FROM (MAX(tc.clock_out_at) - MIN(tc.clock_in_at))) / 3600.0, 0)::numeric, 1)
+           FROM timeclock tc WHERE tc.job_id = j2.id AND tc.clock_out_at IS NOT NULL) AS hours,
+        COALESCE(
+          (SELECT string_agg(DISTINCT u.first_name, ', ')
+             FROM job_technicians jt JOIN users u ON u.id = jt.user_id WHERE jt.job_id = j2.id),
+          (SELECT u2.first_name FROM users u2 WHERE u2.id = j2.assigned_user_id)
+        ) AS techs,
+        (SELECT string_agg(tn.body, ' · ' ORDER BY tn.created_at)
+           FROM technician_notes tn WHERE tn.job_id = j2.id) AS tech_notes
+      FROM jobs j2
+      WHERE j2.company_id = ${companyId}
+        AND j2.id <> ${jobId}
+        AND j2.status = 'complete'
+        AND j2.scheduled_date <= ${baseJob.scheduled_date}
+        AND (
+          (${baseJob.account_property_id ?? null}::int IS NOT NULL AND j2.account_property_id = ${baseJob.account_property_id ?? null})
+          OR (${baseJob.account_property_id ?? null}::int IS NULL AND ${baseJob.client_id ?? null}::int IS NOT NULL AND j2.client_id = ${baseJob.client_id ?? null})
+        )
+      ORDER BY j2.scheduled_date DESC, j2.id DESC
+      LIMIT 5
+    `);
+    return res.json({ data: (rows as any).rows });
+  } catch (err) {
+    console.error("My-jobs history error:", err);
+    return res.status(500).json({ error: "Internal Server Error", message: "Failed to get visit history" });
+  }
+});
+
 // ─── POST /api/jobs/suggest-tech ─────────────────────────────────────────────
 router.post("/suggest-tech", requireAuth, async (req, res) => {
   try {

--- a/artifacts/qleno/src/App.tsx
+++ b/artifacts/qleno/src/App.tsx
@@ -27,6 +27,7 @@ const LeaveRequestPage    = lazy(() => import("@/pages/leave-request"));
 const CleancyclopediaPage = lazy(() => import("@/pages/cleancyclopedia"));
 const DiscountsRedirect   = lazy(() => Promise.resolve({ default: () => { window.location.replace((import.meta.env.BASE_URL.replace(/\/$/, "")) + "/company?tab=pricing"); return null; } }));
 const MyJobsPage          = lazy(() => import("@/pages/my-jobs"));
+const MyJobDetailPage     = lazy(() => import("@/pages/my-job-detail"));
 const MyDayPage           = lazy(() => import("@/pages/my-day"));
 const OpsTodayPage        = lazy(() => import("@/pages/ops-today"));
 const ClockMonitorPage    = lazy(() => import("@/pages/clock-monitor"));
@@ -145,6 +146,7 @@ function Router() {
         <Route path="/company" component={CompanyPage} />
         <Route path="/loyalty" component={LoyaltyPage} />
         <Route path="/discounts" component={DiscountsRedirect} />
+        <Route path="/my-jobs/:id" component={MyJobDetailPage} />
         <Route path="/my-jobs" component={MyJobsPage} />
         <Route path="/my-day" component={MyDayPage} />
         <Route path="/ops/today" component={OpsTodayPage} />

--- a/artifacts/qleno/src/pages/my-job-detail.tsx
+++ b/artifacts/qleno/src/pages/my-job-detail.tsx
@@ -1,0 +1,184 @@
+import { useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useLocation, useRoute } from "wouter";
+import { useAuthStore } from "@/lib/auth";
+import { useEmployeeView } from "@/contexts/employee-view-context";
+import { JobCard, ymd, type Job } from "./my-jobs";
+import { ArrowLeft, History } from "lucide-react";
+
+const BASE = import.meta.env.BASE_URL.replace(/\/$/, "");
+
+function apiFetch(path: string, opts?: RequestInit) {
+  const token = useAuthStore.getState().token;
+  return fetch(`${BASE}/api${path}`, {
+    ...opts,
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}`, ...(opts?.headers || {}) },
+  });
+}
+
+function formatVisitDate(d: string) {
+  const [y, m, day] = String(d).slice(0, 10).split("-").map(Number);
+  return new Date(y, m - 1, day).toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric", year: "numeric" });
+}
+
+function formatServiceType(s: string) {
+  return s.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+}
+
+type Visit = {
+  id: number;
+  scheduled_date: string;
+  service_type: string;
+  hours: string | null;
+  techs: string | null;
+  tech_notes: string | null;
+};
+
+// [job-detail 2026-06-10] Full-screen view of one job, opened by tapping its
+// card on My Jobs. Renders the same interactive JobCard (clock, photos, notes —
+// nothing forks) plus what the list can't show: the visit history at this
+// client/property, including prior techs' notes.
+export default function MyJobDetailPage() {
+  const [, navigate] = useLocation();
+  const [, params] = useRoute("/my-jobs/:id");
+  const jobId = parseInt(params?.id ?? "0", 10);
+  const dateParam = new URLSearchParams(window.location.search).get("date") || ymd(new Date());
+
+  const { employeeView } = useEmployeeView();
+  const [empPos, setEmpPos] = useState<{ lat: number; lng: number } | null>(null);
+
+  useEffect(() => {
+    const update = () => {
+      navigator.geolocation.getCurrentPosition(
+        (pos) => setEmpPos({ lat: pos.coords.latitude, lng: pos.coords.longitude }),
+        () => {},
+        { enableHighAccuracy: true, timeout: 10000 }
+      );
+    };
+    update();
+    const interval = setInterval(update, 60000);
+    return () => clearInterval(interval);
+  }, []);
+
+  // Same query key as the My Jobs list so navigation hits the cache and the
+  // detail screen opens instantly; refetches keep both surfaces in sync.
+  const { data, isLoading, refetch } = useQuery({
+    queryKey: ["my-jobs", employeeView?.employeeId, dateParam],
+    queryFn: async () => {
+      const p = new URLSearchParams({ date: dateParam });
+      if (employeeView) p.set("employee_id", String(employeeView.employeeId));
+      const res = await apiFetch(`/jobs/my-jobs?${p.toString()}`);
+      if (!res.ok) throw new Error("Failed");
+      return res.json();
+    },
+    refetchInterval: 30000,
+  });
+
+  const jobs: Job[] = data?.data || [];
+  const requireAfterPhoto: boolean = data?.require_after_photo_for_clockout ?? false;
+  const job = jobs.find(j => j.id === jobId) || null;
+
+  // prevJobId feeds the on-my-way event's from_job_id (the client-to-client
+  // mileage leg) — derive it from the same active-jobs ordering as the list.
+  const activeJobs = jobs.filter(j => j.status !== "cancelled" && (!j.time_clock_entry || !j.time_clock_entry.clock_out_at || j.status !== "complete"));
+  const idx = activeJobs.findIndex(j => j.id === jobId);
+  const prevJobId = idx > 0 ? activeJobs[idx - 1].id : null;
+
+  const { data: historyData } = useQuery({
+    queryKey: ["job-visit-history", jobId],
+    queryFn: async () => {
+      const res = await apiFetch(`/jobs/my-jobs/${jobId}/history`);
+      return res.ok ? res.json() : { data: [] };
+    },
+    enabled: !!jobId,
+  });
+  const visits: Visit[] = historyData?.data ?? [];
+
+  const goBack = () => {
+    if (window.history.length > 1) window.history.back();
+    else navigate("/my-jobs");
+  };
+
+  return (
+    <div style={{ minHeight: "100vh", backgroundColor: "#F7F6F3", fontFamily: "'Plus Jakarta Sans', sans-serif" }}>
+      <div style={{ maxWidth: 460, margin: "0 auto" }}>
+        <div style={{
+          position: "sticky", top: 0, zIndex: 10,
+          backgroundColor: "#FFFFFF", borderBottom: "1px solid #E5E2DC",
+          padding: "12px 16px", display: "flex", alignItems: "center", gap: 10,
+        }}>
+          <button onClick={goBack} aria-label="Back to My Jobs"
+            style={{ width: 36, height: 36, borderRadius: 8, border: "1px solid #E5E2DC", background: "#FFFFFF", color: "#1A1917", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", flexShrink: 0 }}>
+            <ArrowLeft size={17} />
+          </button>
+          <div style={{ minWidth: 0 }}>
+            <p style={{ fontSize: 15, fontWeight: 700, color: "#1A1917", margin: 0, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+              {job ? job.client_name : "Job Details"}
+            </p>
+            <p style={{ fontSize: 11, color: "#9E9B94", margin: 0 }}>{formatVisitDate(dateParam)}</p>
+          </div>
+        </div>
+
+        {employeeView && (
+          <div style={{ background: "var(--brand, #00C9A0)", padding: "8px 16px" }}>
+            <p style={{ fontSize: 12, fontWeight: 700, color: "#fff", margin: 0 }}>Viewing as {employeeView.employeeName}</p>
+          </div>
+        )}
+
+        <div style={{ padding: 16 }}>
+          {isLoading ? (
+            <p style={{ textAlign: "center", color: "#9E9B94", fontSize: 14, padding: "40px 0" }}>Loading…</p>
+          ) : !job ? (
+            <div style={{ textAlign: "center", padding: "48px 0" }}>
+              <p style={{ fontSize: 15, fontWeight: 700, color: "#1A1917", margin: "0 0 6px" }}>Job not found</p>
+              <p style={{ fontSize: 13, color: "#9E9B94", margin: "0 0 16px" }}>It may have been moved to another day.</p>
+              <button onClick={() => navigate("/my-jobs")}
+                style={{ background: "#1A1917", color: "#fff", border: "none", borderRadius: 9, padding: "9px 16px", fontSize: 13, fontWeight: 700, cursor: "pointer", fontFamily: "inherit" }}>
+                Back to My Jobs
+              </button>
+            </div>
+          ) : (
+            <>
+              <JobCard
+                job={job}
+                empPos={empPos}
+                onRefresh={refetch}
+                isPreviewMode={!!employeeView}
+                actingForUserId={employeeView ? employeeView.employeeId : null}
+                prevJobId={prevJobId}
+                requireAfterPhoto={requireAfterPhoto}
+              />
+
+              {visits.length > 0 && (
+                <div style={{ marginTop: 18 }}>
+                  <p style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 11, color: "#9E9B94", textTransform: "uppercase", letterSpacing: "0.06em", margin: "0 0 10px 4px", fontWeight: 700 }}>
+                    <History size={13} /> Previous Visits Here
+                  </p>
+                  {visits.map(v => (
+                    <div key={v.id} style={{ backgroundColor: "#FFFFFF", border: "1px solid #E5E2DC", borderRadius: 12, padding: "12px 14px", marginBottom: 8 }}>
+                      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", gap: 8 }}>
+                        <p style={{ fontSize: 13, fontWeight: 700, color: "#1A1917", margin: 0 }}>{formatVisitDate(v.scheduled_date)}</p>
+                        {v.hours != null && Number(v.hours) > 0 && (
+                          <span style={{ fontSize: 12, color: "#6B6860", fontWeight: 600, flexShrink: 0 }}>{Number(v.hours).toFixed(1)} hrs</span>
+                        )}
+                      </div>
+                      <p style={{ fontSize: 12, color: "#6B6860", margin: "3px 0 0" }}>
+                        {formatServiceType(v.service_type)}{v.techs ? ` · ${v.techs}` : ""}
+                      </p>
+                      {v.tech_notes && (
+                        <div style={{ backgroundColor: "#F7F6F3", borderRadius: 8, padding: "8px 10px", marginTop: 8 }}>
+                          <p style={{ fontSize: 10, fontWeight: 700, color: "#9E9B94", textTransform: "uppercase", letterSpacing: "0.05em", margin: "0 0 3px" }}>Tech Notes</p>
+                          <p style={{ fontSize: 12, color: "#1A1917", margin: 0, lineHeight: 1.5 }}>{v.tech_notes}</p>
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/artifacts/qleno/src/pages/my-jobs.tsx
+++ b/artifacts/qleno/src/pages/my-jobs.tsx
@@ -5,7 +5,7 @@ import { InlinePriceEdit } from "@/components/inline-price-edit";
 import { EarningsPanel } from "@/components/earnings-panel";
 import { useToast } from "@/hooks/use-toast";
 import { Check, Eye, Navigation, Phone, GraduationCap, DollarSign, Users } from "lucide-react";
-import { Link } from "wouter";
+import { Link, useLocation } from "wouter";
 import { useEmployeeView } from "@/contexts/employee-view-context";
 import { getJobVisualStatus, STATUS_VISUALS, ensureJobStatusStyles } from "@/lib/job-status";
 import { formatAddress, mapsDirectionsUrl } from "@/lib/format-address";
@@ -83,7 +83,7 @@ type TimeclockEntry = {
   flagged: boolean;
 };
 
-type Job = {
+export type Job = {
   id: number;
   client_name: string;
   address: string | null;
@@ -324,7 +324,7 @@ function AddNote({ jobId, onSaved }: { jobId: number; onSaved: () => void }) {
   );
 }
 
-function JobCard({ job, empPos, onRefresh, isPreviewMode, actingForUserId, prevJobId, requireAfterPhoto }: { job: Job; empPos: { lat: number; lng: number } | null; onRefresh: () => void; isPreviewMode?: boolean; actingForUserId?: number | null; prevJobId?: number | null; requireAfterPhoto?: boolean }) {
+export function JobCard({ job, empPos, onRefresh, isPreviewMode, actingForUserId, prevJobId, requireAfterPhoto, onOpenDetail }: { job: Job; empPos: { lat: number; lng: number } | null; onRefresh: () => void; isPreviewMode?: boolean; actingForUserId?: number | null; prevJobId?: number | null; requireAfterPhoto?: boolean; onOpenDetail?: () => void }) {
   const { toast } = useToast();
   const qc = useQueryClient();
   const [geoLoading, setGeoLoading] = useState(false);
@@ -516,17 +516,25 @@ function JobCard({ job, empPos, onRefresh, isPreviewMode, actingForUserId, prevJ
   useEffect(() => { ensureJobStatusStyles(); }, []);
 
   return (
-    <div style={{
-      backgroundColor: "#FFFFFF",
-      // Outline the whole card in the zone color so the tech sees their area at
-      // a glance; status overrides (active/unpaid/no-show/unassigned) win when
-      // present, mirroring the dispatch chip's border behavior.
-      border: `2px solid ${visual.borderOverride || job.zone_color || "#E5E2DC"}`,
-      borderRadius: 12, padding: 18, margin: "0 0 12px 0",
-      position: "relative", overflow: "hidden",
-      opacity: visual.bodyOpacity * (job.status === "cancelled" ? 1 : 1),
-      filter: visual.desaturate ? "grayscale(1)" : "none",
-    }}>
+    <div
+      onClick={onOpenDetail ? (e) => {
+        // Whole-card tap opens the detail screen, but never hijack taps on the
+        // card's own interactive elements (links, buttons, photo inputs).
+        if ((e.target as HTMLElement).closest("a, button, input, img")) return;
+        onOpenDetail();
+      } : undefined}
+      style={{
+        backgroundColor: "#FFFFFF",
+        // Outline the whole card in the zone color so the tech sees their area at
+        // a glance; status overrides (active/unpaid/no-show/unassigned) win when
+        // present, mirroring the dispatch chip's border behavior.
+        border: `2px solid ${visual.borderOverride || job.zone_color || "#E5E2DC"}`,
+        borderRadius: 12, padding: 18, margin: "0 0 12px 0",
+        position: "relative", overflow: "hidden",
+        opacity: visual.bodyOpacity * (job.status === "cancelled" ? 1 : 1),
+        filter: visual.desaturate ? "grayscale(1)" : "none",
+        cursor: onOpenDetail ? "pointer" : undefined,
+      }}>
       {visual.stripe && (
         <div className="qleno-active-stripe" style={{
           position: "absolute", top: 0, bottom: 0, left: 0, width: 4,
@@ -867,18 +875,33 @@ function JobCard({ job, empPos, onRefresh, isPreviewMode, actingForUserId, prevJ
       </div>
 
       <StatusTimeline jobId={job.id} />
+
+      {onOpenDetail && (
+        <button
+          onClick={onOpenDetail}
+          style={{
+            width: "calc(100% + 36px)", margin: "14px -18px -18px", padding: "11px 18px",
+            background: "#F7F6F3", border: "none", borderTop: "1px solid #EEECE7",
+            fontSize: 13, fontWeight: 700, color: "#1A1917", cursor: "pointer",
+            fontFamily: "'Plus Jakarta Sans', sans-serif", textAlign: "center",
+          }}
+        >
+          View job details ›
+        </button>
+      )}
     </div>
   );
 }
 
 // Local YYYY-MM-DD (not UTC) so the day the tech sees matches their wall clock.
-function ymd(d: Date) {
+export function ymd(d: Date) {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
 }
 
 export default function MyJobsPage() {
   const { employeeView, exitView } = useEmployeeView();
   const token = useAuthStore(state => state.token);
+  const [, navigate] = useLocation();
   const qc = useQueryClient();
   const [empPos, setEmpPos] = useState<{ lat: number; lng: number } | null>(null);
   const [showPay, setShowPay] = useState(false);
@@ -1060,13 +1083,15 @@ export default function MyJobsPage() {
               {activeJobs.map((job, i) => (
                 <JobCard key={job.id} job={job} empPos={empPos} onRefresh={refetch} isPreviewMode={!!employeeView}
                   actingForUserId={employeeView ? employeeView.employeeId : null}
-                  prevJobId={i > 0 ? activeJobs[i - 1].id : null} requireAfterPhoto={requireAfterPhoto} />
+                  prevJobId={i > 0 ? activeJobs[i - 1].id : null} requireAfterPhoto={requireAfterPhoto}
+                  onOpenDetail={() => navigate(`/my-jobs/${job.id}?date=${selectedDate}`)} />
               ))}
               {upcomingJobs.length > 0 && (
                 <div style={{ marginTop: 20 }}>
                   <p style={{ fontSize: 11, color: "#9E9B94", textTransform: "uppercase", letterSpacing: "0.06em", margin: "0 0 10px 4px" }}>Up Next</p>
                   {upcomingJobs.map(job => (
-                    <div key={job.id} style={{ opacity: 0.55, backgroundColor: "#FFFFFF", border: "1px solid #E5E2DC", borderLeft: "3px solid var(--brand)", borderRadius: 12, padding: 18, marginBottom: 10 }}>
+                    <div key={job.id} onClick={() => navigate(`/my-jobs/${job.id}?date=${selectedDate}`)}
+                      style={{ opacity: 0.55, backgroundColor: "#FFFFFF", border: `1px solid ${job.zone_color || "#E5E2DC"}`, borderLeft: `3px solid ${job.zone_color || "var(--brand)"}`, borderRadius: 12, padding: 18, marginBottom: 10, cursor: "pointer" }}>
                       <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 4, flexWrap: "wrap" }}>
                         <p style={{ fontSize: 16, fontWeight: 700, color: "#1A1917", margin: 0 }}>{job.client_name}</p>
                         {(job.company_name || job.branch_name) && (


### PR DESCRIPTION
## Tap-through job detail screen for techs

Closes the last open item from field testing: **"Clicking into the job card goes nowhere."** Tapping a card on My Jobs now opens `/my-jobs/:id` — a full-screen view of that job.

### What's on the detail screen
- The **same interactive JobCard** the list uses (clock in/out, pause, photos, notes, status timeline — nothing forks, so the surfaces can't drift apart).
- **Previous Visits Here** — the thing the list can't show: the last 5 completed visits at this client (residential) or this property (commercial), with date, service, who went, on-site hours from the timeclock span, and any **technician notes** prior crews left ("gate code changed", "cat hides under the bed").

### How tapping works
- Whole-card tap navigates, but taps on the card's own links/buttons/photo inputs are ignored, plus an explicit **"View job details ›"** footer for discoverability.
- "Up Next" rows are tappable too, and now carry their zone color.

### Invariants preserved
- The detail page derives `prevJobId` from the same active-jobs ordering as the list, so the on-my-way **`from_job_id` mileage hook** keeps working from the detail screen.
- Reuses the list's React Query key — opening a card is an instant cache hit.
- Office "view-as" preview works on the detail screen with the same `acting_for` attribution.
- New `GET /jobs/my-jobs/:id/history` is tech-accessible (requireAuth) and company-scoped.

### Verification
api-server esbuild bundle + Vite frontend build both pass.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_