### PR TITLE
fix(mobile): batch 2 — responsive Leads/Jobs/Payroll tables + overflow

### DIFF
--- a/artifacts/qleno/src/pages/jobs-list.tsx
+++ b/artifacts/qleno/src/pages/jobs-list.tsx
@@ -309,8 +309,9 @@ export default function JobsListPage() {
           </div>
         </div>
 
-        {/* KPI Strip */}
-        <div style={{ display: "grid", gridTemplateColumns: "repeat(5, 1fr)", gap: 16, marginBottom: 24 }}>
+        {/* KPI Strip — auto-fit so it wraps to 2–3 per row on phones instead of
+            forcing 5 wide columns off-screen. */}
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(150px, 1fr))", gap: 16, marginBottom: 24 }}>
           {[
             { label: "REVENUE", value: kpi ? `${fmtMoney(kpi.revenue_min)} \u2013 ${fmtMoney(kpi.revenue_max)}` : "\u2014", accent: true },
             { label: "COMPLETED", value: kpi?.completed?.toLocaleString() ?? "\u2014" },

--- a/artifacts/qleno/src/pages/leads.tsx
+++ b/artifacts/qleno/src/pages/leads.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { getAuthHeaders } from "@/lib/auth";
 import { formatAddress } from "@/lib/format-address";
 import { DashboardLayout } from "@/components/layout/dashboard-layout";
+import { useIsMobile } from "@/hooks/use-mobile";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -759,8 +760,12 @@ export default function LeadsPage() {
   const searchTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // View + advanced filters
+  const isMobile = useIsMobile();
   const [view, setView] = useState<"list" | "board">(() =>
     (typeof localStorage !== "undefined" && localStorage.getItem("leads_view") === "board") ? "board" : "list");
+  // Force List view on mobile — the kanban board isn't usable on a phone and
+  // widens the page. (Board toggle is also hidden on mobile in the header.)
+  useEffect(() => { if (isMobile && view === "board") setView("list"); }, [isMobile, view]);
   const [showFilters, setShowFilters] = useState(false);
   const [fOwner, setFOwner] = useState("");
   const [fSource, setFSource] = useState("");
@@ -914,7 +919,7 @@ export default function LeadsPage() {
 
         {/* Page header */}
         <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between",
-          marginBottom: 24 }}>
+          gap: 12, flexWrap: "wrap", marginBottom: 24 }}>
           <div>
             <h1 style={{ fontSize: 22, fontWeight: 700, color: "#1A1917", margin: 0 }}>
               Lead Pipeline
@@ -929,8 +934,9 @@ export default function LeadsPage() {
               {total.toLocaleString()} total lead{total !== 1 ? "s" : ""}
             </p>
           </div>
-          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-            {/* View toggle */}
+          <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap", justifyContent: "flex-end" }}>
+            {/* View toggle — Board is hidden on mobile (kanban isn't usable on a phone). */}
+            {!isMobile && (
             <div style={{ display: "flex", border: "1px solid #E5E2DC", borderRadius: 8, overflow: "hidden" }}>
               <button onClick={() => setView("list")} title="List view"
                 style={{ display: "flex", alignItems: "center", gap: 5, padding: "7px 12px", fontSize: 13,
@@ -945,6 +951,7 @@ export default function LeadsPage() {
                 <LayoutGrid size={14} /> Board
               </button>
             </div>
+            )}
             <Button variant="outline" onClick={() => setShowFilters(s => !s)}
               style={{ gap: 6, display: "flex", alignItems: "center",
                 ...(activeFilterCount ? { borderColor: "#1A1917", color: "#1A1917" } : {}) }}>
@@ -1088,8 +1095,8 @@ export default function LeadsPage() {
 
         {/* Table (list view) */}
         {view === "list" && (
-        <div style={{ background: "#fff", border: "1px solid #E5E2DC", borderRadius: 10, overflow: "hidden" }}>
-          <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 14 }}>
+        <div style={{ background: "#fff", border: "1px solid #E5E2DC", borderRadius: 10, overflowX: "auto", WebkitOverflowScrolling: "touch" as any }}>
+          <table style={{ width: "100%", minWidth: 760, borderCollapse: "collapse", fontSize: 14 }}>
             <thead>
               <tr style={{ background: "#F7F6F3", borderBottom: "1px solid #E5E2DC" }}>
                 <th style={{ padding: "10px 0 10px 14px", width: 36 }}>

--- a/artifacts/qleno/src/pages/payroll.tsx
+++ b/artifacts/qleno/src/pages/payroll.tsx
@@ -786,7 +786,7 @@ export default function PayrollPage() {
         <PayrollToRevenueChart />
 
         {/* Employee Payroll Table */}
-        <div style={{ backgroundColor: '#FFFFFF', border: '1px solid #E5E2DC', borderRadius: '10px', overflow: 'hidden' }}>
+        <div style={{ backgroundColor: '#FFFFFF', border: '1px solid #E5E2DC', borderRadius: '10px', overflowX: 'auto', WebkitOverflowScrolling: 'touch' as any }}>
           <div style={{ padding: '16px 20px', borderBottom: '1px solid #EEECE7', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
             <p style={{ fontSize: '15px', fontWeight: 600, color: '#1A1917', margin: 0 }}>Employee Payroll Summary</p>
             <span style={{ fontSize: '12px', color: '#6B7280' }}>{CADENCE_LABEL[cadence] || 'Weekly'} · {periodLabel}</span>


### PR DESCRIPTION
Phase 2 Batch 2. Leads: wrap header/toolbar, contained list-table scroll, force List view on mobile (hide Board). Jobs list: KPI strip auto-fit (overflow source); table already contained. Payroll: summary table scrolls vs clips (detail table already contained). 🤖 Generated with [Claude Code](https://claude.com/claude-code)