### PR TITLE
fix(my-jobs): multi-photo upload + Get Directions on job detail

### DIFF
--- a/artifacts/qleno/src/pages/my-job-detail.tsx
+++ b/artifacts/qleno/src/pages/my-job-detail.tsx
@@ -4,7 +4,8 @@ import { useLocation, useRoute } from "wouter";
 import { useAuthStore } from "@/lib/auth";
 import { useEmployeeView } from "@/contexts/employee-view-context";
 import { JobCard, ymd, type Job } from "./my-jobs";
-import { ArrowLeft, History } from "lucide-react";
+import { formatAddress, mapsDirectionsUrl } from "@/lib/format-address";
+import { ArrowLeft, History, Navigation } from "lucide-react";
 
 const BASE = import.meta.env.BASE_URL.replace(/\/$/, "");
 
@@ -139,6 +140,19 @@ export default function MyJobDetailPage() {
             </div>
           ) : (
             <>
+              {/* [job-detail-directions 2026-06-10] Juliana clicked "Job
+                  details" expecting directions but only saw previous visits.
+                  A prominent Get Directions button (one tap → maps) up top. */}
+              {job.address && (() => {
+                const addr = formatAddress(job.address, job.city, job.state, job.zip);
+                const url = mapsDirectionsUrl(addr);
+                return (
+                  <a href={url ?? "#"} target="_blank" rel="noreferrer"
+                    style={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 8, height: 48, marginBottom: 12, background: "var(--brand, #00C9A0)", color: "#fff", borderRadius: 12, fontSize: 15, fontWeight: 800, textDecoration: "none", fontFamily: "'Plus Jakarta Sans', sans-serif" }}>
+                    <Navigation size={17} /> Get Directions
+                  </a>
+                );
+              })()}
               <JobCard
                 job={job}
                 empPos={empPos}

--- a/artifacts/qleno/src/pages/my-jobs.tsx
+++ b/artifacts/qleno/src/pages/my-jobs.tsx
@@ -165,23 +165,31 @@ function PhotoGrid({ jobId, type, photos, onUploaded }: {
   const inputRef = useRef<HTMLInputElement>(null);
   const { toast } = useToast();
 
+  // [multi-photo 2026-06-10] Juliana: "can't upload more than one photo at a
+  // time." The picker is now `multiple`; we upload every selected file (one
+  // request each — the endpoint takes one photo per POST), skipping any that
+  // are oversized/invalid, and report how many landed.
   const handleFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    if (file.size > 10 * 1024 * 1024) { toast({ variant: "destructive", title: "File too large", description: "Max 10MB" }); return; }
-    if (!["image/jpeg", "image/png", "image/webp"].includes(file.type)) { toast({ variant: "destructive", title: "Invalid file type" }); return; }
+    const files = Array.from(e.target.files ?? []);
+    if (files.length === 0) return;
     setUploading(true);
+    let ok = 0, skipped = 0;
     try {
-      const data_url = await fileToBase64(file);
-      const res = await apiFetch(`/jobs/${jobId}/photos`, {
-        method: "POST",
-        body: JSON.stringify({ photo_type: type, data_url }),
-      });
-      if (!res.ok) throw new Error("Upload failed");
-      onUploaded();
-      toast({ title: `${type === "before" ? "Before" : "After"} photo added` });
-    } catch {
-      toast({ variant: "destructive", title: "Upload failed" });
+      for (const file of files) {
+        if (file.size > 10 * 1024 * 1024 || !["image/jpeg", "image/png", "image/webp"].includes(file.type)) { skipped++; continue; }
+        try {
+          const data_url = await fileToBase64(file);
+          const res = await apiFetch(`/jobs/${jobId}/photos`, {
+            method: "POST",
+            body: JSON.stringify({ photo_type: type, data_url }),
+          });
+          if (!res.ok) { skipped++; continue; }
+          ok++;
+        } catch { skipped++; }
+      }
+      if (ok > 0) onUploaded();
+      if (ok > 0) toast({ title: `${ok} ${type} photo${ok === 1 ? "" : "s"} added${skipped ? ` · ${skipped} skipped` : ""}` });
+      else if (skipped > 0) toast({ variant: "destructive", title: "Couldn't add photos", description: "Too large or unsupported type (max 10MB; JPG/PNG/WebP)." });
     } finally {
       setUploading(false);
       if (inputRef.current) inputRef.current.value = "";
@@ -205,7 +213,7 @@ function PhotoGrid({ jobId, type, photos, onUploaded }: {
         >
           {uploading ? "…" : "+"}
         </button>
-        <input ref={inputRef} type="file" accept="image/*" style={{ display: "none" }} onChange={handleFile} />
+        <input ref={inputRef} type="file" accept="image/*" multiple style={{ display: "none" }} onChange={handleFile} />
       </div>
     </div>
   );


### PR DESCRIPTION
## Field feedback from Juliana

Two fixes from the cleaner in the field:

1. **"Can't upload more than one photo at a time"** — the before/after photo picker is now `multiple`. Every selected file uploads (one POST each — the endpoint takes one photo per request); oversized/invalid files are skipped and the toast reports how many landed vs skipped.
2. **"Clicked Job details but it only shows who did past services — no directions"** — the job-detail screen now leads with a big **Get Directions** button (one tap → maps) above the card, so the address isn't buried under the Previous Visits list.

### Verification
Vite frontend build passes.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_