### PR TITLE
feat(reports): discounts report (PR2)

### DIFF
--- a/artifacts/api-server/src/routes/reports.ts
+++ b/artifacts/api-server/src/routes/reports.ts
@@ -754,6 +754,52 @@ router.get("/tips", requireAuth, requireRole("owner", "admin", "office", "techni
   }
 });
 
+// ─── DISCOUNTS ───────────────────────────────────────────────────────────────
+// Every discount applied to a job in the window (from job_discounts), so the
+// office can see what's being given away and to whom.
+router.get("/discounts", requireAuth, ROLE, async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId!;
+    const now = new Date();
+    const fromStr = (req.query.from as string) || dateStr(new Date(now.getTime() - 30 * 86400000));
+    const toStr   = (req.query.to   as string) || dateStr(now);
+    const rows = await db.execute(sql`
+      SELECT
+        jd.id, jd.code, jd.type, jd.value, jd.amount, jd.reason, jd.created_at,
+        u.first_name AS by_first, u.last_name AS by_last,
+        c.first_name AS client_first, c.last_name AS client_last, c.company_name AS client_company,
+        j.id AS job_id, j.service_type, j.scheduled_date
+      FROM job_discounts jd
+      JOIN jobs j ON j.id = jd.job_id
+      LEFT JOIN clients c ON c.id = j.client_id
+      LEFT JOIN users u ON u.id = jd.applied_by
+      WHERE jd.company_id = ${companyId}
+        AND jd.created_at::date BETWEEN ${fromStr} AND ${toStr}
+        ${branchFilter(req, "j.branch_id")}
+      ORDER BY jd.created_at DESC LIMIT 1000
+    `);
+    const data = (rows.rows as any[]).map(r => ({
+      id: r.id, date: r.created_at,
+      code: r.code, type: r.type, value: parseF(r.value), amount: parseF(r.amount), reason: r.reason,
+      applied_by: r.by_first ? `${r.by_first} ${r.by_last}`.trim() : null,
+      client_name: r.client_first ? `${r.client_first} ${r.client_last}`.trim() : (r.client_company || null),
+      job_id: r.job_id, service_type: r.service_type, job_date: r.scheduled_date,
+    }));
+    const total = data.reduce((s, r) => s + r.amount, 0);
+    return res.json({
+      from: fromStr, to: toStr, data,
+      summary: {
+        total_discount: total, count: data.length,
+        percent_count: data.filter(d => d.type === "percent").length,
+        flat_count: data.filter(d => d.type === "flat").length,
+      },
+    });
+  } catch (err) {
+    console.error("Discounts report error:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
 // ─── WEEK IN REVIEW ──────────────────────────────────────────────────────────
 router.get("/week-review", requireAuth, ROLE, async (req, res) => {
   try {

--- a/artifacts/qleno/src/App.tsx
+++ b/artifacts/qleno/src/App.tsx
@@ -41,6 +41,7 @@ const RevenueReportPage   = lazy(() => import("@/pages/reports/revenue"));
 const PayrollReportPage   = lazy(() => import("@/pages/reports/payroll"));
 const EmployeeStatsPage   = lazy(() => import("@/pages/reports/employee-stats"));
 const TipsReportPage      = lazy(() => import("@/pages/reports/tips"));
+const DiscountsReportPage = lazy(() => import("@/pages/reports/discounts"));
 const ReceivablesPage     = lazy(() => import("@/pages/reports/receivables"));
 const JobCostingPage      = lazy(() => import("@/pages/reports/job-costing"));
 const PayrollToRevenuePage= lazy(() => import("@/pages/reports/payroll-to-revenue"));
@@ -162,6 +163,7 @@ function Router() {
         <Route path="/reports/payroll" component={PayrollReportPage} />
         <Route path="/reports/employee-stats" component={EmployeeStatsPage} />
         <Route path="/reports/tips" component={TipsReportPage} />
+        <Route path="/reports/discounts" component={DiscountsReportPage} />
         <Route path="/reports/receivables" component={ReceivablesPage} />
         <Route path="/reports/job-costing" component={JobCostingPage} />
         <Route path="/reports/payroll-to-revenue" component={PayrollToRevenuePage} />

--- a/artifacts/qleno/src/pages/reports/discounts.tsx
+++ b/artifacts/qleno/src/pages/reports/discounts.tsx
@@ -1,0 +1,65 @@
+import { useState } from "react";
+import { DashboardLayout } from "@/components/layout/dashboard-layout";
+import { fmt$c, fmtDate, fmtSvc, clr, KpiCard, DateRange, ReportHeader, DataTable, useReportData } from "./_shared";
+
+function today() { return new Date().toISOString().split("T")[0]; }
+function daysAgo(n: number) { const d = new Date(); d.setDate(d.getDate() - n); return d.toISOString().split("T")[0]; }
+
+interface DiscountRow {
+  id: number; date: string; code: string | null; type: string; value: number; amount: number;
+  reason: string | null; applied_by: string | null; client_name: string | null;
+  service_type: string | null; job_date: string | null;
+}
+interface DiscountsData {
+  from: string; to: string; data: DiscountRow[];
+  summary: { total_discount: number; count: number; percent_count: number; flat_count: number };
+}
+
+export default function DiscountsReportPage() {
+  const [from, setFrom] = useState(daysAgo(30));
+  const [to, setTo] = useState(today());
+
+  const { data, loading } = useReportData<DiscountsData>(`/reports/discounts?from=${from}&to=${to}`);
+  const rows = data?.data ?? [];
+  const s = data?.summary;
+
+  // Top code/reason by total dollars given away
+  const byCode: Record<string, number> = {};
+  rows.forEach(r => {
+    const k = r.code || r.reason || (r.type === "percent" ? "Custom %" : "Custom $");
+    byCode[k] = (byCode[k] ?? 0) + r.amount;
+  });
+  const topCode = Object.entries(byCode).sort((a, b) => b[1] - a[1])[0];
+
+  const cols = [
+    { header: "Date", render: (r: DiscountRow) => fmtDate(r.date) },
+    { header: "Client", render: (r: DiscountRow) => r.client_name ?? "—" },
+    { header: "Service", render: (r: DiscountRow) => r.service_type ? fmtSvc(r.service_type) : "—" },
+    { header: "Code / Reason", render: (r: DiscountRow) => <span style={{ fontWeight: 500 }}>{r.code || r.reason || "Custom"}</span> },
+    { header: "Discount", render: (r: DiscountRow) => r.type === "percent" ? `${r.value}%` : fmt$c(r.value), align: "right" as const },
+    { header: "Amount Off", render: (r: DiscountRow) => <span style={{ fontWeight: 700, color: clr.green }}>−{fmt$c(r.amount)}</span>, align: "right" as const },
+    { header: "Applied By", render: (r: DiscountRow) => r.applied_by ?? "—" },
+  ];
+
+  return (
+    <DashboardLayout title="Discounts Report">
+      <div style={{ padding: "24px 28px", maxWidth: 1000 }}>
+        <ReportHeader
+          title="Discounts Report"
+          subtitle="Every discount applied to a job in the selected date range."
+          printable
+          filters={<DateRange from={from} to={to} onChange={(f, t) => { setFrom(f); setTo(t); }} />}
+        />
+
+        <div style={{ display: "flex", gap: 14, flexWrap: "wrap", marginBottom: 24 }}>
+          <KpiCard label="Total Discounted" value={fmt$c(s?.total_discount ?? 0)} color={clr.green} />
+          <KpiCard label="Discounts Given" value={String(s?.count ?? 0)} color={clr.secondary} />
+          <KpiCard label="% / $ split" value={`${s?.percent_count ?? 0} / ${s?.flat_count ?? 0}`} />
+          {topCode && <KpiCard label="Top Code" value={topCode[0]} sub={fmt$c(topCode[1])} color={clr.amber} />}
+        </div>
+
+        <DataTable cols={cols} rows={rows} loading={loading} emptyMsg="No discounts applied in this date range." />
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/artifacts/qleno/src/pages/reports/index.tsx
+++ b/artifacts/qleno/src/pages/reports/index.tsx
@@ -4,7 +4,7 @@ import {
   TrendingUp, DollarSign, Banknote, Activity, UserCheck, Star,
   ReceiptText, Clipboard, Calendar, LayoutList, ClipboardList,
   AlertTriangle, FileText, Home, Users, ArrowRight, RefreshCw,
-  Briefcase,
+  Briefcase, Percent,
 } from "lucide-react";
 
 const REPORT_GROUPS = [
@@ -16,6 +16,7 @@ const REPORT_GROUPS = [
       { title: "Accounts Receivable",  desc: "Outstanding invoices grouped by aging bucket.",          url: "/reports/receivables",       icon: ReceiptText },
       { title: "Job Costing",          desc: "Revenue vs labor cost with gross profit margins.",       url: "/reports/job-costing",       icon: Clipboard },
       { title: "Payroll % Revenue",    desc: "Payroll-to-revenue ratio tracked week over week.",       url: "/reports/payroll-to-revenue",icon: Activity },
+      { title: "Discounts",            desc: "Every discount applied to a job — code, amount, and who applied it.", url: "/reports/discounts", icon: Percent },
     ],
   },
   {


### PR DESCRIPTION
## What (PR2 of the discount system)

A **Discounts report** so the office can see every discount given and to whom.

- **API:** `GET /api/reports/discounts` (owner/admin/office) — `job_discounts` joined to jobs + clients + applied-by user, filtered by date range + branch. Returns rows + summary (total $, count, %/$ split).
- **Page:** `/reports/discounts` — date-range filter, KPIs (Total Discounted, Discounts Given, %/$ split, Top Code), table (Date · Client · Service · Code/Reason · Discount · **Amount Off** · Applied By), printable.
- Listed under **Reports → Financial**.

Reads the `job_discounts` table from PR1 (#412), so it populates as discounts get applied via the new "+ Add discount" control.

## Verification
- api-server + frontend builds pass.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_