### PR TITLE
Leads bulk-delete + audit, All Locations revenue fix, dispatch drag-reassign fix

### DIFF
--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -1747,6 +1747,10 @@ async function runScopeZoneFix(): Promise<void> {
 // isn't overridden on boot.
 async function runPhesPayCadenceDefault(): Promise<void> {
   await db.execute(sql`UPDATE companies SET pay_cadence = 'weekly' WHERE id = ${PHES} AND pay_cadence <> 'weekly'`);
+  // [casing 2026-06-15] "PHES Schaumburg" reads as shouty in the company
+  // switcher (Sal). Normalize to title case. Idempotent — only the all-caps
+  // variant matches.
+  await db.execute(sql`UPDATE companies SET name = 'Phes Schaumburg' WHERE name = 'PHES Schaumburg'`);
 }
 
 async function runZoneSync(): Promise<void> {

--- a/artifacts/api-server/src/routes/jobs.ts
+++ b/artifacts/api-server/src/routes/jobs.ts
@@ -4412,8 +4412,18 @@ router.patch("/:id/reassign-tech", requireAuth, async (req, res) => {
     `);
 
     await db.transaction(async (tx) => {
-      // Demote any existing primary (and any row for the new tech that was
-      // sitting at non-primary before today).
+      // [reassign-fix 2026-06-15] REMOVE the primary being replaced — don't
+      // just demote it. Demoting left the old tech on the job as a non-primary
+      // row, so the dispatch board (which fans out a card per job_technicians
+      // row) kept showing them alongside the new tech. Sal: "drag a job from
+      // Juliana to Jose, it adds Jose and keeps Juliana." Genuine helper rows
+      // (any other user_id) are preserved; only the swapped-out primary goes.
+      if (oldAssignedUserId != null) {
+        await tx.execute(sql`
+          DELETE FROM job_technicians WHERE job_id = ${jobId} AND user_id = ${oldAssignedUserId}
+        `);
+      }
+      // Defensive: clear any lingering primary flags before setting the new one.
       await tx.execute(sql`
         UPDATE job_technicians SET is_primary = false
         WHERE job_id = ${jobId}

--- a/artifacts/api-server/src/routes/leads.ts
+++ b/artifacts/api-server/src/routes/leads.ts
@@ -7,6 +7,7 @@ import { Router } from "express";
 import { db } from "@workspace/db";
 import { sql } from "drizzle-orm";
 import { requireAuth, requireRole } from "../lib/auth.js";
+import { logAudit } from "../lib/audit.js";
 
 const router = Router();
 
@@ -213,6 +214,7 @@ router.post("/", requireAuth, requireRole("owner", "admin", "office"), async (re
     const leadId = (result.rows[0] as any).id;
 
     await logActivity(leadId, companyId, "status_change", `Lead created with status: ${status}`, userId);
+    await logAudit(req, "lead.create", "lead", leadId, null, { first_name, last_name, email, phone, source, status });
 
     fireOfficeNotification(companyId, leadId, first_name, last_name, source, phone, scope).catch(() => {});
 
@@ -278,6 +280,9 @@ router.patch("/:id", requireAuth, requireRole("owner", "admin", "office"), async
     if (stageChanged) {
       await logActivity(leadId, companyId, "status_change", `Status changed from ${prev} to ${status}`, userId);
     }
+    await logAudit(req, "lead.update", "lead", leadId,
+      stageChanged ? { status: prev } : null,
+      stageChanged ? { status } : { fields: Object.keys(req.body || {}) });
 
     return res.json({ ok: true });
   } catch (err) {
@@ -291,12 +296,75 @@ router.delete("/:id", requireAuth, requireRole("owner"), async (req, res) => {
   try {
     const companyId = req.auth!.companyId!;
     const leadId = parseInt(req.params.id);
+    // Snapshot before delete so the audit trail keeps who/what was removed.
+    const snap = await db.execute(
+      sql`SELECT id, first_name, last_name, email, phone, status, source FROM leads WHERE id = ${leadId} AND company_id = ${companyId} LIMIT 1`
+    );
+    if (!snap.rows.length) return res.status(404).json({ error: "Not found" });
     await db.execute(
       sql`DELETE FROM leads WHERE id = ${leadId} AND company_id = ${companyId}`
     );
+    await logAudit(req, "lead.delete", "lead", leadId, snap.rows[0] as Record<string, unknown>, null);
     return res.json({ ok: true });
   } catch (err) {
     console.error("DELETE /leads/:id:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
+// ── POST /api/leads/bulk-delete ────────────────────────────────────────────────
+// Owner-only. Two modes:
+//   { ids: number[] }   — delete an explicit selection (the bulk-select UI)
+//   { generic: true }   — delete every placeholder/"generic" lead: no name (or
+//                         first_name = 'Lead'), no email/phone/address, no quote,
+//                         still in 'needs_contacted'. Never touches a lead that
+//                         carries any real contact info or has progressed.
+// Every deleted lead is written to the audit log individually (Sal: "all touches
+// going to audit log"), with a single bulk summary row on top.
+router.post("/bulk-delete", requireAuth, requireRole("owner"), async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId!;
+    const { ids, generic } = req.body as { ids?: unknown; generic?: boolean };
+
+    const genericWhere = sql`
+      (first_name IS NULL OR btrim(first_name) = '' OR lower(btrim(first_name)) = 'lead')
+      AND (last_name IS NULL OR btrim(last_name) = '')
+      AND email IS NULL
+      AND phone IS NULL
+      AND (address IS NULL OR btrim(address) = '')
+      AND quote_amount IS NULL
+      AND status = 'needs_contacted'`;
+
+    // Resolve the target rows (snapshot for audit) under either mode.
+    let targets;
+    if (generic === true) {
+      targets = await db.execute(sql`
+        SELECT id, first_name, last_name, email, phone, status, source
+        FROM leads WHERE company_id = ${companyId} AND ${genericWhere}`);
+    } else {
+      const idList = Array.isArray(ids) ? ids.map(Number).filter(n => Number.isInteger(n)) : [];
+      if (idList.length === 0) return res.status(400).json({ error: "Provide ids[] or generic:true" });
+      targets = await db.execute(sql`
+        SELECT id, first_name, last_name, email, phone, status, source
+        FROM leads WHERE company_id = ${companyId} AND id = ANY(${idList}::int[])`);
+    }
+
+    const rows = targets.rows as Array<Record<string, unknown>>;
+    if (rows.length === 0) return res.json({ ok: true, deleted: 0 });
+    const delIds = rows.map(r => Number(r.id));
+
+    await db.execute(sql`DELETE FROM leads WHERE company_id = ${companyId} AND id = ANY(${delIds}::int[])`);
+
+    // Per-lead audit rows + one summary row.
+    await logAudit(req, "lead.bulk_delete", "lead", null, null,
+      { mode: generic ? "generic" : "selection", count: rows.length, ids: delIds });
+    for (const r of rows) {
+      await logAudit(req, "lead.delete", "lead", Number(r.id), r, null);
+    }
+
+    return res.json({ ok: true, deleted: rows.length });
+  } catch (err) {
+    console.error("POST /leads/bulk-delete:", err);
     return res.status(500).json({ error: "Internal Server Error" });
   }
 });

--- a/artifacts/api-server/src/routes/rollup.ts
+++ b/artifacts/api-server/src/routes/rollup.ts
@@ -34,11 +34,16 @@ router.get("/", requireAuth, async (req, res) => {
 
     const comps = await db.execute(sql`SELECT id, name FROM companies WHERE id = ANY(ARRAY[${sql.raw(idsCsv)}]::int[]) ORDER BY id`);
 
+    // [rollup-fix 2026-06-15] JOBS + REVENUE are COMPLETED work only — the old
+    // query counted every job (future scheduled + cancelled) and summed their
+    // base_fee as "revenue", which inflated both figures. Completed-only matches
+    // how revenue is defined everywhere else (dashboard, payroll, job_history).
+    // UPCOMING stays the forward pipeline of scheduled jobs.
     const jobsAgg = await db.execute(sql`
       SELECT company_id,
-        COUNT(*)::int AS jobs_total,
+        COUNT(*) FILTER (WHERE status='complete')::int AS jobs_total,
         COUNT(*) FILTER (WHERE status='scheduled' AND scheduled_date >= CURRENT_DATE)::int AS jobs_upcoming,
-        COALESCE(SUM(COALESCE(billed_amount, base_fee, 0)), 0) AS revenue
+        COALESCE(SUM(COALESCE(billed_amount, base_fee, 0)) FILTER (WHERE status='complete'), 0) AS revenue
       FROM jobs WHERE company_id = ANY(ARRAY[${sql.raw(idsCsv)}]::int[]) GROUP BY company_id`);
 
     const leadsAgg = await db.execute(sql`

--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -5942,8 +5942,13 @@ export default function JobsPage() {
     const newLeft = originalLeft + delta.x;
     const newMins = DAY_START + Math.round(newLeft / SLOT_W) * 30;
     const patch: any = { scheduled_time: minsToStr(newMins) };
-    if (empId !== job.assigned_user_id) {
-      patch.assigned_user_id = empId;
+    // [reassign-fix 2026-06-15] A tech change on drag must go through
+    // /reassign-tech (swaps the primary AND syncs job_technicians), NOT the
+    // PUT path — PUT only writes assigned_user_id, leaving the old tech's
+    // job_technicians row behind so the board showed both. PUT here only
+    // carries the time.
+    const techChanged = Number.isFinite(empId) && empId !== job.assigned_user_id;
+    if (techChanged) {
       // Cross-zone warning: if job zone differs from employee's primary zone
       const targetEmployee = data.employees.find(emp => emp.id === empId);
       if (targetEmployee?.zone && job.zone_id && targetEmployee.zone.zone_id !== job.zone_id) {
@@ -5965,8 +5970,19 @@ export default function JobsPage() {
         : prev.unassigned_jobs;
       return { ...prev, employees: newEmployees, unassigned_jobs: newUnassigned };
     });
-    try { await patchJob(job.id, patch, token); }
-    catch { toast({ title: "Failed to update job", variant: "destructive" }); load(); }
+    try {
+      if (techChanged) {
+        const API = import.meta.env.BASE_URL.replace(/\/$/, "");
+        const r = await fetch(`${API}/api/jobs/${job.id}/reassign-tech`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+          body: JSON.stringify({ new_tech_id: empId }),
+        });
+        if (!r.ok) { const d = await r.json().catch(() => ({})); throw new Error(d.error || "Reassign failed"); }
+      }
+      await patchJob(job.id, patch, token);
+    }
+    catch (e) { toast({ title: "Failed to update job", description: (e as Error).message, variant: "destructive" }); load(); }
   }
   function chipLeft(job: DispatchJob) { return ((timeToMins(job.scheduled_time) - DAY_START) / 30) * SLOT_W; }
 

--- a/artifacts/qleno/src/pages/leads.tsx
+++ b/artifacts/qleno/src/pages/leads.tsx
@@ -771,8 +771,50 @@ export default function LeadsPage() {
   const [users, setUsers] = useState<OwnerOpt[]>([]);
   const [partners, setPartners] = useState<PartnerOpt[]>([]);
   const [dragOver, setDragOver] = useState<string | null>(null);
+  // [bulk-select 2026-06-15] Multi-select + bulk delete. Selection is by lead id;
+  // a lead is "generic" (a placeholder import row) when it has no name/contact/
+  // quote and is still needs_contacted — those are the ones Sal wants to clear.
+  const [selected, setSelected] = useState<Set<number>>(new Set());
+  const [bulkBusy, setBulkBusy] = useState(false);
 
   const LIMIT = view === "board" ? 300 : 25;
+
+  const isGeneric = (l: Lead) => {
+    const nm = [l.first_name, l.last_name].filter(Boolean).join(" ").trim().toLowerCase();
+    return !l.phone && !l.email && !l.address && !l.quote_amount
+      && (nm === "" || nm === "lead") && l.status === "needs_contacted";
+  };
+  const toggleSel = (id: number) => setSelected(s => { const n = new Set(s); n.has(id) ? n.delete(id) : n.add(id); return n; });
+  const allOnPageSelected = leads.length > 0 && leads.every(l => selected.has(l.id));
+  const toggleAllOnPage = () => setSelected(s => {
+    const n = new Set(s);
+    if (allOnPageSelected) leads.forEach(l => n.delete(l.id));
+    else leads.forEach(l => n.add(l.id));
+    return n;
+  });
+  const selectGenericOnPage = () => setSelected(s => { const n = new Set(s); leads.filter(isGeneric).forEach(l => n.add(l.id)); return n; });
+  const genericCountOnPage = leads.filter(isGeneric).length;
+
+  const bulkDelete = useCallback(async (body: { ids?: number[]; generic?: boolean }, confirmMsg: string) => {
+    if (!window.confirm(confirmMsg)) return;
+    setBulkBusy(true);
+    try {
+      const r = await fetch(`${API}/api/leads/bulk-delete`, {
+        method: "POST",
+        headers: { ...getAuthHeaders(), "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      const d = await r.json().catch(() => ({}));
+      if (!r.ok) throw new Error(d.error || "Delete failed");
+      setSelected(new Set());
+      await loadLeads();
+      await loadCounts();
+    } catch (e) {
+      window.alert((e as Error).message || "Delete failed");
+    } finally {
+      setBulkBusy(false);
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const activeFilterCount = [fOwner, fSource, fPartner, fLocation, fDateFrom, fDateTo].filter(Boolean).length;
 
@@ -829,6 +871,9 @@ export default function LeadsPage() {
 
   useEffect(() => { loadLeads(); loadCounts(); }, [loadLeads, loadCounts]);
   useEffect(() => { loadOptions(); }, [loadOptions]);
+  // Drop selection when the visible set changes (page / filter / search) so a
+  // stale id can't be deleted from a list the operator can no longer see.
+  useEffect(() => { setSelected(new Set()); }, [page, statusFilter, search, fOwner, fSource, fPartner, fLocation, fDateFrom, fDateTo]);
 
   function handleSearchChange(v: string) {
     setSearchInput(v);
@@ -1035,12 +1080,41 @@ export default function LeadsPage() {
           )}
         </div>
 
+        {/* Bulk-action bar (list view) */}
+        {view === "list" && (selected.size > 0 || genericCountOnPage > 0) && (
+          <div style={{ display: "flex", alignItems: "center", gap: 12, flexWrap: "wrap", background: selected.size > 0 ? "#0A0E1A" : "#fff", border: "1px solid #E5E2DC", borderRadius: 10, padding: "10px 14px", marginBottom: -6 }}>
+            {selected.size > 0 ? (
+              <>
+                <span style={{ fontSize: 13, fontWeight: 700, color: "#fff" }}>{selected.size} selected</span>
+                <button disabled={bulkBusy} onClick={() => bulkDelete({ ids: Array.from(selected) }, `Delete ${selected.size} selected lead${selected.size === 1 ? "" : "s"}? This is logged to the audit trail and can't be undone.`)}
+                  style={{ background: "#DC2626", color: "#fff", border: "none", borderRadius: 7, padding: "7px 14px", fontSize: 13, fontWeight: 700, cursor: bulkBusy ? "wait" : "pointer", fontFamily: "inherit" }}>
+                  {bulkBusy ? "Deleting…" : `Delete ${selected.size}`}
+                </button>
+                <button onClick={() => setSelected(new Set())} style={{ background: "transparent", color: "#fff", border: "1px solid #ffffff40", borderRadius: 7, padding: "7px 12px", fontSize: 13, fontWeight: 600, cursor: "pointer", fontFamily: "inherit" }}>Clear</button>
+              </>
+            ) : (
+              <>
+                <span style={{ fontSize: 13, color: "#6B6860" }}>{genericCountOnPage} generic placeholder lead{genericCountOnPage === 1 ? "" : "s"} on this page (no name or contact).</span>
+                <button onClick={selectGenericOnPage} style={{ background: "#F3F4F6", color: "#1A1917", border: "1px solid #E5E2DC", borderRadius: 7, padding: "7px 12px", fontSize: 13, fontWeight: 600, cursor: "pointer", fontFamily: "inherit" }}>Select them</button>
+                <button disabled={bulkBusy} onClick={() => bulkDelete({ generic: true }, "Delete ALL generic placeholder leads across every page (no name, no contact, no quote, still Needs Contacted)? This is logged to the audit trail and can't be undone.")}
+                  style={{ background: "transparent", color: "#DC2626", border: "1px solid #DC262640", borderRadius: 7, padding: "7px 12px", fontSize: 13, fontWeight: 700, cursor: bulkBusy ? "wait" : "pointer", fontFamily: "inherit" }}>
+                  {bulkBusy ? "Deleting…" : "Delete all generic"}
+                </button>
+              </>
+            )}
+          </div>
+        )}
+
         {/* Table (list view) */}
         {view === "list" && (
         <div style={{ background: "#fff", border: "1px solid #E5E2DC", borderRadius: 10, overflow: "hidden" }}>
           <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 14 }}>
             <thead>
               <tr style={{ background: "#F7F6F3", borderBottom: "1px solid #E5E2DC" }}>
+                <th style={{ padding: "10px 0 10px 14px", width: 36 }}>
+                  <input type="checkbox" checked={allOnPageSelected} onChange={toggleAllOnPage} aria-label="Select all on page"
+                    style={{ cursor: "pointer", width: 15, height: 15 }} />
+                </th>
                 {["Name", "Contact", "Source", "Status", "Owner", "Scope", "Quote", "Created", ""].map(h => (
                   <th key={h} style={{ padding: "10px 14px", textAlign: "left", fontSize: 11,
                     fontWeight: 700, color: "#6B6860", textTransform: "uppercase", letterSpacing: "0.05em",
@@ -1051,13 +1125,13 @@ export default function LeadsPage() {
             <tbody>
               {loading ? (
                 <tr>
-                  <td colSpan={9} style={{ padding: "60px 0", textAlign: "center" }}>
+                  <td colSpan={10} style={{ padding: "60px 0", textAlign: "center" }}>
                     <Loader2 size={22} className="animate-spin" color="#6B6860" style={{ margin: "0 auto" }} />
                   </td>
                 </tr>
               ) : leads.length === 0 ? (
                 <tr>
-                  <td colSpan={9} style={{ padding: "60px 0", textAlign: "center" }}>
+                  <td colSpan={10} style={{ padding: "60px 0", textAlign: "center" }}>
                     <UserPlus size={36} color="#D1D5DB" style={{ margin: "0 auto 12px" }} />
                     <div style={{ color: "#6B6860", fontSize: 14 }}>
                       {search || statusFilter ? "No leads match your filters." : "No leads yet — add your first lead."}
@@ -1069,12 +1143,17 @@ export default function LeadsPage() {
                 return (
                   <tr key={lead.id}
                     style={{ borderBottom: i < leads.length - 1 ? "1px solid #F3F4F6" : "none",
-                      cursor: "pointer", transition: "background 0.1s" }}
-                    onMouseEnter={e => (e.currentTarget.style.background = "#FAFAF9")}
-                    onMouseLeave={e => (e.currentTarget.style.background = "")}
+                      cursor: "pointer", transition: "background 0.1s",
+                      background: selected.has(lead.id) ? "#F0FDF9" : undefined }}
+                    onMouseEnter={e => (e.currentTarget.style.background = selected.has(lead.id) ? "#E4F8F0" : "#FAFAF9")}
+                    onMouseLeave={e => (e.currentTarget.style.background = selected.has(lead.id) ? "#F0FDF9" : "")}
                     onClick={() => setSelectedLead(lead)}>
+                    <td style={{ padding: "12px 0 12px 14px", width: 36 }} onClick={e => e.stopPropagation()}>
+                      <input type="checkbox" checked={selected.has(lead.id)} onChange={() => toggleSel(lead.id)}
+                        aria-label={`Select ${name || "lead"}`} style={{ cursor: "pointer", width: 15, height: 15 }} />
+                    </td>
                     <td style={{ padding: "12px 14px" }}>
-                      <div style={{ fontWeight: 600, color: "#1A1917" }}>{name}</div>
+                      <div style={{ fontWeight: 600, color: "#1A1917" }}>{name || <span style={{ color: "#B0ADA6" }}>Lead</span>}</div>
                       {lead.address && (
                         <div style={{ fontSize: 12, color: "#9CA3AF", marginTop: 1 }}>
                           {formatAddress(lead.address, lead.city, lead.state, lead.zip)}


### PR DESCRIPTION
A batch of fixes from today's review of the Lead Pipeline, All Locations, and dispatch.

## Leads — bulk select + delete + audit
- **Bulk selection** on the list view: per-row + select-all-on-page checkboxes, a dark selection bar with **Delete N**, and a **Delete all generic** button that clears placeholder import rows across every page.
- **`POST /api/leads/bulk-delete`** (owner): `{ ids }` for an explicit selection or `{ generic: true }` for all placeholders. The generic guard only matches rows with no name (or name "Lead"), no email/phone/address, no quote, still `needs_contacted` — it never touches a lead carrying real info.
- **Audit log on every touch** (`lead.create` / `lead.update` / `lead.delete` / `lead.bulk_delete` summary + per-lead rows). Single delete now snapshots before removing.

## All Locations roll-up
- JOBS + REVENUE were counting/summing **every** job including future-scheduled and cancelled, inflating both. Now completed-jobs only, matching how revenue is defined everywhere else. UPCOMING unchanged. (Pipeline $0 was already correct — open leads carry no quote.)

## Dispatch drag-and-drop reassign
- Dragging a job to a new tech **added** them and kept the old one. Two root causes: the drag path used `PUT` (no `job_technicians` sync), and `reassign-tech` only *demoted* the old primary (still renders as a team chip). Drag now routes tech changes through `reassign-tech`, and that endpoint now **removes** the swapped-out primary (helpers preserved). Fixes the dropdown path too.

## Polish
- "PHES Schaumburg" → "Phes Schaumburg" in the company switcher (idempotent migration).

Verified: `typecheck:libs` clean, both builds pass; only the repo-wide pre-existing `getAuthHeaders` union tsc warnings remain.

https://claude.ai/code/session_019PiXXwFgtNSnzZQy3MTjAj

---
_Generated by [Claude Code](https://claude.ai/code/session_019PiXXwFgtNSnzZQy3MTjAj)_