### PR TITLE
fix(invoices): generate invoice on ALL completion paths (forward fix — DO NOT MERGE yet)

### DIFF
--- a/artifacts/api-server/src/lib/ensure-invoice.ts
+++ b/artifacts/api-server/src/lib/ensure-invoice.ts
@@ -1,0 +1,164 @@
+// [invoice-on-completion 2026-06-16] Single source of truth for auto-creating a
+// job's DRAFT invoice when the job transitions to `complete`. Extracted from the
+// inline block that used to live only in PATCH /api/jobs/:id so that EVERY
+// completion path generates an invoice — the office modal (PATCH) AND the two
+// field/tech clock-out paths (timeclock last-tech clock-out, tech-clock field
+// clock_out) that previously flipped status='complete' without ever invoicing.
+//
+// Behavior preserved verbatim from the old inline block:
+//   - Idempotent: if an invoice already exists for (job_id, company_id) it is
+//     returned untouched, never duplicated.
+//   - Residential (no account_id): always auto-creates a draft.
+//   - Commercial (account_id): only auto-creates when invoice_frequency is
+//     'per_job'; weekly/monthly are deliberately skipped (batched elsewhere).
+//   - Discounts itemized as negative line items so the total nets out.
+//   - Fire-and-forget QuickBooks push (no-op for non-connected tenants;
+//     accounting, not outbound comms — does not respect COMMS_ENABLED).
+//   - Fully non-fatal: any hiccup is swallowed so it can never break the
+//     underlying job/clock write.
+import { db } from "@workspace/db";
+import { jobsTable, invoicesTable, accountsTable, companiesTable, jobDiscountsTable } from "@workspace/db/schema";
+import { eq, and } from "drizzle-orm";
+
+export type EnsureInvoiceResult = {
+  created: boolean;
+  skipped: boolean;
+  invoiceId: number | null;
+  status: string | null;
+  total: string | null;
+  error: boolean;
+};
+
+const NO_OP: EnsureInvoiceResult = {
+  created: false, skipped: true, invoiceId: null, status: null, total: null, error: false,
+};
+
+export async function ensureInvoiceForCompletedJob(
+  companyId: number,
+  jobId: number,
+  userId: number | null,
+): Promise<EnsureInvoiceResult> {
+  try {
+    // Idempotency: a job gets at most one invoice. If one already exists, hand
+    // it back so callers can surface it without creating a duplicate.
+    const existing = await db
+      .select({ id: invoicesTable.id, status: invoicesTable.status, total: invoicesTable.total })
+      .from(invoicesTable)
+      .where(and(eq(invoicesTable.job_id, jobId), eq(invoicesTable.company_id, companyId)))
+      .limit(1);
+    if (existing[0]) {
+      return { created: false, skipped: false, invoiceId: existing[0].id, status: existing[0].status, total: existing[0].total, error: false };
+    }
+
+    const [job] = await db
+      .select({
+        account_id: jobsTable.account_id,
+        client_id: jobsTable.client_id,
+        service_type: jobsTable.service_type,
+        base_fee: jobsTable.base_fee,
+        billed_amount: jobsTable.billed_amount,
+        billed_hours: jobsTable.billed_hours,
+        hourly_rate: jobsTable.hourly_rate,
+      })
+      .from(jobsTable)
+      .where(and(eq(jobsTable.id, jobId), eq(jobsTable.company_id, companyId)))
+      .limit(1);
+    if (!job) return NO_OP;
+
+    // Resolve payment terms + whether this job should auto-invoice at all.
+    let skipAutoInvoice = false;
+    let termsDays = 0;
+    if (job.account_id) {
+      const [acct] = await db
+        .select({ invoice_frequency: accountsTable.invoice_frequency, payment_terms_days: accountsTable.payment_terms_days })
+        .from(accountsTable)
+        .where(eq(accountsTable.id, job.account_id))
+        .limit(1);
+      if (acct) {
+        termsDays = acct.payment_terms_days ?? 30;
+        // Only auto-invoice on per_job; weekly/monthly get batched via consolidate endpoint
+        if (acct.invoice_frequency !== "per_job") {
+          skipAutoInvoice = true;
+        }
+      }
+    } else {
+      const [co] = await db
+        .select({ payment_terms_days: companiesTable.payment_terms_days })
+        .from(companiesTable)
+        .where(eq(companiesTable.id, companyId))
+        .limit(1);
+      termsDays = co?.payment_terms_days ?? 0;
+    }
+
+    if (skipAutoInvoice) return NO_OP;
+
+    const today = new Date();
+    const due = new Date(today);
+    due.setDate(due.getDate() + termsDays);
+    const dueDateStr = due.toISOString().split("T")[0];
+
+    const termsLabel =
+      termsDays === 30 ? "net_30" :
+      termsDays === 15 ? "net_15" :
+      termsDays === 7  ? "net_7"  : "due_on_receipt";
+
+    // Use billed_amount for hourly jobs; otherwise base_fee.
+    const amount = job.billed_amount
+      ? parseFloat(String(job.billed_amount))
+      : parseFloat(String(job.base_fee ?? "0"));
+    const svcLabel = (job.service_type ?? "Cleaning Service")
+      .split("_").map((w: string) => w.charAt(0).toUpperCase() + w.slice(1)).join(" ");
+    const qty = job.billed_hours ? parseFloat(String(job.billed_hours)) : 1;
+    const unitPrice = job.hourly_rate ? parseFloat(String(job.hourly_rate)) : amount;
+
+    const lineItems: any[] = [{ description: svcLabel, quantity: qty, unit_price: unitPrice, total: amount }];
+
+    // Itemize any discounts applied to this job as negative lines so the
+    // invoice total nets them out (matches the live draft-sync helper).
+    const jobDisc = await db.select().from(jobDiscountsTable)
+      .where(and(eq(jobDiscountsTable.job_id, jobId), eq(jobDiscountsTable.company_id, companyId)));
+    let discTotal = 0;
+    for (const d of jobDisc) {
+      const amt = parseFloat(String(d.amount));
+      discTotal += amt;
+      const label = `Discount${d.code ? ` ${d.code}` : (d.type === "percent" ? ` ${parseFloat(String(d.value))}%` : "")}${d.reason && d.reason !== d.code ? ` — ${d.reason}` : ""}`;
+      lineItems.push({ description: label, quantity: 1, unit_price: -amt, total: -amt });
+    }
+    const netAmount = Math.max(0, Math.round((amount - discTotal) * 100) / 100);
+
+    const [newInv] = await db
+      .insert(invoicesTable)
+      .values({
+        company_id: companyId,
+        job_id: jobId,
+        client_id: job.client_id ?? null,
+        account_id: job.account_id ?? null,
+        status: "draft",
+        line_items: lineItems,
+        subtotal: netAmount.toFixed(2),
+        total: netAmount.toFixed(2),
+        due_date: dueDateStr,
+        payment_terms: termsLabel,
+        created_by: userId,
+      })
+      .returning({ id: invoicesTable.id, status: invoicesTable.status, total: invoicesTable.total });
+
+    // [AF] Fire-and-forget QB invoice push. Enqueue regardless of whether this
+    // tenant is QB-connected — the cron drain (syncAll) checks getValidToken()
+    // and no-ops cleanly for tenants without a connection, so queueing is always
+    // safe. Does NOT respect COMMS_ENABLED: QB push is accounting, not comms.
+    try {
+      const { syncInvoice } = await import("../services/quickbooks-sync.js");
+      syncInvoice(companyId, newInv.id).catch(qbErr => {
+        console.error("[AF] QB invoice push error (non-fatal):", qbErr);
+      });
+    } catch (qbImportErr) {
+      console.error("[AF] QB sync module load error (non-fatal):", qbImportErr);
+    }
+
+    return { created: true, skipped: false, invoiceId: newInv.id, status: newInv.status, total: newInv.total, error: false };
+  } catch (err) {
+    console.error("[ensure-invoice] Auto-invoice error (non-fatal):", err);
+    return { created: false, skipped: false, invoiceId: null, status: null, total: null, error: true };
+  }
+}

--- a/artifacts/api-server/src/routes/jobs.ts
+++ b/artifacts/api-server/src/routes/jobs.ts
@@ -10,6 +10,7 @@ import { geocodeAddress } from "../lib/geocode.js";
 import { resolveZoneForZip } from "./zones.js";
 import { sendNotification, labelServiceType } from "../services/notificationService.js";
 import { parseResRatesRow, resolveResidentialPayPct } from "../lib/commission-rates.js";
+import { ensureInvoiceForCompletedJob } from "../lib/ensure-invoice.js";
 
 const router = Router();
 
@@ -3520,124 +3521,21 @@ router.post("/:id/complete", requireAuth, async (req, res) => {
     }
 
     // ── Auto-invoice on completion ────────────────────────────────────────
+    // Delegates to the shared helper so the office (PATCH) path and the two
+    // field clock-out paths (timeclock / tech-clock) all generate the invoice
+    // through one idempotent code path. The hourly billing block above has
+    // already persisted billed_amount/billed_hours to the job row, so the
+    // helper's fresh fetch sees the same numbers this path used to read inline.
     let autoInvoice: { id: number; status: string; total: string } | null = null;
     let invoiceCreated = false;
     let invoiceError = false;
-
-    try {
-      const companyId = req.auth!.companyId;
-      const job = updated[0] as any;
-
-      const existing = await db
-        .select({ id: invoicesTable.id, status: invoicesTable.status, total: invoicesTable.total })
-        .from(invoicesTable)
-        .where(and(eq(invoicesTable.job_id, jobId), eq(invoicesTable.company_id, companyId)))
-        .limit(1);
-
-      if (existing[0]) {
-        autoInvoice = { id: existing[0].id, status: existing[0].status, total: existing[0].total };
-      } else {
-        // If this job belongs to an account, check invoice_frequency before auto-creating
-        let skipAutoInvoice = false;
-        let termsDays = 0;
-        let clientId = job.client_id ?? null;
-
-        if (job.account_id) {
-          const [acct] = await db
-            .select({ invoice_frequency: accountsTable.invoice_frequency, payment_terms_days: accountsTable.payment_terms_days })
-            .from(accountsTable)
-            .where(eq(accountsTable.id, job.account_id))
-            .limit(1);
-          if (acct) {
-            termsDays = acct.payment_terms_days ?? 30;
-            // Only auto-invoice on per_job; weekly/monthly get batched via consolidate endpoint
-            if (acct.invoice_frequency !== "per_job") {
-              skipAutoInvoice = true;
-            }
-          }
-        } else {
-          const [co] = await db
-            .select({ payment_terms_days: companiesTable.payment_terms_days })
-            .from(companiesTable)
-            .where(eq(companiesTable.id, companyId))
-            .limit(1);
-          termsDays = co?.payment_terms_days ?? 0;
-        }
-
-        if (!skipAutoInvoice) {
-          const today = new Date();
-          const due = new Date(today);
-          due.setDate(due.getDate() + termsDays);
-          const dueDateStr = due.toISOString().split("T")[0];
-
-          const termsLabel =
-            termsDays === 30 ? "net_30" :
-            termsDays === 15 ? "net_15" :
-            termsDays === 7  ? "net_7"  : "due_on_receipt";
-
-          // Use billed_amount for hourly jobs; otherwise base_fee
-          const amount = completedJob.billed_amount
-            ? parseFloat(completedJob.billed_amount)
-            : parseFloat(job.base_fee ?? "0");
-          const svcLabel = (job.service_type ?? "Cleaning Service")
-            .split("_").map((w: string) => w.charAt(0).toUpperCase() + w.slice(1)).join(" ");
-          const qty = completedJob.billed_hours ? parseFloat(completedJob.billed_hours) : 1;
-          const unitPrice = completedJob.hourly_rate ? parseFloat(completedJob.hourly_rate) : amount;
-
-          const lineItems: any[] = [{ description: svcLabel, quantity: qty, unit_price: unitPrice, total: amount }];
-
-          // Itemize any discounts applied to this job as negative lines so the
-          // invoice total nets them out (matches the live draft-sync helper).
-          const jobDisc = await db.select().from(jobDiscountsTable)
-            .where(and(eq(jobDiscountsTable.job_id, jobId), eq(jobDiscountsTable.company_id, companyId)));
-          let discTotal = 0;
-          for (const d of jobDisc) {
-            const amt = parseFloat(String(d.amount));
-            discTotal += amt;
-            const label = `Discount${d.code ? ` ${d.code}` : (d.type === "percent" ? ` ${parseFloat(String(d.value))}%` : "")}${d.reason && d.reason !== d.code ? ` — ${d.reason}` : ""}`;
-            lineItems.push({ description: label, quantity: 1, unit_price: -amt, total: -amt });
-          }
-          const netAmount = Math.max(0, Math.round((amount - discTotal) * 100) / 100);
-
-          const [newInv] = await db
-            .insert(invoicesTable)
-            .values({
-              company_id: companyId,
-              job_id: jobId,
-              client_id: clientId,
-              account_id: job.account_id ?? null,
-              status: "draft",
-              line_items: lineItems,
-              subtotal: netAmount.toFixed(2),
-              total: netAmount.toFixed(2),
-              due_date: dueDateStr,
-              payment_terms: termsLabel,
-              created_by: req.auth!.userId,
-            })
-            .returning({ id: invoicesTable.id, status: invoicesTable.status, total: invoicesTable.total });
-
-          autoInvoice = { id: newInv.id, status: newInv.status, total: newInv.total };
-          invoiceCreated = true;
-
-          // [AF] Fire-and-forget QB invoice push. Enqueue a pending row in
-          // qb_sync_queue regardless of whether this tenant is QB-connected —
-          // the cron drain (syncAll) checks getValidToken() and no-ops cleanly
-          // for tenants without a connection, so queueing is always safe.
-          // Does NOT respect COMMS_ENABLED: QB push is accounting, not
-          // outbound customer comms.
-          try {
-            const { syncInvoice } = await import("../services/quickbooks-sync.js");
-            syncInvoice(companyId, newInv.id).catch(qbErr => {
-              console.error("[AF] QB invoice push error (non-fatal):", qbErr);
-            });
-          } catch (qbImportErr) {
-            console.error("[AF] QB sync module load error (non-fatal):", qbImportErr);
-          }
-        }
+    {
+      const inv = await ensureInvoiceForCompletedJob(req.auth!.companyId, jobId, req.auth!.userId);
+      if (inv.invoiceId != null) {
+        autoInvoice = { id: inv.invoiceId, status: inv.status!, total: inv.total! };
       }
-    } catch (invErr) {
-      console.error("Auto-invoice error (non-fatal):", invErr);
-      invoiceError = true;
+      invoiceCreated = inv.created;
+      invoiceError = inv.error;
     }
     // ─────────────────────────────────────────────────────────────────────
 

--- a/artifacts/api-server/src/routes/tech-clock.ts
+++ b/artifacts/api-server/src/routes/tech-clock.ts
@@ -39,6 +39,7 @@ import { haversineMeters, companyGeofenceMeters } from "../lib/distance.js";
 import { estimateEtaMinutes } from "../lib/eta.js";
 import { sendOnMyWaySms } from "../lib/comms.js";
 import { geocodeAddress } from "../lib/geocode.js";
+import { ensureInvoiceForCompletedJob } from "../lib/ensure-invoice.js";
 
 const router = Router();
 
@@ -501,6 +502,12 @@ async function handleClockEvent(
         .where(
           and(eq(jobsTable.company_id, companyId), eq(jobsTable.id, job.id)),
         );
+      // Generate the job's draft invoice on field clock-out — same idempotent
+      // path the office PATCH uses, so field completions never go uninvoiced.
+      // Fire-and-forget so it never blocks the clock-out response (the helper
+      // is internally non-fatal and skips if an invoice already exists).
+      ensureInvoiceForCompletedJob(companyId, job.id, userId)
+        .catch((e: Error) => console.error("[tech-clock invoice] non-fatal:", e));
     }
 
     return res.json({

--- a/artifacts/api-server/src/routes/timeclock.ts
+++ b/artifacts/api-server/src/routes/timeclock.ts
@@ -5,6 +5,7 @@ import { eq, and, gte, lte, desc, sql, count } from "drizzle-orm";
 import { requireAuth, requireRole } from "../lib/auth.js";
 import { logAudit } from "../lib/audit.js";
 import { computePerTechCommissionRows, type JobTechRow } from "../lib/commission-paytype.js";
+import { ensureInvoiceForCompletedJob } from "../lib/ensure-invoice.js";
 import { parseResRatesRow } from "../lib/commission-rates.js";
 import type { CommissionInputJob } from "../lib/commission-compute.js";
 
@@ -510,8 +511,15 @@ router.post("/:id/clock-out", requireAuth, async (req, res) => {
           RETURNING client_id
         `);
         // RETURNING is non-empty only when THIS call flipped the status — so the
-        // survey + retention fire exactly once, on the transition.
+        // survey + retention + auto-invoice fire exactly once, on the transition.
         const clientId = (done.rows[0] as any)?.client_id;
+        if (done.rows[0]) {
+          // Generate the job's draft invoice on field clock-out — same idempotent
+          // path the office PATCH uses. Fire-and-forget so a slow/failed invoice
+          // never blocks the clock-out response (helper is internally non-fatal).
+          ensureInvoiceForCompletedJob(req.auth!.companyId, jobId, req.auth!.userId)
+            .catch((e: Error) => console.error("[end-job invoice] non-fatal:", e));
+        }
         if (clientId) {
           fetch(`http://localhost:${process.env.PORT || 8080}/api/satisfaction/send`, {
             method: "POST",


### PR DESCRIPTION
## Problem
Scheduled jobs completed **in the field** were never invoiced. Invoice auto-creation lived only inside `PATCH /api/jobs/:id` (the office modal). Jobs marked `complete` via tech clock-out — `timeclock.ts` last-tech clock-out (505-511) and `tech-clock.ts` field `clock_out` (497-503) — flipped `status='complete'` **without ever generating an invoice**.

Empirically (Phes / company 1, prod): of jobs completed via a clock-out path, all were missing invoices. The defect is small in volume today but grows as the field app rolls out.

## Fix (forward-looking only)
Extract the auto-invoice block (previously inline in `jobs.ts:3522-3641`) into one idempotent helper:

```
ensureInvoiceForCompletedJob(companyId, jobId, userId)  // lib/ensure-invoice.ts
```

and call it from **all three** completion paths:
- `PATCH /api/jobs/:id` (office modal) — replaces the inline block
- `timeclock.ts` last-tech clock-out — fire-and-forget on the status transition
- `tech-clock.ts` field `clock_out` — fire-and-forget after the status update

### Behavior preserved verbatim
- **Idempotent** — skips if an invoice already exists for `(job_id, company_id)`
- **Residential** (no `account_id`) — always creates a `draft`
- **Commercial** (`account_id`) — only when `invoice_frequency = 'per_job'`; weekly/monthly still deliberately skipped (batched elsewhere — unchanged)
- Discounts itemized as negative line items so the total nets out
- Fire-and-forget QuickBooks push, fully non-fatal
- The two clock-out call sites invoke the helper fire-and-forget so a slow/failed invoice never blocks the clock-out response

The hourly billing block in the PATCH path already persists `billed_amount`/`billed_hours` to the job row before the helper runs, so the helper's fresh DB fetch sees the same numbers the old inline code read.

## Scope guardrails (explicitly NOT in this PR)
- ❌ No retroactive backfill of missing invoices
- ❌ No change to commercial monthly/weekly billing
- ❌ No change to the 156 past-dated `scheduled` jobs
- ❌ No deploy
- ❌ No quote-tool changes

Those all wait on Sal's 3 pending decisions.

## Verification
- Server entry esbuild-bundles cleanly (mirrors `build-api-server` CI) — all new imports resolve
- tsc on touched files: net **−3 errors** vs `origin/main` baseline (jobs.ts −4, tech-clock 0, ensure-invoice 0, timeclock +1 — the pervasive `req.auth!.companyId` nullable-auth pattern, identical to the adjacent `enrollForJobComplete` call). api-server artifact is outside the CI tsc gate by design.

**DO NOT MERGE / DO NOT DEPLOY** until the orchestrator clears it with Sal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)