### PR TITLE
feat(my-jobs): cadence + home facts on the tech card (MC parity)

### DIFF
--- a/artifacts/api-server/src/routes/jobs.ts
+++ b/artifacts/api-server/src/routes/jobs.ts
@@ -495,6 +495,23 @@ router.get("/my-jobs", requireAuth, async (req, res) => {
         // which painted every tech card with the amber unassigned border
         // override instead of its zone color.
         assigned_user_id: jobsTable.assigned_user_id,
+        // [mc-parity 2026-06-10] Cadence + home facts, MaidCentral-style.
+        // Cadence prefers the recurring schedule's frequency (the template is
+        // the source of truth for generated occurrences), falling back to the
+        // job's own stamp. Home facts come from the client's primary home.
+        frequency: sql<string | null>`COALESCE(
+          (SELECT rs.frequency::text FROM recurring_schedules rs WHERE rs.id = ${jobsTable.recurring_schedule_id}),
+          ${jobsTable.frequency}::text
+        )`,
+        bedrooms: sql<number | null>`(SELECT ch.bedrooms FROM client_homes ch
+          WHERE ch.client_id = ${jobsTable.client_id} AND ch.company_id = ${jobsTable.company_id}
+          ORDER BY ch.is_primary DESC NULLS LAST, ch.id LIMIT 1)`,
+        bathrooms: sql<number | null>`(SELECT ch.bathrooms FROM client_homes ch
+          WHERE ch.client_id = ${jobsTable.client_id} AND ch.company_id = ${jobsTable.company_id}
+          ORDER BY ch.is_primary DESC NULLS LAST, ch.id LIMIT 1)`,
+        sq_footage: sql<number | null>`(SELECT ch.sq_footage FROM client_homes ch
+          WHERE ch.client_id = ${jobsTable.client_id} AND ch.company_id = ${jobsTable.company_id}
+          ORDER BY ch.is_primary DESC NULLS LAST, ch.id LIMIT 1)`,
         zone_name: sql<string | null>`COALESCE(
           (SELECT z.name FROM service_zones z WHERE z.id = ${jobsTable.zone_id}),
           (SELECT z.name FROM service_zones z WHERE z.company_id = ${jobsTable.company_id} AND z.is_active = true
@@ -515,7 +532,9 @@ router.get("/my-jobs", requireAuth, async (req, res) => {
         // visit number (calibrates expectations vs a first-time deep clean).
         add_ons: sql<string | null>`(SELECT string_agg(CASE WHEN jao.quantity > 1 THEN ao.name || ' ×' || jao.quantity ELSE ao.name END, ', ' ORDER BY ao.name)
           FROM job_add_ons jao JOIN add_ons ao ON ao.id = jao.add_on_id WHERE jao.job_id = ${jobsTable.id})`,
-        pets: clientsTable.pets,
+        pets: sql<string | null>`COALESCE(${clientsTable.pets}, (SELECT ch.pet_notes FROM client_homes ch
+          WHERE ch.client_id = ${jobsTable.client_id} AND ch.company_id = ${jobsTable.company_id}
+          ORDER BY ch.is_primary DESC NULLS LAST, ch.id LIMIT 1))`,
         alarm_code: clientsTable.alarm_code,
         job_notes: jobsTable.notes,
         is_recurring: sql<boolean>`${jobsTable.recurring_schedule_id} IS NOT NULL`,

--- a/artifacts/qleno/src/pages/my-jobs.tsx
+++ b/artifacts/qleno/src/pages/my-jobs.tsx
@@ -34,6 +34,18 @@ function formatServiceType(s: string) {
   return s.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
 }
 
+// Cadence labels, MaidCentral-style ("Every Two Weeks"), keyed by the
+// frequency enum. Unknown values title-case as a fallback.
+const FREQUENCY_LABELS: Record<string, string> = {
+  weekly: "Weekly", biweekly: "Every 2 Weeks", every_3_weeks: "Every 3 Weeks",
+  monthly: "Every 4 Weeks", semi_monthly: "Twice a Month", on_demand: "One-Time",
+  daily: "Daily", weekdays: "Weekdays", custom_days: "Custom Days",
+};
+export function frequencyLabel(f: string | null | undefined): string | null {
+  if (!f) return null;
+  return FREQUENCY_LABELS[f] ?? f.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+}
+
 // Expected finish = scheduled start + allowed hours, so the tech sees their
 // target end time on the card (e.g. "9:00 AM · 3.0 hrs allowed · ends ~12:00 PM").
 function addHoursToTime(t: string, hours: number): string {
@@ -121,6 +133,10 @@ export type Job = {
   is_recurring: boolean;
   visit_number: number | null;
   assigned_user_id: number | null;
+  frequency: string | null;
+  bedrooms: number | null;
+  bathrooms: number | null;
+  sq_footage: number | null;
   before_photo_count: number;
   after_photo_count: number;
   time_clock_entry: TimeclockEntry | null;
@@ -598,13 +614,16 @@ export function JobCard({ job, empPos, onRefresh, isPreviewMode, actingForUserId
             {job.zone_name}
           </span>
         )}
-        {/* Visit context — a first visit needs more care than a routine repeat. */}
+        {/* Visit context + cadence (MaidCentral parity: "Every 2 Weeks").
+            A first visit needs more care than a routine repeat. */}
         {job.visit_number === 1 ? (
           <span style={{ fontSize: 10, fontWeight: 700, padding: "2px 8px", borderRadius: 20, background: "#FEF3C7", color: "#92400E", letterSpacing: "0.02em" }}>First visit</span>
         ) : job.is_recurring ? (
           <span style={{ fontSize: 10, fontWeight: 700, padding: "2px 8px", borderRadius: 20, background: "#EEF2FF", color: "#3730A3", letterSpacing: "0.02em" }}>
-            Recurring{job.visit_number ? ` · Visit #${job.visit_number}` : ""}
+            {frequencyLabel(job.frequency) ?? "Recurring"}{job.visit_number ? ` · Visit #${job.visit_number}` : ""}
           </span>
+        ) : job.frequency === "on_demand" ? (
+          <span style={{ fontSize: 10, fontWeight: 700, padding: "2px 8px", borderRadius: 20, background: "#F4F3F0", color: "#6B6860", letterSpacing: "0.02em" }}>One-Time</span>
         ) : null}
       </div>
       <p style={{ fontSize: 11, fontWeight: 600, color: "var(--brand)", textTransform: "uppercase", letterSpacing: "0.05em", margin: "0 0 4px" }}>
@@ -633,6 +652,16 @@ export function JobCard({ job, empPos, onRefresh, isPreviewMode, actingForUserId
           </>
         );
       })()}
+      {/* Home facts (MC parity) — size the work before walking in. */}
+      {(job.bedrooms != null || job.bathrooms != null || job.sq_footage != null) && (
+        <p style={{ fontSize: 12, color: "#6B6860", margin: "2px 0 0", fontWeight: 600 }}>
+          {[
+            job.bedrooms != null ? `${job.bedrooms} bd` : null,
+            job.bathrooms != null ? `${job.bathrooms} ba` : null,
+            job.sq_footage != null ? `${job.sq_footage.toLocaleString("en-US")} sq ft` : null,
+          ].filter(Boolean).join(" · ")}
+        </p>
+      )}
       {job.team && job.team_count > 1 && (
         <p style={{ fontSize: 12, color: "#6B6860", margin: "4px 0 0", display: "inline-flex", alignItems: "center", gap: 5 }}>
           <Users size={13} aria-hidden="true" style={{ color: "#9E9B94", flexShrink: 0 }} />


### PR DESCRIPTION
## Cadence + home facts on the tech card (MaidCentral parity)

From Sal's MC reference screenshot:

- **Cadence:** the recurring badge now reads the actual cadence — `Every 2 Weeks · Visit #11` instead of `Recurring · Visit #11` — sourced from the recurring schedule's frequency (the template is the source of truth for generated occurrences), with the job's own `frequency` stamp as fallback. Non-recurring `on_demand` jobs get a **One-Time** chip.
- **Home facts:** `3 bd · 2 ba · 1,850 sq ft` from the client's primary `client_homes` row, so the tech can size the work before walking in.
- **Pets fallback:** `clients.pets` now falls back to the primary home's `pet_notes` when the client-level field is empty.

### Verification
api-server esbuild + Vite frontend build pass.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_