### PR TITLE
fix(switch): re-scope Messages, banner + unread badge on company switch

### DIFF
--- a/artifacts/qleno/src/components/layout/dashboard-layout.tsx
+++ b/artifacts/qleno/src/components/layout/dashboard-layout.tsx
@@ -495,6 +495,7 @@ function CompanySwitcher({ compact = false }: { compact?: boolean }) {
 
 // Unread SMS count for the Messages bottom-nav badge (office/manager only).
 function useSmsUnread(role: string | undefined) {
+  const token = useAuthStore(s => s.token); // re-fetch on company switch (token changes)
   const [count, setCount] = useState(0);
   useEffect(() => {
     if (role === "technician") return;
@@ -509,7 +510,7 @@ function useSmsUnread(role: string | undefined) {
     fetch_();
     const iv = setInterval(fetch_, 15000);
     return () => { alive = false; clearInterval(iv); };
-  }, [role]);
+  }, [role, token]);
   return count;
 }
 
@@ -535,6 +536,7 @@ function useUnreadCount(userId: number | undefined) {
 // (global master off OR company.comms_enabled false). No hardcoded flag, so a
 // live tenant (e.g. PHES Schaumburg) never shows a misleading "paused" banner.
 function useCommsPaused() {
+  const token = useAuthStore(s => s.token); // re-fetch on company switch (token changes)
   const [paused, setPaused] = useState(false);
   useEffect(() => {
     let alive = true;
@@ -548,7 +550,7 @@ function useCommsPaused() {
     fetch_();
     const iv = setInterval(fetch_, 30000);
     return () => { alive = false; clearInterval(iv); };
-  }, []);
+  }, [token]);
   return paused;
 }
 

--- a/artifacts/qleno/src/pages/messages.tsx
+++ b/artifacts/qleno/src/pages/messages.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from "react";
-import { getAuthHeaders } from "@/lib/auth";
+import { getAuthHeaders, useAuthStore } from "@/lib/auth";
 import { DashboardLayout } from "@/components/layout/dashboard-layout";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useToast } from "@/hooks/use-toast";
@@ -63,6 +63,15 @@ export default function MessagesPage() {
   }, []);
 
   useEffect(() => { loadConvos(); }, [loadConvos]);
+  // Re-scope on company switch: the auth token changes on every switch-company,
+  // so clear the open thread + reload the conversation list for the new tenant
+  // immediately (no manual refresh, no stale co1 data lingering under co4).
+  const authToken = useAuthStore(s => s.token);
+  useEffect(() => {
+    setActive(null); setThread([]); setReply("");
+    loadConvos();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [authToken]);
   // Light polling so new inbound shows up without a manual refresh.
   useEffect(() => {
     const t = setInterval(() => { loadConvos(); if (active) loadThread(active); }, 15000);


### PR DESCRIPTION
**Symptom (Sal):** after switching the account pill to PHES Schaumburg (co4, which has the demo conversation), Messages showed "No conversations yet" AND the "Outbound communications are paused" banner still showed — the view didn't re-scope to co4.

**Cause:** `switch-company` updates the JWT and calls `queryClient.invalidateQueries()` — but that only refetches **react-query** queries. The Messages page, comms-paused banner, and unread badge use plain `useState/useEffect` keyed on mount, so they kept co1's data until their next poll / a manual refresh.

**Fix:** make all three re-fetch reactively on switch. The auth token changes on every switch, so it's the dependency:
- `messages.tsx`: on token change → clear open thread + reload conversation list for the new tenant.
- `useCommsPaused` / `useSmsUnread`: add token to effect deps → banner + badge re-query immediately.

Result: co1↔co4 switching instantly shows the right messages + correct per-tenant banner, no stale flash, no manual refresh. react-query pages (dashboard, profiles) already re-scope via the existing invalidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)