### PR TITLE
fix(dispatch): branch-isolate the Add tech candidate pool (item 1: the pool)

### DIFF
--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -1614,8 +1614,15 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
     const existingIds = new Set<number>();
     for (const t of (job.technicians ?? [])) existingIds.add(t.user_id);
     if (job.assigned_user_id) existingIds.add(job.assigned_user_id);
-    const excludeParam = existingIds.size ? `?exclude=${Array.from(existingIds).join(",")}` : "";
-    fetch(`${_API3}/api/users/techs-with-status${excludeParam}`, { headers: { Authorization: `Bearer ${token}` } })
+    // [pool 2026-06-12] Branch-isolate the candidate pool: an Oak Lawn job
+    // should only offer Oak Lawn (or branch-less) techs. The endpoint already
+    // supports ?branch_id and treats NULL home_branch as dispatchable anywhere;
+    // the modal just never passed it.
+    const params = new URLSearchParams();
+    if (existingIds.size) params.set("exclude", Array.from(existingIds).join(","));
+    if (job.branch_id != null) params.set("branch_id", String(job.branch_id));
+    const qs = params.toString() ? `?${params}` : "";
+    fetch(`${_API3}/api/users/techs-with-status${qs}`, { headers: { Authorization: `Bearer ${token}` } })
       .then(r => r.json())
       .then(d => setAddTechList(Array.isArray(d?.data) ? d.data : []))
       .catch(() => setAddTechList([]))


### PR DESCRIPTION
## Item 1 of the smart-suggestion review: the candidate pool

Audit of who enters the Add tech pool found one gap: the modal fetched `/api/users/techs-with-status` **without the job's branch**, so an Oak Lawn job could list Schaumburg techs as candidates (and vice versa).

The endpoint already supports `?branch_id` — with the right semantics (`NULL home_branch` techs stay dispatchable anywhere) — the modal just never passed it. Now it sends `job.branch_id` when the job has one.

## Pool rules after this PR (item 1 complete)
- Active, **real** techs only (no sandbox/test, no archived) — #420/#424
- Field-worker rule matches the dispatch board — #418
- **Same branch as the job** (or branch-less) — this PR
- Excludes techs already on the job

## Verification
- Frontend build passes.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_