### PR TITLE
feat(payroll): MC-transition reconciliation audit (one screen, five c…

### DIFF
--- a/artifacts/api-server/src/routes/payroll.ts
+++ b/artifacts/api-server/src/routes/payroll.ts
@@ -885,6 +885,174 @@ router.get("/detail", requireAuth, async (req, res) => {
   }
 });
 
+// ── Reconciliation audit (MC transition) ─────────────────────────────────────
+// [recon-audit 2026-06-12] One screen instead of tab-flipping into MaidCentral.
+// For a pay window, surfaces every job/day whose pay inputs look wrong, in the
+// exact categories the Juan Salazar penny-reconciliation exposed:
+//   1. commercial_misroutes — job's service type is a commercial scope (from
+//      the tenant-managed commercial_service_types table + the built-in legacy
+//      slugs) but the client carries no account link / commercial flag, so the
+//      engine paid the residential % instead of commercial hourly. Reports the
+//      paid-vs-expected delta per job (4009 W 93rd Condo: $145.87 vs $44).
+//   2. solo_pools — big residential pool jobs (allowed >= 5h) carrying <= 1
+//      tech: the likely missing-split-partner case (Cameron Goth: one tech
+//      took the whole 32% pool that MC split two ways).
+//   3. stale_scheduled — past jobs in the window never marked complete. They
+//      pay nobody and bill nothing (the May revenue hole + the all-$0 current
+//      week both come from this).
+//   4. clocked_no_job — tech punched a clock on a day with no completed job
+//      attached to them (job missing from Qleno entirely, e.g. Issa Sweis 6/6).
+//   5. unlinked_jobs — completed jobs with neither client_id nor account_id.
+// Read-only; office fixes the data through the normal surfaces.
+router.get("/reconciliation-audit", requireAuth, requireRole("owner", "admin", "office"), async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId as number;
+    const from = String(req.query.from ?? "");
+    const to = String(req.query.to ?? "");
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(from) || !/^\d{4}-\d{2}-\d{2}$/.test(to)) {
+      return res.status(400).json({ error: "Bad Request", message: "from and to (YYYY-MM-DD) are required" });
+    }
+    const r2 = (n: number) => Math.round(n * 100) / 100;
+
+    // Company comp config — same resilient waterfall as /detail.
+    let compSettings: any = {
+      res_tech_pay_pct: 0.35, deep_clean_pay_pct: 0.32, move_in_out_pay_pct: 0.32,
+      commercial_hourly_rate: 20.0, commercial_comp_mode: "allowed_hours",
+    };
+    try {
+      const rows = await db.execute(sql`SELECT res_tech_pay_pct, deep_clean_pay_pct, move_in_out_pay_pct, commercial_hourly_rate, commercial_comp_mode FROM companies WHERE id = ${companyId} LIMIT 1`);
+      if (rows.rows[0]) compSettings = rows.rows[0];
+    } catch { /* tiered columns absent — defaults */ }
+    const resRates = parseResRatesRow(compSettings);
+    const commercialRate = parseFloat(String(compSettings.commercial_hourly_rate ?? 20));
+
+    // Commercial scopes: tenant-managed slugs (active AND deactivated — old
+    // jobs keep their slug) plus the built-in legacy set that predates the
+    // commercial_service_types table.
+    const commercialSlugs = new Set<string>(["commercial_cleaning", "office_cleaning", "common_areas", "ppm_turnover"]);
+    try {
+      const r = await db.execute(sql`SELECT slug FROM commercial_service_types WHERE company_id = ${companyId}`);
+      for (const row of r.rows as any[]) commercialSlugs.add(String(row.slug).toLowerCase());
+    } catch { /* table absent on a fresh tenant */ }
+
+    const [completedRows, staleRows, staleCountRow, clockRows] = await Promise.all([
+      db.execute(sql`
+        SELECT j.id, j.scheduled_date::text AS date, j.service_type::text AS service_type,
+               j.account_id, j.client_id, j.base_fee, j.billed_amount, j.allowed_hours,
+               COALESCE(NULLIF(TRIM(COALESCE(c.first_name,'') || ' ' || COALESCE(c.last_name,'')), ''), a.account_name) AS name,
+               c.client_type,
+               NULLIF(TRIM(COALESCE(u.first_name,'') || ' ' || COALESCE(u.last_name,'')), '') AS tech,
+               (SELECT COUNT(*)::int FROM job_technicians jt WHERE jt.job_id = j.id) AS tech_count,
+               COALESCE((SELECT SUM(EXTRACT(EPOCH FROM (tc.clock_out_at - tc.clock_in_at)) / 3600.0)
+                           FROM timeclock tc WHERE tc.job_id = j.id AND tc.clock_out_at IS NOT NULL), 0) AS clocked_hours
+          FROM jobs j
+          LEFT JOIN clients c ON c.id = j.client_id
+          LEFT JOIN accounts a ON a.id = j.account_id
+          LEFT JOIN users u ON u.id = j.assigned_user_id
+         WHERE j.company_id = ${companyId} AND j.status = 'complete'
+           AND j.scheduled_date >= ${from} AND j.scheduled_date <= ${to}
+      `),
+      db.execute(sql`
+        SELECT j.id, j.scheduled_date::text AS date, j.status::text AS status,
+               COALESCE(NULLIF(TRIM(COALESCE(c.first_name,'') || ' ' || COALESCE(c.last_name,'')), ''), a.account_name) AS name,
+               NULLIF(TRIM(COALESCE(u.first_name,'') || ' ' || COALESCE(u.last_name,'')), '') AS tech,
+               COALESCE(CAST(j.billed_amount AS NUMERIC), CAST(j.base_fee AS NUMERIC), 0) AS amount
+          FROM jobs j
+          LEFT JOIN clients c ON c.id = j.client_id
+          LEFT JOIN accounts a ON a.id = j.account_id
+          LEFT JOIN users u ON u.id = j.assigned_user_id
+         WHERE j.company_id = ${companyId}
+           AND j.status IN ('scheduled', 'in_progress')
+           AND j.scheduled_date >= ${from} AND j.scheduled_date <= ${to}
+           AND j.scheduled_date <= (now() AT TIME ZONE 'America/Chicago')::date
+         ORDER BY j.scheduled_date, j.id
+         LIMIT 50
+      `),
+      db.execute(sql`
+        SELECT COUNT(*)::int AS n FROM jobs j
+         WHERE j.company_id = ${companyId}
+           AND j.status IN ('scheduled', 'in_progress')
+           AND j.scheduled_date >= ${from} AND j.scheduled_date <= ${to}
+           AND j.scheduled_date <= (now() AT TIME ZONE 'America/Chicago')::date
+      `),
+      db.execute(sql`
+        SELECT tc.user_id,
+               NULLIF(TRIM(COALESCE(u.first_name,'') || ' ' || COALESCE(u.last_name,'')), '') AS name,
+               tc.clock_in_at::date::text AS date,
+               ROUND(SUM(EXTRACT(EPOCH FROM (COALESCE(tc.clock_out_at, tc.clock_in_at) - tc.clock_in_at)) / 3600.0)::numeric, 1) AS hours
+          FROM timeclock tc
+          JOIN users u ON u.id = tc.user_id
+         WHERE tc.company_id = ${companyId}
+           AND tc.clock_in_at::date >= ${from} AND tc.clock_in_at::date <= ${to}
+           AND COALESCE(u.is_sandbox, false) = false
+           AND NOT EXISTS (
+             SELECT 1 FROM jobs j
+              WHERE j.company_id = ${companyId} AND j.status = 'complete'
+                AND j.assigned_user_id = tc.user_id
+                AND j.scheduled_date = tc.clock_in_at::date)
+           AND NOT EXISTS (
+             SELECT 1 FROM job_technicians jt
+              JOIN jobs j2 ON j2.id = jt.job_id
+              WHERE jt.user_id = tc.user_id AND j2.status = 'complete'
+                AND j2.scheduled_date = tc.clock_in_at::date)
+         GROUP BY tc.user_id, u.first_name, u.last_name, tc.clock_in_at::date
+         ORDER BY tc.clock_in_at::date, name
+      `),
+    ]);
+
+    const commercial_misroutes: any[] = [];
+    const solo_pools: any[] = [];
+    const unlinked_jobs: any[] = [];
+    for (const r of completedRows.rows as any[]) {
+      const st = String(r.service_type ?? "").toLowerCase();
+      const allowed = parseFloat(String(r.allowed_hours ?? "0")) || 0;
+      const clocked = r2(parseFloat(String(r.clocked_hours ?? "0")) || 0);
+      const jobTotal = parseFloat(String(r.billed_amount ?? "")) || parseFloat(String(r.base_fee ?? "")) || 0;
+      const isCommercialRouted = r.account_id != null || r.client_type === "commercial";
+
+      if (r.client_id == null && r.account_id == null) {
+        unlinked_jobs.push({ job_id: r.id, date: r.date, service_type: st, tech: r.tech, amount: r2(jobTotal) });
+      }
+      if (!isCommercialRouted && commercialSlugs.has(st)) {
+        const pct = resolveResidentialPayPct(st, resRates);
+        const paid = r2(jobTotal * pct);
+        // Hours signal mirrors the engine: allowed when present, else clocked.
+        const hrs = allowed > 0 ? allowed : clocked;
+        const expected = r2(commercialRate * hrs);
+        commercial_misroutes.push({
+          job_id: r.id, date: r.date, name: r.name, service_type: st, tech: r.tech,
+          job_total: r2(jobTotal), pct_paid: Math.round(pct * 100), paid_residential: paid,
+          hours: r2(hrs), expected_commercial: expected, delta: r2(paid - expected),
+        });
+      }
+      if (!isCommercialRouted && !commercialSlugs.has(st) && allowed >= 5 && Number(r.tech_count) <= 1) {
+        const pct = resolveResidentialPayPct(st, resRates);
+        solo_pools.push({
+          job_id: r.id, date: r.date, name: r.name, service_type: st, tech: r.tech,
+          allowed_hours: r2(allowed), clocked_hours: clocked,
+          tech_count: Number(r.tech_count), pool_paid: r2(jobTotal * pct),
+        });
+      }
+    }
+    commercial_misroutes.sort((a, b) => b.delta - a.delta);
+
+    return res.json({
+      data: {
+        from, to,
+        commercial_misroutes,
+        solo_pools,
+        stale_scheduled: { total: Number((staleCountRow.rows[0] as any)?.n ?? 0), rows: staleRows.rows },
+        clocked_no_job: clockRows.rows,
+        unlinked_jobs,
+        potential_overpay: r2(commercial_misroutes.reduce((s, m) => s + m.delta, 0)),
+      },
+    });
+  } catch (err) {
+    console.error("Payroll reconciliation-audit error:", err);
+    return res.status(500).json({ error: "Internal Server Error", message: "Failed to run reconciliation audit" });
+  }
+});
+
 // ── Payroll-to-Revenue trend (weekly, with YOY overlay) ───────────────────────
 // [payroll-trend 2026-06-08] Company-level weekly revenue vs payroll for the
 // Payroll summary chart (MaidCentral "Payroll to Revenue" parity + a YOY

--- a/artifacts/qleno/src/pages/payroll.tsx
+++ b/artifacts/qleno/src/pages/payroll.tsx
@@ -75,6 +75,157 @@ function useCadence(): string {
 const qualityColor = (q: number | null | undefined) =>
   q == null ? '#9E9B94' : q >= 3.5 ? '#16A34A' : q >= 2.5 ? '#D97706' : '#DC2626';
 
+// [recon-audit 2026-06-12] MC-transition reconciliation audit. Surfaces, for
+// the loaded pay window, every pay-input problem the Juan Salazar penny-recon
+// exposed: commercial work paid residential %, big pool jobs missing a split
+// partner, past jobs never marked complete, clock time with no completed job,
+// and unlinked jobs. Read-only — fixes happen in the normal surfaces.
+function ReconciliationAudit({ from, to }: { from: string; to: string }) {
+  const [collapsed, setCollapsed] = useState(false);
+  const { data, isLoading } = useQuery<any>({
+    queryKey: ['payroll-recon-audit', from, to],
+    queryFn: () => apiFetch(`/payroll/reconciliation-audit?from=${from}&to=${to}`),
+    enabled: !!from && !!to,
+  });
+  const d = data?.data;
+  const findings = d
+    ? d.commercial_misroutes.length + d.solo_pools.length + d.stale_scheduled.total + d.clocked_no_job.length + d.unlinked_jobs.length
+    : 0;
+  const money = (n: number) => `$${Number(n).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+  const th: React.CSSProperties = { fontSize: 10.5, fontWeight: 700, color: '#9E9B94', textTransform: 'uppercase', letterSpacing: '0.05em', padding: '6px 10px 4px 0', textAlign: 'left', whiteSpace: 'nowrap' };
+  const td: React.CSSProperties = { fontSize: 12, color: '#1A1917', padding: '5px 10px 5px 0', borderTop: '1px solid #F4F3F0', verticalAlign: 'middle' };
+  const section = (title: string, hint: string, countLabel: string, headers: string[], body: React.ReactNode) => (
+    <div style={{ marginTop: 16 }}>
+      <div style={{ fontSize: 12.5, fontWeight: 700, color: '#1A1917' }}>
+        {title} <span style={{ color: '#DC2626' }}>({countLabel})</span>
+      </div>
+      <div style={{ fontSize: 11, color: '#9E9B94', margin: '2px 0 4px' }}>{hint}</div>
+      <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+        <thead><tr>{headers.map(x => <th key={x} style={th}>{x}</th>)}</tr></thead>
+        <tbody>{body}</tbody>
+      </table>
+    </div>
+  );
+
+  if (isLoading || !d) {
+    return (
+      <div style={{ background: '#fff', border: '1px solid #E5E2DC', borderRadius: 10, padding: '14px 18px', fontSize: 12, color: '#9E9B94' }}>
+        Reconciliation audit: {isLoading ? 'running checks for this period…' : 'unavailable'}
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ background: '#fff', border: `1px solid ${findings > 0 ? '#F3D9B0' : '#E5E2DC'}`, borderRadius: 10, padding: '14px 18px' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10, cursor: 'pointer' }} onClick={() => setCollapsed(c => !c)}>
+        <span style={{ fontSize: 13.5, fontWeight: 700, color: '#1A1917' }}>Reconciliation Audit</span>
+        {findings > 0 ? (
+          <span style={{ fontSize: 11, fontWeight: 700, color: '#B45309', background: '#FEF3E2', border: '1px solid #F3D9B0', borderRadius: 5, padding: '2px 8px' }}>
+            {findings} finding{findings === 1 ? '' : 's'}
+          </span>
+        ) : (
+          <span style={{ fontSize: 11, fontWeight: 700, color: '#166534', background: '#DCFCE7', border: '1px solid #BBF7D0', borderRadius: 5, padding: '2px 8px' }}>
+            Clean
+          </span>
+        )}
+        {d.potential_overpay > 0 && (
+          <span style={{ fontSize: 11, fontWeight: 700, color: '#DC2626' }}>Potential overpay {money(d.potential_overpay)}</span>
+        )}
+        <span style={{ marginLeft: 'auto', fontSize: 11, color: '#9E9B94' }}>{collapsed ? 'Show' : 'Hide'}</span>
+      </div>
+
+      {!collapsed && findings === 0 && (
+        <div style={{ fontSize: 12, color: '#6B6860', marginTop: 8 }}>
+          No findings — this period's pay inputs look clean against the MC-transition checks.
+        </div>
+      )}
+
+      {!collapsed && d.commercial_misroutes.length > 0 && section(
+        'Commercial work paid as residential %',
+        'Service type is a commercial scope, but the client has no account link or commercial flag, so the engine paid the residential pool. Fix: mark the client commercial or link the account, then the row pays hourly.',
+        String(d.commercial_misroutes.length),
+        ['Date', 'Client', 'Scope', 'Paid', 'Should be', 'Overpay'],
+        d.commercial_misroutes.map((m: any) => (
+          <tr key={m.job_id}>
+            <td style={{ ...td, whiteSpace: 'nowrap' }}>{m.date}</td>
+            <td style={td}>{m.name || `Job #${m.job_id}`}</td>
+            <td style={{ ...td, color: '#6B6860' }}>{m.service_type}</td>
+            <td style={td}>{m.pct_paid}% of {money(m.job_total)} = <b>{money(m.paid_residential)}</b></td>
+            <td style={td}>hourly × {Number(m.hours).toFixed(1)}h = <b>{money(m.expected_commercial)}</b></td>
+            <td style={{ ...td, color: '#DC2626', fontWeight: 700 }}>{money(m.delta)}</td>
+          </tr>
+        )),
+      )}
+
+      {!collapsed && d.solo_pools.length > 0 && section(
+        'Possible missing split partner',
+        'Big pool job (5+ allowed hours) with one tech attached — if a second cleaner worked it, the attached tech is being paid the entire pool. Fix: add the partner tech to the job.',
+        String(d.solo_pools.length),
+        ['Date', 'Client', 'Scope', 'Allowed', 'Clocked', 'Techs', 'Pool paid'],
+        d.solo_pools.map((m: any) => (
+          <tr key={m.job_id}>
+            <td style={{ ...td, whiteSpace: 'nowrap' }}>{m.date}</td>
+            <td style={td}>{m.name || `Job #${m.job_id}`}</td>
+            <td style={{ ...td, color: '#6B6860' }}>{m.service_type}</td>
+            <td style={td}>{Number(m.allowed_hours).toFixed(1)}h</td>
+            <td style={td}>{Number(m.clocked_hours).toFixed(1)}h</td>
+            <td style={{ ...td, fontWeight: 700 }}>{m.tech_count}</td>
+            <td style={{ ...td, fontWeight: 700 }}>{money(m.pool_paid)} to {m.tech || 'unassigned'}</td>
+          </tr>
+        )),
+      )}
+
+      {!collapsed && d.stale_scheduled.total > 0 && section(
+        'Past jobs never marked complete',
+        'These pay nobody and count no revenue — the May hole and $0 weeks come from here. Fix: mark complete (or cancel) from the dispatch board.',
+        d.stale_scheduled.total > d.stale_scheduled.rows.length
+          ? `showing ${d.stale_scheduled.rows.length} of ${d.stale_scheduled.total}`
+          : String(d.stale_scheduled.total),
+        ['Date', 'Client', 'Status', 'Tech', 'Amount'],
+        d.stale_scheduled.rows.map((m: any) => (
+          <tr key={m.id}>
+            <td style={{ ...td, whiteSpace: 'nowrap' }}>{m.date}</td>
+            <td style={td}>{m.name || `Job #${m.id}`}</td>
+            <td style={{ ...td, color: '#B45309', fontWeight: 600 }}>{m.status}</td>
+            <td style={td}>{m.tech || 'Unassigned'}</td>
+            <td style={td}>{money(Number(m.amount))}</td>
+          </tr>
+        )),
+      )}
+
+      {!collapsed && d.clocked_no_job.length > 0 && section(
+        'Clock time with no completed job',
+        'The tech punched a clock that day but has no completed job attached — the job may be missing from Qleno entirely (the Issa Sweis case) or just not completed yet.',
+        String(d.clocked_no_job.length),
+        ['Date', 'Tech', 'Hours on clock'],
+        d.clocked_no_job.map((m: any, i: number) => (
+          <tr key={`${m.user_id}-${m.date}-${i}`}>
+            <td style={{ ...td, whiteSpace: 'nowrap' }}>{m.date}</td>
+            <td style={td}>{m.name || `User #${m.user_id}`}</td>
+            <td style={td}>{Number(m.hours).toFixed(1)}h</td>
+          </tr>
+        )),
+      )}
+
+      {!collapsed && d.unlinked_jobs.length > 0 && section(
+        'Completed jobs with no client or account',
+        'No client_id and no account_id — these render nameless and skip per-client stats. Fix: attach the client or account on the job.',
+        String(d.unlinked_jobs.length),
+        ['Date', 'Job', 'Scope', 'Tech', 'Amount'],
+        d.unlinked_jobs.map((m: any) => (
+          <tr key={m.job_id}>
+            <td style={{ ...td, whiteSpace: 'nowrap' }}>{m.date}</td>
+            <td style={td}>Job #{m.job_id}</td>
+            <td style={{ ...td, color: '#6B6860' }}>{m.service_type}</td>
+            <td style={td}>{m.tech || 'Unassigned'}</td>
+            <td style={td}>{money(Number(m.amount))}</td>
+          </tr>
+        )),
+      )}
+    </div>
+  );
+}
+
 function WeeklyDetailView() {
   const cadence = useCadence();
   const [period, setPeriod] = useState(() => periodForCadence('weekly'));
@@ -130,7 +281,7 @@ function WeeklyDetailView() {
             style={{ padding: '7px 16px', background: 'var(--brand)', color: '#fff', border: 'none', borderRadius: 6, fontSize: 13, fontWeight: 600, cursor: 'pointer', fontFamily: FF }}>
             Load
           </button>
-          <span style={{ fontSize: 11, color: '#9E9B94', marginLeft: 'auto' }}>Commission rate: {resPct}% of job total</span>
+          <span style={{ fontSize: 11, color: '#9E9B94', marginLeft: 'auto' }}>Pay rules: {resPct}% residential · tiered deep/move % · commercial hourly</span>
         </div>
       </div>
 
@@ -158,6 +309,8 @@ function WeeklyDetailView() {
           ))}
         </div>
       )}
+
+      <ReconciliationAudit from={period.start} to={period.end} />
 
       {isLoading && <div style={{ padding: '40px', textAlign: 'center', color: '#9E9B94', fontSize: 13 }}>Loading…</div>}
 


### PR DESCRIPTION
…hecks)

New GET /api/payroll/reconciliation-audit (owner/admin/office) + an audit card on the By Employee payroll view, scoped to the loaded pay period. Surfaces every pay-input problem the Juan Salazar penny-reconciliation exposed, so the office can fix data without tab-flipping into MC:

1. Commercial work paid as residential % — service type is a commercial scope (tenant-managed commercial_service_types slugs + built-in legacy set) but the client has no account link / commercial flag. Shows paid vs expected-hourly and the per-job overpay delta, plus a summed potential-overpay headline.
2. Possible missing split partner — pool jobs with 5+ allowed hours and at most one tech attached (whole pool paid to one cleaner).
3. Past jobs never marked complete — scheduled/in_progress jobs at or before today inside the window (the May revenue hole + $0 weeks).
4. Clock time with no completed job — tech punched but has no completed job that day (job missing from Qleno entirely).
5. Completed jobs with no client or account link.

Read-only; fixes happen through the normal surfaces. Also rewords the 'Commission rate: 35% of job total' caption (predates the tiered + commercial engine) to 'Pay rules: 35% residential, tiered deep/move %, commercial hourly'.

https://claude.ai/code/session_019PiXXwFgtNSnzZQy3MTjAj