### PR TITLE
feat(confirmation-email): Pass 2 brand redesign via isolated renderer (no leak)

### DIFF
--- a/artifacts/api-server/src/lib/booking-confirmation.ts
+++ b/artifacts/api-server/src/lib/booking-confirmation.ts
@@ -2,6 +2,7 @@ import type { Request } from "express";
 import { randomBytes } from "crypto";
 import { db } from "@workspace/db";
 import { sql } from "drizzle-orm";
+import { renderConfirmationEmail, extractPolicyCopy, fmtTime12h } from "./confirmation-email.js";
 
 // [booking-confirmation GAP1] Customer booking confirmation: a no-login,
 // token-based "your appointment" view (like /quote/:token, /estimate/:token)
@@ -73,16 +74,27 @@ export function buildAppointmentLink(req: Request, token: string): string | null
   return host ? `${proto}://${host}/appointment/${token}` : null;
 }
 
-function fmtApptDate(dateStr: string): string {
+function fmtApptDate(dateStr: any): string {
   try {
-    const [y, m, d] = String(dateStr).slice(0, 10).split("-").map(Number);
+    // scheduled_date comes back from pg as a Date object (timestamp column), not
+    // an ISO string — normalize both shapes to YYYY-MM-DD before formatting.
+    const iso = dateStr instanceof Date ? dateStr.toISOString().slice(0, 10) : String(dateStr).slice(0, 10);
+    const [y, m, d] = iso.split("-").map(Number);
+    if (!y || !m || !d) return String(dateStr);
     return new Date(y, m - 1, d).toLocaleDateString("en-US", { weekday: "long", month: "long", day: "numeric", year: "numeric" });
-  } catch { return dateStr; }
+  } catch { return String(dateStr); }
 }
 
 function labelService(raw: string | null): string {
   if (!raw) return "Cleaning service";
   return raw.split("_").map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join(" ");
+}
+
+// Origin (proto + host) from the request, for absolute asset/links in email.
+function originFromReq(req: Request): string {
+  const proto = (req.headers["x-forwarded-proto"] as string)?.split(",")[0] || req.protocol || "https";
+  const host = (req.headers["x-forwarded-host"] as string) || req.get("host") || "app.qleno.com";
+  return `${proto}://${host}`;
 }
 
 // ── The send ─────────────────────────────────────────────────────────────────
@@ -94,9 +106,14 @@ export async function sendJobScheduledConfirmation(req: Request, jobId: number):
     const rows = await db.execute(sql`
       SELECT j.id, j.company_id, j.scheduled_date, j.scheduled_time, j.service_type,
              j.address_street, j.address_city, j.address_state, j.address_zip,
-             c.first_name, c.last_name, c.email AS client_email, c.phone AS client_phone
+             c.first_name, c.last_name, c.email AS client_email, c.phone AS client_phone,
+             u.first_name AS tech_first, u.avatar_url AS tech_avatar,
+             co.name AS company_name, co.logo_url AS company_logo,
+             co.phone AS company_phone, co.email AS company_email
       FROM jobs j
       LEFT JOIN clients c ON c.id = j.client_id
+      LEFT JOIN users u ON u.id = j.assigned_user_id
+      JOIN companies co ON co.id = j.company_id
       WHERE j.id = ${jobId} LIMIT 1
     `);
     const j: any = rows.rows[0];
@@ -120,8 +137,34 @@ export async function sendJobScheduledConfirmation(req: Request, jobId: number):
       appointment_link: link || "",
     };
 
+    // Dedicated confirmation-email renderer (Pass 2). Cleaner first name + photo
+    // ONLY — no last name/contact. Per-tenant contact from the record, branch
+    // fallback otherwise. The renderer reuses the merged template body's policy
+    // copy verbatim (extractPolicyCopy) and reskins everything else.
+    const origin = originFromReq(req);
+    const FALLBACK_PHONE = "(847) 538-3729", FALLBACK_PHONE_TEL = "+18475383729", FALLBACK_EMAIL = "schaumburg@phes.io";
+    const cPhone = j.company_phone || FALLBACK_PHONE;
+    const cPhoneTel = j.company_phone ? String(j.company_phone).replace(/[^\d+]/g, "") : FALLBACK_PHONE_TEL;
+    const cEmail = j.company_email || FALLBACK_EMAIL;
+    const renderEmail = (mergedBody: string): string => renderConfirmationEmail({
+      logoUrl: j.company_logo || `${origin}/phes-logo.jpeg`,
+      companyName: j.company_name || "Phes Schaumburg",
+      clientFirst: (j.first_name || "").trim(),
+      apptDate: j.scheduled_date ? fmtApptDate(j.scheduled_date) : "Your scheduled date",
+      apptTime: fmtTime12h(j.scheduled_time),
+      serviceType: labelService(j.service_type),
+      serviceAddress: serviceAddress || "On file",
+      mapsHref: serviceAddress ? `https://maps.google.com/?q=${encodeURIComponent(serviceAddress)}` : null,
+      techFirst: j.tech_first || null,
+      techAvatar: j.tech_avatar || null,
+      link,
+      phone: cPhone, phoneTel: cPhoneTel, email: cEmail,
+      qlenoMark: `${origin}/images/logo-mark.png`,
+      policyCopyHtml: extractPolicyCopy(mergedBody),
+    });
+
     const { sendNotification } = await import("../services/notificationService.js");
-    if (email) await sendNotification("job_scheduled", "email", j.company_id, email, null, mv).catch(() => {});
+    if (email) await sendNotification("job_scheduled", "email", j.company_id, email, null, mv, false, renderEmail).catch(() => {});
     if (phone) await sendNotification("job_scheduled", "sms", j.company_id, null, phone, mv).catch(() => {});
   } catch (err) {
     console.error("[booking-confirmation] sendJobScheduledConfirmation failed:", err);

--- a/artifacts/api-server/src/lib/confirmation-email.ts
+++ b/artifacts/api-server/src/lib/confirmation-email.ts
@@ -1,0 +1,132 @@
+// [confirmation-email Pass2] Pure, dependency-free renderer for the customer
+// booking-confirmation email. No DB / Express imports so it can be unit-rendered
+// and previewed in isolation. Mail-client-safe: table layout, inline styles,
+// Plus Jakarta Sans + sans-serif fallback. Replaces the shared wrapEmailHtml
+// chrome for THIS email only (via sendNotification's renderEmail opt-in) — the
+// other transactional emails are untouched.
+
+// 24-hr "HH:MM" → 12-hr "9:00 AM". Leaves non-times untouched.
+export function fmtTime12h(t: string | null): string {
+  if (!t) return "Your scheduled window";
+  const [h, m] = String(t).split(":").map(Number);
+  if (Number.isNaN(h)) return t;
+  const ampm = h < 12 ? "AM" : "PM";
+  const hour = h % 12 || 12;
+  return `${hour}:${String(m || 0).padStart(2, "0")} ${ampm}`;
+}
+
+const escAttr = (s: string) => String(s).replace(/"/g, "&quot;");
+
+// Pull the per-company policy copy ("What to expect / Cancellation & reschedule
+// policy / Our satisfaction guarantee") VERBATIM out of the merged job_scheduled
+// email body. The seeded body lists those sections between "What to expect" and
+// the trailing "Questions?" line. Fallback returns the whole body so no copy is
+// ever dropped if a tenant customized the template and the markers move.
+export function extractPolicyCopy(mergedBody: string): string {
+  const startKey = mergedBody.indexOf("What to expect");
+  if (startKey < 0) return mergedBody; // never drop copy
+  const start = mergedBody.lastIndexOf("<p", startKey);
+  const qKey = mergedBody.indexOf("Questions?", start);
+  const end = qKey >= 0 ? mergedBody.lastIndexOf("<p", qKey) : mergedBody.length;
+  return mergedBody.slice(start >= 0 ? start : startKey, end > 0 ? end : mergedBody.length);
+}
+
+export type ConfEmailOpts = {
+  logoUrl: string; companyName: string; clientFirst: string;
+  apptDate: string; apptTime: string; serviceType: string;
+  serviceAddress: string; mapsHref: string | null;
+  techFirst: string | null; techAvatar: string | null;
+  link: string | null; phone: string; phoneTel: string; email: string;
+  qlenoMark: string; policyCopyHtml: string;
+};
+
+export function renderConfirmationEmail(o: ConfEmailOpts): string {
+  const FONT = "'Plus Jakarta Sans', Arial, Helvetica, sans-serif";
+  const NAVY = "#0A0E1A", MINT = "#00C9A0", BG = "#F7F6F3", INK = "#1A1917", MUTE = "#6B6860", BORDER = "#E5E2DC", SUBLINE = "#9DA3B0";
+  const initial = (o.techFirst || "?").trim().charAt(0).toUpperCase() || "?";
+
+  // Round 36px cleaner avatar: photo inside a mint cell so a blocked image falls
+  // back to the initial on mint (bgcolor + alt), never a broken image.
+  const avatarCell = `
+    <td width="36" height="36" bgcolor="${MINT}" align="center" valign="middle" style="width:36px;height:36px;border-radius:18px;color:#ffffff;font-family:${FONT};font-size:15px;font-weight:700;mso-line-height-rule:exactly;line-height:36px;overflow:hidden;">${
+      o.techAvatar
+        ? `<img src="${escAttr(o.techAvatar)}" width="36" height="36" alt="${escAttr(initial)}" style="width:36px;height:36px;border-radius:18px;display:block;object-fit:cover;border:0;" />`
+        : initial
+    }</td>`;
+
+  const detailRow = (label: string, value: string) => `
+    <tr>
+      <td style="padding:11px 0;border-bottom:1px solid ${BORDER};font-family:${FONT};font-size:13px;color:${MUTE};">${label}</td>
+      <td align="right" style="padding:11px 0;border-bottom:1px solid ${BORDER};font-family:${FONT};font-size:14px;font-weight:600;color:${INK};">${value}</td>
+    </tr>`;
+
+  const addressVal = o.mapsHref
+    ? `<a href="${escAttr(o.mapsHref)}" style="color:${INK};text-decoration:none;font-weight:600;">${o.serviceAddress}</a>`
+    : o.serviceAddress;
+
+  const cleanerRow = o.techFirst ? `
+    <tr>
+      <td style="padding:11px 0;font-family:${FONT};font-size:13px;color:${MUTE};">Your cleaner</td>
+      <td align="right" style="padding:11px 0;">
+        <table role="presentation" cellpadding="0" cellspacing="0" align="right"><tr>
+          <td style="font-family:${FONT};font-size:14px;font-weight:600;color:${INK};padding-right:10px;">${o.techFirst}</td>
+          ${avatarCell}
+        </tr></table>
+      </td>
+    </tr>` : "";
+
+  const cta = o.link ? `
+    <table role="presentation" cellpadding="0" cellspacing="0" style="margin:24px auto 4px;"><tr>
+      <td bgcolor="${MINT}" align="center" style="border-radius:8px;">
+        <a href="${escAttr(o.link)}" style="display:inline-block;padding:13px 26px;font-family:${FONT};font-size:15px;font-weight:700;color:${NAVY};text-decoration:none;border-radius:8px;">View your appointment</a>
+      </td>
+    </tr></table>` : "";
+
+  return `<!DOCTYPE html>
+<html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Your cleaning is confirmed</title></head>
+<body style="margin:0;padding:0;background:${BG};font-family:${FONT};">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:${BG};padding:24px 14px;"><tr><td align="center">
+  <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width:600px;width:100%;background:#ffffff;border:1px solid ${BORDER};border-radius:14px;overflow:hidden;">
+    <!-- Navy masthead -->
+    <tr><td bgcolor="${NAVY}" style="background:${NAVY};padding:20px 28px;">
+      <table role="presentation" cellpadding="0" cellspacing="0"><tr>
+        <td valign="middle" style="padding-right:13px;"><img src="${escAttr(o.logoUrl)}" width="40" alt="${escAttr(o.companyName)}" style="height:40px;width:auto;border-radius:8px;background:#ffffff;display:block;border:0;" /></td>
+        <td valign="middle">
+          <div style="font-family:${FONT};font-size:18px;font-weight:700;color:#ffffff;line-height:1.2;">${o.companyName}</div>
+          <div style="font-family:${FONT};font-size:12px;color:${SUBLINE};line-height:1.4;">Residential &amp; Commercial Cleaning</div>
+        </td>
+      </tr></table>
+    </td></tr>
+    <!-- Body -->
+    <tr><td style="padding:28px;">
+      <div style="display:inline-block;padding:4px 12px;border-radius:999px;font-family:${FONT};font-size:12px;font-weight:700;background:#EAF7F3;color:#0A7C63;margin-bottom:14px;">Confirmed</div>
+      <h1 style="margin:0 0 6px;font-family:${FONT};font-size:22px;font-weight:700;color:${INK};">Your cleaning is confirmed</h1>
+      <p style="margin:0 0 22px;font-family:${FONT};font-size:14px;color:${MUTE};">${o.clientFirst ? `Hi ${o.clientFirst}, here are your appointment details.` : "Here are your appointment details."}</p>
+
+      <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="border:1px solid ${BORDER};border-radius:10px;padding:2px 16px;">
+        ${detailRow("Date", o.apptDate)}
+        ${detailRow("Time", o.apptTime)}
+        ${detailRow("Service", o.serviceType)}
+        ${detailRow("Address", addressVal)}
+        ${cleanerRow}
+      </table>
+
+      ${cta}
+
+      <div style="margin:24px 0 0;font-family:${FONT};font-size:14px;color:${INK};line-height:1.6;">${o.policyCopyHtml}</div>
+
+      <p style="margin:22px 0 0;text-align:center;font-family:${FONT};font-size:13px;color:${MUTE};line-height:1.6;">
+        Questions? Call or text <a href="tel:${escAttr(o.phoneTel)}" style="color:${INK};font-weight:700;text-decoration:none;">${o.phone}</a> &middot; <a href="mailto:${escAttr(o.email)}" style="color:${INK};font-weight:700;text-decoration:none;">${o.email}</a>
+      </p>
+
+      <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin-top:18px;border-top:1px solid ${BORDER};"><tr>
+        <td align="center" style="padding-top:16px;font-family:${FONT};font-size:11px;color:#9E9B94;">
+          <img src="${escAttr(o.qlenoMark)}" width="14" height="14" alt="" style="width:14px;height:14px;vertical-align:middle;border:0;" />
+          <span style="vertical-align:middle;">&nbsp;Powered by <strong style="color:#9E9B94;">Qleno</strong></span>
+        </td>
+      </tr></table>
+    </td></tr>
+  </table>
+</td></tr></table>
+</body></html>`;
+}

--- a/artifacts/api-server/src/services/notificationService.ts
+++ b/artifacts/api-server/src/services/notificationService.ts
@@ -74,6 +74,13 @@ export async function sendNotification(
   // user action, so it ALWAYS sends: bypasses both the per-tenant comms gate and
   // the global COMMS_ENABLED. Marketing/cadence/notification sends leave this false.
   transactional: boolean = false,
+  // [confirmation-email Pass2] ADDITIVE, opt-in: when provided (email only), the
+  // caller's renderer builds the entire email shell from the merged template body
+  // + merge vars, REPLACING the shared wrapEmailHtml() chrome for THIS send only.
+  // Every other caller omits it → wrapEmailHtml is used exactly as before, so the
+  // other transactional emails are byte-for-byte unchanged. Gating + logging are
+  // untouched. Used solely by the job_scheduled confirmation email.
+  renderEmail?: (mergedBodyHtml: string, vars: Record<string, string>) => string,
 ): Promise<void> {
   let status = "sent";
   let errorMsg: string | null = null;
@@ -140,10 +147,16 @@ export async function sendNotification(
       // the template already references the link — so any tenant's confirmation
       // email gets the customer job-view link without editing their template.
       const apptLink = fullVars.appointment_link;
-      if (apptLink && !rawHtml.includes(apptLink) && !bodyHtml.includes("appointment_link")) {
+      // The GAP1 fallback button only applies when there's no dedicated renderer
+      // (the Pass-2 confirmation renderer supplies its own CTA).
+      if (!renderEmail && apptLink && !rawHtml.includes(apptLink) && !bodyHtml.includes("appointment_link")) {
         rawHtml += `<div style="text-align:center;margin:24px 0 8px"><a href="${apptLink}" style="display:inline-block;background:${BRAND.accent};color:#ffffff;text-decoration:none;font-weight:600;font-size:15px;padding:14px 28px;border-radius:6px">View your appointment</a></div>`;
       }
-      const wrapped  = applyMerge(wrapEmailHtml(rawHtml), fullVars);
+      // Opt-in dedicated renderer (confirmation email) replaces the shared chrome
+      // for this send only; all other emails keep wrapEmailHtml unchanged.
+      const wrapped  = renderEmail
+        ? applyMerge(renderEmail(rawHtml, fullVars), fullVars)
+        : applyMerge(wrapEmailHtml(rawHtml), fullVars);
 
       if (!transactional && process.env.COMMS_ENABLED !== "true") {
         console.log("[COMMS BLOCKED] Email suppressed:", { to: recipientEmail, subject });


### PR DESCRIPTION
**Pass 2 — confirmation EMAIL** (the page shipped in #502). Approach (a): isolated renderer, **other 7 transactional emails untouched**.

- `sendNotification` gains an **additive optional `renderEmail`** callback (email only). Only the job_scheduled confirmation passes it; every other caller keeps `wrapEmailHtml` **byte-for-byte**. Gating/logging unchanged.
- New **`lib/confirmation-email.ts`** — pure, mail-client-safe (table layout, inline styles, Plus Jakarta Sans + sans-serif): navy masthead (Phes logo + wordmark + subline); details Date / Time (12-hr) / Service / Address (maps link) / **Your cleaner = 36px round photo** with **initial-on-mint fallback** for image-blocking (first name only, no PII); **mint CTA / navy text**; tappable contact; muted Powered-by-Qleno footer.
- **Body copy verbatim**: `extractPolicyCopy` pulls What to expect / Cancellation & reschedule policy / Our satisfaction guarantee from the per-company template (fallback keeps whole body — never drops copy).
- Tech data via `LEFT JOIN users` (existing `avatar_url`, no schema change).
- Bug fix: `fmtApptDate` now handles the Date object pg returns (was 'Invalid Date' — latent since GAP1, also fixes the SMS date).

Verified via local preview (no live send): photo + initial fallback, 12-hr time, correct date, mint CTA, copy intact, contact, Qleno footer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)