### PR TITLE
fix(dispatch): Add Team Member picker empty — match the board's field-worker rule

### DIFF
--- a/artifacts/api-server/src/routes/users.ts
+++ b/artifacts/api-server/src/routes/users.ts
@@ -118,7 +118,16 @@ router.get("/techs-with-status", requireAuth, async (req, res) => {
                ORDER BY tc.clock_in_at DESC LIMIT 1) AS active_job_id
         FROM users u
        WHERE u.is_active = true
-         AND u.role IN ('technician','team_lead')
+         -- [add-team-member fix 2026-06-11] Match the dispatch board field-worker
+         -- rule EXACTLY (routes/dispatch.ts): any active user who is not
+         -- office/admin/owner, plus office/admin explicitly tagged field or
+         -- technician. The old role IN (technician, team_lead) was narrower than
+         -- the board, so cleaners shown on the board but carrying any other role
+         -- were missing from the Add Team Member picker.
+         AND (
+              u.role NOT IN ('admin', 'owner', 'office', 'super_admin')
+           OR (COALESCE(u.tags, '{}') && ARRAY['field','technician']::text[])
+         )
          AND (
               u.company_id = ${companyId}
            OR EXISTS (SELECT 1 FROM user_companies uc


### PR DESCRIPTION
## Bug (reported by office — Maribel)

"Can't add cleaners to the job" — the **Add Team Member** drawer comes back **empty** ("No available technicians") even though those cleaners are clearly on the dispatch board.

## Root cause

The picker and the board use **different rules for who's a field worker**:

- **Dispatch board** (`routes/dispatch.ts`): any active user whose role is **not** `admin/owner/office/super_admin`, **plus** office/admin tagged `field`/`technician`.
- **Add Team Member picker** (`/api/users/techs-with-status`): strictly `role IN ('technician','team_lead')`.

So any cleaner on the board carrying a role other than those two (or an office/admin who also cleans, tagged `field`) **vanishes from the picker**.

## Fix

Aligned the picker's predicate to the board's **exactly** — the people you see on the board are now the people you can add to a job. One-line predicate swap; tenant/branch/exclude logic untouched.

## Note on the second report ("same issue with drag and drop")
Drag-drop reassign uses a different path (`PUT /api/jobs/:id` onto a board lane, which already uses the broad field-worker set), so it shouldn't share this cause. I want a touch more detail to fix it confidently — does the dragged job **snap back**, throw an error, or land but not stick? I'll chase it next.

## Verification
- api-server build passes. I couldn't reproduce against the live DB from here (no creds in the sandbox), but the predicate now provably matches the board, so anyone visible on the board is selectable.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_