### PR TITLE
Default new-hire password (chicago23) while comms off + employees inactive-filter fix

### DIFF
--- a/artifacts/api-server/src/routes/users.ts
+++ b/artifacts/api-server/src/routes/users.ts
@@ -15,6 +15,16 @@ import {
 
 const router = Router();
 
+// [onboarding-password 2026-06-16] Until COMMS is enabled (so the temp-password
+// email actually sends), a new hire can't receive a random temp and can't log
+// in. While comms are off, new accounts get a known default the office hands out
+// in person (Sal: "chicago23"). Env-overridable; the moment COMMS_ENABLED=true
+// it reverts to a random per-user temp automatically.
+function onboardingTempPassword(): string {
+  if (process.env.COMMS_ENABLED === "true") return Math.random().toString(36).slice(-8);
+  return process.env.DEFAULT_ONBOARDING_PASSWORD || "chicago23";
+}
+
 router.get("/", requireAuth, async (req, res) => {
   try {
     const { role, is_active, page = "1", limit = "25", branch_id } = req.query;
@@ -295,7 +305,7 @@ router.post("/", requireAuth, requireRole("owner", "admin"), async (req, res) =>
       return res.status(400).json({ error: "email and first_name are required" });
     }
 
-    const tempPassword = Math.random().toString(36).slice(-8);
+    const tempPassword = onboardingTempPassword();
     const password_hash = await bcrypt.hash(tempPassword, 10);
 
     const newUser = await db
@@ -1223,7 +1233,11 @@ router.post(
         });
       }
 
-      const tempPassword = generateLmsTempPassword();
+      // [onboarding-password 2026-06-16] Same default-while-comms-off rule as
+      // POST / — the LMS add path also can't email the temp until comms are on.
+      const tempPassword = process.env.COMMS_ENABLED === "true"
+        ? generateLmsTempPassword()
+        : (process.env.DEFAULT_ONBOARDING_PASSWORD || "chicago23");
       const password_hash = await bcrypt.hash(tempPassword, 10);
 
       const inserted = await db

--- a/artifacts/qleno/src/pages/employees.tsx
+++ b/artifacts/qleno/src/pages/employees.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useLocation } from "wouter";
 import { DashboardLayout } from "@/components/layout/dashboard-layout";
@@ -54,13 +54,21 @@ export default function EmployeesPage() {
   const { activeBranchId } = useBranch();
   const branchQuery = activeBranchId !== "all" ? { branch_id: String(activeBranchId) } : {};
   const { data, isLoading, refetch } = useListUsers(branchQuery, { request: { headers: getAuthHeaders() } });
+  // [inactive-filter 2026-06-16] Refetch on mount so a just-saved
+  // deactivation can't be masked by a stale cached list.
+  useEffect(() => { refetch(); }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Hide inactive by default (toggle to show). Order: technicians → office →
-  // other roles (owner/admin) → generic/test stub accounts pinned at the bottom.
+  // Hide inactive by default (toggle to show). "Inactive" = the same set of
+  // signals payroll uses — is_active=false OR a termination date OR archived —
+  // so a tech deactivated by ANY path (Account Active toggle, Termination Date,
+  // archive) drops off the list, not only the Account Active toggle.
+  // [inactive-filter 2026-06-16] Reported: Juan still listed after being made
+  // inactive because only is_active was checked.
+  const isInactive = (u: any) => u.is_active === false || !!u.termination_date || !!u.archived_at;
   const isStub = (u: any) => /\b(generic|test)\b/i.test(`${u.first_name} ${u.last_name} ${u.email ?? ""}`);
   const roleRank = (u: any) => isStub(u) ? 3 : (u.role === "technician" ? 0 : u.role === "office" ? 1 : 2);
   const employees = (data?.data || [])
-    .filter(u => showInactive || (u as any).is_active !== false)
+    .filter(u => showInactive || !isInactive(u))
     .filter(u => !search || `${u.first_name} ${u.last_name} ${u.email}`.toLowerCase().includes(search.toLowerCase()))
     .sort((a, b) => {
       const ra = roleRank(a), rb = roleRank(b);


### PR DESCRIPTION
Two changes (same branch).

## Default onboarding password while comms are off
`COMMS_ENABLED=false` means the temp-password email never sends, so a new hire got a random temp they could never receive — and couldn't log in. While comms are off, new accounts (both `POST /users` — the **Add Team Member** path — and the LMS add path) now get a **known default the office hands out in person: `chicago23`** (overridable via `DEFAULT_ONBOARDING_PASSWORD`). The instant `COMMS_ENABLED=true`, it reverts to a random per-user temp automatically. Existing users are untouched.

## Employees list: hide inactive by any signal
The list only treated `is_active === false` as inactive, so a tech deactivated via Termination Date or archive (Juan) stayed visible. Now hides on `is_active=false` OR `termination_date` OR `archived_at` (matching payroll), plus refetch-on-mount.

Both builds pass.

https://claude.ai/code/session_019PiXXwFgtNSnzZQy3MTjAj