### PR TITLE
feat(my-jobs): active-job glow + banner shift from business hours

### DIFF
--- a/artifacts/api-server/src/routes/jobs.ts
+++ b/artifacts/api-server/src/routes/jobs.ts
@@ -449,11 +449,15 @@ router.get("/my-jobs", requireAuth, async (req, res) => {
     // disabled clock-out button. Read from the tech's auth company — the same
     // company the clock-out route enforces against.
     const companyCfg = await db
-      .select({ require_after_photo_for_clockout: companiesTable.require_after_photo_for_clockout })
+      .select({
+        require_after_photo_for_clockout: companiesTable.require_after_photo_for_clockout,
+        business_hours: companiesTable.business_hours,
+      })
       .from(companiesTable)
       .where(eq(companiesTable.id, req.auth!.companyId))
       .limit(1);
     const requireAfterPhoto = companyCfg[0]?.require_after_photo_for_clockout ?? false;
+    const businessHours = companyCfg[0]?.business_hours ?? null;
 
     const jobs = await db
       .select({
@@ -633,6 +637,7 @@ router.get("/my-jobs", requireAuth, async (req, res) => {
         time_clock_entry: clockMap.get(j.id) || null,
       })),
       quality,
+      business_hours: businessHours,
       require_after_photo_for_clockout: requireAfterPhoto,
     });
   } catch (err) {

--- a/artifacts/qleno/src/lib/business-hours.ts
+++ b/artifacts/qleno/src/lib/business-hours.ts
@@ -1,0 +1,101 @@
+// [business-hours 2026-06-11] Shared parser for company.business_hours
+// free-form text. Extracted so both the dispatch board (jobs.tsx) and the
+// tech My Jobs day banner read shift windows the same way. The dispatch
+// board still has its own historical copy; this is the canonical home for
+// new consumers.
+
+// Strict 12-hour "H:MM AM/PM" → minutes-since-midnight. null on bad input,
+// so a parse failure is distinguishable from a valid time.
+export function strictParseAmpm(t: string): number | null {
+  const m = t.trim().match(/^(\d{1,2}):(\d{2})\s*([AP]M)$/i);
+  if (!m) return null;
+  let h = parseInt(m[1], 10);
+  const mm = parseInt(m[2], 10);
+  const isPM = m[3].toUpperCase() === "PM";
+  if (h === 12) h = isPM ? 12 : 0;
+  else if (isPM) h += 12;
+  return h * 60 + mm;
+}
+
+// Minutes-since-midnight → "9:00 AM".
+export function minToAmpm(min: number): string {
+  const h24 = Math.floor(min / 60) % 24;
+  const mm = ((min % 60) + 60) % 60;
+  const ampm = h24 >= 12 ? "PM" : "AM";
+  const h12 = h24 % 12 === 0 ? 12 : h24 % 12;
+  return `${h12}:${String(mm).padStart(2, "0")} ${ampm}`;
+}
+
+// 0=Sunday … 6=Saturday (matches JS Date.getDay()).
+export type DayHours = { startMin: number; endMin: number } | "closed";
+export type BusinessHoursMap = Map<number, DayHours>;
+
+const DAY_NAMES: Record<string, number> = {
+  sun: 0, sunday: 0,
+  mon: 1, monday: 1,
+  tue: 2, tues: 2, tuesday: 2,
+  wed: 3, wednesday: 3,
+  thu: 4, thur: 4, thurs: 4, thursday: 4,
+  fri: 5, friday: 5,
+  sat: 6, saturday: 6,
+};
+
+// Parse free-form company.business_hours into a per-weekday map. Accepts
+// en-dash / em-dash / hyphen and day ranges:
+//   "Monday – Friday: 9:00 AM – 6:00 PM"
+//   "Saturday: 9:00 AM – 12:00 PM"
+//   "Sunday: Closed"
+// Unparseable days simply aren't set — the caller decides the fallback.
+export function parseBusinessHours(text: string | null | undefined): BusinessHoursMap {
+  const out: BusinessHoursMap = new Map();
+  if (!text) return out;
+  const lines = text.split(/\r?\n/).map(l => l.trim()).filter(Boolean);
+  for (const line of lines) {
+    const colonIdx = line.indexOf(":");
+    if (colonIdx < 0) continue;
+    const daysPart = line.slice(0, colonIdx).trim();
+    const hoursPart = line.slice(colonIdx + 1).trim();
+
+    const rangeMatch = daysPart.match(/^(\w+)\s*[-–—]\s*(\w+)$/);
+    const daysForLine: number[] = [];
+    if (rangeMatch) {
+      const from = DAY_NAMES[rangeMatch[1].toLowerCase()];
+      const to = DAY_NAMES[rangeMatch[2].toLowerCase()];
+      if (from == null || to == null) continue;
+      let idx = from;
+      for (let safety = 0; safety < 8; safety++) {
+        daysForLine.push(idx);
+        if (idx === to) break;
+        idx = (idx + 1) % 7;
+      }
+    } else {
+      const d = DAY_NAMES[daysPart.toLowerCase()];
+      if (d == null) continue;
+      daysForLine.push(d);
+    }
+
+    if (/^closed$/i.test(hoursPart)) {
+      for (const d of daysForLine) out.set(d, "closed");
+      continue;
+    }
+    const hMatch = hoursPart.match(/^(\d{1,2}:\d{2}\s*[AP]M)\s*[-–—]\s*(\d{1,2}:\d{2}\s*[AP]M)$/i);
+    if (!hMatch) continue;
+    const startMin = strictParseAmpm(hMatch[1]);
+    const endMin = strictParseAmpm(hMatch[2]);
+    if (startMin == null || endMin == null) continue;
+    for (const d of daysForLine) out.set(d, { startMin, endMin });
+  }
+  return out;
+}
+
+// The shift window for a given weekday, formatted, or "closed", or null when
+// the tenant hasn't configured that day.
+export function shiftForWeekday(
+  text: string | null | undefined,
+  weekday: number,
+): { start: string; end: string } | "closed" | null {
+  const h = parseBusinessHours(text).get(weekday);
+  if (!h) return null;
+  if (h === "closed") return "closed";
+  return { start: minToAmpm(h.startMin), end: minToAmpm(h.endMin) };
+}

--- a/artifacts/qleno/src/lib/job-status.ts
+++ b/artifacts/qleno/src/lib/job-status.ts
@@ -238,6 +238,11 @@ export interface StatusVisual {
    *  (en_route only). The icon + motion-line markup is owned by each
    *  consumer; this flag is the trigger. */
   showCarIcon: boolean;
+  /** Whether the card should render a slow pulsating amber glow (active
+   *  only) so "happening now" is unmistakable — and never confused with a
+   *  job that merely sits in an orange-colored zone. Applied by consumers
+   *  via the `qleno-active-glow` class from ensureJobStatusStyles(). */
+  glowActive?: boolean;
 }
 
 export const STATUS_VISUALS: Record<JobVisualStatus, StatusVisual> = {
@@ -273,6 +278,7 @@ export const STATUS_VISUALS: Record<JobVisualStatus, StatusVisual> = {
     // since they need elapsed time to render meaningfully.
     borderOverride: "#EF9F27",
     showCarIcon: false,
+    glowActive: true,
   },
   en_route: {
     label: "On the way",
@@ -402,9 +408,20 @@ export function ensureJobStatusStyles(): void {
     .qleno-en-route-icon {
       animation: qleno-en-route-drive 0.8s ease-in-out infinite;
     }
+    /* Slow "breathing" amber glow on a job that's happening RIGHT NOW. An
+       animated halo, distinct from any static zone-color border, so an active
+       job never reads as just an orange-zone job. */
+    @keyframes qleno-active-glow {
+      0%, 100% { box-shadow: 0 0 6px 1px rgba(245, 158, 11, 0.30); }
+      50%      { box-shadow: 0 0 16px 4px rgba(245, 158, 11, 0.65); }
+    }
+    .qleno-active-glow {
+      animation: qleno-active-glow 2.4s ease-in-out infinite;
+    }
     @media (prefers-reduced-motion: reduce) {
       .qleno-active-stripe { animation: none; opacity: 1; }
       .qleno-en-route-icon { animation: none; }
+      .qleno-active-glow { animation: none; box-shadow: 0 0 8px 1px rgba(245, 158, 11, 0.45); }
     }
   `;
   document.head.appendChild(style);

--- a/artifacts/qleno/src/pages/my-jobs.tsx
+++ b/artifacts/qleno/src/pages/my-jobs.tsx
@@ -13,6 +13,7 @@ import { VoiceAssistant } from "@/components/voice-assistant";
 import { QlenoMark } from "@/components/brand/QlenoMark";
 import { QuoteAttachments } from "@/components/quote-attachments";
 import { enqueueClock, isOfflineError, flushClockQueue, queueLength } from "@/lib/offline-clock";
+import { shiftForWeekday } from "@/lib/business-hours";
 
 const BASE = import.meta.env.BASE_URL.replace(/\/$/, "");
 
@@ -1337,18 +1338,29 @@ export default function MyJobsPage() {
       ? perTypeEff[(effTypeCount - 1) / 2]
       : (perTypeEff[effTypeCount / 2 - 1] + perTypeEff[effTypeCount / 2]) / 2
   );
-  // Shift window = earliest scheduled start → latest (start + allowed/est hours).
-  const timedJobs = nonCancelled.filter(j => j.scheduled_time);
+  // Shift window — driven by the tenant's BUSINESS HOURS for the selected
+  // weekday (e.g. "Mon–Fri 9:00 AM – 6:00 PM"). Falls back to the derived job
+  // span (earliest start → latest finish) only when business hours aren't
+  // configured for that day.
   let shiftStart: string | null = null, shiftEnd: string | null = null;
-  if (timedJobs.length) {
-    const earliest = [...timedJobs].sort((a, b) => (a.scheduled_time! < b.scheduled_time! ? -1 : 1))[0];
-    shiftStart = formatTime(earliest.scheduled_time);
-    let maxEndMins = -1;
-    for (const j of timedJobs) {
-      const hrs = j.allowed_hours ?? j.estimated_hours ?? 0;
-      const [h, m] = j.scheduled_time!.split(":").map(Number);
-      const endMins = (h || 0) * 60 + (m || 0) + Math.round(hrs * 60);
-      if (endMins > maxEndMins) { maxEndMins = endMins; shiftEnd = addHoursToTime(j.scheduled_time!, hrs); }
+  const [sy, sm, sd] = selectedDate.split("-").map(Number);
+  const selWeekday = new Date(sy, sm - 1, sd).getDay();
+  const bizShift = shiftForWeekday(data?.business_hours as string | null | undefined, selWeekday);
+  if (bizShift && bizShift !== "closed") {
+    shiftStart = bizShift.start;
+    shiftEnd = bizShift.end;
+  } else if (bizShift !== "closed") {
+    const timedJobs = nonCancelled.filter(j => j.scheduled_time);
+    if (timedJobs.length) {
+      const earliest = [...timedJobs].sort((a, b) => (a.scheduled_time! < b.scheduled_time! ? -1 : 1))[0];
+      shiftStart = formatTime(earliest.scheduled_time);
+      let maxEndMins = -1;
+      for (const j of timedJobs) {
+        const hrs = j.allowed_hours ?? j.estimated_hours ?? 0;
+        const [h, m] = j.scheduled_time!.split(":").map(Number);
+        const endMins = (h || 0) * 60 + (m || 0) + Math.round(hrs * 60);
+        if (endMins > maxEndMins) { maxEndMins = endMins; shiftEnd = addHoursToTime(j.scheduled_time!, hrs); }
+      }
     }
   }
   // Weather location: the tech's GPS if granted, else the first job's coords.

--- a/artifacts/qleno/src/pages/my-jobs.tsx
+++ b/artifacts/qleno/src/pages/my-jobs.tsx
@@ -792,6 +792,7 @@ export function JobCard({ job, empPos, onRefresh, isPreviewMode, actingForUserId
 
   return (
     <div
+      className={visual.glowActive ? "qleno-active-glow" : undefined}
       onClick={onOpenDetail ? (e) => {
         // Whole-card tap opens the detail screen, but never hijack taps on the
         // card's own interactive elements (links, buttons, photo inputs).


### PR DESCRIPTION
## Two My Jobs polish items

### 1. Slow pulsating glow on the active (in-progress) job
An in-progress job already gets the amber stripe + orange ring, but on the tech card the orange can read as just an orange-zone border. Added a slow "breathing" amber glow (animated box-shadow) so "happening now" is unmistakable and never confused with an orange-zone job.
- New `glowActive` flag on `StatusVisual` (active only).
- `qleno-active-glow` keyframe in `ensureJobStatusStyles()` (2.4s, amber, reduced-motion fallback).

### 2. Banner shift window from company business hours
The day banner's "Shift" was derived from the day's job span (e.g. 9–5), but Phes works 9–6. Now it reads the tenant's configured **business hours** for the selected weekday (`companies.business_hours`, e.g. "Monday – Friday: 9:00 AM – 6:00 PM"), falling back to the derived job span only when hours aren't set for that day.
- New shared `lib/business-hours.ts` (`parseBusinessHours` + `shiftForWeekday`).
- `/my-jobs` feed returns `business_hours`.

## Verification
- api-server + frontend builds pass.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj