### PR TITLE
feat(ui): employee profile photos in emblems (initials fallback)

### DIFF
--- a/artifacts/qleno/src/components/employee-avatar.tsx
+++ b/artifacts/qleno/src/components/employee-avatar.tsx
@@ -1,0 +1,71 @@
+import type { CSSProperties, ReactNode } from "react";
+
+// [employee-avatar 2026-06-10] One emblem everywhere a person shows up. Renders
+// the uploaded profile photo (users.avatar_url) when present, else the brand
+// initials chip as fallback. `badge` overlays a corner indicator (e.g. the
+// dispatch "clocked in" dot). Size drives the font automatically.
+export function EmployeeAvatar({
+  name,
+  avatarUrl,
+  size = 40,
+  fontSize,
+  badge,
+  title,
+}: {
+  name?: string | null;
+  avatarUrl?: string | null;
+  size?: number;
+  fontSize?: number;
+  badge?: ReactNode;
+  title?: string;
+}) {
+  const initials =
+    (name || "")
+      .split(/\s+/)
+      .filter(Boolean)
+      .map((n) => n[0])
+      .slice(0, 2)
+      .join("")
+      .toUpperCase() || "?";
+
+  const base: CSSProperties = {
+    width: size,
+    height: size,
+    borderRadius: "50%",
+    flexShrink: 0,
+    position: "relative",
+  };
+
+  const inner = avatarUrl ? (
+    <img
+      src={avatarUrl}
+      alt={name || ""}
+      title={title}
+      style={{ ...base, objectFit: "cover", backgroundColor: "var(--brand-dim)", display: "block" }}
+    />
+  ) : (
+    <div
+      title={title}
+      style={{
+        ...base,
+        backgroundColor: "var(--brand-dim)",
+        color: "var(--brand)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        fontSize: fontSize ?? Math.round(size * 0.36),
+        fontWeight: 700,
+      }}
+    >
+      {initials}
+    </div>
+  );
+
+  if (!badge) return inner;
+  return (
+    <div style={{ position: "relative", width: size, height: size, flexShrink: 0 }}>
+      {inner}
+      {badge}
+    </div>
+  );
+}

--- a/artifacts/qleno/src/pages/employees.tsx
+++ b/artifacts/qleno/src/pages/employees.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useLocation } from "wouter";
 import { DashboardLayout } from "@/components/layout/dashboard-layout";
+import { EmployeeAvatar } from "@/components/employee-avatar";
 import { useListUsers } from "@workspace/api-client-react";
 import { getAuthHeaders, getTokenRole } from "@/lib/auth";
 import { useBranch } from "@/contexts/branch-context";
@@ -150,8 +151,8 @@ export default function EmployeesPage() {
                 <div key={user.id}
                   onClick={() => navigate(`/employees/${user.id}`)}
                   style={{ borderBottom: '1px solid #F0EEE9', padding: '14px 16px', cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 12 }}>
-                  <div style={{ width: 40, height: 40, borderRadius: '50%', backgroundColor: 'var(--brand-dim)', color: 'var(--brand)', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: '13px', fontWeight: 700, flexShrink: 0 }}>
-                    {user.first_name[0]}{user.last_name[0]}
+                  <div style={{ width: 40, height: 40, flexShrink: 0 }}>
+                    <EmployeeAvatar name={`${user.first_name} ${user.last_name}`} avatarUrl={(user as any).avatar_url} size={40} />
                   </div>
                   <div style={{ flex: 1, minWidth: 0 }}>
                     <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 2 }}>
@@ -227,9 +228,7 @@ export default function EmployeesPage() {
                   >
                     <td style={{ padding: '14px 20px' }}>
                       <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
-                        <div style={{ width: '36px', height: '36px', borderRadius: '50%', backgroundColor: 'var(--brand-dim)', color: 'var(--brand)', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: '12px', fontWeight: 600, flexShrink: 0 }}>
-                          {user.first_name[0]}{user.last_name[0]}
-                        </div>
+                        <EmployeeAvatar name={`${user.first_name} ${user.last_name}`} avatarUrl={(user as any).avatar_url} size={36} fontSize={12} />
                         <div>
                           <p style={{ fontSize: '13px', fontWeight: 600, color: '#1A1917', margin: 0 }}>{user.first_name} {user.last_name}</p>
                           <p style={{ fontSize: '12px', color: '#6B7280', margin: 0 }}>{user.email}</p>

--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback, useLayoutEffect } from "react";
 import { useSearch, useLocation } from "wouter";
 import { DashboardLayout } from "@/components/layout/dashboard-layout";
+import { EmployeeAvatar } from "@/components/employee-avatar";
 import { getAuthHeaders, useAuthStore } from "@/lib/auth";
 import { useBranch } from "@/contexts/branch-context";
 import { useToast } from "@/hooks/use-toast";
@@ -2347,12 +2348,10 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
                         style={{ display: "flex", alignItems: "center", gap: 10, width: "100%", padding: "10px 8px", border: "none", background: "transparent", cursor: addTechBusy ? "wait" : "pointer", borderRadius: 8, fontFamily: FF, textAlign: "left" }}
                         onMouseEnter={e => e.currentTarget.style.background = "#F7F6F3"}
                         onMouseLeave={e => e.currentTarget.style.background = "transparent"}>
-                        <div style={{ width: 32, height: 32, borderRadius: "50%", backgroundColor: "#F0FDFB", color: "#2D9B83", display: "flex", alignItems: "center", justifyContent: "center", fontSize: 11, fontWeight: 700, flexShrink: 0, position: "relative" }}>
-                          {t.name.split(" ").map(p => p[0]).join("").slice(0, 2)}
-                          {t.is_clocked_in && (
+                        <EmployeeAvatar name={t.name} avatarUrl={t.avatar_url} size={32} fontSize={11}
+                          badge={t.is_clocked_in ? (
                             <span style={{ position: "absolute", bottom: -1, right: -1, width: 10, height: 10, borderRadius: "50%", backgroundColor: "#22C55E", border: "2px solid #FFFFFF" }} title="Clocked in" />
-                          )}
-                        </div>
+                          ) : undefined} />
                         <div style={{ minWidth: 0, flex: 1 }}>
                           <div style={{ fontSize: 13, fontWeight: 600, color: "#1A1917", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{t.name}</div>
                           <div style={{ fontSize: 11, color: "#9E9B94", textTransform: "capitalize" }}>{(t.role || "").replace("_", " ")}</div>


### PR DESCRIPTION
## Employee profile photos in the emblem (initials fallback)

New shared **`EmployeeAvatar`** component renders `users.avatar_url` when present, else the brand initials chip. Wired into the record-driven employee emblems (the data already carries `avatar_url`):

- **Employees list** — both the mobile card list and the desktop table rows
- **Dispatch tech chips** — preserves the "clocked in" green corner badge via the component's `badge` slot

Upload already exists on the employee profile page (`PUT /users/:id` with `avatar_url`) and the profile already renders the photo — this propagates that photo to the emblems. No backend change needed (employees list + dispatch already select `avatar_url`).

### Verification
Vite frontend build passes.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_