### PR TITLE
Efficiency engine: live auto-compute on job completion

### DIFF
--- a/artifacts/api-server/src/lib/efficiency-engine.ts
+++ b/artifacts/api-server/src/lib/efficiency-engine.ts
@@ -1,0 +1,124 @@
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+// Resolve a completed job's service_type → the Qleno package name efficiency is
+// keyed to. Commercial: service_type enum === commercial_service_types.slug.
+// Residential: explicit map; standard_clean splits by recurrence. Returns null
+// for non-scored scopes (carpet, hourly, anything not in the 12-package catalog).
+export function resolvePackage(
+  serviceType: string,
+  isRecurring: boolean,
+  commercialNameBySlug: ReadonlyMap<string, string>,
+): string | null {
+  const st = (serviceType || "").toLowerCase();
+  if (commercialNameBySlug.has(st)) return commercialNameBySlug.get(st)!;
+  switch (st) {
+    case "deep_clean":
+    case "move_in":
+    case "move_out":
+      return "Deep Clean or Move In/Out";
+    case "recurring":
+      return "Recurring Cleaning";
+    case "standard_clean":
+      return isRecurring ? "Recurring Cleaning" : "One-Time Flat-Rate Standard Cleaning";
+    default:
+      return null;
+  }
+}
+
+const RECURRING_FREQUENCIES = new Set(["weekly", "biweekly", "bi-weekly", "every_2_weeks", "every_4_weeks", "monthly", "quarterly", "custom_days", "weekdays", "daily"]);
+function jobIsRecurring(frequency: string | null, recurringScheduleId: number | null): boolean {
+  if (recurringScheduleId != null) return true;
+  const f = (frequency || "").toLowerCase();
+  return RECURRING_FREQUENCIES.has(f);
+}
+
+async function commercialMap(companyId: number): Promise<Map<string, string>> {
+  const r = await db.execute(sql`SELECT slug, name FROM commercial_service_types WHERE company_id = ${companyId} AND is_active = true`);
+  return new Map((r.rows as any[]).map(x => [String(x.slug).toLowerCase(), String(x.name)]));
+}
+
+// Recompute the hours-weighted qleno rollup for one (employee, package):
+// efficiency_pct = 100 × Σ allowed_share ÷ Σ actual_hours over that employee's
+// qleno efficiency_entries for the package. Upserts employee_efficiency.
+async function rollupEmployeePackage(companyId: number, employeeId: number, pkg: string): Promise<void> {
+  const agg = await db.execute(sql`
+    SELECT SUM(allowed_share)::numeric AS a, SUM(actual_hours)::numeric AS h
+      FROM efficiency_entries
+     WHERE company_id = ${companyId} AND employee_id = ${employeeId} AND package = ${pkg} AND source = 'qleno'
+  `);
+  const row: any = agg.rows[0];
+  const a = row?.a != null ? parseFloat(row.a) : 0;
+  const h = row?.h != null ? parseFloat(row.h) : 0;
+  if (h <= 0) return;
+  const pct = Math.round((100 * a / h) * 100) / 100;
+  await db.execute(sql`
+    INSERT INTO employee_efficiency (company_id, employee_id, service_type, efficiency_pct, source, period, updated_at)
+    VALUES (${companyId}, ${employeeId}, ${pkg}, ${String(pct)}, 'qleno', 'all_time', NOW())
+    ON CONFLICT (company_id, employee_id, service_type, period)
+    DO UPDATE SET efficiency_pct = ${String(pct)}, source = 'qleno', updated_at = NOW()
+  `);
+}
+
+// Compute + persist per-(job,tech) efficiency for ONE completed job, then refresh
+// the affected (employee, package) rollups. Idempotent (upserts by job+employee).
+// Returns the number of per-tech entries written. Non-fatal on bad data (skips).
+export async function recomputeJobEfficiency(jobId: number, companyId: number): Promise<number> {
+  const jr = await db.execute(sql`
+    SELECT id, service_type, frequency, recurring_schedule_id, allowed_hours, scheduled_date, status
+      FROM jobs WHERE id = ${jobId} AND company_id = ${companyId} LIMIT 1
+  `);
+  const job: any = jr.rows[0];
+  if (!job || job.status !== "complete") return 0;
+  const allowed = job.allowed_hours != null ? parseFloat(job.allowed_hours) : 0;
+  if (!Number.isFinite(allowed) || allowed <= 0) return 0;
+
+  const cmap = await commercialMap(companyId);
+  const pkg = resolvePackage(job.service_type, jobIsRecurring(job.frequency, job.recurring_schedule_id), cmap);
+  if (!pkg) return 0;
+
+  // Per-tech clocked hours from punched timeclock entries (same basis as pay).
+  const hr = await db.execute(sql`
+    SELECT user_id, SUM(EXTRACT(EPOCH FROM (clock_out_at - clock_in_at)) / 3600.0)::numeric AS hours
+      FROM timeclock
+     WHERE company_id = ${companyId} AND job_id = ${jobId}
+       AND clock_out_at IS NOT NULL AND source = 'punched'
+     GROUP BY user_id
+  `);
+  const techHours = (hr.rows as any[])
+    .map(r => ({ user_id: Number(r.user_id), hours: parseFloat(r.hours) }))
+    .filter(t => Number.isFinite(t.hours) && t.hours > 0);
+  const total = techHours.reduce((s, t) => s + t.hours, 0);
+  if (total <= 0) return 0;
+
+  const entryDate = String(job.scheduled_date).slice(0, 10);
+  const affected: number[] = [];
+  for (const t of techHours) {
+    const allowedShare = allowed * (t.hours / total);
+    const ratio = Math.round((100 * allowedShare / t.hours) * 100) / 100; // = 100×allowed/total
+    await db.execute(sql`
+      INSERT INTO efficiency_entries (company_id, employee_id, job_id, package, allowed_share, actual_hours, ratio, source, entry_date)
+      VALUES (${companyId}, ${t.user_id}, ${jobId}, ${pkg}, ${String(allowedShare.toFixed(3))}, ${String(t.hours.toFixed(3))}, ${String(ratio)}, 'qleno', ${entryDate})
+      ON CONFLICT (job_id, employee_id)
+      DO UPDATE SET package = ${pkg}, allowed_share = ${String(allowedShare.toFixed(3))},
+                    actual_hours = ${String(t.hours.toFixed(3))}, ratio = ${String(ratio)}, entry_date = ${entryDate}
+    `);
+    affected.push(t.user_id);
+  }
+  for (const uid of affected) await rollupEmployeePackage(companyId, uid, pkg);
+  return affected.length;
+}
+
+// Backfill: recompute qleno efficiency from every completed job for a company.
+// Returns { jobs_scanned, entries_written }.
+export async function recomputeAllEfficiency(companyId: number): Promise<{ jobs_scanned: number; entries_written: number }> {
+  const jr = await db.execute(sql`
+    SELECT id FROM jobs WHERE company_id = ${companyId} AND status = 'complete'
+      AND allowed_hours IS NOT NULL AND allowed_hours::numeric > 0
+    ORDER BY id
+  `);
+  const ids = (jr.rows as any[]).map(r => Number(r.id));
+  let entries = 0;
+  for (const id of ids) entries += await recomputeJobEfficiency(id, companyId);
+  return { jobs_scanned: ids.length, entries_written: entries };
+}

--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -1335,6 +1335,26 @@ async function runBookingSchemaGuard(): Promise<void> {
     ` },
     { label: "idx_employee_efficiency_emp",
       stmt: `CREATE INDEX IF NOT EXISTS idx_employee_efficiency_emp ON employee_efficiency(company_id, employee_id)` },
+
+    // ── Efficiency per-job audit (drives the rolled-up employee_efficiency) ──
+    { label: "CREATE efficiency_entries", stmt: `
+      CREATE TABLE IF NOT EXISTS efficiency_entries (
+        id            SERIAL PRIMARY KEY,
+        company_id    INTEGER NOT NULL REFERENCES companies(id),
+        employee_id   INTEGER NOT NULL REFERENCES users(id),
+        job_id        INTEGER NOT NULL REFERENCES jobs(id),
+        package       TEXT NOT NULL,
+        allowed_share NUMERIC(8,3) NOT NULL,
+        actual_hours  NUMERIC(8,3) NOT NULL,
+        ratio         NUMERIC(6,2) NOT NULL,
+        source        TEXT NOT NULL DEFAULT 'qleno',
+        entry_date    DATE NOT NULL,
+        created_at    TIMESTAMP NOT NULL DEFAULT NOW(),
+        CONSTRAINT uq_efficiency_entries_job_emp UNIQUE (job_id, employee_id)
+      )
+    ` },
+    { label: "idx_efficiency_entries_emp_pkg",
+      stmt: `CREATE INDEX IF NOT EXISTS idx_efficiency_entries_emp_pkg ON efficiency_entries(company_id, employee_id, package)` },
   ];
 
   for (const { label, stmt } of guards) {

--- a/artifacts/api-server/src/routes/efficiency.ts
+++ b/artifacts/api-server/src/routes/efficiency.ts
@@ -3,6 +3,7 @@ import { db } from "@workspace/db";
 import { employeeEfficiencyTable, usersTable } from "@workspace/db/schema";
 import { eq, and, sql, desc, inArray } from "drizzle-orm";
 import { requireAuth, requireRole } from "../lib/auth.js";
+import { recomputeAllEfficiency } from "../lib/efficiency-engine.js";
 
 const router = Router();
 
@@ -60,7 +61,7 @@ router.get("/:employee_id", requireAuth, async (req, res) => {
     const employeeId = parseInt(req.params.employee_id);
     if (isNaN(employeeId)) return res.status(400).json({ error: "Invalid employee_id" });
 
-    const rows = await db
+    const allRows = await db
       .select()
       .from(employeeEfficiencyTable)
       .where(and(
@@ -68,6 +69,15 @@ router.get("/:employee_id", requireAuth, async (req, res) => {
         eq(employeeEfficiencyTable.employee_id, employeeId),
       ))
       .orderBy(desc(employeeEfficiencyTable.efficiency_pct));
+
+    // One effective row per package, preferring live source='qleno' over the
+    // imported 'mc' baseline (qleno wins regardless of value).
+    const byPkg = new Map<string, any>();
+    for (const r of allRows) {
+      const ex = byPkg.get(r.service_type);
+      if (!ex || (r.source === "qleno" && ex.source !== "qleno")) byPkg.set(r.service_type, r);
+    }
+    const rows = [...byPkg.values()];
 
     const catalog = await loadCatalog(companyId);
     const vals = rows.map(r => parseFloat(r.efficiency_pct)).filter(n => Number.isFinite(n) && n > 0);
@@ -77,6 +87,19 @@ router.get("/:employee_id", requireAuth, async (req, res) => {
   } catch (err) {
     console.error("Efficiency fetch error:", err);
     return res.status(500).json({ error: "Internal Server Error", message: "Failed to fetch efficiency" });
+  }
+});
+
+// POST /api/efficiency/recompute (owner/admin) — backfill the live source='qleno'
+// efficiency from every completed job (allowed vs actual clocked hours). Safe to
+// re-run; leaves the imported source='mc' baseline untouched.
+router.post("/recompute", requireAuth, requireRole("owner", "admin"), async (req, res) => {
+  try {
+    const result = await recomputeAllEfficiency(req.auth!.companyId!);
+    return res.json({ ok: true, ...result });
+  } catch (err) {
+    console.error("Efficiency recompute error:", err);
+    return res.status(500).json({ error: "Internal Server Error", message: "Failed to recompute efficiency" });
   }
 });
 

--- a/artifacts/api-server/src/routes/jobs.ts
+++ b/artifacts/api-server/src/routes/jobs.ts
@@ -3639,6 +3639,16 @@ router.post("/:id/complete", requireAuth, async (req, res) => {
     }
     // ─────────────────────────────────────────────────────────────────────
 
+    // ── efficiency auto-compute (non-blocking) ────────────────────────────
+    // allowed/budgeted hrs ÷ actual clocked hrs → employee_efficiency
+    // (source='qleno'), per package, tenant-scoped. Skips cleanly if the
+    // job lacks allowed_hours or no clock-out yet (the recompute endpoint /
+    // a later run picks it up). Never blocks completion.
+    import("../lib/efficiency-engine.js").then(({ recomputeJobEfficiency }) =>
+      recomputeJobEfficiency(jobId, companyId).catch((e) =>
+        console.error("[efficiency] recompute on complete failed:", e?.message ?? e)),
+    ).catch(() => {});
+
     return res.json({
       ...updated[0],
       client_name: jobDetail[0]?.client_name ?? "",

--- a/artifacts/api-server/src/routes/users.ts
+++ b/artifacts/api-server/src/routes/users.ts
@@ -57,9 +57,13 @@ router.get("/", requireAuth, async (req, res) => {
       SELECT u.id, u.email, u.first_name, u.last_name, u.role::text AS role,
              u.pay_rate, u.pay_type::text AS pay_type, u.is_active,
              u.hire_date, u.avatar_url, u.scorecard_pct,
-             (SELECT ROUND(AVG(ee.efficiency_pct))::int FROM employee_efficiency ee
-               WHERE ee.employee_id = u.id AND ee.company_id = u.company_id
-                 AND ee.efficiency_pct > 0) AS avg_efficiency
+             (SELECT ROUND(AVG(d.pct))::int FROM (
+                SELECT DISTINCT ON (ee.service_type) ee.efficiency_pct AS pct
+                  FROM employee_efficiency ee
+                 WHERE ee.employee_id = u.id AND ee.company_id = u.company_id
+                   AND ee.efficiency_pct > 0
+                 ORDER BY ee.service_type, (ee.source = 'qleno') DESC
+              ) d) AS avg_efficiency
         FROM users u
        WHERE ${whereClause}
        ORDER BY u.first_name, u.last_name

--- a/lib/db/src/schema/efficiency_entries.ts
+++ b/lib/db/src/schema/efficiency_entries.ts
@@ -1,0 +1,33 @@
+import { pgTable, serial, integer, numeric, text, date, timestamp, unique, index } from "drizzle-orm/pg-core";
+import { createInsertSchema } from "drizzle-zod";
+import { z } from "zod/v4";
+import { companiesTable } from "./companies";
+import { usersTable } from "./users";
+import { jobsTable } from "./jobs";
+
+// Per-(job, tech) efficiency audit row — the drill-down behind the rolled-up
+// employee_efficiency aggregate. Captured on job completion (source='qleno').
+// efficiency for a job/tech = allowed_share ÷ actual_hours × 100, where
+// allowed_share = job.allowed_hours × (this tech's clocked share). The rollup
+// (employee_efficiency) is hours-weighted: 100 × Σallowed_share ÷ Σactual_hours
+// over the employee's entries for a package. One row per (job, employee).
+export const efficiencyEntriesTable = pgTable("efficiency_entries", {
+  id: serial("id").primaryKey(),
+  company_id: integer("company_id").references(() => companiesTable.id).notNull(),
+  employee_id: integer("employee_id").references(() => usersTable.id).notNull(),
+  job_id: integer("job_id").references(() => jobsTable.id).notNull(),
+  package: text("package").notNull(), // resolved Qleno package name
+  allowed_share: numeric("allowed_share", { precision: 8, scale: 3 }).notNull(),
+  actual_hours: numeric("actual_hours", { precision: 8, scale: 3 }).notNull(),
+  ratio: numeric("ratio", { precision: 6, scale: 2 }).notNull(), // efficiency %
+  source: text("source").notNull().default("qleno"),
+  entry_date: date("entry_date").notNull(),
+  created_at: timestamp("created_at").notNull().defaultNow(),
+}, (t) => [
+  unique("uq_efficiency_entries_job_emp").on(t.job_id, t.employee_id),
+  index("idx_efficiency_entries_emp_pkg").on(t.company_id, t.employee_id, t.package),
+]);
+
+export const insertEfficiencyEntrySchema = createInsertSchema(efficiencyEntriesTable).omit({ id: true, created_at: true });
+export type InsertEfficiencyEntry = z.infer<typeof insertEfficiencyEntrySchema>;
+export type EfficiencyEntry = typeof efficiencyEntriesTable.$inferSelect;

--- a/lib/db/src/schema/index.ts
+++ b/lib/db/src/schema/index.ts
@@ -9,6 +9,7 @@ export * from "./invoices";
 export * from "./scorecards";
 export * from "./scorecard_entries";
 export * from "./employee_efficiency";
+export * from "./efficiency_entries";
 export * from "./additional_pay";
 export * from "./loyalty";
 export * from "./audit_log";


### PR DESCRIPTION
Auto-computes efficiency = allowed/budgeted hrs ÷ actual clocked hrs, per employee×package, on job completion (source='qleno'), coexisting with the imported source='mc' baseline. New efficiency_entries audit table (per job,tech); lib/efficiency-engine.ts (package resolver + hours-weighted rollup); completion hook in jobs.ts; POST /api/efficiency/recompute backfill; GET + list-avg prefer qleno over mc. Tenant-scoped. After deploy: run recompute to seed from existing completed jobs (incl. Juliana's). Generated with Claude Code.