### PR TITLE
feat(comms): Resend email-status diagnostic

### DIFF
--- a/artifacts/api-server/src/lib/comms-sender.ts
+++ b/artifacts/api-server/src/lib/comms-sender.ts
@@ -99,3 +99,26 @@ export async function validateResend(): Promise<{ ok: boolean; key_present: bool
     return { ok: false, key_present: true, key_prefix: key.slice(0, 8), status: -1, domains: [], error: e?.message || "request_failed" };
   }
 }
+
+// Fetch a single sent email's delivery status from Resend by id (server-side,
+// uses the deployed key). Returns the delivery event (delivered/sent/bounced/…)
+// so we can confirm ACTUAL delivery, not just our "sent". Never throws.
+export async function getResendEmailStatus(id: string): Promise<{ ok: boolean; http: number; last_event: string; to: string; subject: string; created_at: string; error?: string }> {
+  const key = process.env.RESEND_API_KEY;
+  if (!key) return { ok: false, http: 0, last_event: "", to: "", subject: "", created_at: "", error: "RESEND_API_KEY missing" };
+  try {
+    const resp = await fetch(`https://api.resend.com/emails/${encodeURIComponent(id)}`, { headers: { Authorization: "Bearer " + key } });
+    const d: any = await resp.json().catch(() => ({}));
+    return {
+      ok: resp.ok,
+      http: resp.status,
+      last_event: String(d?.last_event ?? d?.status ?? ""),
+      to: Array.isArray(d?.to) ? d.to.join(",") : String(d?.to ?? ""),
+      subject: String(d?.subject ?? ""),
+      created_at: String(d?.created_at ?? ""),
+      error: resp.ok ? undefined : (d?.message || d?.name || `http_${resp.status}`),
+    };
+  } catch (e: any) {
+    return { ok: false, http: -1, last_event: "", to: "", subject: "", created_at: "", error: e?.message || "request_failed" };
+  }
+}

--- a/artifacts/api-server/src/routes/follow-up.ts
+++ b/artifacts/api-server/src/routes/follow-up.ts
@@ -185,6 +185,19 @@ router.get("/resend-status", requireAuth, requireRole("owner", "admin"), async (
   }
 });
 
+// ── GET /api/follow-up/email-status?id= — actual Resend delivery status ────────
+router.get("/email-status", requireAuth, requireRole("owner", "admin"), async (req, res) => {
+  try {
+    const id = String(req.query.id || "");
+    if (!id) return res.status(400).json({ error: "id required" });
+    const { getResendEmailStatus } = await import("../lib/comms-sender.js");
+    return res.json(await getResendEmailStatus(id));
+  } catch (err: any) {
+    console.error("GET /follow-up/email-status:", err);
+    return res.status(500).json({ error: "Internal Server Error", message: err?.message });
+  }
+});
+
 // ── POST /api/follow-up/twilio-check — validate company Twilio creds ───────────
 // Lightweight authenticated GET on the Twilio account resource. Token stays
 // server-side; returns { authenticated, status, detail }.


### PR DESCRIPTION
getResendEmailStatus(id) + GET /api/follow-up/email-status?id= — fetch a sent email's delivery event (delivered/bounced/…) from Resend by id via the deployed key, to confirm actual delivery vs just logged 'sent'. tsc clean apart from tolerated noise.