### PR TITLE
feat(gps): job pin + distance via client geocode (read-time fallback + backfill)

### DIFF
--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -41,6 +41,22 @@ async function runBookingSchemaGuard(): Promise<void> {
     ` },
     { label: "job_discounts job_id index", stmt: "CREATE INDEX IF NOT EXISTS idx_job_discounts_job ON job_discounts(job_id)" },
     { label: "job_discounts company_id index", stmt: "CREATE INDEX IF NOT EXISTS idx_job_discounts_company ON job_discounts(company_id)" },
+    // [gps-geocode-backfill 2026-06-11] Inherit job coords from the already-
+    // geocoded client (residential) / account property (commercial) so the GPS
+    // pin + future clock-in distance work — no new geocoding API calls. Only
+    // touches jobs with NULL coords; idempotent.
+    { label: "backfill jobs.job_lat/lng from client geocode", stmt: `
+      UPDATE jobs j SET job_lat = c.lat, job_lng = c.lng
+      FROM clients c
+      WHERE j.client_id = c.id AND j.company_id = c.company_id
+        AND j.job_lat IS NULL AND c.lat IS NOT NULL
+    ` },
+    { label: "backfill jobs.job_lat/lng from account property geocode", stmt: `
+      UPDATE jobs j SET job_lat = ap.lat, job_lng = ap.lng
+      FROM account_properties ap
+      WHERE j.account_property_id = ap.id
+        AND j.job_lat IS NULL AND ap.lat IS NOT NULL
+    ` },
     // ── jobs extra columns ──────────────────────────────────────────────────
     { label: "jobs.home_condition_rating", stmt: "ALTER TABLE jobs ADD COLUMN IF NOT EXISTS home_condition_rating INTEGER" },
     // [ghl-estimate-bridge 2026-06-10] GoHighLevel inbound-webhook URLs for

--- a/artifacts/api-server/src/routes/timeclock.ts
+++ b/artifacts/api-server/src/routes/timeclock.ts
@@ -706,7 +706,7 @@ router.get("/day", requireAuth, requireRole("owner", "admin", "office"), async (
              j.service_type::text AS service_type, j.address_street,
              j.job_lat, j.job_lng, j.address_lat, j.address_lng,
              j.account_id, j.base_fee, j.billed_amount, j.allowed_hours, j.branch_id, j.scheduled_date::text AS scheduled_date,
-             c.client_type,
+             c.client_type, c.lat AS client_lat, c.lng AS client_lng,
              COALESCE(NULLIF(TRIM(COALESCE(c.first_name,'') || ' ' || COALESCE(c.last_name,'')), ''),
                       c.company_name, 'Client') AS client_name
       FROM jobs j
@@ -839,10 +839,15 @@ router.get("/day", requireAuth, requireRole("owner", "admin", "office"), async (
                  // The job's own coordinates (the expected spot) so the GPS
                  // map modal can drop a second pin + show the punch-vs-job gap.
                  job_lat: number | null; job_lng: number | null };
-    const coordsOf = (j: any) => ({
-      job_lat: (j?.job_lat ?? j?.address_lat) != null ? Number(j.job_lat ?? j.address_lat) : null,
-      job_lng: (j?.job_lng ?? j?.address_lng) != null ? Number(j.job_lng ?? j.address_lng) : null,
-    });
+    // Job pin coords: prefer the job's own geocode, then the per-job address
+    // geocode, then fall back to the (already-geocoded) client coords so the
+    // map pin shows even for jobs that were never geocoded (e.g. recurring
+    // children created before on-create geocoding).
+    const coordsOf = (j: any) => {
+      const lat = j?.job_lat ?? j?.address_lat ?? j?.client_lat;
+      const lng = j?.job_lng ?? j?.address_lng ?? j?.client_lng;
+      return { job_lat: lat != null ? Number(lat) : null, job_lng: lng != null ? Number(lng) : null };
+    };
     const gpsOf = (e: any) => ({
       gps_in_ft: e?.clock_in_distance_ft != null ? Math.round(parseFloat(String(e.clock_in_distance_ft))) : null,
       gps_out_ft: e?.clock_out_distance_ft != null ? Math.round(parseFloat(String(e.clock_out_distance_ft))) : null,


### PR DESCRIPTION
## Why

The GPS punch modal kept showing **"job not geocoded"** with no blue job pin and no distance. Root cause: jobs geocode **on create**, but the **recurring engine doesn't** — so most Phes (recurring) jobs had NULL coordinates.

## Fix (zero new geocoding API cost — inherits the client's existing geocode)
- **Read-time fallback:** `/timeclock/day` now resolves job pin coords `job_lat/lng` → `address_lat/lng` → **client `lat/lng`**, so the pin shows immediately for jobs that were never geocoded.
- **Free SQL backfill (cold-start, idempotent):** `UPDATE jobs.job_lat/lng` from the client (residential) / account property (commercial) wherever job coords are NULL — so **future clock-ins compute real distance**.

## Notes
- Existing punches keep their stored distance (computed at punch time); the backfill makes *new* clock-ins distance-aware.
- Reminder: punches made *for* a tech from the office device record the office location — distance is fully meaningful once techs punch from their own phones.
- Follow-up: stamp coords in the recurring engine at generation time (pin already works now via the read-time fallback).

## Verification
- api-server build passes. Backfill only touches NULL-coord jobs; idempotent.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_