### PR TITLE
Payroll visual pass + quotes crash fix + booked-revenue attribution

### DIFF
--- a/artifacts/api-server/src/routes/lead-analytics.ts
+++ b/artifacts/api-server/src/routes/lead-analytics.ts
@@ -7,9 +7,10 @@
  *  GET/POST/PATCH/DELETE /api/lead-analytics/spend      — marketing spend.
  *  GET/PUT /api/lead-analytics/targets                  — KPI targets.
  *
- * Booked revenue convention (approved): sum of actual booked jobs' value
- * (billed_amount ?? base_fee) for lead-sourced jobs whose scheduled_date is in
- * the window.
+ * Booked revenue convention (approved 2026-06-15): sum of actual booked jobs'
+ * value (billed_amount ?? base_fee) for lead-sourced jobs, attributed to the
+ * period the lead was BOOKED in (booked_at, falling back to created_at) — not
+ * the job's scheduled_date. Matches standard sales-report attribution.
  */
 
 import { Router } from "express";
@@ -127,14 +128,21 @@ router.get("/report", requireAuth, requireRole("owner", "admin", "office"), asyn
       { bucket: "31+ days", count: num(pr.age_31p) },
     ];
 
-    // Booked revenue = lead-sourced jobs whose scheduled_date in window
+    // Booked revenue = actual job value of leads BOOKED in the window.
+    // [revenue-attribution 2026-06-15] Attribute the won deal to WHEN it was
+    // booked (the conversion event), not when the job is scheduled — standard
+    // sales-report convention, and it stops future-dated jobs from
+    // understating the current period. Value still comes from the real job
+    // (billed_amount ?? base_fee). booked_at falls back to created_at for
+    // bookings made without a stage-change timestamp.
     const revRows = await db.execute(sql`
       SELECT COALESCE(SUM(COALESCE(j.billed_amount, j.base_fee, 0)), 0) AS rev
       FROM leads l
       JOIN jobs j ON j.id = l.job_id
       WHERE l.company_id = ${companyId}
-        AND j.scheduled_date >= ${w.from}::date
-        AND j.scheduled_date < (${w.to}::date + interval '1 day')`);
+        AND l.status = 'booked'
+        AND COALESCE(l.booked_at, l.created_at) >= ${w.from}::date
+        AND COALESCE(l.booked_at, l.created_at) < (${w.to}::date + interval '1 day')`);
     const booked_revenue = num((revRows.rows[0] as any)?.rev);
 
     // Marketing spend overlapping the window → CPL / CPA / ROI

--- a/artifacts/qleno/src/pages/payroll.tsx
+++ b/artifacts/qleno/src/pages/payroll.tsx
@@ -278,29 +278,28 @@ function WeeklyDetailView({ period, onPeriodChange }: { period: { start: string;
 
             {isOpen && (
               <div style={{ padding: '16px 20px 18px' }}>
-                {/* Net pay hero — Total pay is commission + tips + mileage −
-                    deductions (advances/breakage), the take-home. Each part
-                    shows as a chip; deductions render red so the net is
-                    explained, not just stated. [payroll-v2 2026-06-13] */}
+                {/* [hierarchy-pass 2026-06-15] Total Pay box — mint (#00A383)
+                    only on the Total Pay headline + Commission chip; every
+                    other figure navy, labels grey. No red/amber. */}
                 {(() => {
                   const deductAmt = sumK('amount_owed');
                   const bonusAmt = sumK('bonus');
                   const chips = [
-                    { label: 'Commission', v: emp.totals.commission, neg: false },
-                    ...(tipsAmt ? [{ label: 'Tips', v: tipsAmt, neg: false }] : []),
-                    ...(mileageAmt ? [{ label: 'Mileage', v: mileageAmt, neg: false }] : []),
-                    ...(bonusAmt ? [{ label: 'Bonus', v: bonusAmt, neg: bonusAmt < 0 }] : []),
-                    ...(timeOffAmt ? [{ label: 'Time Off', v: timeOffAmt, neg: false }] : []),
-                    ...(deductAmt ? [{ label: 'Deductions', v: deductAmt, neg: true }] : []),
+                    { label: 'Commission', v: emp.totals.commission, mint: true, neg: false },
+                    ...(tipsAmt ? [{ label: 'Tips', v: tipsAmt, mint: false, neg: false }] : []),
+                    ...(mileageAmt ? [{ label: 'Mileage', v: mileageAmt, mint: false, neg: false }] : []),
+                    ...(bonusAmt ? [{ label: 'Bonus', v: bonusAmt, mint: false, neg: bonusAmt < 0 }] : []),
+                    ...(timeOffAmt ? [{ label: 'Time Off', v: timeOffAmt, mint: false, neg: false }] : []),
+                    ...(deductAmt ? [{ label: 'Deductions', v: deductAmt, mint: false, neg: true }] : []),
                   ];
                   return (
-                <div style={{ display: 'flex', alignItems: 'center', gap: 30, flexWrap: 'wrap', background: 'linear-gradient(120deg,#F0FDF9,#E9FBF5)', border: '1px solid #B7ECDD', borderRadius: 14, padding: '18px 22px' }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 30, flexWrap: 'wrap', background: 'linear-gradient(120deg,#F0FDF9,#E9FBF5)', border: '1px solid #B7ECDD', borderRadius: 12, padding: '18px 22px' }}>
                   <div style={{ minWidth: 200 }}>
-                    <div style={{ fontSize: 11, fontWeight: 800, color: '#0A6E5A', textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 5 }}>Total pay</div>
-                    <div style={{ fontSize: 30, fontWeight: 800, color: '#04241d', lineHeight: 1 }}>{money(emp.totals.grand_total)}</div>
+                    <div style={{ fontSize: 11, fontWeight: 500, color: '#9B9890', textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 5 }}>Total pay</div>
+                    <div style={{ fontSize: 30, fontWeight: 800, color: '#00A383', lineHeight: 1 }}>{money(emp.totals.grand_total)}</div>
                     <div style={{ marginTop: 11 }}>
                       {chips.map(p => (
-                        <span key={p.label} style={{ display: 'inline-block', fontSize: 11, fontWeight: 700, marginRight: 7, marginBottom: 5, borderRadius: 999, padding: '4px 11px', color: p.neg ? '#B91C1C' : '#0A6E5A', background: p.neg ? '#FEE2E2' : '#D7F5EC' }}>
+                        <span key={p.label} style={{ display: 'inline-block', fontSize: 11, fontWeight: 500, marginRight: 7, marginBottom: 5, borderRadius: 999, padding: '4px 11px', color: p.mint ? '#00A383' : '#6B6860', background: p.mint ? '#E9FBF5' : '#F4F3F0' }}>
                           {p.label} {p.neg && p.v > 0 ? '−' : ''}{money(Math.abs(p.v))}
                         </span>
                       ))}
@@ -313,7 +312,7 @@ function WeeklyDetailView({ period, onPeriodChange }: { period: { start: string;
                       ...(eff != null ? [{ k: 'Efficiency', v: `${eff}%` }] : []),
                       ...(effRate != null ? [{ k: 'Eff. $/hr', v: money(effRate) }] : []),
                     ].map(s => (
-                      <div key={s.k}><div style={{ fontSize: 10, color: '#5C8378', textTransform: 'uppercase', letterSpacing: '0.05em' }}>{s.k}</div><div style={{ fontSize: 17, fontWeight: 800, color: '#04241d', marginTop: 3 }}>{s.v}</div></div>
+                      <div key={s.k}><div style={{ fontSize: 10, color: '#9B9890', textTransform: 'uppercase', letterSpacing: '0.05em' }}>{s.k}</div><div style={{ fontSize: 15, fontWeight: 500, color: '#0A0E1A', marginTop: 3 }}>{s.v}</div></div>
                     ))}
                   </div>
                 </div>
@@ -365,13 +364,15 @@ function WeeklyDetailView({ period, onPeriodChange }: { period: { start: string;
                     const byDay: Record<string, any[]> = {};
                     for (const j of emp.jobs) { const k = String(j.date).slice(0, 10); (byDay[k] = byDay[k] || []).push(j); }
                     const days = Object.keys(byDay).sort();
+                    // [hierarchy-pass 2026-06-15] Eff is plain grey text for
+                    // every row — no pill, no green/amber/red band. 500% and "—"
+                    // read as ordinary values.
                     const effPill = (job: any) => {
                       if (job.hrs_estimated || !(job.hrs_worked > 0) || !(job.hrs_scheduled > 0)) {
-                        return <span style={{ color: '#C4C0B8' }} title={job.hrs_estimated ? 'Not clocked yet' : 'No hours'}>—</span>;
+                        return <span style={{ color: '#9B9890' }} title={job.hrs_estimated ? 'Not clocked yet' : 'No hours'}>—</span>;
                       }
                       const e = Math.round((job.hrs_scheduled / job.hrs_worked) * 100);
-                      const [fg, bg] = e >= 100 ? ['#16A34A', '#DCFCE7'] : e >= 85 ? ['#B45309', '#FEF3E2'] : ['#DC2626', '#FEE2E2'];
-                      return <span style={{ fontSize: 11, fontWeight: 800, color: fg, background: bg, borderRadius: 999, padding: '2px 8px' }}>{e}%</span>;
+                      return <span style={{ fontSize: 12, fontWeight: 400, color: '#9B9890' }}>{e}%</span>;
                     };
                     const laborOf = (billed: number, pay: number) => billed > 0 ? `${Math.round((pay / billed) * 100)}%` : '—';
                     return (
@@ -392,36 +393,38 @@ function WeeklyDetailView({ period, onPeriodChange }: { period: { start: string;
                             const dayPay = byDay[d].reduce((s, j) => s + Number(j.commission || 0), 0);
                             return (
                             <Fragment key={d}>
+                              {/* Day header — stronger 0.5px divider + breathing
+                                  room above; subtotal in quiet greys. */}
                               <tr>
-                                <td colSpan={cols} style={{ padding: '13px 0 4px', borderTop: '1px solid #EEECE7' }}>
-                                  <span style={{ fontSize: 10.5, fontWeight: 800, color: '#6B6860', textTransform: 'uppercase', letterSpacing: '0.07em' }}>{dayName(d)} · {mdy(d)}</span>
-                                  <span style={{ float: 'right', fontSize: 11, fontWeight: 700, color: '#6B6860' }}><span style={{ color: '#9E9B94', fontWeight: 600 }}>{money(dayBilled)} billed · </span>{money(dayPay)}</span>
+                                <td colSpan={cols} style={{ padding: '18px 0 5px', borderTop: '0.5px solid #E5E2DC' }}>
+                                  <span style={{ fontSize: 10.5, fontWeight: 500, color: '#6B6860', textTransform: 'uppercase', letterSpacing: '0.07em' }}>{dayName(d)} · {mdy(d)}</span>
+                                  <span style={{ float: 'right', fontSize: 12, fontWeight: 400 }}><span style={{ color: '#9B9890' }}>{money(dayBilled)} billed · </span><span style={{ color: '#6B6860' }}>{money(dayPay)}</span></span>
                                 </td>
                               </tr>
                               {byDay[d].map((job: any) => {
                                 const billed = Number(job.job_total || 0);
                                 return (
                                 <tr key={job.job_id}>
-                                  <td style={{ ...td, borderTop: 'none', paddingTop: 6, paddingBottom: 6 }}>
-                                    <div style={{ fontSize: 13, fontWeight: 600, color: '#1A1917' }}>{job.client || '—'}</div>
-                                    <div style={{ fontSize: 11, color: '#9E9B94' }} title="How this line's pay was computed">{fmtScope(job.scope)}{job.pay_basis ? ` · ${job.pay_basis}` : ''}</div>
+                                  <td style={{ ...td, borderTop: '0.5px solid #F0EEE8', paddingTop: 7, paddingBottom: 7 }}>
+                                    <div style={{ fontSize: 14, fontWeight: 400, color: '#0A0E1A' }}>{job.client || '—'}</div>
+                                    <div style={{ fontSize: 12, color: '#9B9890' }} title="How this line's pay was computed">{fmtScope(job.scope)}{job.pay_basis ? ` · ${job.pay_basis}` : ''}</div>
                                   </td>
-                                  <td style={{ ...td, borderTop: 'none', textAlign: 'right', fontWeight: 700, whiteSpace: 'nowrap' }}>{billed > 0 ? money(billed) : '—'}</td>
-                                  <td style={{ ...td, borderTop: 'none', textAlign: 'right', whiteSpace: 'nowrap' }}>
-                                    <span style={{ fontWeight: 700, color: job.hrs_estimated ? '#B45309' : '#1A1917' }} title={job.hrs_estimated ? 'Scheduled — not clocked yet' : 'Clocked'}>{job.hrs_estimated ? '≈' : ''}{job.hrs_worked.toFixed(1)}h</span>
-                                    <span style={{ color: '#9E9B94' }}> / {job.hrs_scheduled.toFixed(1)}h</span>
+                                  <td style={{ ...td, borderTop: '0.5px solid #F0EEE8', textAlign: 'right', fontSize: 14, fontWeight: 400, color: '#0A0E1A', whiteSpace: 'nowrap' }}>{billed > 0 ? money(billed) : '—'}</td>
+                                  <td style={{ ...td, borderTop: '0.5px solid #F0EEE8', textAlign: 'right', fontSize: 14, fontWeight: 400, whiteSpace: 'nowrap' }}>
+                                    <span style={{ color: '#0A0E1A' }} title={job.hrs_estimated ? 'Scheduled — not clocked yet' : 'Clocked'}>{job.hrs_estimated ? '≈' : ''}{job.hrs_worked.toFixed(1)}h</span>
+                                    <span style={{ color: '#9B9890' }}> / {job.hrs_scheduled.toFixed(1)}h</span>
                                   </td>
-                                  <td style={{ ...td, borderTop: 'none', textAlign: 'center' }}>{effPill(job)}</td>
+                                  <td style={{ ...td, borderTop: '0.5px solid #F0EEE8', textAlign: 'center' }}>{effPill(job)}</td>
                                   {hasQuality && (
-                                    <td style={{ ...td, borderTop: 'none', textAlign: 'center' }}>
+                                    <td style={{ ...td, borderTop: '0.5px solid #F0EEE8', textAlign: 'center' }}>
                                       {job.quality_score != null
-                                        ? <span style={{ fontWeight: 700, color: qualityColor(job.quality_score) }}>{job.quality_score}/4</span>
-                                        : <span style={{ color: '#C4C0B8' }}>—</span>}
+                                        ? <span style={{ fontSize: 12, fontWeight: 400, color: '#9B9890' }}>{job.quality_score}/4</span>
+                                        : <span style={{ color: '#9B9890' }}>—</span>}
                                     </td>
                                   )}
-                                  <td style={{ ...td, borderTop: 'none', textAlign: 'right', whiteSpace: 'nowrap' }}>
-                                    <span style={{ fontWeight: 700, color: 'var(--brand)' }}>${job.commission.toFixed(2)}</span>
-                                    <span style={{ fontSize: 11, color: '#9E9B94', marginLeft: 6 }}>{laborOf(billed, Number(job.commission || 0))}</span>
+                                  <td style={{ ...td, borderTop: '0.5px solid #F0EEE8', textAlign: 'right', whiteSpace: 'nowrap' }}>
+                                    <span style={{ fontSize: 14, fontWeight: 400, color: '#00A383' }}>${job.commission.toFixed(2)}</span>
+                                    <span style={{ fontSize: 11, fontWeight: 400, color: '#9B9890', marginLeft: 6 }}>{laborOf(billed, Number(job.commission || 0))}</span>
                                   </td>
                                 </tr>
                                 );
@@ -429,15 +432,16 @@ function WeeklyDetailView({ period, onPeriodChange }: { period: { start: string;
                             </Fragment>
                             );
                           })}
+                          {/* Footer total — weight 500, 1.5px divider, mint pay. */}
                           <tr>
-                            <td style={{ ...td, fontWeight: 800, borderTop: '2px solid #E5E2DC' }}>{emp.totals.job_count} jobs</td>
-                            <td style={{ ...td, fontWeight: 800, textAlign: 'right', borderTop: '2px solid #E5E2DC', whiteSpace: 'nowrap' }}>{money(billedTotal)}</td>
-                            <td style={{ ...td, fontWeight: 800, textAlign: 'right', borderTop: '2px solid #E5E2DC', whiteSpace: 'nowrap' }}>{emp.totals.hrs_worked.toFixed(1)}h / {emp.totals.hrs_scheduled.toFixed(1)}h</td>
-                            <td style={{ ...td, fontWeight: 800, textAlign: 'center', borderTop: '2px solid #E5E2DC' }}>{emp.totals.hrs_worked > 0 && emp.totals.hrs_scheduled > 0 ? `${Math.round((emp.totals.hrs_scheduled / emp.totals.hrs_worked) * 100)}%` : '—'}</td>
-                            {hasQuality && <td style={{ ...td, fontWeight: 800, textAlign: 'center', borderTop: '2px solid #E5E2DC', color: qualityColor(emp.totals.quality_avg) }}>{emp.totals.quality_avg != null ? `${emp.totals.quality_avg.toFixed(1)}/4` : '—'}</td>}
-                            <td style={{ ...td, fontWeight: 800, textAlign: 'right', borderTop: '2px solid #E5E2DC', whiteSpace: 'nowrap' }}>
-                              <span style={{ color: 'var(--brand)' }}>${emp.totals.commission.toFixed(2)}</span>
-                              <span style={{ fontSize: 11, color: '#9E9B94', marginLeft: 6 }}>{laborPct != null ? `${laborPct}%` : '—'}</span>
+                            <td style={{ ...td, fontWeight: 500, color: '#0A0E1A', borderTop: '1.5px solid #D8D5CD' }}>{emp.totals.job_count} jobs</td>
+                            <td style={{ ...td, fontWeight: 500, color: '#0A0E1A', textAlign: 'right', borderTop: '1.5px solid #D8D5CD', whiteSpace: 'nowrap' }}>{money(billedTotal)}</td>
+                            <td style={{ ...td, fontWeight: 500, color: '#0A0E1A', textAlign: 'right', borderTop: '1.5px solid #D8D5CD', whiteSpace: 'nowrap' }}>{emp.totals.hrs_worked.toFixed(1)}h / {emp.totals.hrs_scheduled.toFixed(1)}h</td>
+                            <td style={{ ...td, fontWeight: 500, color: '#9B9890', textAlign: 'center', borderTop: '1.5px solid #D8D5CD' }}>{emp.totals.hrs_worked > 0 && emp.totals.hrs_scheduled > 0 ? `${Math.round((emp.totals.hrs_scheduled / emp.totals.hrs_worked) * 100)}%` : '—'}</td>
+                            {hasQuality && <td style={{ ...td, fontWeight: 500, color: '#9B9890', textAlign: 'center', borderTop: '1.5px solid #D8D5CD' }}>{emp.totals.quality_avg != null ? `${emp.totals.quality_avg.toFixed(1)}/4` : '—'}</td>}
+                            <td style={{ ...td, fontWeight: 500, textAlign: 'right', borderTop: '1.5px solid #D8D5CD', whiteSpace: 'nowrap' }}>
+                              <span style={{ color: '#00A383' }}>${emp.totals.commission.toFixed(2)}</span>
+                              <span style={{ fontSize: 11, fontWeight: 400, color: '#9B9890', marginLeft: 6 }}>{laborPct != null ? `${laborPct}%` : '—'}</span>
                             </td>
                           </tr>
                         </tbody>

--- a/artifacts/qleno/src/pages/quotes.tsx
+++ b/artifacts/qleno/src/pages/quotes.tsx
@@ -99,6 +99,15 @@ function displayPrice(q: Quote) {
   return `$${parseFloat(p).toFixed(2)}`;
 }
 
+// [crash-fix 2026-06-15] date-fns format() THROWS on a null/invalid date,
+// which took down the whole Quotes page via the error boundary. Guard it so a
+// bad/missing created_at renders "—" instead of crashing the page.
+function safeDate(value: string | null | undefined, fmt = "MMM d, yyyy") {
+  if (!value) return "—";
+  const d = new Date(value);
+  return isNaN(d.getTime()) ? "—" : format(d, fmt);
+}
+
 function SkeletonCard() {
   return (
     <div style={{ borderBottom: "1px solid #F0EEE9", padding: "16px", display: "flex", flexDirection: "column", gap: 8 }}>
@@ -301,7 +310,7 @@ export default function QuotesPage() {
                     </div>
                     {/* Row 3: date */}
                     <div style={{ fontSize: 12, color: "#6B6860", fontFamily: FF }}>
-                      {format(new Date(quote.created_at), "MMM d, yyyy")}
+                      {safeDate(quote.created_at)}
                     </div>
                   </div>
                 );
@@ -416,7 +425,7 @@ export default function QuotesPage() {
                       <TableCell className="text-sm text-[#6B7280] max-w-[180px] truncate">{quote.address || "—"}</TableCell>
                       <TableCell className="text-sm font-semibold text-[#1A1917]">{displayPrice(quote)}</TableCell>
                       <TableCell><span className={`text-xs px-2 py-0.5 rounded-full font-medium ${cfg.className}`}>{cfg.label}</span></TableCell>
-                      <TableCell className="text-sm text-[#9E9B94]">{format(new Date(quote.created_at), "MMM d, yyyy")}</TableCell>
+                      <TableCell className="text-sm text-[#9E9B94]">{safeDate(quote.created_at)}</TableCell>
                       <TableCell onClick={e => e.stopPropagation()}>
                         <DropdownMenu>
                           <DropdownMenuTrigger asChild>


### PR DESCRIPTION
Three commits on this PR:

## 1. Quotes page crash ("Something went wrong")
`date-fns` `format()` throws on a null/invalid `created_at`, and since it's in render the error boundary turned one bad row into a full-page crash. Added `safeDate()` — invalid/missing dates render "—". Applied to both mobile + desktop rows.

## 2. Lead Reporting — Booked Revenue by booking date
Attributes the won deal to when the lead was **booked** (`booked_at`, fallback `created_at`) instead of the job's `scheduled_date` — standard sales-report convention; stops future-dated jobs from understating the period (the $412 vs 8-bookings issue). Value still = real job `billed_amount ?? base_fee`.

## 3. Payroll By Employee — visual hierarchy pass (CSS/markup only)
Mint `#00A383` as the only accent (per-client Pay, Total Pay headline + Commission chip, footer total); everything else navy, labels grey. No red/amber — Eff is plain grey for every row (incl. 500% and "—"), `≈` no longer amber, deductions chip no longer red. Two weight tiers (400/500), day-group dividers, footer 1.5px rule. Single inline block in `WeeklyDetailView`.
*Spec ambiguity flagged:* day-subtotal pay rendered grey `#6B6860` (not mint) — the per-row Pay column is the single mint anchor. Easy to flip.

Both builds pass.

https://claude.ai/code/session_019PiXXwFgtNSnzZQy3MTjAj