### PR TITLE
feat(time-clock): show GPS distance + geofence per punch

### DIFF
--- a/artifacts/api-server/src/routes/timeclock.ts
+++ b/artifacts/api-server/src/routes/timeclock.ts
@@ -725,6 +725,9 @@ router.get("/day", requireAuth, requireRole("owner", "admin", "office"), async (
 
     const clockRows = inList ? ((await db.execute(sql`
       SELECT t.id, t.job_id, t.user_id, t.clock_in_at, t.clock_out_at, t.flagged, t.source,
+             t.clock_in_distance_ft, t.clock_out_distance_ft,
+             t.clock_in_outside_geofence, t.clock_out_outside_geofence,
+             t.clock_in_lat, t.clock_out_lat,
              TRIM(COALESCE(u.first_name,'') || ' ' || COALESCE(u.last_name,'')) AS name
       FROM timeclock t JOIN users u ON u.id = t.user_id
       WHERE t.company_id = ${companyId} AND t.job_id IN (${inList})
@@ -795,7 +798,20 @@ router.get("/day", requireAuth, requireRole("owner", "admin", "office"), async (
                  flagged: boolean; minutes: number | null;
                  pay_type: string | null; hourly_rate: string | null; commission_pct: string | null;
                  pay_deduction_pct: string | null; pay_deduction_flat: string | null; pay: number | null;
-                 source: string | null };
+                 source: string | null;
+                 // [gps-on-timeclock 2026-06-11] GPS captured at clock-in/out so
+                 // the office can audit field punches right here. has_gps=false
+                 // means the punch carried no location (denied permission, or an
+                 // office-entered correction).
+                 gps_in_ft: number | null; gps_out_ft: number | null;
+                 gps_in_outside: boolean | null; gps_out_outside: boolean | null; has_gps: boolean };
+    const gpsOf = (e: any) => ({
+      gps_in_ft: e?.clock_in_distance_ft != null ? Math.round(parseFloat(String(e.clock_in_distance_ft))) : null,
+      gps_out_ft: e?.clock_out_distance_ft != null ? Math.round(parseFloat(String(e.clock_out_distance_ft))) : null,
+      gps_in_outside: e?.clock_in_outside_geofence ?? null,
+      gps_out_outside: e?.clock_out_outside_geofence ?? null,
+      has_gps: !!(e && (e.clock_in_lat != null || e.clock_out_lat != null || e.clock_in_distance_ft != null)),
+    });
     const payOf = (jid: number, uid: number) => {
       const p = payByJobUser.get(`${jid}:${uid}`);
       return {
@@ -828,6 +844,7 @@ router.get("/day", requireAuth, requireRole("owner", "admin", "office"), async (
           entry_id: e ? Number(e.id) : null, clock_in_at: e?.clock_in_at ?? null, clock_out_at: e?.clock_out_at ?? null,
           flagged: !!e?.flagged, minutes: e ? minutesOf(e.clock_in_at, e.clock_out_at) : null,
           ...payOf(jid, t.user_id), pay: payByKey.get(`${jid}:${t.user_id}`) ?? null, source: e?.source ?? null,
+          ...gpsOf(e),
         });
       }
     }
@@ -840,6 +857,7 @@ router.get("/day", requireAuth, requireRole("owner", "admin", "office"), async (
         scheduled_time: j?.scheduled_time ?? null, entry_id: Number(e.id), clock_in_at: e.clock_in_at ?? null,
         clock_out_at: e.clock_out_at ?? null, flagged: !!e.flagged, minutes: minutesOf(e.clock_in_at, e.clock_out_at),
         ...payOf(Number(e.job_id), Number(e.user_id)), pay: payByKey.get(`${e.job_id}:${e.user_id}`) ?? null, source: e.source ?? null,
+        ...gpsOf(e),
       });
     }
 

--- a/artifacts/qleno/src/pages/time-clock.tsx
+++ b/artifacts/qleno/src/pages/time-clock.tsx
@@ -85,6 +85,8 @@ type Row = {
   pay_type: string | null; hourly_rate: string | null; commission_pct: string | null;
   pay_deduction_pct: string | null; pay_deduction_flat: string | null;
   pay?: number | null; source?: string | null;
+  gps_in_ft?: number | null; gps_out_ft?: number | null;
+  gps_in_outside?: boolean | null; gps_out_outside?: boolean | null; has_gps?: boolean;
 };
 type Emp = {
   user_id: number; name: string; rows: Row[]; worked_minutes: number;
@@ -230,6 +232,12 @@ function RowEditor({ emp, row, dateStr, onChanged, toastFn }: {
           {fmtSvc(row.service_type)}{row.scheduled_time ? ` · sched ${fmtSchedTime(row.scheduled_time)}` : ""}
           {row.entry_id && row.source !== "punched" && <span style={{ color: "#B45309", marginLeft: 6, fontWeight: 700 }}>· estimated — verify</span>}
           {row.flagged && <span style={{ color: "#B45309", marginLeft: 6, fontWeight: 700 }}>· flagged</span>}
+          {row.entry_id && (row.has_gps
+            ? <span title="Distance from the job site at clock-in (from the tech's phone GPS)" style={{ marginLeft: 6, fontWeight: 700, color: row.gps_in_outside ? "#B45309" : "#0A7C66" }}>
+                · GPS {row.gps_in_ft != null ? `${row.gps_in_ft} ft` : "on"}{row.gps_in_outside ? " (outside zone)" : ""}
+              </span>
+            : <span title="This punch carried no location — phone location was off/denied, or it was entered here as an office correction." style={{ marginLeft: 6, fontWeight: 700, color: "#9E9B94" }}>· no GPS</span>
+          )}
         </div>
       </div>
       <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
@@ -397,7 +405,7 @@ export default function TimeClockPage() {
         )}
 
         <div style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 11, color: "#9E9B94", margin: "10px 2px 24px" }}>
-          <AlertTriangle size={12} /> Times are office corrections (no GPS). Every edit is logged. Pay reflects these clocks on the Payroll screen.
+          <AlertTriangle size={12} /> "GPS" is the distance from the job at the tech's field clock-in. Editing a time here saves an office correction (no GPS) and is logged. Pay reflects these clocks on the Payroll screen.
         </div>
       </div>
     </DashboardLayout>


### PR DESCRIPTION
## Show GPS per punch on the Time Clock screen (owner audit)

You (owner) saw **no GPS** for Juliana's real field clock-ins. Root cause found: the `/timeclock/day` endpoint selected the times but **never selected the GPS columns** (`clock_in_distance_ft`, `clock_in/out_outside_geofence`, `clock_in/out_lat`) — even though they're stored on the row. So the screen had nothing to display. This is a **display gap, not a storage gap**.

### Fix
- `/timeclock/day` now returns `gps_in_ft` / `gps_out_ft` / `gps_in_outside` / `gps_out_outside` / `has_gps` per entry.
- Each row shows **`GPS <n> ft`** (green, inside the zone) or **`GPS <n> ft (outside zone)`** (amber) for real field punches, or **`no GPS`** when the punch carried no location.
- Footer reworded so it's clear: GPS = distance from the job at the tech's field clock-in; editing a time here saves an office correction (no GPS).

### What this tells us about Juliana
After this deploys, her two punches will show one of two things:
- **`GPS <n> ft`** → her phone captured location and it was always there; you just couldn't see it. ✅
- **`no GPS`** → the punch genuinely carried no location, which points to **her phone's location permission** being off/denied for the app (or those jobs not being geocoded). That's the real thing to fix, and now you'll see it plainly.

(Note: this is also where the **mileage** chain starts — no GPS / no "On My Way" legs → nothing for Mileage Review to compute.)

### Verification
api-server esbuild bundle passes.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_