### PR TITLE
Connect all revenue reporting to live jobs (job_history bridge + live Payroll % KPI)

### DIFF
--- a/artifacts/api-server/src/index.ts
+++ b/artifacts/api-server/src/index.ts
@@ -12,6 +12,7 @@ import { runSmokeTests } from "./lib/smoke-test.js";
 import { runAnnualCycleAutoOpen } from "./lib/lms-annual-cycle-cron.js";
 import { runLmsCompletionBackfill } from "./lib/lms-completion-backfill.js";
 import { runLmsCertificateBackfill } from "./lib/lms-certificate-backfill.js";
+import { ensureJobHistoryLiveBridgeSchema, syncJobHistoryLiveBridge } from "./lib/job-history-sync.js";
 
 const port = Number(process.env.PORT) || 3000;
 
@@ -165,6 +166,19 @@ async function startup() {
   } catch (err: any) {
     console.error("[startup] runCutoverDataMigration — non-fatal:", err?.message ?? err);
   }
+  // [revenue-connect 2026-06-12] job_history live bridge — mirrors completed
+  // jobs into the revenue ledger past each tenant's MC-import end date, so
+  // the dashboard forecast / business health / client history stay live
+  // after the MC cutover instead of freezing at the last imported week.
+  try {
+    await ensureJobHistoryLiveBridgeSchema();
+    const r = await syncJobHistoryLiveBridge();
+    if (r.inserted || r.updated || r.removed) {
+      console.log(`[job-history-bridge] startup sync: +${r.inserted} ~${r.updated} -${r.removed}`);
+    }
+  } catch (err: any) {
+    console.error("[startup] job-history bridge — non-fatal:", err?.message ?? err);
+  }
   // Cutover 1E — self-check that the 1C GPS-integrity CHECK constraint
   // is live AND enforced in production. Non-fatal: pay computation
   // independently filters at the application layer, but the deploy log
@@ -245,6 +259,22 @@ async function startup() {
   }, 5000); // 5s delay to let migrations finish
   startNotificationCron();
   startFollowUpCron();
+
+  // [revenue-connect 2026-06-12] Hourly job_history re-sync — keeps the
+  // revenue ledger current so yesterday's completions appear in the
+  // dashboard forecast next morning (the forecast reads past days from
+  // job_history, not the jobs table). Cheap: set-based statements gated
+  // by NOT EXISTS / IS DISTINCT FROM.
+  setInterval(async () => {
+    try {
+      const r = await syncJobHistoryLiveBridge();
+      if (r.inserted || r.updated || r.removed) {
+        console.log(`[job-history-bridge] sync: +${r.inserted} ~${r.updated} -${r.removed}`);
+      }
+    } catch (err: any) {
+      console.error("[job-history-bridge] tick failed:", err?.message);
+    }
+  }, 60 * 60 * 1000);
 
   // QuickBooks sync queue drain worker — every 60s, runs syncAll() for each
   // QB-connected tenant. Retries failed rows up to attempts<3 (logic lives in

--- a/artifacts/api-server/src/lib/job-history-sync.ts
+++ b/artifacts/api-server/src/lib/job-history-sync.ts
@@ -1,0 +1,103 @@
+/**
+ * [revenue-connect 2026-06-12] job_history live bridge.
+ *
+ * job_history is the revenue ledger every reporting surface reads (dashboard
+ * weekly forecast actuals, business health rate-trend/avg-bill, payroll %
+ * KPI denominator, prior-year chart, client last-service/job-history). It
+ * was only ever written by the MaidCentral import, so it froze at the MC
+ * cutover and every reader showed $0 for post-cutover weeks while the
+ * payroll page (live jobs table) showed real numbers.
+ *
+ * This bridge mirrors COMPLETED jobs from the live jobs table into the
+ * ledger, per company, strictly AFTER that company's MC-ledger end date
+ * (MAX(job_date) of rows with qleno_job_id IS NULL). The cutoff prevents
+ * double-counting the transition window where the same job exists in both
+ * the MC ledger and the jobs table, and keeps the known Jan–Mar jobs-table
+ * corruption out of trend windows — MC rows stay canonical for their era,
+ * live jobs are canonical after it. Companies with no MC rows (fresh Qleno
+ * tenants) mirror their full completed history.
+ *
+ * Revenue uses the canonical jobRevenueExpr (commercial hourly×allowed wins
+ * over the stale billed_amount cache, then billed_amount, then base_fee) so
+ * ledger revenue matches the dispatch board and mobile cards.
+ *
+ * Idempotent + self-healing: re-runs insert only unmirrored jobs, update
+ * mirrored rows that drifted (rebilled / rescheduled / reassigned), and
+ * delete mirrored rows whose job is no longer complete. MC rows
+ * (qleno_job_id IS NULL) are never touched.
+ */
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+import { jobRevenueExpr } from "./job-revenue-sql.js";
+
+export async function ensureJobHistoryLiveBridgeSchema(): Promise<void> {
+  await db.execute(sql.raw(`ALTER TABLE job_history ADD COLUMN IF NOT EXISTS qleno_job_id integer`));
+  await db.execute(sql.raw(
+    `CREATE UNIQUE INDEX IF NOT EXISTS idx_job_history_qleno_job
+       ON job_history(qleno_job_id) WHERE qleno_job_id IS NOT NULL`,
+  ));
+}
+
+export async function syncJobHistoryLiveBridge(): Promise<{ inserted: number; updated: number; removed: number }> {
+  const rev = sql`ROUND(COALESCE(${jobRevenueExpr(sql`CAST(j.base_fee AS NUMERIC)`)}, 0), 2)`;
+  const techName = sql`NULLIF(TRIM(COALESCE(u.first_name, '') || ' ' || COALESCE(u.last_name, '')), '')`;
+
+  const ins = await db.execute(sql`
+    WITH mc_end AS (
+      SELECT company_id, MAX(job_date) AS ledger_end
+        FROM job_history
+       WHERE qleno_job_id IS NULL
+       GROUP BY company_id
+    )
+    INSERT INTO job_history (company_id, customer_id, job_date, revenue, service_type, technician, qleno_job_id)
+    SELECT j.company_id, j.client_id, j.scheduled_date, ${rev}, j.service_type::text, ${techName}, j.id
+      FROM jobs j
+      LEFT JOIN clients c ON c.id = j.client_id
+      LEFT JOIN users u ON u.id = j.assigned_user_id
+      LEFT JOIN mc_end m ON m.company_id = j.company_id
+     WHERE j.status = 'complete'
+       AND j.scheduled_date IS NOT NULL
+       AND (m.ledger_end IS NULL OR j.scheduled_date > m.ledger_end)
+       AND NOT EXISTS (SELECT 1 FROM job_history jh WHERE jh.qleno_job_id = j.id)
+  `);
+
+  const upd = await db.execute(sql`
+    UPDATE job_history jh
+       SET customer_id  = src.client_id,
+           job_date     = src.scheduled_date,
+           revenue      = src.rev,
+           service_type = src.service_type,
+           technician   = src.tech
+      FROM (
+        SELECT j.id, j.client_id, j.scheduled_date, ${rev} AS rev,
+               j.service_type::text AS service_type, ${techName} AS tech
+          FROM jobs j
+          LEFT JOIN clients c ON c.id = j.client_id
+          LEFT JOIN users u ON u.id = j.assigned_user_id
+         WHERE j.status = 'complete' AND j.scheduled_date IS NOT NULL
+      ) src
+     WHERE jh.qleno_job_id = src.id
+       AND (jh.customer_id  IS DISTINCT FROM src.client_id
+         OR jh.job_date     IS DISTINCT FROM src.scheduled_date
+         OR jh.revenue      IS DISTINCT FROM src.rev
+         OR jh.service_type IS DISTINCT FROM src.service_type
+         OR jh.technician   IS DISTINCT FROM src.tech)
+  `);
+
+  const del = await db.execute(sql`
+    DELETE FROM job_history jh
+     WHERE jh.qleno_job_id IS NOT NULL
+       AND NOT EXISTS (
+         SELECT 1 FROM jobs j
+          WHERE j.id = jh.qleno_job_id
+            AND j.status = 'complete'
+            AND j.scheduled_date IS NOT NULL
+       )
+  `);
+
+  return {
+    inserted: (ins as any)?.rowCount ?? 0,
+    updated: (upd as any)?.rowCount ?? 0,
+    removed: (del as any)?.rowCount ?? 0,
+  };
+}

--- a/artifacts/api-server/src/routes/dashboard.ts
+++ b/artifacts/api-server/src/routes/dashboard.ts
@@ -4,6 +4,8 @@ import { jobsTable, clientsTable, usersTable, invoicesTable, timeclockTable, sco
 import { eq, and, or, gte, lte, lt, isNull, count, sum, avg, desc, sql, isNotNull, ne, notInArray } from "drizzle-orm";
 import { requireAuth } from "../lib/auth.js";
 import { jobRevenueExpr } from "../lib/job-revenue-sql.js";
+import { computeCommissionRows, type CommissionInputJob } from "../lib/commission-compute.js";
+import { parseResRatesRow } from "../lib/commission-rates.js";
 
 const router = Router();
 
@@ -1278,11 +1280,111 @@ async function computeAprilPayrollPct(companyId: number): Promise<{ payroll_pct:
   };
 }
 
+// [revenue-connect 2026-06-12] Payroll % — LAST COMPLETED WEEK (Sun–Sat,
+// America/Chicago), replacing the April-2026 pin now that the job_history
+// live bridge keeps the revenue ledger current past the MC cutover.
+// Numerator: commission via the shared engine (computeCommissionRows +
+// job_technicians.final_pay overrides) — the same formula behind the
+// payroll page's "PAYROLL % OF REV" header, so the two surfaces agree for
+// the same week. Denominator: job_history revenue for the week. Falls back
+// to the pinned April calc when the week has no ledger revenue (bridge not
+// yet run on this deploy / fresh tenant) so the card never blanks.
+async function computeLastWeekPayrollPct(companyId: number): Promise<{ payroll_pct: number; payroll_window: string }> {
+  const nowCt = new Date(new Date().toLocaleString("en-US", { timeZone: "America/Chicago" }));
+  const start = new Date(nowCt);
+  start.setDate(nowCt.getDate() - nowCt.getDay() - 7); // previous Sunday
+  const end = new Date(start);
+  end.setDate(start.getDate() + 6);
+  const d = (dt: Date) => `${dt.getFullYear()}-${String(dt.getMonth() + 1).padStart(2, "0")}-${String(dt.getDate()).padStart(2, "0")}`;
+  const M = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+  const label = `${M[start.getMonth()]} ${start.getDate()} – ${M[end.getMonth()]} ${end.getDate()}`;
+
+  const revRow = await db.execute(sql`
+    SELECT COALESCE(SUM(revenue), 0)::numeric AS revenue FROM job_history
+    WHERE company_id = ${companyId}
+      AND job_date >= ${d(start)} AND job_date <= ${d(end)}
+  `);
+  const revenue = Number((revRow as any).rows[0]?.revenue ?? 0);
+  if (revenue <= 0) return computeAprilPayrollPct(companyId);
+
+  // Company comp settings — same resilient waterfall as /payroll/detail.
+  let compSettings: any = {
+    res_tech_pay_pct: 0.35,
+    deep_clean_pay_pct: 0.32,
+    move_in_out_pay_pct: 0.32,
+    commercial_hourly_rate: 20.0,
+    commercial_comp_mode: "allowed_hours",
+  };
+  try {
+    const rows = await db.execute(sql`SELECT res_tech_pay_pct, deep_clean_pay_pct, move_in_out_pay_pct, commercial_hourly_rate, commercial_comp_mode FROM companies WHERE id = ${companyId} LIMIT 1`);
+    if (rows.rows[0]) compSettings = rows.rows[0];
+  } catch { /* tiered columns absent — keep defaults */ }
+  const resRates = parseResRatesRow(compSettings);
+
+  const jobRows = await db.execute(sql`
+    SELECT j.id, j.assigned_user_id, j.service_type::text AS service_type, j.account_id,
+           j.base_fee, j.billed_amount, j.allowed_hours, j.actual_hours, j.branch_id,
+           j.scheduled_date::text AS scheduled_date, c.client_type
+      FROM jobs j
+      LEFT JOIN clients c ON c.id = j.client_id
+     WHERE j.company_id = ${companyId} AND j.status = 'complete'
+       AND j.scheduled_date >= ${d(start)} AND j.scheduled_date <= ${d(end)}
+  `);
+  const jobs: CommissionInputJob[] = (jobRows.rows as any[]).map(r => ({
+    id: Number(r.id),
+    // Commercial routing matches /payroll/detail: account link OR a
+    // commercial client_type. computeCommissionRows keys on account_id
+    // only, so a commercial client without an account gets a sentinel.
+    account_id: r.account_id != null ? Number(r.account_id) : (r.client_type === "commercial" ? -1 : null),
+    assigned_user_id: r.assigned_user_id != null ? Number(r.assigned_user_id) : null,
+    service_type: r.service_type ?? null,
+    base_fee: r.base_fee ?? null,
+    billed_amount: r.billed_amount ?? null,
+    allowed_hours: r.allowed_hours ?? null,
+    actual_hours: r.actual_hours ?? null,
+    branch_id: r.branch_id != null ? Number(r.branch_id) : null,
+    scheduled_date: String(r.scheduled_date),
+    client_type: r.client_type ?? null,
+  }));
+
+  // Per-job hand-set pay overrides (job_technicians.final_pay) win — same
+  // rule as the payroll surfaces.
+  const overrides = new Map<string, number>();
+  const jobIds = jobs.map(j => j.id);
+  if (jobIds.length > 0) {
+    try {
+      const t = await db.execute(sql`
+        SELECT job_id, user_id, final_pay FROM job_technicians
+        WHERE company_id = ${companyId} AND job_id = ANY(${jobIds}::int[]) AND final_pay IS NOT NULL
+      `);
+      for (const r of t.rows as any[]) {
+        const pay = parseFloat(String(r.final_pay));
+        if (Number.isFinite(pay)) overrides.set(`${r.user_id}:${r.job_id}`, pay);
+      }
+    } catch { /* job_technicians absent on a fresh tenant — engine-computed only */ }
+  }
+
+  const commissionRows = computeCommissionRows({
+    jobs,
+    resRates,
+    commercial: {
+      commercial_hourly_rate: parseFloat(String(compSettings.commercial_hourly_rate ?? 20)),
+      commercial_comp_mode: compSettings.commercial_comp_mode === "actual_hours" ? "actual_hours" : "allowed_hours",
+    },
+    overrides,
+  });
+  const cost = commissionRows.reduce((s, r) => s + r.amount, 0);
+  return {
+    payroll_pct: Math.round((cost / revenue) * 1000) / 10,
+    payroll_window: label,
+  };
+}
+
 // Desktop BUSINESS HEALTH section. Same source-of-truth helpers as mobile.
 router.get("/business-health", requireAuth, async (req, res) => {
   try {
     const companyId = req.auth!.companyId;
-    const [bh, pay] = await Promise.all([computeBusinessHealth(companyId), computeAprilPayrollPct(companyId)]);
+    const [bh, pay] = await Promise.all([computeBusinessHealth(companyId), computeLastWeekPayrollPct(companyId)]);
     return res.json({ ...bh, ...pay });
   } catch (err) {
     console.error("GET /dashboard/business-health error:", err);
@@ -1344,8 +1446,8 @@ router.get("/mobile-cards", requireAuth, async (req, res) => {
       // (job_history-sourced; see computeBusinessHealth). Single source of
       // truth shared with the desktop BUSINESS HEALTH section.
       computeBusinessHealth(companyId),
-      // Payroll % (April 2026 clean month) — shared with desktop.
-      computeAprilPayrollPct(companyId),
+      // Payroll % (last completed week) — shared with desktop.
+      computeLastWeekPayrollPct(companyId),
       // Next 7 days (jobs + revenue)
       db.execute(sql`
         SELECT


### PR DESCRIPTION
## The problem (your two screenshots)
For the **same week (May 31 – Jun 6)**, the payroll page showed **$25,918 revenue / ~70 jobs** while the dashboard's revenue forecast showed **$0 actual · 0 jobs**, and the Payroll % card was pinned to **Apr 2026 (42.8%)** while the payroll page showed **31.8%** for the loaded week.

Root cause: every "historical revenue" surface (weekly forecast actuals, business health, payroll % denominator, prior-year chart, client job history) reads `job_history` — the MaidCentral import ledger — and **nothing has written to it since the MC cutover**. The payroll page reads the live `jobs` table, so the two could never agree.

## The fix — job_history live bridge
- New `lib/job-history-sync.ts`: mirrors **completed** jobs into `job_history`, per company, strictly **after** that company's MC-ledger end date (`MAX(job_date)` of MC rows). Tracked via a new `qleno_job_id` column + partial unique index.
  - Insert new completions, update drifted rows (rebilled / rescheduled / reassigned), delete rows whose job is no longer complete. MC rows are never touched.
  - The cutoff prevents double-counting the transition window and keeps the known Jan–Mar jobs-table corruption out of trend windows — MC stays canonical for its era, live jobs after it.
  - Revenue = the canonical `jobRevenueExpr` (commercial hourly × allowed wins over stale `billed_amount`, then billed, then base fee), matching dispatch and mobile cards.
- Wired at startup (non-fatal, same pattern as the other cold-start backfills) + hourly re-sync, so yesterday's completions appear in the forecast every morning.

## Payroll % KPI — last completed week, same formula as the payroll page
`computeLastWeekPayrollPct` replaces the April pin: commission via the shared `computeCommissionRows` engine (with `job_technicians.final_pay` overrides and commercial-client routing parity with `/payroll/detail`) ÷ ledger revenue, for the last completed Sun–Sat week (Central time). Falls back to the April calc if the week has no ledger revenue yet (first deploy before the bridge runs / fresh tenant). Window label is server-driven (`payroll_window`), so the dashboard card will read e.g. "payroll cost / revenue, May 31 – Jun 6" with no frontend change. Desktop and mobile cards both switched.

## What fixes itself once this deploys
- Dashboard "Last Week" forecast shows real actuals instead of $0.
- Current-week past days populate each morning.
- Business health (rate trend / avg bill) resumes accruing as months close.
- Client profile last-service / job-history continues past the cutover.
- Dashboard Payroll % ≈ payroll page "PAYROLL % OF REV" for the same week.

Verified: `pnpm run typecheck:libs` (CI's tsc gate) clean, api-server build (Railway's command) and frontend build both pass. First sync runs automatically on the Railway deploy's cold start.

https://claude.ai/code/session_019PiXXwFgtNSnzZQy3MTjAj

---
_Generated by [Claude Code](https://claude.ai/code/session_019PiXXwFgtNSnzZQy3MTjAj)_