### PR TITLE
fix(dispatch): drag-and-drop save mirrors job_technicians + static sort toggle

### DIFF
--- a/artifacts/api-server/src/routes/jobs.ts
+++ b/artifacts/api-server/src/routes/jobs.ts
@@ -1117,6 +1117,37 @@ router.put("/:id", requireAuth, async (req, res) => {
       return res.status(404).json({ error: "Not Found", message: "Job not found" });
     }
 
+    // [dispatch drag-and-drop save 2026-06-10]
+    // The dispatch read path (routes/dispatch.ts:914-931) treats
+    // job_technicians as the source of truth for which row a job
+    // appears under — falling back to jobs.assigned_user_id ONLY when
+    // there is no job_technicians row. Updating `assigned_user_id`
+    // alone here used to leave the old primary row in job_technicians
+    // intact, so the very next dispatch reload would render the chip
+    // back under the original tech. That is the "drag let you but it
+    // doesn't save" symptom Maribel reported.
+    //
+    // The fix mirrors the new primary into job_technicians:
+    //   1) demote any current is_primary=true row for this job,
+    //   2) upsert the new tech as primary (promoting an existing helper
+    //      row if they were already on the team — the (job_id, user_id)
+    //      unique index makes this safe via ON CONFLICT).
+    // Helpers in job_technicians are untouched so multi-tech crews
+    // survive a quick reschedule.
+    if (assigned_user_id !== undefined && assigned_user_id !== null) {
+      const companyId = req.auth!.companyId!;
+      await db.execute(sql`
+        UPDATE job_technicians
+        SET is_primary = false
+        WHERE job_id = ${jobId} AND is_primary = true AND user_id <> ${Number(assigned_user_id)}
+      `);
+      await db.execute(sql`
+        INSERT INTO job_technicians (job_id, user_id, company_id, is_primary)
+        VALUES (${jobId}, ${Number(assigned_user_id)}, ${companyId}, true)
+        ON CONFLICT (job_id, user_id) DO UPDATE SET is_primary = true
+      `);
+    }
+
     logAudit(req, "UPDATE", "job", jobId, null, updated[0]);
 
     // [push 2026-06-03] Schedule-change push to the assigned tech. Strictly

--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -5467,6 +5467,15 @@ export default function JobsPage() {
   const refreshRef = useRef(0);
   const [zones, setZones] = useState<{ id: number; name: string; color: string }[]>([]);
   const [selectedZoneFilter, setSelectedZoneFilter] = useState<number | null>(null);
+  // [dispatch tech sort 2026-06-10] Toggle "By time" (current — techs with
+  // the earliest first job rise) vs "Static" (alphabetical A→Z, MaidCentral
+  // parity). Persisted per office so the choice survives reloads.
+  const [techSortMode, setTechSortMode] = useState<"by_time" | "static">(
+    () => (typeof window !== "undefined" && window.localStorage.getItem("dispatchTechSort") === "static") ? "static" : "by_time"
+  );
+  useEffect(() => {
+    if (typeof window !== "undefined") window.localStorage.setItem("dispatchTechSort", techSortMode);
+  }, [techSortMode]);
   const [zoneDropdownOpen, setZoneDropdownOpen] = useState(false);
   const zoneDropdownRef = useRef<HTMLDivElement>(null);
   const [selectedLocationFilter, setSelectedLocationFilter] = useState<"all" | "oak_lawn" | "schaumburg">("all");
@@ -6406,6 +6415,18 @@ export default function JobsPage() {
                 <button title="List view — one card per job, stacked" onClick={() => setDesktopView("list")} style={{ padding: "5px 10px", border: "none", cursor: "pointer", backgroundColor: desktopView === "list" ? "var(--brand)" : "#FAFAF9", color: desktopView === "list" ? "#fff" : "#6B7280", display: "flex", alignItems: "center", gap: 5, fontSize: 12, fontWeight: 600 }}><List size={14} /> List</button>
               </div>
 
+              {/* Tech-row sort toggle. "By time" floats whoever starts first
+                  to the top of the timeline; "Static" is alphabetical A→Z so
+                  the order matches MaidCentral and the same tech is always
+                  in the same place. Persisted in localStorage so the choice
+                  sticks per browser. */}
+              {desktopView === "timeline" && (
+                <div style={{ display: "flex", border: "1px solid #E5E2DC", borderRadius: 8, overflow: "hidden" }}>
+                  <button title="Sort tech rows by their earliest scheduled job" onClick={() => setTechSortMode("by_time")} style={{ padding: "5px 10px", border: "none", cursor: "pointer", backgroundColor: techSortMode === "by_time" ? "var(--brand)" : "#FAFAF9", color: techSortMode === "by_time" ? "#fff" : "#6B7280", display: "flex", alignItems: "center", gap: 5, fontSize: 12, fontWeight: 600, fontFamily: FF }}>By time</button>
+                  <button title="Sort tech rows alphabetically (MaidCentral parity — same tech, same place every day)" onClick={() => setTechSortMode("static")} style={{ padding: "5px 10px", border: "none", cursor: "pointer", backgroundColor: techSortMode === "static" ? "var(--brand)" : "#FAFAF9", color: techSortMode === "static" ? "#fff" : "#6B7280", display: "flex", alignItems: "center", gap: 5, fontSize: 12, fontWeight: 600, fontFamily: FF }}>Static</button>
+                </div>
+              )}
+
               {/* Cutover 3B — Attendance overlay drawer trigger. Sibling
                   of the Timeline/List toggle group, not inside it. Hidden
                   for tech-role; backend also 403s. */}
@@ -6530,15 +6551,26 @@ export default function JobsPage() {
                     {filteredData.unassigned_jobs.length > 0 && (
                       <UnassignedGanttRow jobs={filteredData.unassigned_jobs} onChipClick={setSelectedJob} nowLine={nowLine} />
                     )}
-                    {/* Row order: techs with jobs first, ordered by their
-                        earliest job time; then idle techs (no jobs today);
-                        then generic/test stub accounts pinned at the bottom. */}
+                    {/* Row order: controlled by the techSortMode toggle.
+                        - "by_time": techs with jobs first, ordered by their
+                          earliest job time; then idle; stubs at the bottom.
+                        - "static": pure alphabetical A→Z (with stubs still
+                          pinned at the bottom); MaidCentral parity, so the
+                          office can pattern-match a familiar order across
+                          tools. */}
                     {[...filteredData.employees].sort((a, b) => {
                       const isStub = (e: Employee) => /\b(generic|test)\b/i.test(e.name);
-                      const rank = (e: Employee) => isStub(e) ? 3 : (e.jobs.length === 0 ? 2 : 1);
+                      // Stubs always last in both modes.
+                      const sa = isStub(a) ? 1 : 0, sb = isStub(b) ? 1 : 0;
+                      if (sa !== sb) return sa - sb;
+                      if (techSortMode === "static") {
+                        return a.name.localeCompare(b.name);
+                      }
+                      // by_time: working > idle, then earliest first within working.
+                      const rank = (e: Employee) => e.jobs.length === 0 ? 1 : 0;
                       const ra = rank(a), rb = rank(b);
                       if (ra !== rb) return ra - rb;
-                      if (ra === 1) {
+                      if (ra === 0) {
                         const earliest = (e: Employee) => {
                           const t = e.jobs.map(j => timeToMins(j.scheduled_time)).filter(n => Number.isFinite(n));
                           return t.length ? Math.min(...t) : Infinity;


### PR DESCRIPTION
## Problem — drag-and-drop doesn't save

Maribel: *"this problem still persists, even worst now, it won't even let me drag and drop it, actually it let's you but it doesn't save, when you go to another day and come back it's all messed up"*

## Root cause

The dispatch read path (`routes/dispatch.ts:914-931`) treats `job_technicians` as the source of truth for which row a job appears under, falling back to `jobs.assigned_user_id` only when there is NO `job_technicians` row.

`PUT /api/jobs/:id` (used by drag-and-drop quick reschedule) updated `jobs.assigned_user_id` alone, leaving the old primary row in `job_technicians` intact. So the chip moved optimistically on screen, the API returned 200, but the next dispatch reload pulled the job back under the original tech's row.

CLAUDE.md documented PUT as the exception that "doesn't touch job_technicians." **The exception was wrong** because the read path uses `job_technicians` as primary truth. Closing the invariant gap so all four assignment-write entry points mirror correctly.

## Fix

`PUT /api/jobs/:id` now mirrors the new primary into `job_technicians` whenever `assigned_user_id` is sent:

1. Demote any existing `is_primary=true` row that points at a different user.
2. Upsert the new tech as primary — promoting an existing helper if they were already on the team (safe via the `(job_id, user_id)` unique index + `ON CONFLICT DO UPDATE`).

Helpers stay intact, so multi-tech crews survive a quick reschedule.

## Bonus — static tech sort toggle

Maribel also asked: *"can we make the order of the cleaners static please? it moves around based on who is scheduled earlier... could be the same order as MC."*

Added a **"By time" / "Static"** toggle to the dispatch toolbar, sitting next to the Timeline/List view toggle. Choice persists in `localStorage`.

- **By time** (default, current behavior preserved) — techs with the earliest scheduled job rise to the top
- **Static** — alphabetical A→Z, MaidCentral parity, so the same tech is always in the same place

Stubs (Generic / Test) stay pinned at the bottom in both modes.

## Files
- `artifacts/api-server/src/routes/jobs.ts` — PUT mirrors `job_technicians`
- `artifacts/qleno/src/pages/jobs.tsx` — sort mode state + toolbar toggle + updated sort logic

## Verification
- Typecheck: api-server + frontend both flat with baseline (zero new errors)
- No DB schema change — uses the existing `(job_id, user_id)` unique index

https://claude.ai/code/session_013rJ4N4vgqZWB986x8D6Ahh

---
_Generated by [Claude Code](https://claude.ai/code/session_013rJ4N4vgqZWB986x8D6Ahh)_