### PR TITLE
fix(comms): resolveSender falls back to company gate for foreign/stale branchId (cron cadence Fix B)

### DIFF
--- a/artifacts/api-server/src/lib/comms-sender.ts
+++ b/artifacts/api-server/src/lib/comms-sender.ts
@@ -23,19 +23,29 @@ export async function resolveSender(companyId: number, branchId?: number | null)
 
   let branchNumber: string | null = null;
   let branchComms = false;
+  let branchFound = false;
   if (branchId != null) {
     const br = await db.execute(sql`
       SELECT twilio_from_number, comms_enabled FROM branches WHERE id = ${branchId} AND company_id = ${companyId} LIMIT 1`);
-    branchNumber = (br.rows[0] as any)?.twilio_from_number ?? null;
-    branchComms = !!(br.rows[0] as any)?.comms_enabled;
+    if (br.rows[0]) {
+      branchFound = true;
+      branchNumber = (br.rows[0] as any)?.twilio_from_number ?? null;
+      branchComms = !!(br.rows[0] as any)?.comms_enabled;
+    }
   }
   const from_number = branchNumber || c.twilio_from_number || null;
   const account_sid = c.twilio_account_sid ?? null;
   const auth_token = c.twilio_auth_token ?? null;
   const enabled = !!c.twilio_enabled;
   const company_comms_enabled = !!c.comms_enabled;
-  // When no branch is specified, fall back to the company master for the branch gate.
-  const branch_comms_enabled = branchId != null ? branchComms : enabled;
+  // Branch gate ONLY applies when the passed branchId actually maps to a branch
+  // of THIS company. When no branch is specified — OR a branchId is passed that
+  // doesn't belong to this company (e.g. the legacy getBranchByZip 1/2 mapping
+  // hitting a tenant whose branches have different ids, like co4) — fall back to
+  // the company-level gate so a stale/foreign branchId can't falsely suppress a
+  // tenant whose company gate is open. Tenants with real matching branches keep
+  // per-branch gating unchanged.
+  const branch_comms_enabled = (branchId != null && branchFound) ? branchComms : enabled;
 
   const reason =
     process.env.COMMS_ENABLED !== "true" ? "comms_disabled"          // global master


### PR DESCRIPTION
**Bug:** the cadence cron resolves a branch via `getBranchByZip` → branch ids **1/2** (legacy co1 mapping) and passes that to `resolveSender`. For co4 (branch id 4), no row matches `id=branchId AND company_id=4`, so `branch_comms_enabled` was forced **false** → `reason='branch_comms_disabled'` → co4's automated **7-touch cadence was suppressed** despite its company gate being fully open. (Manual/inbox sends pass `branchId=null` so they were unaffected — which is why Sal's manual reply still delivered.)

**Fix (one-liner intent):** apply the per-branch gate **only when the branchId actually maps to a branch of this company** (`branchFound`). Otherwise — no branchId, or a foreign/stale branchId — fall back to the **company-level gate** (`twilio_enabled`).

**No regression:** tenants with real matching branches still get per-branch gating (`branchFound=true` → uses the branch's `comms_enabled`). From-number fallback to the company number is unchanged.

## Verify post-deploy (read-only, no sends)
- `resolveSender(4, 2)` → `branch_comms_enabled=true`, `reason=ready` (was `branch_comms_disabled`).
- A tenant/branch that genuinely has its branch gated off still resolves `branch_comms_disabled`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)