### PR TITLE
feat(my-jobs): logo reliably returns to today's job list from anywhere

### DIFF
--- a/artifacts/qleno/src/pages/my-job-detail.tsx
+++ b/artifacts/qleno/src/pages/my-job-detail.tsx
@@ -6,6 +6,7 @@ import { useEmployeeView } from "@/contexts/employee-view-context";
 import { JobCard, StreetViewThumb, ymd, type Job } from "./my-jobs";
 import { formatAddress, mapsDirectionsUrl } from "@/lib/format-address";
 import { ArrowLeft, History } from "lucide-react";
+import { QlenoMark } from "@/components/brand/QlenoMark";
 
 const BASE = import.meta.env.BASE_URL.replace(/\/$/, "");
 
@@ -118,6 +119,11 @@ export default function MyJobDetailPage() {
             </p>
             <p style={{ fontSize: 11, color: "#9E9B94", margin: 0 }}>{formatVisitDate(dateParam)}</p>
           </div>
+          {/* Tapping the logo returns to today's job list — the main screen. */}
+          <button type="button" onClick={() => navigate("/my-jobs")} aria-label="Back to today's jobs"
+            style={{ marginLeft: "auto", background: "none", border: "none", padding: 0, cursor: "pointer", flexShrink: 0, display: "inline-flex" }}>
+            <QlenoMark size={26} />
+          </button>
         </div>
 
         {employeeView && (

--- a/artifacts/qleno/src/pages/my-jobs.tsx
+++ b/artifacts/qleno/src/pages/my-jobs.tsx
@@ -1374,7 +1374,7 @@ export default function MyJobsPage() {
         }}>
           <div style={{ display: "flex", alignItems: "center", gap: 8, minWidth: 0 }}>
             {/* Tapping the logo/title returns the tech to today's main screen. */}
-            <button type="button" onClick={() => setSelectedDate(todayYmd)} aria-label="Back to today"
+            <button type="button" onClick={() => { setSelectedDate(todayYmd); navigate("/my-jobs"); window.scrollTo({ top: 0, behavior: "smooth" }); }} aria-label="Back to today"
               style={{ display: "inline-flex", alignItems: "center", gap: 8, background: "none", border: "none", padding: 0, cursor: "pointer", fontFamily: "inherit", minWidth: 0 }}>
               <QlenoMark size={24} />
               <span style={{ fontSize: 15, fontWeight: 700, color: "#1A1917", letterSpacing: "-0.01em" }}>My Jobs</span>


### PR DESCRIPTION
## Why

The Qleno logo was supposed to take a tech back to the main screen for the day, but it only reset the date to today and did nothing else — so on the list (already on today) it looked inert, and the **job-detail screen had no logo at all**.

## What

- **List logo**: now resets to today **+ `navigate("/my-jobs")` + scroll to top**.
- **Job-detail header**: added a tappable Qleno logo (right side) that navigates back to `/my-jobs` (which opens on today), so "tap the logo to get to the main screen" works from inside a job too.

## Verification
- `pnpm run build` passes.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_