### PR TITLE
feat(notifications): C — per-user notification settings

### DIFF
--- a/artifacts/api-server/src/lib/notify-prefs.ts
+++ b/artifacts/api-server/src/lib/notify-prefs.ts
@@ -1,0 +1,63 @@
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+// ── Per-user notification preferences ─────────────────────────────────────────
+// Categories: messages | new_jobs | job_changes. Channels: inapp | email.
+// A pref column NULL = fall back to a role-sensible default; explicit true/false
+// = the user's choice. notification type → category mapping is centralized here.
+
+export type Category = "messages" | "new_jobs" | "job_changes";
+export type Channel = "inapp" | "email";
+
+export const TYPE_TO_CATEGORY: Record<string, Category> = {
+  new_message: "messages",
+  job_assigned: "new_jobs",
+  job_changed: "job_changes",
+};
+
+// Role-sensible defaults (in-app). Email defaults OFF everywhere (opt-in).
+//  - messages    → office ON, techs OFF
+//  - new_jobs    → techs ON, office OFF
+//  - job_changes → techs ON, office OFF
+function roleDefault(role: string, category: Category, channel: Channel): boolean {
+  if (channel === "email") return false;
+  const isOffice = ["owner", "admin", "office", "super_admin"].includes(role);
+  const isTech = ["technician", "team_lead"].includes(role);
+  if (category === "messages") return isOffice;
+  if (category === "new_jobs") return isTech;
+  if (category === "job_changes") return isTech;
+  return false;
+}
+
+export interface EffectivePrefs {
+  messages_inapp: boolean; messages_email: boolean;
+  new_jobs_inapp: boolean; new_jobs_email: boolean;
+  job_changes_inapp: boolean; job_changes_email: boolean;
+}
+
+export async function getEffectivePrefs(userId: number): Promise<EffectivePrefs & { role: string }> {
+  const ur = await db.execute(sql`SELECT role FROM users WHERE id = ${userId} LIMIT 1`);
+  const role = String((ur.rows[0] as any)?.role ?? "");
+  const pr = await db.execute(sql`SELECT * FROM notification_prefs WHERE user_id = ${userId} LIMIT 1`);
+  const p: any = pr.rows[0] ?? {};
+  const eff = (col: string, cat: Category, ch: Channel) =>
+    p[col] === true ? true : p[col] === false ? false : roleDefault(role, cat, ch);
+  return {
+    role,
+    messages_inapp: eff("messages_inapp", "messages", "inapp"),
+    messages_email: eff("messages_email", "messages", "email"),
+    new_jobs_inapp: eff("new_jobs_inapp", "new_jobs", "inapp"),
+    new_jobs_email: eff("new_jobs_email", "new_jobs", "email"),
+    job_changes_inapp: eff("job_changes_inapp", "job_changes", "inapp"),
+    job_changes_email: eff("job_changes_email", "job_changes", "email"),
+  };
+}
+
+// Is a given channel allowed for the user, for the category implied by `type`?
+// Types with no category mapping (e.g. new_booking) are always allowed.
+export async function isAllowed(userId: number, type: string, channel: Channel): Promise<boolean> {
+  const cat = TYPE_TO_CATEGORY[type];
+  if (!cat) return true;
+  const p = await getEffectivePrefs(userId);
+  return (p as any)[`${cat}_${channel}`] === true;
+}

--- a/artifacts/api-server/src/lib/notify.ts
+++ b/artifacts/api-server/src/lib/notify.ts
@@ -17,6 +17,13 @@ export interface NotifyArgs {
 
 export async function notifyUser(a: NotifyArgs): Promise<void> {
   try {
+    // Respect the user's per-category in-app preference (role-defaulted). Types
+    // without a category mapping are always delivered. Broadcasts (userId null)
+    // skip the per-user check.
+    if (a.userId != null) {
+      const { isAllowed } = await import("./notify-prefs.js");
+      if (!(await isAllowed(a.userId, a.type, "inapp"))) return;
+    }
     await db.execute(sql`
       INSERT INTO notifications (company_id, user_id, type, title, body, link, meta, read, created_at)
       VALUES (${a.companyId}, ${a.userId}, ${a.type}, ${a.title}, ${a.body ?? null},

--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -1504,6 +1504,22 @@ async function runBookingSchemaGuard(): Promise<void> {
     { label: "notifications user idx", stmt:
       `CREATE INDEX IF NOT EXISTS notifications_user_idx ON notifications (company_id, user_id, read)` },
 
+    // Per-user notification preferences. NULL column = use role default; explicit
+    // true/false = the user's choice. Categories: messages / new_jobs / job_changes.
+    // Channels: in-app / email.
+    { label: "CREATE notification_prefs", stmt: `
+      CREATE TABLE IF NOT EXISTS notification_prefs (
+        user_id           INTEGER PRIMARY KEY,
+        company_id        INTEGER,
+        messages_inapp    BOOLEAN,
+        messages_email    BOOLEAN,
+        new_jobs_inapp    BOOLEAN,
+        new_jobs_email    BOOLEAN,
+        job_changes_inapp BOOLEAN,
+        job_changes_email BOOLEAN,
+        updated_at        TIMESTAMP NOT NULL DEFAULT NOW()
+      )` },
+
     // Two-way SMS — unified conversation store (inbound + outbound, leads + clients).
     { label: "CREATE sms_messages", stmt: `
       CREATE TABLE IF NOT EXISTS sms_messages (

--- a/artifacts/api-server/src/routes/notifications.ts
+++ b/artifacts/api-server/src/routes/notifications.ts
@@ -195,4 +195,41 @@ router.patch("/inbox/:id/read", requireAuth, async (req, res) => {
   }
 });
 
+// ── GET /api/notifications/settings — this user's effective prefs ──────────────
+router.get("/settings", requireAuth, async (req, res) => {
+  try {
+    const { getEffectivePrefs } = await import("../lib/notify-prefs.js");
+    const prefs = await getEffectivePrefs(req.auth!.userId!);
+    return res.json(prefs);
+  } catch (err) {
+    console.error("GET /notifications/settings:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
+// ── PUT /api/notifications/settings — upsert this user's prefs ─────────────────
+router.put("/settings", requireAuth, async (req, res) => {
+  try {
+    const userId = req.auth!.userId!;
+    const companyId = req.auth!.companyId!;
+    const b = req.body ?? {};
+    const bool = (v: any) => (v === true ? true : v === false ? false : null);
+    await db.execute(sql`
+      INSERT INTO notification_prefs
+        (user_id, company_id, messages_inapp, messages_email, new_jobs_inapp, new_jobs_email, job_changes_inapp, job_changes_email, updated_at)
+      VALUES (${userId}, ${companyId}, ${bool(b.messages_inapp)}, ${bool(b.messages_email)},
+              ${bool(b.new_jobs_inapp)}, ${bool(b.new_jobs_email)}, ${bool(b.job_changes_inapp)}, ${bool(b.job_changes_email)}, NOW())
+      ON CONFLICT (user_id) DO UPDATE SET
+        messages_inapp = EXCLUDED.messages_inapp, messages_email = EXCLUDED.messages_email,
+        new_jobs_inapp = EXCLUDED.new_jobs_inapp, new_jobs_email = EXCLUDED.new_jobs_email,
+        job_changes_inapp = EXCLUDED.job_changes_inapp, job_changes_email = EXCLUDED.job_changes_email,
+        updated_at = NOW()`);
+    const { getEffectivePrefs } = await import("../lib/notify-prefs.js");
+    return res.json(await getEffectivePrefs(userId));
+  } catch (err) {
+    console.error("PUT /notifications/settings:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
 export default router;

--- a/artifacts/qleno/src/App.tsx
+++ b/artifacts/qleno/src/App.tsx
@@ -17,6 +17,7 @@ const AcceptInvitePage    = lazy(() => import("@/pages/accept-invite"));
 const CustomersPage       = lazy(() => import("@/pages/customers"));
 const CustomerProfilePage = lazy(() => import("@/pages/customer-profile"));
 const MessagesPage = lazy(() => import("@/pages/messages"));
+const NotificationSettingsPage = lazy(() => import("@/pages/notification-settings"));
 const AddClientPage       = lazy(() => import("@/pages/add-client"));
 const AddEmployeePage     = lazy(() => import("@/pages/add-employee"));
 const InvoicesPage        = lazy(() => import("@/pages/invoices"));
@@ -148,6 +149,7 @@ function Router() {
         <Route path="/customers/:id" component={CustomerProfilePage} />
         <Route path="/customers" component={CustomersPage} />
         <Route path="/messages" component={MessagesPage} />
+        <Route path="/settings/notifications" component={NotificationSettingsPage} />
         <Route path="/invoices/:id" component={InvoiceDetailPage} />
         <Route path="/invoices" component={InvoicesPage} />
         <Route path="/time-clock" component={TimeClockPage} />

--- a/artifacts/qleno/src/components/layout/dashboard-layout.tsx
+++ b/artifacts/qleno/src/components/layout/dashboard-layout.tsx
@@ -1121,6 +1121,13 @@ export function DashboardLayout({ children, title, fullBleed, onNewJob }: Dashbo
                         <KeyRound size={15} style={{ color: '#6B7280' }} />
                         Change Password
                       </button>
+                      <button
+                        onClick={() => { setUserDropOpen(false); setLocation('/settings/notifications'); }}
+                        style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '9px 12px', borderRadius: 7, background: 'none', border: 'none', cursor: 'pointer', width: '100%', textAlign: 'left', fontFamily: "'Plus Jakarta Sans', sans-serif", fontSize: 13, fontWeight: 500, color: '#1A1917' }}
+                      >
+                        <Bell size={15} style={{ color: '#6B7280' }} />
+                        Notification settings
+                      </button>
                       <div style={{ height: 1, background: '#F0EDEA', margin: '2px 0' }} />
                       <button
                         onClick={() => { setUserDropOpen(false); logout(); }}

--- a/artifacts/qleno/src/pages/notification-settings.tsx
+++ b/artifacts/qleno/src/pages/notification-settings.tsx
@@ -1,0 +1,99 @@
+import { useState, useEffect } from "react";
+import { getAuthHeaders } from "@/lib/auth";
+import { DashboardLayout } from "@/components/layout/dashboard-layout";
+import { useToast } from "@/hooks/use-toast";
+import { Bell } from "lucide-react";
+
+const API = import.meta.env.BASE_URL.replace(/\/$/, "");
+const FF = "'Plus Jakarta Sans', sans-serif";
+const INK = "#1A1917";
+const MUTE = "#6B6860";
+const BORDER = "#E5E2DC";
+const BRAND = "#00C9A0";
+
+const CATEGORIES = [
+  { key: "messages", label: "Messages", desc: "New inbound text messages from customers" },
+  { key: "new_jobs", label: "New jobs", desc: "A job is scheduled or assigned to you" },
+  { key: "job_changes", label: "Job changes", desc: "A job's date, time, assignment, or status changes" },
+] as const;
+
+function Toggle({ on, onChange, disabled }: { on: boolean; onChange: (v: boolean) => void; disabled?: boolean }) {
+  return (
+    <button onClick={() => !disabled && onChange(!on)} disabled={disabled}
+      style={{ width: 42, height: 24, borderRadius: 999, border: "none", cursor: disabled ? "default" : "pointer",
+        background: on ? BRAND : "#D6D3CC", position: "relative", transition: "background 120ms", opacity: disabled ? 0.5 : 1, flexShrink: 0 }}>
+      <span style={{ position: "absolute", top: 2, left: on ? 20 : 2, width: 20, height: 20, borderRadius: "50%", background: "#fff", transition: "left 120ms" }} />
+    </button>
+  );
+}
+
+export default function NotificationSettingsPage() {
+  const { toast } = useToast();
+  const [prefs, setPrefs] = useState<Record<string, boolean> | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const r = await fetch(`${API}/api/notifications/settings`, { headers: getAuthHeaders() });
+        if (r.ok) setPrefs(await r.json());
+      } catch { /* silent */ }
+    })();
+  }, []);
+
+  async function save(next: Record<string, boolean>) {
+    setPrefs(next);
+    setSaving(true);
+    try {
+      const r = await fetch(`${API}/api/notifications/settings`, {
+        method: "PUT", headers: { ...getAuthHeaders(), "Content-Type": "application/json" },
+        body: JSON.stringify(next),
+      });
+      if (r.ok) setPrefs(await r.json());
+      else toast({ title: "Couldn't save", variant: "destructive" as any });
+    } catch { toast({ title: "Couldn't save", variant: "destructive" as any }); }
+    finally { setSaving(false); }
+  }
+
+  const setKey = (k: string, v: boolean) => prefs && save({ ...prefs, [k]: v });
+
+  return (
+    <DashboardLayout>
+      <div style={{ fontFamily: FF, maxWidth: 640, margin: "0 auto" }}>
+        <h1 style={{ fontSize: 22, fontWeight: 800, color: INK, margin: "0 0 4px", display: "flex", alignItems: "center", gap: 8 }}>
+          <Bell size={20} /> Notification settings
+        </h1>
+        <p style={{ fontSize: 13, color: MUTE, margin: "0 0 20px" }}>Choose how you want to be alerted. These are your personal settings.</p>
+
+        {!prefs ? (
+          <p style={{ color: MUTE, fontSize: 14 }}>Loading…</p>
+        ) : (
+          <div style={{ border: `1px solid ${BORDER}`, borderRadius: 12, background: "#fff", overflow: "hidden" }}>
+            <div style={{ display: "flex", padding: "10px 16px", borderBottom: `1px solid ${BORDER}`, fontSize: 12, fontWeight: 700, color: MUTE, textTransform: "uppercase", letterSpacing: "0.05em" }}>
+              <span style={{ flex: 1 }}>Alert me about</span>
+              <span style={{ width: 70, textAlign: "center" }}>In-app</span>
+              <span style={{ width: 70, textAlign: "center" }}>Email</span>
+            </div>
+            {CATEGORIES.map(c => (
+              <div key={c.key} style={{ display: "flex", alignItems: "center", padding: "14px 16px", borderBottom: `1px solid ${BORDER}` }}>
+                <div style={{ flex: 1, minWidth: 0, paddingRight: 12 }}>
+                  <div style={{ fontSize: 14, fontWeight: 700, color: INK }}>{c.label}</div>
+                  <div style={{ fontSize: 12, color: MUTE, marginTop: 2 }}>{c.desc}</div>
+                </div>
+                <div style={{ width: 70, display: "flex", justifyContent: "center" }}>
+                  <Toggle on={!!prefs[`${c.key}_inapp`]} onChange={v => setKey(`${c.key}_inapp`, v)} disabled={saving} />
+                </div>
+                <div style={{ width: 70, display: "flex", justifyContent: "center" }}>
+                  <Toggle on={!!prefs[`${c.key}_email`]} onChange={v => setKey(`${c.key}_email`, v)} disabled={saving} />
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+        <p style={{ fontSize: 12, color: MUTE, marginTop: 14 }}>
+          Email alerts go to your own staff email and are internal — customers never receive them.
+        </p>
+      </div>
+    </DashboardLayout>
+  );
+}


### PR DESCRIPTION
Milestone **C**: per-user notification settings.

- `notification_prefs` table: messages / new_jobs / job_changes × in-app / email. NULL = role default, explicit = user choice.
- Role-sensible defaults: office → messages on; techs → new_jobs + job_changes on; email opt-in (off).
- `notifyUser` respects the recipient's in-app pref (skips when off); unmapped types always deliver.
- `GET/PUT /api/notifications/settings`; `/settings/notifications` page (toggle grid) linked from the user menu.
- Email toggles are persisted now; the **email channel** sends in the next milestone.

Test (no sends): default prefs by role; toggling messages-inapp off suppresses a simulated inbound alert for that user; back on restores it. Purge after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)