### PR TITLE
feat(assistant): answer about any day in a 2-week window, not just today

### DIFF
--- a/artifacts/api-server/src/routes/assistant.ts
+++ b/artifacts/api-server/src/routes/assistant.ts
@@ -1,7 +1,7 @@
 import { Router } from "express";
 import { db } from "@workspace/db";
 import { jobsTable, clientsTable, accountsTable, accountPropertiesTable, usersTable } from "@workspace/db/schema";
-import { eq, and, asc, sql } from "drizzle-orm";
+import { eq, and, asc, gte, lte, sql } from "drizzle-orm";
 import Anthropic from "@anthropic-ai/sdk";
 import { requireAuth } from "../lib/auth.js";
 import { parseResRatesRow } from "../lib/commission-rates.js";
@@ -20,6 +20,18 @@ import { computeCommissionRows } from "../lib/commission-compute.js";
 const router = Router();
 
 const LANG_NAME: Record<string, string> = { en: "English", es: "Spanish" };
+
+// [assistant-window 2026-06-10] Add days to a YYYY-MM-DD string (UTC math is
+// fine — we only need the calendar date, never a wall-clock instant).
+function addDaysYmd(ymd: string, days: number): string {
+  const [y, m, d] = ymd.split("-").map(Number);
+  const dt = new Date(Date.UTC(y, m - 1, d + days));
+  return dt.toISOString().slice(0, 10);
+}
+function weekdayOf(ymd: string): string {
+  const [y, m, d] = ymd.split("-").map(Number);
+  return new Date(Date.UTC(y, m - 1, d)).toLocaleDateString("en-US", { weekday: "long", timeZone: "UTC" });
+}
 
 function fmtAddr(street?: string | null, city?: string | null, state?: string | null, zip?: string | null): string {
   const s = (v: any) => (v == null ? "" : String(v).trim());
@@ -46,6 +58,16 @@ router.post("/ask", requireAuth, async (req, res) => {
     const now = typeof req.body?.now === "string" && /^\d{1,2}:\d{2}/.test(req.body.now)
       ? req.body.now.slice(0, 5)
       : null;
+
+    // [assistant-window 2026-06-10] Load a rolling window, not just today, so
+    // "tomorrow", "this week", "next week", and specific upcoming dates have
+    // data. `date` stays "today" (drives now/current-job logic); the schedule
+    // payload spans [today .. today+RANGE_DAYS]. Each job carries its date +
+    // weekday so the model answers per-day.
+    const RANGE_DAYS = 14;
+    const fromDate = date;
+    const toDate = addDaysYmd(date, RANGE_DAYS);
+    const OFFICE_JOB_CAP = 400;
 
     if (!question) { res.status(400).json({ error: "question required" }); return; }
     if (question.length > 1000) { res.status(400).json({ error: "question too long" }); return; }
@@ -99,10 +121,12 @@ router.post("/ask", requireAuth, async (req, res) => {
         .leftJoin(accountPropertiesTable, eq(jobsTable.account_property_id, accountPropertiesTable.id))
         .where(and(
           eq(jobsTable.company_id, companyId),
-          eq(jobsTable.scheduled_date, date),
+          gte(jobsTable.scheduled_date, fromDate),
+          lte(jobsTable.scheduled_date, toDate),
           sql`${jobsTable.status} <> 'cancelled'`,
         ))
-        .orderBy(asc(jobsTable.scheduled_time), asc(jobsTable.id));
+        .orderBy(asc(jobsTable.scheduled_date), asc(jobsTable.scheduled_time), asc(jobsTable.id))
+        .limit(OFFICE_JOB_CAP);
 
       // Per-job commission via the canonical engine (+ final_pay overrides), so
       // the numbers match what the office sees on the payroll screens.
@@ -134,8 +158,11 @@ router.post("/ask", requireAuth, async (req, res) => {
         const tech = `${r.tech_first ?? ""} ${r.tech_last ?? ""}`.trim() || "Unassigned";
         const address = fmtAddr(r.address_street, r.address_city, r.address_state, r.address_zip);
         const revenue = parseFloat(String(r.billed_amount ?? r.base_fee ?? 0)) || 0;
+        const dstr = r.scheduled_date ? String(r.scheduled_date).slice(0, 10) : null;
         return {
           n: i + 1,
+          date: dstr,
+          day: dstr ? weekdayOf(dstr) : null,
           tech,
           client: r.property_name ? `${cname} — ${r.property_name}` : cname,
           address: address || null,
@@ -147,21 +174,27 @@ router.post("/ask", requireAuth, async (req, res) => {
           actual_hours: r.actual_hours != null ? Number(r.actual_hours) : null,
         };
       });
-      const totalRevenue = Math.round(jobs.reduce((s, j) => s + j.revenue, 0) * 100) / 100;
-      const totalCommission = Math.round(jobs.reduce((s, j) => s + j.commission, 0) * 100) / 100;
+      const todayJobs = jobs.filter(j => j.date === date);
+      const todayRevenue = Math.round(todayJobs.reduce((s, j) => s + j.revenue, 0) * 100) / 100;
+      const todayCommission = Math.round(todayJobs.reduce((s, j) => s + j.commission, 0) * 100) / 100;
+      const truncated = jobs.length >= OFFICE_JOB_CAP;
 
       system =
         `You are an assistant for the OFFICE/OWNER (role: ${role}) of a residential & commercial cleaning company using Qleno. ` +
-        `Today is ${date}${now ? `, current local time ${now}` : ""}. ` +
-        `You can answer about the WHOLE company's day using ONLY the provided data: total revenue, total commission, each technician's schedule, and per-technician commission. ` +
+        `Today is ${date} (${weekdayOf(date)})${now ? `, current local time ${now}` : ""}. ` +
+        `You have the company's scheduled jobs from ${fromDate} (${weekdayOf(fromDate)}) through ${toDate} (${weekdayOf(toDate)}) — about two weeks. Each job includes its "date" and "day" (weekday). ` +
+        `Answer about ANY date or range in that window: "today", "tomorrow" (${addDaysYmd(date, 1)}), "this week", "next week" (the Mon–Sun after this one), or a specific date — by filtering jobs on their "date"/"day" and summing as needed. ` +
+        `If asked about a date OUTSIDE ${fromDate}..${toDate}, say you only have the schedule through ${toDate}. ` +
+        (truncated ? `NOTE: the schedule was truncated at ${OFFICE_JOB_CAP} jobs, so far-out days may be incomplete; say so if relevant. ` : ``) +
         `Use ONLY this data — never invent numbers, jobs, names, or addresses; if it isn't here, say you don't have it. ` +
-        `For a specific technician's commission or schedule, match jobs by that tech's name (case-insensitive) and sum their commission. All money is USD. ` +
-        `When asked which job a technician is on "right now" / "currently" / "at the moment", DO answer from the schedule and the current local time — do not refuse for lack of GPS. The current job is the latest one whose scheduled start time is at or before ${now || "now"}; name that client and time, and mention the next upcoming job if one remains. Add a brief caveat that this is based on the schedule, not live tracking. If the tech's first job today is still in the future, say they haven't started yet and give the first job's time. ` +
-        `Reply in ${langName}, concise and natural for reading aloud (a few sentences; brief lists for schedules). ` +
+        `For a specific technician, match jobs by that tech's name (case-insensitive). All money is USD. ` +
+        `When asked which job a technician is on "right now" / "currently" / "at the moment", answer from TODAY's (${date}) schedule and the current local time — do not refuse for lack of GPS. The current job is the latest TODAY job whose scheduled start time is at or before ${now || "now"}; name that client and time, mention the next upcoming job if one remains, and add a brief caveat that this is schedule-based, not live tracking. If their first job today is still in the future, say they haven't started yet. ` +
+        `Reply in ${langName}, concise and natural for reading aloud (a few sentences; brief lists for schedules grouped by day). ` +
         `When asked to navigate / get directions to a job, put that job's exact address in "navigate_to"; otherwise null. ` +
         `Respond with ONLY a JSON object: {"answer": string, "navigate_to": string|null}. No other text.\n\n` +
-        `Company day for ${date} — totals: revenue $${totalRevenue.toFixed(2)}, commission $${totalCommission.toFixed(2)}, ${jobs.length} jobs.\n` +
-        `Jobs:\n${JSON.stringify(jobs)}`;
+        `Today (${date}) totals: revenue $${todayRevenue.toFixed(2)}, commission $${todayCommission.toFixed(2)}, ${todayJobs.length} jobs. ` +
+        `Full window has ${jobs.length} jobs. Compute any other day/week's totals yourself from the per-job revenue/commission + date below.\n` +
+        `Jobs (${fromDate}..${toDate}):\n${JSON.stringify(jobs)}`;
     } else {
     // The tech's OWN jobs for the day (privacy: assigned_user_id = the caller).
     // Address resolves account_property → client, mirroring routes/tech.ts.
@@ -178,6 +211,7 @@ router.post("/ask", requireAuth, async (req, res) => {
         address_state: sql<string | null>`CASE WHEN ${jobsTable.account_property_id} IS NOT NULL THEN ${accountPropertiesTable.state} ELSE ${clientsTable.state} END`,
         address_zip: sql<string | null>`CASE WHEN ${jobsTable.account_property_id} IS NOT NULL THEN ${accountPropertiesTable.zip} ELSE ${clientsTable.zip} END`,
         service_type: jobsTable.service_type,
+        scheduled_date: jobsTable.scheduled_date,
         scheduled_time: jobsTable.scheduled_time,
         allowed_hours: jobsTable.allowed_hours,
         status: jobsTable.status,
@@ -192,17 +226,22 @@ router.post("/ask", requireAuth, async (req, res) => {
       .where(and(
         eq(jobsTable.company_id, companyId),
         eq(jobsTable.assigned_user_id, userId),
-        eq(jobsTable.scheduled_date, date),
+        gte(jobsTable.scheduled_date, fromDate),
+        lte(jobsTable.scheduled_date, toDate),
+        sql`${jobsTable.status} <> 'cancelled'`,
       ))
-      .orderBy(asc(jobsTable.scheduled_time), asc(jobsTable.id));
+      .orderBy(asc(jobsTable.scheduled_date), asc(jobsTable.scheduled_time), asc(jobsTable.id));
 
     jobs = rows.map((r, i) => {
       const name = r.account_name || r.client_company_name
         || `${r.client_first_name ?? ""} ${r.client_last_name ?? ""}`.trim() || "Unknown";
       const address = fmtAddr(r.address_street, r.address_city, r.address_state, r.address_zip);
       const notes = [r.office_notes, r.notes].filter(Boolean).join(" / ");
+      const dstr = r.scheduled_date ? String(r.scheduled_date).slice(0, 10) : null;
       return {
         n: i + 1,
+        date: dstr,
+        day: dstr ? weekdayOf(dstr) : null,
         client: r.property_name ? `${name} — ${r.property_name}` : name,
         address: address || null,
         time: r.scheduled_time ? String(r.scheduled_time).slice(0, 5) : null,
@@ -215,19 +254,21 @@ router.post("/ask", requireAuth, async (req, res) => {
 
     system =
       `You are a friendly, concise voice assistant for a house-cleaning technician using the Qleno app. ` +
-      `Today is ${date}.${now ? ` The current local time is ${now}; "my next job" / "next stop" means the earliest job scheduled at or after ${now} (or the first job today if none remain).` : ""} You are given ONLY this technician's own jobs for the day as JSON. ` +
-      `Answer the technician's question using ONLY that data — never invent jobs, addresses, times, or notes. ` +
+      `Today is ${date} (${weekdayOf(date)}).${now ? ` The current local time is ${now}; "my next job" / "next stop" means the earliest job TODAY at or after ${now} (or today's first job if none remain).` : ""} ` +
+      `You are given this technician's OWN jobs from ${fromDate} through ${toDate} (about two weeks) as JSON; each job has its "date" and "day" (weekday). ` +
+      `Answer about any date in that window — "today", "tomorrow" (${addDaysYmd(date, 1)}), "this week", "next week", or a specific date — by filtering on each job's "date"/"day". If asked about a date outside ${fromDate}..${toDate}, say you only have the schedule through ${toDate}. ` +
+      `Answer using ONLY that data — never invent jobs, addresses, times, or notes. ` +
       `If the answer isn't in the data, say you don't have that information. ` +
       // [assistant-guardrail 2026-06-08] Defense-in-depth: pay/commission and
       // other employees' data are NEVER placed in this context, so they can't
       // leak — but instruct an explicit, friendly refusal so a tech who asks
       // "what's my coworker's pay/schedule?" or "is her commission higher?"
       // gets a clean "can't help with that" instead of a guess.
-      `You ONLY have this technician's own job schedule for today — nothing else. You do NOT have pay, wages, commission, hours-as-money, or ANY other person's schedule or information. If asked about pay, commission, earnings, or anyone other than themselves, politely decline in one short sentence (e.g. "I can only help with your own schedule and job details") and set navigate_to to null. Never guess or fabricate such information. ` +
+      `You ONLY have this technician's own job schedule — nothing else. You do NOT have pay, wages, commission, hours-as-money, or ANY other person's schedule or information. If asked about pay, commission, earnings, or anyone other than themselves, politely decline in one short sentence (e.g. "I can only help with your own schedule and job details") and set navigate_to to null. Never guess or fabricate such information. ` +
       `Reply in ${langName}. Keep it short and natural for reading aloud (1–3 sentences; for a full schedule give a brief list with time + client). ` +
       `When the technician asks to navigate / get directions / go to a job, choose the intended job (by client name, or the next upcoming job if unspecified) and put its exact address string in "navigate_to". Otherwise "navigate_to" MUST be null. ` +
       `Respond with ONLY a JSON object: {"answer": string, "navigate_to": string|null}. No other text.\n\n` +
-      `Technician's jobs for ${date}:\n${JSON.stringify(jobs)}`;
+      `Technician's jobs (${fromDate}..${toDate}):\n${JSON.stringify(jobs)}`;
     }
 
     const client = new Anthropic();


### PR DESCRIPTION
## Assistant can answer about any day, not just today

You asked the assistant "what day next week" and it said *"I only have information for today, June 10th."* Root cause: the assistant's query hard-scoped `scheduled_date = today`, so it literally had no data for any other date.

Now it loads a rolling **[today .. today + 14 days]** window (both the office/owner branch and the tech branch), stamps each job with its **date + weekday**, and the prompt teaches it to filter and sum by date — "today", "tomorrow", "this week", "next week", or a specific date. For a date outside the window it says it only has the schedule through the end date.

- **Office/owner:** company-wide window, capped at 400 jobs (tells the model if truncated). Today's revenue/commission still surfaced as a headline; any other day's/week's totals are computed by the model from the per-job data.
- **Tech:** their own jobs across the window — the `assigned_user_id` privacy scope and the "no pay / no other person" guardrails are unchanged. Cancelled jobs now excluded.
- **"Right now / current job"** logic still anchors on **today** + local time, so that behavior is unchanged.

> Requires `ANTHROPIC_API_KEY` (already needed by the assistant). No schema change.

### Verification
api-server esbuild bundle passes.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_