### PR TITLE
feat(comms): per-tenant comms gate (companies.comms_enabled)

### DIFF
--- a/artifacts/api-server/src/lib/comms-sender.ts
+++ b/artifacts/api-server/src/lib/comms-sender.ts
@@ -2,7 +2,8 @@ import { db } from "@workspace/db";
 import { sql } from "drizzle-orm";
 
 export interface ResolvedSender {
-  enabled: boolean;               // company twilio_enabled gate (company master)
+  enabled: boolean;               // company twilio_enabled gate (Twilio go-live)
+  company_comms_enabled: boolean; // per-TENANT comms master (companies.comms_enabled)
   branch_comms_enabled: boolean;  // per-branch comms gate (false unless branch flipped on)
   account_sid: string | null;
   auth_token: string | null;
@@ -16,7 +17,7 @@ export interface ResolvedSender {
 // COMMS_ENABLED global gate is enforced separately at the call site.
 export async function resolveSender(companyId: number, branchId?: number | null): Promise<ResolvedSender> {
   const cr = await db.execute(sql`
-    SELECT twilio_enabled, twilio_account_sid, twilio_auth_token, twilio_from_number
+    SELECT twilio_enabled, comms_enabled, twilio_account_sid, twilio_auth_token, twilio_from_number
       FROM companies WHERE id = ${companyId} LIMIT 1`);
   const c: any = cr.rows[0] ?? {};
 
@@ -32,18 +33,20 @@ export async function resolveSender(companyId: number, branchId?: number | null)
   const account_sid = c.twilio_account_sid ?? null;
   const auth_token = c.twilio_auth_token ?? null;
   const enabled = !!c.twilio_enabled;
+  const company_comms_enabled = !!c.comms_enabled;
   // When no branch is specified, fall back to the company master for the branch gate.
   const branch_comms_enabled = branchId != null ? branchComms : enabled;
 
   const reason =
     process.env.COMMS_ENABLED !== "true" ? "comms_disabled"          // global master
-    : !enabled ? "twilio_disabled"                                    // company master
+    : !company_comms_enabled ? "company_comms_disabled"               // per-tenant master
+    : !enabled ? "twilio_disabled"                                    // company Twilio go-live
     : !branch_comms_enabled ? "branch_comms_disabled"                 // per-branch gate
     : !(account_sid && auth_token) ? "twilio_unconfigured"
     : !from_number ? "no_from_number"
     : undefined;
 
-  return { enabled, branch_comms_enabled, account_sid, auth_token, from_number, reason };
+  return { enabled, company_comms_enabled, branch_comms_enabled, account_sid, auth_token, from_number, reason };
 }
 
 // Send an SMS via Twilio REST (no SDK). Returns the Twilio response (sid, status,

--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -1481,6 +1481,12 @@ async function runBookingSchemaGuard(): Promise<void> {
     { label: "branches.comms_enabled",
       stmt: `ALTER TABLE branches ADD COLUMN IF NOT EXISTS comms_enabled boolean NOT NULL DEFAULT false` },
 
+    // Per-tenant comms master. Default OFF so enabling one tenant (e.g. Schaumburg
+    // company 4) can never message another tenant's (Oak Lawn company 1) customers,
+    // including via the legacy reminder/review/survey notification crons.
+    { label: "companies.comms_enabled",
+      stmt: `ALTER TABLE companies ADD COLUMN IF NOT EXISTS comms_enabled boolean NOT NULL DEFAULT false` },
+
     // ── Leads PR4 — cost / KPI reporting tables ───────────────────────────────
     // Marketing spend per channel + period → CPL / CPA / ROI.
     { label: "marketing_spend table",

--- a/artifacts/api-server/src/routes/follow-up.ts
+++ b/artifacts/api-server/src/routes/follow-up.ts
@@ -172,6 +172,33 @@ router.post("/send-one", requireAuth, requireRole("owner", "admin"), async (req,
   }
 });
 
+// ── GET /api/follow-up/comms-gate?company_id= — per-tenant comms gate state ────
+// Owner-only diagnostic. Reports, for a company, whether its sends would be
+// allowed — separating the global master from the per-tenant gate so we can
+// prove tenant isolation (e.g. Schaumburg on, Oak Lawn off → Oak Lawn blocked).
+router.get("/comms-gate", requireAuth, requireRole("owner", "admin"), async (req, res) => {
+  try {
+    const companyId = parseInt(String(req.query.company_id || req.auth!.companyId));
+    const { resolveSender } = await import("../lib/comms-sender.js");
+    const s = await resolveSender(companyId, null);
+    const globalOn = process.env.COMMS_ENABLED === "true";
+    return res.json({
+      company_id: companyId,
+      global_COMMS_ENABLED: globalOn,
+      company_comms_enabled: s.company_comms_enabled,
+      twilio_enabled: s.enabled,
+      resolve_reason: s.reason ?? "ready",
+      // Would ANY automatic send to this company be possible right now?
+      sends_possible_now: !s.reason,
+      // Would this tenant be blocked purely by its own per-tenant gate (independent of the global master)?
+      blocked_by_tenant_gate: !s.company_comms_enabled,
+    });
+  } catch (err: any) {
+    console.error("GET /follow-up/comms-gate:", err);
+    return res.status(500).json({ error: "Internal Server Error", message: err?.message });
+  }
+});
+
 // ── GET /api/follow-up/resend-status — diagnose the deployed Resend key ────────
 // Reports which account/domains the deployed RESEND_API_KEY can send from, so we
 // can tell whether a from-domain (e.g. phes.io) is actually verified for THIS key.

--- a/artifacts/api-server/src/services/followUpService.ts
+++ b/artifacts/api-server/src/services/followUpService.ts
@@ -355,7 +355,7 @@ async function processEnrollment(enr: any): Promise<void> {
   const sender = await resolveSender(enr.company_id, branchId);
   // Email rides Resend (not Twilio), so it only needs the master/company/branch
   // gates — not from_number/creds. SMS needs the full sender.reason check.
-  const masterGate = process.env.COMMS_ENABLED === "true" && sender.enabled && sender.branch_comms_enabled;
+  const masterGate = process.env.COMMS_ENABLED === "true" && sender.company_comms_enabled && sender.enabled && sender.branch_comms_enabled;
   try {
     if (step.channel === "sms" && recipientPhone) {
       if (sender.reason) {

--- a/artifacts/api-server/src/services/notificationService.ts
+++ b/artifacts/api-server/src/services/notificationService.ts
@@ -1,6 +1,6 @@
 import { db } from "@workspace/db";
 import { notificationTemplatesTable, notificationLogTable, clientsTable, companiesTable } from "@workspace/db/schema";
-import { eq, and } from "drizzle-orm";
+import { eq, and, sql } from "drizzle-orm";
 import { getBranchByZip } from "../lib/branchRouter";
 import { buildReminderEmail } from "../lib/emailTemplates";
 import { Resend } from "resend";
@@ -97,6 +97,16 @@ export async function sendNotification(
 
     if (!tpl) {
       await logNotification(companyId, recipientEmail || recipientPhone || "unknown", channel, templateKey, "skipped", "Template not found or inactive", {});
+      return;
+    }
+
+    // Per-TENANT comms gate: this company must have comms enabled. Default OFF, so
+    // enabling one tenant can never message another tenant's customers via these
+    // legacy reminder/review/survey notifications. (Raw SQL to avoid coupling to
+    // the regenerated drizzle column type.)
+    const commsRow = await db.execute(sql`SELECT comms_enabled FROM companies WHERE id = ${companyId} LIMIT 1`);
+    if (!(commsRow.rows[0] as any)?.comms_enabled) {
+      await logNotification(companyId, recipientEmail || recipientPhone || "unknown", channel, templateKey, "suppressed", "company_comms_disabled", {});
       return;
     }
 

--- a/lib/db/src/schema/companies.ts
+++ b/lib/db/src/schema/companies.ts
@@ -142,6 +142,11 @@ export const companiesTable = pgTable("companies", {
   // already exists above. twilio_enabled is the go-live gate — surveys/SMS only
   // actually send when this is true AND creds are set AND COMMS_ENABLED=true.
   twilio_enabled: boolean("twilio_enabled").notNull().default(false),
+  // Per-TENANT comms master. ALL automatic send paths (follow-up cadence +
+  // legacy reminder/review/survey notifications) require the SENDING record's
+  // company.comms_enabled AND the global COMMS_ENABLED. Default OFF so enabling
+  // one tenant can never message another tenant's customers.
+  comms_enabled: boolean("comms_enabled").notNull().default(false),
   twilio_account_sid: text("twilio_account_sid"),
   twilio_auth_token: text("twilio_auth_token"),
   created_at: timestamp("created_at").notNull().defaultNow(),


### PR DESCRIPTION
Adds companies.comms_enabled (default OFF) and gates ALL automatic send paths on the sending record's company flag AND global COMMS_ENABLED — cadence cron (resolveSender + masterGate) and legacy notifications (sendNotification: reminders/review/survey). Enabling one tenant can never message another tenant's customers. Default OFF preserves the fully-gated state. Includes GET /api/follow-up/comms-gate diagnostic. tsc clean apart from tolerated noise.