### PR TITLE
fix(sms): deterministic tenant resolution for inbound (exact E.164 + ordering)

### DIFF
--- a/artifacts/api-server/src/lib/sms-store.ts
+++ b/artifacts/api-server/src/lib/sms-store.ts
@@ -18,11 +18,26 @@ export function phone10(raw: string | null | undefined): string {
 export async function resolveTenantByNumber(toRaw: string): Promise<number | null> {
   const to = phone10(toRaw);
   if (!to) return null;
+  // Match on last-10 (robust to formatting) but rank deterministically so a
+  // malformed/duplicate number can never win: (1) exact E.164 match to the
+  // incoming To, (2) well-formed numbers with a country code (>=11 digits) over
+  // bare 10-digit leftovers, (3) lowest id. Company match takes precedence over
+  // branch match.
   const co = await db.execute(sql`
-    SELECT id FROM companies WHERE right(regexp_replace(coalesce(twilio_from_number,''),'\\D','','g'),10) = ${to} LIMIT 1`);
+    SELECT id FROM companies
+     WHERE right(regexp_replace(coalesce(twilio_from_number,''),'\\D','','g'),10) = ${to}
+     ORDER BY (twilio_from_number = ${toRaw}) DESC,
+              (length(regexp_replace(coalesce(twilio_from_number,''),'\\D','','g')) >= 11) DESC,
+              id ASC
+     LIMIT 1`);
   if ((co.rows[0] as any)?.id != null) return Number((co.rows[0] as any).id);
   const br = await db.execute(sql`
-    SELECT company_id FROM branches WHERE right(regexp_replace(coalesce(twilio_from_number,''),'\\D','','g'),10) = ${to} LIMIT 1`);
+    SELECT company_id FROM branches
+     WHERE right(regexp_replace(coalesce(twilio_from_number,''),'\\D','','g'),10) = ${to}
+     ORDER BY (twilio_from_number = ${toRaw}) DESC,
+              (length(regexp_replace(coalesce(twilio_from_number,''),'\\D','','g')) >= 11) DESC,
+              id ASC
+     LIMIT 1`);
   return (br.rows[0] as any)?.company_id != null ? Number((br.rows[0] as any).company_id) : null;
 }
 


### PR DESCRIPTION
Hardens `resolveTenantByNumber` so a malformed/duplicate last-10 can never win: rank by exact E.164 match → well-formed (>=11 digits) → lowest id; company before branch. Defense-in-depth alongside the data fix (nulled co1's stale 6308844318). Multi-tenant safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)