### PR TITLE
Fix Maryury's stuck onboarding login (comms-off cutover)

### DIFF
--- a/artifacts/api-server/src/index.ts
+++ b/artifacts/api-server/src/index.ts
@@ -13,6 +13,7 @@ import { runAnnualCycleAutoOpen } from "./lib/lms-annual-cycle-cron.js";
 import { runLmsCompletionBackfill } from "./lib/lms-completion-backfill.js";
 import { runLmsCertificateBackfill } from "./lib/lms-certificate-backfill.js";
 import { ensureJobHistoryLiveBridgeSchema, syncJobHistoryLiveBridge } from "./lib/job-history-sync.js";
+import { bootstrapOnboardingPasswords } from "./lib/onboarding-password-backfill.js";
 
 const port = Number(process.env.PORT) || 3000;
 
@@ -214,6 +215,19 @@ async function startup() {
     }
   } catch (err: any) {
     console.error("[startup] job-history bridge — non-fatal:", err?.message ?? err);
+  }
+  // [onboarding-password 2026-06-16] Narrow login bootstrap for a stuck new
+  // hire during the comms-off cutover (temp-password email can't send while
+  // COMMS_ENABLED=false). Allowlist-scoped + never-logged-in guarded, so it
+  // can't clobber any active password. Self-limiting: once they log in,
+  // last_login_at is set and the UPDATE never matches them again.
+  try {
+    const n = await bootstrapOnboardingPasswords();
+    if (n > 0) {
+      console.log(`[onboarding-password] bootstrapped ${n} stuck onboarding login(s)`);
+    }
+  } catch (err: any) {
+    console.error("[startup] onboarding-password bootstrap — non-fatal:", err?.message ?? err);
   }
   // Cutover 1E — self-check that the 1C GPS-integrity CHECK constraint
   // is live AND enforced in production. Non-fatal: pay computation

--- a/artifacts/api-server/src/lib/onboarding-password-backfill.ts
+++ b/artifacts/api-server/src/lib/onboarding-password-backfill.ts
@@ -1,0 +1,36 @@
+/**
+ * [onboarding-password 2026-06-16] Narrow, one-time login bootstrap for a
+ * specific stuck new hire during the comms-off cutover.
+ *
+ * NOT a mass reset. It only touches an explicit allowlist of user ids
+ * (default: the one new hire who can't log in, Maryury = 817), and only when:
+ *   - COMMS_ENABLED !== 'true' (the window the temp-password email can't send),
+ *   - the account is_active, and
+ *   - last_login_at IS NULL (never logged in) — so the instant they log in it
+ *     stops touching them and can never clobber a real, active password.
+ *
+ * Override the target set with ONBOARDING_RESET_USER_IDS (comma-separated) and
+ * the password with DEFAULT_ONBOARDING_PASSWORD. Remove this step after the
+ * cutover once everyone has logged in.
+ */
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+import bcrypt from "bcryptjs";
+
+export async function bootstrapOnboardingPasswords(): Promise<number> {
+  if (process.env.COMMS_ENABLED === "true") return 0;
+  const ids = (process.env.ONBOARDING_RESET_USER_IDS || "817")
+    .split(",").map(s => parseInt(s.trim(), 10)).filter(n => Number.isInteger(n));
+  if (ids.length === 0) return 0;
+  const pw = process.env.DEFAULT_ONBOARDING_PASSWORD || "chicago23";
+  const hash = await bcrypt.hash(pw, 10);
+  const csv = ids.join(",");
+  const r = await db.execute(sql`
+    UPDATE users
+       SET password_hash = ${hash}
+     WHERE id = ANY(ARRAY[${sql.raw(csv)}]::int[])
+       AND is_active = true
+       AND last_login_at IS NULL
+  `);
+  return (r as any).rowCount ?? 0;
+}


### PR DESCRIPTION
Follow-up to #498. The chicago23 default in #498 only applies to **new** accounts created from now on. Maryury (user 817, marjuryj@gmail.com) was added *before* that rule landed, so she already holds an unusable random temp hash and still can't log in — and we don't want to re-add her.

## The fix
`bootstrapOnboardingPasswords()` — a narrow, allowlist-scoped, one-time startup reset that sets the known onboarding password (`chicago23`) for a specific set of stuck never-logged-in accounts, then stops touching them.

Guards (all must hold):
- `COMMS_ENABLED !== 'true'` — only the window where the temp-password email can't send
- `id` in `ONBOARDING_RESET_USER_IDS` allowlist (default: `817`)
- `is_active = true`
- `last_login_at IS NULL` — **self-limiting**: the instant she logs in, `last_login_at` is stamped and the UPDATE never matches her again, so it can never clobber a real, active password.

This is deliberately **not** a mass reset — it targets one explicit user id. Remove this startup step after the cutover once everyone has logged in.

Wired into `index.ts` startup next to the other non-fatal cold-start backfills. Uses the proven `ANY(ARRAY[${sql.raw(csv)}]::int[])` binding pattern. api-server + frontend builds pass.

https://claude.ai/code/session_019PiXXwFgtNSnzZQy3MTjAj

---
_Generated by [Claude Code](https://claude.ai/code/session_019PiXXwFgtNSnzZQy3MTjAj)_