### PR TITLE
fix(discounts): audit + repair the MaidCentral discount migration

### DIFF
--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -4455,11 +4455,20 @@ async function runDiscountMigration() {
     const MIO = scopeMap["Move In / Move Out"];
     const HS  = scopeMap["Hourly Standard Cleaning"];
     const HD  = scopeMap["Hourly Deep Clean"];
-    const R   = scopeMap["Recurring Cleaning"];
     const C   = scopeMap["Commercial Cleaning"];
 
     // "Deep Clean or Move In/Out" maps to both DC + MIO
     const DC_MIO = [DC, MIO].filter(Boolean);
+
+    // [audit-fix 2026-06-11] The plain "Recurring Cleaning" scope is kept
+    // INACTIVE for backward-compat (scope 11); the live recurring scopes are
+    // "Recurring Cleaning - Weekly / Every 2 Weeks / Every 4 Weeks". Mapping the
+    // recurring discounts to the inactive scope left them scope-less (applying to
+    // nothing). Map them to whichever "Recurring Cleaning*" scopes are active.
+    const recurringScopeIds = Object.keys(scopeMap)
+      .filter(n => /^Recurring Cleaning/i.test(n))
+      .map(n => scopeMap[n])
+      .filter(Boolean);
 
     const discounts: Array<{
       code: string; value: number; type: string;
@@ -4484,6 +4493,7 @@ async function runDiscountMigration() {
       { code: "Realtor Discount",                 value: 12, type: "percent", scope_ids: DC_MIO, office: true, online: true },
       { code: "ROA",                              value: 15, type: "percent", scope_ids: DC_MIO, office: true, online: true },
       { code: "Senior Citizen Discount",          value: 12, type: "percent", scope_ids: DC_MIO, office: true, online: true },
+      { code: "oakparkmom",                       value: 15, type: "percent", scope_ids: DC_MIO, office: true, online: true },
       { code: "smartcity10",                      value: 10, type: "percent", scope_ids: DC_MIO, office: true, online: false },
 
       // Scope: Commercial Cleaning
@@ -4497,13 +4507,31 @@ async function runDiscountMigration() {
       { code: "Compass Discount",               value: 15, type: "percent", scope_ids: [HD].filter(Boolean), office: true, online: true },
       { code: "Manager Discretion Discount 25", value: 25, type: "flat",    scope_ids: [HD].filter(Boolean), office: true, online: true },
 
-      // Scope: Recurring Cleaning
-      { code: "fb15",      value: 15, type: "percent", scope_ids: [R].filter(Boolean), office: true, online: true },
-      { code: "PHES10OFF", value: 10, type: "percent", scope_ids: [R].filter(Boolean), office: true, online: true },
+      // Scope: Recurring Cleaning (active sub-frequency scopes)
+      { code: "fb15",      value: 15, type: "percent", scope_ids: recurringScopeIds, office: true, online: true },
+      { code: "PHES10OFF", value: 10, type: "percent", scope_ids: recurringScopeIds, office: true, online: true },
     ];
 
-    let seeded = 0;
+    // [audit-fix 2026-06-11] Remove any earlier scope-less seeds of these codes
+    // — a prior run inserted scope_ids='[]' whenever a scope name didn't resolve
+    // (e.g. the recurring discounts above). Clear them so the corrected scopes
+    // win cleanly on re-seed (the unique key includes scope_ids, so a fixed row
+    // is a different key and would otherwise leave the broken one behind).
+    const codeInList = [...new Set(discounts.map(d => d.code))]
+      .map(c => `'${c.replace(/'/g, "''")}'`).join(", ");
+    await db.execute(sql.raw(
+      `DELETE FROM pricing_discounts WHERE company_id = ${PHES} AND scope_ids = '[]' AND code IN (${codeInList})`
+    ));
+
+    let seeded = 0, skipped = 0;
     for (const d of discounts) {
+      // Never seed a discount that resolved to no scope — it would apply to
+      // nothing. Skip + log so the gap is visible instead of silently broken.
+      if (d.scope_ids.length === 0) {
+        console.warn(`[phes-migration] discount "${d.code}" has no resolved scope — skipped (check pricing_scopes names)`);
+        skipped++;
+        continue;
+      }
       const scopeIdsJson = JSON.stringify([...d.scope_ids].sort((a, b) => a - b));
       await db.execute(sql`
         INSERT INTO pricing_discounts
@@ -4522,7 +4550,7 @@ async function runDiscountMigration() {
       `);
       seeded++;
     }
-    console.log(`[phes-migration] MC discounts seeded: ${seeded} rows`);
+    console.log(`[phes-migration] MC discounts seeded: ${seeded} rows${skipped ? `, ${skipped} skipped (unresolved scope)` : ""}`);
 
     // Delete placeholder discount add-ons
     const deleted = await db.execute(sql`


### PR DESCRIPTION
## Audit result

Audited `runDiscountMigration()` — the function that seeds your MaidCentral discounts into `pricing_discounts` (runs on cold-start, idempotent via `ON CONFLICT`). The catalog is wired and the read endpoint (`GET /api/pricing/discounts`) does `SELECT * FROM pricing_discounts`, so everything surfaces in **Settings → Pricing → Discount Codes**. But two real defects:

### Bugs fixed
1. **Recurring discounts seeded scope-less.** `fb15` and `PHES10OFF` were mapped to a scope named `"Recurring Cleaning"`, which is kept **inactive** for backward-compat (the live scopes are `"Recurring Cleaning - Weekly / Every 2 Weeks / Every 4 Weeks"`). The lookup filters `is_active=true`, so it resolved to nothing → both discounts applied to **no service**. Now mapped to whichever active `Recurring Cleaning - *` scopes exist.
2. **`oakparkmom` (15%, Deep Clean / Move In/Out) was missing** from the catalog entirely — added.

### Hardening
- Skip + `console.warn` on any discount that resolves to no scope, instead of silently inserting a `scope_ids='[]'` row that can never apply.
- Pre-delete prior scope-less seeds of these codes so the corrected scope wins cleanly on re-seed (the unique key includes `scope_ids`).

Re-seeds automatically on the next cold-start; idempotent.

## Note
I couldn't query your live DB from here (Railway injects creds at runtime — none in the sandbox), so this is a code-level audit + fix. After deploy, the recurring discounts will apply correctly and `oakparkmom` will appear under Settings → Pricing. If the list there is *empty* rather than just missing those, tell me and I'll dig into why the migration didn't run at all.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_