### PR TITLE
Scorecard engine + post-job customer survey (MC 0-4 model, Twilio-gated)

### DIFF
--- a/artifacts/api-server/src/lib/scorecard-engine.ts
+++ b/artifacts/api-server/src/lib/scorecard-engine.ts
@@ -1,0 +1,72 @@
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+// MaidCentral-verified scorecard formula: scorecard_pct = unweighted MEAN of
+// non-excluded per-job customer responses (0–4 scale) ÷ max × 100. Written to
+// users.scorecard_pct as the LIVE value (source='qleno'); the imported MC
+// baseline is preserved in users.scorecard_pct_mc. Only recomputes employees
+// who actually have qleno responses (others keep their MC baseline).
+
+export async function recomputeEmployeeScorecard(companyId: number, employeeId: number): Promise<void> {
+  await db.execute(sql`
+    UPDATE users u SET scorecard_pct = sub.pct, scorecard_pct_source = 'qleno'
+    FROM (
+      SELECT employee_id, ROUND(AVG(score_value / NULLIF(max_value, 0)) * 100, 2) AS pct
+        FROM scorecard_entries
+       WHERE company_id = ${companyId} AND employee_id = ${employeeId}
+         AND source = 'qleno' AND excluded = false
+       GROUP BY employee_id
+    ) sub
+    WHERE u.id = sub.employee_id AND u.company_id = ${companyId}
+  `);
+}
+
+export async function recomputeAllScorecards(companyId: number): Promise<{ employees_updated: number }> {
+  const r = await db.execute(sql`
+    UPDATE users u SET scorecard_pct = sub.pct, scorecard_pct_source = 'qleno'
+    FROM (
+      SELECT employee_id, ROUND(AVG(score_value / NULLIF(max_value, 0)) * 100, 2) AS pct
+        FROM scorecard_entries
+       WHERE company_id = ${companyId} AND source = 'qleno' AND excluded = false
+       GROUP BY employee_id
+    ) sub
+    WHERE u.id = sub.employee_id AND u.company_id = ${companyId}
+    RETURNING u.id
+  `);
+  return { employees_updated: (r.rows as any[]).length };
+}
+
+// Write per-tech scorecard_entries for a survey response (0–4), attributed to
+// every tech on the job (job_technicians; falls back to assigned_user_id), then
+// recompute each tech's scorecard. Idempotent per (job, employee) via the
+// uq_scorecard_entries_survey upsert key. Returns the employee ids written.
+export async function captureSurveyScore(args: {
+  companyId: number; jobId: number; surveyId: number; score: number; entryDate: string; notes?: string | null;
+}): Promise<number[]> {
+  const { companyId, jobId, surveyId, score, entryDate, notes } = args;
+
+  // Techs on the job: job_technicians, else the primary assigned_user_id.
+  const techRows = await db.execute(sql`
+    SELECT user_id FROM job_technicians WHERE job_id = ${jobId} AND company_id = ${companyId}
+    UNION
+    SELECT assigned_user_id AS user_id FROM jobs
+     WHERE id = ${jobId} AND company_id = ${companyId} AND assigned_user_id IS NOT NULL
+  `);
+  const techIds = [...new Set((techRows.rows as any[]).map(r => Number(r.user_id)).filter(Boolean))];
+  if (!techIds.length) return [];
+
+  for (const uid of techIds) {
+    // Idempotent without a unique constraint (avoids colliding with existing mc
+    // rows): clear this job/tech's prior qleno entry, then insert fresh.
+    await db.execute(sql`
+      DELETE FROM scorecard_entries
+       WHERE company_id = ${companyId} AND employee_id = ${uid} AND job_id = ${jobId} AND source = 'qleno'
+    `);
+    await db.execute(sql`
+      INSERT INTO scorecard_entries (company_id, employee_id, job_id, entry_date, score_value, max_value, source, survey_id, notes)
+      VALUES (${companyId}, ${uid}, ${jobId}, ${entryDate}, ${String(score)}, '4', 'qleno', ${surveyId}, ${notes ?? null})
+    `);
+  }
+  for (const uid of techIds) await recomputeEmployeeScorecard(companyId, uid);
+  return techIds;
+}

--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -1355,6 +1355,34 @@ async function runBookingSchemaGuard(): Promise<void> {
     ` },
     { label: "idx_efficiency_entries_emp_pkg",
       stmt: `CREATE INDEX IF NOT EXISTS idx_efficiency_entries_emp_pkg ON efficiency_entries(company_id, employee_id, package)` },
+
+    // ── Scorecard customer-survey system (per-tenant; Twilio-gated send) ──
+    { label: "companies.survey_enabled",
+      stmt: `ALTER TABLE companies ADD COLUMN IF NOT EXISTS survey_enabled BOOLEAN NOT NULL DEFAULT false` },
+    { label: "companies.survey_message_template",
+      stmt: `ALTER TABLE companies ADD COLUMN IF NOT EXISTS survey_message_template TEXT DEFAULT 'Hi {{first_name}}, thanks for choosing us! How was your cleaning today? Tap to rate: {{survey_link}}'` },
+    { label: "companies.survey_send_after_hours",
+      stmt: `ALTER TABLE companies ADD COLUMN IF NOT EXISTS survey_send_after_hours INTEGER NOT NULL DEFAULT 0` },
+    { label: "companies.twilio_enabled",
+      stmt: `ALTER TABLE companies ADD COLUMN IF NOT EXISTS twilio_enabled BOOLEAN NOT NULL DEFAULT false` },
+    { label: "companies.twilio_account_sid",
+      stmt: `ALTER TABLE companies ADD COLUMN IF NOT EXISTS twilio_account_sid TEXT` },
+    { label: "companies.twilio_auth_token",
+      stmt: `ALTER TABLE companies ADD COLUMN IF NOT EXISTS twilio_auth_token TEXT` },
+    { label: "satisfaction_surveys.survey_score",
+      stmt: `ALTER TABLE satisfaction_surveys ADD COLUMN IF NOT EXISTS survey_score INTEGER` },
+    { label: "scorecard_entries.excluded",
+      stmt: `ALTER TABLE scorecard_entries ADD COLUMN IF NOT EXISTS excluded BOOLEAN NOT NULL DEFAULT false` },
+    { label: "scorecard_entries.survey_id",
+      stmt: `ALTER TABLE scorecard_entries ADD COLUMN IF NOT EXISTS survey_id INTEGER` },
+    { label: "users.scorecard_pct_mc",
+      stmt: `ALTER TABLE users ADD COLUMN IF NOT EXISTS scorecard_pct_mc NUMERIC(5,2)` },
+    { label: "users.scorecard_pct_source",
+      stmt: `ALTER TABLE users ADD COLUMN IF NOT EXISTS scorecard_pct_source TEXT DEFAULT 'mc'` },
+    // Snapshot the imported MC baseline into scorecard_pct_mc once (idempotent:
+    // only fills rows where the baseline isn't captured yet).
+    { label: "backfill scorecard_pct_mc",
+      stmt: `UPDATE users SET scorecard_pct_mc = scorecard_pct WHERE scorecard_pct IS NOT NULL AND scorecard_pct_mc IS NULL` },
   ];
 
   for (const { label, stmt } of guards) {

--- a/artifacts/api-server/src/routes/satisfaction.ts
+++ b/artifacts/api-server/src/routes/satisfaction.ts
@@ -3,9 +3,23 @@ import { db } from "@workspace/db";
 import { satisfactionSurveysTable, jobsTable, clientsTable, usersTable, companiesTable } from "@workspace/db/schema";
 import { eq, and, desc, isNotNull, avg, count, sql, gte, isNull } from "drizzle-orm";
 import { requireAuth } from "../lib/auth.js";
+import { captureSurveyScore } from "../lib/scorecard-engine.js";
 import crypto from "crypto";
 
 const router = Router();
+
+// Send an SMS via the tenant's Twilio REST credentials. No SDK dependency.
+async function sendTwilioSms(sid: string, authToken: string, from: string, to: string, body: string): Promise<void> {
+  const resp = await fetch(`https://api.twilio.com/2010-04-01/Accounts/${sid}/Messages.json`, {
+    method: "POST",
+    headers: {
+      "Authorization": "Basic " + Buffer.from(`${sid}:${authToken}`).toString("base64"),
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({ From: from, To: to, Body: body }).toString(),
+  });
+  if (!resp.ok) throw new Error(`Twilio ${resp.status}: ${(await resp.text()).slice(0, 200)}`);
+}
 
 // ── POST /api/satisfaction/send — with 30-day throttle ──
 router.post("/send", requireAuth, async (req, res) => {
@@ -43,15 +57,60 @@ router.post("/send", requireAuth, async (req, res) => {
       return res.json({ sent: false, reason: "throttled", survey });
     }
 
-    const [survey] = await db.insert(satisfactionSurveysTable).values({
-      company_id: companyId,
-      job_id: parseInt(job_id),
-      customer_id: parseInt(customer_id),
-      token,
-      sent_at: new Date(),
-    }).returning();
+    // Tenant survey/Twilio config + customer phone. The SMS only actually sends
+    // when survey + Twilio are enabled, creds present, COMMS on, and a phone
+    // exists — otherwise the survey row is created but suppressed with the
+    // reason (Twilio is OFF until go-live, so today it suppresses, by design).
+    const [company] = await db
+      .select({
+        survey_enabled: companiesTable.survey_enabled,
+        survey_message_template: companiesTable.survey_message_template,
+        twilio_enabled: companiesTable.twilio_enabled,
+        twilio_account_sid: companiesTable.twilio_account_sid,
+        twilio_auth_token: companiesTable.twilio_auth_token,
+        twilio_from_number: companiesTable.twilio_from_number,
+      })
+      .from(companiesTable).where(eq(companiesTable.id, companyId)).limit(1);
+    const [client] = await db
+      .select({ phone: clientsTable.phone, first_name: clientsTable.first_name })
+      .from(clientsTable).where(eq(clientsTable.id, parseInt(customer_id))).limit(1);
 
-    return res.status(201).json({ sent: true, ...survey, survey_url: `/survey/${token}` });
+    const gate =
+      !company?.survey_enabled ? "survey_disabled"
+      : !company?.twilio_enabled ? "twilio_disabled"
+      : !(company.twilio_account_sid && company.twilio_auth_token && company.twilio_from_number) ? "twilio_unconfigured"
+      : process.env.COMMS_ENABLED !== "true" ? "comms_disabled"
+      : !client?.phone ? "no_phone"
+      : null;
+
+    if (gate) {
+      const [survey] = await db.insert(satisfactionSurveysTable).values({
+        company_id: companyId, job_id: parseInt(job_id), customer_id: parseInt(customer_id),
+        token, sent_at: new Date(), suppressed: true, suppressed_reason: gate,
+      }).returning();
+      return res.status(201).json({ sent: false, reason: gate, survey, survey_url: `/survey/${token}` });
+    }
+
+    const base = (process.env.APP_BASE_URL || "https://app.qleno.com").replace(/\/$/, "");
+    const link = `${base}/survey/${token}`;
+    const body = (company.survey_message_template || "How was your cleaning? Rate us: {{survey_link}}")
+      .replace(/\{\{\s*first_name\s*\}\}/g, client!.first_name || "there")
+      .replace(/\{\{\s*survey_link\s*\}\}/g, link);
+    try {
+      await sendTwilioSms(company.twilio_account_sid!, company.twilio_auth_token!, company.twilio_from_number!, client!.phone!, body);
+    } catch (e: any) {
+      const [survey] = await db.insert(satisfactionSurveysTable).values({
+        company_id: companyId, job_id: parseInt(job_id), customer_id: parseInt(customer_id),
+        token, sent_at: new Date(), suppressed: true, suppressed_reason: `twilio_error: ${String(e?.message ?? e).slice(0, 120)}`,
+      }).returning();
+      return res.status(201).json({ sent: false, reason: "twilio_error", survey, survey_url: link });
+    }
+
+    const [survey] = await db.insert(satisfactionSurveysTable).values({
+      company_id: companyId, job_id: parseInt(job_id), customer_id: parseInt(customer_id),
+      token, sent_at: new Date(),
+    }).returning();
+    return res.status(201).json({ sent: true, ...survey, survey_url: link });
   } catch (err) {
     console.error("[satisfaction/send]", err);
     return res.status(500).json({ error: "Server error" });
@@ -61,7 +120,9 @@ router.post("/send", requireAuth, async (req, res) => {
 // ── POST /api/satisfaction/respond — PUBLIC, no auth ──
 router.post("/respond", async (req, res) => {
   try {
-    const { token, nps_score, rating, comment } = req.body;
+    // survey_score = MaidCentral 0–4 satisfaction (the scorecard input).
+    // nps_score/rating still accepted for back-compat with the legacy page.
+    const { token, survey_score, nps_score, rating, comment } = req.body;
     if (!token) return res.status(400).json({ error: "token required" });
 
     const survey = await db.select().from(satisfactionSurveysTable)
@@ -70,10 +131,14 @@ router.post("/respond", async (req, res) => {
     if (!survey[0]) return res.status(404).json({ error: "Survey not found" });
     if (survey[0].responded_at) return res.status(409).json({ error: "Already responded" });
 
-    const follow_up_required = nps_score != null && nps_score <= 6;
+    const score04 = survey_score != null && Number.isFinite(Number(survey_score))
+      ? Math.max(0, Math.min(4, Math.round(Number(survey_score)))) : null;
+    // Follow-up when the 0–4 score signals concerns (≤2), or legacy NPS ≤6.
+    const follow_up_required = (score04 != null && score04 <= 2) || (nps_score != null && nps_score <= 6);
 
     const [updated] = await db.update(satisfactionSurveysTable)
       .set({
+        survey_score: score04,
         nps_score: nps_score ?? null,
         rating: rating ?? null,
         comment: comment || null,
@@ -82,6 +147,21 @@ router.post("/respond", async (req, res) => {
       })
       .where(eq(satisfactionSurveysTable.token, token))
       .returning();
+
+    // Attribute the 0–4 to the job's tech(s) → scorecard_entries → recompute.
+    if (score04 != null && updated.job_id) {
+      try {
+        const [job] = await db.select({ dt: jobsTable.scheduled_date })
+          .from(jobsTable).where(eq(jobsTable.id, updated.job_id)).limit(1);
+        const entryDate = job?.dt ? String(job.dt).slice(0, 10) : new Date().toISOString().slice(0, 10);
+        await captureSurveyScore({
+          companyId: updated.company_id, jobId: updated.job_id, surveyId: updated.id,
+          score: score04, entryDate, notes: comment || null,
+        });
+      } catch (e: any) {
+        console.error("[satisfaction/respond] scorecard capture failed (non-fatal):", e?.message ?? e);
+      }
+    }
 
     return res.json(updated);
   } catch (err) {

--- a/artifacts/api-server/src/routes/scorecards.ts
+++ b/artifacts/api-server/src/routes/scorecards.ts
@@ -3,8 +3,92 @@ import { db } from "@workspace/db";
 import { scorecardsTable, scorecardEntriesTable, usersTable, clientsTable } from "@workspace/db/schema";
 import { eq, and, avg, count, desc, sql, inArray } from "drizzle-orm";
 import { requireAuth, requireRole } from "../lib/auth.js";
+import { resolveWindow } from "../lib/report-periods.js";
+import { recomputeAllScorecards, recomputeEmployeeScorecard } from "../lib/scorecard-engine.js";
 
 const router = Router();
+
+// GET /api/scorecards/report — time-bucketed scorecard over a window.
+//   ?scope=employee|company &period=rolling_90d|month|quarter|year|custom
+//   &date= (anchor) &from=&to= (custom) &employee_id= (employee scope)
+// MC formula: score % = unweighted MEAN of non-excluded 0–4 responses ÷ max ×100.
+// Company = unweighted mean of ALL responses (entry-level — NOT avg of tech
+// averages). Computed from live source='qleno' dated entries.
+router.get("/report", requireAuth, requireRole("owner", "admin", "office"), async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId!;
+    const scope = req.query.scope === "company" ? "company" : "employee";
+    const win = resolveWindow(String(req.query.period ?? "rolling_90d"), {
+      anchor: req.query.date, from: req.query.from, to: req.query.to,
+    });
+    const base = sql`source = 'qleno' AND excluded = false AND company_id = ${companyId}
+      AND entry_date >= ${win.from} AND entry_date <= ${win.to}`;
+
+    if (scope === "employee") {
+      const employeeId = parseInt(String(req.query.employee_id ?? ""));
+      if (isNaN(employeeId)) return res.status(400).json({ error: "employee_id required for scope=employee" });
+      const r = await db.execute(sql`
+        SELECT ROUND(AVG(score_value / NULLIF(max_value, 0)) * 100, 2) AS score_pct, COUNT(*)::int AS responses
+          FROM scorecard_entries WHERE ${base} AND employee_id = ${employeeId}`);
+      const row: any = r.rows[0] ?? {};
+      return res.json({ scope, employee_id: employeeId, window: win, score_pct: row.score_pct != null ? parseFloat(row.score_pct) : null, responses: Number(row.responses ?? 0) });
+    }
+
+    // Company: overall (unweighted mean of all responses) + per-tech breakdown.
+    const overall = await db.execute(sql`
+      SELECT ROUND(AVG(score_value / NULLIF(max_value, 0)) * 100, 2) AS score_pct, COUNT(*)::int AS responses
+        FROM scorecard_entries WHERE ${base}`);
+    const byTech = await db.execute(sql`
+      SELECT e.employee_id, (u.first_name || ' ' || u.last_name) AS name,
+             ROUND(AVG(e.score_value / NULLIF(e.max_value, 0)) * 100, 2) AS score_pct, COUNT(*)::int AS responses
+        FROM scorecard_entries e LEFT JOIN users u ON u.id = e.employee_id
+       WHERE ${base} GROUP BY e.employee_id, u.first_name, u.last_name
+       ORDER BY score_pct DESC NULLS LAST`);
+    const o: any = overall.rows[0] ?? {};
+    return res.json({
+      scope: "company", window: win,
+      score_pct: o.score_pct != null ? parseFloat(o.score_pct) : null,
+      responses: Number(o.responses ?? 0),
+      employees: (byTech.rows as any[]).map(r => ({ employee_id: r.employee_id, name: r.name, score_pct: r.score_pct != null ? parseFloat(r.score_pct) : null, responses: Number(r.responses) })),
+    });
+  } catch (err) {
+    console.error("Scorecard report error:", err);
+    return res.status(500).json({ error: "Internal Server Error", message: "Failed to build scorecard report" });
+  }
+});
+
+// PATCH /api/scorecards/entries/:id/exclude { excluded } — office "Exclude from
+// employee" action; recomputes the affected tech's headline.
+router.patch("/entries/:id/exclude", requireAuth, requireRole("owner", "admin", "office"), async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId!;
+    const id = parseInt(req.params.id);
+    if (isNaN(id)) return res.status(400).json({ error: "Invalid id" });
+    const excluded = req.body?.excluded !== false;
+    const [row] = await db.update(scorecardEntriesTable)
+      .set({ excluded })
+      .where(and(eq(scorecardEntriesTable.id, id), eq(scorecardEntriesTable.company_id, companyId)))
+      .returning({ employee_id: scorecardEntriesTable.employee_id });
+    if (!row) return res.status(404).json({ error: "Entry not found" });
+    await recomputeEmployeeScorecard(companyId, row.employee_id);
+    return res.json({ ok: true, excluded, employee_id: row.employee_id });
+  } catch (err) {
+    console.error("Scorecard exclude error:", err);
+    return res.status(500).json({ error: "Internal Server Error", message: "Failed to update entry" });
+  }
+});
+
+// POST /api/scorecards/recompute — backfill qleno scorecard headlines from
+// non-excluded survey responses. MC baseline preserved.
+router.post("/recompute", requireAuth, requireRole("owner", "admin"), async (req, res) => {
+  try {
+    const result = await recomputeAllScorecards(req.auth!.companyId!);
+    return res.json({ ok: true, ...result });
+  } catch (err) {
+    console.error("Scorecard recompute error:", err);
+    return res.status(500).json({ error: "Internal Server Error", message: "Failed to recompute scorecards" });
+  }
+});
 
 router.get("/", requireAuth, async (req, res) => {
   try {

--- a/lib/db/src/schema/companies.ts
+++ b/lib/db/src/schema/companies.ts
@@ -131,6 +131,19 @@ export const companiesTable = pgTable("companies", {
   ot_seventh_day_rule: boolean("ot_seventh_day_rule").notNull().default(false),
   ot_multiplier: numeric("ot_multiplier", { precision: 4, scale: 2 }).notNull().default("1.50"),
   ot_doubletime_multiplier: numeric("ot_doubletime_multiplier", { precision: 4, scale: 2 }).notNull().default("2.00"),
+  // ── Post-job customer survey (scorecard input) — Company Settings → Customer
+  //    Comms. Per-tenant. The SMS send is Twilio-gated and OFF until go-live. ──
+  survey_enabled: boolean("survey_enabled").notNull().default(false),
+  survey_message_template: text("survey_message_template").default(
+    "Hi {{first_name}}, thanks for choosing us! How was your cleaning today? Tap to rate: {{survey_link}}",
+  ),
+  survey_send_after_hours: integer("survey_send_after_hours").notNull().default(0),
+  // Per-tenant Twilio connection (Settings → Integrations). twilio_from_number
+  // already exists above. twilio_enabled is the go-live gate — surveys/SMS only
+  // actually send when this is true AND creds are set AND COMMS_ENABLED=true.
+  twilio_enabled: boolean("twilio_enabled").notNull().default(false),
+  twilio_account_sid: text("twilio_account_sid"),
+  twilio_auth_token: text("twilio_auth_token"),
   created_at: timestamp("created_at").notNull().defaultNow(),
 });
 

--- a/lib/db/src/schema/satisfaction_surveys.ts
+++ b/lib/db/src/schema/satisfaction_surveys.ts
@@ -13,6 +13,10 @@ export const satisfactionSurveysTable = pgTable("satisfaction_surveys", {
   responded_at: timestamp("responded_at"),
   nps_score: integer("nps_score"),
   rating: integer("rating"),
+  // MaidCentral 0–4 satisfaction scale (4 Thrilled … 0 Considering Another
+  // Company) — the scorecard input. Replaces nps/rating going forward; old
+  // columns kept for back-compat with any legacy responses.
+  survey_score: integer("survey_score"),
   comment: text("comment"),
   follow_up_required: boolean("follow_up_required").notNull().default(false),
   suppressed: boolean("suppressed").notNull().default(false),

--- a/lib/db/src/schema/scorecard_entries.ts
+++ b/lib/db/src/schema/scorecard_entries.ts
@@ -1,4 +1,4 @@
-import { pgTable, serial, integer, numeric, text, date, timestamp, index } from "drizzle-orm/pg-core";
+import { pgTable, serial, integer, numeric, text, date, timestamp, boolean, index } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod/v4";
 import { companiesTable } from "./companies";
@@ -22,6 +22,11 @@ export const scorecardEntriesTable = pgTable("scorecard_entries", {
   score_value: numeric("score_value", { precision: 8, scale: 2 }).notNull(),
   max_value: numeric("max_value", { precision: 8, scale: 2 }).notNull().default("100"),
   source: text("source").notNull().default("mc"), // 'mc' | 'qleno'
+  // Office "Exclude from employee" action (MC parity) — excluded responses
+  // (e.g. 0-scores / churn flags) drop out of the tech's mean.
+  excluded: boolean("excluded").notNull().default(false),
+  // Links a qleno entry back to its customer survey response.
+  survey_id: integer("survey_id"),
   notes: text("notes"),
   created_at: timestamp("created_at").notNull().defaultNow(),
 }, (t) => [

--- a/lib/db/src/schema/users.ts
+++ b/lib/db/src/schema/users.ts
@@ -61,6 +61,12 @@ export const usersTable = pgTable("users", {
   // MC's authoritative value on import (NOT recomputed — MC's % is not a simple
   // average of job scores). Per-job history lives in scorecard_entries.
   scorecard_pct: numeric("scorecard_pct", { precision: 5, scale: 2 }),
+  // Coexistence (mirrors efficiency mc/qleno): scorecard_pct is the LIVE headline
+  // — the qleno survey-derived value once responses exist, else the imported MC
+  // baseline. scorecard_pct_mc preserves the MC import; scorecard_pct_source
+  // tracks which is currently shown.
+  scorecard_pct_mc: numeric("scorecard_pct_mc", { precision: 5, scale: 2 }),
+  scorecard_pct_source: text("scorecard_pct_source").default("mc"),
   // [pay-matrix 2026-04-29] Per-employee 4-cell pay matrix. Replaces
   // the company-wide single-rate model. Type can be 'commission' (rate
   // is a fraction 0.00–1.00) or 'hourly' (rate is dollars/hour). The


### PR DESCRIPTION
Builds the MaidCentral-style scorecard: post-job customer survey (0-4) → per-tech scorecard_entries → scorecard_pct = unweighted mean ÷4×100. Twilio SMS send built but gated OFF until go-live (per-tenant survey_enabled + twilio_enabled + creds + COMMS_ENABLED). Exclude-from-employee action. GET /scorecards/report (per-tech + company, company=mean of all responses) reusing the period resolver. Tenant-scoped. Frontend (survey page 0-4 question + Settings UI) is the next slice. Generated with Claude Code.