### PR TITLE
feat(time-clock): interactive GPS punch map modal (beat MaidCentral)

### DIFF
--- a/artifacts/api-server/src/routes/timeclock.ts
+++ b/artifacts/api-server/src/routes/timeclock.ts
@@ -704,6 +704,7 @@ router.get("/day", requireAuth, requireRole("owner", "admin", "office"), async (
     const jobsRes = await db.execute(sql`
       SELECT j.id AS job_id, j.scheduled_time, j.assigned_user_id,
              j.service_type::text AS service_type, j.address_street,
+             j.job_lat, j.job_lng, j.address_lat, j.address_lng,
              j.account_id, j.base_fee, j.billed_amount, j.allowed_hours, j.branch_id, j.scheduled_date::text AS scheduled_date,
              c.client_type,
              COALESCE(NULLIF(TRIM(COALESCE(c.first_name,'') || ' ' || COALESCE(c.last_name,'')), ''),
@@ -834,7 +835,14 @@ router.get("/day", requireAuth, requireRole("owner", "admin", "office"), async (
                  // Raw punch coordinates so the office can open the exact spot on
                  // a map — surfaced even when distance is null (job not geocoded).
                  gps_in_lat: number | null; gps_in_lng: number | null;
-                 gps_out_lat: number | null; gps_out_lng: number | null };
+                 gps_out_lat: number | null; gps_out_lng: number | null;
+                 // The job's own coordinates (the expected spot) so the GPS
+                 // map modal can drop a second pin + show the punch-vs-job gap.
+                 job_lat: number | null; job_lng: number | null };
+    const coordsOf = (j: any) => ({
+      job_lat: (j?.job_lat ?? j?.address_lat) != null ? Number(j.job_lat ?? j.address_lat) : null,
+      job_lng: (j?.job_lng ?? j?.address_lng) != null ? Number(j.job_lng ?? j.address_lng) : null,
+    });
     const gpsOf = (e: any) => ({
       gps_in_ft: e?.clock_in_distance_ft != null ? Math.round(parseFloat(String(e.clock_in_distance_ft))) : null,
       gps_out_ft: e?.clock_out_distance_ft != null ? Math.round(parseFloat(String(e.clock_out_distance_ft))) : null,
@@ -878,7 +886,7 @@ router.get("/day", requireAuth, requireRole("owner", "admin", "office"), async (
           entry_id: e ? Number(e.id) : null, clock_in_at: e?.clock_in_at ?? null, clock_out_at: e?.clock_out_at ?? null,
           flagged: !!e?.flagged, minutes: e ? minutesOf(e.clock_in_at, e.clock_out_at) : null,
           ...payOf(jid, t.user_id), pay: payByKey.get(`${jid}:${t.user_id}`) ?? null, source: e?.source ?? null,
-          ...gpsOf(e),
+          ...gpsOf(e), ...coordsOf(j),
         });
       }
     }
@@ -891,7 +899,7 @@ router.get("/day", requireAuth, requireRole("owner", "admin", "office"), async (
         scheduled_time: j?.scheduled_time ?? null, entry_id: Number(e.id), clock_in_at: e.clock_in_at ?? null,
         clock_out_at: e.clock_out_at ?? null, flagged: !!e.flagged, minutes: minutesOf(e.clock_in_at, e.clock_out_at),
         ...payOf(Number(e.job_id), Number(e.user_id)), pay: payByKey.get(`${e.job_id}:${e.user_id}`) ?? null, source: e.source ?? null,
-        ...gpsOf(e),
+        ...gpsOf(e), ...coordsOf(j),
       });
     }
 

--- a/artifacts/qleno/src/components/punch-map-modal.tsx
+++ b/artifacts/qleno/src/components/punch-map-modal.tsx
@@ -1,0 +1,164 @@
+import { useEffect, useRef, useState } from "react";
+import { getAuthHeaders } from "@/lib/auth";
+
+// [punch-map-modal 2026-06-11] Office GPS audit modal for a time-clock punch.
+// Interactive Google map with the tech's clock-in/out pin(s) AND the job's
+// expected location, so the office sees the punch-vs-job gap at a glance —
+// richer than MaidCentral's single-pin popover. Loads the Maps JS SDK lazily.
+
+const API = import.meta.env.BASE_URL.replace(/\/$/, "");
+const FF = "'Plus Jakarta Sans', sans-serif";
+
+let mapsPromise: Promise<any> | null = null;
+async function loadMaps(): Promise<any> {
+  const w = window as any;
+  if (w.google?.maps) return w.google.maps;
+  if (mapsPromise) return mapsPromise;
+  mapsPromise = (async () => {
+    let key = "";
+    try {
+      const r = await fetch(`${API}/api/config/google-maps-key`, { headers: getAuthHeaders() });
+      if (r.ok) key = (await r.json())?.key ?? "";
+    } catch { /* fall through to build-time key */ }
+    if (!key) key = (import.meta as any).env?.VITE_GOOGLE_MAPS_API_KEY ?? "";
+    if (!key) throw new Error("no maps key");
+    await new Promise<void>((resolve, reject) => {
+      const existing = document.getElementById("qleno-gmaps-js");
+      if (existing) { existing.addEventListener("load", () => resolve()); existing.addEventListener("error", () => reject()); return; }
+      const s = document.createElement("script");
+      s.id = "qleno-gmaps-js";
+      s.src = `https://maps.googleapis.com/maps/api/js?key=${encodeURIComponent(key)}&v=weekly`;
+      s.async = true;
+      s.onload = () => resolve();
+      s.onerror = () => reject(new Error("maps script failed"));
+      document.head.appendChild(s);
+    });
+    return (window as any).google.maps;
+  })();
+  return mapsPromise;
+}
+
+export type PunchMapData = {
+  techName: string;
+  clientName: string;
+  inAt: string | null;       // display time, e.g. "9:11 AM"
+  outAt: string | null;
+  inLat: number | null; inLng: number | null; inFt: number | null; inOutside: boolean | null;
+  outLat: number | null; outLng: number | null; outFt: number | null; outOutside: boolean | null;
+  jobLat: number | null; jobLng: number | null;
+};
+
+export function PunchMapModal({ data, onClose }: { data: PunchMapData; onClose: () => void }) {
+  const mapRef = useRef<HTMLDivElement>(null);
+  const [err, setErr] = useState<string | null>(null);
+  const hasIn = data.inLat != null && data.inLng != null;
+  const hasOut = data.outLat != null && data.outLng != null;
+  const hasJob = data.jobLat != null && data.jobLng != null;
+
+  useEffect(() => {
+    let cancelled = false;
+    loadMaps().then((maps) => {
+      if (cancelled || !mapRef.current) return;
+      const map = new maps.Map(mapRef.current, {
+        zoom: 15, mapTypeControl: false, streetViewControl: false, fullscreenControl: true,
+        center: { lat: data.inLat ?? data.jobLat ?? 0, lng: data.inLng ?? data.jobLng ?? 0 },
+      });
+      const bounds = new maps.LatLngBounds();
+      const pin = (lat: number, lng: number, color: string, label: string, title: string) => {
+        const p = new maps.LatLng(lat, lng);
+        new maps.Marker({
+          position: p, map, title,
+          label: { text: label, color: "#fff", fontSize: "11px", fontWeight: "700" },
+          icon: {
+            path: maps.SymbolPath.CIRCLE, scale: 12, fillColor: color, fillOpacity: 1,
+            strokeColor: "#fff", strokeWeight: 2,
+          },
+        });
+        bounds.extend(p);
+      };
+      if (hasJob) pin(data.jobLat!, data.jobLng!, "#2563EB", "J", `${data.clientName} (job)`);
+      if (hasIn) pin(data.inLat!, data.inLng!, "#0A7C66", "In", `Clock-in${data.inAt ? ` · ${data.inAt}` : ""}`);
+      if (hasOut) pin(data.outLat!, data.outLng!, "#EA580C", "Out", `Clock-out${data.outAt ? ` · ${data.outAt}` : ""}`);
+      if (hasJob && hasIn) {
+        new maps.Polyline({
+          map, geodesic: true,
+          path: [{ lat: data.jobLat!, lng: data.jobLng! }, { lat: data.inLat!, lng: data.inLng! }],
+          strokeColor: data.inOutside ? "#B91C1C" : "#0A7C66", strokeOpacity: 0.7, strokeWeight: 2,
+        });
+      }
+      if (!bounds.isEmpty()) {
+        map.fitBounds(bounds, 64);
+        if ((hasIn ? 1 : 0) + (hasOut ? 1 : 0) + (hasJob ? 1 : 0) === 1) map.setZoom(16);
+      }
+    }).catch(() => { if (!cancelled) setErr("Map unavailable — open the coordinates in Google Maps below."); });
+    return () => { cancelled = true; };
+  }, []);
+
+  const row = (label: string, value: string, color?: string) => (
+    <div style={{ display: "flex", justifyContent: "space-between", gap: 12, fontSize: 12.5, padding: "3px 0" }}>
+      <span style={{ color: "#6B6860", fontWeight: 600 }}>{label}</span>
+      <span style={{ color: color || "#1A1917", fontWeight: 700, textAlign: "right" }}>{value}</span>
+    </div>
+  );
+  const coordStr = (lat: number | null, lng: number | null) => (lat != null && lng != null ? `${lat.toFixed(5)}, ${lng.toFixed(5)}` : "—");
+
+  return (
+    <div onClick={onClose} style={{ position: "fixed", inset: 0, background: "rgba(10,14,26,0.55)", zIndex: 1000, display: "flex", alignItems: "center", justifyContent: "center", padding: 16, fontFamily: FF }}>
+      <div onClick={e => e.stopPropagation()} style={{ background: "#fff", borderRadius: 14, width: "min(560px, 100%)", maxHeight: "90vh", overflow: "hidden", display: "flex", flexDirection: "column", boxShadow: "0 12px 48px rgba(0,0,0,0.25)" }}>
+        <div style={{ padding: "13px 16px", borderBottom: "1px solid #E5E2DC", display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+          <div style={{ minWidth: 0 }}>
+            <p style={{ fontSize: 14, fontWeight: 800, color: "#1A1917", margin: 0 }}>{data.techName}</p>
+            <p style={{ fontSize: 11.5, color: "#9E9B94", margin: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{data.clientName} · GPS punch location</p>
+          </div>
+          <button type="button" onClick={onClose} aria-label="Close" style={{ width: 30, height: 30, borderRadius: 8, border: "1px solid #E5E2DC", background: "#fff", color: "#1A1917", fontSize: 18, lineHeight: 1, cursor: "pointer", fontFamily: "inherit", flexShrink: 0 }}>×</button>
+        </div>
+
+        <div style={{ position: "relative", height: 300, background: "#EEF0F2" }}>
+          <div ref={mapRef} style={{ width: "100%", height: "100%" }} />
+          {err && <div style={{ position: "absolute", inset: 0, display: "flex", alignItems: "center", justifyContent: "center", padding: 24, textAlign: "center", fontSize: 13, color: "#6B6860" }}>{err}</div>}
+        </div>
+
+        <div style={{ padding: "12px 16px", overflowY: "auto" }}>
+          <div style={{ display: "flex", gap: 14, flexWrap: "wrap", marginBottom: 8 }}>
+            <Legend color="#0A7C66" label="Clock-in" show={hasIn} />
+            <Legend color="#EA580C" label="Clock-out" show={hasOut} />
+            <Legend color="#2563EB" label="Job location" show={hasJob} />
+          </div>
+          {hasIn && (
+            <div style={{ borderTop: "1px solid #F0EEE9", paddingTop: 6 }}>
+              {row("Clock-in", data.inAt || "—")}
+              {row("Coordinates", coordStr(data.inLat, data.inLng))}
+              {row("Distance from job", data.inFt != null ? `${data.inFt} ft${data.inOutside ? " · outside zone" : " · within zone"}` : "job not geocoded", data.inFt == null ? "#9E9B94" : data.inOutside ? "#B91C1C" : "#0A7C66")}
+            </div>
+          )}
+          {hasOut && (
+            <div style={{ borderTop: "1px solid #F0EEE9", paddingTop: 6, marginTop: 6 }}>
+              {row("Clock-out", data.outAt || "—")}
+              {row("Coordinates", coordStr(data.outLat, data.outLng))}
+              {row("Distance from job", data.outFt != null ? `${data.outFt} ft${data.outOutside ? " · outside zone" : " · within zone"}` : "job not geocoded", data.outFt == null ? "#9E9B94" : data.outOutside ? "#B91C1C" : "#0A7C66")}
+            </div>
+          )}
+          {!hasJob && (
+            <p style={{ fontSize: 11.5, color: "#9E9B94", margin: "8px 0 0" }}>This job has no saved coordinates, so distance can't be measured — geocode the client's address to enable it.</p>
+          )}
+          {hasIn && (
+            <a href={`https://www.google.com/maps?q=${data.inLat},${data.inLng}`} target="_blank" rel="noopener noreferrer"
+               style={{ display: "inline-block", marginTop: 12, fontSize: 12.5, fontWeight: 700, color: "#0A7C66", textDecoration: "underline" }}>
+              Open clock-in pin in Google Maps ▸
+            </a>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Legend({ color, label, show }: { color: string; label: string; show: boolean }) {
+  if (!show) return null;
+  return (
+    <span style={{ display: "inline-flex", alignItems: "center", gap: 5, fontSize: 11.5, fontWeight: 700, color: "#6B6860" }}>
+      <span style={{ width: 11, height: 11, borderRadius: "50%", background: color, border: "2px solid #fff", boxShadow: "0 0 0 1px #E5E2DC" }} />
+      {label}
+    </span>
+  );
+}

--- a/artifacts/qleno/src/pages/time-clock.tsx
+++ b/artifacts/qleno/src/pages/time-clock.tsx
@@ -3,6 +3,7 @@ import { DashboardLayout } from "@/components/layout/dashboard-layout";
 import { getAuthHeaders } from "@/lib/auth";
 import { useToast } from "@/hooks/use-toast";
 import { ChevronLeft, ChevronRight, Clock, Trash2, AlertTriangle, Check, CalendarDays } from "lucide-react";
+import { PunchMapModal } from "@/components/punch-map-modal";
 
 // [time-clock-portal 2026-06-05] Office Time Clock portal. The office reconciles
 // Qleno's per-job clock times against MaidCentral so commission (proportional by
@@ -89,6 +90,7 @@ type Row = {
   gps_in_outside?: boolean | null; gps_out_outside?: boolean | null; has_gps?: boolean;
   gps_in_lat?: number | null; gps_in_lng?: number | null;
   gps_out_lat?: number | null; gps_out_lng?: number | null;
+  job_lat?: number | null; job_lng?: number | null;
 };
 type Emp = {
   user_id: number; name: string; rows: Row[]; worked_minutes: number;
@@ -175,6 +177,7 @@ function RowEditor({ emp, row, dateStr, onChanged, toastFn }: {
   const [inVal, setInVal] = useState(isoToDisplay(row.clock_in_at));
   const [outVal, setOutVal] = useState(isoToDisplay(row.clock_out_at));
   const [busy, setBusy] = useState(false);
+  const [gpsOpen, setGpsOpen] = useState(false);
   useEffect(() => { setInVal(isoToDisplay(row.clock_in_at)); setOutVal(isoToDisplay(row.clock_out_at)); }, [row.clock_in_at, row.clock_out_at, row.entry_id]);
 
   const parsedIn = parseTimeInput(inVal);   // 24h "HH:MM" or null
@@ -241,14 +244,13 @@ function RowEditor({ emp, row, dateStr, onChanged, toastFn }: {
                 const label = `GPS ${row.gps_in_ft != null ? `${row.gps_in_ft} ft` : "on"}${row.gps_in_outside ? " (outside zone)" : ""}`;
                 const color = row.gps_in_outside ? "#B45309" : "#0A7C66";
                 const tip = coords
-                  ? `Clock-in location: ${lat!.toFixed(5)}, ${lng!.toFixed(5)}${row.gps_in_ft != null ? ` · ${row.gps_in_ft} ft from job` : " · job not geocoded, distance unavailable"}. Tap to open the map.`
+                  ? `Clock-in location: ${lat!.toFixed(5)}, ${lng!.toFixed(5)}${row.gps_in_ft != null ? ` · ${row.gps_in_ft} ft from job` : " · job not geocoded, distance unavailable"}. Tap to see it on the map.`
                   : "Distance from the job site at clock-in (from the tech's phone GPS).";
                 return coords ? (
-                  <a href={`https://www.google.com/maps?q=${lat},${lng}`} target="_blank" rel="noopener noreferrer"
-                     title={tip} onClick={e => e.stopPropagation()}
-                     style={{ marginLeft: 6, fontWeight: 700, color, textDecoration: "underline" }}>
+                  <button type="button" title={tip} onClick={e => { e.stopPropagation(); setGpsOpen(true); }}
+                     style={{ marginLeft: 6, fontWeight: 700, color, textDecoration: "underline", background: "none", border: "none", padding: 0, cursor: "pointer", fontFamily: "inherit", fontSize: "inherit" }}>
                     · {label} ▸
-                  </a>
+                  </button>
                 ) : (
                   <span title={tip} style={{ marginLeft: 6, fontWeight: 700, color }}>· {label}</span>
                 );
@@ -286,6 +288,20 @@ function RowEditor({ emp, row, dateStr, onChanged, toastFn }: {
       </button>
     </div>
     <PayEditor emp={emp} row={row} onChanged={onChanged} toastFn={toastFn} />
+    {gpsOpen && (
+      <PunchMapModal
+        onClose={() => setGpsOpen(false)}
+        data={{
+          techName: emp.name,
+          clientName: row.client_name,
+          inAt: fmtClock(row.clock_in_at),
+          outAt: row.clock_out_at ? fmtClock(row.clock_out_at) : null,
+          inLat: row.gps_in_lat ?? null, inLng: row.gps_in_lng ?? null, inFt: row.gps_in_ft ?? null, inOutside: row.gps_in_outside ?? null,
+          outLat: row.gps_out_lat ?? null, outLng: row.gps_out_lng ?? null, outFt: row.gps_out_ft ?? null, outOutside: row.gps_out_outside ?? null,
+          jobLat: row.job_lat ?? null, jobLng: row.job_lng ?? null,
+        }}
+      />
+    )}
     </div>
   );
 }


### PR DESCRIPTION
## What

The "beat MaidCentral" GPS view. Clicking a punch's GPS chip on the Time Clock now opens an **interactive map modal** instead of a plain new-tab link.

The modal shows, on one fit-to-bounds Google map:
- 🟢 the tech's **clock-in** pin
- 🟠 the **clock-out** pin (when present)
- 🔵 the **job's expected location** — with a line from job → punch so the gap is obvious

Plus a details panel: coordinates, distance from job, and inside/outside-zone status **per punch**, and an "open in Google Maps" link. Richer than MaidCentral's single-pin popover (it shows in + out + job together).

## How
- `/timeclock/day` now returns each job's coordinates (`job_lat`/`job_lng`, falling back to `address_lat`/`address_lng`) for the second pin.
- New `PunchMapModal` lazy-loads the Maps JS SDK (reusing the existing `/config/google-maps-key` endpoint, same pattern as Street View). If the map can't load it degrades to a coords + maps-link view.

## Notes
- For a punch with no job coordinates (job not geocoded), the modal still shows the punch pin and notes distance can't be measured until the address is geocoded.
- Reminder: a punch made *for* a tech from the office device records the office device's location, not the tech's.

## Verification
- api-server + frontend builds pass.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_