### PR TITLE
feat(team): use EmployeeAvatar emblem in team profile circles

### DIFF
--- a/artifacts/qleno/src/pages/employee-profile.tsx
+++ b/artifacts/qleno/src/pages/employee-profile.tsx
@@ -3,6 +3,7 @@ import { useIsMobile } from "@/hooks/use-mobile";
 import { useParams, useLocation } from "wouter";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { DashboardLayout } from "@/components/layout/dashboard-layout";
+import { EmployeeAvatar } from "@/components/employee-avatar";
 import { getAuthHeaders, getTokenRole } from "@/lib/auth";
 import {
   ArrowLeft, Camera, Plus, X, ChevronLeft, ChevronRight,
@@ -1898,9 +1899,7 @@ export default function EmployeeProfilePage() {
                             <label key={e.id} style={{ display:'flex',alignItems:'center',gap:12,padding:'10px 14px',borderBottom:'1px solid #F3F4F6',cursor:'pointer',background: isChecked ? '#F0FBF8' : '#FFFFFF' }}>
                               <input type="checkbox" checked={isChecked} onChange={() => setBulkSelectedEmps(prev => isChecked ? prev.filter(id => id !== e.id) : [...prev, e.id])}
                                 style={{ accentColor:'var(--brand)',width:15,height:15,flexShrink:0 }}/>
-                              <div style={{ width:30,height:30,borderRadius:'50%',background:'var(--brand-dim)',color:'var(--brand)',display:'flex',alignItems:'center',justifyContent:'center',fontSize:11,fontWeight:700,flexShrink:0 }}>
-                                {e.first_name?.[0]}{e.last_name?.[0]}
-                              </div>
+                              <EmployeeAvatar name={`${e.first_name ?? ''} ${e.last_name ?? ''}`} avatarUrl={e.avatar_url} size={30} fontSize={11} />
                               <div>
                                 <div style={{ fontSize:13,fontWeight:600,color:'#1A1917' }}>{e.first_name} {e.last_name}</div>
                                 <div style={{ fontSize:11,color:'#9E9B94',textTransform:'capitalize' }}>{e.role}</div>
@@ -1955,9 +1954,7 @@ export default function EmployeeProfilePage() {
                         {selectedEmpObjects.map((e: any) => (
                           <div key={e.id} style={{ display:'flex',alignItems:'center',justifyContent:'space-between',padding:'9px 14px',borderBottom:'1px solid #F3F4F6' }}>
                             <div style={{ display:'flex',alignItems:'center',gap:10 }}>
-                              <div style={{ width:28,height:28,borderRadius:'50%',background:'var(--brand-dim)',color:'var(--brand)',display:'flex',alignItems:'center',justifyContent:'center',fontSize:10,fontWeight:700 }}>
-                                {e.first_name?.[0]}{e.last_name?.[0]}
-                              </div>
+                              <EmployeeAvatar name={`${e.first_name ?? ''} ${e.last_name ?? ''}`} avatarUrl={e.avatar_url} size={28} fontSize={10} />
                               <span style={{ fontSize:13,fontWeight:600,color:'#1A1917' }}>{e.first_name} {e.last_name}</span>
                             </div>
                             <span style={{ fontSize:13,fontWeight:700,color:'#166534' }}>${parseFloat(bulkAmount||'0').toFixed(2)}</span>

--- a/artifacts/qleno/src/pages/payroll.tsx
+++ b/artifacts/qleno/src/pages/payroll.tsx
@@ -5,6 +5,7 @@ import { useListUsers } from "@workspace/api-client-react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { getAuthHeaders, getTokenRole } from "@/lib/auth";
 import { useBranch } from "@/contexts/branch-context";
+import { EmployeeAvatar } from "@/components/employee-avatar";
 import { Download, Calendar, Plus, X, Zap, Trash2, ChevronDown, ChevronRight, AlertTriangle } from "lucide-react";
 import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid, Legend } from "recharts";
 
@@ -687,9 +688,8 @@ export default function PayrollPage() {
                         {canOpen
                           ? (isOpen ? <ChevronDown size={14} style={{ color: '#9E9B94', flexShrink: 0 }} /> : <ChevronRight size={14} style={{ color: '#9E9B94', flexShrink: 0 }} />)
                           : <span style={{ width: 14, flexShrink: 0 }} />}
-                        <div style={{ width: '32px', height: '32px', borderRadius: '50%', backgroundColor: 'var(--brand-dim)', color: 'var(--brand)', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: '12px', fontWeight: 600, flexShrink: 0 }}>
-                          {emp.first_name?.[0]}{emp.last_name?.[0]}
-                        </div>
+                        <EmployeeAvatar name={`${emp.first_name ?? ''} ${emp.last_name ?? ''}`} avatarUrl={emp.avatar_url} size={32} fontSize={12} />
+
                         <div>
                           <p style={{ fontSize: '13px', fontWeight: 600, color: '#1A1917', margin: 0 }}>{emp.first_name} {emp.last_name}</p>
                           <p style={{ fontSize: '12px', color: '#6B7280', margin: 0 }}>{emp.email}</p>


### PR DESCRIPTION
## Why

The Payroll table (and the bulk-action modals on the employee profile page) rendered **plain initial circles** instead of the shared `EmployeeAvatar` emblem that shows a team member's uploaded photo. So team photos were missing in those spots.

## What

Routed those circles through `EmployeeAvatar` (uploaded photo when present, initials fallback otherwise). `avatar_url` already flows through the `/users` list and the employee objects, so this is **frontend-only** — anyone without a photo shows the same initials as before, anyone with one now shows their emblem.

Surfaces converted:
- Payroll → Employee Payroll Summary table
- Employee profile → bulk-select + bulk-confirm modals

## Not touched (flagged for follow-up)
- **Dashboard tech capacity list** — its tech objects don't currently carry `avatar_url`; would need an API field to show photos (falls back to initials today).
- **Quote-builder tech-picker pills** — tiny 18px selection chips with selected-state colors, not really profile circles.

## Verification
- `pnpm run build` passes.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_