### PR TITLE
feat(estimates): branded hosted estimate page + Accept (Phase 1b)

### DIFF
--- a/artifacts/api-server/src/routes/estimates.ts
+++ b/artifacts/api-server/src/routes/estimates.ts
@@ -178,6 +178,97 @@ router.delete("/templates/:id", requireAuth, async (req, res) => {
   }
 });
 
+// ─── Public hosted estimate (no auth — tokenized) ───────────────────────────
+// [estimate-hosted-page 2026-06-10] The link the office texts/emails to the
+// property manager. GET marks first view (sent → viewed); accept/decline are
+// idempotent one-way transitions, blocked after expiry. Registered BEFORE
+// /:id so "public" never parses as an estimate id.
+router.get("/public/:token", async (req, res) => {
+  try {
+    const token = String(req.params.token || "").trim();
+    if (!token) return res.status(404).json({ error: "Not Found" });
+    const rows = await db.execute(sql`
+      SELECT e.*, c.name AS company_name, c.logo_url AS company_logo, c.brand_color AS company_brand_color
+      FROM estimates e JOIN companies c ON c.id = e.company_id
+      WHERE e.public_token = ${token} AND e.status <> 'draft'
+      LIMIT 1
+    `);
+    const est = (rows as any).rows[0];
+    if (!est) return res.status(404).json({ error: "Not Found" });
+
+    const expired = est.valid_until && new Date(est.valid_until) < new Date() && est.status !== "accepted";
+    if (expired && est.status !== "expired") {
+      await db.execute(sql`UPDATE estimates SET status = 'expired', updated_at = now() WHERE id = ${est.id}`);
+      est.status = "expired";
+    }
+    if (est.status === "sent") {
+      await db.execute(sql`UPDATE estimates SET status = 'viewed', viewed_at = COALESCE(viewed_at, now()), updated_at = now() WHERE id = ${est.id}`);
+      est.status = "viewed";
+      est.viewed_at = est.viewed_at || new Date().toISOString();
+    }
+
+    const items = await db.execute(sql`
+      SELECT name, description, pricing_type, frequency, quantity, unit_rate, amount
+      FROM estimate_line_items WHERE estimate_id = ${est.id} ORDER BY sort_order
+    `);
+    // Public payload — strip internal fields.
+    const {
+      internal_notes: _i, created_by: _c, ghl_synced_at: _g,
+      account_id: _a, account_property_id: _p, client_id: _cl, branch_id: _b,
+      ...pub
+    } = est;
+    return res.json({ ...pub, items: (items as any).rows });
+  } catch (err) {
+    console.error("Public estimate error:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
+router.post("/public/:token/accept", async (req, res) => {
+  try {
+    const token = String(req.params.token || "").trim();
+    const name = String(req.body?.name || "").trim().slice(0, 200);
+    if (!name) return res.status(400).json({ error: "Bad Request", message: "Please enter your name to accept" });
+    const rows = await db.execute(sql`
+      SELECT id, status, valid_until FROM estimates WHERE public_token = ${token} AND status <> 'draft' LIMIT 1
+    `);
+    const est = (rows as any).rows[0];
+    if (!est) return res.status(404).json({ error: "Not Found" });
+    if (est.status === "accepted") return res.json({ ok: true, status: "accepted" });
+    if (est.status === "declined") return res.status(409).json({ error: "Conflict", message: "This estimate was declined" });
+    if (est.valid_until && new Date(est.valid_until) < new Date()) {
+      return res.status(409).json({ error: "Conflict", message: "This estimate has expired — please contact us for an updated quote" });
+    }
+    await db.execute(sql`
+      UPDATE estimates SET status = 'accepted', accepted_at = now(), accepted_name = ${name}, updated_at = now()
+      WHERE id = ${est.id}
+    `);
+    return res.json({ ok: true, status: "accepted" });
+  } catch (err) {
+    console.error("Accept estimate error:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
+router.post("/public/:token/decline", async (req, res) => {
+  try {
+    const token = String(req.params.token || "").trim();
+    const rows = await db.execute(sql`
+      SELECT id, status FROM estimates WHERE public_token = ${token} AND status <> 'draft' LIMIT 1
+    `);
+    const est = (rows as any).rows[0];
+    if (!est) return res.status(404).json({ error: "Not Found" });
+    if (est.status === "accepted") return res.status(409).json({ error: "Conflict", message: "Already accepted" });
+    if (est.status !== "declined") {
+      await db.execute(sql`UPDATE estimates SET status = 'declined', declined_at = now(), updated_at = now() WHERE id = ${est.id}`);
+    }
+    return res.json({ ok: true, status: "declined" });
+  } catch (err) {
+    console.error("Decline estimate error:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
 // ─── List estimates ──────────────────────────────────────────────────────────
 router.get("/", requireAuth, async (req, res) => {
   try {

--- a/artifacts/qleno/src/App.tsx
+++ b/artifacts/qleno/src/App.tsx
@@ -58,6 +58,7 @@ const QuotesPage          = lazy(() => import("@/pages/quotes"));
 const QuoteBuilderPage    = lazy(() => import("@/pages/quote-builder"));
 const EstimatesPage       = lazy(() => import("@/pages/estimates"));
 const EstimateBuilderPage = lazy(() => import("@/pages/estimate-builder"));
+const EstimatePublicPage  = lazy(() => import("@/pages/estimate-public"));
 const QuoteDetailPage     = lazy(() => import("@/pages/quote-detail"));
 const QuotingPage         = lazy(() => import("@/pages/quoting"));
 const InvoiceDetailPage   = lazy(() => import("@/pages/invoice-detail"));
@@ -201,6 +202,8 @@ function Router() {
         <Route path="/estimates/new" component={EstimateBuilderPage} />
         <Route path="/estimates/:id" component={EstimateBuilderPage} />
         <Route path="/estimates" component={EstimatesPage} />
+        {/* Public hosted estimate — no login, tokenized (like /pay/:token). */}
+        <Route path="/estimate/:token" component={EstimatePublicPage} />
 
         <Route path="/book/:slug" component={BookPage} />
         <Route path="/pay/:token" component={PayPage} />

--- a/artifacts/qleno/src/pages/estimate-builder.tsx
+++ b/artifacts/qleno/src/pages/estimate-builder.tsx
@@ -59,6 +59,7 @@ export default function EstimateBuilderPage() {
   const [id, setId] = useState<number | null>(estimateId);
   const [status, setStatus] = useState("draft");
   const [estimateNumber, setEstimateNumber] = useState<string>("");
+  const [publicToken, setPublicToken] = useState<string | null>(null);
 
   const [contactName, setContactName] = useState("");
   const [contactEmail, setContactEmail] = useState("");
@@ -80,6 +81,7 @@ export default function EstimateBuilderPage() {
         if (!isNew && estimateId) {
           const e = await apiFetch(`/api/estimates/${estimateId}`);
           setStatus(e.status); setEstimateNumber(e.estimate_number || "");
+          setPublicToken(e.public_token || null);
           setContactName(e.contact_name || ""); setContactEmail(e.contact_email || ""); setContactPhone(e.contact_phone || "");
           setPropertyName(e.property_name || ""); setServiceAddress(e.service_address || "");
           setTitle(e.title || ""); setIntroNote(e.intro_note || ""); setTerms(e.terms || ""); setInternalNotes(e.internal_notes || "");
@@ -153,13 +155,25 @@ export default function EstimateBuilderPage() {
     }
   }
 
+  function publicLink(token: string) {
+    return `${window.location.origin}${API}/estimate/${token}`;
+  }
+
   async function markSent() {
     const savedId = id || (await save());
     if (!savedId) return;
     try {
-      await apiFetch(`/api/estimates/${savedId}/send`, { method: "POST" });
+      const r = await apiFetch(`/api/estimates/${savedId}/send`, { method: "POST" });
       setStatus("sent");
-      toast.success("Marked as sent — hosted link, PDF & GoHighLevel follow-up land in the next update.");
+      setPublicToken(r.public_token || null);
+      if (r.public_token) {
+        try {
+          await navigator.clipboard.writeText(publicLink(r.public_token));
+          toast.success("Estimate link copied — paste it into a text or email.");
+        } catch {
+          toast.success("Estimate is live — copy the link below to share it.");
+        }
+      }
     } catch {
       toast.error("Failed to mark sent");
     }
@@ -178,6 +192,25 @@ export default function EstimateBuilderPage() {
         <button onClick={() => navigate("/estimates")} style={{ display: "inline-flex", alignItems: "center", gap: 5, background: "none", border: "none", color: MUTE, fontSize: 13, fontWeight: 600, cursor: "pointer", fontFamily: FF, padding: 0, marginBottom: 12 }}>
           <ArrowLeft size={15} /> Estimates
         </button>
+
+        {publicToken && (
+          <div style={{ display: "flex", alignItems: "center", gap: 10, background: "#ECFDF8", border: "1px solid #99E9D3", borderRadius: 10, padding: "10px 14px", marginBottom: 14, flexWrap: "wrap" }}>
+            <div style={{ flex: 1, minWidth: 200 }}>
+              <p style={{ fontSize: 11, fontWeight: 700, color: "#047857", textTransform: "uppercase", letterSpacing: "0.05em", margin: "0 0 2px" }}>Customer link — text or email this</p>
+              <p style={{ fontSize: 12, color: "#065F46", margin: 0, wordBreak: "break-all" }}>{publicLink(publicToken)}</p>
+            </div>
+            <div style={{ display: "flex", gap: 6 }}>
+              <button onClick={async () => { try { await navigator.clipboard.writeText(publicLink(publicToken)); toast.success("Link copied"); } catch { toast.error("Couldn't copy — select and copy manually"); } }}
+                style={{ background: "#047857", color: "#fff", border: "none", borderRadius: 8, padding: "8px 13px", fontSize: 12, fontWeight: 700, cursor: "pointer", fontFamily: FF }}>
+                Copy link
+              </button>
+              <a href={publicLink(publicToken)} target="_blank" rel="noreferrer"
+                style={{ background: "#fff", color: "#047857", border: "1px solid #99E9D3", borderRadius: 8, padding: "8px 13px", fontSize: 12, fontWeight: 700, textDecoration: "none", fontFamily: FF }}>
+                Preview
+              </a>
+            </div>
+          </div>
+        )}
 
         <div style={{ display: "flex", alignItems: "baseline", justifyContent: "space-between", flexWrap: "wrap", gap: 8, marginBottom: 18 }}>
           <h1 style={{ fontSize: 23, fontWeight: 800, color: INK, margin: 0 }}>{isNew && !id ? "New Estimate" : (estimateNumber || "Estimate")}</h1>
@@ -266,7 +299,7 @@ export default function EstimateBuilderPage() {
           <button onClick={saveAsTemplate} style={ghostBtn}><LayoutTemplate size={15} /> Save as template</button>
           <div style={{ flex: 1 }} />
           <button onClick={save} disabled={saving} style={ghostBtn}><Save size={15} /> {saving ? "Saving…" : "Save"}</button>
-          <button onClick={markSent} style={primaryBtn}><Send size={15} /> Mark sent</button>
+          <button onClick={markSent} style={primaryBtn}><Send size={15} /> {publicToken ? "Re-copy link" : "Send — get link"}</button>
         </div>
       </div>
     </DashboardLayout>

--- a/artifacts/qleno/src/pages/estimate-public.tsx
+++ b/artifacts/qleno/src/pages/estimate-public.tsx
@@ -1,0 +1,277 @@
+import { useEffect, useState } from "react";
+import { useRoute } from "wouter";
+
+const FF = "'Plus Jakarta Sans', sans-serif";
+const API = import.meta.env.BASE_URL.replace(/\/$/, "");
+const INK = "#1A1917";
+const MUTE = "#6B7280";
+const BORDER = "#E5E2DC";
+
+type Item = {
+  name: string | null;
+  description: string | null;
+  pricing_type: string;
+  frequency: string | null;
+  quantity: string;
+  unit_rate: string;
+  amount: string;
+};
+
+type PublicEstimate = {
+  id: number;
+  estimate_number: string | null;
+  title: string | null;
+  intro_note: string | null;
+  terms: string | null;
+  status: string;
+  subtotal: string;
+  discount_amount: string;
+  total: string;
+  valid_until: string | null;
+  contact_name: string | null;
+  property_name: string | null;
+  service_address: string | null;
+  accepted_name: string | null;
+  accepted_at: string | null;
+  company_name: string;
+  company_logo: string | null;
+  company_brand_color: string | null;
+  items: Item[];
+};
+
+const money = (n: any) => `$${Number(n || 0).toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+const fmtDate = (d: string) => {
+  const [y, m, day] = String(d).slice(0, 10).split("-").map(Number);
+  return new Date(y, m - 1, day).toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric" });
+};
+
+// [estimate-hosted-page 2026-06-10] The customer-facing estimate: the link the
+// office texts/emails to a property manager. No login. Branded with the
+// tenant's logo + brand color, line items, totals, terms, Accept (records the
+// acceptor's name) and Download PDF (print-optimized layout — the browser's
+// Save as PDF produces the document).
+export default function EstimatePublicPage() {
+  const [, params] = useRoute("/estimate/:token");
+  const token = params?.token ?? "";
+
+  const [est, setEst] = useState<PublicEstimate | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [showAccept, setShowAccept] = useState(false);
+  const [acceptName, setAcceptName] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [actionMsg, setActionMsg] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const r = await fetch(`${API}/api/estimates/public/${encodeURIComponent(token)}`);
+        if (!r.ok) throw new Error();
+        setEst(await r.json());
+      } catch {
+        setError("This estimate link is invalid or no longer available.");
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [token]);
+
+  async function accept() {
+    if (!acceptName.trim()) { setActionMsg("Please enter your name."); return; }
+    setSubmitting(true);
+    setActionMsg(null);
+    try {
+      const r = await fetch(`${API}/api/estimates/public/${encodeURIComponent(token)}/accept`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: acceptName.trim() }),
+      });
+      const body = await r.json().catch(() => ({}));
+      if (!r.ok) { setActionMsg(body.message || "Could not accept — please contact us."); return; }
+      setEst(e => e ? { ...e, status: "accepted", accepted_name: acceptName.trim(), accepted_at: new Date().toISOString() } : e);
+      setShowAccept(false);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const brand = est?.company_brand_color || "#00C9A0";
+
+  if (loading) {
+    return <div style={{ minHeight: "100vh", background: "#F7F6F3", display: "flex", alignItems: "center", justifyContent: "center", fontFamily: FF, color: MUTE }}>Loading estimate…</div>;
+  }
+  if (error || !est) {
+    return (
+      <div style={{ minHeight: "100vh", background: "#F7F6F3", display: "flex", alignItems: "center", justifyContent: "center", fontFamily: FF, padding: 20 }}>
+        <div style={{ background: "#fff", border: `1px solid ${BORDER}`, borderRadius: 14, padding: "32px 28px", maxWidth: 420, textAlign: "center" }}>
+          <p style={{ fontSize: 16, fontWeight: 700, color: INK, margin: "0 0 6px" }}>Estimate unavailable</p>
+          <p style={{ fontSize: 14, color: MUTE, margin: 0 }}>{error}</p>
+        </div>
+      </div>
+    );
+  }
+
+  const isAccepted = est.status === "accepted";
+  const isDeclined = est.status === "declined";
+  const isExpired = est.status === "expired";
+
+  return (
+    <div style={{ minHeight: "100vh", background: "#F7F6F3", fontFamily: FF, padding: "24px 14px 60px" }}>
+      <style>{`
+        @media print {
+          body { background: #fff !important; }
+          .est-noprint { display: none !important; }
+          .est-card { border: none !important; box-shadow: none !important; }
+        }
+      `}</style>
+      <div style={{ maxWidth: 680, margin: "0 auto" }}>
+
+        {/* Status banner */}
+        {isAccepted && (
+          <div style={{ background: "#ECFDF5", border: "1px solid #99E9D3", borderRadius: 12, padding: "14px 18px", marginBottom: 14 }}>
+            <p style={{ fontSize: 14, fontWeight: 700, color: "#047857", margin: 0 }}>
+              Accepted{est.accepted_name ? ` by ${est.accepted_name}` : ""} — thank you! We'll be in touch shortly to schedule.
+            </p>
+          </div>
+        )}
+        {isDeclined && (
+          <div style={{ background: "#FEF2F2", border: "1px solid #FECACA", borderRadius: 12, padding: "14px 18px", marginBottom: 14 }}>
+            <p style={{ fontSize: 14, fontWeight: 700, color: "#991B1B", margin: 0 }}>This estimate was declined. Contact us if you'd like a revised proposal.</p>
+          </div>
+        )}
+        {isExpired && (
+          <div style={{ background: "#FFFBEB", border: "1px solid #FDE68A", borderRadius: 12, padding: "14px 18px", marginBottom: 14 }}>
+            <p style={{ fontSize: 14, fontWeight: 700, color: "#92400E", margin: 0 }}>This estimate has expired. Contact us for updated pricing.</p>
+          </div>
+        )}
+
+        <div className="est-card" style={{ background: "#fff", border: `1px solid ${BORDER}`, borderRadius: 16, overflow: "hidden" }}>
+          {/* Branded header */}
+          <div style={{ padding: "26px 28px 20px", borderBottom: `3px solid ${brand}` }}>
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 16, flexWrap: "wrap" }}>
+              <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+                {est.company_logo && (
+                  <img src={est.company_logo} alt="" style={{ height: 44, width: "auto", borderRadius: 8 }} />
+                )}
+                <div>
+                  <p style={{ fontSize: 18, fontWeight: 800, color: INK, margin: 0, letterSpacing: "-0.01em" }}>{est.company_name}</p>
+                  <p style={{ fontSize: 12, color: MUTE, margin: "2px 0 0", textTransform: "uppercase", letterSpacing: "0.08em", fontWeight: 700 }}>Estimate</p>
+                </div>
+              </div>
+              <div style={{ textAlign: "right" }}>
+                {est.estimate_number && <p style={{ fontSize: 13, fontWeight: 700, color: INK, margin: 0 }}>{est.estimate_number}</p>}
+                {est.valid_until && (
+                  <p style={{ fontSize: 12, color: isExpired ? "#991B1B" : MUTE, margin: "3px 0 0" }}>Valid until {fmtDate(est.valid_until)}</p>
+                )}
+              </div>
+            </div>
+          </div>
+
+          <div style={{ padding: "22px 28px" }}>
+            {/* Who / where */}
+            {(est.contact_name || est.property_name || est.service_address) && (
+              <div style={{ marginBottom: 18 }}>
+                <p style={{ fontSize: 11, fontWeight: 700, color: MUTE, textTransform: "uppercase", letterSpacing: "0.06em", margin: "0 0 5px" }}>Prepared for</p>
+                {est.contact_name && <p style={{ fontSize: 15, fontWeight: 700, color: INK, margin: 0 }}>{est.contact_name}</p>}
+                {est.property_name && <p style={{ fontSize: 13, color: "#4B5563", margin: "2px 0 0" }}>{est.property_name}</p>}
+                {est.service_address && <p style={{ fontSize: 13, color: MUTE, margin: "2px 0 0" }}>{est.service_address}</p>}
+              </div>
+            )}
+
+            {est.title && <h1 style={{ fontSize: 19, fontWeight: 800, color: INK, margin: "0 0 8px" }}>{est.title}</h1>}
+            {est.intro_note && <p style={{ fontSize: 14, color: "#4B5563", margin: "0 0 18px", lineHeight: 1.6, whiteSpace: "pre-wrap" }}>{est.intro_note}</p>}
+
+            {/* Line items */}
+            <div style={{ border: `1px solid ${BORDER}`, borderRadius: 12, overflow: "hidden", marginBottom: 18 }}>
+              {est.items.map((it, i) => (
+                <div key={i} style={{ display: "flex", justifyContent: "space-between", gap: 14, padding: "13px 16px", borderTop: i === 0 ? "none" : `1px solid ${BORDER}`, alignItems: "flex-start" }}>
+                  <div style={{ minWidth: 0 }}>
+                    <p style={{ fontSize: 14, fontWeight: 700, color: INK, margin: 0 }}>{it.name || "Service"}</p>
+                    <p style={{ fontSize: 12, color: MUTE, margin: "3px 0 0" }}>
+                      {[
+                        it.frequency,
+                        it.pricing_type === "hourly" ? `${Number(it.quantity).toFixed(1)} hrs × ${money(it.unit_rate)}/hr`
+                          : Number(it.quantity) !== 1 ? `${Number(it.quantity)} × ${money(it.unit_rate)}` : null,
+                      ].filter(Boolean).join(" · ")}
+                    </p>
+                    {it.description && <p style={{ fontSize: 12, color: "#4B5563", margin: "4px 0 0", lineHeight: 1.5 }}>{it.description}</p>}
+                  </div>
+                  <p style={{ fontSize: 14, fontWeight: 700, color: INK, margin: 0, flexShrink: 0 }}>{money(it.amount)}</p>
+                </div>
+              ))}
+            </div>
+
+            {/* Totals */}
+            <div style={{ marginBottom: 18 }}>
+              <div style={{ display: "flex", justifyContent: "space-between", fontSize: 13, color: MUTE, padding: "3px 0" }}>
+                <span>Subtotal</span><span>{money(est.subtotal)}</span>
+              </div>
+              {Number(est.discount_amount) > 0 && (
+                <div style={{ display: "flex", justifyContent: "space-between", fontSize: 13, color: "#047857", padding: "3px 0" }}>
+                  <span>Discount</span><span>−{money(est.discount_amount)}</span>
+                </div>
+              )}
+              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", borderTop: `2px solid ${INK}`, marginTop: 8, paddingTop: 10 }}>
+                <span style={{ fontSize: 15, fontWeight: 800, color: INK }}>Total</span>
+                <span style={{ fontSize: 24, fontWeight: 800, color: INK }}>{money(est.total)}</span>
+              </div>
+            </div>
+
+            {est.terms && (
+              <div style={{ background: "#F7F6F3", borderRadius: 10, padding: "12px 14px", marginBottom: 4 }}>
+                <p style={{ fontSize: 11, fontWeight: 700, color: MUTE, textTransform: "uppercase", letterSpacing: "0.06em", margin: "0 0 4px" }}>Terms</p>
+                <p style={{ fontSize: 12, color: "#4B5563", margin: 0, lineHeight: 1.6, whiteSpace: "pre-wrap" }}>{est.terms}</p>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div className="est-noprint" style={{ display: "flex", gap: 10, marginTop: 16, flexWrap: "wrap" }}>
+          {!isAccepted && !isDeclined && !isExpired && (
+            <button onClick={() => setShowAccept(true)}
+              style={{ flex: "1 1 200px", height: 50, background: brand, color: "#fff", border: "none", borderRadius: 12, fontSize: 16, fontWeight: 800, cursor: "pointer", fontFamily: FF }}>
+              Accept Estimate
+            </button>
+          )}
+          <button onClick={() => window.print()}
+            style={{ flex: "1 1 160px", height: 50, background: "#fff", color: INK, border: `1px solid ${BORDER}`, borderRadius: 12, fontSize: 15, fontWeight: 700, cursor: "pointer", fontFamily: FF }}>
+            Download PDF
+          </button>
+        </div>
+
+        <p className="est-noprint" style={{ textAlign: "center", fontSize: 11, color: "#9E9B94", marginTop: 22 }}>
+          Questions? Reply to the message that brought you here and we'll help right away.
+        </p>
+      </div>
+
+      {/* Accept modal */}
+      {showAccept && (
+        <div className="est-noprint" style={{ position: "fixed", inset: 0, background: "rgba(10,14,26,0.45)", display: "flex", alignItems: "center", justifyContent: "center", padding: 18, zIndex: 50 }}>
+          <div style={{ background: "#fff", borderRadius: 16, padding: "24px 22px", width: "100%", maxWidth: 380 }}>
+            <p style={{ fontSize: 17, fontWeight: 800, color: INK, margin: "0 0 4px" }}>Accept this estimate</p>
+            <p style={{ fontSize: 13, color: MUTE, margin: "0 0 14px" }}>Total: <strong style={{ color: INK }}>{money(est.total)}</strong>. Enter your name to confirm.</p>
+            <input
+              value={acceptName}
+              onChange={e => setAcceptName(e.target.value)}
+              placeholder="Your full name"
+              autoFocus
+              style={{ width: "100%", padding: "11px 13px", border: `1px solid ${BORDER}`, borderRadius: 10, fontSize: 15, fontFamily: FF, boxSizing: "border-box", marginBottom: 10 }}
+            />
+            {actionMsg && <p style={{ fontSize: 12, color: "#991B1B", margin: "0 0 10px" }}>{actionMsg}</p>}
+            <div style={{ display: "flex", gap: 8 }}>
+              <button onClick={() => { setShowAccept(false); setActionMsg(null); }} disabled={submitting}
+                style={{ flex: 1, height: 44, background: "#fff", color: INK, border: `1px solid ${BORDER}`, borderRadius: 10, fontSize: 14, fontWeight: 700, cursor: "pointer", fontFamily: FF }}>
+                Cancel
+              </button>
+              <button onClick={accept} disabled={submitting}
+                style={{ flex: 1.4, height: 44, background: brand, color: "#fff", border: "none", borderRadius: 10, fontSize: 14, fontWeight: 800, cursor: "pointer", fontFamily: FF, opacity: submitting ? 0.7 : 1 }}>
+                {submitting ? "Confirming…" : "Confirm Accept"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Branded hosted estimate page + Accept (Phase 1b)

The customer-facing piece of the estimate tool: a **no-login, tokenized page** the office texts or emails to a property manager (church, CPA office, condo board…).

### Backend
Public routes (registered before `/:id` so `public` never parses as an estimate id):
- `GET /api/estimates/public/:token` — estimate + line items + **tenant branding** (company name, logo, brand color). First open flips `sent → viewed` (stamps `viewed_at`); past `valid_until` flips to `expired`. Internal fields (notes, FKs, GHL bookkeeping) are stripped from the payload.
- `POST /public/:token/accept` — records `accepted_at` + the acceptor's typed name. Idempotent; blocked after decline/expiry.
- `POST /public/:token/decline` — one-way; blocked after accept.

### Frontend
- **`/estimate/:token`** public page: branded header (logo + brand-color rule), "Prepared for" block, line items (hourly lines render `X hrs × $Y/hr`), totals with discount, terms, valid-until date. **Accept Estimate** opens a name-confirm modal; clear status banners for accepted / declined / expired. **Download PDF** uses a print-optimized layout (buttons hidden under `@media print`) — the browser's Save-as-PDF produces the document.
- **Builder**: "Send — get link" now copies the customer link to the clipboard and shows a persistent link bar (Copy + Preview) whenever the estimate has a token.

### What's next (separate PR)
GoHighLevel webhook bridge — POST contact + estimate link to a GHL inbound-webhook on send (GHL runs the SMS drip from the office line) and fire the stop webhook on accept.

### Verification
api-server esbuild bundle + Vite frontend build both pass.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_