### PR TITLE
Maryury login follow-up: email-anchored onboarding bootstrap + normalize stored email

### DIFF
--- a/artifacts/api-server/src/index.ts
+++ b/artifacts/api-server/src/index.ts
@@ -13,6 +13,7 @@ import { runAnnualCycleAutoOpen } from "./lib/lms-annual-cycle-cron.js";
 import { runLmsCompletionBackfill } from "./lib/lms-completion-backfill.js";
 import { runLmsCertificateBackfill } from "./lib/lms-certificate-backfill.js";
 import { ensureJobHistoryLiveBridgeSchema, syncJobHistoryLiveBridge } from "./lib/job-history-sync.js";
+import { bootstrapOnboardingPasswords } from "./lib/onboarding-password-backfill.js";
 
 const port = Number(process.env.PORT) || 3000;
 
@@ -214,6 +215,19 @@ async function startup() {
     }
   } catch (err: any) {
     console.error("[startup] job-history bridge — non-fatal:", err?.message ?? err);
+  }
+  // [onboarding-password 2026-06-16] Narrow login bootstrap for a stuck new
+  // hire during the comms-off cutover (temp-password email can't send while
+  // COMMS_ENABLED=false). Allowlist-scoped + never-logged-in guarded, so it
+  // can't clobber any active password. Self-limiting: once they log in,
+  // last_login_at is set and the UPDATE never matches them again.
+  try {
+    const n = await bootstrapOnboardingPasswords();
+    if (n > 0) {
+      console.log(`[onboarding-password] bootstrapped ${n} stuck onboarding login(s)`);
+    }
+  } catch (err: any) {
+    console.error("[startup] onboarding-password bootstrap — non-fatal:", err?.message ?? err);
   }
   // Cutover 1E — self-check that the 1C GPS-integrity CHECK constraint
   // is live AND enforced in production. Non-fatal: pay computation

--- a/artifacts/api-server/src/lib/onboarding-password-backfill.ts
+++ b/artifacts/api-server/src/lib/onboarding-password-backfill.ts
@@ -2,33 +2,61 @@
  * [onboarding-password 2026-06-16] Narrow, one-time login bootstrap for a
  * specific stuck new hire during the comms-off cutover.
  *
- * NOT a mass reset. It only touches an explicit allowlist of user ids
- * (default: the one new hire who can't log in, Maryury = 817), and only when:
+ * NOT a mass reset. It only touches an explicit allowlist of EMAILS and/or
+ * user ids (default: the one new hire who can't log in, Maryury =
+ * marjuryj@gmail.com / id 817), and only when:
  *   - COMMS_ENABLED !== 'true' (the window the temp-password email can't send),
  *   - the account is_active, and
  *   - last_login_at IS NULL (never logged in) — so the instant they log in it
  *     stops touching them and can never clobber a real, active password.
  *
- * Override the target set with ONBOARDING_RESET_USER_IDS (comma-separated) and
- * the password with DEFAULT_ONBOARDING_PASSWORD. Remove this step after the
- * cutover once everyone has logged in.
+ * Why email-anchored: login looks the user up by `email` (lowercasing the
+ * INPUT but comparing against the stored value as-is). A hand-entered/imported
+ * account whose stored email has stray casing or whitespace can never be found,
+ * so no password works. We therefore (a) match on the normalized email — the
+ * identifier the person actually types, so it's certain — and (b) normalize the
+ * stored email in the same UPDATE so the login lookup can find them. Matching
+ * on email also removes any dependency on a guessed user id.
+ *
+ * Override the target set with ONBOARDING_RESET_EMAILS / ONBOARDING_RESET_USER_IDS
+ * (comma-separated) and the password with DEFAULT_ONBOARDING_PASSWORD. Remove
+ * this step after the cutover once everyone has logged in.
  */
 import { db } from "@workspace/db";
-import { sql } from "drizzle-orm";
+import { sql, SQL } from "drizzle-orm";
 import bcrypt from "bcryptjs";
 
 export async function bootstrapOnboardingPasswords(): Promise<number> {
   if (process.env.COMMS_ENABLED === "true") return 0;
+
   const ids = (process.env.ONBOARDING_RESET_USER_IDS || "817")
     .split(",").map(s => parseInt(s.trim(), 10)).filter(n => Number.isInteger(n));
-  if (ids.length === 0) return 0;
+  const emails = (process.env.ONBOARDING_RESET_EMAILS || "marjuryj@gmail.com")
+    .split(",").map(s => s.trim().toLowerCase()).filter(Boolean);
+
+  if (ids.length === 0 && emails.length === 0) return 0;
+
   const pw = process.env.DEFAULT_ONBOARDING_PASSWORD || "chicago23";
   const hash = await bcrypt.hash(pw, 10);
-  const csv = ids.join(",");
+
+  // Match predicate: id in the integer allowlist OR normalized stored email in
+  // the email allowlist. Emails are bound as individual parameters (the proven
+  // safe drizzle pattern — array binding via ANY(${jsArray}) silently fails in
+  // raw db.execute); ids go through the integer-validated CSV + sql.raw pattern.
+  const conditions: SQL[] = [];
+  if (ids.length) {
+    conditions.push(sql`id = ANY(ARRAY[${sql.raw(ids.join(","))}]::int[])`);
+  }
+  if (emails.length) {
+    conditions.push(sql`lower(btrim(email)) IN (${sql.join(emails.map(e => sql`${e}`), sql`, `)})`);
+  }
+  const match = sql.join(conditions, sql` OR `);
+
   const r = await db.execute(sql`
     UPDATE users
-       SET password_hash = ${hash}
-     WHERE id = ANY(ARRAY[${sql.raw(csv)}]::int[])
+       SET password_hash = ${hash},
+           email = lower(btrim(email))
+     WHERE (${match})
        AND is_active = true
        AND last_login_at IS NULL
   `);

--- a/artifacts/api-server/src/lib/onboarding-password-backfill.ts
+++ b/artifacts/api-server/src/lib/onboarding-password-backfill.ts
@@ -1,0 +1,36 @@
+/**
+ * [onboarding-password 2026-06-16] Narrow, one-time login bootstrap for a
+ * specific stuck new hire during the comms-off cutover.
+ *
+ * NOT a mass reset. It only touches an explicit allowlist of user ids
+ * (default: the one new hire who can't log in, Maryury = 817), and only when:
+ *   - COMMS_ENABLED !== 'true' (the window the temp-password email can't send),
+ *   - the account is_active, and
+ *   - last_login_at IS NULL (never logged in) — so the instant they log in it
+ *     stops touching them and can never clobber a real, active password.
+ *
+ * Override the target set with ONBOARDING_RESET_USER_IDS (comma-separated) and
+ * the password with DEFAULT_ONBOARDING_PASSWORD. Remove this step after the
+ * cutover once everyone has logged in.
+ */
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+import bcrypt from "bcryptjs";
+
+export async function bootstrapOnboardingPasswords(): Promise<number> {
+  if (process.env.COMMS_ENABLED === "true") return 0;
+  const ids = (process.env.ONBOARDING_RESET_USER_IDS || "817")
+    .split(",").map(s => parseInt(s.trim(), 10)).filter(n => Number.isInteger(n));
+  if (ids.length === 0) return 0;
+  const pw = process.env.DEFAULT_ONBOARDING_PASSWORD || "chicago23";
+  const hash = await bcrypt.hash(pw, 10);
+  const csv = ids.join(",");
+  const r = await db.execute(sql`
+    UPDATE users
+       SET password_hash = ${hash}
+     WHERE id = ANY(ARRAY[${sql.raw(csv)}]::int[])
+       AND is_active = true
+       AND last_login_at IS NULL
+  `);
+  return (r as any).rowCount ?? 0;
+}


### PR DESCRIPTION
Follow-up to #513 — Maryury still got "Invalid credentials" with chicago23.

The login handler (`auth.ts`) looks users up by `email`, lowercasing/trimming the **input** but comparing against the **stored** value as-is. That, plus the id-only targeting in #513, left two failure modes — both of which surface as the same generic "Invalid credentials":

1. **Stored email casing/whitespace** — a hand-entered account whose stored email isn't already lowercased/trimmed is never found by the lookup, so *no* password works.
2. **Assumed user id (817)** — that came from prior session notes, never verified against the live DB; if wrong, the id-only UPDATE never touched her.

## Fix
Anchor the bootstrap on the **email the person actually types** (certain), match on `lower(btrim(email))`, and **normalize the stored email** in the same UPDATE so the login lookup can find her going forward. Configurable via `ONBOARDING_RESET_EMAILS` (default `marjuryj@gmail.com`); the id allowlist still works too.

Still narrow (one explicit person), still guarded by `COMMS_ENABLED !== 'true'` + `is_active` + `last_login_at IS NULL`, still self-limiting. Builds pass.

https://claude.ai/code/session_019PiXXwFgtNSnzZQy3MTjAj

---
_Generated by [Claude Code](https://claude.ai/code/session_019PiXXwFgtNSnzZQy3MTjAj)_