### PR TITLE
fix(my-jobs): On My Way works in preview + Spanish translate on notes

### DIFF
--- a/artifacts/api-server/src/routes/tech-clock.ts
+++ b/artifacts/api-server/src/routes/tech-clock.ts
@@ -131,11 +131,27 @@ async function ensureSiteCoords(
 router.post("/:jobId/on-my-way", requireAuth, async (req, res) => {
   try {
     const companyId = req.auth!.companyId;
-    const userId = req.auth!.userId;
     if (companyId == null) {
       return res
         .status(400)
         .json({ error: "Bad Request", message: "User has no company assignment" });
+    }
+    // [acting-for 2026-06-10] Office "view-as" preview (and a real
+    // act-on-behalf) sends acting_for_user_id; attribute the on-my-way event,
+    // ownership check, and SMS to the VIEWED tech, not the office token holder.
+    // Mirrors the clock-in acting-for guard. owner/admin/office/super_admin only.
+    const body = (req.body ?? {}) as Record<string, unknown>;
+    let userId = req.auth!.userId;
+    const actingForRaw = body.acting_for_user_id;
+    if (typeof actingForRaw === "number" && Number.isFinite(actingForRaw) && actingForRaw !== req.auth!.userId) {
+      const role = req.auth!.role || "";
+      if (!["owner", "admin", "office", "super_admin"].includes(role)) {
+        return res.status(403).json({ error: "Forbidden", message: "Not allowed to act for another user" });
+      }
+      const target = await db.select({ id: usersTable.id }).from(usersTable)
+        .where(and(eq(usersTable.id, actingForRaw), eq(usersTable.company_id, companyId))).limit(1);
+      if (!target[0]) return res.status(404).json({ error: "Not Found", message: "Target employee not found in this company" });
+      userId = actingForRaw;
     }
     const jobId = Number(req.params.jobId);
     if (!Number.isFinite(jobId)) {
@@ -151,7 +167,6 @@ router.post("/:jobId/on-my-way", requireAuth, async (req, res) => {
     // Optional inputs from the client (tech's current location, ETA
     // adjustment, deferred flag, from_job_id). All optional. Defaults
     // keep the one-tap happy path frictionless.
-    const body = (req.body ?? {}) as Record<string, unknown>;
     const fromLatRaw = body.from_latitude;
     const fromLngRaw = body.from_longitude;
     const fromLat =

--- a/artifacts/api-server/src/routes/translate.ts
+++ b/artifacts/api-server/src/routes/translate.ts
@@ -1,11 +1,15 @@
 import { Router } from "express";
 import Anthropic from "@anthropic-ai/sdk";
-import { requireAuth, requireRole } from "../lib/auth.js";
+import { requireAuth } from "../lib/auth.js";
 
 // [translate-job-notes 2026-05-27] Office types Job Notes in English; some
 // Phes techs are more comfortable in Spanish. One-click translation via
 // Claude gives the same text in Spanish that the tech sees alongside the
-// English original. Office-only — customer-facing fields don't route here.
+// English original.
+// [tech-note-translate 2026-06-10] Opened from office-only to any authed user
+// — the cleaner in the field is the primary consumer (tap "Ver en español" on
+// the job/client notes). It only translates text supplied in the request; no
+// tenant data is read, so there's nothing role-sensitive to gate.
 //
 // Requires ANTHROPIC_API_KEY in Railway env. If missing, we surface a
 // clear error instead of a 500 so the operator knows to set it.
@@ -16,7 +20,7 @@ const MAX_INPUT_CHARS = 5000;
 const SUPPORTED_TARGETS = new Set(["es", "en"]);
 const LANG_NAME: Record<string, string> = { es: "Spanish", en: "English" };
 
-router.post("/", requireAuth, requireRole("owner", "admin", "office"), async (req, res) => {
+router.post("/", requireAuth, async (req, res) => {
   try {
     const text = typeof req.body?.text === "string" ? req.body.text : "";
     const target = typeof req.body?.target === "string" ? req.body.target : "es";

--- a/artifacts/qleno/src/pages/my-jobs.tsx
+++ b/artifacts/qleno/src/pages/my-jobs.tsx
@@ -341,6 +341,49 @@ function AddNote({ jobId, onSaved }: { jobId: number; onSaved: () => void }) {
   );
 }
 
+// [tech-note-translate 2026-06-10] Notes are authored in English (the bridge
+// from customer instructions to the cleaner). Spanish-first techs tap "Ver en
+// español" to translate any note in place via /api/translate (Claude). The
+// translation is cached on first tap; the toggle flips back to the English
+// original. Used for both note tiers.
+function TranslatableNote({ text, color, linkColor, fontSize, fontWeight }: { text: string; color: string; linkColor: string; fontSize: number; fontWeight: number }) {
+  const [translated, setTranslated] = useState<string | null>(null);
+  const [showTranslated, setShowTranslated] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const { toast } = useToast();
+
+  const translate = async () => {
+    if (translated) { setShowTranslated(true); return; }
+    setBusy(true);
+    try {
+      const res = await apiFetch("/translate", { method: "POST", body: JSON.stringify({ text, target: "es" }) });
+      const d = await res.json();
+      if (!res.ok || !d.translated) throw new Error();
+      setTranslated(d.translated);
+      setShowTranslated(true);
+    } catch {
+      toast({ variant: "destructive", title: "No se pudo traducir", description: "Translation unavailable" });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <>
+      <p style={{ fontSize, fontWeight, color, margin: 0, lineHeight: 1.55, whiteSpace: "pre-wrap" }}>
+        {showTranslated && translated ? translated : text}
+      </p>
+      <button
+        onClick={() => (showTranslated ? setShowTranslated(false) : translate())}
+        disabled={busy}
+        style={{ marginTop: 6, background: "none", border: "none", padding: 0, color: linkColor, fontSize: 12, fontWeight: 700, cursor: "pointer", fontFamily: "inherit", textDecoration: "underline" }}
+      >
+        {busy ? "Traduciendo…" : showTranslated ? "View original (English)" : "Ver en español"}
+      </button>
+    </>
+  );
+}
+
 export function JobCard({ job, empPos, onRefresh, isPreviewMode, actingForUserId, prevJobId, requireAfterPhoto, onOpenDetail }: { job: Job; empPos: { lat: number; lng: number } | null; onRefresh: () => void; isPreviewMode?: boolean; actingForUserId?: number | null; prevJobId?: number | null; requireAfterPhoto?: boolean; onOpenDetail?: () => void }) {
   const { toast } = useToast();
   const qc = useQueryClient();
@@ -470,6 +513,7 @@ export function JobCard({ job, empPos, onRefresh, isPreviewMode, actingForUserId
       const body: Record<string, unknown> = {};
       if (typeof lat === "number" && typeof lng === "number") { body.from_latitude = lat; body.from_longitude = lng; }
       if (prevJobId != null) body.from_job_id = prevJobId;
+      if (actingForUserId != null) body.acting_for_user_id = actingForUserId;
       const res = await apiFetch(`/tech/jobs/${job.id}/on-my-way`, { method: "POST", body: JSON.stringify(body) });
       if (!res.ok) throw new Error();
       return res.json();
@@ -487,7 +531,6 @@ export function JobCard({ job, empPos, onRefresh, isPreviewMode, actingForUserId
     onSettled: () => setOmwBusy(false),
   });
   const fireOnMyWay = () => {
-    if (isPreviewMode) return;
     setOmwBusy(true);
     if (!navigator.geolocation) { omwMutation.mutate({}); return; }
     navigator.geolocation.getCurrentPosition(
@@ -761,7 +804,7 @@ export function JobCard({ job, empPos, onRefresh, isPreviewMode, actingForUserId
           <p style={{ fontSize: 11, fontWeight: 800, color: "#047857", textTransform: "uppercase", letterSpacing: "0.06em", margin: "0 0 5px" }}>
             Today's Job Notes — this visit only
           </p>
-          <p style={{ fontSize: 14, fontWeight: 600, color: "#065F46", margin: 0, lineHeight: 1.55, whiteSpace: "pre-wrap" }}>{job.job_notes}</p>
+          <TranslatableNote text={job.job_notes} color="#065F46" linkColor="#047857" fontSize={14} fontWeight={600} />
         </div>
       )}
 
@@ -770,7 +813,7 @@ export function JobCard({ job, empPos, onRefresh, isPreviewMode, actingForUserId
           <p style={{ fontSize: 11, fontWeight: 800, color: "#3730A3", textTransform: "uppercase", letterSpacing: "0.06em", margin: "0 0 5px" }}>
             Client Notes — every visit
           </p>
-          <p style={{ fontSize: 13, color: "#312E81", margin: 0, lineHeight: 1.55, whiteSpace: "pre-wrap" }}>{job.client_notes}</p>
+          <TranslatableNote text={job.client_notes} color="#312E81" linkColor="#3730A3" fontSize={13} fontWeight={400} />
         </div>
       )}
 


### PR DESCRIPTION
## On My Way fix + Spanish note translation

### On My Way was dead for Juliana
`fireOnMyWay` still had its own `if (isPreviewMode) return;` guard that PR #368 missed when it made the other clock buttons actionable in office "view-as" — so the tap silently no-oped. And even if it fired, the backend's `loadOwnedJob` rejects a job not assigned to the token user, so it would 404 in preview.
- **Frontend:** removed the preview early-return; passes `acting_for_user_id`.
- **Backend** `/tech/jobs/:id/on-my-way`: accepts `acting_for_user_id` (owner/admin/office/super_admin, same-company) and attributes the ownership check, the `on_my_way_event`, and the SMS to the **viewed tech** — mirrors the clock-in acting-for guard. (The SMS itself is still gated by `COMMS_ENABLED`, which is the "not plugged into Twilio yet" you noted — that's expected; the event + mileage leg are captured regardless.)

### Spanish translation on notes
Notes are authored in **English** (the customer→cleaner bridge). Spanish-first techs tap **"Ver en español"** to translate any note in place via `/api/translate` (Claude). Added to **both** note tiers (Today's Job Notes + Client Notes). Translation is cached on first tap and toggles back to the English original. Opened the `/translate` route from office-only to any authenticated user — the field cleaner is the primary consumer, and it only translates request-supplied text (no tenant data read).

> Note: requires `ANTHROPIC_API_KEY` in Railway (already used by the office translate feature). Without it the tech gets a clean "translation unavailable" toast.

### Verification
api-server esbuild + Vite frontend build pass.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_