### PR TITLE
Cadence saves on click + one-click commercial flag + past-job retro Add tech

### DIFF
--- a/artifacts/api-server/src/routes/payroll.ts
+++ b/artifacts/api-server/src/routes/payroll.ts
@@ -1020,7 +1020,7 @@ router.get("/reconciliation-audit", requireAuth, requireRole("owner", "admin", "
         const hrs = allowed > 0 ? allowed : clocked;
         const expected = r2(commercialRate * hrs);
         commercial_misroutes.push({
-          job_id: r.id, date: r.date, name: r.name, service_type: st, tech: r.tech,
+          job_id: r.id, client_id: r.client_id ?? null, date: r.date, name: r.name, service_type: st, tech: r.tech,
           job_total: r2(jobTotal), pct_paid: Math.round(pct * 100), paid_residential: paid,
           hours: r2(hrs), expected_commercial: expected, delta: r2(paid - expected),
         });

--- a/artifacts/api-server/src/routes/users.ts
+++ b/artifacts/api-server/src/routes/users.ts
@@ -126,7 +126,7 @@ router.get("/techs-with-status", requireAuth, async (req, res) => {
     // only when both sides actually carry it (NULL home_branch is fine —
     // those techs are dispatchable to any branch).
     const rows = await db.execute(sql`
-      SELECT u.id, u.first_name, u.last_name, u.role, u.home_branch_id AS branch_id,
+      SELECT u.id, u.first_name, u.last_name, u.role, u.avatar_url, u.home_branch_id AS branch_id,
              (SELECT tc.job_id FROM timeclock tc
                WHERE tc.user_id = u.id
                  AND tc.clock_out_at IS NULL
@@ -202,6 +202,10 @@ router.get("/techs-with-status", requireAuth, async (req, res) => {
         last_name: r.last_name,
         name: `${r.first_name ?? ""} ${r.last_name ?? ""}`.trim(),
         role: r.role,
+        // [avatar-parity 2026-06-12] Same photo everywhere: the Add tech
+        // picker fell back to initials for every tech because this endpoint
+        // never returned avatar_url while the roster surfaces did.
+        avatar_url: r.avatar_url ?? null,
         branch_id: r.branch_id ?? null,
         is_clocked_in: r.active_job_id !== null,
         currently_at: r.active_job_id ? (clientByJob.get(r.active_job_id) ?? null) : null,

--- a/artifacts/qleno/src/pages/company.tsx
+++ b/artifacts/qleno/src/pages/company.tsx
@@ -473,7 +473,7 @@ function GeneralTab() {
   const { toast } = useToast();
   const { activeBranchId } = useBranch();
   const [name, setName] = useState('');
-  const [payCadence, setPayCadence] = useState('biweekly');
+  const [payCadence, setPayCadence] = useState('weekly');
   const [paymentTermsDays, setPaymentTermsDays] = useState(0);
   const [overheadRatePct, setOverheadRatePct] = useState(10);
   const [dispatchStartHour, setDispatchStartHour] = useState(8);
@@ -483,7 +483,10 @@ function GeneralTab() {
   useEffect(() => {
     if (company) {
       setName(company.name || '');
-      setPayCadence(company.pay_cadence || 'biweekly');
+      // Default WEEKLY when unset — matches the payroll page's useCadence
+      // fallback. The old 'biweekly' fallback made the two surfaces disagree
+      // for tenants that never explicitly saved a cadence.
+      setPayCadence(company.pay_cadence || 'weekly');
       setPaymentTermsDays((company as any).payment_terms_days ?? 0);
       setOverheadRatePct(parseFloat(String((company as any).overhead_rate_pct ?? 10)));
       setDispatchStartHour((company as any).dispatch_start_hour ?? 8);
@@ -526,7 +529,17 @@ function GeneralTab() {
       <Section title="Pay Cadence" desc="How often payroll is processed.">
         <div style={{ display: 'flex', gap: '8px' }}>
           {[{ id: 'weekly', label: 'Weekly' }, { id: 'biweekly', label: 'Bi-weekly' }, { id: 'semimonthly', label: 'Semi-monthly' }].map(opt => (
-            <button key={opt.id} onClick={() => setPayCadence(opt.id)} style={{ padding: '7px 16px', borderRadius: '6px', fontSize: '12px', fontFamily: FF, cursor: 'pointer', border: payCadence === opt.id ? 'none' : '1px solid #E5E2DC', backgroundColor: payCadence === opt.id ? 'var(--brand)' : 'transparent', color: payCadence === opt.id ? '#FFFFFF' : '#6B7280' }}>
+            <button key={opt.id} onClick={() => {
+              setPayCadence(opt.id);
+              // [cadence-save 2026-06-12] Persist immediately. The section's
+              // save button sits far below the fold, so Sal kept clicking
+              // Weekly without it ever reaching the DB — payroll then
+              // re-seeded a 14-day window from the stored 'biweekly'.
+              updateCompany.mutate({ data: { pay_cadence: opt.id } as any }, {
+                onSuccess: () => toast({ title: "Pay cadence saved", description: `Payroll defaults to ${opt.label.toLowerCase()} periods now.` }),
+                onError: () => toast({ variant: "destructive", title: "Error", description: "Failed to save pay cadence." }),
+              });
+            }} style={{ padding: '7px 16px', borderRadius: '6px', fontSize: '12px', fontFamily: FF, cursor: 'pointer', border: payCadence === opt.id ? 'none' : '1px solid #E5E2DC', backgroundColor: payCadence === opt.id ? 'var(--brand)' : 'transparent', color: payCadence === opt.id ? '#FFFFFF' : '#6B7280' }}>
               {opt.label}
             </button>
           ))}

--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -1603,7 +1603,7 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
   // vs "Currently on a job") using /api/users/techs-with-status. The endpoint
   // excludes already-assigned techs server-side via ?exclude=<ids>.
   const [addTechOpen, setAddTechOpen] = useState(false);
-  type TechRow = { id: number; name: string; role: string; is_clocked_in: boolean; currently_at: string | null };
+  type TechRow = { id: number; name: string; role: string; avatar_url?: string | null; is_clocked_in: boolean; currently_at: string | null };
   const [addTechList, setAddTechList] = useState<TechRow[]>([]);
   const [addTechLoading, setAddTechLoading] = useState(false);
   const [addTechBusy, setAddTechBusy] = useState(false);

--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -2601,6 +2601,28 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
                         </div>
                       </button>
                     );
+                    // [retro-add 2026-06-12] PAST job: adding a tech is
+                    // record-keeping ("who actually worked it"), not dispatch.
+                    // Suggested picks, frees-up times, time-off, and the
+                    // end-of-shift / turnaround warnings are meaningless after
+                    // the fact (Sal hit "frees up 4:00 PM" on a June 9 job
+                    // three days later) — show the flat roster instead. The
+                    // commission split picks the late addition up from
+                    // job_technicians, which is exactly the missing-split-
+                    // partner fix path.
+                    const nowChi = new Date(new Date().toLocaleString("en-US", { timeZone: "America/Chicago" }));
+                    const todayYmd = `${nowChi.getFullYear()}-${String(nowChi.getMonth() + 1).padStart(2, "0")}-${String(nowChi.getDate()).padStart(2, "0")}`;
+                    const isPastJob = !!job.scheduled_date && job.scheduled_date < todayYmd;
+                    if (isPastJob) {
+                      return (
+                        <>
+                          <div style={{ fontSize: 11, color: "#B45309", background: "#FEF3E2", border: "1px solid #F3D9B0", borderRadius: 7, padding: "8px 10px", marginBottom: 4, fontFamily: FF }}>
+                            Past job — availability checks skipped. Add whoever actually worked it; the pay split updates from the team list.
+                          </div>
+                          {[...addTechList].sort((a, b) => a.name.localeCompare(b.name)).map(t => row(t))}
+                        </>
+                      );
+                    }
                     return (
                       <>
                         {suggested.length > 0 && groupHeader("Suggested")}

--- a/artifacts/qleno/src/pages/payroll.tsx
+++ b/artifacts/qleno/src/pages/payroll.tsx
@@ -226,13 +226,10 @@ function ReconciliationAudit({ from, to }: { from: string; to: string }) {
   );
 }
 
-function WeeklyDetailView() {
-  const cadence = useCadence();
-  const [period, setPeriod] = useState(() => periodForCadence('weekly'));
-  // Re-seed the default window from the tenant's cadence once it loads, unless
-  // the office has manually picked dates.
-  const [periodEdited, setPeriodEdited] = useState(false);
-  useEffect(() => { if (!periodEdited) setPeriod(periodForCadence(cadence)); }, [cadence, periodEdited]);
+// [period-sync 2026-06-12] Period state lives in PayrollPage now (shared with
+// the Summary tab, banners, and the top-right label) — this view just reads
+// and reports changes up.
+function WeeklyDetailView({ period, onPeriodChange }: { period: { start: string; end: string }; onPeriodChange: (p: { start: string; end: string }) => void }) {
   const [expanded, setExpanded] = useState<number[]>([]);
   const FF = "inherit";
   const { activeBranchId } = useBranch();
@@ -274,9 +271,9 @@ function WeeklyDetailView() {
       <div style={{ backgroundColor: '#fff', border: '1px solid #E5E2DC', borderRadius: 10, padding: '16px 20px' }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
           <span style={{ fontSize: 13, fontWeight: 600, color: '#1A1917', fontFamily: FF }}>Pay Period:</span>
-          <CalendarPopover value={period.start} onChange={v => { setPeriodEdited(true); setPeriod(p => ({ ...p, start: v })); }} ariaLabel="Pay period start" />
+          <CalendarPopover value={period.start} onChange={v => onPeriodChange({ ...period, start: v })} ariaLabel="Pay period start" />
           <span style={{ fontSize: 12, color: '#9E9B94' }}>to</span>
-          <CalendarPopover value={period.end} onChange={v => { setPeriodEdited(true); setPeriod(p => ({ ...p, end: v })); }} ariaLabel="Pay period end" />
+          <CalendarPopover value={period.end} onChange={v => onPeriodChange({ ...period, end: v })} ariaLabel="Pay period end" />
           <button onClick={() => refetch()}
             style={{ padding: '7px 16px', background: 'var(--brand)', color: '#fff', border: 'none', borderRadius: 6, fontSize: 13, fontWeight: 600, cursor: 'pointer', fontFamily: FF }}>
             Load
@@ -694,10 +691,16 @@ export default function PayrollPage() {
     return true;
   });
 
-  // Real payroll for the current pay period, sized by the tenant's pay cadence
-  // (weekly for Phes) — same source as the detail view and the Earnings panel.
+  // Pay window shared by BOTH tabs, the top-right label, and the banners.
+  // [period-sync 2026-06-12] Previously By Employee kept its own period state,
+  // so loading May 31 – Jun 6 there left the top-right label, the Summary tab
+  // cards, and the Employee Payroll Summary pinned to the current week (Sal:
+  // "dates on top right not updating based on filter"). One state, one window.
   const cadence = useCadence();
-  const payPeriod = useMemo(() => periodForCadence(cadence), [cadence]);
+  const [periodEdited, setPeriodEdited] = useState(false);
+  const [payPeriod, setPayPeriod] = useState(() => periodForCadence('weekly'));
+  useEffect(() => { if (!periodEdited) setPayPeriod(periodForCadence(cadence)); }, [cadence, periodEdited]);
+  const onPeriodChange = (p: { start: string; end: string }) => { setPeriodEdited(true); setPayPeriod(p); };
   const periodLabel = useMemo(() => {
     const fmt = (s: string) => new Date(`${s}T00:00:00`).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
     const yr = new Date(`${payPeriod.end}T00:00:00`).getFullYear();
@@ -759,7 +762,7 @@ export default function PayrollPage() {
           </div>
         </div>
 
-        {activeView === 'weekly-detail' && <WeeklyDetailView />}
+        {activeView === 'weekly-detail' && <WeeklyDetailView period={payPeriod} onPeriodChange={onPeriodChange} />}
 
         {activeView === 'overview' && <>
         {/* Controls */}

--- a/artifacts/qleno/src/pages/payroll.tsx
+++ b/artifacts/qleno/src/pages/payroll.tsx
@@ -82,11 +82,28 @@ const qualityColor = (q: number | null | undefined) =>
 // and unlinked jobs. Read-only — fixes happen in the normal surfaces.
 function ReconciliationAudit({ from, to }: { from: string; to: string }) {
   const [collapsed, setCollapsed] = useState(false);
+  const qc = useQueryClient();
+  const [marking, setMarking] = useState<number | null>(null);
   const { data, isLoading } = useQuery<any>({
     queryKey: ['payroll-recon-audit', from, to],
     queryFn: () => apiFetch(`/payroll/reconciliation-audit?from=${from}&to=${to}`),
     enabled: !!from && !!to,
   });
+  // [one-click-fix 2026-06-12] Flip the client to commercial right from the
+  // misroute row — the same PUT the Edit Client modal's type toggle uses.
+  // The row disappears from the audit (and the engine repays hourly) on the
+  // refetch, which is the confirmation.
+  const markCommercial = async (clientId: number) => {
+    setMarking(clientId);
+    try {
+      await apiFetch(`/clients/${clientId}`, { method: 'PUT', body: JSON.stringify({ client_type: 'commercial' }) });
+      qc.invalidateQueries({ queryKey: ['payroll-recon-audit'] });
+      qc.invalidateQueries({ queryKey: ['payroll-detail'] });
+      qc.invalidateQueries({ queryKey: ['payroll-overview'] });
+    } finally {
+      setMarking(null);
+    }
+  };
   const d = data?.data;
   const findings = d
     ? d.commercial_misroutes.length + d.solo_pools.length + d.stale_scheduled.total + d.clocked_no_job.length + d.unlinked_jobs.length
@@ -144,7 +161,7 @@ function ReconciliationAudit({ from, to }: { from: string; to: string }) {
         'Commercial work paid as residential %',
         'Service type is a commercial scope, but the client has no account link or commercial flag, so the engine paid the residential pool. Fix: mark the client commercial or link the account, then the row pays hourly.',
         String(d.commercial_misroutes.length),
-        ['Date', 'Client', 'Scope', 'Paid', 'Should be', 'Overpay'],
+        ['Date', 'Client', 'Scope', 'Paid', 'Should be', 'Overpay', ''],
         d.commercial_misroutes.map((m: any) => (
           <tr key={m.job_id}>
             <td style={{ ...td, whiteSpace: 'nowrap' }}>{m.date}</td>
@@ -153,6 +170,14 @@ function ReconciliationAudit({ from, to }: { from: string; to: string }) {
             <td style={td}>{m.pct_paid}% of {money(m.job_total)} = <b>{money(m.paid_residential)}</b></td>
             <td style={td}>hourly × {Number(m.hours).toFixed(1)}h = <b>{money(m.expected_commercial)}</b></td>
             <td style={{ ...td, color: '#DC2626', fontWeight: 700 }}>{money(m.delta)}</td>
+            <td style={{ ...td, whiteSpace: 'nowrap' }}>
+              {m.client_id != null && (
+                <button onClick={() => markCommercial(m.client_id)} disabled={marking === m.client_id}
+                  style={{ padding: '4px 10px', borderRadius: 6, border: '1px solid var(--brand)', background: 'transparent', color: 'var(--brand)', fontSize: 11, fontWeight: 700, cursor: marking === m.client_id ? 'wait' : 'pointer', fontFamily: 'inherit' }}>
+                  {marking === m.client_id ? 'Saving…' : 'Mark commercial'}
+                </button>
+              )}
+            </td>
           </tr>
         )),
       )}


### PR DESCRIPTION
Three fixes from this afternoon's reconciliation session:

## 1. Pay cadence "keeps defaulting to two weeks"
Root cause: the Settings cadence pill only updated local component state — the section's save button sits far below the fold, so clicking **Weekly** never reached the DB. The stored value stayed `biweekly`, and payroll re-seeded a 14-day window (May 31 – Jun 13 is exactly 14 days ending Saturday) every visit.

Fix: the cadence pill **saves immediately on click** (with a toast). Also aligned the unset-cadence fallback to `weekly` on both surfaces — the settings selector previously defaulted to `biweekly` while payroll defaulted to `weekly`.

## 2. One-click "Mark commercial" on the audit
Each row in the audit's "Commercial work paid as residential %" section now has a **Mark commercial** button — same `PUT /clients/:id` the Edit Client modal's Residential/Commercial toggle uses. The row drops off the audit and the engine repays the job hourly on refetch. (The setting also remains available manually: client profile → **Edit** → Client Type toggle.)

## 3. Add tech on a past job → retro mode
Sal's screenshot: a June 9 job opened on June 12 showed "Suggested" picks and "On a job · frees up 4:00 PM." For a past job, adding a tech is record-keeping — *who actually worked it* — not dispatch. The picker now suppresses suggestions, availability labels, time-off grouping, and the end-of-shift/turnaround warnings for past-dated jobs, showing a flat alphabetical roster with an amber explainer instead. The late addition flows into `job_technicians`, which is exactly the missing-split-partner fix path the audit points at (Cameron Goth case).

Verified: `typecheck:libs` clean, both builds pass; remaining tsc errors in company.tsx/payroll.tsx pre-exist on main.

https://claude.ai/code/session_019PiXXwFgtNSnzZQy3MTjAj

---
_Generated by [Claude Code](https://claude.ai/code/session_019PiXXwFgtNSnzZQy3MTjAj)_