### PR TITLE
fix(quotes): list visibility + quote→lead enrichment + Save & Send delivery

### DIFF
--- a/artifacts/api-server/src/lib/lead-sync.ts
+++ b/artifacts/api-server/src/lib/lead-sync.ts
@@ -18,12 +18,20 @@ async function logActivity(companyId: number, leadId: number, action: string, no
 // link quotes.lead_id, return the lead id.
 export async function upsertLeadForQuote(companyId: number, quote: any): Promise<number | null> {
   try {
-    if (quote.lead_id) return quote.lead_id;
     const email = quote.lead_email ? String(quote.lead_email).toLowerCase().trim() : null;
     const phone10 = digits(quote.lead_phone).slice(-10) || null;
+    const nameParts = String(quote.lead_name ?? "").trim().split(/\s+/).filter(Boolean);
+    const first = nameParts[0] || null;
+    const last = nameParts.slice(1).join(" ") || null;
+    // Scope label for the lead pipeline (the quote stamps the scope name onto
+    // service_type at create).
+    const scope = quote.service_type || null;
+    const address = quote.address ?? null;
 
-    let leadId: number | null = null;
-    if (email || phone10) {
+    // Resolve the lead: the quote's existing link first, else match by
+    // email/phone within the company, else create.
+    let leadId: number | null = quote.lead_id ?? null;
+    if (!leadId && (email || phone10)) {
       const m = await db.execute(sql`
         SELECT id FROM leads WHERE company_id = ${companyId} AND (
           (${email}::text IS NOT NULL AND lower(email) = ${email}) OR
@@ -33,16 +41,31 @@ export async function upsertLeadForQuote(companyId: number, quote: any): Promise
     }
 
     if (!leadId) {
-      const nameParts = String(quote.lead_name ?? "").trim().split(/\s+/);
-      const first = nameParts[0] || quote.lead_name || "Lead";
-      const last = nameParts.slice(1).join(" ") || "";
+      // Create. Only fall back to "Lead" as a last resort when there's truly no
+      // name yet (e.g. a draft autosave before the office filled in the quote).
+      const insFirst = first || quote.lead_name || "Lead";
       const ins = await db.execute(sql`
-        INSERT INTO leads (company_id, first_name, last_name, email, phone, address, source, status, created_at, updated_at)
-        VALUES (${companyId}, ${first}, ${last}, ${quote.lead_email ?? null}, ${quote.lead_phone ?? null},
-                ${quote.address ?? null}, ${quote.referral_source || "quote"}, 'needs_contacted', NOW(), NOW())
+        INSERT INTO leads (company_id, first_name, last_name, email, phone, address, scope, source, status, created_at, updated_at)
+        VALUES (${companyId}, ${insFirst}, ${last}, ${quote.lead_email ?? null}, ${quote.lead_phone ?? null},
+                ${address}, ${scope}, ${quote.referral_source || "quote"}, 'needs_contacted', NOW(), NOW())
         RETURNING id`);
       leadId = (ins.rows[0] as any).id;
       await logActivity(companyId, leadId!, "created", "Lead created from quote", null);
+    } else {
+      // Enrich the existing lead. The lead is frequently created bare during
+      // draft autosave (no name/contact); fill/refresh its descriptive fields
+      // from the quote. COALESCE(NULLIF(...)) overwrites a placeholder/value
+      // when the quote provides one, but never wipes an existing value with null.
+      await db.execute(sql`
+        UPDATE leads SET
+          first_name = COALESCE(NULLIF(${first}, ''), first_name),
+          last_name  = COALESCE(NULLIF(${last}, ''), last_name),
+          email      = COALESCE(${quote.lead_email ?? null}, email),
+          phone      = COALESCE(${quote.lead_phone ?? null}, phone),
+          address    = COALESCE(${address}, address),
+          scope      = COALESCE(${scope}, scope),
+          updated_at = NOW()
+        WHERE id = ${leadId} AND company_id = ${companyId}`);
     }
     await db.execute(sql`UPDATE quotes SET lead_id = ${leadId} WHERE id = ${quote.id} AND company_id = ${companyId}`);
     return leadId;
@@ -61,6 +84,7 @@ export async function advanceLeadStage(
         ${stampCol ? sql`, ${sql.raw(stampCol)} = COALESCE(${sql.raw(stampCol)}, NOW())` : sql``}
         ${opts.jobId != null ? sql`, job_id = ${opts.jobId}` : sql``}
         ${opts.quoteAmount != null ? sql`, quote_amount = ${String(opts.quoteAmount)}` : sql``}
+        ${opts.userId != null ? sql`, assigned_to = COALESCE(assigned_to, ${opts.userId})` : sql``}
        WHERE id = ${leadId} AND company_id = ${companyId}`);
     await logActivity(companyId, leadId, `stage_${stage}`, opts.note ?? null, opts.userId);
   } catch (e) { console.error("[lead-sync] advanceLeadStage", e); }

--- a/artifacts/api-server/src/routes/quotes.ts
+++ b/artifacts/api-server/src/routes/quotes.ts
@@ -91,9 +91,11 @@ router.get("/stats", requireAuth, async (req, res) => {
   try {
     const now = new Date();
     const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
-    const { branch_id } = req.query;
+    // NOTE: quotes are NOT branch-columned (the quotes table has no branch_id),
+    // so we do NOT filter by branch here. A prior branch_id filter referenced a
+    // nonexistent column and made the whole query fail → empty list + KPIs at 0
+    // whenever a branch was selected (which single-branch tenants always do).
     const statsConds: any[] = [eq(quotesTable.company_id, req.auth!.companyId)];
-    if (branch_id && branch_id !== "all") statsConds.push(eq(quotesTable.branch_id, parseInt(branch_id as string)));
 
     const allQuotes = await db.select({ status: quotesTable.status, accepted_at: quotesTable.accepted_at, booked_job_id: quotesTable.booked_job_id })
       .from(quotesTable)
@@ -113,11 +115,13 @@ router.get("/stats", requireAuth, async (req, res) => {
 
 router.get("/", requireAuth, async (req, res) => {
   try {
-    const { status, client_id, branch_id } = req.query;
+    const { status, client_id } = req.query;
     const conditions: any[] = [eq(quotesTable.company_id, req.auth!.companyId)];
     if (status && status !== "all") conditions.push(eq(quotesTable.status, status as string));
     if (client_id) conditions.push(eq(quotesTable.client_id, parseInt(client_id as string)));
-    if (branch_id && branch_id !== "all") conditions.push(eq(quotesTable.branch_id, parseInt(branch_id as string)));
+    // No branch filter: quotes have no branch_id column. Filtering by it
+    // referenced a nonexistent column and broke the list whenever a branch was
+    // selected (see /stats note above).
 
     const quotes = await db
       .select({
@@ -267,6 +271,11 @@ router.patch("/:id", requireAuth, requireRole("owner", "admin", "office"), async
     if (!q) return res.status(404).json({ error: "Not found" });
     const auditAction = updates.status === "draft" ? "DRAFT_SAVED" : "UPDATE";
     logAudit(req, auditAction, "quote", id, null, { status: q.status, total_price: q.total_price });
+    // Keep the linked lead's name/contact/scope in step with quote edits. The
+    // lead is often created bare during draft autosave (empty fields); this
+    // enriches it once the office fills the quote in. Non-blocking.
+    import("../lib/lead-sync.js").then(({ upsertLeadForQuote }) =>
+      upsertLeadForQuote(req.auth!.companyId, q).catch(() => {})).catch(() => {});
     return res.json(q);
   } catch (err) {
     console.error("Update quote error:", err);

--- a/artifacts/qleno/src/pages/quote-builder.tsx
+++ b/artifacts/qleno/src/pages/quote-builder.tsx
@@ -885,7 +885,23 @@ export default function QuoteBuilderPage() {
         toast.success("Quote converted to job.");
         navigate(selectedDate ? `/dispatch?date=${selectedDate}` : "/jobs");
       } else if (status === "sent") {
-        toast.success(isEdit ? "Quote sent" : "Quote created and marked as sent.");
+        // Saving with status "sent" only persists the row — it does NOT deliver
+        // the quote or advance the lead. The canonical /send endpoint enrolls
+        // the quote-followup cadence (which actually emails + texts the customer
+        // via the tenant sender) and advances the lead to "Quoted". Without this
+        // call the customer received nothing and the lead stayed "Needs
+        // Contacted". Best-effort so a comms hiccup doesn't lose the saved quote.
+        if (savedId) {
+          try {
+            await apiFetch(`/api/quotes/${savedId}/send`, { method: "POST" });
+          } catch (sendErr) {
+            console.error("Quote /send failed:", sendErr);
+            toast.error("Quote saved, but sending failed — open it and try Send again.");
+            navigate(`/quotes/${savedId}`);
+            return;
+          }
+        }
+        toast.success(isEdit ? "Quote sent" : "Quote created and sent.");
         navigate(`/quotes/${savedId}`);
       } else {
         toast.success("Quote saved as draft");


### PR DESCRIPTION
Three live-test bugs in the quote flow (Schaumburg/co4, Quote #106).

**1. Quotes list empty / KPIs 0** — `GET /api/quotes` + `/stats` filtered by `quotesTable.branch_id`, a column the quotes table doesn't have. With a branch selected (single-branch tenants always do), the query failed → empty list + 0 KPIs while quotes existed. Removed the branch filter.

**2. Quote→lead not populated/advanced** — the lead is created bare during draft autosave; `upsertLeadForQuote` returned early when `lead_id` was set, never enriching it. Now it refreshes name/email/phone/address/scope (COALESCE — fills blanks, never wipes), PATCH re-syncs on edit, and `advanceLeadStage` stamps the owner (`assigned_to`).

**3. Save & Send didn't send** — the builder's `save('sent')` only persisted `status='sent'`; it never called `POST /quotes/:id/send` (the path that enrolls the cadence delivering email+SMS and advances the lead to Quoted). The builder now calls `/send` after save. Quote email is step 1 of the cadence (due immediately, delivered on the 30-min follow-up cron / `/follow-up/process`).

Stored contact on Q#106 was correct (`info@phes.io` / `7738188400`). Demo lead 37 purged separately.

Multi-tenant, comms gated via the tenant sender. No Phes hardcoding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)