### PR TITLE
feat(confirmation-page): Pass 2 brand redesign of /appointment/:token

### DIFF
--- a/artifacts/api-server/src/routes/appointment.ts
+++ b/artifacts/api-server/src/routes/appointment.ts
@@ -33,7 +33,7 @@ router.get("/:token", async (req, res) => {
       SELECT j.id, j.scheduled_date, j.scheduled_time, j.arrival_window, j.service_type, j.status,
              j.address_street, j.address_city, j.address_state, j.address_zip,
              c.first_name AS client_first,
-             u.first_name AS tech_first,
+             u.first_name AS tech_first, u.avatar_url AS tech_avatar,
              co.name AS company_name, co.logo_url AS company_logo,
              co.brand_color AS company_brand_color, co.phone AS company_phone, co.email AS company_email
       FROM jobs j
@@ -57,7 +57,10 @@ router.get("/:token", async (req, res) => {
       arrival_window: j.arrival_window || null,
       service_type: labelService(j.service_type),
       service_address: serviceAddress,
+      // Cleaner-as-a-person: first name + existing profile photo ONLY. No last
+      // name, phone, or email is ever exposed for the tech.
       tech_first: j.tech_first || null,
+      tech_avatar: j.tech_avatar || null,
       company_name: j.company_name,
       company_logo: j.company_logo,
       company_brand_color: j.company_brand_color,

--- a/artifacts/qleno/src/pages/appointment.tsx
+++ b/artifacts/qleno/src/pages/appointment.tsx
@@ -1,14 +1,25 @@
 import { useEffect, useState } from "react";
 import { useRoute } from "wouter";
+import { QlenoMark } from "@/components/brand/QlenoMark";
 
 const FF = "'Plus Jakarta Sans', sans-serif";
 const API = import.meta.env.BASE_URL.replace(/\/$/, "");
 const BG = "#F7F6F3";
 const CARD = "#FFFFFF";
 const INK = "#1A1917";
-const MUTE = "#6B7280";
+const MUTE = "#6B6860";
 const BORDER = "#E5E2DC";
-const ACCENT = "#00C9A0";
+const MINT = "#00C9A0";
+// Locked brand palette (same as Pass 1, the quote page).
+const NAVY = "#0A0E1A";
+const SUBLINE = "#9DA3B0";
+// Real Phes logo asset (public/) — same asset Pass 1 resolved. Used when the
+// tenant has no logo_url of its own.
+const PHES_LOGO = `${API}/phes-logo.jpeg`;
+// Branch contact fallback (used only if the tenant record has no phone/email).
+const FALLBACK_PHONE = "(847) 538-3729";
+const FALLBACK_PHONE_TEL = "+18475383729";
+const FALLBACK_EMAIL = "schaumburg@phes.io";
 
 type Appt = {
   client_first: string | null;
@@ -19,12 +30,30 @@ type Appt = {
   service_type: string;
   service_address: string | null;
   tech_first: string | null;
+  tech_avatar: string | null;
   company_name: string;
   company_logo: string | null;
   company_brand_color: string | null;
   company_phone: string | null;
   company_email: string | null;
 };
+
+// Round cleaner avatar — the tech's existing profile photo, or an initial-on-mint
+// fallback so it's never a broken image. First name only is shown elsewhere.
+function CleanerAvatar({ photo, name, size }: { photo: string | null; name: string | null; size: number }) {
+  const [broken, setBroken] = useState(false);
+  const initial = (name || "?").trim().charAt(0).toUpperCase() || "?";
+  const base: React.CSSProperties = { width: size, height: size, borderRadius: "50%", flexShrink: 0 };
+  if (photo && !broken) {
+    return <img src={photo} alt={name || "Your cleaner"} onError={() => setBroken(true)}
+      style={{ ...base, objectFit: "cover", border: `1px solid ${BORDER}` }} />;
+  }
+  return (
+    <div style={{ ...base, background: MINT, color: "#fff", display: "flex", alignItems: "center", justifyContent: "center", fontWeight: 700, fontSize: Math.round(size * 0.42) }}>
+      {initial}
+    </div>
+  );
+}
 
 const fmtDate = (d: string) => {
   const [y, m, day] = String(d).slice(0, 10).split("-").map(Number);
@@ -72,8 +101,6 @@ export default function AppointmentPage() {
     })();
   }, [token]);
 
-  const brand = appt?.company_brand_color || ACCENT;
-
   const wrap: React.CSSProperties = {
     minHeight: "100vh", background: BG, fontFamily: FF, color: INK,
     padding: "32px 16px", display: "flex", justifyContent: "center", alignItems: "flex-start",
@@ -98,51 +125,83 @@ export default function AppointmentPage() {
   }
 
   const st = STATUS_LABEL[appt.status] || STATUS_LABEL.scheduled;
-  const rows: Array<[string, string | null]> = [
-    ["Date", appt.scheduled_date ? fmtDate(appt.scheduled_date) : null],
-    ["Time", appt.scheduled_time ? fmtTime(appt.scheduled_time) : (appt.arrival_window || "Scheduled window")],
-    ["Service", appt.service_type],
-    ["Address", appt.service_address],
-    ["Your cleaner", appt.tech_first],
-  ];
+  const logoSrc = appt.company_logo || PHES_LOGO;
+  const timeLabel = appt.scheduled_time ? fmtTime(appt.scheduled_time) : (appt.arrival_window || "Scheduled window");
+  const mapsHref = appt.service_address ? `https://maps.google.com/?q=${encodeURIComponent(appt.service_address)}` : null;
+  // Tenant contact from the record, falling back to the branch defaults.
+  const phone = appt.company_phone || FALLBACK_PHONE;
+  const phoneTel = appt.company_phone ? appt.company_phone.replace(/[^\d+]/g, "") : FALLBACK_PHONE_TEL;
+  const email = appt.company_email || FALLBACK_EMAIL;
+
+  const rowWrap: React.CSSProperties = { display: "flex", justifyContent: "space-between", gap: 16, padding: "13px 16px", alignItems: "center" };
+  const labelStyle: React.CSSProperties = { color: MUTE, fontSize: 13 };
+  const valStyle: React.CSSProperties = { fontWeight: 600, fontSize: 14, color: INK, textAlign: "right" };
+
+  // Plain rows (cleaner row is rendered separately with the avatar).
+  const rows: Array<[string, React.ReactNode]> = [];
+  if (appt.scheduled_date) rows.push(["Date", fmtDate(appt.scheduled_date)]);
+  rows.push(["Time", timeLabel]);
+  if (appt.service_type) rows.push(["Service", appt.service_type]);
+  if (appt.service_address) rows.push(["Address",
+    <a href={mapsHref!} target="_blank" rel="noreferrer" style={{ ...valStyle, color: INK, textDecoration: "none" }}>{appt.service_address}</a>,
+  ]);
 
   return (
     <div style={wrap}>
       <div style={card}>
-        {/* Branded header */}
-        <div style={{ background: brand, padding: "20px 28px", display: "flex", alignItems: "center", gap: 12 }}>
-          {appt.company_logo
-            ? <img src={appt.company_logo} alt={appt.company_name} style={{ height: 32, maxWidth: 160, objectFit: "contain" }} />
-            : <span style={{ color: "#fff", fontSize: 20, fontWeight: 800 }}>{appt.company_name}</span>}
+        {/* Navy masthead — logo + wordmark + subline */}
+        <div style={{ background: NAVY, padding: "20px 28px", display: "flex", alignItems: "center", gap: 13 }}>
+          <img src={logoSrc} alt={appt.company_name} style={{ height: 38, width: "auto", borderRadius: 8, background: "#fff", objectFit: "contain" }} />
+          <div>
+            <p style={{ fontSize: 18, fontWeight: 700, color: "#FFFFFF", margin: 0, letterSpacing: "-0.01em" }}>{appt.company_name}</p>
+            <p style={{ fontSize: 12, color: SUBLINE, margin: "2px 0 0" }}>Residential &amp; Commercial Cleaning</p>
+          </div>
         </div>
 
         <div style={{ padding: 28 }}>
           <div style={{ display: "inline-block", padding: "4px 12px", borderRadius: 999, fontSize: 12, fontWeight: 700, background: st.bg, color: st.fg, marginBottom: 16 }}>
             {st.label}
           </div>
-          <h1 style={{ fontSize: 22, fontWeight: 800, margin: "0 0 6px" }}>
+          <h1 style={{ fontSize: 22, fontWeight: 700, color: INK, margin: "0 0 6px" }}>
             {appt.status === "complete" ? "Your cleaning is complete" : "Your cleaning is confirmed"}
           </h1>
           <p style={{ color: MUTE, fontSize: 14, margin: "0 0 24px" }}>
             {appt.client_first ? `Hi ${appt.client_first}, here are your appointment details.` : "Here are your appointment details."}
           </p>
 
-          <div style={{ border: `1px solid ${BORDER}`, borderRadius: 10 }}>
-            {rows.filter(([, v]) => v).map(([label, value], i, arr) => (
-              <div key={label} style={{ display: "flex", justifyContent: "space-between", gap: 16, padding: "13px 16px", borderBottom: i < arr.length - 1 ? `1px solid ${BORDER}` : "none" }}>
-                <span style={{ color: MUTE, fontSize: 13 }}>{label}</span>
-                <span style={{ fontWeight: 600, fontSize: 14, textAlign: "right" }}>{value}</span>
+          <div style={{ border: `1px solid ${BORDER}`, borderRadius: 10, overflow: "hidden" }}>
+            {rows.map(([label, value]) => (
+              <div key={label as string} style={{ ...rowWrap, borderBottom: `1px solid ${BORDER}` }}>
+                <span style={labelStyle}>{label}</span>
+                <span style={valStyle}>{value}</span>
               </div>
             ))}
+            {/* Your cleaner — round avatar (photo or initial) + first name only */}
+            {appt.tech_first && (
+              <div style={rowWrap}>
+                <span style={labelStyle}>Your cleaner</span>
+                <span style={{ display: "flex", alignItems: "center", gap: 10 }}>
+                  <span style={valStyle}>{appt.tech_first}</span>
+                  <CleanerAvatar photo={appt.tech_avatar} name={appt.tech_first} size={40} />
+                </span>
+              </div>
+            )}
           </div>
 
-          {(appt.company_phone || appt.company_email) && (
-            <p style={{ color: MUTE, fontSize: 13, margin: "20px 0 0", textAlign: "center" }}>
-              Questions? Contact {appt.company_name}
-              {appt.company_phone ? ` at ${appt.company_phone}` : ""}
-              {appt.company_email ? ` · ${appt.company_email}` : ""}.
-            </p>
-          )}
+          {/* Contact block */}
+          <p style={{ color: MUTE, fontSize: 13, margin: "22px 0 0", textAlign: "center", lineHeight: 1.6 }}>
+            Questions? Call or text{" "}
+            <a href={`tel:${phoneTel}`} style={{ color: INK, fontWeight: 700, textDecoration: "none" }}>{phone}</a>
+            {" · "}
+            <a href={`mailto:${email}`} style={{ color: INK, fontWeight: 700, textDecoration: "none" }}>{email}</a>
+          </p>
+
+          {/* Footer — Powered by Qleno (only Qleno mention) */}
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 7, marginTop: 18, paddingTop: 16, borderTop: `1px solid ${BORDER}` }}>
+            <span style={{ fontSize: 11, color: "#9E9B94", fontWeight: 500 }}>Powered by</span>
+            <QlenoMark size={15} />
+            <span style={{ fontSize: 11, color: "#9E9B94", fontWeight: 700 }}>Qleno</span>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
**Pass 2 — customer confirmation PAGE** (`/appointment/:token`). Markup/CSS/asset-wiring only; no appointment-data/scheduling/routing/assignment changes. Two files (route API + page).

- **Navy masthead**: real Phes logo (`/phes-logo.jpeg`; tenant logo wins) + company wordmark + 'Residential & Commercial Cleaning' subline — matches Pass 1.
- **Cleaner as a person**: 'Your cleaner' row shows the tech's **existing profile photo** (`users.avatar_url`) as a 40px round avatar + **first name only**; initial-on-mint fallback (never a broken image). API exposes only `tech_first` + `tech_avatar` — no last name/phone/email.
- **Details**: Date / Time (12-hr) / Service / Address (tappable Maps) / Your cleaner.
- **Contact**: tel:/mailto:, per-tenant from record, hardcoded fallback only.
- **Footer**: muted 'Powered by Qleno' + QlenoMark.

**Email NOT in this PR** — its masthead/footer are the shared `wrapEmailHtml()` used by 8 transactional email types across all tenants; an inline redesign would leak (per the STOP rule). Drafted separately for approval. Tech photo IS available to the email send path too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)