### PR TITLE
feat: transactional-email ungate + per-tenant from-address + internal/comped billing

### DIFF
--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -1486,6 +1486,12 @@ async function runBookingSchemaGuard(): Promise<void> {
     // including via the legacy reminder/review/survey notification crons.
     { label: "companies.comms_enabled",
       stmt: `ALTER TABLE companies ADD COLUMN IF NOT EXISTS comms_enabled boolean NOT NULL DEFAULT false` },
+    // Per-tenant send-from email identity (Resend-verified domain).
+    { label: "companies.email_from_address",
+      stmt: `ALTER TABLE companies ADD COLUMN IF NOT EXISTS email_from_address text` },
+    // Internal/comped tenant flag — excluded from SaaS MRR/ARR/revenue metrics.
+    { label: "companies.is_internal",
+      stmt: `ALTER TABLE companies ADD COLUMN IF NOT EXISTS is_internal boolean NOT NULL DEFAULT false` },
 
     // ── Leads PR4 — cost / KPI reporting tables ───────────────────────────────
     // Marketing spend per channel + period → CPL / CPA / ROI.

--- a/artifacts/api-server/src/routes/admin.ts
+++ b/artifacts/api-server/src/routes/admin.ts
@@ -56,8 +56,11 @@ router.get("/dashboard", ...isSuperAdmin, async (_req, res) => {
   try {
     const companies = await db.select().from(companiesTable);
 
+    // Internal/comped tenants are excluded from all paying-revenue metrics.
+    const paying = companies.filter((c) => !(c as any).is_internal);
+
     const totalCompanies = companies.length;
-    const activeSubs = companies.filter(
+    const activeSubs = paying.filter(
       (c) => c.subscription_status === "active"
     ).length;
     const trialSubs = companies.filter(
@@ -70,7 +73,7 @@ router.get("/dashboard", ...isSuperAdmin, async (_req, res) => {
       (c) => c.subscription_status === "canceled"
     ).length;
 
-    const mrr = companies
+    const mrr = paying
       .filter((c) => c.subscription_status === "active")
       .reduce((sum, c) => sum + (PLAN_MRR[c.plan] || 0), 0);
 
@@ -139,7 +142,7 @@ router.get("/companies", ...isSuperAdmin, async (req, res) => {
     const result = filtered.map((c) => ({
       ...c,
       owner: ownerMap[c.id] || null,
-      mrr: c.subscription_status === "active" ? PLAN_MRR[c.plan] || 0 : 0,
+      mrr: (c.subscription_status === "active" && !(c as any).is_internal) ? PLAN_MRR[c.plan] || 0 : 0,
     }));
 
     return res.json(result);
@@ -155,12 +158,12 @@ router.get("/tenants", ...isSuperAdmin, async (_req, res) => {
     const rows = await db.execute(sql`
       SELECT
         c.id, c.name, c.subscription_status, c.plan, c.early_tenant,
-        c.trial_ends_at, c.stripe_customer_id, c.created_at,
+        c.trial_ends_at, c.stripe_customer_id, c.created_at, c.is_internal,
         t.name AS tier_name, t.slug AS tier_slug, t.price_monthly,
         (SELECT COUNT(*)::int FROM users u WHERE u.company_id=c.id AND u.role='technician' AND u.is_active=true AND u.archived_at IS NULL AND u.is_sandbox=false) AS active_techs,
         (SELECT COUNT(*)::int FROM users u WHERE u.company_id=c.id AND u.role IN ('office','admin') AND u.is_active=true AND u.archived_at IS NULL AND u.is_sandbox=false) AS active_office,
         (SELECT COUNT(*)::int FROM users u WHERE u.company_id=c.id AND u.is_active=true AND u.archived_at IS NULL AND u.is_sandbox=false) AS total_users,
-        CASE WHEN c.subscription_status='active' THEN COALESCE(t.price_monthly::numeric, 0) ELSE 0 END AS mrr
+        CASE WHEN c.subscription_status='active' AND c.is_internal IS NOT TRUE THEN COALESCE(t.price_monthly::numeric, 0) ELSE 0 END AS mrr
       FROM companies c
       LEFT JOIN subscription_tiers t ON t.id=c.tier_id
       ORDER BY c.id
@@ -275,7 +278,7 @@ router.get("/billing", ...isSuperAdmin, async (_req, res) => {
     let mrr = 0;
 
     for (const c of companies) {
-      if (c.subscription_status === "active") {
+      if (c.subscription_status === "active" && !(c as any).is_internal) {
         const key = c.plan as keyof typeof byPlan;
         byPlan[key] = (byPlan[key] || 0) + 1;
         mrr += PLAN_MRR[c.plan] || 0;

--- a/artifacts/api-server/src/routes/auth.ts
+++ b/artifacts/api-server/src/routes/auth.ts
@@ -186,13 +186,15 @@ router.post("/forgot-password", async (req, res) => {
       .set({ reset_token: token, reset_token_expires_at: expires } as any)
       .where(eq(usersTable.id, user.id));
 
-    const resetLink = `https://clean-ops-pro.replit.app/reset-password?token=${token}`;
+    const resetLink = `https://app.qleno.com/reset-password?token=${token}`;
     const mv = {
       first_name:   user.first_name || "",
       reset_link:   resetLink,
       reset_expiry: "1 hour",
     };
-    await sendNotification("password_reset", "email", user.company_id, user.email, null, mv);
+    // transactional=true → always sends (bypasses the comms gates); a password
+    // reset is user-initiated and must reach them regardless of marketing gating.
+    await sendNotification("password_reset", "email", user.company_id, user.email, null, mv, true);
 
     return res.json({ success: true, message: "If that email exists, a reset link has been sent." });
   } catch (err) {

--- a/artifacts/api-server/src/services/followUpService.ts
+++ b/artifacts/api-server/src/services/followUpService.ts
@@ -57,7 +57,18 @@ export function clampToBusinessHours(raw: Date): Date {
 // Raw send — performs the actual Resend call with NO COMMS_ENABLED gate. Only
 // callers that are themselves explicitly scoped/authorized may use this
 // directly (see sendSingleEnrollmentTouch). Returns the Resend message id.
-async function sendEmailRaw(to: string, subject: string, body: string): Promise<string | null> {
+// Resolve a company's per-tenant send-from address (Resend-verified domain),
+// falling back to the default Phes sender. Raw SQL to avoid the regenerated
+// drizzle column-type coupling.
+async function companyFromAddress(companyId: number): Promise<string> {
+  try {
+    const r = await db.execute(sql`SELECT email_from_address FROM companies WHERE id = ${companyId} LIMIT 1`);
+    const addr = (r.rows[0] as any)?.email_from_address;
+    return addr ? `Phes Cleaning <${addr}>` : "Phes Cleaning <noreply@phes.io>";
+  } catch { return "Phes Cleaning <noreply@phes.io>"; }
+}
+
+async function sendEmailRaw(to: string, subject: string, body: string, fromAddress = "Phes Cleaning <noreply@phes.io>"): Promise<string | null> {
   const key = process.env.RESEND_API_KEY;
   if (!key) throw new Error("Resend not configured");
   const { Resend } = await import("resend");
@@ -71,7 +82,7 @@ async function sendEmailRaw(to: string, subject: string, body: string): Promise<
 <p style="font-size:13px;color:#9E9B94;margin:0;">Phes Cleaning &mdash; (773) 706-6000 &mdash; info@phes.io</p>
 </div></div>`;
   const res: any = await resend.emails.send({
-    from: "Phes Cleaning <noreply@phes.io>",
+    from: fromAddress,
     to: [to],
     subject,
     html: bodyHtml,
@@ -86,12 +97,12 @@ async function sendEmailRaw(to: string, subject: string, body: string): Promise<
   return res?.data?.id ?? res?.id ?? null;
 }
 
-async function sendEmail(to: string, subject: string, body: string): Promise<void> {
+async function sendEmail(to: string, subject: string, body: string, fromAddress?: string): Promise<void> {
   if (process.env.COMMS_ENABLED !== "true") {
     console.log("[COMMS BLOCKED] Follow-up email suppressed:", { to, subject });
     return;
   }
-  await sendEmailRaw(to, subject, body);
+  await sendEmailRaw(to, subject, body, fromAddress);
 }
 
 // ── Enroll for quote follow-up ─────────────────────────────────────────────────
@@ -371,7 +382,7 @@ async function processEnrollment(enr: any): Promise<void> {
         sendError  = sender.reason || "branch_comms_disabled";
         console.log(`[follow-up] email suppressed (${sendError}) enrollment ${enr.id}`);
       } else {
-        await sendEmail(recipientEmail, subject, body);
+        await sendEmail(recipientEmail, subject, body, await companyFromAddress(enr.company_id));
       }
     } else {
       sendStatus = "failed";
@@ -483,7 +494,7 @@ export async function sendSingleEnrollmentTouch(
     if (!recipientEmail) return { sent: false, channel: "email", reason: "no_recipient_email", step: step.step_number };
     recipient = recipientEmail;
     try {
-      providerId = await sendEmailRaw(recipientEmail, subject, body);
+      providerId = await sendEmailRaw(recipientEmail, subject, body, await companyFromAddress(companyId));
     } catch (e: any) {
       logStatus = "failed"; logErr = e?.message || "email_send_error";
     }

--- a/artifacts/api-server/src/services/notificationService.ts
+++ b/artifacts/api-server/src/services/notificationService.ts
@@ -77,10 +77,15 @@ export async function sendNotification(
   companyId: number,
   recipientEmail: string | null,
   recipientPhone: string | null,
-  mergeVars: Record<string, string>
+  mergeVars: Record<string, string>,
+  // Transactional (password reset, user invite, etc.) — triggered by an explicit
+  // user action, so it ALWAYS sends: bypasses both the per-tenant comms gate and
+  // the global COMMS_ENABLED. Marketing/cadence/notification sends leave this false.
+  transactional: boolean = false,
 ): Promise<void> {
   let status = "sent";
   let errorMsg: string | null = null;
+  let providerId: string | null = null;
 
   try {
     // Fetch template
@@ -100,12 +105,13 @@ export async function sendNotification(
       return;
     }
 
-    // Per-TENANT comms gate: this company must have comms enabled. Default OFF, so
-    // enabling one tenant can never message another tenant's customers via these
-    // legacy reminder/review/survey notifications. (Raw SQL to avoid coupling to
-    // the regenerated drizzle column type.)
-    const commsRow = await db.execute(sql`SELECT comms_enabled FROM companies WHERE id = ${companyId} LIMIT 1`);
-    if (!(commsRow.rows[0] as any)?.comms_enabled) {
+    // Per-tenant comms gate + per-tenant send-from address. Raw SQL to avoid
+    // coupling to the regenerated drizzle column types.
+    const commsRow = await db.execute(sql`SELECT comms_enabled, email_from_address FROM companies WHERE id = ${companyId} LIMIT 1`);
+    const fromAddr = (commsRow.rows[0] as any)?.email_from_address || "info@phes.io";
+    // Marketing/notification sends require the tenant's comms gate. Transactional
+    // sends (reset/invite) skip it — they must always reach the user.
+    if (!transactional && !(commsRow.rows[0] as any)?.comms_enabled) {
       await logNotification(companyId, recipientEmail || recipientPhone || "unknown", channel, templateKey, "suppressed", "company_comms_disabled", {});
       return;
     }
@@ -139,19 +145,23 @@ export async function sendNotification(
       const rawHtml  = applyMerge(bodyHtml, fullVars);
       const wrapped  = applyMerge(wrapEmailHtml(rawHtml), fullVars);
 
-      if (process.env.COMMS_ENABLED !== "true") {
+      if (!transactional && process.env.COMMS_ENABLED !== "true") {
         console.log("[COMMS BLOCKED] Email suppressed:", { to: recipientEmail, subject });
         await logNotification(companyId, recipientEmail, channel, templateKey, "suppressed", "COMMS_ENABLED=false", fullVars);
         return;
       }
       const resend = new Resend(process.env.RESEND_API_KEY);
-      await resend.emails.send({
-        from:     "info@phes.io",
-        replyTo:  "info@phes.io",
+      const sendRes: any = await resend.emails.send({
+        from:     fromAddr,
+        replyTo:  fromAddr,
         to:       recipientEmail,
         subject,
         html:     wrapped,
       });
+      // The Resend SDK returns { error } instead of throwing — surface it so a
+      // rejected send isn't logged as success.
+      if (sendRes?.error) throw new Error(`Resend error: ${sendRes.error?.message ?? JSON.stringify(sendRes.error)}`);
+      providerId = sendRes?.data?.id ?? null;
 
     } else if (channel === "sms") {
       if (!recipientPhone) {
@@ -180,7 +190,8 @@ export async function sendNotification(
     templateKey,
     status,
     errorMsg,
-    mergeVars,
+    // Stamp the Resend provider id into metadata for delivery traceability.
+    { ...mergeVars, ...(providerId ? { _provider_id: providerId } : {}) },
   );
 }
 

--- a/lib/db/src/schema/companies.ts
+++ b/lib/db/src/schema/companies.ts
@@ -147,6 +147,12 @@ export const companiesTable = pgTable("companies", {
   // company.comms_enabled AND the global COMMS_ENABLED. Default OFF so enabling
   // one tenant can never message another tenant's customers.
   comms_enabled: boolean("comms_enabled").notNull().default(false),
+  // Per-tenant send-from identity for outbound email (must be on a Resend-verified
+  // domain). Falls back to a default when null. e.g. Schaumburg = schaumburg@phes.io.
+  email_from_address: text("email_from_address"),
+  // Internal/comped account — excluded from SaaS MRR/ARR/revenue metrics. Net $0,
+  // no Stripe. Used for owner-comped tenants (e.g. PHES Schaumburg).
+  is_internal: boolean("is_internal").notNull().default(false),
   twilio_account_sid: text("twilio_account_sid"),
   twilio_auth_token: text("twilio_auth_token"),
   created_at: timestamp("created_at").notNull().defaultNow(),


### PR DESCRIPTION
**1.** Transactional emails (password reset, invites) always send — sendNotification gains a transactional flag bypassing the per-tenant comms gate + global COMMS_ENABLED; forgot-password uses it (and reset link → app.qleno.com). Marketing/cadence stay gated. **2.** Per-tenant from-address (companies.email_from_address); notification + cadence send FROM the company's address; Resend errors surfaced + message id logged. **3.** companies.is_internal — admin MRR/ARR/active-subs/billing exclude internal/comped tenants. Schema guards idempotent. tsc clean apart from tolerated noise.