### PR TITLE
fix(dispatch): Add Tech picker empty during work hours (real cause) + rename

### DIFF
--- a/artifacts/api-server/src/routes/users.ts
+++ b/artifacts/api-server/src/routes/users.ts
@@ -139,21 +139,32 @@ router.get("/techs-with-status", requireAuth, async (req, res) => {
        ORDER BY u.first_name, u.last_name
     `);
 
-    // Fetch client names for any active_job_ids (small set — typically < 30 techs).
+    // Client-name enrichment for the "currently at <client>" label. BEST-EFFORT
+    // ONLY — it must never be able to blank out the whole tech list.
+    // [fix 2026-06-12] The previous `sql\`id = ANY(${activeJobIds})\`` bound a JS
+    // array straight into ANY(), which throws — and this block only runs when a
+    // tech is clocked in, so during work hours it 500'd the endpoint and the Add
+    // Tech picker showed "No available technicians". Use inArray() for a correct
+    // array bind, and wrap in try/catch so a failure degrades the label, not the
+    // list.
     const activeJobIds = Array.from(new Set((rows.rows as any[]).map(r => r.active_job_id).filter((v): v is number => typeof v === "number")));
     const clientByJob = new Map<number, string>();
     if (activeJobIds.length > 0) {
-      const jobRows = await db
-        .select({
-          job_id: jobsTable.id,
-          first_name: clientsTable.first_name,
-          last_name: clientsTable.last_name,
-        })
-        .from(jobsTable)
-        .leftJoin(clientsTable, eq(jobsTable.client_id, clientsTable.id))
-        .where(and(eq(jobsTable.company_id, companyId), sql`${jobsTable.id} = ANY(${activeJobIds})`));
-      for (const j of jobRows) {
-        clientByJob.set(j.job_id, `${j.first_name ?? ""} ${j.last_name ?? ""}`.trim() || "Unknown");
+      try {
+        const jobRows = await db
+          .select({
+            job_id: jobsTable.id,
+            first_name: clientsTable.first_name,
+            last_name: clientsTable.last_name,
+          })
+          .from(jobsTable)
+          .leftJoin(clientsTable, eq(jobsTable.client_id, clientsTable.id))
+          .where(and(eq(jobsTable.company_id, companyId), inArray(jobsTable.id, activeJobIds)));
+        for (const j of jobRows) {
+          clientByJob.set(j.job_id, `${j.first_name ?? ""} ${j.last_name ?? ""}`.trim() || "Unknown");
+        }
+      } catch (enrichErr) {
+        console.error("techs-with-status client-name enrichment failed (non-fatal):", enrichErr);
       }
     }
 

--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -2064,7 +2064,7 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
                     <button onClick={() => !isLocked && setAddTechOpen(true)}
                       disabled={isLocked}
                       style={{ display: "inline-flex", alignItems: "center", gap: 4, padding: "3px 9px", fontSize: 11, fontWeight: 700, color: isLocked ? "#9E9B94" : "#2D9B83", border: `1px dashed ${isLocked ? "#D1D5DB" : "#2D9B83"}`, borderRadius: 999, background: "transparent", cursor: isLocked ? "not-allowed" : "pointer", fontFamily: FF, opacity: isLocked ? 0.6 : 1 }}>
-                      <Plus size={11} /> Add helper
+                      <Plus size={11} /> Add tech
                     </button>
                   )}
                 </div>
@@ -2357,7 +2357,7 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
               <button onClick={() => !isLocked && setAddTechOpen(true)}
                 disabled={isLocked}
                 style={{ marginTop: 8, width: "100%", height: 32, display: "flex", alignItems: "center", justifyContent: "center", gap: 6, fontSize: 12, fontWeight: 600, color: isLocked ? "#9E9B94" : "#2D9B83", border: `1px dashed ${isLocked ? "#D1D5DB" : "#2D9B83"}`, borderRadius: 8, background: "transparent", cursor: isLocked ? "not-allowed" : "pointer", fontFamily: FF, opacity: isLocked ? 0.6 : 1 }}>
-                <Plus size={12} /> Add Team Member
+                <Plus size={12} /> Add tech
               </button>
             </PS>
           )}
@@ -2418,7 +2418,7 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
               <div onClick={() => setAddTechOpen(false)} style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,0.3)", zIndex: 300 }} />
               <div style={{ position: "fixed", top: "50%", left: "50%", transform: "translate(-50%, -50%)", zIndex: 301, width: 340, backgroundColor: "#FFFFFF", borderRadius: 12, boxShadow: "0 12px 40px rgba(0,0,0,0.2)", fontFamily: FF, overflow: "hidden" }}>
                 <div style={{ padding: "16px 20px", borderBottom: "1px solid #E5E2DC", display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-                  <span style={{ fontSize: 15, fontWeight: 700, color: "#1A1917" }}>Add Team Member</span>
+                  <span style={{ fontSize: 15, fontWeight: 700, color: "#1A1917" }}>Add tech</span>
                   <button onClick={() => setAddTechOpen(false)} style={{ border: "none", background: "none", cursor: "pointer", color: "#9E9B94", padding: 4 }}><X size={16} /></button>
                 </div>
                 <div style={{ padding: "12px 20px", maxHeight: 360, overflowY: "auto" }}>


### PR DESCRIPTION
## The real cause (my #416 was wrong)

#416 assumed a too-narrow role filter — but those cleaners are role `technician` and matched **either** filter, so the list stayed empty. Real bug:

`/api/users/techs-with-status` enriches each tech with the client they're "currently at" using:
```ts
.where(and(eq(jobsTable.company_id, companyId), sql`${jobsTable.id} = ANY(${activeJobIds})`))
```
That binds a **JS array straight into `ANY()`, which throws.** And the block **only runs when a tech is clocked in** — so during work hours `activeJobIds` is non-empty → the whole endpoint **500s** → the picker shows "No available technicians." The board kept working because it's a different endpoint. Off-hours (nobody clocked in) the block was skipped and the list populated — hence the "intermittent" feel.

## Fix
- Correct array bind: `inArray(jobsTable.id, activeJobIds)`.
- Wrap the enrichment in `try/catch` so a label lookup can **never blank the whole list again** — it degrades the "currently at" text, not the picker.

## Also (per request)
Renamed **"Add helper" / "Add Team Member" → "Add tech"** ("helper" reads unprofessional).

## Next
Smart-suggestion feature (scan schedule → top 1–2 available/closest, then full team) is a follow-up PR.

## Verification
- api-server + frontend builds pass. This time the fix is in the code path that actually 500s during work hours, with a guard so it can't regress to a blank list.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_