### PR TITLE
feat(scorecards): GAP3 — office reply to customer feedback on employee profile

### DIFF
--- a/artifacts/api-server/src/index.ts
+++ b/artifacts/api-server/src/index.ts
@@ -173,6 +173,13 @@ async function startup() {
   } catch (err: any) {
     console.error("[startup] ensureBookingConfirmationSetup — non-fatal:", err?.message ?? err);
   }
+  // [GAP3] office-reply columns on scorecard_entries
+  try {
+    const { ensureScorecardReplyColumns } = await import("./lib/scorecard-engine.js");
+    await ensureScorecardReplyColumns();
+  } catch (err: any) {
+    console.error("[startup] ensureScorecardReplyColumns — non-fatal:", err?.message ?? err);
+  }
   // [revenue-connect 2026-06-12] job_history live bridge — mirrors completed
   // jobs into the revenue ledger past each tenant's MC-import end date, so
   // the dashboard forecast / business health / client history stay live

--- a/artifacts/api-server/src/lib/scorecard-engine.ts
+++ b/artifacts/api-server/src/lib/scorecard-engine.ts
@@ -1,6 +1,20 @@
 import { db } from "@workspace/db";
 import { sql } from "drizzle-orm";
 
+// [GAP3] Idempotent startup migration for the office-reply columns on
+// scorecard_entries. The drizzle schema declares them; this brings the live DB
+// in line (no auto-migrate). Safe to re-run.
+export async function ensureScorecardReplyColumns(): Promise<void> {
+  try {
+    await db.execute(sql`ALTER TABLE scorecard_entries ADD COLUMN IF NOT EXISTS office_reply text`);
+    await db.execute(sql`ALTER TABLE scorecard_entries ADD COLUMN IF NOT EXISTS office_reply_by_user_id integer`);
+    await db.execute(sql`ALTER TABLE scorecard_entries ADD COLUMN IF NOT EXISTS office_reply_at timestamp`);
+    console.log("[scorecard-reply] columns ready");
+  } catch (err) {
+    console.error("[scorecard-reply] ensure columns error (non-fatal):", err);
+  }
+}
+
 // MaidCentral-verified scorecard formula: scorecard_pct = unweighted MEAN of
 // non-excluded per-job customer responses (0–4 scale) ÷ max × 100. Written to
 // users.scorecard_pct as the LIVE value (source='qleno'); the imported MC

--- a/artifacts/api-server/src/routes/scorecards.ts
+++ b/artifacts/api-server/src/routes/scorecards.ts
@@ -205,6 +205,38 @@ router.get("/entries/:employee_id", requireAuth, async (req, res) => {
   }
 });
 
+// [GAP3] Office/owner reply to the customer's feedback on a scorecard entry.
+// Surfaces on the employee profile Scorecards tab next to the customer comment.
+// Owner/admin/office only; tenant-scoped. Send reply: "" to clear.
+router.post("/entries/:entryId/reply", requireAuth, requireRole("owner", "admin", "office"), async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId!;
+    const entryId = parseInt(req.params.entryId);
+    if (isNaN(entryId)) return res.status(400).json({ error: "Invalid entryId" });
+    const reply = typeof req.body?.reply === "string" ? req.body.reply.trim() : "";
+    const cleared = reply.length === 0;
+
+    const updated = await db
+      .update(scorecardEntriesTable)
+      .set({
+        office_reply: cleared ? null : reply.slice(0, 2000),
+        office_reply_by_user_id: cleared ? null : req.auth!.userId,
+        office_reply_at: cleared ? null : new Date(),
+      })
+      .where(and(
+        eq(scorecardEntriesTable.id, entryId),
+        eq(scorecardEntriesTable.company_id, companyId),
+      ))
+      .returning();
+
+    if (!updated[0]) return res.status(404).json({ error: "Not Found", message: "Scorecard entry not found" });
+    return res.json({ entry: updated[0] });
+  } catch (err) {
+    console.error("Scorecard reply error:", err);
+    return res.status(500).json({ error: "Internal Server Error", message: "Failed to save reply" });
+  }
+});
+
 // ── MaidCentral scorecard import (bulk) ──────────────────────────────────────
 // Loads (a) each employee's authoritative MC scorecard % into users.scorecard_pct
 // (stored as-is, NOT recomputed) and (b) per-job history into scorecard_entries.

--- a/artifacts/qleno/src/pages/employee-profile.tsx
+++ b/artifacts/qleno/src/pages/employee-profile.tsx
@@ -598,12 +598,31 @@ export default function EmployeeProfilePage() {
   });
 
   // MaidCentral % model: per-job history (scorecard_entries) + authoritative %.
-  const { data: scEntriesData } = useQuery({
+  const { data: scEntriesData, refetch: refetchScEntries } = useQuery({
     queryKey: ['scorecard-entries', userId],
     queryFn: () => apiFetch(`/scorecards/entries/${userId}`),
     enabled: activeTab === 'Scorecards',
   });
   const scEntries: any[] = scEntriesData?.entries || [];
+
+  // [GAP3] Office reply to customer feedback on a scorecard entry.
+  const canReplyToFeedback = ['owner', 'admin', 'office'].includes(getTokenRole() || '');
+  const [replyOpenId, setReplyOpenId] = useState<number | null>(null);
+  const [replyText, setReplyText] = useState('');
+  const [replySaving, setReplySaving] = useState(false);
+  async function submitFeedbackReply(entryId: number) {
+    setReplySaving(true);
+    try {
+      await apiFetch(`/scorecards/entries/${entryId}/reply`, { method: 'POST', body: JSON.stringify({ reply: replyText }) });
+      setReplyOpenId(null); setReplyText('');
+      await refetchScEntries();
+      showToast('Reply saved');
+    } catch {
+      showToast('Failed to save reply');
+    } finally {
+      setReplySaving(false);
+    }
+  }
 
   // Efficiency by Qleno package/scope (MaidCentral parity). catalog = every
   // Qleno package; rows = the ones with data. No-data packages render blank.
@@ -1343,7 +1362,39 @@ export default function EmployeeProfilePage() {
                               {scoreLabel}
                             </span>
                           </td>
-                          <td style={{ padding:'12px 16px',fontSize:13,color:'#6B7280' }}>{s.notes || '—'}</td>
+                          <td style={{ padding:'12px 16px',fontSize:13,color:'#6B7280' }}>
+                            <div>{s.notes || '—'}</div>
+                            {s.office_reply && (
+                              <div style={{ marginTop:8, padding:'8px 10px', background:'#F3F8F6', border:'1px solid #D7EBE4', borderRadius:8, color:'#1A1917' }}>
+                                <span style={{ fontSize:11, fontWeight:700, color:'#0A7C63', textTransform:'uppercase', letterSpacing:'0.04em' }}>Office reply</span>
+                                <div style={{ fontSize:13, marginTop:2 }}>{s.office_reply}</div>
+                              </div>
+                            )}
+                            {canReplyToFeedback && (
+                              replyOpenId === s.id ? (
+                                <div style={{ marginTop:8 }}>
+                                  <textarea value={replyText} onChange={e => setReplyText(e.target.value)} rows={2} autoFocus
+                                    placeholder="Write a reply to this feedback…"
+                                    style={{ width:'100%', resize:'vertical', padding:'8px 10px', border:'1px solid #E5E2DC', borderRadius:8, fontSize:13, fontFamily:"'Plus Jakarta Sans', sans-serif" }} />
+                                  <div style={{ display:'flex', gap:8, marginTop:6 }}>
+                                    <button onClick={() => submitFeedbackReply(s.id)} disabled={replySaving}
+                                      style={{ background:'var(--brand)', color:'#04241d', border:'none', borderRadius:6, padding:'5px 12px', fontSize:12, fontWeight:700, cursor:'pointer', opacity:replySaving?0.6:1 }}>
+                                      {replySaving ? 'Saving…' : 'Save reply'}
+                                    </button>
+                                    <button onClick={() => { setReplyOpenId(null); setReplyText(''); }}
+                                      style={{ background:'none', color:'#6B7280', border:'1px solid #E5E2DC', borderRadius:6, padding:'5px 12px', fontSize:12, cursor:'pointer' }}>
+                                      Cancel
+                                    </button>
+                                  </div>
+                                </div>
+                              ) : (
+                                <button onClick={() => { setReplyOpenId(s.id); setReplyText(s.office_reply || ''); }}
+                                  style={{ marginTop:6, background:'none', color:'var(--brand)', border:'none', padding:0, fontSize:12, fontWeight:600, cursor:'pointer' }}>
+                                  {s.office_reply ? 'Edit reply' : 'Reply'}
+                                </button>
+                              )
+                            )}
+                          </td>
                         </tr>
                       );
                     })}

--- a/lib/db/src/schema/scorecard_entries.ts
+++ b/lib/db/src/schema/scorecard_entries.ts
@@ -28,6 +28,11 @@ export const scorecardEntriesTable = pgTable("scorecard_entries", {
   // Links a qleno entry back to its customer survey response.
   survey_id: integer("survey_id"),
   notes: text("notes"),
+  // [GAP3] Office/owner reply to the customer's feedback on this entry. Shown
+  // on the employee profile Scorecards tab next to the customer comment.
+  office_reply: text("office_reply"),
+  office_reply_by_user_id: integer("office_reply_by_user_id").references(() => usersTable.id),
+  office_reply_at: timestamp("office_reply_at"),
   created_at: timestamp("created_at").notNull().defaultNow(),
 }, (t) => [
   index("idx_scorecard_entries_emp").on(t.company_id, t.employee_id),


### PR DESCRIPTION
**Readiness GAP 3 (Step 6).** The office/owner can now reply to a customer's scorecard feedback; the reply appears on the employee profile next to the comment.

- `scorecard_entries` gains `office_reply` / `office_reply_by_user_id` / `office_reply_at` (drizzle schema + idempotent startup ALTER).
- `POST /api/scorecards/entries/:entryId/reply` (owner/admin/office, tenant-scoped) saves/clears the reply. The existing `GET /entries/:employee_id` returns the fields automatically.
- Employee profile Scorecards tab: each entry shows the customer note, the office reply when present, and a Reply/Edit control for office roles.

Multi-tenant, role-gated, no Phes hardcoding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)