### PR TITLE
fix(my-jobs): Street View on the job detail screen only, not the list cards

### DIFF
--- a/artifacts/qleno/src/pages/my-job-detail.tsx
+++ b/artifacts/qleno/src/pages/my-job-detail.tsx
@@ -3,7 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useLocation, useRoute } from "wouter";
 import { useAuthStore } from "@/lib/auth";
 import { useEmployeeView } from "@/contexts/employee-view-context";
-import { JobCard, ymd, type Job } from "./my-jobs";
+import { JobCard, StreetViewThumb, ymd, type Job } from "./my-jobs";
 import { formatAddress, mapsDirectionsUrl } from "@/lib/format-address";
 import { ArrowLeft, History, Navigation } from "lucide-react";
 
@@ -153,6 +153,17 @@ export default function MyJobDetailPage() {
                   </a>
                 );
               })()}
+              {/* [street-view 2026-06-11] Sal: Street View belongs on the detail
+                  screen only (not the list cards). Sits right under Get Directions,
+                  above the address, so the tech can recognize the property. */}
+              {job.address && (
+                <StreetViewThumb
+                  lat={job.job_lat ?? job.lat}
+                  lng={job.job_lng ?? job.lng}
+                  address={formatAddress(job.address, job.city, job.state, job.zip)}
+                  directionsUrl={mapsDirectionsUrl(formatAddress(job.address, job.city, job.state, job.zip)) ?? null}
+                />
+              )}
               <JobCard
                 job={job}
                 empPos={empPos}

--- a/artifacts/qleno/src/pages/my-jobs.tsx
+++ b/artifacts/qleno/src/pages/my-jobs.tsx
@@ -44,7 +44,9 @@ function getMapsKey(): Promise<string> {
   }
   return _mapsKeyPromise;
 }
-function StreetViewThumb({ lat, lng, address, directionsUrl }: { lat: number | null; lng: number | null; address: string | null; directionsUrl: string | null }) {
+// Rendered on the job DETAIL screen only (not the My Jobs list cards) — see
+// my-job-detail.tsx. Exported so the detail page can place it above the address.
+export function StreetViewThumb({ lat, lng, address, directionsUrl }: { lat: number | null; lng: number | null; address: string | null; directionsUrl: string | null }) {
   const [key, setKey] = useState<string | null>(_mapsKey);
   const [keyResolved, setKeyResolved] = useState<boolean>(_mapsKey != null);
   const [failed, setFailed] = useState(false);
@@ -809,14 +811,6 @@ export function JobCard({ job, empPos, onRefresh, isPreviewMode, actingForUserId
           <Users size={13} aria-hidden="true" style={{ color: "#9E9B94", flexShrink: 0 }} />
           Team: {job.team}
         </p>
-      )}
-      {job.address && (
-        <StreetViewThumb
-          lat={job.job_lat ?? job.lat}
-          lng={job.job_lng ?? job.lng}
-          address={formatAddress(job.address, job.city, job.state, job.zip)}
-          directionsUrl={mapsDirectionsUrl(formatAddress(job.address, job.city, job.state, job.zip)) ?? null}
-        />
       )}
       {job.address && (
         <a


### PR DESCRIPTION
## Why

Two issues from field testing:
1. The Street View thumbnail was showing on **every My Jobs list card** because it lived in the shared `JobCard`. It should only appear on the **job detail** screen.
2. (Separate, not code) The thumbnail shows the gray "Open in Maps" fallback rather than a photo — confirmed the bundle is live; that's a Google key config issue (enable **Street View Static API** + allow the Railway domain), not an app bug.

## What changed (issue 1)

- Removed `StreetViewThumb` from the shared `JobCard` (rendered on both the list and detail).
- Exported it from `my-jobs.tsx` and render it **once**, in `my-job-detail.tsx`, right under **Get Directions** and above the address.

No change to the thumbnail's own behavior — it still falls back to the tappable map tile when the Street View image can't load (PR #395).

## Verification

- `pnpm run build` passes.
- List cards: no Street View. Detail screen: Street View (or its fallback tile) above the address.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_