### PR TITLE
fix(dispatch): Add tech picker — real techs only (exclude sandbox/archived)

### DIFF
--- a/artifacts/api-server/src/routes/users.ts
+++ b/artifacts/api-server/src/routes/users.ts
@@ -118,6 +118,11 @@ router.get("/techs-with-status", requireAuth, async (req, res) => {
                ORDER BY tc.clock_in_at DESC LIMIT 1) AS active_job_id
         FROM users u
        WHERE u.is_active = true
+         -- [real-techs-only 2026-06-12] Exclude sandbox/test logins and archived
+         -- staff (e.g. "Test Auditor", "Generic Cleaner") — the canonical
+         -- "real active tech" filter used elsewhere (admin.ts).
+         AND u.archived_at IS NULL
+         AND COALESCE(u.is_sandbox, false) = false
          -- [add-team-member fix 2026-06-11] Match the dispatch board field-worker
          -- rule EXACTLY (routes/dispatch.ts): any active user who is not
          -- office/admin/owner, plus office/admin explicitly tagged field or


### PR DESCRIPTION
## What

"Generic Cleaner" / "Test Auditor" were showing in the **Add tech** picker. The `techs-with-status` query filtered `is_active` but not the rest of the canonical "real active tech" rule used elsewhere (`admin.ts`). Added:
```sql
AND u.archived_at IS NULL
AND COALESCE(u.is_sandbox, false) = false
```
so only real, active staff populate the list.

## Note
This catches anything flagged `is_sandbox` or archived. If **"Generic Cleaner"** still appears after deploy, that account simply isn't flagged as sandbox — archive it (or set `is_sandbox`) on its employee record and it'll drop off.

## Verification
- api-server build passes.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_