### PR TITLE
fix(quotes): repoint scope_id FK to pricing_scopes + correct service_type + real rate in builder preview

### DIFF
--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -1540,6 +1540,40 @@ async function runBookingSchemaGuard(): Promise<void> {
               (seq.id, 7, 192, 'email', 'Closing out your quote', 'Hi {{first_name}}, we will pause our follow-ups for now so we are not crowding your inbox. Whenever you are ready for a cleaning, just reply and we will pick right back up. Thank you from the Phes team.');
           END LOOP;
         END $$;` },
+
+    // ── Quote scope_id FK fix (BUG-1) ─────────────────────────────────────────
+    //   The quote builder lists/prices scopes from pricing_scopes (ids 1..N) and
+    //   posts scope_id = pricing_scopes.id, but quotes.scope_id used to FK the
+    //   legacy quote_scopes table (5 rows). Any scope whose pricing id wasn't
+    //   also a quote_scopes id (Move In/Out, Recurring 2/4-wk, Hourly Standard,
+    //   commercial, …) 500'd on save. Every existing quotes.scope_id is already
+    //   a valid pricing_scopes id (verified: 0 orphans across all tenants), so
+    //   repointing the FK changes no rows. Multi-tenant safe; idempotent.
+    { label: "repoint quotes.scope_id FK → pricing_scopes",
+      stmt: `DO $$
+        BEGIN
+          IF EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'quotes_scope_id_quote_scopes_id_fk') THEN
+            ALTER TABLE quotes DROP CONSTRAINT quotes_scope_id_quote_scopes_id_fk;
+          END IF;
+          IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'quotes_scope_id_pricing_scopes_id_fk') THEN
+            ALTER TABLE quotes ADD CONSTRAINT quotes_scope_id_pricing_scopes_id_fk
+              FOREIGN KEY (scope_id) REFERENCES pricing_scopes(id);
+          END IF;
+        END $$;` },
+
+    // Backfill the secondary mislabel: quotes created before the fix stored
+    // service_type from the WRONG table (quote_scopes name). Correct it to the
+    // pricing_scopes name the operator actually picked. Guarded to only rewrite
+    // rows whose current service_type is a quote_scopes name (the bug signature),
+    // so it never clobbers a correct value and is a no-op once aligned.
+    { label: "backfill quotes.service_type from pricing_scopes",
+      stmt: `UPDATE quotes q
+                SET service_type = ps.name
+               FROM pricing_scopes ps
+              WHERE q.scope_id = ps.id
+                AND q.scope_id IS NOT NULL
+                AND q.service_type IS DISTINCT FROM ps.name
+                AND q.service_type IN (SELECT name FROM quote_scopes)` },
   ];
 
   for (const { label, stmt } of guards) {

--- a/artifacts/api-server/src/routes/quotes.ts
+++ b/artifacts/api-server/src/routes/quotes.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import { db } from "@workspace/db";
-import { quotesTable, clientsTable, quoteScopesTable, recurringSchedulesTable, usersTable } from "@workspace/db/schema";
+import { quotesTable, clientsTable, pricingScopesTable, recurringSchedulesTable, usersTable } from "@workspace/db/schema";
 import { eq, and, desc, count, sql } from "drizzle-orm";
 import { requireAuth, requireRole } from "../lib/auth.js";
 import { logAudit } from "../lib/audit.js";
@@ -75,12 +75,12 @@ async function getQuoteWithDetails(id: number, companyId: number) {
       client_last: clientsTable.last_name,
       client_email: clientsTable.email,
       client_phone: clientsTable.phone,
-      scope_name: quoteScopesTable.name,
-      scope_category: quoteScopesTable.category,
+      scope_name: pricingScopesTable.name,
+      scope_category: pricingScopesTable.scope_group,
     })
     .from(quotesTable)
     .leftJoin(clientsTable, eq(quotesTable.client_id, clientsTable.id))
-    .leftJoin(quoteScopesTable, eq(quotesTable.scope_id, quoteScopesTable.id))
+    .leftJoin(pricingScopesTable, eq(quotesTable.scope_id, pricingScopesTable.id))
     .where(and(eq(quotesTable.id, id), eq(quotesTable.company_id, companyId)))
     .limit(1);
   return quote;
@@ -142,7 +142,7 @@ router.get("/", requireAuth, async (req, res) => {
         client_first: clientsTable.first_name,
         client_last: clientsTable.last_name,
         client_email: clientsTable.email,
-        scope_name: quoteScopesTable.name,
+        scope_name: pricingScopesTable.name,
         // [quote-breakdown 2026-06-08] who quoted + residential/commercial split.
         created_by: quotesTable.created_by,
         quoted_by_first: usersTable.first_name,
@@ -151,7 +151,7 @@ router.get("/", requireAuth, async (req, res) => {
       })
       .from(quotesTable)
       .leftJoin(clientsTable, eq(quotesTable.client_id, clientsTable.id))
-      .leftJoin(quoteScopesTable, eq(quotesTable.scope_id, quoteScopesTable.id))
+      .leftJoin(pricingScopesTable, eq(quotesTable.scope_id, pricingScopesTable.id))
       .leftJoin(usersTable, eq(quotesTable.created_by, usersTable.id))
       .where(and(...conditions))
       .orderBy(desc(quotesTable.created_at));
@@ -184,7 +184,7 @@ router.post("/", requireAuth, requireRole("owner", "admin", "office"), async (re
       unit_suite, referral_source, office_notes, manual_adjustments,
     } = req.body;
 
-    const scope = scope_id ? await db.select().from(quoteScopesTable).where(eq(quoteScopesTable.id, scope_id)).limit(1) : null;
+    const scope = scope_id ? await db.select().from(pricingScopesTable).where(eq(pricingScopesTable.id, scope_id)).limit(1) : null;
 
     // Resolve branch from client zip for branch tagging
     let quoteBranch = "oak_lawn";

--- a/artifacts/qleno/src/pages/quote-builder.tsx
+++ b/artifacts/qleno/src/pages/quote-builder.tsx
@@ -2149,7 +2149,7 @@ export default function QuoteBuilderPage() {
                               <div style={{ padding: "12px 14px" }}>
                                 {!isHourly && s.calc && (
                                   <div style={{ fontSize: 12, color: "#6B6860", fontFamily: FF }}>
-                                    {sqft > 0 ? `${sqft.toLocaleString()} sqft` : "No sqft"} {"\u2192"} {s.calc.base_hours || estHours} hrs {"\u00D7"} $70/hr = ${s.calc.base_price.toFixed(2)}
+                                    {sqft > 0 ? `${sqft.toLocaleString()} sqft` : "No sqft"} {"\u2192"} {s.calc.base_hours || estHours} hrs {"\u00D7"} ${Number(s.calc.hourly_rate ?? scope.hourly_rate).toFixed(2)}/hr = ${s.calc.base_price.toFixed(2)}
                                   </div>
                                 )}
                                 {isHourly && (
@@ -2163,7 +2163,7 @@ export default function QuoteBuilderPage() {
                                     <button onClick={() => updateScopeHoursManual(s.scope_id, (s.hours || 0) + 0.5)}
                                       style={{ width: 28, height: 28, border: "1px solid #E5E2DC", borderRadius: 6, background: "#F7F6F3", cursor: "pointer", fontSize: 14, display: "flex", alignItems: "center", justifyContent: "center" }}>+</button>
                                     <span style={{ fontSize: 12, color: "#9E9B94", fontFamily: FF }}>
-                                      {s.hours ? `= $${(s.hours * 70).toFixed(2)}` : "Enter hours to calculate"}
+                                      {s.hours ? `= $${(s.hours * Number(scope.hourly_rate)).toFixed(2)}` : "Enter hours to calculate"}
                                     </span>
                                   </div>
                                 )}

--- a/lib/db/src/schema/quotes.ts
+++ b/lib/db/src/schema/quotes.ts
@@ -5,7 +5,7 @@ import { companiesTable } from "./companies";
 import { clientsTable } from "./clients";
 import { usersTable } from "./users";
 import { jobsTable } from "./jobs";
-import { quoteScopesTable } from "./quote_scopes";
+import { pricingScopesTable } from "./pricing";
 
 export const quotesTable = pgTable("quotes", {
   id: serial("id").primaryKey(),
@@ -27,7 +27,7 @@ export const quotesTable = pgTable("quotes", {
   notes: text("notes"),
   created_by: integer("created_by").references(() => usersTable.id),
   created_at: timestamp("created_at").notNull().defaultNow(),
-  scope_id: integer("scope_id").references(() => quoteScopesTable.id),
+  scope_id: integer("scope_id").references(() => pricingScopesTable.id),
   pricing_method: text("pricing_method"),
   addons: jsonb("addons").default([]),
   discount_code: text("discount_code"),


### PR DESCRIPTION
## Surgical fix for two QA findings in the quoting path

### BUG-1 (high) — office quote builder 500s on save for most of the catalog
The builder lists/prices scopes from **`pricing_scopes`** and posts `scope_id = pricing_scopes.id`, but `quotes.scope_id` FK'd the legacy **`quote_scopes`** table (5 rows). Any scope whose pricing id wasn't also a `quote_scopes` id (Move In/Out, Recurring Every-2/4-Weeks, Hourly Standard, all commercial) violated the FK → **500 on save**.

- **Repoint FK** `quotes.scope_id` → `pricing_scopes(id)` (drizzle schema + idempotent cold-start guard: drop old FK, add new). **0 rows changed** — every existing `scope_id` is already a valid `pricing_scopes` id (verified **0 orphans across all tenants**).
- `quotes.ts` create resolves scope name/method from `pricing_scopes` (was `quote_scopes`) → correct `service_type`/`pricing_method` on new quotes; list & detail joins repointed so `scope_name` displays correctly.
- **Backfill** existing mislabeled `service_type` (`quote_scopes` name → `pricing_scopes` name), guarded to the bug signature so it never clobbers a correct value and is idempotent. **32 rows** corrected (e.g. "One-Time Flat-Rate Standard Cleaning" → "Standard Clean").

### BUG-2 (low) — hardcoded `$70/hr` in office builder preview
Replaced both literal `$70` spots with the actual per-scope rate (`s.calc.hourly_rate` / `scope.hourly_rate`) so the on-screen preview matches the server total for any rate/tenant.

### Safety
- Multi-tenant safe; no Phes hardcoding. FK repoint changes no rows; backfill is bounded + idempotent.
- `tsc` clean for the changed files apart from the repo-wide tolerated noise (drizzle TS2769, `companyId: number|null`, pre-existing `branch_id`). DB schema + frontend `tsc` clean.

### Follow-up
After deploy I'll re-run the 8 previously-blocked QA cases end-to-end (save → book → carryover → drag×2 → no comms) to confirm 18/18, then purge all QA test data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)