### PR TITLE
docs: bilingual (EN/ES) employee time-clock printable guide

### DIFF
--- a/docs/time-clock-guide.html
+++ b/docs/time-clock-guide.html
@@ -1,0 +1,99 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Qleno — Employee Time Clock Guide / Guía del Reloj</title>
+<style>
+  :root { --mint:#00C9A0; --night:#0A0E1A; --ink:#1A1917; --mute:#6B7280; --line:#E5E2DC; --bg:#F7F6F3; }
+  * { box-sizing: border-box; }
+  body { font-family: -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; color: var(--ink); margin: 0; background: #fff; }
+  .page { max-width: 820px; margin: 0 auto; padding: 28px 34px 50px; }
+  .brandbar { display:flex; align-items:center; gap:12px; border-bottom: 3px solid var(--mint); padding-bottom: 14px; margin-bottom: 18px; }
+  .logo { width:38px;height:38px;border-radius:9px;background:var(--mint);color:#063;display:flex;align-items:center;justify-content:center;font-weight:800;font-size:20px; }
+  h1 { font-size: 22px; margin: 0; letter-spacing:-0.01em; }
+  .sub { font-size: 12px; color: var(--mute); text-transform: uppercase; letter-spacing:.08em; font-weight:700; margin-top:3px; }
+  h2 { font-size: 16px; margin: 26px 0 6px; color: var(--night); border-bottom:1px solid var(--line); padding-bottom:5px; }
+  .lang { display:inline-block; font-size:11px; font-weight:800; color:#fff; background:var(--night); padding:3px 9px; border-radius:5px; letter-spacing:.05em; margin: 22px 0 6px; }
+  ol { margin: 8px 0 8px 0; padding-left: 20px; }
+  li { margin: 7px 0; line-height: 1.5; font-size: 14px; }
+  .pill { display:inline-block; background:#063; color:#fff; background:var(--mint); color:#063; border-radius:6px; padding:1px 7px; font-weight:800; font-size:12px; }
+  .note { background: var(--bg); border:1px solid var(--line); border-radius:10px; padding:12px 14px; margin:12px 0; font-size:13px; line-height:1.55; }
+  .note b { color: var(--night); }
+  .rules { display:grid; grid-template-columns:1fr 1fr; gap:10px; margin-top:8px; }
+  .rule { background:#ECFDF8; border:1px solid #99E9D3; border-radius:9px; padding:10px 12px; font-size:12.5px; line-height:1.5; color:#065F46; }
+  .rule b { color:#047857; }
+  @media print { .page { padding: 0 18px; } h2 { page-break-after: avoid; } li { page-break-inside: avoid; } .pagebreak { page-break-before: always; } }
+</style>
+</head>
+<body>
+<div class="page">
+
+  <div class="brandbar">
+    <div class="logo">Q</div>
+    <div>
+      <h1>Phes — Employee Time Clock</h1>
+      <div class="sub">How to use the Qleno time clock · Cómo usar el reloj de Qleno</div>
+    </div>
+  </div>
+
+  <div class="note">
+    <b>The big idea:</b> there is <b>ONE clock at each house</b> — Clock In when you start, Clock Out when you finish.
+    There is no separate "check in / check out." Your paid day is figured out automatically from your first Clock In to your last Clock Out.
+    <br><b>La idea principal:</b> hay <b>UN reloj en cada casa</b> — marca entrada (Clock In) al empezar y salida (Clock Out) al terminar.
+    No hay "check in / check out" aparte. Tu día pagado se calcula solo, desde tu primer Clock In hasta tu último Clock Out.
+  </div>
+
+  <span class="lang">ENGLISH</span>
+
+  <h2>Your day, step by step</h2>
+  <ol>
+    <li><b>Open the job.</b> On <b>My Jobs</b>, tap the job you're headed to. Tap <b>Get Directions</b> for the route and the Street View photo to recognize the place.</li>
+    <li><b>On My Way</b> (optional). Tap it when you leave for the job so the office and customer know you're coming.</li>
+    <li><b>Add Before photos.</b> Tap the <span class="pill">+</span> under <b>Before Photos</b> and take photos of how the home looks when you arrive. You can add several at once.</li>
+    <li><b>Clock In — at the house.</b> When you arrive and are ready to start, tap <span class="pill">Clock In</span>. The timer starts. Allow location when asked — it confirms you're at the right address.</li>
+    <li><b>Pause / Resume.</b> Taking a real break (like a 30-minute lunch)? Tap <b>Pause Job</b>, then <b>Resume</b> when you start again. Short waits don't need a pause.</li>
+    <li><b>Add After photos.</b> When you finish, take After photos of the same areas.</li>
+    <li><b>Clock Out.</b> Tap <span class="pill">Clock Out</span>. The job moves to <b>Complete</b>. That's it for this house — no separate "check out."</li>
+    <li><b>Next house?</b> Open the next job and do the same. Your day just keeps going. After your last house, you'll see a short end-of-day summary.</li>
+  </ol>
+
+  <h2>Rules that matter</h2>
+  <div class="rules">
+    <div class="rule"><b>Clock in AT the house</b>, not in the car or at home. Your location is checked.</div>
+    <div class="rule"><b>One clock per house:</b> Clock In → Clock Out. No separate check-in.</div>
+    <div class="rule"><b>Allowed hours</b> on the card is your time target for the job.</div>
+    <div class="rule"><b>Read the notes</b> (green = today only, blue = every visit) before you start. Tap "Ver en español" to translate.</div>
+  </div>
+
+  <div class="pagebreak"></div>
+  <span class="lang">ESPAÑOL</span>
+
+  <h2>Tu día, paso a paso</h2>
+  <ol>
+    <li><b>Abre el trabajo.</b> En <b>Mis Trabajos</b>, toca el trabajo al que vas. Toca <b>Get Directions</b> para la ruta y la foto de Street View para reconocer el lugar.</li>
+    <li><b>On My Way</b> (opcional). Tócalo al salir hacia el trabajo para que la oficina y el cliente sepan que vas en camino.</li>
+    <li><b>Agrega fotos "Antes".</b> Toca el <span class="pill">+</span> bajo <b>Before Photos</b> y toma fotos de cómo está la casa al llegar. Puedes agregar varias a la vez.</li>
+    <li><b>Marca entrada — en la casa.</b> Cuando llegues y estés listo/a, toca <span class="pill">Clock In</span>. El cronómetro empieza. Permite la ubicación cuando te la pida — confirma que estás en la dirección correcta.</li>
+    <li><b>Pausar / Reanudar.</b> ¿Vas a tomar un descanso real (como un almuerzo de 30 minutos)? Toca <b>Pause Job</b> y luego <b>Resume</b> al volver. Las esperas cortas no necesitan pausa.</li>
+    <li><b>Agrega fotos "Después".</b> Al terminar, toma fotos "Después" de las mismas áreas.</li>
+    <li><b>Marca salida.</b> Toca <span class="pill">Clock Out</span>. El trabajo pasa a <b>Completado</b>. Eso es todo para esta casa — no hay "salida" aparte.</li>
+    <li><b>¿Siguiente casa?</b> Abre el siguiente trabajo y haz lo mismo. Tu día simplemente continúa. Después de tu última casa verás un resumen del día.</li>
+  </ol>
+
+  <h2>Reglas importantes</h2>
+  <div class="rules">
+    <div class="rule"><b>Marca entrada EN la casa</b>, no en el carro ni en tu hogar. Se verifica tu ubicación.</div>
+    <div class="rule"><b>Un reloj por casa:</b> Clock In → Clock Out. No hay entrada aparte.</div>
+    <div class="rule"><b>Las horas asignadas</b> (allowed hours) en la tarjeta son tu meta de tiempo.</div>
+    <div class="rule"><b>Lee las notas</b> (verde = solo hoy, azul = cada visita) antes de empezar. Toca "Ver en español".</div>
+  </div>
+
+  <div class="note" style="margin-top:24px">
+    To save this as a PDF: open this file and choose <b>Print → Save as PDF</b>.<br>
+    Para guardarlo como PDF: abre este archivo y elige <b>Imprimir → Guardar como PDF</b>.
+  </div>
+
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Bilingual (EN/ES) employee time-clock printable guide

A self-contained, print-optimized HTML one-pager for the field team, covering the locked time-clock workflow:
- **One clock pair at the house** — Clock In → Pause/Resume → Clock Out
- The auto-derived day (no separate check-in/out, no "end day" button)
- Before/after photos, directions/Street View, reading the notes
- The key rules (clock at the house, location is checked, allowed hours = target)

English and Spanish, side by side. Open it and **Print → Save as PDF** to distribute to the team.

Docs-only — no code paths touched.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_