### PR TITLE
feat(estimates): GoHighLevel webhook bridge — drip on send, stop on outcome

### DIFF
--- a/artifacts/api-server/src/lib/ghl.ts
+++ b/artifacts/api-server/src/lib/ghl.ts
@@ -1,0 +1,53 @@
+// [ghl-estimate-bridge 2026-06-10] GoHighLevel inbound-webhook bridge.
+//
+// Qleno does NOT text estimate follow-ups itself — GHL owns the drip, sending
+// from the office line the tenant already texts from. Qleno's only job is to
+// notify GHL's workflow webhooks at two moments:
+//   - estimate sent    → GHL creates/updates the contact and starts the drip
+//   - accept / decline → GHL stops the drip (and can notify the office)
+//
+// Opt-in by design: a webhook only fires when the tenant pasted its URL into
+// Estimate Settings. These are integration events to the tenant's own CRM,
+// not Qleno comms — the COMMS_ENABLED Twilio/Resend gate does not apply.
+// Fire-and-forget: a GHL outage must never fail the user-facing request.
+
+const TIMEOUT_MS = 5000;
+
+export type GhlEstimatePayload = {
+  event: "estimate_sent" | "estimate_accepted" | "estimate_declined";
+  estimate_id: number;
+  estimate_number: string | null;
+  title: string | null;
+  contact_name: string | null;
+  contact_email: string | null;
+  contact_phone: string | null;
+  property_name: string | null;
+  service_address: string | null;
+  total: string | null;
+  valid_until: string | null;
+  estimate_link: string | null;
+  accepted_name?: string | null;
+};
+
+export async function fireGhlWebhook(url: string | null | undefined, payload: GhlEstimatePayload): Promise<boolean> {
+  if (!url || !/^https:\/\//i.test(url.trim())) return false;
+  try {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
+    const res = await fetch(url.trim(), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+      signal: ctrl.signal,
+    });
+    clearTimeout(timer);
+    if (!res.ok) {
+      console.warn(`[ghl] webhook ${payload.event} for estimate ${payload.estimate_id} returned ${res.status}`);
+      return false;
+    }
+    return true;
+  } catch (err: any) {
+    console.warn(`[ghl] webhook ${payload.event} for estimate ${payload.estimate_id} failed:`, err?.message ?? err);
+    return false;
+  }
+}

--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -25,6 +25,10 @@ async function runBookingSchemaGuard(): Promise<void> {
   const guards: Array<{ label: string; stmt: string }> = [
     // ── jobs extra columns ──────────────────────────────────────────────────
     { label: "jobs.home_condition_rating", stmt: "ALTER TABLE jobs ADD COLUMN IF NOT EXISTS home_condition_rating INTEGER" },
+    // [ghl-estimate-bridge 2026-06-10] GoHighLevel inbound-webhook URLs for
+    // the estimate drip. Opt-in: bridge fires only when a URL is set.
+    { label: "companies.ghl_estimate_sent_webhook", stmt: "ALTER TABLE companies ADD COLUMN IF NOT EXISTS ghl_estimate_sent_webhook TEXT" },
+    { label: "companies.ghl_estimate_outcome_webhook", stmt: "ALTER TABLE companies ADD COLUMN IF NOT EXISTS ghl_estimate_outcome_webhook TEXT" },
     // [recurring-delete-skip 2026-06-05] Deleted-occurrence tombstones so a
     // recurring occurrence the office removed isn't regenerated next run.
     { label: "recurring_schedules.skipped_dates", stmt: "ALTER TABLE recurring_schedules ADD COLUMN IF NOT EXISTS skipped_dates DATE[] DEFAULT '{}'" },

--- a/artifacts/api-server/src/routes/companies.ts
+++ b/artifacts/api-server/src/routes/companies.ts
@@ -120,6 +120,17 @@ router.patch("/me", requireAuth, async (req, res) => {
     if (sms_paused_enabled !== undefined) patch.sms_paused_enabled = sms_paused_enabled;
     if (sms_complete_enabled !== undefined) patch.sms_complete_enabled = sms_complete_enabled;
     if (twilio_from_number !== undefined) patch.twilio_from_number = twilio_from_number;
+    // [ghl-estimate-bridge 2026-06-10] GoHighLevel webhook URLs (estimate drip).
+    // https-only; empty string clears (disables the bridge).
+    {
+      const { ghl_estimate_sent_webhook, ghl_estimate_outcome_webhook } = req.body;
+      const cleanGhlUrl = (v: unknown) => {
+        const s = String(v ?? "").trim();
+        return s && /^https:\/\//i.test(s) ? s.slice(0, 500) : null;
+      };
+      if (ghl_estimate_sent_webhook !== undefined) patch.ghl_estimate_sent_webhook = cleanGhlUrl(ghl_estimate_sent_webhook);
+      if (ghl_estimate_outcome_webhook !== undefined) patch.ghl_estimate_outcome_webhook = cleanGhlUrl(ghl_estimate_outcome_webhook);
+    }
     if (geofence_enabled !== undefined) patch.geofence_enabled = geofence_enabled;
     if (geofence_clockin_radius_ft !== undefined) patch.geofence_clockin_radius_ft = geofence_clockin_radius_ft;
     if (geofence_clockout_radius_ft !== undefined) patch.geofence_clockout_radius_ft = geofence_clockout_radius_ft;

--- a/artifacts/api-server/src/routes/estimates.ts
+++ b/artifacts/api-server/src/routes/estimates.ts
@@ -1,8 +1,9 @@
-import { Router } from "express";
+import { Router, type Request } from "express";
 import { db } from "@workspace/db";
 import { sql } from "drizzle-orm";
 import { randomUUID } from "crypto";
 import { requireAuth } from "../lib/auth.js";
+import { fireGhlWebhook, type GhlEstimatePayload } from "../lib/ghl.js";
 
 // [commercial-estimate-tool 2026-06-09] Commercial / common-area estimates.
 // Raw SQL (db.execute) on purpose: the estimate tables are brand-new and the
@@ -15,6 +16,52 @@ import { requireAuth } from "../lib/auth.js";
 const router = Router();
 
 const PRICING_TYPES = new Set(["flat", "hourly", "one_time"]);
+
+// [ghl-estimate-bridge 2026-06-10] Absolute customer link for webhook payloads.
+// Behind Railway's proxy the public scheme arrives in x-forwarded-proto.
+function publicEstimateLink(req: Request, token: string | null): string | null {
+  if (!token) return null;
+  const proto = (req.headers["x-forwarded-proto"] as string)?.split(",")[0]?.trim() || req.protocol || "https";
+  const host = req.get("host");
+  return host ? `${proto}://${host}/estimate/${token}` : null;
+}
+
+// Fire-and-forget GHL notification. Loads the tenant's webhook URL for the
+// event class, posts the payload, and stamps ghl_synced_at on a successful
+// 'sent' notification. Never blocks or fails the calling request.
+function notifyGhl(req: Request, estimateId: number, event: GhlEstimatePayload["event"], acceptedName?: string | null): void {
+  (async () => {
+    const rows = await db.execute(sql`
+      SELECT e.id, e.estimate_number, e.title, e.contact_name, e.contact_email, e.contact_phone,
+             e.property_name, e.service_address, e.total, e.valid_until, e.public_token,
+             c.ghl_estimate_sent_webhook, c.ghl_estimate_outcome_webhook
+      FROM estimates e JOIN companies c ON c.id = e.company_id
+      WHERE e.id = ${estimateId} LIMIT 1
+    `);
+    const est = (rows as any).rows[0];
+    if (!est) return;
+    const url = event === "estimate_sent" ? est.ghl_estimate_sent_webhook : est.ghl_estimate_outcome_webhook;
+    if (!url) return;
+    const ok = await fireGhlWebhook(url, {
+      event,
+      estimate_id: est.id,
+      estimate_number: est.estimate_number,
+      title: est.title,
+      contact_name: est.contact_name,
+      contact_email: est.contact_email,
+      contact_phone: est.contact_phone,
+      property_name: est.property_name,
+      service_address: est.service_address,
+      total: est.total != null ? String(est.total) : null,
+      valid_until: est.valid_until ? String(est.valid_until).slice(0, 10) : null,
+      estimate_link: publicEstimateLink(req, est.public_token),
+      accepted_name: acceptedName ?? null,
+    });
+    if (ok && event === "estimate_sent") {
+      await db.execute(sql`UPDATE estimates SET ghl_synced_at = now() WHERE id = ${estimateId}`);
+    }
+  })().catch(err => console.warn("[ghl] notify failed:", err?.message ?? err));
+}
 
 type NormalizedItem = {
   sort_order: number;
@@ -243,6 +290,7 @@ router.post("/public/:token/accept", async (req, res) => {
       UPDATE estimates SET status = 'accepted', accepted_at = now(), accepted_name = ${name}, updated_at = now()
       WHERE id = ${est.id}
     `);
+    notifyGhl(req, Number(est.id), "estimate_accepted", name);
     return res.json({ ok: true, status: "accepted" });
   } catch (err) {
     console.error("Accept estimate error:", err);
@@ -261,6 +309,7 @@ router.post("/public/:token/decline", async (req, res) => {
     if (est.status === "accepted") return res.status(409).json({ error: "Conflict", message: "Already accepted" });
     if (est.status !== "declined") {
       await db.execute(sql`UPDATE estimates SET status = 'declined', declined_at = now(), updated_at = now() WHERE id = ${est.id}`);
+      notifyGhl(req, Number(est.id), "estimate_declined");
     }
     return res.json({ ok: true, status: "declined" });
   } catch (err) {
@@ -434,7 +483,7 @@ router.post("/:id/save-as-template", requireAuth, async (req, res) => {
   }
 });
 
-// ─── Send: mark sent + mint the public token (hosted view + GHL come next) ────
+// ─── Send: mark sent, mint the public token, notify GHL to start the drip ────
 router.post("/:id/send", requireAuth, async (req, res) => {
   try {
     const companyId = req.auth!.companyId;
@@ -450,6 +499,7 @@ router.post("/:id/send", requireAuth, async (req, res) => {
       SET status = 'sent', sent_at = COALESCE(sent_at, now()), public_token = ${token}, valid_until = ${validUntil}, updated_at = now()
       WHERE id = ${id} AND company_id = ${companyId}
     `);
+    notifyGhl(req, id, "estimate_sent");
     return res.json({ id, public_token: token });
   } catch (err) {
     console.error("Send estimate error:", err);

--- a/artifacts/qleno/src/pages/estimates.tsx
+++ b/artifacts/qleno/src/pages/estimates.tsx
@@ -49,7 +49,10 @@ export default function EstimatesPage() {
   const [, navigate] = useLocation();
   const qc = useQueryClient();
   const [search, setSearch] = useState("");
-  const [tab, setTab] = useState<"estimates" | "templates">("estimates");
+  const [tab, setTab] = useState<"estimates" | "templates" | "ghl">("estimates");
+  const [ghlSent, setGhlSent] = useState("");
+  const [ghlOutcome, setGhlOutcome] = useState("");
+  const [ghlLoaded, setGhlLoaded] = useState(false);
 
   const { data: statsData } = useQuery({ queryKey: ["estimate-stats"], queryFn: () => apiFetch("/api/estimates/stats") });
   const { data: listData, isLoading } = useQuery({
@@ -71,6 +74,22 @@ export default function EstimatesPage() {
     mutationFn: (id: number) => apiFetch(`/api/estimates/templates/${id}`, { method: "DELETE" }),
     onSuccess: () => { qc.invalidateQueries({ queryKey: ["estimate-templates"] }); toast.success("Template deleted"); },
     onError: () => toast.error("Failed to delete template"),
+  });
+
+  // GoHighLevel bridge settings live on the company row.
+  const { data: companyData } = useQuery({ queryKey: ["company-me"], queryFn: () => apiFetch("/api/companies/me") });
+  if (companyData && !ghlLoaded) {
+    setGhlSent(companyData.ghl_estimate_sent_webhook || "");
+    setGhlOutcome(companyData.ghl_estimate_outcome_webhook || "");
+    setGhlLoaded(true);
+  }
+  const saveGhl = useMutation({
+    mutationFn: () => apiFetch("/api/companies/me", {
+      method: "PATCH",
+      body: { ghl_estimate_sent_webhook: ghlSent.trim(), ghl_estimate_outcome_webhook: ghlOutcome.trim() },
+    }),
+    onSuccess: () => { qc.invalidateQueries({ queryKey: ["company-me"] }); toast.success("GoHighLevel settings saved"); },
+    onError: () => toast.error("Failed to save settings"),
   });
 
   const statCards = [
@@ -107,7 +126,7 @@ export default function EstimatesPage() {
 
         {/* Tabs */}
         <div style={{ display: "flex", gap: 6, borderBottom: `1px solid ${BORDER}`, marginBottom: 16 }}>
-          {([["estimates", "Estimates"], ["templates", "Templates"]] as const).map(([key, label]) => (
+          {([["estimates", "Estimates"], ["templates", "Templates"], ["ghl", "GoHighLevel"]] as const).map(([key, label]) => (
             <button key={key} onClick={() => setTab(key)}
               style={{ background: "none", border: "none", borderBottom: tab === key ? `2px solid ${INK}` : "2px solid transparent", color: tab === key ? INK : MUTE, fontWeight: 700, fontSize: 14, padding: "8px 12px", cursor: "pointer", fontFamily: FF, marginBottom: -1 }}>
               {label}
@@ -162,6 +181,41 @@ export default function EstimatesPage() {
               )}
             </div>
           </>
+        ) : tab === "ghl" ? (
+          <div style={{ background: "#fff", border: `1px solid ${BORDER}`, borderRadius: 12, padding: "20px 22px", maxWidth: 640 }}>
+            <p style={{ fontSize: 15, fontWeight: 800, color: INK, margin: "0 0 4px" }}>GoHighLevel follow-up bridge</p>
+            <p style={{ fontSize: 13, color: MUTE, margin: "0 0 16px", lineHeight: 1.6 }}>
+              When you send an estimate, Qleno pushes the contact + estimate link to your GHL workflow so GHL runs the
+              SMS follow-up drip from your office line. When the customer accepts (or declines), Qleno fires the second
+              webhook so GHL stops the drip. Build the two workflows once in GHL (Inbound Webhook trigger), then paste
+              their webhook URLs here. Setup guide: <code style={{ fontSize: 12 }}>docs/GHL_ESTIMATE_BRIDGE.md</code>.
+            </p>
+            <label style={{ display: "block", marginBottom: 14 }}>
+              <span style={{ display: "block", fontSize: 11, fontWeight: 700, color: MUTE, textTransform: "uppercase", letterSpacing: "0.04em", marginBottom: 5 }}>
+                "Estimate sent" webhook URL — starts the drip
+              </span>
+              <input value={ghlSent} onChange={e => setGhlSent(e.target.value)} placeholder="https://services.leadconnectorhq.com/hooks/…"
+                style={{ width: "100%", padding: "9px 11px", border: `1px solid ${BORDER}`, borderRadius: 9, fontSize: 13, fontFamily: FF, boxSizing: "border-box" }} />
+            </label>
+            <label style={{ display: "block", marginBottom: 16 }}>
+              <span style={{ display: "block", fontSize: 11, fontWeight: 700, color: MUTE, textTransform: "uppercase", letterSpacing: "0.04em", marginBottom: 5 }}>
+                "Outcome" webhook URL — stops the drip on accept / decline
+              </span>
+              <input value={ghlOutcome} onChange={e => setGhlOutcome(e.target.value)} placeholder="https://services.leadconnectorhq.com/hooks/…"
+                style={{ width: "100%", padding: "9px 11px", border: `1px solid ${BORDER}`, borderRadius: 9, fontSize: 13, fontFamily: FF, boxSizing: "border-box" }} />
+            </label>
+            <button onClick={() => saveGhl.mutate()} disabled={saveGhl.isPending}
+              style={{ background: INK, color: "#fff", border: "none", borderRadius: 9, padding: "10px 18px", fontSize: 13, fontWeight: 700, cursor: "pointer", fontFamily: FF }}>
+              {saveGhl.isPending ? "Saving…" : "Save settings"}
+            </button>
+            <div style={{ background: "#F7F6F3", borderRadius: 10, padding: "12px 14px", marginTop: 18 }}>
+              <p style={{ fontSize: 11, fontWeight: 700, color: MUTE, textTransform: "uppercase", letterSpacing: "0.05em", margin: "0 0 6px" }}>Payload fields you can map in GHL</p>
+              <p style={{ fontSize: 12, color: "#4B5563", margin: 0, lineHeight: 1.7, fontFamily: "monospace" }}>
+                event · contact_name · contact_email · contact_phone · property_name · service_address · total ·
+                estimate_link · estimate_number · title · valid_until · accepted_name
+              </p>
+            </div>
+          </div>
         ) : (
           <div style={{ background: "#fff", border: `1px solid ${BORDER}`, borderRadius: 12, overflow: "hidden" }}>
             {templates.length === 0 ? (

--- a/docs/GHL_ESTIMATE_BRIDGE.md
+++ b/docs/GHL_ESTIMATE_BRIDGE.md
@@ -1,0 +1,86 @@
+# GoHighLevel Estimate Bridge — One-Time Setup
+
+Qleno pushes estimate events to GoHighLevel; **GHL owns the texting** (from the
+office line 773-706-6000 already connected in GHL). Two webhooks:
+
+| Event | When Qleno fires it | What your GHL workflow does |
+|---|---|---|
+| `estimate_sent` | Office clicks "Send — get link" on an estimate | Create/update the contact, text the estimate link, start the follow-up drip |
+| `estimate_accepted` / `estimate_declined` | Customer taps Accept (or Decline) on the hosted estimate page | Stop the drip; optionally notify the office |
+
+Plan note: the **Inbound Webhook trigger works on the $97 Starter plan** — it's
+a metered "premium workflow" feature (~$0.01 per execution after the monthly
+free allowance), so each estimate costs roughly a penny plus normal SMS usage.
+
+## Payload Qleno sends (JSON)
+
+```json
+{
+  "event": "estimate_sent",
+  "estimate_id": 42,
+  "estimate_number": "EST-1042",
+  "title": "Common Area Cleaning — Monthly Service",
+  "contact_name": "Jane Property Manager",
+  "contact_email": "jane@example.com",
+  "contact_phone": "(773) 555-0123",
+  "property_name": "5721 W 103rd St Condos",
+  "service_address": "5721 W 103rd St, Oak Lawn, IL 60453",
+  "total": "850.00",
+  "valid_until": "2026-07-10",
+  "estimate_link": "https://<your-app-domain>/estimate/<token>",
+  "accepted_name": null
+}
+```
+
+`estimate_accepted` carries the same fields plus `accepted_name` (the name the
+customer typed when accepting).
+
+## Workflow 1 — "Qleno Estimate Sent" (starts the drip)
+
+1. GHL → **Automation → Workflows → Create Workflow → Start from Scratch**.
+2. **Add Trigger → Inbound Webhook.** GHL shows a webhook URL — copy it.
+   Keep this tab open; you'll post a sample to it in step 7.
+3. Action: **Create/Update Contact** — map from the webhook payload:
+   name ← `contact_name`, phone ← `contact_phone`, email ← `contact_email`.
+4. Action: **Add Tag** → `qleno-estimate-out` (this is the drip's membership
+   tag — removal stops the drip if you build the drip on tag).
+5. Action: **Send SMS** (from the office number):
+   > Hi {{contact.first_name}} — here's your cleaning estimate for
+   > {{inboundWebhookRequest.property_name}}: {{inboundWebhookRequest.estimate_link}}
+   > Total: ${{inboundWebhookRequest.total}}. Tap the link to view or accept.
+   > — Phes
+6. Drip: add **Wait 2 days → If/Else (contact has tag `qleno-estimate-out`) →
+   Send SMS** ("Any questions on the estimate? Happy to walk it over the
+   phone."), then **Wait 3 days → SMS**, then **Wait 4 days → final SMS**.
+   Every follow-up SMS sits inside an If/Else that checks the tag, so removing
+   the tag (Workflow 2) silences the rest of the drip.
+7. **Save + Publish.** In the trigger, use "Check webhook" / send a test —
+   you can paste the sample JSON above.
+8. Paste the trigger's webhook URL into Qleno → **Estimates → GoHighLevel tab
+   → "Estimate sent" webhook URL** → Save.
+
+## Workflow 2 — "Qleno Estimate Outcome" (stops the drip)
+
+1. New workflow → **Trigger: Inbound Webhook** — copy its URL.
+2. Action: **Find/Update Contact** by phone/email (same mapping).
+3. Action: **Remove Tag** → `qleno-estimate-out` (drip goes quiet).
+4. Optional: **If/Else on `{{inboundWebhookRequest.event}}`**:
+   - `estimate_accepted` → Send SMS to the customer ("Thank you! We'll reach
+     out shortly to schedule.") and/or an internal notification to the office.
+   - `estimate_declined` → internal notification only.
+5. Save + Publish → paste this URL into Qleno → **Estimates → GoHighLevel tab
+   → "Outcome" webhook URL** → Save.
+
+## Behavior notes
+
+- The bridge is **opt-in**: nothing fires until a URL is saved. Clearing a URL
+  field disables that webhook.
+- Webhooks are **fire-and-forget** with a 5-second timeout — a GHL outage never
+  blocks sending or accepting an estimate. A successful `estimate_sent` stamp
+  is recorded on the estimate (`ghl_synced_at`).
+- Qleno itself sends **no SMS or email** for estimates; GHL is the only sender,
+  consistent with the COMMS_ENABLED=false posture (which governs Qleno's own
+  Twilio/Resend, not the tenant's CRM).
+- Re-clicking "Send" on an estimate fires `estimate_sent` again — GHL's
+  Create/Update Contact is idempotent, but if you don't want the drip to
+  restart, add an If/Else on the tag at the top of Workflow 1.

--- a/lib/db/src/schema/companies.ts
+++ b/lib/db/src/schema/companies.ts
@@ -46,6 +46,14 @@ export const companiesTable = pgTable("companies", {
   sms_paused_enabled: boolean("sms_paused_enabled").notNull().default(false),
   sms_complete_enabled: boolean("sms_complete_enabled").notNull().default(true),
   twilio_from_number: text("twilio_from_number"),
+  // [ghl-estimate-bridge 2026-06-10] GoHighLevel inbound-webhook URLs for the
+  // estimate follow-up drip. Opt-in: the bridge only fires when a URL is set
+  // (pasting the URL IS the explicit enable). Sent fires on estimate send;
+  // outcome fires on accept/decline so GHL can stop the drip. These are
+  // outbound integration events to the tenant's own CRM — Qleno's
+  // COMMS_ENABLED gate (Twilio/Resend suppression) does not apply.
+  ghl_estimate_sent_webhook: text("ghl_estimate_sent_webhook"),
+  ghl_estimate_outcome_webhook: text("ghl_estimate_outcome_webhook"),
   default_payment_terms_residential: text("default_payment_terms_residential").default("due_on_receipt"),
   default_payment_terms_commercial: text("default_payment_terms_commercial").default("net_30"),
   // [pay-matrix 2026-04-29] Tenant defaults inherited by every new


### PR DESCRIPTION
## GoHighLevel webhook bridge (estimate drip)

Final piece of the estimate flow. Qleno never texts estimate follow-ups itself — **GHL owns the drip** from the office line. Qleno notifies GHL's inbound-webhook workflows at two moments:

- **`estimate_sent`** (on "Send — get link") — contact + `estimate_link` + total etc., so GHL creates/updates the contact, texts the link, and starts the follow-up drip. A successful post stamps `estimates.ghl_synced_at`.
- **`estimate_accepted` / `estimate_declined`** (hosted-page actions) — same payload + `accepted_name`, so GHL removes the drip tag and can notify the office.

### Implementation
- `lib/ghl.ts` — fire-and-forget POST, https-only, 5-second timeout; a GHL outage never blocks sending or accepting.
- `companies.ghl_estimate_sent_webhook` / `ghl_estimate_outcome_webhook` columns (schema + idempotent cold-start ALTERs); `PATCH /companies/me` accepts both (https-only validation, empty clears = disables).
- **Opt-in by design:** nothing fires until a URL is saved. These are integration events to the tenant's own CRM — the COMMS_ENABLED Twilio/Resend gate is not bypassed (Qleno still sends no SMS/email).
- Estimates page gains a **GoHighLevel tab**: the two URL fields + payload field reference.
- `docs/GHL_ESTIMATE_BRIDGE.md` — step-by-step one-time GHL setup (Inbound Webhook trigger, tag-gated drip, stop workflow), including the Starter-plan note (premium-trigger metering ≈ $0.01/execution — no upgrade needed).

### Verification
`typecheck:libs` + api-server esbuild + Vite frontend build all pass.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_