### PR TITLE
feat(sms): Pass 3 — de-spam customer SMS (clean short links + branded copy)

### DIFF
--- a/artifacts/api-server/src/app.ts
+++ b/artifacts/api-server/src/app.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "url";
 import rateLimit from "express-rate-limit";
 import router from "./routes";
 import stripeWebhookRouter from "./routes/stripe-webhook.js";
+import { resolveShortLink } from "./lib/short-link.js";
 
 const __appDir: string =
   typeof __dirname !== "undefined"
@@ -108,6 +109,18 @@ app.use("/api/clients/:id/communications/email", messageLimiter);
 app.use("/api/job-sms", messageLimiter);
 app.use("/api", generalLimiter);
 app.use("/api", router);
+
+// ── Short-link redirect ───────────────────────────────────────────────────────
+// [sms Pass3] GET /s/:code → 302 to the stored target (the token page). Lets
+// customer SMS carry a clean app.qleno.com/s/<code> instead of a long hex token.
+// Registered before the landing / SPA so it owns the /s/ path.
+app.get("/s/:code", async (req: Request, res: Response) => {
+  const code = String(req.params.code || "").trim();
+  const target = code ? await resolveShortLink(code) : null;
+  if (!target) return res.status(404).send("Link not found or expired.");
+  res.setHeader("Cache-Control", "no-cache, no-store, must-revalidate");
+  return res.redirect(302, target);
+});
 
 // ── Landing Page ────────────────────────────────────────────────────────────
 const landingDir = path.resolve(__appDir, "../../../landing");

--- a/artifacts/api-server/src/index.ts
+++ b/artifacts/api-server/src/index.ts
@@ -180,6 +180,15 @@ async function startup() {
   } catch (err: any) {
     console.error("[startup] ensureScorecardReplyColumns — non-fatal:", err?.message ?? err);
   }
+  // [sms Pass3] short-link table + customer-facing SMS copy upgrade
+  try {
+    const { ensureShortLinkTable } = await import("./lib/short-link.js");
+    await ensureShortLinkTable();
+    const { upgradeCustomerSmsCopy } = await import("./lib/sms-copy.js");
+    await upgradeCustomerSmsCopy();
+  } catch (err: any) {
+    console.error("[startup] sms Pass3 setup — non-fatal:", err?.message ?? err);
+  }
   // [revenue-connect 2026-06-12] job_history live bridge — mirrors completed
   // jobs into the revenue ledger past each tenant's MC-import end date, so
   // the dashboard forecast / business health / client history stay live

--- a/artifacts/api-server/src/lib/booking-confirmation.ts
+++ b/artifacts/api-server/src/lib/booking-confirmation.ts
@@ -3,6 +3,8 @@ import { randomBytes } from "crypto";
 import { db } from "@workspace/db";
 import { sql } from "drizzle-orm";
 import { renderConfirmationEmail, extractPolicyCopy, fmtTime12h } from "./confirmation-email.js";
+import { shortenUrl } from "./short-link.js";
+import { BOOKING_SMS } from "./sms-copy.js";
 
 // [booking-confirmation GAP1] Customer booking confirmation: a no-login,
 // token-based "your appointment" view (like /quote/:token, /estimate/:token)
@@ -27,11 +29,7 @@ export async function ensureBookingConfirmationSetup(): Promise<void> {
     // template but no SMS one yet. WHERE NOT EXISTS keeps it idempotent and
     // never clobbers a tenant's customization. The {{appointment_link}} merge
     // var is injected at send time by sendJobScheduledConfirmation().
-    const smsBody =
-      "Hi {{first_name}}, your cleaning with {{company_name}} is confirmed for " +
-      "{{appointment_date}} at {{appointment_time}} — {{service_type}} at " +
-      "{{service_address}}. View your appointment: {{appointment_link}} " +
-      "Questions? {{company_phone}}.";
+    const smsBody = BOOKING_SMS;
     await db.execute(sql`
       INSERT INTO notification_templates
         (company_id, trigger, channel, subject, body, body_html, body_text, is_active)
@@ -123,7 +121,10 @@ export async function sendJobScheduledConfirmation(req: Request, jobId: number):
     if (!email && !phone) return; // nothing to send to
 
     const token = await ensureJobViewToken(jobId);
-    const link = token ? buildAppointmentLink(req, token) : null;
+    // Clean short link (/s/<code>) instead of the long hex token URL in the SMS
+    // (and the email CTA). Falls back to the full URL if shortening fails.
+    const fullLink = token ? buildAppointmentLink(req, token) : null;
+    const link = await shortenUrl(fullLink, j.company_id);
 
     const stateZip = [j.address_state, j.address_zip].filter(Boolean).join(" ");
     const serviceAddress = [j.address_street, j.address_city, stateZip].filter(Boolean).join(", ");

--- a/artifacts/api-server/src/lib/comms.ts
+++ b/artifacts/api-server/src/lib/comms.ts
@@ -29,6 +29,7 @@ export type OnMyWaySmsResult =
 export async function sendOnMyWaySms(opts: {
   toPhone: string | null | undefined;
   fromPhone: string | null | undefined;
+  companyName: string;
   techName: string;
   clientFirstName: string;
   serviceAddress: string;
@@ -46,11 +47,11 @@ export async function sendOnMyWaySms(opts: {
   if (!opts.clientOptedIn) return { status: "suppressed_client_opted_out" };
   if (!opts.toPhone || !opts.fromPhone) return { status: "suppressed_no_phone" };
 
-  const body = `Hi ${opts.clientFirstName || "there"}! Your cleaner ${
+  // Lead with the tenant's name; tech FIRST name only; concise, no ALL-CAPS.
+  const sender = (opts.companyName || "").trim();
+  const body = `${sender ? sender + ": " : ""}your cleaner ${
     opts.techName
-  } is on the way to ${
-    opts.serviceAddress
-  }. Estimated arrival: ${opts.promisedArrivalLabel}.`;
+  } is on the way, arriving around ${opts.promisedArrivalLabel}.`;
 
   const accountSid = process.env.TWILIO_ACCOUNT_SID;
   const authToken = process.env.TWILIO_AUTH_TOKEN;

--- a/artifacts/api-server/src/lib/short-link.ts
+++ b/artifacts/api-server/src/lib/short-link.ts
@@ -1,0 +1,77 @@
+import { randomBytes } from "crypto";
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+import { appBaseUrl } from "./app-url.js";
+
+// [sms Pass3] Internal short-link redirect — replaces the long hex-token URLs in
+// customer SMS (e.g. app.qleno.com/quote/5272680c…) with a clean
+// app.qleno.com/s/<code>. No third-party shortener. A small code→target table;
+// GET /s/:code 302s to the stored target (the same token page).
+
+let ready = false;
+export async function ensureShortLinkTable(): Promise<void> {
+  if (ready) return;
+  try {
+    await db.execute(sql`
+      CREATE TABLE IF NOT EXISTS short_links (
+        id          serial PRIMARY KEY,
+        code        text NOT NULL UNIQUE,
+        target      text NOT NULL,
+        company_id  integer,
+        created_at  timestamp NOT NULL DEFAULT now()
+      )
+    `);
+    await db.execute(sql`CREATE UNIQUE INDEX IF NOT EXISTS short_links_target_key ON short_links (target)`);
+    ready = true;
+  } catch (err) {
+    console.error("[short-link] ensure table failed (non-fatal):", err);
+  }
+}
+
+// URL-safe short code (base62-ish). 7 chars ≈ 3.5e12 space — ample, unguessable.
+function genCode(len = 7): string {
+  const alphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+  const bytes = randomBytes(len);
+  let out = "";
+  for (let i = 0; i < len; i++) out += alphabet[bytes[i] % alphabet.length];
+  return out;
+}
+
+// Find-or-create a short link for a target URL; returns the public short URL.
+// Idempotent per target (a re-sent quote/appointment reuses the same code).
+// On any failure, falls back to the original target so a send never breaks.
+export async function shortenUrl(target: string | null, companyId?: number | null): Promise<string | null> {
+  if (!target) return target;
+  try {
+    await ensureShortLinkTable();
+    const existing = await db.execute(sql`SELECT code FROM short_links WHERE target = ${target} LIMIT 1`);
+    let code = (existing.rows[0] as any)?.code as string | undefined;
+    if (!code) {
+      // Retry a couple of times on the rare code collision.
+      for (let attempt = 0; attempt < 3 && !code; attempt++) {
+        const candidate = genCode();
+        const ins = await db.execute(sql`
+          INSERT INTO short_links (code, target, company_id)
+          VALUES (${candidate}, ${target}, ${companyId ?? null})
+          ON CONFLICT (target) DO UPDATE SET target = EXCLUDED.target
+          RETURNING code
+        `);
+        code = (ins.rows[0] as any)?.code;
+      }
+    }
+    return code ? `${appBaseUrl()}/s/${code}` : target;
+  } catch (err) {
+    console.error("[short-link] shortenUrl failed (using full URL):", err);
+    return target;
+  }
+}
+
+// Resolve a code to its target (for the /s/:code redirect). Null if unknown.
+export async function resolveShortLink(code: string): Promise<string | null> {
+  try {
+    const row = await db.execute(sql`SELECT target FROM short_links WHERE code = ${code} LIMIT 1`);
+    return (row.rows[0] as any)?.target ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/artifacts/api-server/src/lib/sms-copy.ts
+++ b/artifacts/api-server/src/lib/sms-copy.ts
@@ -1,0 +1,72 @@
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+// [sms Pass3] Professional, branded customer-facing SMS copy. Multi-tenant via
+// {{company_name}} / {{company_phone}} merge vars — no company hardcoded. Copy
+// leads with the sender's name, no ALL-CAPS, no spam phrasing, GSM-7-safe
+// (plain hyphens/quotes) to stay single-segment where possible. The long
+// hex-token links are shortened to /s/<code> at send time (see short-link.ts).
+
+// Booking confirmation (job_scheduled SMS template body_text).
+export const BOOKING_SMS =
+  "{{company_name}}: your cleaning is confirmed for {{appointment_date}} at {{appointment_time}}. Details: {{appointment_link}}";
+
+// Post-job satisfaction survey (companies.survey_message_template + fallback).
+export const SURVEY_SMS =
+  "{{company_name}}: thanks for letting us clean for you. How did we do? {{survey_link}}";
+
+// Quote follow-up cadence (quote_followup SMS steps).
+export const QUOTE_SMS =
+  "{{company_name}}: your quote is ready - ${{quote_total}}. View and book: {{estimate_link}}";
+export const QUOTE_NUDGE_SMS =
+  "{{company_name}}: checking in on your quote. Happy to answer questions or get you booked whenever you're ready.";
+export const QUOTE_LAST_SMS =
+  "{{company_name}}: we'd still love to help with your cleaning. Want us to hold a spot for you this week?";
+
+// Exact CURRENT defaults, so the upgrade only touches un-customized rows (a
+// tenant that edited their copy keeps it) and is idempotent (after the update
+// the old text is gone, so it won't run again).
+const OLD = {
+  booking:
+    "Hi {{first_name}}, your cleaning with {{company_name}} is confirmed for {{appointment_date}} at {{appointment_time}} — {{service_type}} at {{service_address}}. View your appointment: {{appointment_link}} Questions? {{company_phone}}.",
+  survey:
+    "Hi {{first_name}}, thanks for choosing us! How was your cleaning today? Tap to rate: {{survey_link}}",
+  quote:
+    "Hi {{first_name}}, your {{company_name}} quote is ready - ${{quote_total}}. View and book: {{estimate_link}} or reply with questions.",
+  quoteNudge:
+    "Hi {{first_name}}, checking in on your {{company_name}} quote. Happy to answer any questions or book your first clean whenever you are ready.",
+  quoteLast:
+    "Hi {{first_name}}, the {{company_name}} team would still love to help with your cleaning. Want me to hold a spot for you this week?",
+};
+
+// Idempotent startup upgrade: rewrite the customer-facing SMS copy across all
+// tenants, only where the row still holds the known default. Internal staff
+// alerts are untouched (none of these triggers/columns are staff-facing).
+export async function upgradeCustomerSmsCopy(): Promise<void> {
+  try {
+    await db.execute(sql`
+      UPDATE notification_templates SET body_text = ${BOOKING_SMS}
+      WHERE trigger = 'job_scheduled' AND channel = 'sms' AND body_text = ${OLD.booking}`);
+    await db.execute(sql`
+      UPDATE companies SET survey_message_template = ${SURVEY_SMS}
+      WHERE survey_message_template = ${OLD.survey}`);
+    await db.execute(sql`
+      UPDATE follow_up_steps st SET message_template = ${QUOTE_SMS}
+      FROM follow_up_sequences s
+      WHERE st.sequence_id = s.id AND s.sequence_type = 'quote_followup'
+        AND st.channel = 'sms' AND st.message_template = ${OLD.quote}`);
+    await db.execute(sql`
+      UPDATE follow_up_steps st SET message_template = ${QUOTE_NUDGE_SMS}
+      FROM follow_up_sequences s
+      WHERE st.sequence_id = s.id AND s.sequence_type = 'quote_followup'
+        AND st.channel = 'sms' AND st.message_template = ${OLD.quoteNudge}`);
+    await db.execute(sql`
+      UPDATE follow_up_steps st SET message_template = ${QUOTE_LAST_SMS}
+      FROM follow_up_sequences s
+      WHERE st.sequence_id = s.id AND s.sequence_type = 'quote_followup'
+        AND st.channel = 'sms' AND st.message_template = ${OLD.quoteLast}`);
+    console.log("[sms-copy] customer SMS copy upgrade applied (idempotent)");
+  } catch (err) {
+    console.error("[sms-copy] upgrade error (non-fatal):", err);
+  }
+}

--- a/artifacts/api-server/src/routes/satisfaction.ts
+++ b/artifacts/api-server/src/routes/satisfaction.ts
@@ -4,6 +4,8 @@ import { satisfactionSurveysTable, jobsTable, clientsTable, usersTable, companie
 import { eq, and, desc, isNotNull, avg, count, sql, gte, isNull } from "drizzle-orm";
 import { requireAuth } from "../lib/auth.js";
 import { captureSurveyScore } from "../lib/scorecard-engine.js";
+import { shortenUrl } from "../lib/short-link.js";
+import { SURVEY_SMS } from "../lib/sms-copy.js";
 import crypto from "crypto";
 
 const router = Router();
@@ -63,6 +65,7 @@ router.post("/send", requireAuth, async (req, res) => {
     // reason (Twilio is OFF until go-live, so today it suppresses, by design).
     const [company] = await db
       .select({
+        name: companiesTable.name,
         survey_enabled: companiesTable.survey_enabled,
         survey_message_template: companiesTable.survey_message_template,
         twilio_enabled: companiesTable.twilio_enabled,
@@ -92,8 +95,10 @@ router.post("/send", requireAuth, async (req, res) => {
     }
 
     const base = (process.env.APP_BASE_URL || "https://app.qleno.com").replace(/\/$/, "");
-    const link = `${base}/survey/${token}`;
-    const body = (company.survey_message_template || "How was your cleaning? Rate us: {{survey_link}}")
+    // Clean short link instead of the long hex token URL.
+    const link = (await shortenUrl(`${base}/survey/${token}`, companyId)) || `${base}/survey/${token}`;
+    const body = (company.survey_message_template || SURVEY_SMS)
+      .replace(/\{\{\s*company_name\s*\}\}/g, company.name || "We")
       .replace(/\{\{\s*first_name\s*\}\}/g, client!.first_name || "there")
       .replace(/\{\{\s*survey_link\s*\}\}/g, link);
     try {

--- a/artifacts/api-server/src/routes/tech-clock.ts
+++ b/artifacts/api-server/src/routes/tech-clock.ts
@@ -276,6 +276,7 @@ async function sendOnMyWayForJob(
   const [tenantRows, clientRows, techRows] = await Promise.all([
     db
       .select({
+        name: companiesTable.name,
         sms_on_my_way_enabled: companiesTable.sms_on_my_way_enabled,
         twilio_from_number: companiesTable.twilio_from_number,
       })
@@ -339,7 +340,9 @@ async function sendOnMyWayForJob(
   return sendOnMyWaySms({
     toPhone: client?.phone ?? null,
     fromPhone: tenant?.twilio_from_number ?? null,
-    techName: `${tech?.first_name ?? ""} ${tech?.last_name ?? ""}`.trim(),
+    companyName: tenant?.name ?? "",
+    // First name only — never the tech's full name to the customer.
+    techName: tech?.first_name ?? "",
     clientFirstName: client?.first_name ?? "",
     serviceAddress,
     promisedArrivalLabel: promisedLabel,

--- a/artifacts/api-server/src/services/followUpService.ts
+++ b/artifacts/api-server/src/services/followUpService.ts
@@ -8,6 +8,7 @@ import { sql } from "drizzle-orm";
 import { resolveSender, sendSmsVia } from "../lib/comms-sender.js";
 import { getBranchByZip } from "../lib/branchRouter.js";
 import { appBaseUrl } from "../lib/app-url.js";
+import { shortenUrl } from "../lib/short-link.js";
 
 // ── Merge field resolver ───────────────────────────────────────────────────────
 function resolveMergeFields(template: string, vars: Record<string, string>): string {
@@ -151,7 +152,10 @@ async function buildQuoteMergeVars(companyId: number, quoteId: number): Promise<
   const total = q.total_price ?? q.base_price ?? "0";
   // Residential quotes use the /quote/ route (the hosted page self-labels as
   // "Quote"). Commercial estimates use /estimate/. This is a quote, so /quote/.
-  const link = q.sign_token ? `${appBaseUrl()}/quote/${q.sign_token}` : `${appBaseUrl()}/quote`;
+  // Clean short link (/s/<code>) for the customer SMS/email instead of the long
+  // hex sign_token URL. Falls back to the full URL on any failure.
+  const fullLink = q.sign_token ? `${appBaseUrl()}/quote/${q.sign_token}` : `${appBaseUrl()}/quote`;
+  const link = q.sign_token ? ((await shortenUrl(fullLink, companyId)) || fullLink) : fullLink;
   const addons = Array.isArray(q.addons) ? q.addons : [];
   const rows: string[] = [];
   if (q.base_price != null) rows.push(`<tr><td style="padding:6px 0;color:#1A1917;">${q.service_type || "Cleaning service"}</td><td style="padding:6px 0;text-align:right;color:#1A1917;">$${Number(q.base_price).toFixed(2)}</td></tr>`);


### PR DESCRIPTION
Customer-facing SMS only; internal staff alerts untouched.

**Short links:** new `short_links` table + `GET /s/:code` → 302 to the token page (no third-party shortener). `shortenUrl()` find-or-creates a 7-char code per target (idempotent, falls back to full URL). Wired into booking (appointment_link), survey (survey_link), quote cadence (estimate_link) — kills the long hex token in the SMS.

**Copy:** leads with the tenant name, no ALL-CAPS / spam phrasing, GSM-7-safe, concise, multi-tenant (`{{company_name}}`/`{{company_phone}}`). Booking/survey/cadence rewritten via an idempotent startup upgrade that only touches rows still on the known default (preserves customizations). On-my-way (code) now leads with company name + **tech first-name only** (was full name).

No new deps; only the new `short_links` table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)