### PR TITLE
Scorecard/survey frontend: 0-4 survey page + Settings UI + Quality&Efficiency report

### DIFF
--- a/artifacts/api-server/src/routes/companies.ts
+++ b/artifacts/api-server/src/routes/companies.ts
@@ -52,6 +52,13 @@ router.get("/me", requireAuth, async (req, res) => {
       return res.status(404).json({ error: "Not Found", message: "Company not found" });
     }
 
+    // Never expose the Twilio auth token to the client; surface a boolean so the
+    // Integrations UI can show "connected" without the secret.
+    if (company.twilio_auth_token !== undefined) {
+      company.twilio_auth_token_set = !!company.twilio_auth_token;
+      delete company.twilio_auth_token;
+    }
+
     return res.json(company);
   } catch (err) {
     console.error("Get company error:", err);
@@ -120,6 +127,21 @@ router.patch("/me", requireAuth, async (req, res) => {
     if (sms_paused_enabled !== undefined) patch.sms_paused_enabled = sms_paused_enabled;
     if (sms_complete_enabled !== undefined) patch.sms_complete_enabled = sms_complete_enabled;
     if (twilio_from_number !== undefined) patch.twilio_from_number = twilio_from_number;
+    // [scorecard-survey 2026-06-12] Per-tenant post-job survey config (Customer
+    // Comms) + Twilio connection (Integrations). twilio_enabled is the go-live
+    // gate; auth token is write-only (only set when a non-empty value is sent).
+    {
+      const {
+        survey_enabled, survey_message_template, survey_send_after_hours,
+        twilio_enabled, twilio_account_sid, twilio_auth_token,
+      } = req.body;
+      if (survey_enabled !== undefined) patch.survey_enabled = !!survey_enabled;
+      if (survey_message_template !== undefined) patch.survey_message_template = survey_message_template;
+      if (survey_send_after_hours !== undefined) patch.survey_send_after_hours = Number(survey_send_after_hours) || 0;
+      if (twilio_enabled !== undefined) patch.twilio_enabled = !!twilio_enabled;
+      if (twilio_account_sid !== undefined) patch.twilio_account_sid = twilio_account_sid || null;
+      if (twilio_auth_token !== undefined && twilio_auth_token !== "") patch.twilio_auth_token = twilio_auth_token;
+    }
     // [ghl-estimate-bridge 2026-06-10] GoHighLevel webhook URLs (estimate drip).
     // https-only; empty string clears (disables the bridge).
     {

--- a/artifacts/qleno/src/App.tsx
+++ b/artifacts/qleno/src/App.tsx
@@ -48,6 +48,7 @@ const PayrollToRevenuePage= lazy(() => import("@/pages/reports/payroll-to-revenu
 const EfficiencyPage      = lazy(() => import("@/pages/reports/efficiency"));
 const WeekReviewPage      = lazy(() => import("@/pages/reports/week-review"));
 const ScorecardsReportPage= lazy(() => import("@/pages/reports/scorecards"));
+const QualityEfficiencyReportPage = lazy(() => import("@/pages/reports/quality-efficiency"));
 const CancellationsPage   = lazy(() => import("@/pages/reports/cancellations"));
 const ContactTicketsReportPage = lazy(() => import("@/pages/reports/contact-tickets"));
 const HotSheetPage        = lazy(() => import("@/pages/reports/hot-sheet"));
@@ -170,6 +171,7 @@ function Router() {
         <Route path="/reports/efficiency" component={EfficiencyPage} />
         <Route path="/reports/week-review" component={WeekReviewPage} />
         <Route path="/reports/scorecards" component={ScorecardsReportPage} />
+        <Route path="/reports/quality-efficiency" component={QualityEfficiencyReportPage} />
         <Route path="/reports/cancellations" component={CancellationsPage} />
         <Route path="/reports/contact-tickets" component={ContactTicketsReportPage} />
         <Route path="/reports/hot-sheet" component={HotSheetPage} />

--- a/artifacts/qleno/src/pages/company.tsx
+++ b/artifacts/qleno/src/pages/company.tsx
@@ -12,7 +12,7 @@ import { DocumentsTab } from "./company/documents";
 import { PricingTab } from "./company/pricing";
 import { AddonsTab } from "./company/addons-tab";
 
-type Tab = 'general' | 'branding' | 'integrations' | 'payroll' | 'notifications' | 'clock-inout' | 'invoicing' | 'hr-policies' | 'documents' | 'pricing' | 'addons' | 'online-booking' | 'service-zones' | 'follow-up';
+type Tab = 'general' | 'branding' | 'integrations' | 'payroll' | 'notifications' | 'clock-inout' | 'invoicing' | 'hr-policies' | 'documents' | 'pricing' | 'addons' | 'online-booking' | 'service-zones' | 'follow-up' | 'survey';
 
 // [settings-nav 2026-05-26] Grouped sidebar replaces the 14-tab flat strip.
 // Groups reflect how the day actually flows: Business (identity), Pricing &
@@ -52,6 +52,7 @@ const TAB_GROUPS: { label: string; tabs: { id: Tab; label: string }[] }[] = [
     tabs: [
       { id: 'follow-up', label: 'Follow-Up Sequences' },
       { id: 'notifications', label: 'Notifications' },
+      { id: 'survey', label: 'Customer Survey' },
     ],
   },
   {
@@ -125,6 +126,7 @@ export default function CompanyPage() {
             {activeTab === 'branding' && <BrandingTab />}
             {activeTab === 'general' && <GeneralTab />}
             {activeTab === 'notifications' && <NotificationsTab />}
+            {activeTab === 'survey' && <CustomerSurveyTab />}
             {activeTab === 'clock-inout' && <ClockInOutTab />}
             {activeTab === 'invoicing' && <InvoicingTab />}
             {activeTab === 'integrations' && <IntegrationsTab />}
@@ -2768,6 +2770,119 @@ function FollowUpSequencesTab() {
           );
         })}
       </div>
+    </div>
+  );
+}
+
+// [scorecard-survey 2026-06-12] Customer Comms → Customer Survey. Per-tenant
+// post-job survey config + Twilio connection. SMS only sends once Twilio is
+// connected AND enabled (go-live gate) AND COMMS_ENABLED — off by default.
+function CustomerSurveyTab() {
+  const CS_API = import.meta.env.BASE_URL.replace(/\/$/, "");
+  const { toast } = useToast();
+  const { data: company, refetch } = useGetMyCompany({ request: { headers: getAuthHeaders() } });
+  const [f, setF] = useState({
+    survey_enabled: false, survey_message_template: "", survey_send_after_hours: 0,
+    twilio_enabled: false, twilio_account_sid: "", twilio_from_number: "", twilio_auth_token: "",
+  });
+  const [tokenSet, setTokenSet] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    const c = company as any;
+    if (!c) return;
+    setF({
+      survey_enabled: !!c.survey_enabled,
+      survey_message_template: c.survey_message_template ?? "",
+      survey_send_after_hours: Number(c.survey_send_after_hours ?? 0),
+      twilio_enabled: !!c.twilio_enabled,
+      twilio_account_sid: c.twilio_account_sid ?? "",
+      twilio_from_number: c.twilio_from_number ?? "",
+      twilio_auth_token: "",
+    });
+    setTokenSet(!!c.twilio_auth_token_set);
+  }, [company]);
+
+  async function save() {
+    setSaving(true);
+    try {
+      const body: any = {
+        survey_enabled: f.survey_enabled,
+        survey_message_template: f.survey_message_template,
+        survey_send_after_hours: f.survey_send_after_hours,
+        twilio_enabled: f.twilio_enabled,
+        twilio_account_sid: f.twilio_account_sid,
+        twilio_from_number: f.twilio_from_number,
+      };
+      if (f.twilio_auth_token) body.twilio_auth_token = f.twilio_auth_token; // write-only
+      const r = await fetch(`${CS_API}/api/companies/me`, {
+        method: "PATCH",
+        headers: { ...getAuthHeaders(), "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!r.ok) throw new Error();
+      toast({ title: "Survey settings saved" });
+      setF(p => ({ ...p, twilio_auth_token: "" }));
+      refetch();
+    } catch { toast({ title: "Failed to save", variant: "destructive" }); }
+    setSaving(false);
+  }
+
+  const card: React.CSSProperties = { background: "#FFFFFF", border: "1px solid #E5E2DC", borderRadius: 12, padding: "20px 24px", marginBottom: 20 };
+  const label: React.CSSProperties = { display: "block", fontSize: 11, fontWeight: 600, color: "#9E9B94", textTransform: "uppercase", letterSpacing: "0.06em", marginBottom: 6 };
+  const input: React.CSSProperties = { width: "100%", padding: "9px 12px", border: "1px solid #E5E2DC", borderRadius: 8, fontSize: 14, color: "#1A1917", background: "#FFFFFF", boxSizing: "border-box", fontFamily: "inherit" };
+  const Toggle = ({ on, onChange }: { on: boolean; onChange: (v: boolean) => void }) => (
+    <button onClick={() => onChange(!on)} style={{ width: 44, height: 24, borderRadius: 12, border: "none", cursor: "pointer", background: on ? "var(--brand)" : "#D1CFC9", position: "relative", flexShrink: 0 }}>
+      <span style={{ position: "absolute", top: 2, left: on ? 22 : 2, width: 20, height: 20, borderRadius: "50%", background: "#FFF", transition: "left 0.15s" }} />
+    </button>
+  );
+
+  return (
+    <div style={{ maxWidth: 640 }}>
+      <h2 style={{ fontSize: 20, fontWeight: 700, color: "#1A1917", margin: "0 0 4px" }}>Customer Survey</h2>
+      <p style={{ fontSize: 13, color: "#6B7280", margin: "0 0 20px" }}>
+        Text a 0–4 satisfaction survey after each job. Responses feed each tech's scorecard. Sending stays off until Twilio is connected and enabled below.
+      </p>
+
+      <div style={card}>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 16 }}>
+          <div><div style={{ fontSize: 14, fontWeight: 700, color: "#1A1917" }}>Send post-job surveys</div>
+            <div style={{ fontSize: 12, color: "#9E9B94" }}>Master toggle for the survey program</div></div>
+          <Toggle on={f.survey_enabled} onChange={v => setF(p => ({ ...p, survey_enabled: v }))} />
+        </div>
+        <div style={{ marginBottom: 16 }}>
+          <label style={label}>Message template</label>
+          <textarea rows={3} style={{ ...input, resize: "vertical" }} value={f.survey_message_template}
+            onChange={e => setF(p => ({ ...p, survey_message_template: e.target.value }))} />
+          <p style={{ fontSize: 11, color: "#9E9B94", margin: "6px 0 0" }}>Variables: <code>{"{{first_name}}"}</code>, <code>{"{{survey_link}}"}</code></p>
+        </div>
+        <div style={{ maxWidth: 220 }}>
+          <label style={label}>Send delay after completion (hours)</label>
+          <input type="number" min={0} style={input} value={f.survey_send_after_hours}
+            onChange={e => setF(p => ({ ...p, survey_send_after_hours: Number(e.target.value) || 0 }))} />
+        </div>
+      </div>
+
+      <div style={card}>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 16 }}>
+          <div><div style={{ fontSize: 14, fontWeight: 700, color: "#1A1917" }}>Twilio connection <span style={{ fontSize: 11, fontWeight: 600, color: tokenSet ? "var(--brand)" : "#9E9B94" }}>{tokenSet ? "• Connected" : "• Not connected"}</span></div>
+            <div style={{ fontSize: 12, color: "#9E9B94" }}>Go-live gate — surveys/SMS only send when this is on</div></div>
+          <Toggle on={f.twilio_enabled} onChange={v => setF(p => ({ ...p, twilio_enabled: v }))} />
+        </div>
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 14 }}>
+          <div><label style={label}>Account SID</label>
+            <input style={input} value={f.twilio_account_sid} placeholder="AC…" onChange={e => setF(p => ({ ...p, twilio_account_sid: e.target.value }))} /></div>
+          <div><label style={label}>From number</label>
+            <input style={input} value={f.twilio_from_number} placeholder="+1…" onChange={e => setF(p => ({ ...p, twilio_from_number: e.target.value }))} /></div>
+          <div style={{ gridColumn: "1 / -1" }}><label style={label}>Auth token {tokenSet && <span style={{ textTransform: "none", color: "#9E9B94" }}>(leave blank to keep current)</span>}</label>
+            <input type="password" style={input} value={f.twilio_auth_token} placeholder={tokenSet ? "••••••••" : "Auth token"} onChange={e => setF(p => ({ ...p, twilio_auth_token: e.target.value }))} /></div>
+        </div>
+      </div>
+
+      <button onClick={save} disabled={saving}
+        style={{ padding: "10px 22px", background: "var(--brand)", color: "#FFFFFF", border: "none", borderRadius: 8, fontSize: 14, fontWeight: 600, cursor: saving ? "default" : "pointer", fontFamily: "inherit" }}>
+        {saving ? "Saving…" : "Save"}
+      </button>
     </div>
   );
 }

--- a/artifacts/qleno/src/pages/reports/index.tsx
+++ b/artifacts/qleno/src/pages/reports/index.tsx
@@ -39,6 +39,7 @@ const REPORT_GROUPS = [
       { title: "Employee Stats",       desc: "Individual attendance, efficiency, and revenue stats.",  url: "/reports/employee-stats",   icon: UserCheck },
       { title: "Tips Report",          desc: "Tips earned by employee across a date range.",           url: "/reports/tips",             icon: Star },
       { title: "Scorecard Results",    desc: "Client ratings distribution and employee averages.",     url: "/reports/scorecards",       icon: ClipboardList },
+      { title: "Quality & Efficiency", desc: "Scorecard % + efficiency by package — company or per-tech, time-bucketed.", url: "/reports/quality-efficiency", icon: ClipboardList },
       { title: "Cancellations",        desc: "Clients with cancelled jobs, tenure, and revenue lost.", url: "/reports/cancellations",    icon: AlertTriangle },
       { title: "Contact Tickets",      desc: "Complaints, breakages, compliments, and incidents.",     url: "/reports/contact-tickets",  icon: FileText },
     ],

--- a/artifacts/qleno/src/pages/reports/quality-efficiency.tsx
+++ b/artifacts/qleno/src/pages/reports/quality-efficiency.tsx
@@ -1,0 +1,105 @@
+import { useState } from "react";
+import { DashboardLayout } from "@/components/layout/dashboard-layout";
+import { ReportHeader, KpiCard, DataTable, useReportData, clr } from "./_shared";
+
+type Period = "rolling_90d" | "month" | "quarter" | "year";
+const PERIODS: { id: Period; label: string }[] = [
+  { id: "rolling_90d", label: "Last 90 days" },
+  { id: "month", label: "This month" },
+  { id: "quarter", label: "This quarter" },
+  { id: "year", label: "This year" },
+];
+
+interface ScorecardReport {
+  scope: string; window: { from: string; to: string; label: string };
+  score_pct: number | null; responses: number;
+  employees?: { employee_id: number; name: string; score_pct: number | null; responses: number }[];
+}
+interface EffReport {
+  scope: string; window: { from: string; to: string; label: string };
+  overall: number | null;
+  packages: { package: string; efficiency_pct: number | null; jobs: number; techs?: number }[];
+}
+
+const effColor = (p: number | null) => p == null ? clr.muted : p >= 100 ? clr.brand : p >= 80 ? clr.text : clr.red;
+
+export default function QualityEfficiencyReport() {
+  const [period, setPeriod] = useState<Period>("rolling_90d");
+  const [empId, setEmpId] = useState<number | "company">("company");
+
+  const empQ = empId === "company" ? "scope=company" : `scope=employee&employee_id=${empId}`;
+  const sc = useReportData<ScorecardReport>(`/scorecards/report?${empQ}&period=${period}`);
+  const eff = useReportData<EffReport>(`/efficiency/report?${empQ}&period=${period}`);
+  // The company scorecard report doubles as the tech picker source.
+  const techPickerList = useReportData<ScorecardReport>(`/scorecards/report?scope=company&period=${period}`);
+
+  const loading = sc.loading || eff.loading;
+  const win = sc.data?.window || eff.data?.window;
+
+  const pillRow = (
+    <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
+      {PERIODS.map(p => (
+        <button key={p.id} onClick={() => setPeriod(p.id)}
+          style={{ padding: "6px 12px", borderRadius: 8, fontSize: 12, fontWeight: period === p.id ? 600 : 400, cursor: "pointer",
+            border: `1px solid ${period === p.id ? clr.brand : clr.border}`, background: period === p.id ? `${clr.brand}14` : "#FFFFFF", color: period === p.id ? clr.brand : clr.secondary }}>
+          {p.label}
+        </button>
+      ))}
+      <span style={{ width: 1, height: 20, background: clr.border, margin: "0 4px" }} />
+      <select value={String(empId)} onChange={e => setEmpId(e.target.value === "company" ? "company" : Number(e.target.value))}
+        style={{ padding: "6px 10px", borderRadius: 8, fontSize: 12, border: `1px solid ${clr.border}`, background: "#FFFFFF", color: clr.text, fontFamily: "inherit" }}>
+        <option value="company">Company-wide</option>
+        {(techPickerList.data?.employees || []).map(t => <option key={t.employee_id} value={t.employee_id}>{t.name}</option>)}
+      </select>
+    </div>
+  );
+
+  return (
+    <DashboardLayout title="Quality & Efficiency">
+      <div style={{ padding: "24px 28px", maxWidth: 1000 }}>
+        <ReportHeader
+          title="Quality & Efficiency"
+          subtitle={win ? `${win.label} · ${win.from} → ${win.to}` : "Scorecard + efficiency by service"}
+          filters={pillRow}
+        />
+      <div style={{ display: "flex", gap: 16, flexWrap: "wrap", marginBottom: 24 }}>
+        <KpiCard label="Scorecard" value={sc.data?.score_pct != null ? `${sc.data.score_pct.toFixed(1)}%` : "—"}
+          sub={`${sc.data?.responses ?? 0} survey responses`} />
+        <KpiCard label="Efficiency" value={eff.data?.overall != null ? `${eff.data.overall.toFixed(1)}%` : "—"}
+          sub="Allowed ÷ actual hours" color={effColor(eff.data?.overall ?? null)} />
+      </div>
+
+      {/* Efficiency by package */}
+      <h3 style={{ fontSize: 13, fontWeight: 700, color: clr.text, margin: "8px 0 10px" }}>Efficiency by service package</h3>
+      <DataTable
+        loading={loading}
+        emptyMsg="No efficiency data for this period."
+        cols={[
+          { header: "Package", render: (r: any) => r.package },
+          { header: "Efficiency", render: (r: any) => <span style={{ fontWeight: 600, color: effColor(r.efficiency_pct) }}>{r.efficiency_pct != null ? `${r.efficiency_pct.toFixed(1)}%` : "—"}</span> },
+          { header: "Jobs", render: (r: any) => r.jobs },
+          ...(empId === "company" ? [{ header: "Techs", render: (r: any) => r.techs ?? "—" }] : []),
+        ]}
+        rows={eff.data?.packages || []}
+      />
+
+      {/* Scorecard — per-tech only in company scope */}
+      {empId === "company" && (
+        <>
+          <h3 style={{ fontSize: 13, fontWeight: 700, color: clr.text, margin: "24px 0 10px" }}>Scorecard by technician</h3>
+          <DataTable
+            loading={loading}
+            emptyMsg="No survey responses for this period."
+            cols={[
+              { header: "Technician", render: (r: any) => r.name },
+              { header: "Score", render: (r: any) => <span style={{ fontWeight: 600, color: clr.brand }}>{r.score_pct != null ? `${r.score_pct.toFixed(1)}%` : "—"}</span> },
+              { header: "Responses", render: (r: any) => r.responses },
+            ]}
+            rows={sc.data?.employees || []}
+          />
+        </>
+      )}
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/artifacts/qleno/src/pages/survey.tsx
+++ b/artifacts/qleno/src/pages/survey.tsx
@@ -6,6 +6,16 @@ import { QlenoLogo } from "@/components/brand/QlenoLogo";
 const API = import.meta.env.BASE_URL.replace(/\/$/, "");
 const FF = "'Plus Jakarta Sans', sans-serif";
 
+// MaidCentral 0–4 satisfaction scale — the single question that feeds the
+// employee scorecard. Highest first (reads top-down on a phone).
+const OPTIONS: { score: number; label: string; sub: string; color: string }[] = [
+  { score: 4, label: "Thrilled — Great Work", sub: "Everything was excellent", color: "#16A34A" },
+  { score: 3, label: "Happy — Good Work", sub: "A good cleaning", color: "#65A30D" },
+  { score: 2, label: "A Few Concerns", sub: "Some things to improve", color: "#D97706" },
+  { score: 1, label: "Major Concerns", sub: "Several problems", color: "#DC2626" },
+  { score: 0, label: "Considering Another Company", sub: "Strongly dissatisfied", color: "#991B1B" },
+];
+
 export default function SurveyPage() {
   const [, params] = useRoute("/survey/:token");
   const token = params?.token || "";
@@ -17,8 +27,7 @@ export default function SurveyPage() {
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState("");
 
-  const [rating, setRating] = useState<number | null>(null);
-  const [nps, setNps] = useState<number | null>(null);
+  const [score, setScore] = useState<number | null>(null);
   const [comment, setComment] = useState("");
 
   useEffect(() => {
@@ -35,14 +44,14 @@ export default function SurveyPage() {
   }, [token]);
 
   async function submit() {
-    if (rating === null || nps === null) return;
+    if (score === null) return;
     setSubmitting(true);
     setSubmitError("");
     try {
       const r = await fetch(`${API}/api/satisfaction/respond`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ token, nps_score: nps, rating, comment }),
+        body: JSON.stringify({ token, survey_score: score, comment }),
       });
       const d = await r.json();
       if (d.error) setSubmitError(d.error === "Already responded" ? "This survey has already been submitted. Thank you." : d.error);
@@ -53,7 +62,7 @@ export default function SurveyPage() {
     setSubmitting(false);
   }
 
-  const brand = meta?.brand_color || "#5B9BD5";
+  const brand = meta?.brand_color || "#00C9A0";
   const companyName = meta?.company_name || "Your cleaning company";
 
   if (loading) {
@@ -80,7 +89,7 @@ export default function SurveyPage() {
     return (
       <div style={{ minHeight: "100vh", display: "flex", alignItems: "center", justifyContent: "center", background: "#F8F7F4", fontFamily: FF, padding: 24 }}>
         <div style={{ background: "#FFFFFF", borderRadius: 16, padding: "48px 40px", maxWidth: 440, width: "100%", textAlign: "center", boxShadow: "0 8px 32px rgba(0,0,0,0.08)" }}>
-          <CheckCircle size={48} style={{ color: "#22C55E", marginBottom: 16 }} />
+          <CheckCircle size={48} style={{ color: brand, marginBottom: 16 }} />
           <h2 style={{ fontSize: 22, fontWeight: 700, color: "#1A1917", margin: "0 0 10px" }}>Thank you for your feedback.</h2>
           <p style={{ fontSize: 14, color: "#6B7280", margin: 0, lineHeight: "1.6" }}>
             We appreciate you trusting us with your home.
@@ -90,75 +99,54 @@ export default function SurveyPage() {
     );
   }
 
-  const RATING_LABELS: Record<number, string> = { 1: "Poor", 2: "Fair", 3: "Good", 4: "Great", 5: "Excellent" };
-  const canSubmit = rating !== null && nps !== null;
+  const canSubmit = score !== null;
 
   return (
     <div style={{ minHeight: "100vh", background: "#F8F7F4", fontFamily: FF, padding: "24px 16px", display: "flex", alignItems: "flex-start", justifyContent: "center" }}>
-      <div style={{ background: "#FFFFFF", borderRadius: 16, padding: "36px 28px", maxWidth: 500, width: "100%", boxShadow: "0 8px 32px rgba(0,0,0,0.08)", marginTop: 24 }}>
+      <div style={{ background: "#FFFFFF", borderRadius: 16, padding: "36px 24px", maxWidth: 480, width: "100%", boxShadow: "0 8px 32px rgba(0,0,0,0.08)", marginTop: 24 }}>
         {/* Header */}
-        <div style={{ textAlign: "center", marginBottom: 32 }}>
-          <div style={{ display: "flex", justifyContent: "center", marginBottom: 20 }}>
+        <div style={{ textAlign: "center", marginBottom: 28 }}>
+          <div style={{ display: "flex", justifyContent: "center", marginBottom: 18 }}>
             <QlenoLogo size="sm" theme="light" layout="horizontal" />
           </div>
           <div style={{ width: 44, height: 44, borderRadius: 11, backgroundColor: brand, display: "flex", alignItems: "center", justifyContent: "center", margin: "0 auto 10px", fontSize: 18, fontWeight: 800, color: "#FFFFFF" }}>
             {companyName[0]}
           </div>
           <h1 style={{ fontSize: 17, fontWeight: 700, color: "#1A1917", margin: "0 0 2px" }}>{companyName}</h1>
-          <p style={{ fontSize: 10, color: "#9E9B94", margin: "0 0 8px", letterSpacing: "0.02em" }}>Powered by Qleno</p>
-          <p style={{ fontSize: 14, color: "#6B7280", margin: 0 }}>How was your cleaning today?</p>
+          <p style={{ fontSize: 10, color: "#9E9B94", margin: "0 0 10px", letterSpacing: "0.02em" }}>Powered by Qleno</p>
+          <p style={{ fontSize: 15, color: "#1A1917", fontWeight: 600, margin: 0 }}>How was your cleaning?</p>
         </div>
 
-        {/* Q1 — 1–5 circle rating */}
-        <div style={{ marginBottom: 28 }}>
-          <p style={{ fontSize: 13, fontWeight: 700, color: "#1A1917", marginBottom: 14 }}>Rate your cleaning today</p>
-          <div style={{ display: "flex", gap: 10, justifyContent: "center" }}>
-            {[1, 2, 3, 4, 5].map(s => (
-              <button key={s} onClick={() => setRating(s)} style={{
-                width: 52, height: 52, borderRadius: "50%",
-                border: `2px solid ${rating === s ? brand : "#E5E2DC"}`,
-                backgroundColor: rating === s ? brand : "#FFFFFF",
-                color: rating === s ? "#FFFFFF" : "#6B7280",
-                fontSize: 16, fontWeight: 700, cursor: "pointer",
-                display: "flex", alignItems: "center", justifyContent: "center",
+        {/* 0–4 satisfaction choices */}
+        <div style={{ display: "flex", flexDirection: "column", gap: 10, marginBottom: 24 }}>
+          {OPTIONS.map(o => {
+            const sel = score === o.score;
+            return (
+              <button key={o.score} onClick={() => setScore(o.score)} style={{
+                display: "flex", alignItems: "center", gap: 14, textAlign: "left" as const,
+                padding: "14px 16px", borderRadius: 12, cursor: "pointer", width: "100%",
+                border: `2px solid ${sel ? o.color : "#E5E2DC"}`,
+                backgroundColor: sel ? `${o.color}12` : "#FFFFFF",
                 transition: "all 0.12s", fontFamily: FF,
               }}>
-                {s}
+                <div style={{
+                  width: 34, height: 34, borderRadius: "50%", flexShrink: 0,
+                  backgroundColor: sel ? o.color : "#F3F4F6",
+                  color: sel ? "#FFFFFF" : "#6B7280",
+                  display: "flex", alignItems: "center", justifyContent: "center",
+                  fontSize: 16, fontWeight: 800,
+                }}>{o.score}</div>
+                <div>
+                  <div style={{ fontSize: 14, fontWeight: 700, color: sel ? o.color : "#1A1917" }}>{o.label}</div>
+                  <div style={{ fontSize: 12, color: "#9E9B94" }}>{o.sub}</div>
+                </div>
               </button>
-            ))}
-          </div>
-          <div style={{ display: "flex", justifyContent: "space-between", marginTop: 6, paddingLeft: 4, paddingRight: 4 }}>
-            <span style={{ fontSize: 10, color: "#9E9B94" }}>Poor</span>
-            <span style={{ fontSize: 10, color: "#9E9B94" }}>Good</span>
-            <span style={{ fontSize: 10, color: "#9E9B94" }}>Excellent</span>
-          </div>
-          {rating && (
-            <p style={{ textAlign: "center", fontSize: 12, color: brand, fontWeight: 600, marginTop: 6 }}>{RATING_LABELS[rating]}</p>
-          )}
+            );
+          })}
         </div>
 
-        {/* Q2 — NPS 0–10 */}
-        <div style={{ marginBottom: 28 }}>
-          <p style={{ fontSize: 13, fontWeight: 700, color: "#1A1917", marginBottom: 4 }}>How likely are you to recommend us to a friend or neighbor?</p>
-          <p style={{ fontSize: 11, color: "#9E9B94", margin: "0 0 14px" }}>0 = Not at all likely · 10 = Extremely likely</p>
-          <div style={{ display: "flex", gap: 5, flexWrap: "wrap" as const }}>
-            {Array.from({ length: 11 }, (_, i) => (
-              <button key={i} onClick={() => setNps(i)} style={{
-                width: 40, height: 40, borderRadius: 8,
-                border: `2px solid ${nps === i ? brand : "#E5E2DC"}`,
-                backgroundColor: nps === i ? brand : "#FFFFFF",
-                color: nps === i ? "#FFFFFF" : "#1A1917",
-                fontSize: 13, fontWeight: 600, cursor: "pointer",
-                transition: "all 0.12s", fontFamily: FF,
-              }}>
-                {i}
-              </button>
-            ))}
-          </div>
-        </div>
-
-        {/* Q3 — Optional comment */}
-        <div style={{ marginBottom: 28 }}>
+        {/* Optional comment */}
+        <div style={{ marginBottom: 22 }}>
           <label style={{ fontSize: 13, fontWeight: 700, color: "#1A1917", display: "block", marginBottom: 8 }}>
             Anything else you'd like to share? <span style={{ color: "#9E9B94", fontWeight: 400 }}>(optional)</span>
           </label>


### PR DESCRIPTION
Frontend slice for the scorecard system. (1) /survey/:token → MC 0-4 question, POSTs survey_score, brand-aware. (2) companies PATCH allowlist for survey+Twilio fields; GET masks auth token. (3) Company Settings → Customer Comms → Customer Survey tab (survey config + Twilio connect, twilio_enabled go-live gate). (4) Reports → Quality & Efficiency view (period selector + company/per-tech scope) on the new report endpoints. Per-tenant. Generated with Claude Code.