### PR TITLE
fix(auth): surface the real login-failure reason

### DIFF
--- a/artifacts/api-server/src/routes/auth.ts
+++ b/artifacts/api-server/src/routes/auth.ts
@@ -30,6 +30,16 @@ router.post("/login", async (req, res) => {
       return res.status(401).json({ error: "Unauthorized", message: "Invalid credentials" });
     }
 
+    // [login-diagnostics 2026-06-10] An imported/invited account can have a
+    // NULL password_hash (never set). bcrypt.compare(pw, null) THROWS, which
+    // surfaced as a 500 masked by the login page's generic message — making
+    // it look like "wrong password" when really no password exists. Detect it
+    // explicitly and tell the operator the real cause.
+    if (!user[0].password_hash) {
+      await logAudit(req, "login_failed", "user", user[0].id, null, { email, reason: "no_password_set" });
+      return res.status(401).json({ error: "Unauthorized", message: "No password set for this account yet. The office needs to set or reset your password." });
+    }
+
     const validPassword = await bcrypt.compare(password, user[0].password_hash);
     if (!validPassword) {
       await logAudit(req, "login_failed", "user", user[0].id, null, { email, reason: "wrong_password" });

--- a/artifacts/qleno/src/pages/login.tsx
+++ b/artifacts/qleno/src/pages/login.tsx
@@ -56,8 +56,19 @@ export default function Login() {
             setLocation("/dashboard");
           }
         },
-        onError: () => {
-          toast({ variant: "destructive", title: "Login Failed", description: "Invalid email or password" });
+        onError: (err: any) => {
+          // [login-diagnostics 2026-06-10] Surface the REAL server reason
+          // instead of always saying "Invalid email or password." The backend
+          // distinguishes wrong credentials (401 "Invalid credentials") from
+          // an inactive account ("Account is inactive") and server errors
+          // (500 — e.g. a null password_hash on an imported account that was
+          // never given a password). Masking them all made field logins
+          // impossible to diagnose. ApiError carries .status + .data.
+          const serverMsg = err?.data?.message || err?.data?.error;
+          const description = err?.status === 500
+            ? "Something went wrong signing in. Your account may not have a password set yet — contact the office."
+            : (serverMsg || "Invalid email or password");
+          toast({ variant: "destructive", title: "Login Failed", description });
         }
       }
     );


### PR DESCRIPTION
## Unmask the real login-failure reason

Juliana (field) can't log in, and the screen only ever says "Invalid email or password" — which hides which of several different failures is actually happening. This makes field logins impossible to diagnose. Two fixes, neither of which assumes a cause — they just make the cause **visible**:

- **Login page:** `onError` now reads `ApiError.status` + `.data.message` and shows the **real** server reason ("Account is inactive", the no-password message, etc.) instead of a hardcoded string. A 500 shows "your account may not have a password set yet — contact the office" rather than masquerading as a wrong password.
- **`/auth/login`:** an imported/invited account with a **NULL `password_hash`** made `bcrypt.compare(pw, null)` throw a 500 (masked as wrong password). Now detected explicitly → clean 401 *"No password set for this account yet. The office needs to set or reset your password."* (audit reason `no_password_set`).

After this deploys, retrying Juliana's login will show the actual reason, which tells us the exact fix.

### Verification
api-server esbuild + Vite frontend build pass. (No prod DB in this environment — this change is specifically to surface the prod reason we can't query.)

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_