### PR TITLE
fix(dispatch): stale open punches faked "currently on a job" + flag test accounts

### DIFF
--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -57,6 +57,17 @@ async function runBookingSchemaGuard(): Promise<void> {
       WHERE j.account_property_id = ap.id
         AND j.job_lat IS NULL AND ap.lat IS NOT NULL
     ` },
+    // [real-techs-only 2026-06-12] Flag Phes's known placeholder/test logins as
+    // sandbox so the Add tech picker (which filters is_sandbox) stops listing
+    // them. They were never flagged in the DB, so the #420 filter alone didn't
+    // drop them. is_sandbox keeps them OFF the picker while leaving their board
+    // rows/history intact (the dispatch board doesn't filter sandbox).
+    { label: "flag Generic Cleaner / Test Auditor as sandbox", stmt: `
+      UPDATE users SET is_sandbox = true
+      WHERE company_id = 1
+        AND COALESCE(is_sandbox, false) = false
+        AND lower(trim(COALESCE(first_name,'') || ' ' || COALESCE(last_name,''))) IN ('generic cleaner', 'test auditor')
+    ` },
     // ── jobs extra columns ──────────────────────────────────────────────────
     { label: "jobs.home_condition_rating", stmt: "ALTER TABLE jobs ADD COLUMN IF NOT EXISTS home_condition_rating INTEGER" },
     // [ghl-estimate-bridge 2026-06-10] GoHighLevel inbound-webhook URLs for

--- a/artifacts/api-server/src/routes/users.ts
+++ b/artifacts/api-server/src/routes/users.ts
@@ -115,6 +115,11 @@ router.get("/techs-with-status", requireAuth, async (req, res) => {
              (SELECT tc.job_id FROM timeclock tc
                WHERE tc.user_id = u.id
                  AND tc.clock_out_at IS NULL
+                 -- [stale-punch fix 2026-06-12] Only TODAY's open punches count as
+                 -- "currently on a job". Without this, an office-keyed IN with no
+                 -- OUT from a previous day (e.g. MC reconciliation) marked the
+                 -- tech as on that job indefinitely.
+                 AND tc.clock_in_at::date = CURRENT_DATE
                ORDER BY tc.clock_in_at DESC LIMIT 1) AS active_job_id
         FROM users u
        WHERE u.is_active = true


### PR DESCRIPTION
## Bug 1 — Alma showing "Currently at: Jaira Estrada" without using the app

Confirmed: **not** the field app, and not live data. The Add tech picker decides "currently on a job" via a clock-entry subquery that matched **any** entry with no clock-out — **no date limit**. An office-keyed IN with no OUT from a previous day (e.g. the MC time-clock reconciliation) marked Alma as on that job **indefinitely**.

**Fix:** the subquery now only counts punches clocked in **today** (`clock_in_at::date = CURRENT_DATE`). Same-day punches — field app *or* office-entered — still show correctly (Juliana's real punch is unaffected).

**Cleanup tip:** the dangling entry itself is still in the data — on the Time Clock page (yesterday's date), Alma's Jaira Estrada row will have an IN with an empty OUT. Key an OUT or delete the punch to tidy it.

## Bug 2 — Generic Cleaner / Test Auditor still in the picker

They were never flagged in the DB, so the #420 `is_sandbox` filter had nothing to catch. Added an idempotent Phes migration guard flagging those two known placeholder logins `is_sandbox = true` — they drop off the **picker** (and Suggested), while their **dispatch-board rows/history stay intact** (the board doesn't filter sandbox).

## Verification
- api-server build passes. Migration guard is idempotent (`COALESCE(is_sandbox,false) = false` predicate) and Phes-scoped (`company_id = 1`).

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_