### PR TITLE
chore: default Claude Code sessions on this repo to Fable 5

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,3 @@
+{
+  "model": "claude-fable-5"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -55,4 +55,5 @@ migration/
 !.env.example
 
 # Per-developer tool config (contains absolute paths)
-.claude/
+.claude/*
+!.claude/settings.json


### PR DESCRIPTION
## What

Makes **Fable 5 the default model for every Claude Code session on this repo** — the static fix for "/model keeps defaulting back to Opus."

## Why it kept reverting
- `/model` only applies to the **live connection**; cloud sessions fall back to the configured default when they re-attach.
- The earlier `settings.local.json` attempt was **gitignored**, so it only existed in one ephemeral container — new sessions clone fresh and never saw it.

## Changes
- **`.claude/settings.json`** (committed): `{ "model": "claude-fable-5" }` — read at session start by every new session on this repo. Falls back gracefully on surfaces where Fable isn't available.
- **`.gitignore`**: narrowed the blanket `.claude/` ignore to `.claude/*` + `!.claude/settings.json`, so the shared settings file can be committed while personal files (`settings.local.json`, caches) stay ignored.

## Note
This applies to anyone opening Claude Code on this repo. In-flight sessions keep their current model until restarted.

https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkABaEdY8hFWXD4onZjzj)_