### PR TITLE
Leads: fix bulk-delete array binding (the actual reason it did nothing)

### DIFF
--- a/artifacts/api-server/src/routes/leads.ts
+++ b/artifacts/api-server/src/routes/leads.ts
@@ -344,24 +344,31 @@ router.post("/bulk-delete", requireAuth, requireRole("owner"), async (req, res) 
     } else {
       const idList = Array.isArray(ids) ? ids.map(Number).filter(n => Number.isInteger(n)) : [];
       if (idList.length === 0) return res.status(400).json({ error: "Provide ids[] or generic:true" });
+      // [array-fix 2026-06-15] Build an integer CSV and use ANY(ARRAY[...]) via
+      // sql.raw — drizzle's `ANY(${jsArray})` binding silently fails in raw
+      // db.execute here (same issue that broke techs-with-status). idList is
+      // already integer-filtered so the raw interpolation is injection-safe.
+      const idsCsv = idList.join(",");
       targets = await db.execute(sql`
         SELECT id, first_name, last_name, email, phone, status, source
-        FROM leads WHERE company_id = ${companyId} AND id = ANY(${idList}::int[])`);
+        FROM leads WHERE company_id = ${companyId} AND id = ANY(ARRAY[${sql.raw(idsCsv)}]::int[])`);
     }
 
     const rows = targets.rows as Array<Record<string, unknown>>;
     if (rows.length === 0) return res.json({ ok: true, deleted: 0 });
-    const delIds = rows.map(r => Number(r.id));
+    const delIds = rows.map(r => Number(r.id)).filter(n => Number.isInteger(n));
+    const delCsv = delIds.join(",");
+    const delArr = sql`ANY(ARRAY[${sql.raw(delCsv)}]::int[])`;
 
     await db.transaction(async (tx) => {
       // Clear/clean dependents first so a lead with history deletes cleanly
       // (and stays clean even if FKs are added later). Each guarded so a
       // missing table on a fresh tenant can't abort the delete.
-      try { await tx.execute(sql`DELETE FROM lead_activity_log WHERE company_id = ${companyId} AND lead_id = ANY(${delIds}::int[])`); } catch { /* table absent */ }
-      try { await tx.execute(sql`DELETE FROM follow_up_enrollments WHERE lead_id = ANY(${delIds}::int[])`); } catch { /* table/col absent */ }
-      try { await tx.execute(sql`UPDATE quotes SET lead_id = NULL WHERE lead_id = ANY(${delIds}::int[])`); } catch { /* col absent */ }
-      try { await tx.execute(sql`UPDATE sms_messages SET lead_id = NULL WHERE lead_id = ANY(${delIds}::int[])`); } catch { /* col absent */ }
-      await tx.execute(sql`DELETE FROM leads WHERE company_id = ${companyId} AND id = ANY(${delIds}::int[])`);
+      try { await tx.execute(sql`DELETE FROM lead_activity_log WHERE company_id = ${companyId} AND lead_id = ${delArr}`); } catch { /* table absent */ }
+      try { await tx.execute(sql`DELETE FROM follow_up_enrollments WHERE lead_id = ${delArr}`); } catch { /* table/col absent */ }
+      try { await tx.execute(sql`UPDATE quotes SET lead_id = NULL WHERE lead_id = ${delArr}`); } catch { /* col absent */ }
+      try { await tx.execute(sql`UPDATE sms_messages SET lead_id = NULL WHERE lead_id = ${delArr}`); } catch { /* col absent */ }
+      await tx.execute(sql`DELETE FROM leads WHERE company_id = ${companyId} AND id = ${delArr}`);
     });
 
     await logAudit(req, "lead.bulk_delete", "lead", null, null,


### PR DESCRIPTION
The selection UI worked, but clicking Delete did nothing — this is why.

Every id match in the bulk-delete used `ANY(${jsArray}::int[])` inside a **raw `db.execute`**, which doesn't bind correctly in this setup (the same failure that broke `techs-with-status` earlier this session). So the leads `DELETE` threw and 500'd the request — silently, from the operator's side.

Fix: switch to the CSV + `sql.raw` `ANY(ARRAY[...]::int[])` pattern that's proven in `rollup.ts`. The ids are integer-filtered (`Number.isInteger`) before interpolation, so it's injection-safe. Applied to the select, the leads delete, and every child-cleanup statement.

After this deploys: select rows → Delete N → they're gone.

api-server build passes (the pre-existing `parseInt(req.params.id)` tsc warnings are unrelated and present on main).

https://claude.ai/code/session_019PiXXwFgtNSnzZQy3MTjAj

---
_Generated by [Claude Code](https://claude.ai/code/session_019PiXXwFgtNSnzZQy3MTjAj)_