### PR TITLE
feat(sms): two-way SMS A+B — inbound capture/storage/routing + conversation view

### DIFF
--- a/artifacts/api-server/src/lib/sms-store.ts
+++ b/artifacts/api-server/src/lib/sms-store.ts
@@ -1,0 +1,110 @@
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+// ── Two-way SMS conversation store ────────────────────────────────────────────
+// Canonical helpers for persisting + reading SMS in the unified sms_messages
+// table. Tenant-scoped throughout; no per-tenant hardcoding.
+
+// Last-10 digits — the canonical thread key. Robust to formatting differences
+// across records ("+16308844318", "6308844318", "(630) 884-4318").
+export function phone10(raw: string | null | undefined): string {
+  return String(raw ?? "").replace(/\D/g, "").slice(-10);
+}
+
+// Resolve the receiving tenant from the destination ("To") number. Company-level
+// twilio_from_number is unique per tenant, so match it FIRST (avoids the
+// duplicate-branch ambiguity); fall back to a branch number only if no company
+// matches. Returns companyId or null.
+export async function resolveTenantByNumber(toRaw: string): Promise<number | null> {
+  const to = phone10(toRaw);
+  if (!to) return null;
+  const co = await db.execute(sql`
+    SELECT id FROM companies WHERE right(regexp_replace(coalesce(twilio_from_number,''),'\\D','','g'),10) = ${to} LIMIT 1`);
+  if ((co.rows[0] as any)?.id != null) return Number((co.rows[0] as any).id);
+  const br = await db.execute(sql`
+    SELECT company_id FROM branches WHERE right(regexp_replace(coalesce(twilio_from_number,''),'\\D','','g'),10) = ${to} LIMIT 1`);
+  return (br.rows[0] as any)?.company_id != null ? Number((br.rows[0] as any).company_id) : null;
+}
+
+export interface ContactMatch { client_id: number | null; lead_id: number | null; name: string | null }
+
+// Match a customer phone (last-10) to a CLIENT first, then a LEAD, within the
+// tenant. Either/both may be null when the number is unknown.
+export async function matchContact(companyId: number, fromRaw: string): Promise<ContactMatch> {
+  const p = phone10(fromRaw);
+  if (!p) return { client_id: null, lead_id: null, name: null };
+  const cl = await db.execute(sql`
+    SELECT id, first_name, last_name FROM clients
+     WHERE company_id = ${companyId}
+       AND right(regexp_replace(coalesce(phone,''),'\\D','','g'),10) = ${p}
+     LIMIT 1`);
+  if (cl.rows[0]) {
+    const c = cl.rows[0] as any;
+    return { client_id: Number(c.id), lead_id: null, name: [c.first_name, c.last_name].filter(Boolean).join(" ") || null };
+  }
+  const ld = await db.execute(sql`
+    SELECT id, first_name, last_name FROM leads
+     WHERE company_id = ${companyId}
+       AND right(regexp_replace(coalesce(phone,''),'\\D','','g'),10) = ${p}
+     LIMIT 1`);
+  if (ld.rows[0]) {
+    const l = ld.rows[0] as any;
+    return { client_id: null, lead_id: Number(l.id), name: [l.first_name, l.last_name].filter(Boolean).join(" ") || null };
+  }
+  return { client_id: null, lead_id: null, name: null };
+}
+
+// Persist an INBOUND SMS. Matches the sender to a client/lead and stores the
+// body unread (read_at null). Returns the inserted row id + the match.
+export async function recordInboundSms(args: {
+  companyId: number; fromRaw: string; toRaw: string; body: string; providerId?: string | null;
+}): Promise<{ id: number; match: ContactMatch }> {
+  const match = await matchContact(args.companyId, args.fromRaw);
+  const cp = phone10(args.fromRaw);
+  const r = await db.execute(sql`
+    INSERT INTO sms_messages
+      (company_id, contact_phone, client_id, lead_id, direction, body, from_number, to_number, provider_id, status, read_at)
+    VALUES
+      (${args.companyId}, ${cp}, ${match.client_id}, ${match.lead_id}, 'inbound', ${args.body},
+       ${args.fromRaw}, ${args.toRaw}, ${args.providerId ?? null}, 'received', NULL)
+    RETURNING id`);
+  return { id: Number((r.rows[0] as any).id), match };
+}
+
+// Persist an OUTBOUND SMS (manual reply / send). Outbound is "read" on insert.
+export async function recordOutboundSms(args: {
+  companyId: number; toRaw: string; fromNumber: string | null; body: string;
+  providerId?: string | null; sentBy?: number | null; clientId?: number | null; leadId?: number | null;
+  status?: string;
+}): Promise<{ id: number }> {
+  const cp = phone10(args.toRaw);
+  const r = await db.execute(sql`
+    INSERT INTO sms_messages
+      (company_id, contact_phone, client_id, lead_id, direction, body, from_number, to_number, provider_id, status, read_at, sent_by)
+    VALUES
+      (${args.companyId}, ${cp}, ${args.clientId ?? null}, ${args.leadId ?? null}, 'outbound', ${args.body},
+       ${args.fromNumber ?? null}, ${args.toRaw}, ${args.providerId ?? null}, ${args.status ?? "sent"}, NOW(), ${args.sentBy ?? null})
+    RETURNING id`);
+  return { id: Number((r.rows[0] as any).id) };
+}
+
+// Read a contact's SMS thread (chronological) by client_id, lead_id, or phone.
+export async function getThread(companyId: number, key: { clientId?: number | null; leadId?: number | null; phone?: string | null }) {
+  let where;
+  if (key.clientId != null) where = sql`client_id = ${key.clientId}`;
+  else if (key.leadId != null) where = sql`lead_id = ${key.leadId}`;
+  else where = sql`contact_phone = ${phone10(key.phone)}`;
+  const r = await db.execute(sql`
+    SELECT id, direction, body, from_number, to_number, status, read_at, created_at, contact_phone, client_id, lead_id
+      FROM sms_messages
+     WHERE company_id = ${companyId} AND ${where}
+     ORDER BY created_at ASC`);
+  return r.rows;
+}
+
+// Mark a contact's inbound messages read (called when the thread is opened).
+export async function markThreadRead(companyId: number, phone: string) {
+  await db.execute(sql`
+    UPDATE sms_messages SET read_at = NOW()
+     WHERE company_id = ${companyId} AND contact_phone = ${phone10(phone)} AND direction = 'inbound' AND read_at IS NULL`);
+}

--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -1498,6 +1498,29 @@ async function runBookingSchemaGuard(): Promise<void> {
     { label: "companies.lead_notify_phone",
       stmt: `ALTER TABLE companies ADD COLUMN IF NOT EXISTS lead_notify_phone text` },
 
+    // Two-way SMS — unified conversation store (inbound + outbound, leads + clients).
+    { label: "CREATE sms_messages", stmt: `
+      CREATE TABLE IF NOT EXISTS sms_messages (
+        id            SERIAL PRIMARY KEY,
+        company_id    INTEGER NOT NULL,
+        contact_phone TEXT NOT NULL,
+        client_id     INTEGER,
+        lead_id       INTEGER,
+        direction     TEXT NOT NULL,
+        body          TEXT NOT NULL,
+        from_number   TEXT,
+        to_number     TEXT,
+        provider_id   TEXT,
+        status        TEXT NOT NULL DEFAULT 'received',
+        read_at       TIMESTAMP,
+        sent_by       INTEGER,
+        created_at    TIMESTAMP NOT NULL DEFAULT NOW()
+      )` },
+    { label: "sms_messages thread idx", stmt:
+      `CREATE INDEX IF NOT EXISTS sms_messages_thread_idx ON sms_messages (company_id, contact_phone, created_at)` },
+    { label: "sms_messages unread idx", stmt:
+      `CREATE INDEX IF NOT EXISTS sms_messages_unread_idx ON sms_messages (company_id, read_at)` },
+
     // ── Leads PR4 — cost / KPI reporting tables ───────────────────────────────
     // Marketing spend per channel + period → CPL / CPA / ROI.
     { label: "marketing_spend table",

--- a/artifacts/api-server/src/routes/clients.ts
+++ b/artifacts/api-server/src/routes/clients.ts
@@ -844,9 +844,29 @@ router.get("/:id/communications", requireAuth, async (req, res) => {
       sent_by_last: usersTable.last_name,
     }).from(clientCommunicationsTable)
       .leftJoin(usersTable, eq(clientCommunicationsTable.sent_by, usersTable.id))
-      .where(and(...conditions))
+      // SMS now lives in the unified sms_messages store (canonical for in+out
+      // threading), so exclude any legacy 'sms' rows here to avoid double-listing.
+      .where(and(...conditions, ne(clientCommunicationsTable.type, "sms")))
       .orderBy(desc(clientCommunicationsTable.created_at));
-    return res.json(comms);
+
+    // Merge in the SMS thread (inbound + outbound) from sms_messages.
+    let merged: any[] = comms as any[];
+    if (!type || type === "all" || type === "sms") {
+      const smsRows = await db.execute(sql`
+        SELECT id, direction, body, from_number, to_number, status, read_at, created_at
+          FROM sms_messages WHERE company_id = ${req.auth!.companyId} AND client_id = ${clientId}
+          ORDER BY created_at DESC`);
+      const sms = (smsRows.rows as any[]).map(r => ({
+        id: `sms-${r.id}`, type: "sms", direction: r.direction, subject: null, body: r.body,
+        from_name: r.direction === "inbound" ? r.from_number : null,
+        to_contact: r.direction === "inbound" ? r.to_number : r.to_number,
+        has_attachment: false, attachment_url: null, created_at: r.created_at,
+        sent_by_first: null, sent_by_last: null, status: r.status,
+      }));
+      merged = type === "sms" ? sms : [...sms, ...(comms as any[])]
+        .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
+    }
+    return res.json(merged);
   } catch (err) {
     return res.status(500).json({ error: "Internal Server Error" });
   }
@@ -872,27 +892,32 @@ router.post("/:id/communications/sms", requireAuth, async (req, res) => {
   try {
     const clientId = parseInt(req.params.id);
     const { to, message } = req.body;
-    let twilioResult = null;
+    let twilioResult: any = null;
+    let fromNumber: string | null = null;
+    let status = "suppressed";
     // Per-tenant send only — resolveSender(companyId) picks THIS company's creds
     // + from-number (full gate ladder). No global-env number.
     try {
       const { resolveSender, sendSmsVia } = await import("../lib/comms-sender.js");
       const sender = await resolveSender(req.auth!.companyId, null);
+      fromNumber = sender.from_number;
       if (sender.reason) {
         console.log("[clients] Client SMS suppressed:", sender.reason);
       } else {
         twilioResult = await sendSmsVia(sender, to, message);
+        status = "sent";
       }
     } catch (e: any) {
+      status = "failed";
       console.error("[clients] Client SMS error:", e?.message || e);
     }
-    const [comm] = await db.insert(clientCommunicationsTable).values({
-      company_id: req.auth!.companyId, client_id: clientId,
-      type: "sms", direction: "outbound", body: message, to_contact: to,
-      from_name: req.auth!.email,
-      sent_by: req.auth!.userId,
-    }).returning();
-    return res.status(201).json({ ...comm, twilio: twilioResult });
+    // Persist into the unified SMS conversation store (canonical for threads/inbox).
+    const { recordOutboundSms } = await import("../lib/sms-store.js");
+    const { id } = await recordOutboundSms({
+      companyId: req.auth!.companyId, toRaw: to, fromNumber, body: message,
+      providerId: twilioResult?.sid ?? null, sentBy: req.auth!.userId, clientId, status,
+    });
+    return res.status(201).json({ id, direction: "outbound", type: "sms", body: message, to_contact: to, status, twilio: twilioResult });
   } catch (err) {
     return res.status(500).json({ error: "Internal Server Error" });
   }

--- a/artifacts/api-server/src/routes/comms-inbound.ts
+++ b/artifacts/api-server/src/routes/comms-inbound.ts
@@ -1,35 +1,43 @@
 import { Router } from "express";
-import { db } from "@workspace/db";
-import { sql } from "drizzle-orm";
 import { handleInboundReply } from "../lib/lead-sync.js";
+import { resolveTenantByNumber, recordInboundSms } from "../lib/sms-store.js";
 
 const router = Router();
 
 const OPT_OUT = new Set(["STOP", "STOPALL", "UNSUBSCRIBE", "CANCEL", "END", "QUIT"]);
 
 // POST /api/comms/inbound — Twilio inbound-SMS webhook (PUBLIC, no auth).
-// Twilio posts form-encoded { From, To, Body }. The `To` number maps to a
-// branch (or company) → tenant; the customer reply stops their active cadence
-// (stop-on-reply) and STOP-words flag an opt-out. Responds 200 (empty TwiML).
+// Twilio posts form-encoded { From, To, Body, MessageSid }. The `To` number maps
+// to a tenant (company number first — unique — then branch). We:
+//   1) persist the inbound message in the unified sms_messages store (matched to
+//      a CLIENT or LEAD by the sender's last-10 digits),
+//   2) stop the active follow-up cadence for the matching lead AND client
+//      (stop-on-reply), flagging opt-out on STOP-words.
+// Always responds 200 with empty TwiML.
 router.post("/inbound", async (req, res) => {
   try {
     const from = String(req.body?.From ?? "");
     const to = String(req.body?.To ?? "");
     const body = String(req.body?.Body ?? "").trim();
+    const sid = String(req.body?.MessageSid ?? req.body?.SmsSid ?? "") || null;
     if (!from || !to) return res.type("text/xml").send("<Response/>");
 
-    // Resolve tenant from the receiving number (branch first, then company).
-    let companyId: number | null = null;
-    const br = await db.execute(sql`SELECT company_id FROM branches WHERE twilio_from_number = ${to} LIMIT 1`);
-    companyId = (br.rows[0] as any)?.company_id ?? null;
-    if (companyId == null) {
-      const co = await db.execute(sql`SELECT id AS company_id FROM companies WHERE twilio_from_number = ${to} LIMIT 1`);
-      companyId = (co.rows[0] as any)?.company_id ?? null;
-    }
+    const companyId = await resolveTenantByNumber(to);
     if (companyId == null) return res.type("text/xml").send("<Response/>");
 
+    // 1) Persist + match (client or lead).
+    const { match } = await recordInboundSms({ companyId, fromRaw: from, toRaw: to, body, providerId: sid });
+
+    // 2) Stop-on-reply + opt-out. Leads via handleInboundReply (matches by phone,
+    //    stops cadence, logs activity). Clients via stopEnrollmentsForClient.
     const optOut = OPT_OUT.has(body.toUpperCase());
     await handleInboundReply(companyId, from, optOut);
+    if (match.client_id != null) {
+      try {
+        const { stopEnrollmentsForClient } = await import("../services/followUpService.js");
+        await stopEnrollmentsForClient(match.client_id, optOut ? "opted_out" : "replied");
+      } catch (e) { console.warn("[comms/inbound] client cadence stop failed:", e); }
+    }
     return res.type("text/xml").send("<Response/>");
   } catch (err) {
     console.error("[comms/inbound]", err);

--- a/artifacts/api-server/src/routes/communication-log.ts
+++ b/artifacts/api-server/src/routes/communication-log.ts
@@ -54,7 +54,31 @@ router.get("/", requireAuth, async (req, res) => {
       LIMIT ${parseInt(limit as string)}
     `);
 
-    return res.json(rows.rows);
+    // Merge in the unified two-way SMS thread (sms_messages) for this customer so
+    // inbound texts render in the conversation alongside logged comms. SMS is
+    // excluded for non-SMS channel filters (email/phone/in_person/system/staff).
+    let out: any[] = rows.rows as any[];
+    const includeSms = !f || f === "all" || f === "sms" || f === "inbound" || f === "outbound";
+    if (includeSms) {
+      const smsRows = await db.execute(sql`
+        SELECT id, direction, body, from_number, to_number, status, provider_id, created_at
+          FROM sms_messages
+         WHERE company_id = ${companyId} AND client_id = ${parseInt(customer_id as string)}
+         ${f === "inbound" ? sql`AND direction = 'inbound'` : f === "outbound" ? sql`AND direction = 'outbound'` : sql``}
+         ORDER BY created_at DESC LIMIT ${parseInt(limit as string)}`);
+      const sms = (smsRows.rows as any[]).map(r => ({
+        id: `sms-${r.id}`, customer_id: parseInt(customer_id as string), job_id: null,
+        direction: r.direction, channel: "sms", summary: r.body, body: r.body, subject: null,
+        source: r.direction === "inbound" ? "customer" : "staff", sent_by: null,
+        recipient: r.direction === "inbound" ? r.from_number : r.to_number,
+        twilio_message_sid: r.provider_id, resend_email_id: null, delivery_status: r.status,
+        opened_at: null, clicked_at: null, logged_at: r.created_at, created_at: r.created_at,
+        logged_by_name: null, tags: null,
+      }));
+      out = [...out, ...sms].sort((a, b) =>
+        new Date(b.created_at || 0).getTime() - new Date(a.created_at || 0).getTime());
+    }
+    return res.json(out);
   } catch (err) {
     console.error("[comms GET]", err);
     return res.status(500).json({ error: "Server error" });

--- a/artifacts/api-server/src/routes/leads.ts
+++ b/artifacts/api-server/src/routes/leads.ts
@@ -344,25 +344,51 @@ router.post("/:id/activity", requireAuth, requireRole("owner", "admin", "office"
 });
 
 // ── GET /api/leads/:id/messages ───────────────────────────────────────────────
-// Returns activity log entries of type email_sent or sms_sent for the lead
+// The lead's SMS conversation thread (inbound + outbound), chronological.
 router.get("/:id/messages", requireAuth, requireRole("owner", "admin", "office"), async (req, res) => {
   try {
     const companyId = req.auth!.companyId!;
     const leadId = parseInt(req.params.id);
-
     const rows = await db.execute(sql`
-      SELECT a.*, u.first_name as performer_first_name, u.last_name as performer_last_name
-      FROM lead_activity_log a
-      LEFT JOIN users u ON u.id = a.performed_by
-      WHERE a.lead_id = ${leadId}
-        AND a.company_id = ${companyId}
-        AND a.action_type IN ('email_sent', 'sms_sent')
-      ORDER BY a.created_at DESC
-      LIMIT 100
-    `);
+      SELECT id, direction, body, from_number, to_number, status, read_at, created_at
+        FROM sms_messages
+       WHERE company_id = ${companyId} AND lead_id = ${leadId}
+       ORDER BY created_at ASC`);
     return res.json(rows.rows);
   } catch (err) {
     console.error("GET /leads/:id/messages:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
+// ── POST /api/leads/:id/communications/sms — send an SMS to a lead ─────────────
+// Per-tenant send via resolveSender; persists outbound into the sms_messages thread.
+router.post("/:id/communications/sms", requireAuth, requireRole("owner", "admin", "office"), async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId!;
+    const leadId = parseInt(req.params.id);
+    const { message } = req.body;
+    if (!message || typeof message !== "string") return res.status(400).json({ error: "message required" });
+    const [lead] = (await db.execute(sql`SELECT phone FROM leads WHERE id = ${leadId} AND company_id = ${companyId} LIMIT 1`)).rows as any[];
+    if (!lead?.phone) return res.status(400).json({ error: "Lead has no phone number" });
+
+    let twilioResult: any = null, fromNumber: string | null = null, status = "suppressed";
+    try {
+      const { resolveSender, sendSmsVia } = await import("../lib/comms-sender.js");
+      const sender = await resolveSender(companyId, null);
+      fromNumber = sender.from_number;
+      if (sender.reason) { console.log("[leads] SMS suppressed:", sender.reason); }
+      else { twilioResult = await sendSmsVia(sender, lead.phone, message); status = "sent"; }
+    } catch (e: any) { status = "failed"; console.error("[leads] SMS error:", e?.message || e); }
+
+    const { recordOutboundSms } = await import("../lib/sms-store.js");
+    const { id } = await recordOutboundSms({
+      companyId, toRaw: lead.phone, fromNumber, body: message,
+      providerId: twilioResult?.sid ?? null, sentBy: req.auth!.userId, leadId, status,
+    });
+    return res.status(201).json({ id, direction: "outbound", body: message, status, twilio: twilioResult });
+  } catch (err) {
+    console.error("POST /leads/:id/communications/sms:", err);
     return res.status(500).json({ error: "Internal Server Error" });
   }
 });

--- a/artifacts/api-server/src/routes/sms-inbound.ts
+++ b/artifacts/api-server/src/routes/sms-inbound.ts
@@ -36,15 +36,22 @@ async function sendTwilioSms(to: string, from: string, body: string) {
   }
 }
 
+// Persist survey-route SMS into the unified sms_messages store. (The previous
+// implementation INSERTed columns that don't exist on message_log — direction,
+// to_phone, from_phone, job_id — and silently failed, so nothing was ever saved.
+// `toPhone`/`fromPhone` here are the message endpoints; the CUSTOMER's number is
+// the From on inbound and the To on outbound — recordInbound/Outbound key the
+// thread on that.)
 async function logMessage(companyId: number, clientId: number | null, jobId: number | null, direction: string, body: string, toPhone: string, fromPhone: string) {
   try {
-    await db.execute(sql`
-      INSERT INTO message_log (company_id, client_id, job_id, direction, body, to_phone, from_phone, channel, created_at)
-      VALUES (${companyId}, ${clientId}, ${jobId}, ${direction}, ${body}, ${toPhone}, ${fromPhone}, 'sms', NOW())
-      ON CONFLICT DO NOTHING
-    `);
-  } catch {
-    // message_log columns may differ — ignore
+    const { recordInboundSms, recordOutboundSms } = await import("../lib/sms-store.js");
+    if (direction === "inbound") {
+      await recordInboundSms({ companyId, fromRaw: fromPhone, toRaw: toPhone, body });
+    } else {
+      await recordOutboundSms({ companyId, toRaw: toPhone, fromNumber: fromPhone, body, clientId });
+    }
+  } catch (e) {
+    console.warn("[sms-inbound] logMessage persist failed:", e);
   }
 }
 

--- a/artifacts/qleno/src/pages/leads.tsx
+++ b/artifacts/qleno/src/pages/leads.tsx
@@ -630,27 +630,29 @@ function LeadDetailDrawer({
           {/* Messages */}
           {tab === "messages" && (
             <div>
-              <div style={{ fontSize: 13, fontWeight: 600, color: "#1A1917", marginBottom: 14 }}>Messages Sent</div>
+              <div style={{ fontSize: 13, fontWeight: 600, color: "#1A1917", marginBottom: 14 }}>SMS Conversation</div>
               {messages.length === 0 ? (
                 <div style={{ textAlign: "center", padding: "40px 0", color: "#6B6860", fontSize: 14 }}>
-                  No messages logged for this lead yet.
+                  No texts with this lead yet.
                 </div>
               ) : (
-                <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
-                  {messages.map(m => (
-                    <div key={m.id} style={{ border: "1px solid #E5E2DC", borderRadius: 8,
-                      padding: "12px 14px", background: "#FAFAF9" }}>
-                      <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 4 }}>
-                        <span style={{ fontSize: 12, fontWeight: 600, color: m.action_type === "sms_sent" ? "#059669" : "#0369A1",
-                          background: m.action_type === "sms_sent" ? "#ECFDF5" : "#EFF6FF",
-                          padding: "1px 7px", borderRadius: 999 }}>
-                          {m.action_type === "sms_sent" ? "SMS" : "Email"}
-                        </span>
-                        <span style={{ fontSize: 11, color: "#9CA3AF" }}>{fmtDateTime(m.created_at)}</span>
+                <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                  {(messages as any[]).map(m => {
+                    const inbound = m.direction === "inbound";
+                    return (
+                      <div key={m.id} style={{ display: "flex", justifyContent: inbound ? "flex-start" : "flex-end" }}>
+                        <div style={{ maxWidth: "78%", padding: "9px 12px", borderRadius: 12,
+                          background: inbound ? "#F1F0EC" : "var(--brand, #00C9A0)",
+                          color: inbound ? "#1A1917" : "#fff",
+                          borderBottomLeftRadius: inbound ? 3 : 12, borderBottomRightRadius: inbound ? 12 : 3 }}>
+                          <div style={{ fontSize: 13, lineHeight: 1.45, whiteSpace: "pre-wrap" }}>{m.body}</div>
+                          <div style={{ fontSize: 10, marginTop: 4, opacity: 0.7, textAlign: "right" }}>
+                            {fmtDateTime(m.created_at)}{!inbound && m.status && m.status !== "sent" ? ` · ${m.status}` : ""}
+                          </div>
+                        </div>
                       </div>
-                      {m.note && <div style={{ fontSize: 13, color: "#374151" }}>{m.note}</div>}
-                    </div>
-                  ))}
+                    );
+                  })}
                 </div>
               )}
             </div>

--- a/lib/db/src/schema/index.ts
+++ b/lib/db/src/schema/index.ts
@@ -32,6 +32,7 @@ export * from "./client_homes";
 export * from "./technician_preferences";
 export * from "./client_notifications";
 export * from "./client_communications";
+export * from "./sms_messages";
 export * from "./client_agreements";
 export * from "./quotes";
 export * from "./payments";

--- a/lib/db/src/schema/sms_messages.ts
+++ b/lib/db/src/schema/sms_messages.ts
@@ -1,0 +1,38 @@
+import { pgTable, serial, text, integer, timestamp, index } from "drizzle-orm/pg-core";
+import { createInsertSchema } from "drizzle-zod";
+import { z } from "zod/v4";
+import { companiesTable } from "./companies";
+import { clientsTable } from "./clients";
+import { usersTable } from "./users";
+
+// Unified two-way SMS conversation store. Holds BOTH inbound and outbound SMS for
+// BOTH leads and clients, threaded by the customer's phone number (canonical:
+// last-10 digits in contact_phone). Tenant-scoped by company_id. Distinct from
+// client_communications (client-only, mixes email/notes) — this is the purpose-
+// built SMS conversation table backing the inbox + per-contact thread + reply.
+export const smsMessagesTable = pgTable("sms_messages", {
+  id: serial("id").primaryKey(),
+  company_id: integer("company_id").references(() => companiesTable.id).notNull(),
+  // Canonical thread key — the CUSTOMER's number normalized to last-10 digits.
+  // For inbound this is the sender (From); for outbound the recipient (To).
+  contact_phone: text("contact_phone").notNull(),
+  // Linkage — either/both may be null when the number matches no record yet.
+  client_id: integer("client_id").references(() => clientsTable.id),
+  lead_id: integer("lead_id"),
+  direction: text("direction").notNull(), // 'inbound' | 'outbound'
+  body: text("body").notNull(),
+  from_number: text("from_number"),
+  to_number: text("to_number"),
+  provider_id: text("provider_id"),       // Twilio message SID (outbound) / inbound SID
+  status: text("status").notNull().default("received"), // received | sent | failed | suppressed
+  read_at: timestamp("read_at"),          // null = unread (inbound); outbound stamped on insert
+  sent_by: integer("sent_by").references(() => usersTable.id), // staff user for outbound
+  created_at: timestamp("created_at").notNull().defaultNow(),
+}, (t) => ({
+  threadIdx: index("sms_messages_thread_idx").on(t.company_id, t.contact_phone, t.created_at),
+  unreadIdx: index("sms_messages_unread_idx").on(t.company_id, t.read_at),
+}));
+
+export const insertSmsMessageSchema = createInsertSchema(smsMessagesTable).omit({ id: true, created_at: true });
+export type InsertSmsMessage = z.infer<typeof insertSmsMessageSchema>;
+export type SmsMessage = typeof smsMessagesTable.$inferSelect;


### PR DESCRIPTION
Milestone **A + B** of the two-way SMS build. Comms stay gated; inbound capture is gate-independent.

## A — Inbound capture + storage + routing
- **New `sms_messages` table** — unified conversation store: `company_id`, `contact_phone` (canonical last-10 thread key), nullable `client_id` + `lead_id`, `direction`, `body`, `from_number`/`to_number`, `provider_id`, `status`, `read_at`. Holds inbound **and** outbound for **leads and clients**.
- **New `lib/sms-store.ts`** — `resolveTenantByNumber` (matches company number first — unique — then branch, sidestepping the duplicate-branch ambiguity), `matchContact` (client then lead by last-10), `recordInbound/OutboundSms`, `getThread`, `markThreadRead`.
- **`/api/comms/inbound` rewritten** — resolve tenant by `To`, persist inbound matched to client OR lead, stop cadence for **lead AND client** (stop-on-reply), STOP/opt-out.
- **Fixed `/api/sms/inbound`** — `logMessage` was inserting columns that don't exist on `message_log` and failing silently; now persists via the store.
- **Outbound** client SMS persists to `sms_messages` with the Twilio SID + per-tenant from-number + status.

## B — Conversation view
- **`/api/comms`** (CommLog2's source) now merges the SMS thread → inbound texts render in the customer-profile conversation.
- **`/api/leads/:id/messages`** returns the lead's SMS thread; the leads Messages tab renders inbound/outbound chat bubbles. Added `POST /api/leads/:id/communications/sms`.

## Testing plan (post-deploy)
Simulate Twilio inbound POSTs (form-encoded From/To/Body) to `/api/comms/inbound` for co4's number against a known lead/client phone; verify a `sms_messages` row persists, cadence stops, and the thread/`/api/comms` returns it. No real sends.

## Next
C (global inbox) → D (reply/send in thread) → E (mobile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)