### PR TITLE
fix(comms): per-tenant SMS/links/lead-notify + MaidCentral-styled quote email

### DIFF
--- a/artifacts/api-server/src/lib/app-url.ts
+++ b/artifacts/api-server/src/lib/app-url.ts
@@ -1,0 +1,7 @@
+// Single source of truth for the public, customer-facing app base URL.
+// APP_BASE_URL (Railway env) wins; defaults to the live Qleno domain.
+// NEVER the old Replit backup (clean-ops-pro.replit.app) — that domain 404s.
+// Trailing slashes are trimmed so callers can safely append "/estimate/<token>".
+export function appBaseUrl(): string {
+  return (process.env.APP_BASE_URL || "https://app.qleno.com").replace(/\/+$/, "");
+}

--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -1493,6 +1493,11 @@ async function runBookingSchemaGuard(): Promise<void> {
     { label: "companies.is_internal",
       stmt: `ALTER TABLE companies ADD COLUMN IF NOT EXISTS is_internal boolean NOT NULL DEFAULT false` },
 
+    { label: "companies.lead_notify_email",
+      stmt: `ALTER TABLE companies ADD COLUMN IF NOT EXISTS lead_notify_email text` },
+    { label: "companies.lead_notify_phone",
+      stmt: `ALTER TABLE companies ADD COLUMN IF NOT EXISTS lead_notify_phone text` },
+
     // ── Leads PR4 — cost / KPI reporting tables ───────────────────────────────
     // Marketing spend per channel + period → CPL / CPA / ROI.
     { label: "marketing_spend table",

--- a/artifacts/api-server/src/routes/clients.ts
+++ b/artifacts/api-server/src/routes/clients.ts
@@ -873,17 +873,18 @@ router.post("/:id/communications/sms", requireAuth, async (req, res) => {
     const clientId = parseInt(req.params.id);
     const { to, message } = req.body;
     let twilioResult = null;
-    if (process.env.COMMS_ENABLED !== "true") {
-      console.log("[COMMS BLOCKED] Client SMS suppressed:", { to, message: message?.substring(0, 80) });
-    } else if (process.env.TWILIO_ACCOUNT_SID && process.env.TWILIO_AUTH_TOKEN) {
-      try {
-        const fromNum = process.env.TWILIO_FROM_NUMBER || "";
-        const url = `https://api.twilio.com/2010-04-01/Accounts/${process.env.TWILIO_ACCOUNT_SID}/Messages.json`;
-        const auth = Buffer.from(`${process.env.TWILIO_ACCOUNT_SID}:${process.env.TWILIO_AUTH_TOKEN}`).toString("base64");
-        const body = new URLSearchParams({ To: to, From: fromNum, Body: message });
-        const r = await fetch(url, { method: "POST", headers: { Authorization: `Basic ${auth}`, "Content-Type": "application/x-www-form-urlencoded" }, body });
-        twilioResult = await r.json();
-      } catch { /* log but don't fail */ }
+    // Per-tenant send only — resolveSender(companyId) picks THIS company's creds
+    // + from-number (full gate ladder). No global-env number.
+    try {
+      const { resolveSender, sendSmsVia } = await import("../lib/comms-sender.js");
+      const sender = await resolveSender(req.auth!.companyId, null);
+      if (sender.reason) {
+        console.log("[clients] Client SMS suppressed:", sender.reason);
+      } else {
+        twilioResult = await sendSmsVia(sender, to, message);
+      }
+    } catch (e: any) {
+      console.error("[clients] Client SMS error:", e?.message || e);
     }
     const [comm] = await db.insert(clientCommunicationsTable).values({
       company_id: req.auth!.companyId, client_id: clientId,

--- a/artifacts/api-server/src/routes/estimates.ts
+++ b/artifacts/api-server/src/routes/estimates.ts
@@ -241,7 +241,60 @@ router.get("/public/:token", async (req, res) => {
       LIMIT 1
     `);
     const est = (rows as any).rows[0];
-    if (!est) return res.status(404).json({ error: "Not Found" });
+    if (!est) {
+      // Fallback: a QUOTE's sign_token. Quotes have no dedicated hosted page,
+      // so the quote email links here (app.qleno.com/estimate/<sign_token>).
+      // Map the quote into the public estimate shape so this same page renders
+      // it (read-only — quote accept/decline stays in the office flow).
+      const qrows = await db.execute(sql`
+        SELECT q.id, q.lead_name, q.address, q.service_type, q.total_price, q.base_price,
+               q.addons, q.status, q.created_at, q.sent_at,
+               c.name AS company_name, c.logo_url AS company_logo, c.brand_color AS company_brand_color
+        FROM quotes q JOIN companies c ON c.id = q.company_id
+        WHERE q.sign_token = ${token} LIMIT 1
+      `);
+      const qt = (qrows as any).rows[0];
+      if (!qt) return res.status(404).json({ error: "Not Found" });
+
+      const items: any[] = [];
+      if (qt.base_price != null) {
+        items.push({
+          name: qt.service_type || "Cleaning service", description: null,
+          pricing_type: "flat", frequency: null, quantity: 1,
+          unit_rate: String(qt.base_price), amount: String(qt.base_price),
+        });
+      }
+      const addons = Array.isArray(qt.addons) ? qt.addons : [];
+      for (const a of addons) {
+        const amt = (a?.amount ?? a?.price);
+        items.push({
+          name: a?.name || "Add-on", description: null,
+          pricing_type: "flat", frequency: null, quantity: 1,
+          unit_rate: amt != null ? String(amt) : null, amount: amt != null ? String(amt) : null,
+        });
+      }
+      const pubStatus = qt.status === "booked" || qt.status === "accepted" ? "accepted" : "sent";
+      return res.json({
+        estimate_number: `Q-${qt.id}`,
+        title: "Your cleaning quote",
+        status: pubStatus,
+        contact_name: qt.lead_name || null,
+        property_name: null,
+        service_address: qt.address || null,
+        subtotal: qt.total_price != null ? String(qt.total_price) : (qt.base_price != null ? String(qt.base_price) : null),
+        total: qt.total_price != null ? String(qt.total_price) : (qt.base_price != null ? String(qt.base_price) : null),
+        valid_until: null,
+        sent_at: qt.sent_at || null,
+        viewed_at: null,
+        accepted_at: null,
+        created_at: qt.created_at || null,
+        company_name: qt.company_name,
+        company_logo: qt.company_logo,
+        company_brand_color: qt.company_brand_color,
+        items,
+        is_quote: true,
+      });
+    }
 
     const expired = est.valid_until && new Date(est.valid_until) < new Date() && est.status !== "accepted";
     if (expired && est.status !== "expired") {

--- a/artifacts/api-server/src/routes/invoices.ts
+++ b/artifacts/api-server/src/routes/invoices.ts
@@ -6,6 +6,7 @@ import { requireAuth, requireRole } from "../lib/auth.js";
 import { logAudit } from "../lib/audit.js";
 import { syncInvoice, syncPayment, queueSync } from "../services/quickbooks-sync.js";
 import { sendNotification } from "../services/notificationService.js";
+import { appBaseUrl } from "../lib/app-url.js";
 
 const router = Router();
 
@@ -444,7 +445,11 @@ router.post("/:id/send", requireAuth, requireRole("owner", "admin", "office"), a
 
     const companyId = req.auth!.companyId;
     const invNum  = invoice.invoice_number || generateInvoiceNumber(invoiceId);
-    const invLink = `https://clean-ops-pro.replit.app/pay/${invoiceId}`;
+    // TODO(invoice-pay-token): the public /pay route resolves a payment_links
+    // token, not a bare invoice id. Wiring invoice-send to mint a payment_links
+    // row (Stripe setup-intent) is a separate task; for now this is on the
+    // correct domain (no more Replit) but still id-based.
+    const invLink = `${appBaseUrl()}/pay/${invoiceId}`;
     const mergeVars = {
       first_name:       client?.first_name || "",
       invoice_number:   invNum,
@@ -500,7 +505,7 @@ router.post("/:id/remind", requireAuth, requireRole("owner", "admin", "office"),
       } else {
       const { Resend } = await import("resend");
       const resend = new Resend(process.env.RESEND_API_KEY);
-      const payLink = `https://clean-ops-pro.replit.app/pay/${invoiceId}`;
+      const payLink = `${appBaseUrl()}/pay/${invoiceId}`;
       await resend.emails.send({
         from: "notifications@phes.io",
         to: clientEmail,

--- a/artifacts/api-server/src/routes/leads.ts
+++ b/artifacts/api-server/src/routes/leads.ts
@@ -418,37 +418,44 @@ export async function fireOfficeNotification(
   const fullName = [firstName, lastName].filter(Boolean).join(" ");
   const smsBody = `New lead — ${fullName} — ${source}${phone ? ` — ${phone}` : ""}. Log in to review.`;
 
-  try {
-    const accountSid = process.env.TWILIO_ACCOUNT_SID;
-    const authToken  = process.env.TWILIO_AUTH_TOKEN;
-    const from       = process.env.TWILIO_FROM_NUMBER;
-    const officeNum  = "+17737869902";
-    if (accountSid && authToken && from) {
-      const smsRes = await fetch(
-        `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/Messages.json`,
-        {
-          method: "POST",
-          headers: {
-            Authorization: "Basic " + Buffer.from(`${accountSid}:${authToken}`).toString("base64"),
-            "Content-Type": "application/x-www-form-urlencoded",
-          },
-          body: new URLSearchParams({ To: officeNum, From: from, Body: smsBody }).toString(),
-        }
-      );
-      if (!smsRes.ok) console.error("[leads] Twilio SMS failed:", await smsRes.text());
+  // Per-tenant routing. Email goes TO companies.lead_notify_email FROM
+  // companies.email_from_address; SMS goes TO companies.lead_notify_phone FROM
+  // the tenant's own number via resolveSender. NOTHING is hardcoded to Oak Lawn
+  // anymore (the old +17737869902 / info@phes.io / global-env Twilio path is
+  // gone), so a Schaumburg lead never alerts the Oak Lawn office.
+  const cfgRows = await db.execute(sql`
+    SELECT email_from_address, lead_notify_email, lead_notify_phone, email AS company_email
+    FROM companies WHERE id = ${companyId} LIMIT 1
+  `);
+  const cfg: any = cfgRows.rows[0] ?? {};
+  const notifyEmail = cfg.lead_notify_email || cfg.company_email || null;
+  const notifyPhone = cfg.lead_notify_phone || null;
+  const fromAddr = cfg.email_from_address ? `Qleno <${cfg.email_from_address}>` : "Qleno <noreply@phes.io>";
+
+  // Internal office SMS — only when a per-tenant alert number is configured,
+  // routed through resolveSender (tenant creds + from-number, full gate ladder).
+  if (notifyPhone) {
+    try {
+      const { resolveSender, sendSmsVia } = await import("../lib/comms-sender.js");
+      const sender = await resolveSender(companyId, null);
+      if (sender.reason) {
+        console.log(`[leads] office SMS suppressed (${sender.reason}) company=${companyId}`);
+      } else {
+        await sendSmsVia(sender, notifyPhone, smsBody);
+      }
+    } catch (err) {
+      console.error("[leads] office SMS error:", err);
     }
-  } catch (err) {
-    console.error("[leads] office SMS error:", err);
   }
 
   try {
     const resendKey = process.env.RESEND_API_KEY;
-    if (resendKey) {
+    if (resendKey && notifyEmail) {
       const { Resend } = await import("resend");
       const resend = new Resend(resendKey);
       await resend.emails.send({
-        from: "Qleno <noreply@phes.io>",
-        to: ["info@phes.io"],
+        from: fromAddr,
+        to: [notifyEmail],
         subject: `New Lead: ${fullName}`,
         html: `<div style="font-family:Arial,sans-serif;max-width:600px;margin:0 auto;padding:32px;background:#F7F6F3;">
 <div style="background:#fff;border:1px solid #E5E2DC;border-radius:8px;padding:32px;">

--- a/artifacts/api-server/src/routes/payment-links.ts
+++ b/artifacts/api-server/src/routes/payment-links.ts
@@ -5,15 +5,18 @@ import {
 } from "@workspace/db/schema";
 import { eq, and } from "drizzle-orm";
 import { requireAuth, requireRole } from "../lib/auth.js";
+import { appBaseUrl } from "../lib/app-url.js";
 import crypto from "crypto";
 
 const router = Router();
 
 // ─── Helper: get app base URL ─────────────────────────────────────────────────
+// Delegates to the single source of truth (APP_BASE_URL → https://app.qleno.com).
+// The previous implementation had an operator-precedence bug: `A || B ? C : D`
+// parsed as `(A || B) ? C : D`, so it returned the Replit domain even when
+// APP_URL was set, and never returned APP_URL at all.
 function getAppBaseUrl(): string {
-  return process.env.APP_URL || process.env.REPLIT_DEV_DOMAIN
-    ? `https://${process.env.REPLIT_DEV_DOMAIN}`
-    : "http://localhost:5173";
+  return appBaseUrl();
 }
 
 // ─── POST /payment-links — create & optionally send ───────────────────────────
@@ -105,7 +108,7 @@ router.post("/", requireAuth, requireRole("owner", "admin", "office"), async (re
       const toPhone = client.billing_contact_phone || client.phone;
       const twilioSid = process.env.TWILIO_ACCOUNT_SID;
       const twilioToken = process.env.TWILIO_AUTH_TOKEN;
-      const twilioFrom = company.twilio_from_number || process.env.TWILIO_FROM_NUMBER;
+      const twilioFrom = company.twilio_from_number; // per-tenant only — no global-env fallback
       if (!twilioSid || !twilioToken || !twilioFrom || !toPhone) {
         console.warn("Twilio not configured or no phone — skipping SMS");
       } else {

--- a/artifacts/api-server/src/routes/public.ts
+++ b/artifacts/api-server/src/routes/public.ts
@@ -927,31 +927,23 @@ router.post("/book/confirm", rateLimit, async (req, res) => {
       }
     }
 
-    // ── Office SMS notification on confirm ───────────────────────────────────
+    // ── Office SMS notification on confirm (per-tenant) ──────────────────────
+    // FROM the tenant's own number via resolveSender; TO the tenant's configured
+    // lead_notify_phone. No global-env number, no hardcoded Oak Lawn recipient.
     try {
-      const accountSid = process.env.TWILIO_ACCOUNT_SID;
-      const authToken  = process.env.TWILIO_AUTH_TOKEN;
-      const fromNum    = process.env.TWILIO_FROM_NUMBER;
-      if (process.env.COMMS_ENABLED !== "true") {
-        console.log("[COMMS BLOCKED] Booking office SMS suppressed:", { first_name, last_name, jobId });
-      } else if (accountSid && authToken && fromNum) {
+      const { resolveSender, sendSmsVia } = await import("../lib/comms-sender.js");
+      const sender = await resolveSender(Number(company_id), null);
+      const notifyRow = await db.execute(drizzleSql`SELECT lead_notify_phone FROM companies WHERE id = ${company_id} LIMIT 1`);
+      const officeTo = (notifyRow.rows[0] as any)?.lead_notify_phone || null;
+      if (sender.reason) {
+        console.log("[confirm] Office SMS suppressed:", sender.reason);
+      } else if (officeTo) {
         const dateStr2 = preferred_date
           ? new Date(preferred_date + "T12:00:00").toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric" })
           : "TBD";
         const windowLabel = arrivalWindowVal === "morning" ? "9AM–12PM" : arrivalWindowVal === "afternoon" ? "12PM–2PM" : "";
         const smsBody = `📋 New Booking — ${first_name} ${last_name} | ${scopeName} | ${sqft} sqft | ${dateStr2}${windowLabel ? ` ${windowLabel}` : ""} | Job #${jobId}${recurringJobId ? ` + #${recurringJobId}` : ""}`;
-        const smsRes = await fetch(
-          `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/Messages.json`,
-          {
-            method: "POST",
-            headers: {
-              Authorization: `Basic ${Buffer.from(`${accountSid}:${authToken}`).toString("base64")}`,
-              "Content-Type": "application/x-www-form-urlencoded",
-            },
-            body: new URLSearchParams({ To: "+17737869902", From: branchConfig.twilioFrom || fromNum, Body: smsBody }).toString(),
-          }
-        );
-        if (!smsRes.ok) console.error("[confirm] Twilio SMS failed:", await smsRes.text());
+        await sendSmsVia(sender, officeTo, smsBody);
       }
     } catch (smsErr) {
       console.error("[confirm] Office SMS error:", smsErr);
@@ -1372,31 +1364,17 @@ router.post("/leads", rateLimit, async (req, res) => {
     `);
     const leadId = (insertResult.rows[0] as any)?.id;
 
-    // Office SMS alert
+    // Office SMS alert (per-tenant) — FROM the tenant's own number via
+    // resolveSender, TO the tenant's lead_notify_phone. No global-env / Oak Lawn.
     try {
-      const accountSid = process.env.TWILIO_ACCOUNT_SID;
-      const authToken  = process.env.TWILIO_AUTH_TOKEN;
-      const from       = process.env.TWILIO_FROM_NUMBER;
-      const officeNum  = "+17737869902";
-      if (process.env.COMMS_ENABLED !== "true") {
-        console.log("[COMMS BLOCKED] Very-dirty lead office SMS suppressed:", { first_name, last_name, phone });
-      } else if (accountSid && authToken && from) {
-        const smsRes = await fetch(
-          `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/Messages.json`,
-          {
-            method: "POST",
-            headers: {
-              Authorization: "Basic " + Buffer.from(`${accountSid}:${authToken}`).toString("base64"),
-              "Content-Type": "application/x-www-form-urlencoded",
-            },
-            body: new URLSearchParams({
-              To: officeNum,
-              From: from,
-              Body: `Very Dirty Lead — ${first_name} ${last_name || ""} — ${phone}. Needs manual callback. Lead #${leadId || "N/A"}.`,
-            }).toString(),
-          }
-        );
-        if (!smsRes.ok) console.error("[very-dirty] Twilio SMS failed:", await smsRes.text());
+      const { resolveSender, sendSmsVia } = await import("../lib/comms-sender.js");
+      const sender = await resolveSender(Number(company_id), null);
+      const notifyRow = await db.execute(drizzleSql`SELECT lead_notify_phone FROM companies WHERE id = ${company_id} LIMIT 1`);
+      const officeTo = (notifyRow.rows[0] as any)?.lead_notify_phone || null;
+      if (sender.reason) {
+        console.log("[very-dirty] Office SMS suppressed:", sender.reason);
+      } else if (officeTo) {
+        await sendSmsVia(sender, officeTo, `Very Dirty Lead — ${first_name} ${last_name || ""} — ${phone}. Needs manual callback. Lead #${leadId || "N/A"}.`);
       }
     } catch (smsErr) {
       console.error("[very-dirty] SMS error:", smsErr);

--- a/artifacts/api-server/src/routes/quotes.ts
+++ b/artifacts/api-server/src/routes/quotes.ts
@@ -5,6 +5,7 @@ import { eq, and, desc, count, sql } from "drizzle-orm";
 import { requireAuth, requireRole } from "../lib/auth.js";
 import { logAudit } from "../lib/audit.js";
 import { getBranchByZip } from "../lib/branchRouter";
+import { randomBytes } from "crypto";
 import { generateJobsFromSchedule, DAYS_AHEAD } from "../lib/recurring-jobs.js";
 import { persistJobAddOns } from "./jobs.js";
 
@@ -282,6 +283,16 @@ router.post("/:id/send", requireAuth, requireRole("owner", "admin", "office"), a
       .where(and(eq(quotesTable.id, id), eq(quotesTable.company_id, companyId)))
       .returning();
     if (!q) return res.status(404).json({ error: "Not found" });
+
+    // Ensure a public sign_token exists so the customer-facing quote page
+    // (app.qleno.com/estimate/<token>, served by the estimates public endpoint
+    // with a quote fallback) resolves instead of 404ing. Generated once and
+    // reused; idempotent on re-send.
+    if (!(q as any).sign_token) {
+      const tok = randomBytes(24).toString("hex");
+      await db.execute(sql`UPDATE quotes SET sign_token = ${tok} WHERE id = ${id}`);
+      (q as any).sign_token = tok;
+    }
     console.log(`[QUOTE SENT] id=${id} lead_email=${q.lead_email}`);
     // Enroll in quote_followup sequence (non-blocking)
     import("../services/followUpService.js").then(({ enrollForQuoteSent }) => {
@@ -302,19 +313,14 @@ router.post("/:id/send", requireAuth, requireRole("owner", "admin", "office"), a
         await linkEnrollmentToLead(companyId, id, leadId);
       }
     }).catch(() => {});
-    // fire quote_sent notification (non-blocking)
-    import("../services/notificationService.js").then(({ sendNotification }) => {
-      const mv = {
-        first_name:     (q as any).lead_name?.split(" ")[0] || "",
-        quote_number:   String(id),
-        quote_total:    parseFloat((q as any).total_price || (q as any).base_price || "0").toFixed(2),
-        quote_link:     `https://clean-ops-pro.replit.app/quote/${id}`,
-        quote_expires:  new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric" }),
-        service_address: (q as any).address || "",
-      };
-      sendNotification("quote_sent", "email", companyId, (q as any).lead_email ?? null, null, mv).catch(() => {});
-      sendNotification("quote_sent", "sms",   companyId, null, (q as any).lead_phone ?? null, mv).catch(() => {});
-    });
+    // NOTE: the quote email + SMS are delivered by the quote-followup CADENCE
+    // (touch 1 = the MaidCentral-styled quote email, touch 2 = the quote SMS),
+    // enrolled just above via enrollForQuoteSent. The old immediate `quote_sent`
+    // notification was removed — it was the source of the broken Replit link and
+    // the wrong (global-env Oak Lawn) SMS number, and it double-sent on top of
+    // cadence touch 1. The cadence renders the link from sign_token via the
+    // per-tenant sender (resolveSender), so this consolidates quote comms onto a
+    // single correct path.
     return res.json({ success: true, quote: q });
   } catch (err) {
     return res.status(500).json({ error: "Internal Server Error" });

--- a/artifacts/api-server/src/services/followUpService.ts
+++ b/artifacts/api-server/src/services/followUpService.ts
@@ -7,6 +7,7 @@ import { db } from "@workspace/db";
 import { sql } from "drizzle-orm";
 import { resolveSender, sendSmsVia } from "../lib/comms-sender.js";
 import { getBranchByZip } from "../lib/branchRouter.js";
+import { appBaseUrl } from "../lib/app-url.js";
 
 // ── Merge field resolver ───────────────────────────────────────────────────────
 function resolveMergeFields(template: string, vars: Record<string, string>): string {
@@ -68,18 +69,32 @@ async function companyFromAddress(companyId: number): Promise<string> {
   } catch { return "Phes Cleaning <noreply@phes.io>"; }
 }
 
-async function sendEmailRaw(to: string, subject: string, body: string, fromAddress = "Phes Cleaning <noreply@phes.io>"): Promise<string | null> {
+interface EmailBrand { companyName?: string | null; phone?: string | null; email?: string | null }
+
+async function sendEmailRaw(
+  to: string, subject: string, body: string,
+  fromAddress = "Phes Cleaning <noreply@phes.io>",
+  brand?: EmailBrand,
+): Promise<string | null> {
   const key = process.env.RESEND_API_KEY;
   if (!key) throw new Error("Resend not configured");
   const { Resend } = await import("resend");
   const resend = new Resend(key);
+  const brandName  = brand?.companyName || "Phes Cleaning";
+  const brandPhone = brand?.phone || "(773) 706-6000";
+  const brandEmail = brand?.email || "info@phes.io";
+  // A body that already starts with a block tag is rich HTML (e.g. the quote
+  // email) — inject it verbatim. Plain-text bodies get newline→<br> + a <p>.
+  const inner = /^\s*</.test(body)
+    ? body
+    : `<p style="font-size:15px;color:#1A1917;line-height:1.7;margin:0 0 20px;">${body.replace(/\n/g, "<br>")}</p>`;
   const bodyHtml = `<div style="font-family:Arial,sans-serif;max-width:600px;margin:0 auto;padding:32px 24px;background:#F7F6F3;">
 <div style="background:#fff;border:1px solid #E5E2DC;border-radius:8px;padding:32px;">
 <div style="background:#5B9BD5;padding:14px 20px;border-radius:4px;margin-bottom:24px;">
-  <span style="color:#fff;font-size:16px;font-weight:bold;">Phes Cleaning</span>
+  <span style="color:#fff;font-size:16px;font-weight:bold;">${brandName}</span>
 </div>
-<p style="font-size:15px;color:#1A1917;line-height:1.7;margin:0 0 20px;">${body.replace(/\n/g, "<br>")}</p>
-<p style="font-size:13px;color:#9E9B94;margin:0;">Phes Cleaning &mdash; (773) 706-6000 &mdash; info@phes.io</p>
+${inner}
+<p style="font-size:13px;color:#9E9B94;margin:20px 0 0;">${brandName} &mdash; ${brandPhone} &mdash; ${brandEmail}</p>
 </div></div>`;
   const res: any = await resend.emails.send({
     from: fromAddress,
@@ -97,12 +112,51 @@ async function sendEmailRaw(to: string, subject: string, body: string, fromAddre
   return res?.data?.id ?? res?.id ?? null;
 }
 
-async function sendEmail(to: string, subject: string, body: string, fromAddress?: string): Promise<void> {
+async function sendEmail(to: string, subject: string, body: string, fromAddress?: string, brand?: EmailBrand): Promise<void> {
   if (process.env.COMMS_ENABLED !== "true") {
     console.log("[COMMS BLOCKED] Follow-up email suppressed:", { to, subject });
     return;
   }
-  await sendEmailRaw(to, subject, body, fromAddress);
+  await sendEmailRaw(to, subject, body, fromAddress, brand);
+}
+
+// Build the merge vars for a quote-tied enrollment touch (the quote email + SMS).
+// Pulls the quote's public sign_token (→ the customer-facing estimate page),
+// total, line items, address, contact + the tenant's company/brand info so the
+// MaidCentral-styled quote email renders fully on BOTH the cron and send-one
+// paths. Returns extra vars merged on top of the base {first_name, company_name}.
+async function buildQuoteMergeVars(companyId: number, quoteId: number): Promise<Record<string, string>> {
+  const r = await db.execute(sql`
+    SELECT q.id, q.total_price, q.base_price, q.address, q.service_type, q.addons,
+           q.sign_token, q.lead_email, q.lead_phone,
+           c.name AS company_name, c.phone AS company_phone, c.email AS company_email
+    FROM quotes q JOIN companies c ON c.id = q.company_id
+    WHERE q.id = ${quoteId} AND q.company_id = ${companyId} LIMIT 1
+  `);
+  const q: any = r.rows[0];
+  if (!q) return {};
+  const total = q.total_price ?? q.base_price ?? "0";
+  const link = q.sign_token ? `${appBaseUrl()}/estimate/${q.sign_token}` : `${appBaseUrl()}/estimate`;
+  const addons = Array.isArray(q.addons) ? q.addons : [];
+  const rows: string[] = [];
+  if (q.base_price != null) rows.push(`<tr><td style="padding:6px 0;color:#1A1917;">${q.service_type || "Cleaning service"}</td><td style="padding:6px 0;text-align:right;color:#1A1917;">$${Number(q.base_price).toFixed(2)}</td></tr>`);
+  for (const a of addons) {
+    const amt = a?.amount ?? a?.price;
+    rows.push(`<tr><td style="padding:6px 0;color:#1A1917;">${a?.name || "Add-on"}</td><td style="padding:6px 0;text-align:right;color:#1A1917;">${amt != null ? "$" + Number(amt).toFixed(2) : "—"}</td></tr>`);
+  }
+  const lineItems = `<table style="width:100%;border-collapse:collapse;font-size:14px;margin:8px 0;">${rows.join("")}<tr><td style="padding:8px 0 0;font-weight:700;border-top:1px solid #E5E2DC;">Total</td><td style="padding:8px 0 0;text-align:right;font-weight:700;border-top:1px solid #E5E2DC;">$${Number(total).toFixed(2)}</td></tr></table>`;
+  return {
+    company_name:    q.company_name || "Phes",
+    company_phone:   q.company_phone || "(773) 706-6000",
+    company_email:   q.company_email || "info@phes.io",
+    estimate_link:   link,
+    quote_number:    String(q.id),
+    quote_total:     Number(total).toFixed(2),
+    service_address: q.address || "",
+    customer_email:  q.lead_email || "",
+    customer_phone:  q.lead_phone || "",
+    line_items:      lineItems,
+  };
 }
 
 // ── Enroll for quote follow-up ─────────────────────────────────────────────────
@@ -356,8 +410,12 @@ async function processEnrollment(enr: any): Promise<void> {
     first_name:   firstName,
     company_name: "Phes",
   };
+  // Quote-tied enrollments (the quote email/SMS) get the full quote merge set:
+  // public estimate link, total, itemized line items, address, contact, brand.
+  if (enr.quote_id) Object.assign(mergeVars, await buildQuoteMergeVars(enr.company_id, enr.quote_id));
   const body    = resolveMergeFields(rawBody, mergeVars);
   const subject = rawSubject ? resolveMergeFields(rawSubject, mergeVars) : "";
+  const emailBrand: EmailBrand = { companyName: mergeVars.company_name, phone: mergeVars.company_phone, email: mergeVars.company_email };
 
   let sendStatus = "sent";
   let sendError  = "";
@@ -382,7 +440,7 @@ async function processEnrollment(enr: any): Promise<void> {
         sendError  = sender.reason || "branch_comms_disabled";
         console.log(`[follow-up] email suppressed (${sendError}) enrollment ${enr.id}`);
       } else {
-        await sendEmail(recipientEmail, subject, body, await companyFromAddress(enr.company_id));
+        await sendEmail(recipientEmail, subject, body, await companyFromAddress(enr.company_id), emailBrand);
       }
     } else {
       sendStatus = "failed";
@@ -478,9 +536,11 @@ export async function sendSingleEnrollmentTouch(
     const t = await db.execute(sql`SELECT body, subject FROM message_templates WHERE id = ${step.template_id} AND company_id = ${companyId} AND active = true LIMIT 1`);
     if (t.rows.length) { rawBody = (t.rows[0] as any).body || rawBody; rawSubject = (t.rows[0] as any).subject || rawSubject; }
   }
-  const mergeVars = { first_name: firstName, company_name: "Phes" };
+  const mergeVars: Record<string, string> = { first_name: firstName, company_name: "Phes" };
+  if (enr.quote_id) Object.assign(mergeVars, await buildQuoteMergeVars(companyId, enr.quote_id));
   const body = resolveMergeFields(rawBody, mergeVars);
   const subject = rawSubject ? resolveMergeFields(rawSubject, mergeVars) : "";
+  const emailBrand: EmailBrand = { companyName: mergeVars.company_name, phone: mergeVars.company_phone, email: mergeVars.company_email };
 
   // ── Send the touch. EMAIL → Resend raw; SMS → Twilio raw via the saved
   //    company creds + branch from-number. BOTH bypass the global COMMS_ENABLED
@@ -494,7 +554,7 @@ export async function sendSingleEnrollmentTouch(
     if (!recipientEmail) return { sent: false, channel: "email", reason: "no_recipient_email", step: step.step_number };
     recipient = recipientEmail;
     try {
-      providerId = await sendEmailRaw(recipientEmail, subject, body, await companyFromAddress(companyId));
+      providerId = await sendEmailRaw(recipientEmail, subject, body, await companyFromAddress(companyId), emailBrand);
     } catch (e: any) {
       logStatus = "failed"; logErr = e?.message || "email_send_error";
     }

--- a/artifacts/api-server/src/services/notificationService.ts
+++ b/artifacts/api-server/src/services/notificationService.ts
@@ -3,6 +3,7 @@ import { notificationTemplatesTable, notificationLogTable, clientsTable, compani
 import { eq, and, sql } from "drizzle-orm";
 import { getBranchByZip } from "../lib/branchRouter";
 import { buildReminderEmail } from "../lib/emailTemplates";
+import { resolveSender, sendSmsVia } from "../lib/comms-sender.js";
 import { Resend } from "resend";
 
 // ── Email brand constants ────────────────────────────────────────────────────
@@ -47,27 +48,18 @@ ${contentHtml}
 }
 
 // ── Twilio SMS sender ─────────────────────────────────────────────────────────
-async function sendTwilioSms(to: string, body: string): Promise<void> {
-  if (process.env.COMMS_ENABLED !== "true") {
-    console.log("[COMMS BLOCKED] SMS suppressed:", { to, body: body.substring(0, 80) });
+// Per-tenant ONLY. Resolves the company's own creds + from-number via
+// resolveSender(companyId) and sends through sendSmsVia. The old global-env
+// path (process.env.TWILIO_FROM_NUMBER = the Oak Lawn / MaidCentral number
+// +17737869902) is GONE — Qleno must never send from a shared global number
+// again. Honors the full gate ladder (global + company + twilio + creds + from).
+async function sendTenantSms(companyId: number, to: string, body: string): Promise<void> {
+  const sender = await resolveSender(companyId, null);
+  if (sender.reason) {
+    console.log(`[COMMS BLOCKED] SMS suppressed (${sender.reason}) company=${companyId} to=${to}`);
     return;
   }
-  const accountSid = process.env.TWILIO_ACCOUNT_SID;
-  const authToken  = process.env.TWILIO_AUTH_TOKEN;
-  const from       = process.env.TWILIO_FROM_NUMBER;
-  if (!accountSid || !authToken || !from) throw new Error("Twilio not configured");
-  const res = await fetch(`https://api.twilio.com/2010-04-01/Accounts/${accountSid}/Messages.json`, {
-    method: "POST",
-    headers: {
-      Authorization: `Basic ${Buffer.from(`${accountSid}:${authToken}`).toString("base64")}`,
-      "Content-Type": "application/x-www-form-urlencoded",
-    },
-    body: new URLSearchParams({ To: to, From: from, Body: body }).toString(),
-  });
-  if (!res.ok) {
-    const err: any = await res.json();
-    throw new Error(err?.message || "Twilio error");
-  }
+  await sendSmsVia(sender, to, body);
 }
 
 // ── Core send function ───────────────────────────────────────────────────────
@@ -168,13 +160,11 @@ export async function sendNotification(
         await logNotification(companyId, "no-phone", channel, templateKey, "skipped", "No recipient phone", fullVars);
         return;
       }
-      if (!process.env.TWILIO_ACCOUNT_SID) {
-        await logNotification(companyId, recipientPhone, channel, templateKey, "skipped", "Twilio not configured", fullVars);
-        return;
-      }
 
       const bodyText = applyMerge(tpl.body_text || tpl.body || "", fullVars);
-      await sendTwilioSms(recipientPhone, bodyText);
+      // Per-tenant send only — resolveSender(companyId) picks THIS company's
+      // creds + from-number. Never the global env number.
+      await sendTenantSms(companyId, recipientPhone, bodyText);
     }
 
   } catch (err: any) {

--- a/docs/LEAD_LIFECYCLE_AND_COMMS_GUIDE.md
+++ b/docs/LEAD_LIFECYCLE_AND_COMMS_GUIDE.md
@@ -1,0 +1,163 @@
+# Qleno Lead Lifecycle & Communications Guide
+
+**Status:** Research / proposal for Sal's approval. **Nothing in section C/D is deployed.**
+Prepared from the live system: imported MaidCentral templates (`message_templates`),
+the active 7-touch cadence (`follow_up_steps`, company 4), Qleno's notification
+templates (`notification_templates`, company 4), and the lead-pipeline code.
+
+---
+
+## A. Lead Lifecycle — Stages & Transitions
+
+Seven canonical stages (source of truth: `leads.status`, UI `STATUS_CONFIG` /
+`STATUS_ORDER` in `leads.tsx`). Pipeline order:
+
+| # | Stage | Label | Entered when… | Trigger / source |
+|---|-------|-------|---------------|------------------|
+| 1 | `needs_contacted` | Needs Contacted | Lead created (manual, quote-sync, online form, contact form, booking widget) | `POST /api/leads`; `upsertLeadForQuote()` on quote create |
+| 2 | `contacted` | Contacted | Office logs first outreach | **Manual** (office sets it); stamps `contacted_at` |
+| 3 | `quoted` | Quoted | A quote is **sent** to the lead | `POST /api/quotes/:id/send` → `advanceLeadStage(…, "quoted")`; stamps `quoted_at` |
+| 4 | `follow_up` | Follow Up | Lead is in the nurture window (quote out, not yet booked) | **Manual** stage; the 7-touch cadence runs during 3→4 |
+| 5 | `booked` | Booked | Quote converted to a job (or accepted) | `POST /api/quotes/:id/convert` (and `/accept`) → `advanceLeadStage(…, "booked")`; stamps `booked_at`; **stops cadence** |
+| 6 | `no_response` | No Response | Cadence exhausted, no engagement | **Manual** (office sets it) |
+| 7 | `not_interested` | Not Interested | Lead declines | **Manual** (office sets it) |
+
+**Notes**
+- Stages 2, 4, 6, 7 are **operator-set** today (drag on the board / status change). Only `needs_contacted` (create), `quoted` (quote send), and `booked` (convert) are **automatic**.
+- Every transition writes a `lead_activity_log` row (`stage_<name>`), so the lead's Activity tab shows the full history.
+- Current Schaumburg/Phes data: 17 `needs_contacted`, 9 `booked` (no leads parked in the other stages yet).
+
+---
+
+## B. Every Communication a Lead Receives (in order)
+
+### B0. Internal — "New Lead" office notification (fires on lead creation)
+- **Audience:** internal office (NOT the customer). Function `fireOfficeNotification()` in `routes/leads.ts`.
+- **Email** — to `info@phes.io` (hardcoded), from `Qleno <noreply@phes.io>` (hardcoded). Subject: `New Lead: <Full Name>`. Body: branded card with Name / Source / Scope / Phone / Lead ID + "Log in to Qleno to review and assign this lead."
+- **SMS** — to `+17737869902` (hardcoded Oak Lawn), from the **global** Twilio env number. Body: `New lead — <name> — <source> — <phone>. Log in to review.`
+- ⚠️ **Both recipient + sender are hardcoded to Oak Lawn** regardless of tenant — see Section D fix.
+
+### B1. Quote email + SMS — the "your quote is ready" send (fires on quote send)
+Two systems fire on `POST /api/quotes/:id/send`:
+
+**(i) `quote_sent` notification** (immediate; `notificationService.sendNotification`)
+- **Email** — subject `Your quote from {{company_name}} — #{{quote_number}}`
+  Body: `Hi {{first_name}}, your quote #{{quote_number}} from {{company_name}} is ready — ${{quote_total}} estimated. Review: {{quote_link}} or call {{company_phone}} to book.`
+- **SMS** — same copy.
+- ⚠️ `{{quote_link}}` = `https://clean-ops-pro.replit.app/quote/<id>` → **404** (wrong domain + nonexistent path). SMS goes from the **global** Twilio number, not the tenant's. See Section D.
+
+**(ii) 7-touch quote follow-up cadence** (enrolled on send; processed by the cron / `send-one`). Full content below.
+
+### B2. The 7-touch follow-up cadence (company 4 — "Quote Follow-Up")
+Delays are measured from the **previous** touch; all sends clamped to business hours (8:00–21:00 local).
+
+| Touch | Channel | Cumulative timing | Subject (email) | Body |
+|-------|---------|-------------------|-----------------|------|
+| 1 | Email | ~0 (on send) | **Your cleaning quote from Phes** | Hi {{first_name}}, thank you for reaching out to Phes. Your quote is ready and we would love to get you on the schedule. Reply any time with questions. |
+| 2 | SMS | ~0 (on send) | — | Hi {{first_name}}, this is the Phes office following up on your cleaning quote. Want us to find you a time? Just reply here. |
+| 3 | SMS | +24h (~Day 1) | — | Hi {{first_name}}, checking in on your Phes quote. Happy to answer any questions or book your first clean whenever you are ready. |
+| 4 | Email | +48h (~Day 3) | **Still here when you are ready** | Hi {{first_name}}, just following up on your cleaning quote. We have openings this week and can usually match the day that works best for you. Reply to get started. |
+| 5 | SMS | +48h (~Day 5) | — | Hi {{first_name}}, the Phes team would still love to help with your cleaning. Want me to hold a spot for you this week? |
+| 6 | Email | +120h (~Day 10) | **A clean home is closer than you think** | Hi {{first_name}}, we know life gets busy. Your Phes quote is still good and booking only takes a minute. Reply and we will take it from there. |
+| 7 | Email | +192h (~Day 18) | **Closing out your quote** | Hi {{first_name}}, we will pause our follow-ups for now so we are not crowding your inbox. Whenever you are ready for a cleaning, just reply and we will pick right back up. Thank you from the Phes team. |
+
+### B3. Booking confirmation (fires on convert/book)
+- `job_scheduled` notification — email subject `Your cleaning is confirmed for {{date}}`.
+- `new_client_welcome` (email + SMS) when a client record is created: `Hi {{first_name}}, welcome to {{company_name}}! We look forward to your first cleaning. Questions anytime: {{company_phone}}. See you soon.`
+
+### B4. Cadence stop conditions
+1. **Booked / accepted / converted** → `stopEnrollmentsForQuote(reason="booked")`.
+2. **Customer replies** (any inbound SMS) → `handleInboundReply()` stops the active cadence (stop-on-reply), `POST /api/comms/inbound`.
+3. **Opt-out keyword** — STOP / STOPALL / UNSUBSCRIBE / CANCEL / END / QUIT → flagged opt-out + cadence stopped.
+4. **Cadence completes** (touch 7 sent) → enrollment marked completed.
+
+---
+
+## C. Proposed Qleno Quote Email — modeled on Phes's MaidCentral version
+
+### C1. The MaidCentral source (verbatim) — "Quote Send (Many Lines)"
+This is the customized initial quote email Phes edited in MaidCentral.
+
+- **Subject:** `Thank you for your interest!`
+- **Structure / sections:**
+  1. H1 greeting: `{{C_FIRSTNAME}}, thank you for your interest!`
+  2. "Below is the quote we've discussed."
+  3. "Please verify the information below and contact us at `{{SVCCOPHONE}}` or `{{SVCCOEMAIL}}` to get started."
+  4. **Office hours + 48-hour notice** paragraph (Mon–Fri 9–6, Sat 9–12 CT; Sundays don't count).
+  5. **Cancellations & Rescheduling** bullets: 48h notice; Monday→notify by Fri 6pm CT; Tuesday→notify by Sat noon CT; <48h = 100% charge; late arrival wait max 20 min then forfeit.
+  6. **Satisfaction Guarantee:** miss a spot → free re-clean, **NO REFUNDS**, report within 24h.
+  7. Link to the **Checklist** (`https://phes.io/cleaning-checklist`).
+  8. **Customer info block:** Address `{{H_ADDRESS}} {{H_ADDRESS2}}`, Payment Method `{{PAYMENTMETHOD}}`, Email `{{C_EMAILADDRESS}}`, Phone `{{C_PHONE}}`.
+  9. **"Quote Details"** heading → "We've itemized the services we are quoting." → itemized fee table `{{FEETABLE}}`.
+- **Tone:** warm, professional, policy-forward (sets expectations up front). MaidCentral merge fields: `{{C_FIRSTNAME}}`, `{{SVCCONAME}}`, `{{SVCCOPHONE}}`, `{{SVCCOEMAIL}}`, `{{H_ADDRESS}}/{{H_ADDRESS2}}`, `{{PAYMENTMETHOD}}`, `{{C_EMAILADDRESS}}`, `{{C_PHONE}}`, `{{FEETABLE}}`.
+
+(Companion templates Phes also customized: **"Quote Customer Convert (Many Lines)"** = booking confirmation with full cancellation/site-prep/liability/right-to-rectify/home-access/non-solicitation policy; **"Quote Follow Up"** = simple "still interested?" nudge; **"Online Quote Text Follow Up"** = the "Hi, this is Sal from Phes…" SMS; **"New Lead"** email/SMS = first-touch acknowledgements.)
+
+### C2. Proposed Qleno quote email (Phes-styled, with corrected merge fields + link)
+
+> **Subject:** Thank you for your interest, {{first_name}}! — Your Phes cleaning quote
+>
+> **{{first_name}}, thank you for your interest!**
+>
+> Below is the quote we've discussed. Please review the details and tap the button to view your full quote or book your first clean.
+>
+> **[ View & Book Your Quote ]** → `https://app.qleno.com/estimate/{{sign_token}}`
+>
+> Questions? Call or text us at {{company_phone}} or reply to this email.
+>
+> ---
+> **Quote Details** — we've itemized the services we're quoting:
+> {{line_items_table}}  ·  **Total: ${{quote_total}}**
+>
+> **Your info**
+> Address: {{service_address}} · Email: {{customer_email}} · Phone: {{customer_phone}}
+>
+> ---
+> **Office hours:** Mon–Fri 9 AM–6 PM, Sat 9 AM–12 PM CT (closed Sun).
+>
+> **Cancellations & Rescheduling**
+> 🔹 48 hours' notice to cancel or reschedule (Sundays don't count)
+> 🔹 Monday appointments: notify by Friday 6 PM CT · Tuesday: by Saturday noon CT
+> 🔹 Cancellations within 48 hours are charged 100% of the invoice
+> 🔹 Late arrivals: we wait a max of 20 minutes, then the visit is forfeited
+>
+> **Satisfaction Guarantee**
+> 🔹 If we miss a spot, we'll return and re-clean for free — **no refunds**
+> 🔹 Contact us within 24 hours of your cleaning if there's an issue
+>
+> See everything we do on our [Checklist](https://phes.io/cleaning-checklist).
+>
+> — The {{company_name}} Team
+
+**Proposed Qleno merge fields:** `{{first_name}}`, `{{company_name}}`, `{{company_phone}}`,
+`{{sign_token}}`, `{{quote_total}}`, `{{line_items_table}}`, `{{service_address}}`,
+`{{customer_email}}`, `{{customer_phone}}`. The matching SMS keeps the existing short copy but
+swaps `{{quote_link}}` for the corrected `app.qleno.com/estimate/{{sign_token}}` URL.
+
+---
+
+## D. Deployment Spec (to ship AFTER approval — not yet built)
+
+### D1. Corrected customer-facing links
+- **Single source of truth:** standardize on `process.env.APP_BASE_URL` (default `https://app.qleno.com`). Retire the hardcoded `clean-ops-pro.replit.app` strings and the buggy `getAppBaseUrl()` (operator-precedence bug returns the Replit domain even when `APP_URL` is set).
+- **Quote link target:** the public, unauthenticated estimate page — `https://app.qleno.com/estimate/{{sign_token}}` (route `/estimate/:token` → `EstimatePublicPage`). Requires populating `quotes.sign_token` on send (the column exists; confirm it's set, else generate on `/send`).
+- **Invoice/pay link:** `https://app.qleno.com/pay/{{pay_token}}` (route `/pay/:token` takes a **token**, not the invoice id — current `clean-ops-pro/pay/<invoiceId>` is wrong twice over).
+- Call sites to fix: `routes/quotes.ts:311`, `routes/invoices.ts:447,503`, `routes/payment-links.ts:14`.
+
+### D2. Per-tenant SMS from-number (all paths)
+- Route **every** SMS send through `resolveSender(companyId, branchId)` + `sendSmsVia()` so each tenant sends from its own `companies.twilio_from_number` (Schaumburg = **+16308844318**).
+- Retire the legacy global-env path `notificationService.sendTwilioSms()` (uses `TWILIO_FROM_NUMBER` = Oak Lawn +17737869902). Update `sendNotification`'s SMS branch (it already has `companyId`) and the two stray paths (`notificationService.ts:330`, `lib/comms.ts:73`).
+
+### D3. Per-tenant internal "New Lead" notification routing
+- `fireOfficeNotification()` must route by `companyId` instead of hardcoding Oak Lawn:
+  - **From (email):** the tenant's `companies.email_from_address` → Schaumburg = `schaumburg@phes.io`.
+  - **To (email):** the tenant's office inbox → **Schaumburg lead alerts go to `salmartinez8@gmail.com`** (per Sal). (Oak Lawn keeps its existing inbox.) Suggest a dedicated `companies.lead_notify_email` column rather than overloading `companies.email`.
+  - **SMS:** office number + from-number via `resolveSender(companyId)`, not the hardcoded `+17737869902` / global env.
+
+### D4. Quote email content
+- Replace the one-line `quote_sent` email/SMS with the **Phes-styled quote email** in Section C2 (policy-forward, itemized, public-estimate CTA), using the corrected merge fields and `APP_BASE_URL`.
+
+---
+
+*All sends remain gated off (global `COMMS_ENABLED=false`, all tenants `comms_enabled=false`)
+until Sal approves this spec and we re-run the go-live sequence.*

--- a/lib/db/src/schema/companies.ts
+++ b/lib/db/src/schema/companies.ts
@@ -153,6 +153,13 @@ export const companiesTable = pgTable("companies", {
   // Internal/comped account — excluded from SaaS MRR/ARR/revenue metrics. Net $0,
   // no Stripe. Used for owner-comped tenants (e.g. PHES Schaumburg).
   is_internal: boolean("is_internal").notNull().default(false),
+  // Per-tenant routing for the internal "New Lead" office alert. The alert is
+  // sent TO lead_notify_email (FROM email_from_address) and, when set, an SMS
+  // TO lead_notify_phone (FROM the tenant's own number via resolveSender).
+  // Distinct from companies.email (the tenant's public/from inbox) so alerts can
+  // route to an owner's personal inbox without landing in the public mailbox.
+  lead_notify_email: text("lead_notify_email"),
+  lead_notify_phone: text("lead_notify_phone"),
   twilio_account_sid: text("twilio_account_sid"),
   twilio_auth_token: text("twilio_auth_token"),
   created_at: timestamp("created_at").notNull().defaultNow(),


### PR DESCRIPTION
Implements the approved deployment spec. **Comms stay gated** (no COMMS_ENABLED / co4 comms_enabled change in this PR).

## 1. Links
- New `lib/app-url.ts` `appBaseUrl()` — single source of truth (`APP_BASE_URL` → `https://app.qleno.com`).
- Quote email links to the **public estimate page** `/estimate/<sign_token>`; `sign_token` generated on `/send`. The estimates public endpoint now **falls back to a quote by sign_token**, so the link resolves (was 404 — there was no public quote page).
- Fixed `payment-links.getAppBaseUrl()` operator-precedence bug.
- Removed every `clean-ops-pro.replit.app` reference.

## 2. SMS from-number
- All `sendNotification` SMS route through `resolveSender`+`sendSmsVia` (per-tenant number).
- Retired the global-env `sendTwilioSms` / `TWILIO_FROM_NUMBER` path **everywhere** (notificationService, leads office alert, clients manual SMS, payment-links, public booking + very-dirty office alerts) → the Oak Lawn number +17737869902 can never be sent from again.

## 3. Internal lead notify
- `fireOfficeNotification` routes per `companyId`: email **TO** `companies.lead_notify_email` **FROM** `companies.email_from_address`; office SMS **TO** `companies.lead_notify_phone` via `resolveSender`.
- Added `lead_notify_email` + `lead_notify_phone` columns (schema + idempotent migration guards).

## 4. Quote email
- Consolidated quote comms onto the quote-followup **cadence** (removed the duplicate, broken-link/wrong-number `quote_sent` notification from `/send`).
- Cadence touch 1 = MaidCentral-styled quote email (CTA → public estimate page, itemized line items + total, office hours, cancellation policy, satisfaction guarantee, checklist). Per-tenant from-address + footer. `buildQuoteMergeVars()` enriches both cron + send-one paths.

## Post-deploy data (applied separately, not in PR)
co4 `lead_notify_email=salmartinez8@gmail.com`, `lead_notify_phone=+17738188400`; co1/co4 cadence step 1/2 content. Then a scoped sample send to Sal only via the send-one path.

## Deferred (flagged)
Invoice pay links are on the right domain now but still id-based; wiring them to a real `payment_links` token (Stripe setup-intent) is a separate task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)