### PR TITLE
fix(mileage): drop departure_time=now so Distance Matrix isn't REQUEST_DENIED

### DIFF
--- a/artifacts/api-server/src/lib/distance-provider.ts
+++ b/artifacts/api-server/src/lib/distance-provider.ts
@@ -95,7 +95,12 @@ async function tryDistanceMatrix(
       `?origins=${encodeURIComponent(origins)}` +
       `&destinations=${encodeURIComponent(destinations)}` +
       `&mode=driving` +
-      `&departure_time=now` +
+      // NOTE: do NOT send departure_time. It switches the request into
+      // traffic-aware mode, which Google authorizes as a separate API surface
+      // and rejects with REQUEST_DENIED unless the key is granted that extra
+      // entitlement. Mileage is paid on DISTANCE, not duration, so the
+      // traffic-aware duration buys us nothing — we use the plain driving
+      // distance (and the non-traffic duration for office visibility).
       `&key=${apiKey}`;
     const res = await fetch(url);
     if (!res.ok) {


### PR DESCRIPTION
## Why

Mileage drive legs were all falling back to straight-line (haversine) estimates because every Google Distance Matrix call returned `REQUEST_DENIED`. Diagnosed live against the production key:

- Plain Distance Matrix call → **works** (returns real driving distance).
- Same call **with `departure_time=now`** → `REQUEST_DENIED` ("not authorized... check API restrictions").

`departure_time=now` switches the request into Google's **traffic-aware** mode, which is authorized as a separate API surface and rejected unless the key carries an extra entitlement — even when plain Distance Matrix is allowed on the key.

## Fix

Remove `departure_time=now`. Mileage is paid on **driving distance, not duration**, so the traffic-aware duration buys nothing. The request now uses the plain (allowed) Distance Matrix call; duration gracefully falls back to the non-traffic `duration` value (the extraction already does `duration_in_traffic?.value ?? duration?.value`) for office visibility.

## Verification

- Built `@workspace/api-server` (esbuild) — clean.
- Live key test: plain call returns `9941 Maple Ave, Oak Lawn → Chicago = 38.6 km / 33 mins`; the `departure_time=now` variant is the only one denied.

(Companion to the Google-side fix: the key's API-restriction allowlist was also missing **Distance Matrix API** and **Street View Static API**, now added. Street View is confirmed working.)

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_