### PR TITLE
feat(comms): per-location (per-branch) comms toggle

### DIFF
--- a/artifacts/api-server/src/lib/comms-sender.ts
+++ b/artifacts/api-server/src/lib/comms-sender.ts
@@ -2,11 +2,12 @@ import { db } from "@workspace/db";
 import { sql } from "drizzle-orm";
 
 export interface ResolvedSender {
-  enabled: boolean;          // company twilio_enabled gate (go-live)
+  enabled: boolean;               // company twilio_enabled gate (company master)
+  branch_comms_enabled: boolean;  // per-branch comms gate (false unless branch flipped on)
   account_sid: string | null;
   auth_token: string | null;
-  from_number: string | null; // branch number, else company number
-  reason?: string;            // why a send would be suppressed, if not ready
+  from_number: string | null;     // branch number, else company number
+  reason?: string;                // why a send would be suppressed, if not ready
 }
 
 // Resolve the Twilio sender for a message. Company holds the account creds + the
@@ -20,24 +21,29 @@ export async function resolveSender(companyId: number, branchId?: number | null)
   const c: any = cr.rows[0] ?? {};
 
   let branchNumber: string | null = null;
+  let branchComms = false;
   if (branchId != null) {
     const br = await db.execute(sql`
-      SELECT twilio_from_number FROM branches WHERE id = ${branchId} AND company_id = ${companyId} LIMIT 1`);
+      SELECT twilio_from_number, comms_enabled FROM branches WHERE id = ${branchId} AND company_id = ${companyId} LIMIT 1`);
     branchNumber = (br.rows[0] as any)?.twilio_from_number ?? null;
+    branchComms = !!(br.rows[0] as any)?.comms_enabled;
   }
   const from_number = branchNumber || c.twilio_from_number || null;
   const account_sid = c.twilio_account_sid ?? null;
   const auth_token = c.twilio_auth_token ?? null;
   const enabled = !!c.twilio_enabled;
+  // When no branch is specified, fall back to the company master for the branch gate.
+  const branch_comms_enabled = branchId != null ? branchComms : enabled;
 
   const reason =
-    !enabled ? "twilio_disabled"
+    process.env.COMMS_ENABLED !== "true" ? "comms_disabled"          // global master
+    : !enabled ? "twilio_disabled"                                    // company master
+    : !branch_comms_enabled ? "branch_comms_disabled"                 // per-branch gate
     : !(account_sid && auth_token) ? "twilio_unconfigured"
     : !from_number ? "no_from_number"
-    : process.env.COMMS_ENABLED !== "true" ? "comms_disabled"
     : undefined;
 
-  return { enabled, account_sid, auth_token, from_number, reason };
+  return { enabled, branch_comms_enabled, account_sid, auth_token, from_number, reason };
 }
 
 // Send an SMS via Twilio REST (no SDK). Throws on non-2xx.

--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -1476,6 +1476,11 @@ async function runBookingSchemaGuard(): Promise<void> {
     { label: "phes schaumburg from-number",
       stmt: `UPDATE branches SET twilio_from_number = '+16308844318' WHERE company_id = 1 AND name = 'Schaumburg' AND twilio_from_number IS NULL` },
 
+    // Per-location comms gate (tenant-generic). Defaults OFF for every branch so
+    // the fully-gated state is preserved until an owner flips a location on.
+    { label: "branches.comms_enabled",
+      stmt: `ALTER TABLE branches ADD COLUMN IF NOT EXISTS comms_enabled boolean NOT NULL DEFAULT false` },
+
     // ── Leads PR4 — cost / KPI reporting tables ───────────────────────────────
     // Marketing spend per channel + period → CPL / CPA / ROI.
     { label: "marketing_spend table",

--- a/artifacts/api-server/src/routes/branches.ts
+++ b/artifacts/api-server/src/routes/branches.ts
@@ -53,7 +53,7 @@ router.post("/", requireAuth, requireRole("owner", "admin"), async (req, res) =>
 router.patch("/:id", requireAuth, requireRole("owner", "admin"), async (req, res) => {
   try {
     const branchId = parseInt(req.params.id);
-    const { name, address, city, state, zip, phone, is_active } = req.body;
+    const { name, address, city, state, zip, phone, is_active, comms_enabled } = req.body;
 
     const existing = await db
       .select({ id: branchesTable.id })
@@ -71,6 +71,7 @@ router.patch("/:id", requireAuth, requireRole("owner", "admin"), async (req, res
     if (zip !== undefined) updates.zip = zip;
     if (phone !== undefined) updates.phone = phone;
     if (is_active !== undefined) updates.is_active = is_active;
+    if (comms_enabled !== undefined) updates.comms_enabled = comms_enabled;
 
     const [updated] = await db
       .update(branchesTable)

--- a/artifacts/api-server/src/services/followUpService.ts
+++ b/artifacts/api-server/src/services/followUpService.ts
@@ -335,9 +335,14 @@ async function processEnrollment(enr: any): Promise<void> {
 
   let sendStatus = "sent";
   let sendError  = "";
+  // Resolve the per-branch sender once; gates BOTH channels on
+  // global master (COMMS_ENABLED) AND company master AND the branch comms flag.
+  const sender = await resolveSender(enr.company_id, branchId);
+  // Email rides Resend (not Twilio), so it only needs the master/company/branch
+  // gates — not from_number/creds. SMS needs the full sender.reason check.
+  const masterGate = process.env.COMMS_ENABLED === "true" && sender.enabled && sender.branch_comms_enabled;
   try {
     if (step.channel === "sms" && recipientPhone) {
-      const sender = await resolveSender(enr.company_id, branchId);
       if (sender.reason) {
         sendStatus = "blocked";
         sendError  = sender.reason;
@@ -346,7 +351,13 @@ async function processEnrollment(enr: any): Promise<void> {
         await sendSmsVia(sender, recipientPhone, body);
       }
     } else if (step.channel === "email" && recipientEmail) {
-      await sendEmail(recipientEmail, subject, body);
+      if (!masterGate) {
+        sendStatus = "blocked";
+        sendError  = sender.reason || "branch_comms_disabled";
+        console.log(`[follow-up] email suppressed (${sendError}) enrollment ${enr.id}`);
+      } else {
+        await sendEmail(recipientEmail, subject, body);
+      }
     } else {
       sendStatus = "failed";
       sendError  = "No recipient contact info";

--- a/artifacts/qleno/src/pages/company.tsx
+++ b/artifacts/qleno/src/pages/company.tsx
@@ -469,6 +469,59 @@ function BranchContactCard({ branchId }: { branchId: number }) {
   );
 }
 
+function BranchCommsCard({ branchId }: { branchId: number }) {
+  const { toast } = useToast();
+  const qc = useQueryClient();
+  const FF = "'Plus Jakarta Sans', sans-serif";
+  const { data: branches } = useQuery({
+    queryKey: ['branches-list'],
+    queryFn: async () => {
+      const r = await fetch(`${API}/api/branches`, { headers: getAuthHeaders() });
+      if (!r.ok) throw new Error('Failed');
+      return r.json();
+    },
+  });
+  const branch = Array.isArray(branches) ? branches.find((b: any) => b.id === branchId) : null;
+  const enabled = !!branch?.comms_enabled;
+  const [saving, setSaving] = useState(false);
+  const toggle = async () => {
+    setSaving(true);
+    try {
+      const r = await fetch(`${API}/api/branches/${branchId}`, {
+        method: 'PATCH', headers: { ...getAuthHeaders(), 'Content-Type': 'application/json' },
+        body: JSON.stringify({ comms_enabled: !enabled }),
+      });
+      if (!r.ok) throw new Error();
+      qc.invalidateQueries({ queryKey: ['branches-list'] });
+      toast({ title: `Communications ${!enabled ? 'ENABLED' : 'disabled'} for this location` });
+    } catch { toast({ variant: 'destructive', title: 'Failed to update communications setting' }); }
+    setSaving(false);
+  };
+  return (
+    <div style={{ backgroundColor: 'var(--brand-dim)', border: '1px solid rgba(91,155,213,0.25)', borderRadius: 10, padding: '20px 24px', display: 'flex', flexDirection: 'column', gap: 16 }}>
+      <div>
+        <p style={{ fontFamily: FF, fontWeight: 700, fontSize: 14, color: 'var(--brand)', margin: '0 0 4px' }}>Location Communications</p>
+        <p style={{ fontFamily: FF, fontSize: 12, color: '#6B7280', margin: 0 }}>
+          Master switch for SMS &amp; email from this location. A message only sends when the
+          company comms master AND this location toggle are both on. Defaults off.
+        </p>
+      </div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+        <button onClick={toggle} disabled={saving} aria-pressed={enabled}
+          style={{ position: 'relative', width: 46, height: 26, borderRadius: 999, border: 'none',
+            cursor: saving ? 'not-allowed' : 'pointer', backgroundColor: enabled ? 'var(--brand)' : '#CBD2D9',
+            transition: 'background-color 0.15s', flexShrink: 0 }}>
+          <span style={{ position: 'absolute', top: 3, left: enabled ? 23 : 3, width: 20, height: 20,
+            borderRadius: '50%', backgroundColor: '#fff', transition: 'left 0.15s' }} />
+        </button>
+        <span style={{ fontFamily: FF, fontSize: 13, fontWeight: 600, color: enabled ? 'var(--brand)' : '#6B7280' }}>
+          {enabled ? 'Sending enabled for this location' : 'Sending off for this location'}
+        </span>
+      </div>
+    </div>
+  );
+}
+
 function GeneralTab() {
   const { data: company } = useGetMyCompany({ request: { headers: getAuthHeaders() } });
   const updateCompany = useUpdateMyCompany({ request: { headers: getAuthHeaders() } });
@@ -521,6 +574,7 @@ function GeneralTab() {
   return (
     <div style={{ maxWidth: '560px', display: 'flex', flexDirection: 'column', gap: '24px' }}>
       {activeBranchId !== "all" && <BranchContactCard branchId={activeBranchId as number} />}
+      {activeBranchId !== "all" && <BranchCommsCard branchId={activeBranchId as number} />}
       <Section title="Company Name" desc="">
         <input
           value={name}

--- a/lib/db/src/schema/branches.ts
+++ b/lib/db/src/schema/branches.ts
@@ -15,6 +15,10 @@ export const branchesTable = pgTable("branches", {
   // Per-location Twilio sender. Company holds the account creds + enable gate;
   // each branch sends from its own number (e.g. Oak Lawn vs Schaumburg).
   twilio_from_number: text("twilio_from_number"),
+  // Per-location comms gate. A branch only sends when the global master
+  // (COMMS_ENABLED) AND the company master (companies.twilio_enabled) AND this
+  // flag are all on. Defaults OFF so adding a branch never opens a send path.
+  comms_enabled: boolean("comms_enabled").notNull().default(false),
   is_default: boolean("is_default").notNull().default(false),
   is_active: boolean("is_active").notNull().default(true),
   created_at: timestamp("created_at").notNull().defaultNow(),


### PR DESCRIPTION
## Per-location comms control (multi-tenant)

Adds a **per-branch** comms gate on top of the existing global (`COMMS_ENABLED`) + company (`twilio_enabled`) masters. A branch sends **only when ALL three are on**: global master AND company master AND that branch's `comms_enabled`. **Defaults OFF** for every branch, so the current fully-gated state is preserved and adding a branch never opens a send path.

### Changes
- **Schema:** `branches.comms_enabled` boolean default false — drizzle + idempotent cold-start guard. Tenant-scoped (branches are per-company).
- **Send path:** `resolveSender()` reads the branch flag, returns `branch_comms_enabled` and a `branch_comms_disabled` reason; SMS gates on `sender.reason`. `followUpService.processEnrollment` gates **email** (Resend) on master AND company AND branch — not on Twilio creds/from-number.
- **API:** `PATCH /api/branches/:id` accepts `comms_enabled`.
- **Settings UI:** a per-location **"Location Communications"** toggle on the active branch (`company.tsx`). Tenant-generic, no Phes hardcoding.

### Safety / verification
- Default-off preserves the gated state; no behavior change until an owner flips a location on.
- `tsc` clean for the changed files apart from the repo-wide tolerated noise (drizzle TS2769, Express-handler TS7030, `getAuthHeaders()` HeadersInit TS2322). db schema + core gate files clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)