### PR TITLE
fix(comms): surface Resend send errors + add Resend diagnostic

### DIFF
--- a/artifacts/api-server/src/lib/comms-sender.ts
+++ b/artifacts/api-server/src/lib/comms-sender.ts
@@ -82,3 +82,20 @@ export async function validateTwilioCreds(companyId: number): Promise<{ authenti
     return { authenticated: false, status: -1, detail: e?.message || "request_failed" };
   }
 }
+
+// Diagnose the DEPLOYED Resend key: which account/domains it can actually send
+// from. A send from an unverified domain (or a wrong/invalid key) is the classic
+// "API said ok but nothing arrived" — this surfaces it. Never throws.
+export async function validateResend(): Promise<{ ok: boolean; key_present: boolean; key_prefix: string; status: number; domains: Array<{ name: string; status: string; region?: string }>; error?: string }> {
+  const key = process.env.RESEND_API_KEY;
+  if (!key) return { ok: false, key_present: false, key_prefix: "", status: 0, domains: [], error: "RESEND_API_KEY missing" };
+  try {
+    const resp = await fetch("https://api.resend.com/domains", { headers: { Authorization: "Bearer " + key } });
+    const data: any = await resp.json().catch(() => ({}));
+    const list = Array.isArray(data?.data) ? data.data : Array.isArray(data) ? data : [];
+    const domains = list.map((d: any) => ({ name: d.name, status: d.status, region: d.region }));
+    return { ok: resp.ok, key_present: true, key_prefix: key.slice(0, 8), status: resp.status, domains, error: resp.ok ? undefined : (data?.message || data?.name || `http_${resp.status}`) };
+  } catch (e: any) {
+    return { ok: false, key_present: true, key_prefix: key.slice(0, 8), status: -1, domains: [], error: e?.message || "request_failed" };
+  }
+}

--- a/artifacts/api-server/src/routes/follow-up.ts
+++ b/artifacts/api-server/src/routes/follow-up.ts
@@ -172,6 +172,19 @@ router.post("/send-one", requireAuth, requireRole("owner", "admin"), async (req,
   }
 });
 
+// ── GET /api/follow-up/resend-status — diagnose the deployed Resend key ────────
+// Reports which account/domains the deployed RESEND_API_KEY can send from, so we
+// can tell whether a from-domain (e.g. phes.io) is actually verified for THIS key.
+router.get("/resend-status", requireAuth, requireRole("owner", "admin"), async (_req, res) => {
+  try {
+    const { validateResend } = await import("../lib/comms-sender.js");
+    return res.json(await validateResend());
+  } catch (err: any) {
+    console.error("GET /follow-up/resend-status:", err);
+    return res.status(500).json({ error: "Internal Server Error", message: err?.message });
+  }
+});
+
 // ── POST /api/follow-up/twilio-check — validate company Twilio creds ───────────
 // Lightweight authenticated GET on the Twilio account resource. Token stays
 // server-side; returns { authenticated, status, detail }.

--- a/artifacts/api-server/src/services/followUpService.ts
+++ b/artifacts/api-server/src/services/followUpService.ts
@@ -76,6 +76,13 @@ async function sendEmailRaw(to: string, subject: string, body: string): Promise<
     subject,
     html: bodyHtml,
   });
+  // The Resend SDK returns { data, error } and does NOT throw on API errors
+  // (unverified domain, invalid key, etc.). Surface it so callers don't record
+  // a failed send as "sent" — the bug behind "Resend said ok but nothing arrived".
+  if (res?.error) {
+    const e = res.error;
+    throw new Error(`Resend error: ${e?.name ? e.name + " — " : ""}${e?.message ?? JSON.stringify(e)}`);
+  }
   return res?.data?.id ?? res?.id ?? null;
 }
 
@@ -475,7 +482,11 @@ export async function sendSingleEnrollmentTouch(
   if (step.channel === "email") {
     if (!recipientEmail) return { sent: false, channel: "email", reason: "no_recipient_email", step: step.step_number };
     recipient = recipientEmail;
-    providerId = await sendEmailRaw(recipientEmail, subject, body);
+    try {
+      providerId = await sendEmailRaw(recipientEmail, subject, body);
+    } catch (e: any) {
+      logStatus = "failed"; logErr = e?.message || "email_send_error";
+    }
   } else if (step.channel === "sms") {
     if (!recipientPhone) return { sent: false, channel: "sms", reason: "no_recipient_phone", step: step.step_number };
     recipient = recipientPhone;


### PR DESCRIPTION
sendEmailRaw swallowed the Resend SDK's `{ error }` (the SDK doesn't throw on API errors), so a rejected send was logged as "sent" — the bug behind "Resend said sent but nothing arrived." Now throws on res.error; the one-off email path logs 'failed' with the real reason. Adds GET /api/follow-up/resend-status to report which account/domains the deployed RESEND_API_KEY can send from. tsc clean apart from tolerated noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)