### PR TITLE
fix(time-clock): stop the GPS punch map over-zooming to a gray tile

### DIFF
--- a/artifacts/qleno/src/components/punch-map-modal.tsx
+++ b/artifacts/qleno/src/components/punch-map-modal.tsx
@@ -61,6 +61,10 @@ export function PunchMapModal({ data, onClose }: { data: PunchMapData; onClose: 
       if (cancelled || !mapRef.current) return;
       const map = new maps.Map(mapRef.current, {
         zoom: 15, mapTypeControl: false, streetViewControl: false, fullscreenControl: true,
+        // Cap zoom so near-identical punches (often a few feet apart) don't slam
+        // to max zoom and render as a gray no-detail tile. Drop the rotate/tilt
+        // controls that clutter the view at high zoom.
+        maxZoom: 18, rotateControl: false, clickableIcons: false, tilt: 0,
         center: { lat: data.inLat ?? data.jobLat ?? 0, lng: data.inLng ?? data.jobLng ?? 0 },
       });
       const bounds = new maps.LatLngBounds();


### PR DESCRIPTION
## Why

The GPS punch map looked broken ("like 2007"). When the clock-in and clock-out punches are only a few feet apart — and the job isn't geocoded so there's no third pin — `fitBounds` slammed the map to max zoom, rendering a **gray no-detail tile** with stray rotate-control arrows.

## Fix
- `maxZoom: 18` so close punches don't over-zoom into the gray tile.
- `rotateControl: false`, `tilt: 0`, `clickableIcons: false` to clean up the high-zoom clutter.

Punch pins now sit on a normal street map.

## Verification
- Frontend build passes.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_