### PR TITLE
fix(dispatch): drag-to-assign didn't work on touch devices

### DIFF
--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -9,7 +9,7 @@ import { mapsDirectionsUrl } from "@/lib/format-address";
 import { JobWizard } from "@/components/job-wizard";
 import EditJobModal from "@/components/edit-job-modal";
 import {
-  DndContext, DragOverlay, PointerSensor, useSensor, useSensors,
+  DndContext, DragOverlay, MouseSensor, TouchSensor, useSensor, useSensors,
   useDraggable, useDroppable, type DragEndEvent, type DragStartEvent,
 } from "@dnd-kit/core";
 import {
@@ -5752,7 +5752,15 @@ export default function JobsPage() {
   })();
 
   // DnD
-  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 6 } }));
+  // [drag-drop touch fix 2026-06-11] A single PointerSensor with a distance
+  // constraint never starts a drag on touch — the browser claims the gesture as
+  // a scroll first, so the dispatch board's drag-to-assign did nothing on a
+  // phone/tablet ("can't drag and drop"). Split into MouseSensor (desktop, 6px)
+  // + TouchSensor (press-and-hold ~180ms then drag; a quick swipe still scrolls).
+  const sensors = useSensors(
+    useSensor(MouseSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 180, tolerance: 8 } }),
+  );
   function onDragStart(e: DragStartEvent) { setDraggingJob(e.active.data.current?.job ?? null); }
   async function onDragEnd(e: DragEndEvent) {
     setDraggingJob(null);


### PR DESCRIPTION
## Bug (office — Maribel, from a phone)

"Still same issue with drag and drop" — dragging a job onto a cleaner on the dispatch board did nothing.

## Root cause

The board's dnd-kit setup was a single **`PointerSensor` with a 6px distance** activation:
```ts
useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 6 } }))
```
On a **touch device** the browser claims the gesture as a **scroll** before that drag can start, so drag-to-assign never initiated on a phone/tablet. (Works fine with a mouse — which is why it looked "broken" only for the office on mobile.)

## Fix

Split into the dnd-kit-recommended dual-sensor setup:
```ts
useSensors(
  useSensor(MouseSensor, { activationConstraint: { distance: 6 } }),       // desktop
  useSensor(TouchSensor, { activationConstraint: { delay: 180, tolerance: 8 } }), // mobile: press-hold then drag
)
```
On touch you now **press-and-hold ~180ms, then drag** to reassign; a quick swipe still scrolls the board. Desktop mouse behavior is unchanged. **Reassign + reschedule logic is untouched — only how a drag is recognized.**

## Note
This pairs with #416 (Add Team Member picker). Inferred from the mobile screenshots since I couldn't watch the repro — if drag-drop was *also* failing on desktop, there's a second cause and I'll keep digging, but the touch sensor was a definite gap.

## Verification
- Frontend build passes.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_