### PR TITLE
feat(notifications): A.1 — per-user alert feed + inbound-SMS trigger + bell (desktop+mobile)

### DIFF
--- a/artifacts/api-server/src/lib/notify.ts
+++ b/artifacts/api-server/src/lib/notify.ts
@@ -1,0 +1,44 @@
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+// ── In-app notification emitter ───────────────────────────────────────────────
+// Internal staff alerts. Tenant-scoped (company_id) and per-user (user_id). Raw
+// SQL so it doesn't couple to regenerated drizzle types for the user_id column.
+
+export interface NotifyArgs {
+  companyId: number;
+  userId: number | null;          // null = company/office broadcast
+  type: string;                   // 'new_message' | 'job_assigned' | 'job_changed' | …
+  title: string;
+  body?: string | null;
+  link?: string | null;           // in-app route, e.g. '/messages' or '/dispatch?job=123'
+  meta?: Record<string, any> | null;
+}
+
+export async function notifyUser(a: NotifyArgs): Promise<void> {
+  try {
+    await db.execute(sql`
+      INSERT INTO notifications (company_id, user_id, type, title, body, link, meta, read, created_at)
+      VALUES (${a.companyId}, ${a.userId}, ${a.type}, ${a.title}, ${a.body ?? null},
+              ${a.link ?? null}, ${a.meta ? JSON.stringify(a.meta) : null}::jsonb, false, NOW())`);
+  } catch (e) {
+    // Never let an alert failure break the triggering action.
+    console.error("[notify] insert failed:", e);
+  }
+}
+
+// Fan out to every active office/owner/admin user in the tenant (one row each,
+// so per-user settings can later filter individually). Used for message alerts.
+export async function notifyOfficeUsers(companyId: number, n: Omit<NotifyArgs, "companyId" | "userId">): Promise<void> {
+  try {
+    const users = await db.execute(sql`
+      SELECT id FROM users
+       WHERE company_id = ${companyId} AND is_active = true
+         AND role IN ('owner', 'admin', 'office')`);
+    for (const u of users.rows as any[]) {
+      await notifyUser({ companyId, userId: Number(u.id), ...n });
+    }
+  } catch (e) {
+    console.error("[notify] office fan-out failed:", e);
+  }
+}

--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -1498,6 +1498,12 @@ async function runBookingSchemaGuard(): Promise<void> {
     { label: "companies.lead_notify_phone",
       stmt: `ALTER TABLE companies ADD COLUMN IF NOT EXISTS lead_notify_phone text` },
 
+    // Per-user in-app notifications: target a specific user (NULL = office broadcast).
+    { label: "notifications.user_id",
+      stmt: `ALTER TABLE notifications ADD COLUMN IF NOT EXISTS user_id integer` },
+    { label: "notifications user idx", stmt:
+      `CREATE INDEX IF NOT EXISTS notifications_user_idx ON notifications (company_id, user_id, read)` },
+
     // Two-way SMS — unified conversation store (inbound + outbound, leads + clients).
     { label: "CREATE sms_messages", stmt: `
       CREATE TABLE IF NOT EXISTS sms_messages (

--- a/artifacts/api-server/src/routes/comms-inbound.ts
+++ b/artifacts/api-server/src/routes/comms-inbound.ts
@@ -28,6 +28,20 @@ router.post("/inbound", async (req, res) => {
     // 1) Persist + match (client or lead).
     const { match } = await recordInboundSms({ companyId, fromRaw: from, toRaw: to, body, providerId: sid });
 
+    // Alert office staff (in-app). Internal staff notification — never customer-facing.
+    try {
+      const { notifyOfficeUsers } = await import("../lib/notify.js");
+      const d = from.replace(/\D/g, "").slice(-10);
+      const who = match.name || (d.length === 10 ? `(${d.slice(0, 3)}) ${d.slice(3, 6)}-${d.slice(6)}` : from);
+      await notifyOfficeUsers(companyId, {
+        type: "new_message",
+        title: `New text from ${who}`,
+        body: body.slice(0, 160),
+        link: "/messages",
+        meta: { phone: d, client_id: match.client_id, lead_id: match.lead_id },
+      });
+    } catch (e) { console.warn("[comms/inbound] notify failed:", e); }
+
     // 2) Stop-on-reply + opt-out. Leads via handleInboundReply (matches by phone,
     //    stops cadence, logs activity). Clients via stopEnrollmentsForClient.
     const optOut = OPT_OUT.has(body.toUpperCase());

--- a/artifacts/api-server/src/routes/notifications.ts
+++ b/artifacts/api-server/src/routes/notifications.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import { db } from "@workspace/db";
-import { notificationTemplatesTable, notificationLogTable, inAppNotificationsTable } from "@workspace/db/schema";
+import { notificationTemplatesTable, notificationLogTable } from "@workspace/db/schema";
 import { eq, and, desc, sql } from "drizzle-orm";
 import { requireAuth, requireRole } from "../lib/auth.js";
 
@@ -131,47 +131,47 @@ router.get("/log", requireAuth, requireRole("owner", "admin"), async (req, res) 
 
 // ── In-app notification center ──────────────────────────────────────────────
 
-router.get("/inbox", requireAuth, requireRole("owner", "office"), async (req, res) => {
+// Per-user inbox (ALL roles). A user sees notifications targeted at them
+// (user_id = me) plus legacy company/office broadcasts (user_id IS NULL) when
+// they're office/owner/admin. Techs see only their own targeted alerts.
+function inboxScope(userId: number, isOffice: boolean) {
+  return isOffice ? sql`(user_id = ${userId} OR user_id IS NULL)` : sql`user_id = ${userId}`;
+}
+
+router.get("/inbox", requireAuth, async (req, res) => {
   try {
     const companyId = req.auth!.companyId!;
+    const userId = req.auth!.userId!;
+    const isOffice = ["owner", "admin", "office"].includes(String(req.auth!.role));
     const limit = Math.min(parseInt((req.query.limit as string) || "50"), 100);
     const unreadOnly = req.query.unread === "true";
+    const scope = inboxScope(userId, isOffice);
 
-    const conditions = [eq(inAppNotificationsTable.company_id, companyId)];
-    if (unreadOnly) conditions.push(eq(inAppNotificationsTable.read, false));
-
-    const rows = await db
-      .select()
-      .from(inAppNotificationsTable)
-      .where(and(...conditions))
-      .orderBy(desc(inAppNotificationsTable.created_at))
-      .limit(limit);
-
-    const [countRow] = await db
-      .select({ count: sql<number>`count(*)::int` })
-      .from(inAppNotificationsTable)
-      .where(and(
-        eq(inAppNotificationsTable.company_id, companyId),
-        eq(inAppNotificationsTable.read, false),
-      ));
-
-    return res.json({ data: rows, unread_count: countRow?.count ?? 0 });
+    const rows = await db.execute(sql`
+      SELECT id, company_id, user_id, type, title, body, link, meta, read, created_at
+        FROM notifications
+       WHERE company_id = ${companyId} AND ${scope}
+       ${unreadOnly ? sql`AND read = false` : sql``}
+       ORDER BY created_at DESC
+       LIMIT ${limit}`);
+    const cnt = await db.execute(sql`
+      SELECT count(*)::int AS count FROM notifications
+       WHERE company_id = ${companyId} AND ${scope} AND read = false`);
+    return res.json({ data: rows.rows, unread_count: (cnt.rows[0] as any)?.count ?? 0 });
   } catch (err) {
     console.error("Inbox fetch error:", err);
     return res.status(500).json({ error: "Internal Server Error" });
   }
 });
 
-router.patch("/inbox/read-all", requireAuth, requireRole("owner", "office"), async (req, res) => {
+router.patch("/inbox/read-all", requireAuth, async (req, res) => {
   try {
     const companyId = req.auth!.companyId!;
-    await db
-      .update(inAppNotificationsTable)
-      .set({ read: true })
-      .where(and(
-        eq(inAppNotificationsTable.company_id, companyId),
-        eq(inAppNotificationsTable.read, false),
-      ));
+    const userId = req.auth!.userId!;
+    const isOffice = ["owner", "admin", "office"].includes(String(req.auth!.role));
+    await db.execute(sql`
+      UPDATE notifications SET read = true
+       WHERE company_id = ${companyId} AND read = false AND ${inboxScope(userId, isOffice)}`);
     return res.json({ ok: true });
   } catch (err) {
     console.error("Read-all error:", err);
@@ -179,17 +179,15 @@ router.patch("/inbox/read-all", requireAuth, requireRole("owner", "office"), asy
   }
 });
 
-router.patch("/inbox/:id/read", requireAuth, requireRole("owner", "office"), async (req, res) => {
+router.patch("/inbox/:id/read", requireAuth, async (req, res) => {
   try {
     const companyId = req.auth!.companyId!;
+    const userId = req.auth!.userId!;
+    const isOffice = ["owner", "admin", "office"].includes(String(req.auth!.role));
     const id = req.params.id;
-    await db
-      .update(inAppNotificationsTable)
-      .set({ read: true })
-      .where(and(
-        eq(inAppNotificationsTable.id, id),
-        eq(inAppNotificationsTable.company_id, companyId),
-      ));
+    await db.execute(sql`
+      UPDATE notifications SET read = true
+       WHERE id = ${id} AND company_id = ${companyId} AND ${inboxScope(userId, isOffice)}`);
     return res.json({ ok: true });
   } catch (err) {
     console.error("Mark-read error:", err);

--- a/artifacts/qleno/src/components/layout/dashboard-layout.tsx
+++ b/artifacts/qleno/src/components/layout/dashboard-layout.tsx
@@ -641,13 +641,15 @@ export function DashboardLayout({ children, title, fullBleed, onNewJob }: Dashbo
   const isManager = user?.role === 'owner' || user?.role === 'office';
 
   const { data: notifData } = useQuery({
-    queryKey: ['notifications-inbox'],
+    // Per-user inbox for ALL roles (techs get job alerts too). token in the key
+    // so a company switch re-scopes the feed cleanly.
+    queryKey: ['notifications-inbox', token],
     queryFn: async () => {
       const r = await fetch(`${API}/api/notifications/inbox?limit=20`, { headers: getAuthHeaders() as any });
       if (!r.ok) return { data: [], unread_count: 0 };
       return r.json();
     },
-    enabled: !!token && isManager,
+    enabled: !!token,
     refetchInterval: 30_000,
     staleTime: 20_000,
   });
@@ -756,6 +758,16 @@ export function DashboardLayout({ children, title, fullBleed, onNewJob }: Dashbo
             <button onClick={() => setChatOpen(p => !p)} style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#6B7280', padding: '4px', position: 'relative', display: 'flex', alignItems: 'center' }}>
               <MessageSquare size={19} />
               {unreadCount > 0 && <span style={{ position: 'absolute', top: 2, right: 2, width: 8, height: 8, borderRadius: 4, background: '#EF4444', border: '1px solid #fff' }} />}
+            </button>
+
+            {/* Notifications bell → full notifications page (all roles) */}
+            <button onClick={() => setLocation('/notifications')} title="Notifications" style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#6B7280', padding: '4px', position: 'relative', display: 'flex', alignItems: 'center' }}>
+              <Bell size={19} />
+              {notifUnread > 0 && (
+                <span style={{ position: 'absolute', top: 0, right: 0, minWidth: 14, height: 14, borderRadius: 7, background: '#EF4444', border: '2px solid #fff', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 8, color: '#fff', fontWeight: 800, padding: '0 2px' }}>
+                  {notifUnread > 9 ? '9+' : notifUnread}
+                </span>
+              )}
             </button>
 
             {/* ── Mobile Quick Create ─────────────────────────────────────── */}
@@ -999,7 +1011,7 @@ export function DashboardLayout({ children, title, fullBleed, onNewJob }: Dashbo
               <CircleHelp size={18} />
             </button>
 
-            {isManager && (
+            {user && (
               <div ref={notifRef} style={{ position: 'relative' }}>
                 <button
                   onClick={() => setNotifOpen(p => !p)}
@@ -1042,7 +1054,12 @@ export function DashboardLayout({ children, title, fullBleed, onNewJob }: Dashbo
                           No notifications yet
                         </div>
                       ) : notifItems.map((n: any) => {
-                        const icon = n.type === 'new_booking' ? <Bell size={14} style={{ color: '#2563EB' }} /> : n.type === 'late_clockin' ? <AlertTriangle size={14} style={{ color: '#F59E0B' }} /> : <UserMinus size={14} style={{ color: '#DC2626' }} />;
+                        const icon = n.type === 'new_message' ? <MessageSquare size={14} style={{ color: '#00C9A0' }} />
+                          : n.type === 'job_assigned' ? <Briefcase size={14} style={{ color: '#2563EB' }} />
+                          : n.type === 'job_changed' ? <CalendarDays size={14} style={{ color: '#F59E0B' }} />
+                          : n.type === 'new_booking' ? <Bell size={14} style={{ color: '#2563EB' }} />
+                          : n.type === 'late_clockin' ? <AlertTriangle size={14} style={{ color: '#F59E0B' }} />
+                          : <Bell size={14} style={{ color: '#6B7280' }} />;
                         return (
                           <button
                             key={n.id}

--- a/lib/db/src/schema/notifications.ts
+++ b/lib/db/src/schema/notifications.ts
@@ -3,6 +3,10 @@ import { pgTable, uuid, integer, varchar, text, boolean, timestamp, jsonb } from
 export const inAppNotificationsTable = pgTable("notifications", {
   id: uuid("id").primaryKey().defaultRandom(),
   company_id: integer("company_id").notNull(),
+  // Target user. NULL = company/office broadcast (legacy, e.g. new-booking
+  // alerts seen by office). Set = a specific user (per-user targeting — a tech's
+  // job alerts, an office user's message alerts).
+  user_id: integer("user_id"),
   type: varchar("type", { length: 50 }).notNull(),
   title: varchar("title", { length: 255 }).notNull(),
   body: text("body"),


### PR DESCRIPTION
Milestone **A.1** of the in-app notification system (A split: A.1 = feed + inbound trigger + bell; A.2 = job triggers).

**A — foundation + trigger 1**
- `notifications.user_id` (NULL = office broadcast, set = targeted user) + index + migration guard.
- `lib/notify.ts`: `notifyUser` / `notifyOfficeUsers` (per-user fan-out).
- `/api/notifications/inbox` (+ read / read-all) rewritten **user-scoped, all roles**: own targeted alerts + (office) legacy broadcasts; techs see only their own.
- **Trigger 1:** inbound SMS → `new_message` alert to office users → links to /messages. Internal in-app only, **not** customer-facing, **not** comms-gated.

**B — bell UI**
- Bell + dropdown now for **all roles** (was office-only), re-scopes on company switch, click → mark read + navigate, mark-all-read, new icons.
- **Mobile:** bell in the mobile header → /notifications page, with unread badge.

Next: A.2 (job assigned / job changed → tech), then C (settings), then email channel.

Test (simulated, no live sends): a simulated inbound POST creates a `new_message` row per office user; tech sees none; inbox returns it; mark-read works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)