### PR TITLE
feat(jobs): per-job tracked discounts — "Add discount" in the edit modal (PR1)

### DIFF
--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -23,6 +23,24 @@ const PHES = 1; // company_id
 // raw SQL inserts in the booking route can never fail with "column does not exist".
 async function runBookingSchemaGuard(): Promise<void> {
   const guards: Array<{ label: string; stmt: string }> = [
+    // [job-discounts 2026-06-11] Per-job applied discounts (tracked for the
+    // discounts report). Distinct from the pricing_discounts catalog.
+    { label: "job_discounts table", stmt: `
+      CREATE TABLE IF NOT EXISTS job_discounts (
+        id SERIAL PRIMARY KEY,
+        company_id INTEGER NOT NULL REFERENCES companies(id),
+        job_id INTEGER NOT NULL REFERENCES jobs(id),
+        code TEXT,
+        type TEXT NOT NULL,
+        value NUMERIC(10,2) NOT NULL,
+        amount NUMERIC(10,2) NOT NULL,
+        reason TEXT,
+        applied_by INTEGER REFERENCES users(id),
+        created_at TIMESTAMP NOT NULL DEFAULT now()
+      )
+    ` },
+    { label: "job_discounts job_id index", stmt: "CREATE INDEX IF NOT EXISTS idx_job_discounts_job ON job_discounts(job_id)" },
+    { label: "job_discounts company_id index", stmt: "CREATE INDEX IF NOT EXISTS idx_job_discounts_company ON job_discounts(company_id)" },
     // ── jobs extra columns ──────────────────────────────────────────────────
     { label: "jobs.home_condition_rating", stmt: "ALTER TABLE jobs ADD COLUMN IF NOT EXISTS home_condition_rating INTEGER" },
     // [ghl-estimate-bridge 2026-06-10] GoHighLevel inbound-webhook URLs for

--- a/artifacts/api-server/src/routes/jobs.ts
+++ b/artifacts/api-server/src/routes/jobs.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import { db } from "@workspace/db";
-import { jobsTable, clientsTable, usersTable, jobPhotosTable, timeclockTable, invoicesTable, scorecardsTable, serviceZonesTable, serviceZoneEmployeesTable, companiesTable, accountsTable, accountRateCardsTable, accountPropertiesTable, paymentsTable, recurringSchedulesTable, branchesTable, userCompaniesTable } from "@workspace/db/schema";
+import { jobsTable, clientsTable, usersTable, jobPhotosTable, timeclockTable, invoicesTable, scorecardsTable, serviceZonesTable, serviceZoneEmployeesTable, companiesTable, accountsTable, accountRateCardsTable, accountPropertiesTable, paymentsTable, recurringSchedulesTable, branchesTable, userCompaniesTable, jobDiscountsTable } from "@workspace/db/schema";
 import { eq, and, gte, lte, count, desc, sql, notExists, inArray, isNotNull, isNull } from "drizzle-orm";
 import { requireAuth } from "../lib/auth.js";
 import { notifyUserAsync } from "../lib/push.js";
@@ -4030,6 +4030,60 @@ router.post("/:id/technicians", requireAuth, async (req, res) => {
 // next remaining tech (lowest job_technicians.id) to primary and update
 // jobs.assigned_user_id. If no techs remain, jobs.assigned_user_id goes
 // NULL (job back to unassigned). Audit row written for traceability.
+// ── Per-job discounts (tracked; feeds the discounts report) ─────────────────
+// Distinct from the pricing_discounts catalog: this records each discount
+// actually applied to a job, with the $ taken off snapshotted at apply time.
+router.get("/:id/discounts", requireAuth, async (req, res) => {
+  try {
+    const jobId = parseInt(req.params.id);
+    const rows = await db.select().from(jobDiscountsTable)
+      .where(and(eq(jobDiscountsTable.job_id, jobId), eq(jobDiscountsTable.company_id, req.auth!.companyId!)))
+      .orderBy(desc(jobDiscountsTable.created_at));
+    return res.json({ data: rows.map(r => ({ ...r, value: Number(r.value), amount: Number(r.amount) })) });
+  } catch (e) { console.error("list job discounts:", e); return res.status(500).json({ error: "Internal Server Error" }); }
+});
+
+router.post("/:id/discounts", requireAuth, async (req, res) => {
+  try {
+    const jobId = parseInt(req.params.id);
+    const { code, type, value, reason } = req.body ?? {};
+    if (type !== "percent" && type !== "flat") return res.status(400).json({ error: "type must be 'percent' or 'flat'" });
+    const v = Number(value);
+    if (!Number.isFinite(v) || v <= 0) return res.status(400).json({ error: "value must be a positive number" });
+    const jobRows = await db.select({ base_fee: jobsTable.base_fee })
+      .from(jobsTable)
+      .where(and(eq(jobsTable.id, jobId), eq(jobsTable.company_id, req.auth!.companyId!)))
+      .limit(1);
+    if (jobRows.length === 0) return res.status(404).json({ error: "Job not found" });
+    const baseFee = jobRows[0].base_fee != null ? parseFloat(String(jobRows[0].base_fee)) : 0;
+    // Dollars off this job, snapshotted. Cap at the base fee so it never goes
+    // negative; a percent resolves against the current base fee.
+    let amount = type === "percent" ? (baseFee * v) / 100 : v;
+    amount = Math.round(Math.min(Math.max(amount, 0), baseFee) * 100) / 100;
+    const [row] = await db.insert(jobDiscountsTable).values({
+      company_id: req.auth!.companyId!, job_id: jobId,
+      code: code ? String(code).slice(0, 64) : null, type, value: String(v), amount: String(amount),
+      reason: reason ? String(reason).slice(0, 200) : null, applied_by: req.auth!.userId ?? null,
+    }).returning();
+    try { await logAudit(req, "job_discount.add", "job", jobId, null, { code: row.code, type, value: v, amount }); } catch {}
+    return res.json({ data: { ...row, value: Number(row.value), amount: Number(row.amount) } });
+  } catch (e) { console.error("add job discount:", e); return res.status(500).json({ error: "Internal Server Error" }); }
+});
+
+router.delete("/:id/discounts/:discountId", requireAuth, async (req, res) => {
+  try {
+    const jobId = parseInt(req.params.id);
+    const discountId = parseInt(req.params.discountId);
+    await db.delete(jobDiscountsTable).where(and(
+      eq(jobDiscountsTable.id, discountId),
+      eq(jobDiscountsTable.job_id, jobId),
+      eq(jobDiscountsTable.company_id, req.auth!.companyId!),
+    ));
+    try { await logAudit(req, "job_discount.remove", "job", jobId, null, { discount_id: discountId }); } catch {}
+    return res.json({ ok: true });
+  } catch (e) { console.error("delete job discount:", e); return res.status(500).json({ error: "Internal Server Error" }); }
+});
+
 router.delete("/:id/technicians/:techId", requireAuth, async (req, res) => {
   try {
     const jobId = parseInt(req.params.id);

--- a/artifacts/qleno/src/components/edit-job-modal.tsx
+++ b/artifacts/qleno/src/components/edit-job-modal.tsx
@@ -304,6 +304,60 @@ export default function EditJobModal({
   const [manualOpen, setManualOpen] = useState(false);
   const [manualValue, setManualValue] = useState<string>(String(initialBaseFee));
 
+  // [job-discounts 2026-06-11] Tracked discounts on this job — separate from the
+  // gross base_fee (net = base_fee − applied discounts). Applied immediately via
+  // the job's discount sub-resource so each lands in the discounts report,
+  // instead of silently overriding the rate.
+  const [jobDiscounts, setJobDiscounts] = useState<Array<{ id: number; code: string | null; type: string; value: number; amount: number; reason: string | null }>>([]);
+  const [discountCatalog, setDiscountCatalog] = useState<Array<{ id: number; code: string; discount_type: string; discount_value: string }>>([]);
+  const [discOpen, setDiscOpen] = useState(false);
+  const [discType, setDiscType] = useState<"percent" | "flat">("percent");
+  const [discValue, setDiscValue] = useState("");
+  const [discReason, setDiscReason] = useState("");
+  const [discCode, setDiscCode] = useState<string | null>(null);
+  const [discBusy, setDiscBusy] = useState(false);
+  const discountTotal = jobDiscounts.reduce((s, d) => s + (d.amount || 0), 0);
+
+  const reloadDiscounts = async () => {
+    if (!job?.id) return;
+    try {
+      const r = await fetch(`${API}/api/jobs/${job.id}/discounts`, { headers: { Authorization: `Bearer ${token}` } });
+      if (r.ok) { const d = await r.json(); setJobDiscounts(d.data ?? []); }
+    } catch { /* non-fatal */ }
+  };
+  useEffect(() => {
+    reloadDiscounts();
+    (async () => {
+      try {
+        const r = await fetch(`${API}/api/pricing/discounts`, { headers: { Authorization: `Bearer ${token}` } });
+        if (r.ok) { const d = await r.json(); setDiscountCatalog(Array.isArray(d) ? d : (d.data ?? [])); }
+      } catch { /* non-fatal */ }
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [job?.id, API, token]);
+
+  const applyDiscount = async () => {
+    const v = parseFloat(discValue);
+    if (!job?.id || !(v > 0)) return;
+    setDiscBusy(true);
+    try {
+      const r = await fetch(`${API}/api/jobs/${job.id}/discounts`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+        body: JSON.stringify({ type: discType, value: v, reason: discReason || null, code: discCode }),
+      });
+      if (r.ok) { await reloadDiscounts(); setDiscOpen(false); setDiscValue(""); setDiscReason(""); setDiscCode(null); }
+    } catch { /* non-fatal */ } finally { setDiscBusy(false); }
+  };
+  const removeDiscount = async (id: number) => {
+    if (!job?.id) return;
+    setDiscBusy(true);
+    try {
+      await fetch(`${API}/api/jobs/${job.id}/discounts/${id}`, { method: "DELETE", headers: { Authorization: `Bearer ${token}` } });
+      await reloadDiscounts();
+    } catch { /* non-fatal */ } finally { setDiscBusy(false); }
+  };
+
   // [AH] Commercial state. clientType is 'residential' until the client
   // profile loads. clientLoaded gates rendering so we don't flash residential
   // UI for a commercial client. commercialServiceType holds the dropdown
@@ -2046,6 +2100,67 @@ export default function EditJobModal({
                 <button onClick={() => setManualOpen(false)} style={{ fontSize: 12, color: "#6B7280", background: "none", border: "none", cursor: "pointer", fontFamily: FF }}>Cancel</button>
               </div>
             )}
+
+            {/* [job-discounts 2026-06-11] Tracked discounts — preferred over a
+                raw rate override so every discount is recorded for the report. */}
+            <div style={{ marginTop: 12, borderTop: "1px solid #EEECE7", paddingTop: 10 }}>
+              {jobDiscounts.length > 0 && (
+                <div style={{ marginBottom: 8 }}>
+                  {jobDiscounts.map(d => (
+                    <div key={d.id} style={{ display: "flex", justifyContent: "space-between", alignItems: "center", fontSize: 13, padding: "3px 0" }}>
+                      <span style={{ color: "#1A1917", fontWeight: 600, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                        {d.code || (d.type === "percent" ? `${d.value}% discount` : "Discount")}
+                        {d.reason && d.reason !== d.code ? <span style={{ color: "#9E9B94", fontWeight: 400 }}> · {d.reason}</span> : null}
+                      </span>
+                      <span style={{ display: "flex", alignItems: "center", gap: 8, flexShrink: 0 }}>
+                        <span style={{ color: "#16A34A", fontWeight: 700 }}>−${d.amount.toFixed(2)}{d.type === "percent" ? ` (${d.value}%)` : ""}</span>
+                        <button onClick={() => removeDiscount(d.id)} disabled={discBusy} title="Remove discount" style={{ background: "none", border: "none", cursor: "pointer", color: "#B91C1C", fontWeight: 700, fontSize: 15, padding: 0, lineHeight: 1 }}>×</button>
+                      </span>
+                    </div>
+                  ))}
+                  <div style={{ display: "flex", justifyContent: "space-between", fontSize: 13, fontWeight: 700, color: "#1A1917", marginTop: 5, paddingTop: 5, borderTop: "1px dashed #E5E2DC" }}>
+                    <span>Net after discounts</span>
+                    <span>${Math.max(0, baseFee - discountTotal).toFixed(2)}</span>
+                  </div>
+                </div>
+              )}
+              {!discOpen && (
+                <button onClick={() => setDiscOpen(true)}
+                  style={{ fontSize: 12, color: "#00936F", background: "none", border: "none", cursor: "pointer", fontFamily: FF, fontWeight: 700, padding: 0 }}>
+                  + Add discount
+                </button>
+              )}
+              {discOpen && (
+                <div style={{ marginTop: 6, display: "flex", flexDirection: "column", gap: 6 }}>
+                  {discountCatalog.length > 0 && (
+                    <select value="" onChange={e => {
+                      const c = discountCatalog.find(x => String(x.id) === e.target.value);
+                      if (c) { setDiscType(c.discount_type === "flat" ? "flat" : "percent"); setDiscValue(String(Number(c.discount_value))); setDiscReason(c.code); setDiscCode(c.code); }
+                    }} style={{ ...INPUT }}>
+                      <option value="">Pick a saved code (or enter custom below)…</option>
+                      {discountCatalog.map(c => (
+                        <option key={c.id} value={c.id}>{c.code} · {c.discount_type === "flat" ? `$${Number(c.discount_value)}` : `${Number(c.discount_value)}%`}</option>
+                      ))}
+                    </select>
+                  )}
+                  <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
+                    <div style={{ display: "flex", border: "1px solid #E5E2DC", borderRadius: 6, overflow: "hidden", flexShrink: 0 }}>
+                      <button type="button" onClick={() => { setDiscType("percent"); setDiscCode(null); }} style={{ padding: "7px 11px", fontSize: 12, fontWeight: 700, border: "none", cursor: "pointer", background: discType === "percent" ? "var(--brand, #00C9A0)" : "#fff", color: discType === "percent" ? "#fff" : "#6B6860", fontFamily: FF }}>%</button>
+                      <button type="button" onClick={() => { setDiscType("flat"); setDiscCode(null); }} style={{ padding: "7px 11px", fontSize: 12, fontWeight: 700, border: "none", cursor: "pointer", background: discType === "flat" ? "var(--brand, #00C9A0)" : "#fff", color: discType === "flat" ? "#fff" : "#6B6860", fontFamily: FF }}>$</button>
+                    </div>
+                    <input type="number" min={0} step={0.01} value={discValue} onChange={e => { setDiscValue(e.target.value); setDiscCode(null); }} placeholder={discType === "percent" ? "15" : "25.00"} style={{ ...INPUT, width: 90 }} />
+                    <input type="text" value={discReason} onChange={e => setDiscReason(e.target.value)} placeholder="Reason (Senior, Goodwill…)" style={{ ...INPUT, flex: 1, minWidth: 0 }} />
+                  </div>
+                  <div style={{ display: "flex", gap: 6 }}>
+                    <button type="button" disabled={discBusy || !(parseFloat(discValue) > 0)} onClick={applyDiscount}
+                      style={{ fontSize: 12, fontWeight: 700, color: "#fff", background: "var(--brand, #00C9A0)", border: "none", borderRadius: 6, padding: "8px 14px", cursor: discBusy || !(parseFloat(discValue) > 0) ? "default" : "pointer", fontFamily: FF, opacity: discBusy || !(parseFloat(discValue) > 0) ? 0.6 : 1 }}>
+                      Apply discount
+                    </button>
+                    <button type="button" onClick={() => { setDiscOpen(false); setDiscValue(""); setDiscReason(""); setDiscCode(null); }} style={{ fontSize: 12, color: "#6B7280", background: "none", border: "none", cursor: "pointer", fontFamily: FF }}>Cancel</button>
+                  </div>
+                </div>
+              )}
+            </div>
           </div>
 
           {/* Section 6 — Instructions */}

--- a/lib/db/src/schema/index.ts
+++ b/lib/db/src/schema/index.ts
@@ -12,6 +12,7 @@ export * from "./loyalty";
 export * from "./audit_log";
 export * from "./articles";
 export * from "./discounts";
+export * from "./job_discounts";
 export * from "./availability";
 export * from "./contact_tickets";
 export * from "./employee_notes";

--- a/lib/db/src/schema/job_discounts.ts
+++ b/lib/db/src/schema/job_discounts.ts
@@ -1,0 +1,30 @@
+import { pgTable, serial, integer, timestamp, text, numeric } from "drizzle-orm/pg-core";
+import { createInsertSchema } from "drizzle-zod";
+import { z } from "zod/v4";
+import { companiesTable } from "./companies";
+import { jobsTable } from "./jobs";
+import { usersTable } from "./users";
+
+// [job-discounts 2026-06-11] A discount APPLIED to a specific job. Distinct from
+// the pricing_discounts catalog (the reusable codes) — this records each actual
+// application so the office can track + report every discount given. A job can
+// have more than one. `code` is the catalog code when picked from the catalog,
+// null for a one-off custom discount. `type`/`value` mirror the catalog's
+// 'percent' | 'flat' shape; `amount` is the dollars actually taken off THIS job
+// at apply time (snapshot, so the report is stable even if the price changes).
+export const jobDiscountsTable = pgTable("job_discounts", {
+  id: serial("id").primaryKey(),
+  company_id: integer("company_id").references(() => companiesTable.id).notNull(),
+  job_id: integer("job_id").references(() => jobsTable.id).notNull(),
+  code: text("code"),
+  type: text("type").notNull(), // 'percent' | 'flat'
+  value: numeric("value", { precision: 10, scale: 2 }).notNull(),
+  amount: numeric("amount", { precision: 10, scale: 2 }).notNull(),
+  reason: text("reason"),
+  applied_by: integer("applied_by").references(() => usersTable.id),
+  created_at: timestamp("created_at").notNull().defaultNow(),
+});
+
+export const insertJobDiscountSchema = createInsertSchema(jobDiscountsTable).omit({ id: true, created_at: true });
+export type InsertJobDiscount = z.infer<typeof insertJobDiscountSchema>;
+export type JobDiscount = typeof jobDiscountsTable.$inferSelect;


### PR DESCRIPTION
## What (PR1 of the discount system)

Instead of a raw rate override, the office now applies a **tracked discount** to a job — **$ or %, with a reason**, from your (now-correct) saved catalog or custom. Each application is recorded so the upcoming **discounts report** has data.

- **New `job_discounts` table** (company/job, `code` | null, `type` `percent`/`flat`, `value`, snapshotted `$ amount`, `reason`, `applied_by`) + cold-start DDL so it exists in prod.
- **API:** `GET/POST/DELETE /api/jobs/:id/discounts`. POST resolves the $ off the current `base_fee`, caps at the base (never negative), snapshots the amount, audit-logged.
- **Edit-job modal pricing section:** "**+ Add discount**" — pick a saved code or enter custom **$/%** + reason; shows applied discounts and a **"Net after discounts"** line. The override-rate option stays as a secondary path.

## Follow-ups
- **PR2:** Discounts report (date · client · job · code/reason · type · value · $ · applied by).
- **PR3:** flow the discount onto the **invoice** as its own line item (ties into the invoice auto-create/sync work).

## Verification
- api-server + frontend builds pass; new code typechecks clean.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_