### PR TITLE
Leads: fix bulk delete (empty-string match + clean transaction), drop generic button

### DIFF
--- a/artifacts/api-server/src/routes/leads.ts
+++ b/artifacts/api-server/src/routes/leads.ts
@@ -315,27 +315,27 @@ router.delete("/:id", requireAuth, requireRole("owner"), async (req, res) => {
 // ── POST /api/leads/bulk-delete ────────────────────────────────────────────────
 // Owner-only. Two modes:
 //   { ids: number[] }   — delete an explicit selection (the bulk-select UI)
-//   { generic: true }   — delete every placeholder/"generic" lead: no name (or
-//                         first_name = 'Lead'), no email/phone/address, no quote,
-//                         still in 'needs_contacted'. Never touches a lead that
-//                         carries any real contact info or has progressed.
-// Every deleted lead is written to the audit log individually (Sal: "all touches
-// going to audit log"), with a single bulk summary row on top.
+//   { generic: true }   — delete placeholder leads: no name (or first_name
+//                         'Lead'), no email/phone/address, no quote, still
+//                         needs_contacted. Empty strings count as empty.
+// Child rows (activity log, follow-up enrollments) are removed and quote/sms
+// back-references cleared in the same transaction so nothing orphans. Every
+// deleted lead is audited (Sal: "all touches going to audit log").
 router.post("/bulk-delete", requireAuth, requireRole("owner"), async (req, res) => {
   try {
     const companyId = req.auth!.companyId!;
     const { ids, generic } = req.body as { ids?: unknown; generic?: boolean };
 
+    // NULL-or-empty checks — these placeholder rows carry '' not NULL.
     const genericWhere = sql`
       (first_name IS NULL OR btrim(first_name) = '' OR lower(btrim(first_name)) = 'lead')
       AND (last_name IS NULL OR btrim(last_name) = '')
-      AND email IS NULL
-      AND phone IS NULL
+      AND (email IS NULL OR btrim(email) = '')
+      AND (phone IS NULL OR btrim(phone) = '')
       AND (address IS NULL OR btrim(address) = '')
       AND quote_amount IS NULL
       AND status = 'needs_contacted'`;
 
-    // Resolve the target rows (snapshot for audit) under either mode.
     let targets;
     if (generic === true) {
       targets = await db.execute(sql`
@@ -353,9 +353,17 @@ router.post("/bulk-delete", requireAuth, requireRole("owner"), async (req, res) 
     if (rows.length === 0) return res.json({ ok: true, deleted: 0 });
     const delIds = rows.map(r => Number(r.id));
 
-    await db.execute(sql`DELETE FROM leads WHERE company_id = ${companyId} AND id = ANY(${delIds}::int[])`);
+    await db.transaction(async (tx) => {
+      // Clear/clean dependents first so a lead with history deletes cleanly
+      // (and stays clean even if FKs are added later). Each guarded so a
+      // missing table on a fresh tenant can't abort the delete.
+      try { await tx.execute(sql`DELETE FROM lead_activity_log WHERE company_id = ${companyId} AND lead_id = ANY(${delIds}::int[])`); } catch { /* table absent */ }
+      try { await tx.execute(sql`DELETE FROM follow_up_enrollments WHERE lead_id = ANY(${delIds}::int[])`); } catch { /* table/col absent */ }
+      try { await tx.execute(sql`UPDATE quotes SET lead_id = NULL WHERE lead_id = ANY(${delIds}::int[])`); } catch { /* col absent */ }
+      try { await tx.execute(sql`UPDATE sms_messages SET lead_id = NULL WHERE lead_id = ANY(${delIds}::int[])`); } catch { /* col absent */ }
+      await tx.execute(sql`DELETE FROM leads WHERE company_id = ${companyId} AND id = ANY(${delIds}::int[])`);
+    });
 
-    // Per-lead audit rows + one summary row.
     await logAudit(req, "lead.bulk_delete", "lead", null, null,
       { mode: generic ? "generic" : "selection", count: rows.length, ids: delIds });
     for (const r of rows) {
@@ -365,7 +373,7 @@ router.post("/bulk-delete", requireAuth, requireRole("owner"), async (req, res) 
     return res.json({ ok: true, deleted: rows.length });
   } catch (err) {
     console.error("POST /leads/bulk-delete:", err);
-    return res.status(500).json({ error: "Internal Server Error" });
+    return res.status(500).json({ error: "Internal Server Error", message: (err as Error).message });
   }
 });
 

--- a/artifacts/qleno/src/pages/leads.tsx
+++ b/artifacts/qleno/src/pages/leads.tsx
@@ -771,19 +771,13 @@ export default function LeadsPage() {
   const [users, setUsers] = useState<OwnerOpt[]>([]);
   const [partners, setPartners] = useState<PartnerOpt[]>([]);
   const [dragOver, setDragOver] = useState<string | null>(null);
-  // [bulk-select 2026-06-15] Multi-select + bulk delete. Selection is by lead id;
-  // a lead is "generic" (a placeholder import row) when it has no name/contact/
-  // quote and is still needs_contacted — those are the ones Sal wants to clear.
+  // [bulk-select 2026-06-15] Multi-select + bulk delete, by lead id. Tick rows
+  // or the header select-all, then Delete — no auto "generic" detection.
   const [selected, setSelected] = useState<Set<number>>(new Set());
   const [bulkBusy, setBulkBusy] = useState(false);
 
   const LIMIT = view === "board" ? 300 : 25;
 
-  const isGeneric = (l: Lead) => {
-    const nm = [l.first_name, l.last_name].filter(Boolean).join(" ").trim().toLowerCase();
-    return !l.phone && !l.email && !l.address && !l.quote_amount
-      && (nm === "" || nm === "lead") && l.status === "needs_contacted";
-  };
   const toggleSel = (id: number) => setSelected(s => { const n = new Set(s); n.has(id) ? n.delete(id) : n.add(id); return n; });
   const allOnPageSelected = leads.length > 0 && leads.every(l => selected.has(l.id));
   const toggleAllOnPage = () => setSelected(s => {
@@ -792,8 +786,6 @@ export default function LeadsPage() {
     else leads.forEach(l => n.add(l.id));
     return n;
   });
-  const selectGenericOnPage = () => setSelected(s => { const n = new Set(s); leads.filter(isGeneric).forEach(l => n.add(l.id)); return n; });
-  const genericCountOnPage = leads.filter(isGeneric).length;
 
   const bulkDelete = useCallback(async (body: { ids?: number[]; generic?: boolean }, confirmMsg: string) => {
     if (!window.confirm(confirmMsg)) return;
@@ -1080,28 +1072,17 @@ export default function LeadsPage() {
           )}
         </div>
 
-        {/* Bulk-action bar (list view) */}
-        {view === "list" && (selected.size > 0 || genericCountOnPage > 0) && (
-          <div style={{ display: "flex", alignItems: "center", gap: 12, flexWrap: "wrap", background: selected.size > 0 ? "#0A0E1A" : "#fff", border: "1px solid #E5E2DC", borderRadius: 10, padding: "10px 14px", marginBottom: -6 }}>
-            {selected.size > 0 ? (
-              <>
-                <span style={{ fontSize: 13, fontWeight: 700, color: "#fff" }}>{selected.size} selected</span>
-                <button disabled={bulkBusy} onClick={() => bulkDelete({ ids: Array.from(selected) }, `Delete ${selected.size} selected lead${selected.size === 1 ? "" : "s"}? This is logged to the audit trail and can't be undone.`)}
-                  style={{ background: "#DC2626", color: "#fff", border: "none", borderRadius: 7, padding: "7px 14px", fontSize: 13, fontWeight: 700, cursor: bulkBusy ? "wait" : "pointer", fontFamily: "inherit" }}>
-                  {bulkBusy ? "Deleting…" : `Delete ${selected.size}`}
-                </button>
-                <button onClick={() => setSelected(new Set())} style={{ background: "transparent", color: "#fff", border: "1px solid #ffffff40", borderRadius: 7, padding: "7px 12px", fontSize: 13, fontWeight: 600, cursor: "pointer", fontFamily: "inherit" }}>Clear</button>
-              </>
-            ) : (
-              <>
-                <span style={{ fontSize: 13, color: "#6B6860" }}>{genericCountOnPage} generic placeholder lead{genericCountOnPage === 1 ? "" : "s"} on this page (no name or contact).</span>
-                <button onClick={selectGenericOnPage} style={{ background: "#F3F4F6", color: "#1A1917", border: "1px solid #E5E2DC", borderRadius: 7, padding: "7px 12px", fontSize: 13, fontWeight: 600, cursor: "pointer", fontFamily: "inherit" }}>Select them</button>
-                <button disabled={bulkBusy} onClick={() => bulkDelete({ generic: true }, "Delete ALL generic placeholder leads across every page (no name, no contact, no quote, still Needs Contacted)? This is logged to the audit trail and can't be undone.")}
-                  style={{ background: "transparent", color: "#DC2626", border: "1px solid #DC262640", borderRadius: 7, padding: "7px 12px", fontSize: 13, fontWeight: 700, cursor: bulkBusy ? "wait" : "pointer", fontFamily: "inherit" }}>
-                  {bulkBusy ? "Deleting…" : "Delete all generic"}
-                </button>
-              </>
-            )}
+        {/* Bulk-action bar (list view) — appears only when rows are selected.
+            [bulk-ux 2026-06-15] Plain selection: tick rows (or the header
+            select-all), then Delete. No auto "delete all generic" button. */}
+        {view === "list" && selected.size > 0 && (
+          <div style={{ display: "flex", alignItems: "center", gap: 12, flexWrap: "wrap", background: "#0A0E1A", borderRadius: 10, padding: "10px 14px", marginBottom: -6 }}>
+            <span style={{ fontSize: 13, fontWeight: 700, color: "#fff" }}>{selected.size} selected</span>
+            <button disabled={bulkBusy} onClick={() => bulkDelete({ ids: Array.from(selected) }, `Delete ${selected.size} selected lead${selected.size === 1 ? "" : "s"}? This is logged to the audit trail and can't be undone.`)}
+              style={{ background: "#DC2626", color: "#fff", border: "none", borderRadius: 7, padding: "7px 14px", fontSize: 13, fontWeight: 700, cursor: bulkBusy ? "wait" : "pointer", fontFamily: "inherit" }}>
+              {bulkBusy ? "Deleting…" : `Delete ${selected.size}`}
+            </button>
+            <button onClick={() => setSelected(new Set())} style={{ background: "transparent", color: "#fff", border: "1px solid #ffffff40", borderRadius: 7, padding: "7px 12px", fontSize: 13, fontWeight: 600, cursor: "pointer", fontFamily: "inherit" }}>Clear</button>
           </div>
         )}
 


### PR DESCRIPTION
Follow-up to #481 — two things Sal flagged.

## Bulk delete silently did nothing
The generic filter matched on `email IS NULL` / `phone IS NULL`, but the placeholder leads carry **empty strings** (`''`), not NULL — so it matched zero rows and looked broken. Now treats empty strings as empty. The delete also runs in a **transaction** that first clears dependents (`lead_activity_log`, `follow_up_enrollments`) and nulls back-references (`quotes.lead_id`, `sms_messages.lead_id`) so a lead with history deletes cleanly and stays clean if FKs are ever added. Error responses now return the message so failures are visible instead of silent.

## Dropped the "Delete all generic" button
Per Sal ("why would I want a delete all generic button"). The bulk-action bar now appears **only when rows are selected** — tick rows or the header select-all checkbox, then **Delete N**. Plain, standard bulk selection; no auto-magic.

Verified: both builds pass; only the repo-wide pre-existing `getAuthHeaders` tsc warnings remain.

https://claude.ai/code/session_019PiXXwFgtNSnzZQy3MTjAj

---
_Generated by [Claude Code](https://claude.ai/code/session_019PiXXwFgtNSnzZQy3MTjAj)_