### PR TITLE
feat(time-clock): surface GPS data — tappable map pin + coordinates

### DIFF
--- a/artifacts/api-server/src/routes/timeclock.ts
+++ b/artifacts/api-server/src/routes/timeclock.ts
@@ -753,7 +753,7 @@ router.get("/day", requireAuth, requireRole("owner", "admin", "office"), async (
       SELECT t.id, t.job_id, t.user_id, t.clock_in_at, t.clock_out_at, t.flagged, t.source,
              t.clock_in_distance_ft, t.clock_out_distance_ft,
              t.clock_in_outside_geofence, t.clock_out_outside_geofence,
-             t.clock_in_lat, t.clock_out_lat,
+             t.clock_in_lat, t.clock_in_lng, t.clock_out_lat, t.clock_out_lng,
              TRIM(COALESCE(u.first_name,'') || ' ' || COALESCE(u.last_name,'')) AS name
       FROM timeclock t JOIN users u ON u.id = t.user_id
       WHERE t.company_id = ${companyId} AND t.job_id IN (${inList})
@@ -830,13 +830,21 @@ router.get("/day", requireAuth, requireRole("owner", "admin", "office"), async (
                  // means the punch carried no location (denied permission, or an
                  // office-entered correction).
                  gps_in_ft: number | null; gps_out_ft: number | null;
-                 gps_in_outside: boolean | null; gps_out_outside: boolean | null; has_gps: boolean };
+                 gps_in_outside: boolean | null; gps_out_outside: boolean | null; has_gps: boolean;
+                 // Raw punch coordinates so the office can open the exact spot on
+                 // a map — surfaced even when distance is null (job not geocoded).
+                 gps_in_lat: number | null; gps_in_lng: number | null;
+                 gps_out_lat: number | null; gps_out_lng: number | null };
     const gpsOf = (e: any) => ({
       gps_in_ft: e?.clock_in_distance_ft != null ? Math.round(parseFloat(String(e.clock_in_distance_ft))) : null,
       gps_out_ft: e?.clock_out_distance_ft != null ? Math.round(parseFloat(String(e.clock_out_distance_ft))) : null,
       gps_in_outside: e?.clock_in_outside_geofence ?? null,
       gps_out_outside: e?.clock_out_outside_geofence ?? null,
       has_gps: !!(e && (e.clock_in_lat != null || e.clock_out_lat != null || e.clock_in_distance_ft != null)),
+      gps_in_lat: e?.clock_in_lat != null ? Number(e.clock_in_lat) : null,
+      gps_in_lng: e?.clock_in_lng != null ? Number(e.clock_in_lng) : null,
+      gps_out_lat: e?.clock_out_lat != null ? Number(e.clock_out_lat) : null,
+      gps_out_lng: e?.clock_out_lng != null ? Number(e.clock_out_lng) : null,
     });
     const payOf = (jid: number, uid: number) => {
       const p = payByJobUser.get(`${jid}:${uid}`);

--- a/artifacts/qleno/src/pages/time-clock.tsx
+++ b/artifacts/qleno/src/pages/time-clock.tsx
@@ -87,6 +87,8 @@ type Row = {
   pay?: number | null; source?: string | null;
   gps_in_ft?: number | null; gps_out_ft?: number | null;
   gps_in_outside?: boolean | null; gps_out_outside?: boolean | null; has_gps?: boolean;
+  gps_in_lat?: number | null; gps_in_lng?: number | null;
+  gps_out_lat?: number | null; gps_out_lng?: number | null;
 };
 type Emp = {
   user_id: number; name: string; rows: Row[]; worked_minutes: number;
@@ -233,9 +235,24 @@ function RowEditor({ emp, row, dateStr, onChanged, toastFn }: {
           {row.entry_id && row.source !== "punched" && <span style={{ color: "#B45309", marginLeft: 6, fontWeight: 700 }}>· estimated — verify</span>}
           {row.flagged && <span style={{ color: "#B45309", marginLeft: 6, fontWeight: 700 }}>· flagged</span>}
           {row.entry_id && (row.has_gps
-            ? <span title="Distance from the job site at clock-in (from the tech's phone GPS)" style={{ marginLeft: 6, fontWeight: 700, color: row.gps_in_outside ? "#B45309" : "#0A7C66" }}>
-                · GPS {row.gps_in_ft != null ? `${row.gps_in_ft} ft` : "on"}{row.gps_in_outside ? " (outside zone)" : ""}
-              </span>
+            ? (() => {
+                const lat = row.gps_in_lat, lng = row.gps_in_lng;
+                const coords = lat != null && lng != null;
+                const label = `GPS ${row.gps_in_ft != null ? `${row.gps_in_ft} ft` : "on"}${row.gps_in_outside ? " (outside zone)" : ""}`;
+                const color = row.gps_in_outside ? "#B45309" : "#0A7C66";
+                const tip = coords
+                  ? `Clock-in location: ${lat!.toFixed(5)}, ${lng!.toFixed(5)}${row.gps_in_ft != null ? ` · ${row.gps_in_ft} ft from job` : " · job not geocoded, distance unavailable"}. Tap to open the map.`
+                  : "Distance from the job site at clock-in (from the tech's phone GPS).";
+                return coords ? (
+                  <a href={`https://www.google.com/maps?q=${lat},${lng}`} target="_blank" rel="noopener noreferrer"
+                     title={tip} onClick={e => e.stopPropagation()}
+                     style={{ marginLeft: 6, fontWeight: 700, color, textDecoration: "underline" }}>
+                    · {label} ▸
+                  </a>
+                ) : (
+                  <span title={tip} style={{ marginLeft: 6, fontWeight: 700, color }}>· {label}</span>
+                );
+              })()
             : <span title="This punch carried no location — phone location was off/denied, or it was entered here as an office correction." style={{ marginLeft: 6, fontWeight: 700, color: "#9E9B94" }}>· no GPS</span>
           )}
         </div>


### PR DESCRIPTION
## Why

On the time-clock day screen, Juliana's punch showed **"GPS on"** but no actual data. "GPS on" means coordinates *were* captured, but the **distance is null because the job (Jerry Berlin) isn't geocoded** — there's no job location to measure against, so no "X ft". The raw coordinates were never sent to the screen, so there was nothing to look at.

## What

- `/timeclock/day` now returns the **raw clock-in/out coordinates** (added `clock_in_lng` / `clock_out_lng` to the query; coords added to `gpsOf` + the `Row` type).
- The **GPS label is now a link** to the exact punch location on Google Maps, with the coordinates + distance in the tooltip. Distance in feet still shows when the job is geocoded; "GPS on ▸" opens the map either way.

## Note for this specific punch
Because you clocked in **for Juliana from your own device**, the coordinates are **your** location at punch time, not hers. When Juliana punches from her own phone at the house, this pin will land on the job. Also: to get a **distance** (not just a pin), Jerry Berlin's job/address needs to be geocoded.

## Verification
- api-server + frontend builds pass.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_