### PR TITLE
Scorecard: MaidCentral percentage model (schema + import + % UI)

### DIFF
--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -1109,6 +1109,28 @@ async function runBookingSchemaGuard(): Promise<void> {
       stmt: `CREATE UNIQUE INDEX IF NOT EXISTS device_tokens_token_key ON device_tokens(token)` },
     { label: "idx_device_tokens_user",
       stmt: `CREATE INDEX IF NOT EXISTS idx_device_tokens_user ON device_tokens(company_id, user_id)` },
+
+    // ── Scorecard percentage model (MaidCentral parity) ──
+    // users.scorecard_pct = authoritative per-employee % (stored as-is from MC).
+    // scorecard_entries = per-job history (781 MC rows + future Qleno entries).
+    { label: "users.scorecard_pct",
+      stmt: `ALTER TABLE users ADD COLUMN IF NOT EXISTS scorecard_pct NUMERIC(5,2)` },
+    { label: "CREATE scorecard_entries", stmt: `
+      CREATE TABLE IF NOT EXISTS scorecard_entries (
+        id           SERIAL PRIMARY KEY,
+        company_id   INTEGER NOT NULL REFERENCES companies(id),
+        employee_id  INTEGER NOT NULL REFERENCES users(id),
+        job_id       INTEGER REFERENCES jobs(id),
+        entry_date   DATE NOT NULL,
+        score_value  NUMERIC(8,2) NOT NULL,
+        max_value    NUMERIC(8,2) NOT NULL DEFAULT 100,
+        source       TEXT NOT NULL DEFAULT 'mc',
+        notes        TEXT,
+        created_at   TIMESTAMP NOT NULL DEFAULT NOW()
+      )
+    ` },
+    { label: "idx_scorecard_entries_emp",
+      stmt: `CREATE INDEX IF NOT EXISTS idx_scorecard_entries_emp ON scorecard_entries(company_id, employee_id)` },
   ];
 
   for (const { label, stmt } of guards) {

--- a/artifacts/api-server/src/routes/scorecards.ts
+++ b/artifacts/api-server/src/routes/scorecards.ts
@@ -1,8 +1,8 @@
 import { Router } from "express";
 import { db } from "@workspace/db";
-import { scorecardsTable, usersTable, clientsTable } from "@workspace/db/schema";
+import { scorecardsTable, scorecardEntriesTable, usersTable, clientsTable } from "@workspace/db/schema";
 import { eq, and, avg, count, desc, sql } from "drizzle-orm";
-import { requireAuth } from "../lib/auth.js";
+import { requireAuth, requireRole } from "../lib/auth.js";
 
 const router = Router();
 
@@ -85,6 +85,94 @@ router.post("/", requireAuth, async (req, res) => {
   } catch (err) {
     console.error("Create scorecard error:", err);
     return res.status(500).json({ error: "Internal Server Error", message: "Failed to create scorecard" });
+  }
+});
+
+// ── MaidCentral scorecard import (bulk) ──────────────────────────────────────
+// Loads (a) each employee's authoritative MC scorecard % into users.scorecard_pct
+// (stored as-is, NOT recomputed) and (b) per-job history into scorecard_entries.
+// Employees resolved by user_id, else email, else exact "First Last" (case-insensitive).
+// Idempotent for %s (upsert). Entries: pass replace=true to clear existing
+// source='mc' rows for the matched employees before inserting (safe re-runs).
+//
+// Body: {
+//   replace?: boolean,
+//   employee_pcts?: [{ user_id?, email?, name?, pct }],
+//   entries?: [{ user_id?, email?, name?, job_id?, entry_date, score_value, max_value?, source?, notes? }]
+// }
+router.post("/import", requireAuth, requireRole("owner", "admin"), async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId!;
+    const { employee_pcts = [], entries = [], replace = false } = req.body ?? {};
+
+    // Resolver: build a lookup of this company's users by id / email / name.
+    const users = await db
+      .select({ id: usersTable.id, email: usersTable.email, first_name: usersTable.first_name, last_name: usersTable.last_name })
+      .from(usersTable)
+      .where(eq(usersTable.company_id, companyId));
+    const byId = new Map(users.map(u => [u.id, u]));
+    const byEmail = new Map(users.filter(u => u.email).map(u => [u.email!.toLowerCase(), u]));
+    const byName = new Map(users.map(u => [`${u.first_name} ${u.last_name}`.trim().toLowerCase(), u]));
+    const resolve = (r: any): number | null => {
+      if (r.user_id != null && byId.has(Number(r.user_id))) return Number(r.user_id);
+      if (r.email && byEmail.has(String(r.email).toLowerCase())) return byEmail.get(String(r.email).toLowerCase())!.id;
+      if (r.name && byName.has(String(r.name).trim().toLowerCase())) return byName.get(String(r.name).trim().toLowerCase())!.id;
+      return null;
+    };
+
+    const unresolved: any[] = [];
+    let pctsUpdated = 0;
+
+    // (a) per-employee authoritative %
+    for (const p of employee_pcts) {
+      const uid = resolve(p);
+      if (uid == null) { unresolved.push({ kind: "pct", ref: p.email ?? p.name ?? p.user_id }); continue; }
+      const pct = Number(p.pct);
+      if (!Number.isFinite(pct)) { unresolved.push({ kind: "pct_value", ref: p.email ?? p.name }); continue; }
+      await db.update(usersTable).set({ scorecard_pct: String(pct) })
+        .where(and(eq(usersTable.id, uid), eq(usersTable.company_id, companyId)));
+      pctsUpdated++;
+    }
+
+    // (b) per-job history
+    const resolvedEntryEmps = new Set<number>();
+    const rows: any[] = [];
+    for (const e of entries) {
+      const uid = resolve(e);
+      if (uid == null) { unresolved.push({ kind: "entry", ref: e.email ?? e.name ?? e.user_id, date: e.entry_date }); continue; }
+      if (!e.entry_date || e.score_value == null) { unresolved.push({ kind: "entry_fields", ref: e.email ?? e.name }); continue; }
+      resolvedEntryEmps.add(uid);
+      rows.push({
+        company_id: companyId,
+        employee_id: uid,
+        job_id: e.job_id != null ? Number(e.job_id) : null,
+        entry_date: String(e.entry_date),
+        score_value: String(Number(e.score_value)),
+        max_value: e.max_value != null ? String(Number(e.max_value)) : "100",
+        source: e.source === "qleno" ? "qleno" : "mc",
+        notes: e.notes ?? null,
+      });
+    }
+
+    if (replace && resolvedEntryEmps.size > 0) {
+      await db.delete(scorecardEntriesTable).where(and(
+        eq(scorecardEntriesTable.company_id, companyId),
+        eq(scorecardEntriesTable.source, "mc"),
+        sql`${scorecardEntriesTable.employee_id} = ANY(${[...resolvedEntryEmps]}::int[])`,
+      ));
+    }
+
+    let entriesInserted = 0;
+    // Chunked insert to stay well under parameter limits for 781 rows.
+    for (let i = 0; i < rows.length; i += 200) {
+      const chunk = rows.slice(i, i + 200);
+      if (chunk.length) { await db.insert(scorecardEntriesTable).values(chunk); entriesInserted += chunk.length; }
+    }
+
+    return res.json({ ok: true, pcts_updated: pctsUpdated, entries_inserted: entriesInserted, unresolved });
+  } catch (err) {
+    console.error("Scorecard import error:", err);
+    return res.status(500).json({ error: "Internal Server Error", message: "Failed to import scorecards" });
   }
 });
 

--- a/artifacts/api-server/src/routes/users.ts
+++ b/artifacts/api-server/src/routes/users.ts
@@ -56,7 +56,7 @@ router.get("/", requireAuth, async (req, res) => {
     const usersRows = await db.execute(sql`
       SELECT u.id, u.email, u.first_name, u.last_name, u.role::text AS role,
              u.pay_rate, u.pay_type::text AS pay_type, u.is_active,
-             u.hire_date, u.avatar_url
+             u.hire_date, u.avatar_url, u.scorecard_pct
         FROM users u
        WHERE ${whereClause}
        ORDER BY u.first_name, u.last_name

--- a/artifacts/qleno/src/pages/employee-profile.tsx
+++ b/artifacts/qleno/src/pages/employee-profile.tsx
@@ -744,6 +744,10 @@ export default function EmployeeProfilePage() {
 
   const fullName = `${user.first_name} ${user.last_name}`;
   const scoreAvg = user.scorecard_avg ? parseFloat(user.scorecard_avg) : null;
+  // MaidCentral-style percentage: prefer the authoritative imported %; fall back
+  // to deriving from the legacy star average (score/4) until MC data is loaded.
+  const scorePct = user.scorecard_pct != null ? parseFloat(user.scorecard_pct)
+    : (scoreAvg != null ? Math.round(scoreAvg / 4 * 100) : null);
 
   return (
     <DashboardLayout>
@@ -838,11 +842,8 @@ export default function EmployeeProfilePage() {
                 <div style={{ display:'flex', justifyContent:'space-between', alignItems:'center' }}>
                   <span style={{ fontSize:11,fontWeight:600,color:'#9E9B94',textTransform:'uppercase',letterSpacing:'0.05em' }}>Score</span>
                   <div style={{ display:'flex',alignItems:'center',gap:6 }}>
-                    {scoreAvg ? (
-                      <>
-                        <StarRating score={scoreAvg}/>
-                        <span style={{ fontSize:13,fontWeight:700,color:'var(--brand)' }}>{scoreAvg.toFixed(1)}</span>
-                      </>
+                    {scorePct != null ? (
+                      <span style={{ fontSize:18,fontWeight:700,color:'var(--brand)' }}>{scorePct.toFixed(0)}%</span>
                     ) : <span style={{ fontSize:11,color:'#9E9B94' }}>No scores yet</span>}
                   </div>
                 </div>
@@ -1102,7 +1103,7 @@ export default function EmployeeProfilePage() {
                     {label:'Paid Time Off', value: 3, pct:'2%'},
                     {label:'Sick', value: 4, pct:'3%'},
                     {label:'Late', value: 6, pct:'5%'},
-                    {label:'Score', value: scoreAvg ? `${(scoreAvg/4*100).toFixed(0)}` : '—'},
+                    {label:'Score', value: scorePct != null ? `${scorePct.toFixed(0)}%` : '—'},
                   ].map(row => (
                     <div key={row.label} style={{ display:'flex', justifyContent:'space-between', alignItems:'center', padding:'5px 0', borderBottom:'1px solid #F3F4F6' }}>
                       <span style={{ fontSize:12,color:'#6B7280' }}>{row.label}</span>

--- a/artifacts/qleno/src/pages/employees.tsx
+++ b/artifacts/qleno/src/pages/employees.tsx
@@ -251,12 +251,11 @@ export default function EmployeesPage() {
                       </div>
                     </td>
                     <td style={{ padding: '14px 20px', textAlign: 'center' }}>
-                      <div style={{ display: 'inline-flex', alignItems: 'center', gap: '4px' }}>
-                        <svg width="16" height="16" viewBox="0 0 24 24" fill="var(--brand)" stroke="none">
-                          <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
-                        </svg>
-                        <span style={{ fontSize: '13px', fontWeight: 500, color: '#1A1917' }}>3.9</span>
-                      </div>
+                      {(user as any).scorecard_pct != null ? (
+                        <span style={{ fontSize: '14px', fontWeight: 700, color: 'var(--brand)' }}>{Math.round(parseFloat((user as any).scorecard_pct))}%</span>
+                      ) : (
+                        <span style={{ fontSize: '13px', color: '#9E9B94' }}>—</span>
+                      )}
                     </td>
                     <td style={{ padding: '14px 20px' }} onClick={e => e.stopPropagation()}>
                       {invited ? (

--- a/lib/db/src/schema/index.ts
+++ b/lib/db/src/schema/index.ts
@@ -7,6 +7,7 @@ export * from "./job_photos";
 export * from "./timeclock";
 export * from "./invoices";
 export * from "./scorecards";
+export * from "./scorecard_entries";
 export * from "./additional_pay";
 export * from "./loyalty";
 export * from "./audit_log";

--- a/lib/db/src/schema/scorecard_entries.ts
+++ b/lib/db/src/schema/scorecard_entries.ts
@@ -1,0 +1,33 @@
+import { pgTable, serial, integer, numeric, text, date, timestamp, index } from "drizzle-orm/pg-core";
+import { createInsertSchema } from "drizzle-zod";
+import { z } from "zod/v4";
+import { companiesTable } from "./companies";
+import { usersTable } from "./users";
+import { jobsTable } from "./jobs";
+
+// Per-job scorecard history backing the MaidCentral-style percentage model.
+// The rolled-up per-employee % lives on users.scorecard_pct (stored as MC's
+// authoritative value — NOT recomputed from these rows, since MC's % is not a
+// simple average). These rows are the underlying history (781 imported from MC
+// + any Qleno-generated entries going forward) for drill-down / audit.
+export const scorecardEntriesTable = pgTable("scorecard_entries", {
+  id: serial("id").primaryKey(),
+  company_id: integer("company_id").references(() => companiesTable.id).notNull(),
+  employee_id: integer("employee_id").references(() => usersTable.id).notNull(),
+  // Nullable: historical MC rows may not map to a Qleno job.
+  job_id: integer("job_id").references(() => jobsTable.id),
+  entry_date: date("entry_date").notNull(),
+  // The raw per-job score and its scale (e.g. 95 / 100, or 4 / 4). Kept as
+  // captured so we can re-derive later if MC's rollup formula is provided.
+  score_value: numeric("score_value", { precision: 8, scale: 2 }).notNull(),
+  max_value: numeric("max_value", { precision: 8, scale: 2 }).notNull().default("100"),
+  source: text("source").notNull().default("mc"), // 'mc' | 'qleno'
+  notes: text("notes"),
+  created_at: timestamp("created_at").notNull().defaultNow(),
+}, (t) => [
+  index("idx_scorecard_entries_emp").on(t.company_id, t.employee_id),
+]);
+
+export const insertScorecardEntrySchema = createInsertSchema(scorecardEntriesTable).omit({ id: true, created_at: true });
+export type InsertScorecardEntry = z.infer<typeof insertScorecardEntrySchema>;
+export type ScorecardEntry = typeof scorecardEntriesTable.$inferSelect;

--- a/lib/db/src/schema/users.ts
+++ b/lib/db/src/schema/users.ts
@@ -57,6 +57,10 @@ export const usersTable = pgTable("users", {
   notes: text("notes"),
   hr_status: hrStatusEnum("hr_status").default("active"),
   commission_rate_override: numeric("commission_rate_override", { precision: 6, scale: 2 }),
+  // MaidCentral-style scorecard: a single percentage per employee. Stored as
+  // MC's authoritative value on import (NOT recomputed — MC's % is not a simple
+  // average of job scores). Per-job history lives in scorecard_entries.
+  scorecard_pct: numeric("scorecard_pct", { precision: 5, scale: 2 }),
   // [pay-matrix 2026-04-29] Per-employee 4-cell pay matrix. Replaces
   // the company-wide single-rate model. Type can be 'commission' (rate
   // is a fraction 0.00–1.00) or 'hourly' (rate is dollars/hour). The


### PR DESCRIPTION
Replaces the /4.0 star scorecard with MC's per-employee percentage. users.scorecard_pct (authoritative MC %, stored as-is) + scorecard_entries (per-job history) + idempotent guards. POST /api/scorecards/import bulk-loads per-employee %s + the 781-job history (resolve by id/email/name). UI: employee profile + employees list show %. Data NOT loaded yet (awaiting dataset). reports/scorecards (per-job 1-4 QA scores) left as-is. NOTE: touches phes-data-migration.ts guards-end like PR #360 — whichever merges second needs a trivial rebase. Generated with Claude Code.