### PR TITLE
fix(my-jobs): zone border color/thickness + two-tier notes model

### DIFF
--- a/artifacts/api-server/src/routes/jobs.ts
+++ b/artifacts/api-server/src/routes/jobs.ts
@@ -490,6 +490,11 @@ router.get("/my-jobs", requireAuth, async (req, res) => {
         // gray/zoneless tile is a data error per the zone-resolution invariant.
         // Team = every assigned tech so the cleaner knows who else is going.
         allowed_hours: jobsTable.allowed_hours,
+        // [zone-border-fix 2026-06-10] assigned_user_id must ride along — the
+        // card's getJobVisualStatus treats a missing value as "unassigned",
+        // which painted every tech card with the amber unassigned border
+        // override instead of its zone color.
+        assigned_user_id: jobsTable.assigned_user_id,
         zone_name: sql<string | null>`COALESCE(
           (SELECT z.name FROM service_zones z WHERE z.id = ${jobsTable.zone_id}),
           (SELECT z.name FROM service_zones z WHERE z.company_id = ${jobsTable.company_id} AND z.is_active = true

--- a/artifacts/qleno/src/pages/my-jobs.tsx
+++ b/artifacts/qleno/src/pages/my-jobs.tsx
@@ -120,6 +120,7 @@ export type Job = {
   job_notes: string | null;
   is_recurring: boolean;
   visit_number: number | null;
+  assigned_user_id: number | null;
   before_photo_count: number;
   after_photo_count: number;
   time_clock_entry: TimeclockEntry | null;
@@ -528,7 +529,7 @@ export function JobCard({ job, empPos, onRefresh, isPreviewMode, actingForUserId
         // Outline the whole card in the zone color so the tech sees their area at
         // a glance; status overrides (active/unpaid/no-show/unassigned) win when
         // present, mirroring the dispatch chip's border behavior.
-        border: `2px solid ${visual.borderOverride || job.zone_color || "#E5E2DC"}`,
+        border: `3px solid ${visual.borderOverride || job.zone_color || "#E5E2DC"}`,
         borderRadius: 12, padding: 18, margin: "0 0 12px 0",
         position: "relative", overflow: "hidden",
         opacity: visual.bodyOpacity * (job.status === "cancelled" ? 1 : 1),
@@ -720,18 +721,27 @@ export function JobCard({ job, empPos, onRefresh, isPreviewMode, actingForUserId
         </div>
       )}
 
-      {!job.access_notes && job.client_notes && (
-        <div style={{ backgroundColor: "#F7F6F3", borderRadius: 8, padding: "10px 12px", marginTop: 12 }}>
-          <p style={{ fontSize: 10, fontWeight: 600, color: "#9E9B94", textTransform: "uppercase", letterSpacing: "0.06em", margin: "0 0 4px" }}>Client Notes</p>
-          <p style={{ fontSize: 12, color: "#1A1917", margin: 0 }}>{job.client_notes}</p>
+      {/* Two-tier notes — the bridge from customer instructions to the cleaner.
+          TODAY'S notes (jobs.notes) are one-off for this visit ("today make 2
+          beds") — loudest, first. EVERY-VISIT notes (clients.notes) are sticky
+          per client ("dog and cat — treats in kitchen") and follow the client
+          onto every job regardless of which tech goes. Distinct colors so the
+          tech never confuses a one-off with a standing instruction. */}
+      {job.job_notes && (
+        <div style={{ backgroundColor: "#ECFDF8", border: "2px solid #00C9A0", borderRadius: 10, padding: "12px 14px", marginTop: 12 }}>
+          <p style={{ fontSize: 11, fontWeight: 800, color: "#047857", textTransform: "uppercase", letterSpacing: "0.06em", margin: "0 0 5px" }}>
+            Today's Job Notes — this visit only
+          </p>
+          <p style={{ fontSize: 14, fontWeight: 600, color: "#065F46", margin: 0, lineHeight: 1.55, whiteSpace: "pre-wrap" }}>{job.job_notes}</p>
         </div>
       )}
 
-      {/* Per-job instructions (distinct from the standing client notes). */}
-      {job.job_notes && (
-        <div style={{ backgroundColor: "#F7F6F3", borderRadius: 8, padding: "10px 12px", marginTop: 10 }}>
-          <p style={{ fontSize: 10, fontWeight: 600, color: "#9E9B94", textTransform: "uppercase", letterSpacing: "0.06em", margin: "0 0 4px" }}>Job Instructions</p>
-          <p style={{ fontSize: 12, color: "#1A1917", margin: 0, lineHeight: 1.5 }}>{job.job_notes}</p>
+      {job.client_notes && (
+        <div style={{ backgroundColor: "#EEF2FF", border: "1px solid #C7D2FE", borderRadius: 10, padding: "12px 14px", marginTop: 10 }}>
+          <p style={{ fontSize: 11, fontWeight: 800, color: "#3730A3", textTransform: "uppercase", letterSpacing: "0.06em", margin: "0 0 5px" }}>
+            Client Notes — every visit
+          </p>
+          <p style={{ fontSize: 13, color: "#312E81", margin: 0, lineHeight: 1.55, whiteSpace: "pre-wrap" }}>{job.client_notes}</p>
         </div>
       )}
 


### PR DESCRIPTION
## Tech card: zone border fix + the two-tier notes model

From Sal's field testing (round 3):

### Zone border discrepancy — root-caused
The `/jobs/my-jobs` payload never included `assigned_user_id`, so `getJobVisualStatus` classified **every** tech card as `unassigned` and painted the **amber** border override instead of the zone color — hence the amber card next to a red South Suburbs dot. `assigned_user_id` now rides along; the border matches the dot. Also thickened **2px → 3px**.

### Two-tier notes — bridging customer instructions to the cleaner
- **TODAY'S JOB NOTES** (`jobs.notes`) — one-off, this visit only ("today make 2 beds"). Loudest treatment: mint border, bold, listed first.
- **CLIENT NOTES — EVERY VISIT** (`clients.notes`) — sticky per client ("dog and cat — treats in kitchen"); follows the client onto every job regardless of which tech goes. Indigo treatment.

Client notes previously only rendered when the job had **no** building-access notes — that gate is removed; both tiers always show when present, with distinct colors so a one-off is never confused with a standing instruction.

No new tables: the model maps onto existing columns the office already edits (per-job notes in the edit-job modal; client notes on the customer profile).

### Verification
api-server esbuild + Vite frontend build pass.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_