### PR TITLE
Payroll: shared pay window across tabs + avatar parity in Add tech picker

### DIFF
--- a/artifacts/api-server/src/routes/users.ts
+++ b/artifacts/api-server/src/routes/users.ts
@@ -126,7 +126,7 @@ router.get("/techs-with-status", requireAuth, async (req, res) => {
     // only when both sides actually carry it (NULL home_branch is fine —
     // those techs are dispatchable to any branch).
     const rows = await db.execute(sql`
-      SELECT u.id, u.first_name, u.last_name, u.role, u.home_branch_id AS branch_id,
+      SELECT u.id, u.first_name, u.last_name, u.role, u.avatar_url, u.home_branch_id AS branch_id,
              (SELECT tc.job_id FROM timeclock tc
                WHERE tc.user_id = u.id
                  AND tc.clock_out_at IS NULL
@@ -202,6 +202,10 @@ router.get("/techs-with-status", requireAuth, async (req, res) => {
         last_name: r.last_name,
         name: `${r.first_name ?? ""} ${r.last_name ?? ""}`.trim(),
         role: r.role,
+        // [avatar-parity 2026-06-12] Same photo everywhere: the Add tech
+        // picker fell back to initials for every tech because this endpoint
+        // never returned avatar_url while the roster surfaces did.
+        avatar_url: r.avatar_url ?? null,
         branch_id: r.branch_id ?? null,
         is_clocked_in: r.active_job_id !== null,
         currently_at: r.active_job_id ? (clientByJob.get(r.active_job_id) ?? null) : null,

--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -1603,7 +1603,7 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
   // vs "Currently on a job") using /api/users/techs-with-status. The endpoint
   // excludes already-assigned techs server-side via ?exclude=<ids>.
   const [addTechOpen, setAddTechOpen] = useState(false);
-  type TechRow = { id: number; name: string; role: string; is_clocked_in: boolean; currently_at: string | null };
+  type TechRow = { id: number; name: string; role: string; avatar_url?: string | null; is_clocked_in: boolean; currently_at: string | null };
   const [addTechList, setAddTechList] = useState<TechRow[]>([]);
   const [addTechLoading, setAddTechLoading] = useState(false);
   const [addTechBusy, setAddTechBusy] = useState(false);

--- a/artifacts/qleno/src/pages/payroll.tsx
+++ b/artifacts/qleno/src/pages/payroll.tsx
@@ -226,13 +226,10 @@ function ReconciliationAudit({ from, to }: { from: string; to: string }) {
   );
 }
 
-function WeeklyDetailView() {
-  const cadence = useCadence();
-  const [period, setPeriod] = useState(() => periodForCadence('weekly'));
-  // Re-seed the default window from the tenant's cadence once it loads, unless
-  // the office has manually picked dates.
-  const [periodEdited, setPeriodEdited] = useState(false);
-  useEffect(() => { if (!periodEdited) setPeriod(periodForCadence(cadence)); }, [cadence, periodEdited]);
+// [period-sync 2026-06-12] Period state lives in PayrollPage now (shared with
+// the Summary tab, banners, and the top-right label) — this view just reads
+// and reports changes up.
+function WeeklyDetailView({ period, onPeriodChange }: { period: { start: string; end: string }; onPeriodChange: (p: { start: string; end: string }) => void }) {
   const [expanded, setExpanded] = useState<number[]>([]);
   const FF = "inherit";
   const { activeBranchId } = useBranch();
@@ -274,9 +271,9 @@ function WeeklyDetailView() {
       <div style={{ backgroundColor: '#fff', border: '1px solid #E5E2DC', borderRadius: 10, padding: '16px 20px' }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
           <span style={{ fontSize: 13, fontWeight: 600, color: '#1A1917', fontFamily: FF }}>Pay Period:</span>
-          <CalendarPopover value={period.start} onChange={v => { setPeriodEdited(true); setPeriod(p => ({ ...p, start: v })); }} ariaLabel="Pay period start" />
+          <CalendarPopover value={period.start} onChange={v => onPeriodChange({ ...period, start: v })} ariaLabel="Pay period start" />
           <span style={{ fontSize: 12, color: '#9E9B94' }}>to</span>
-          <CalendarPopover value={period.end} onChange={v => { setPeriodEdited(true); setPeriod(p => ({ ...p, end: v })); }} ariaLabel="Pay period end" />
+          <CalendarPopover value={period.end} onChange={v => onPeriodChange({ ...period, end: v })} ariaLabel="Pay period end" />
           <button onClick={() => refetch()}
             style={{ padding: '7px 16px', background: 'var(--brand)', color: '#fff', border: 'none', borderRadius: 6, fontSize: 13, fontWeight: 600, cursor: 'pointer', fontFamily: FF }}>
             Load
@@ -694,10 +691,16 @@ export default function PayrollPage() {
     return true;
   });
 
-  // Real payroll for the current pay period, sized by the tenant's pay cadence
-  // (weekly for Phes) — same source as the detail view and the Earnings panel.
+  // Pay window shared by BOTH tabs, the top-right label, and the banners.
+  // [period-sync 2026-06-12] Previously By Employee kept its own period state,
+  // so loading May 31 – Jun 6 there left the top-right label, the Summary tab
+  // cards, and the Employee Payroll Summary pinned to the current week (Sal:
+  // "dates on top right not updating based on filter"). One state, one window.
   const cadence = useCadence();
-  const payPeriod = useMemo(() => periodForCadence(cadence), [cadence]);
+  const [periodEdited, setPeriodEdited] = useState(false);
+  const [payPeriod, setPayPeriod] = useState(() => periodForCadence('weekly'));
+  useEffect(() => { if (!periodEdited) setPayPeriod(periodForCadence(cadence)); }, [cadence, periodEdited]);
+  const onPeriodChange = (p: { start: string; end: string }) => { setPeriodEdited(true); setPayPeriod(p); };
   const periodLabel = useMemo(() => {
     const fmt = (s: string) => new Date(`${s}T00:00:00`).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
     const yr = new Date(`${payPeriod.end}T00:00:00`).getFullYear();
@@ -759,7 +762,7 @@ export default function PayrollPage() {
           </div>
         </div>
 
-        {activeView === 'weekly-detail' && <WeeklyDetailView />}
+        {activeView === 'weekly-detail' && <WeeklyDetailView period={payPeriod} onPeriodChange={onPeriodChange} />}
 
         {activeView === 'overview' && <>
         {/* Controls */}


### PR DESCRIPTION
Two fixes from Sal's reconciliation session:

## 1. One pay window for the whole payroll page
The By Employee tab kept its own period state, so loading **May 31 – Jun 6** there left everything else pinned to the current week: the top-right "Pay period" label, the Summary tab's Gross Payroll / Total Hours / Employees Paid cards, the Employee Payroll Summary table header, and the preflight/overtime banners — Sal's "dates on top right not updating based on filter" and half of "numbers not updating."

Period state now lives in `PayrollPage` and is shared by both tabs, the label, and the banners; `WeeklyDetailView` reads it via props. Load a window once and **every number and date on the page follows it** — including the Summary tab, which previously could only ever show the current week.

## 2. Same profile photo everywhere
`/api/users/techs-with-status` never returned `avatar_url`, so the Add tech picker showed initials for techs whose photos render fine on the roster and dispatch surfaces. The endpoint now returns it and `TechRow` carries it (this also clears the long-standing `TechRow.avatar_url` tsc error).

Note on the rest of "numbers not updating": the By Employee header figures ($25,918 / $8,250.66 / 31.8%) are computed correctly over data that still has the known holes — they move as the Reconciliation Audit findings (#437) get fixed, not from code.

Verified: `typecheck:libs` clean, both builds pass; remaining payroll.tsx tsc errors pre-exist on main.

https://claude.ai/code/session_019PiXXwFgtNSnzZQy3MTjAj

---
_Generated by [Claude Code](https://claude.ai/code/session_019PiXXwFgtNSnzZQy3MTjAj)_