### PR TITLE
feat(my-jobs): cleaner time line, bolder zone outline, interactive Street View

### DIFF
--- a/artifacts/qleno/src/pages/my-job-detail.tsx
+++ b/artifacts/qleno/src/pages/my-job-detail.tsx
@@ -5,7 +5,7 @@ import { useAuthStore } from "@/lib/auth";
 import { useEmployeeView } from "@/contexts/employee-view-context";
 import { JobCard, StreetViewThumb, ymd, type Job } from "./my-jobs";
 import { formatAddress, mapsDirectionsUrl } from "@/lib/format-address";
-import { ArrowLeft, History, Navigation } from "lucide-react";
+import { ArrowLeft, History } from "lucide-react";
 
 const BASE = import.meta.env.BASE_URL.replace(/\/$/, "");
 
@@ -140,22 +140,10 @@ export default function MyJobDetailPage() {
             </div>
           ) : (
             <>
-              {/* [job-detail-directions 2026-06-10] Juliana clicked "Job
-                  details" expecting directions but only saw previous visits.
-                  A prominent Get Directions button (one tap → maps) up top. */}
-              {job.address && (() => {
-                const addr = formatAddress(job.address, job.city, job.state, job.zip);
-                const url = mapsDirectionsUrl(addr);
-                return (
-                  <a href={url ?? "#"} target="_blank" rel="noreferrer"
-                    style={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 8, height: 48, marginBottom: 12, background: "var(--brand, #00C9A0)", color: "#fff", borderRadius: 12, fontSize: 15, fontWeight: 800, textDecoration: "none", fontFamily: "'Plus Jakarta Sans', sans-serif" }}>
-                    <Navigation size={17} /> Get Directions
-                  </a>
-                );
-              })()}
-              {/* [street-view 2026-06-11] Sal: Street View belongs on the detail
-                  screen only (not the list cards). Sits right under Get Directions,
-                  above the address, so the tech can recognize the property. */}
+              {/* [street-view 2026-06-11] Street View at the top of the detail
+                  screen; tap to look around (HCP-style). The big Get Directions
+                  button was removed — the underlined address link inside the
+                  card is the one-tap route. */}
               {job.address && (
                 <StreetViewThumb
                   lat={job.job_lat ?? job.lat}

--- a/artifacts/qleno/src/pages/my-jobs.tsx
+++ b/artifacts/qleno/src/pages/my-jobs.tsx
@@ -44,42 +44,111 @@ function getMapsKey(): Promise<string> {
   }
   return _mapsKeyPromise;
 }
+// Lazy-load the Google Maps JS SDK once (shared promise). Used to upgrade the
+// static Street View thumbnail into an interactive, drag-to-look-around
+// panorama when the tech taps it (HouseCall-Pro style). Maps JavaScript API is
+// already enabled + allow-listed on the Phes key, so this needs no extra setup.
+let _mapsJsPromise: Promise<any> | null = null;
+function loadMapsJs(key: string): Promise<any> {
+  const w = window as any;
+  if (w.google?.maps) return Promise.resolve(w.google.maps);
+  if (_mapsJsPromise) return _mapsJsPromise;
+  _mapsJsPromise = new Promise((resolve, reject) => {
+    const s = document.createElement("script");
+    s.src = `https://maps.googleapis.com/maps/api/js?key=${encodeURIComponent(key)}&v=weekly`;
+    s.async = true;
+    s.defer = true;
+    s.onload = () => (w.google?.maps ? resolve(w.google.maps) : reject(new Error("maps unavailable")));
+    s.onerror = () => reject(new Error("maps script failed"));
+    document.head.appendChild(s);
+  });
+  return _mapsJsPromise;
+}
+
 // Rendered on the job DETAIL screen only (not the My Jobs list cards) — see
 // my-job-detail.tsx. Exported so the detail page can place it above the address.
+// Shows a static Street View thumbnail; tapping it loads an interactive
+// panorama the tech can pan around to recognize the property (HCP-style).
 export function StreetViewThumb({ lat, lng, address, directionsUrl }: { lat: number | null; lng: number | null; address: string | null; directionsUrl: string | null }) {
   const [key, setKey] = useState<string | null>(_mapsKey);
   const [keyResolved, setKeyResolved] = useState<boolean>(_mapsKey != null);
   const [failed, setFailed] = useState(false);
+  const [mode, setMode] = useState<"thumb" | "loading" | "live">("thumb");
+  const panoRef = useRef<HTMLDivElement>(null);
+  const builtRef = useRef(false);
   useEffect(() => {
     if (!keyResolved) getMapsKey().then(k => { setKey(k); setKeyResolved(true); });
   }, [keyResolved]);
+  // When we flip to "live", the panorama container mounts; build the
+  // interactive Street View on it (the SDK is already loaded by then).
+  useEffect(() => {
+    if (mode !== "live" || builtRef.current || !panoRef.current || lat == null || lng == null) return;
+    const maps = (window as any).google?.maps;
+    if (!maps) { setMode("thumb"); return; }
+    try {
+      new maps.StreetViewPanorama(panoRef.current, {
+        position: { lat, lng },
+        pov: { heading: 0, pitch: 0 },
+        zoom: 0,
+        addressControl: false,
+        motionTracking: false,
+        motionTrackingControl: false,
+        showRoadLabels: false,
+        fullscreenControl: true,
+      });
+      builtRef.current = true;
+    } catch { setMode("thumb"); }
+  }, [mode, lat, lng]);
+
   const loc = (lat != null && lng != null) ? `${lat},${lng}` : (address || "");
   if (!loc) return null; // nothing to point at — render nothing
-  // Show the real Street View image only when the key resolved and the image
-  // hasn't errored. When the key is missing (endpoint returned empty) or the
-  // image is denied (Street View Static API not enabled, key referrer-restricted,
-  // or no imagery at the spot), fall back to a tappable map placeholder rather
-  // than a SILENT BLANK. The placeholder doubles as a deploy check: if a tech
-  // sees this tile, the new bundle is live and the only thing missing is the
-  // Google key config.
   const canShowImg = keyResolved && !!key && !failed;
-  const inner = canShowImg ? (
-    <img src={`https://maps.googleapis.com/maps/api/streetview?size=640x240&location=${encodeURIComponent(loc)}&fov=80&pitch=8&key=${key}`}
-      alt="Street view of the property" loading="lazy"
-      onError={() => setFailed(true)}
-      style={{ width: "100%", height: 120, objectFit: "cover", borderRadius: 10, border: "1px solid #EEECE7", display: "block" }} />
-  ) : (
-    <div style={{ width: "100%", height: 120, borderRadius: 10, border: "1px dashed #D9D5CC", background: "#F2F0EB", display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", gap: 5 }}>
-      <MapPin size={20} color="#9E9B94" aria-hidden="true" />
-      <span style={{ fontSize: 11, fontWeight: 700, color: "#6B6860" }}>{directionsUrl ? "Open in Maps" : "Map preview unavailable"}</span>
-    </div>
-  );
+  const hasCoords = lat != null && lng != null;
+
+  const lookAround = async () => {
+    if (!key || !hasCoords || mode !== "thumb") return;
+    setMode("loading");
+    try { await loadMapsJs(key); setMode("live"); }
+    catch { setMode("thumb"); }
+  };
+
+  // No key / denied image / no coords → tappable "Open in Maps" fallback tile.
+  if (!canShowImg) {
+    const tile = (
+      <div style={{ width: "100%", height: 120, borderRadius: 10, border: "1px dashed #D9D5CC", background: "#F2F0EB", display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", gap: 5 }}>
+        <MapPin size={20} color="#9E9B94" aria-hidden="true" />
+        <span style={{ fontSize: 11, fontWeight: 700, color: "#6B6860" }}>{directionsUrl ? "Open in Maps" : "Map preview unavailable"}</span>
+      </div>
+    );
+    return (
+      <div style={{ margin: "10px 0 6px" }}>
+        {directionsUrl ? <a href={directionsUrl} target="_blank" rel="noreferrer">{tile}</a> : tile}
+      </div>
+    );
+  }
+
+  // Live interactive panorama — the tech can drag to look around.
+  if (mode === "live") {
+    return (
+      <div style={{ margin: "10px 0 6px" }}>
+        <div ref={panoRef} style={{ width: "100%", height: 220, borderRadius: 10, border: "1px solid #EEECE7", overflow: "hidden" }} />
+      </div>
+    );
+  }
+
+  // Static thumbnail → tap to load the interactive view.
   return (
-    <div style={{ margin: "10px 0 6px", position: "relative" }}>
-      {directionsUrl ? <a href={directionsUrl} target="_blank" rel="noreferrer">{inner}</a> : inner}
-      {canShowImg && (
-        <span style={{ position: "absolute", bottom: 6, left: 8, fontSize: 9, fontWeight: 700, color: "#fff", background: "rgba(10,14,26,0.6)", padding: "2px 6px", borderRadius: 4, letterSpacing: "0.03em" }}>STREET VIEW</span>
-      )}
+    <div style={{ margin: "10px 0 6px" }}>
+      <button type="button" onClick={lookAround} disabled={!hasCoords || mode === "loading"}
+        style={{ display: "block", width: "100%", padding: 0, border: "none", background: "none", cursor: hasCoords ? "pointer" : "default", position: "relative", borderRadius: 10 }}>
+        <img src={`https://maps.googleapis.com/maps/api/streetview?size=640x240&location=${encodeURIComponent(loc)}&fov=80&pitch=8&key=${key}`}
+          alt="Street view of the property" loading="lazy"
+          onError={() => setFailed(true)}
+          style={{ width: "100%", height: 120, objectFit: "cover", borderRadius: 10, border: "1px solid #EEECE7", display: "block" }} />
+        <span style={{ position: "absolute", bottom: 6, left: 8, fontSize: 9, fontWeight: 700, color: "#fff", background: "rgba(10,14,26,0.72)", padding: "3px 7px", borderRadius: 5, letterSpacing: "0.02em" }}>
+          {mode === "loading" ? "Loading…" : (hasCoords ? "STREET VIEW · Tap to look around" : "STREET VIEW")}
+        </span>
+      </button>
     </div>
   );
 }
@@ -117,6 +186,15 @@ function addHoursToTime(t: string, hours: number): string {
   const ampm = hh >= 12 ? "PM" : "AM";
   const h12 = hh > 12 ? hh - 12 : hh || 12;
   return `${h12}:${String(mm).padStart(2, "0")} ${ampm}`;
+}
+
+// "3 Allowed Hours" / "3.5 Allowed Hours" / "1 Allowed Hour" — trailing .0
+// dropped, singular when exactly one. Falls back to "Est." when the number is
+// the stale estimated_hours stamp rather than the live allowed_hours budget.
+function formatHoursLabel(hrs: number, allowed: boolean): string {
+  const n = Number.isInteger(hrs) ? String(hrs) : hrs.toFixed(1).replace(/\.0$/, "");
+  const unit = hrs === 1 ? "Hour" : "Hours";
+  return `${n} ${allowed ? "Allowed" : "Est."} ${unit}`;
 }
 
 function formatDuration(ms: number) {
@@ -689,7 +767,7 @@ export function JobCard({ job, empPos, onRefresh, isPreviewMode, actingForUserId
         // Outline the whole card in the zone color so the tech sees their area at
         // a glance; status overrides (active/unpaid/no-show/unassigned) win when
         // present, mirroring the dispatch chip's border behavior.
-        border: `3px solid ${visual.borderOverride || job.zone_color || "#E5E2DC"}`,
+        border: `4.5px solid ${visual.borderOverride || job.zone_color || "#E5E2DC"}`,
         borderRadius: 12, padding: 18, margin: "0 0 12px 0",
         position: "relative", overflow: "hidden",
         opacity: visual.bodyOpacity * (job.status === "cancelled" ? 1 : 1),
@@ -775,25 +853,28 @@ export function JobCard({ job, empPos, onRefresh, isPreviewMode, actingForUserId
       </p>
       {(() => {
         // Allowed hours is the budget the tech needs; estimated_hours is the
-        // stale creation stamp and only a fallback.
+        // stale creation stamp and only a fallback. New treatment: lead with the
+        // "N Allowed Hours" budget chip, then the clean start–end window
+        // (e.g. "9:00 AM – 12:00 PM") — same on every job, list and detail.
         const hrs = job.allowed_hours ?? job.estimated_hours;
-        const label = job.allowed_hours != null ? "hrs allowed" : "hrs est.";
+        const allowed = job.allowed_hours != null;
+        const hasHrs = hrs != null && hrs > 0;
+        const start = job.scheduled_time ? formatTime(job.scheduled_time) : null;
+        const end = job.scheduled_time && hasHrs ? addHoursToTime(job.scheduled_time, hrs!) : null;
+        if (!hasHrs && !start) return null;
         return (
-          <>
-            {job.scheduled_time && (
-              <p style={{ fontSize: 12, color: "#6B6860", margin: "0 0 2px" }}>
-                {formatTime(job.scheduled_time)}
-                {hrs != null && hrs > 0 && (
-                  <span style={{ marginLeft: 8, color: "#9E9B94" }}>
-                    · {hrs.toFixed(1)} {label} · ends ~{addHoursToTime(job.scheduled_time, hrs)}
-                  </span>
-                )}
-              </p>
+          <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap", margin: "0 0 6px" }}>
+            {hasHrs && (
+              <span style={{ fontSize: 12.5, fontWeight: 800, color: "#00936F", background: "#E7F9F3", border: "1px solid #BFEFE2", borderRadius: 8, padding: "3px 9px", whiteSpace: "nowrap" }}>
+                {formatHoursLabel(hrs!, allowed)}
+              </span>
             )}
-            {!job.scheduled_time && hrs != null && hrs > 0 && (
-              <p style={{ fontSize: 12, color: "#9E9B94", margin: "0 0 2px" }}>{hrs.toFixed(1)} {label}</p>
+            {start && (
+              <span style={{ fontSize: 13, fontWeight: 700, color: "#1A1917", whiteSpace: "nowrap" }}>
+                {start}{end ? ` – ${end}` : ""}
+              </span>
             )}
-          </>
+          </div>
         );
       })()}
       {/* Home facts (MC parity) — size the work before walking in. */}


### PR DESCRIPTION
## What changed

**The customer card (all jobs, list + detail):**
- **Time line redesigned** — leads with an **"N Allowed Hours"** mint budget chip, then a clean **start–end window** (`9:00 AM – 12:00 PM`), replacing the wordy `9:00 AM · 3.0 hrs allowed · ends ~12:00 PM`. Drops trailing `.0`, singular `1 Allowed Hour`, and shows `Est.` when falling back to the stale `estimated_hours` stamp. `bd · ba · sq ft` stays directly beneath (only when known).
- **Bolder zone outline** — the zone-color border around the card went `3px → 4.5px` so the tech reads their area at a glance.

**Job detail screen:**
- **Removed the big green "Get Directions" button** — the underlined address link inside the card is the one-tap route, so it was redundant.
- **Interactive Street View** — the static thumbnail now shows **"Tap to look around"**, and tapping loads a **drag-to-pan Street View panorama** in place (HouseCall-Pro style). Uses the **Maps JavaScript API** (already enabled + allow-listed on the key), so **no extra Google setup**. Falls back to the "Open in Maps" tile when there's no key / coordinates / imagery.

## Preview
The time-line redesign was approved from a rendered mockup before implementation.

## Verification
- `pnpm run build` passes.
- Single shared `JobCard` → the time-line + outline changes are identical on every job, list and detail.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_