### PR TITLE
fix(mobile): target /dispatch (not /jobs) for voice FAB suppression

### DIFF
--- a/artifacts/qleno/src/components/voice-assistant.tsx
+++ b/artifacts/qleno/src/components/voice-assistant.tsx
@@ -7,8 +7,9 @@ import { Mic, X, Navigation, Loader2, Volume2 } from "lucide-react";
 // right-edge row controls that the floating mic would overlap (message-thread
 // Send button, dispatch list rows). The FAB is suppressed on these so it can
 // never sit on top of an interactive control. Prefix-matched, route-based
-// (not tenant data) so this stays multi-tenant safe.
-const FAB_HIDDEN_ROUTES = ["/messages", "/jobs"];
+// (not tenant data) so this stays multi-tenant safe. Note: the dispatch board
+// is /dispatch (JobsPage); /jobs only redirects to the reports list.
+const FAB_HIDDEN_ROUTES = ["/messages", "/dispatch"];
 
 // [voice-assistant 2026-06-08] Push-to-talk field assistant for techs. Browser
 // speech-to-text captures the spoken question, POSTs it to /api/assistant/ask


### PR DESCRIPTION
Follow-up to #489. The dispatch board is JobsPage at `/dispatch`; `/jobs` only redirects to the reports jobs list. The first cut listed `/jobs`, which matched no real rendered route, so the mic FAB still showed over dispatch list-row controls. Corrected to `/dispatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)