### PR TITLE
fix(quotes): quote-detail add-on crash + carry scope to lead

### DIFF
--- a/artifacts/api-server/src/lib/lead-sync.ts
+++ b/artifacts/api-server/src/lib/lead-sync.ts
@@ -23,9 +23,17 @@ export async function upsertLeadForQuote(companyId: number, quote: any): Promise
     const nameParts = String(quote.lead_name ?? "").trim().split(/\s+/).filter(Boolean);
     const first = nameParts[0] || null;
     const last = nameParts.slice(1).join(" ") || null;
-    // Scope label for the lead pipeline (the quote stamps the scope name onto
-    // service_type at create).
-    const scope = quote.service_type || null;
+    // Scope label for the lead pipeline. The quote stamps the scope name onto
+    // service_type at CREATE, but PATCH (the builder's edit/save path) doesn't —
+    // so fall back to resolving the name from scope_id, else the lead's Scope
+    // column stays blank.
+    let scope = quote.service_type || null;
+    if (!scope && quote.scope_id) {
+      try {
+        const sc = await db.execute(sql`SELECT name FROM pricing_scopes WHERE id = ${quote.scope_id} LIMIT 1`);
+        scope = (sc.rows[0] as any)?.name ?? null;
+      } catch { /* leave scope null */ }
+    }
     const address = quote.address ?? null;
 
     // Resolve the lead: the quote's existing link first, else match by

--- a/artifacts/qleno/src/pages/quote-detail.tsx
+++ b/artifacts/qleno/src/pages/quote-detail.tsx
@@ -135,7 +135,14 @@ export default function QuoteDetailPage() {
 
   const statusCfg = STATUS_CONFIG[quote.status] ?? STATUS_CONFIG.draft;
   const clientName = quote.client_name || quote.lead_name || "No client";
-  const addons: { name: string; price: number }[] = Array.isArray(quote.addons) ? quote.addons : [];
+  // Stored add-ons use { name, amount, price_type } (the quote builder's shape);
+  // older/other rows may use { price }. Normalize to a numeric price so the
+  // render's a.price.toFixed() can't crash on a missing field (the cause of the
+  // quote-detail "Something went wrong" page on quotes with add-ons).
+  const addons: { name: string; price: number }[] = (Array.isArray(quote.addons) ? quote.addons : []).map((a: any) => ({
+    name: a?.name ?? "Add-on",
+    price: Number(a?.price ?? a?.amount ?? 0) || 0,
+  }));
   const total = parseFloat(quote.total_price || quote.base_price || "0");
   const basePrice = parseFloat(quote.base_price || "0");
   const discountAmt = parseFloat(quote.discount_amount || "0");


### PR DESCRIPTION
Two follow-ups found while validating the live quote flow (quote #107, Schaumburg).

1. **Quote detail crash** — `quote-detail.tsx` assumed each add-on had `.price`, but stored add-ons use `{ name, amount, price_type }`. `a.price.toFixed()` threw → the error boundary blanked the page for any quote with an add-on. Normalized to `price ?? amount ?? 0`.

2. **Lead scope blank** — `upsertLeadForQuote` read scope from `quote.service_type`, which the PATCH/builder save path never sets. Now falls back to resolving the scope name from `scope_id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)