### PR TITLE
fix(landing): redirect logged-in visitors from marketing root to the app

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -2,6 +2,14 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <!-- Logged-in users should never see the marketing landing — bounce them to
+       the app dashboard before the page paints. Runs only on this root landing
+       page; SPA routes (/login, /dashboard, and the public /quote/:token,
+       /estimate/:token, /appointment/:token, /survey/:token token views) are
+       served by the app and unaffected. -->
+  <script>
+    try { if (window.localStorage && localStorage.getItem('qleno_token')) { window.location.replace('/dashboard'); } } catch (e) {}
+  </script>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Qleno — Software for Residential Cleaning Businesses</title>
   <meta name="description" content="Your cleaning business deserves better software. Online booking, recurring schedules, and team management — starting at $100/month flat. No per-user fees.">


### PR DESCRIPTION
A logged-in user hitting `app.qleno.com/` saw the server-served marketing landing. Added an early client-side check on the landing page: if `qleno_token` is in localStorage, `replace()` to `/dashboard` before paint.

- Logged-out (no token) → marketing page, unchanged.
- Logged-in → /dashboard.
- Untouched: /login + public `/quote/:token`, `/estimate/:token`, `/appointment/:token`, `/survey/:token` (SPA routes, not this page).
- Post-login already routes to /dashboard|/admin|/my-jobs by role (never /), so it's unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)