### PR TITLE
fix(my-jobs): even active-job border (drop the redundant left stripe)

### DIFF
--- a/artifacts/qleno/src/pages/my-jobs.tsx
+++ b/artifacts/qleno/src/pages/my-jobs.tsx
@@ -812,12 +812,9 @@ export function JobCard({ job, empPos, onRefresh, isPreviewMode, actingForUserId
         filter: visual.desaturate ? "grayscale(1)" : "none",
         cursor: onOpenDetail ? "pointer" : undefined,
       }}>
-      {visual.stripe && (
-        <div className="qleno-active-stripe" style={{
-          position: "absolute", top: 0, bottom: 0, left: 0, width: 4,
-          backgroundColor: visual.stripe,
-        }} />
-      )}
+      {/* No left active-stripe on this card: the active state already shows an
+          EVEN orange border all the way around + the breathing glow, so the
+          extra 4px left bar only made the outline look thicker on the left. */}
       {visual.showCheckmark && (
         <div style={{ position: "absolute", top: 12, right: 12, width: 18, height: 18, borderRadius: "50%", backgroundColor: "#16A34A", display: "flex", alignItems: "center", justifyContent: "center" }}>
           <Check size={11} color="#FFFFFF" strokeWidth={3} />


### PR DESCRIPTION
## Why

On the active job card the outline looked **thicker on the left** — it had an even 4.5px orange border *plus* a 4px left "active stripe", so the left edge read ~8px while the rest was 4.5px.

## Fix

Removed the left active stripe on the My Jobs card. The active state already shows an **even orange border all the way around** + the breathing glow (#403), so the extra left bar was redundant and was the only thing making the outline uneven. Border is now uniform.

## Verification
- `pnpm run build` passes.
- Only affects the active state (the stripe rendered only when `visual.stripe` was set, which is active-only).

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_