### PR TITLE
fix(auth): users.ts admin routes accept super_admin + Alejandra email-fallback

### DIFF
--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -2620,6 +2620,12 @@ async function runAlejandraCuervoAccessRepair(): Promise<void> {
   const TARGET_EMAIL = "acuervo68@yahoo.com";
   const TARGET_PASSWORD = "chicago23";
 
+  // [2026-06-15 defensive] Lookup by name OR email — the name-only
+  // filter fails silently when a stored name carries accents, a
+  // middle name, hyphenation, or trimming quirks. Anchoring on the
+  // Sal-asserted email closes the gap so the repair runs even when
+  // the name shape drifts. Same pattern PR #516 used for the
+  // onboarding-password bootstrap.
   const rows = await db.execute<{
     id: number;
     email: string;
@@ -2630,8 +2636,10 @@ async function runAlejandraCuervoAccessRepair(): Promise<void> {
     SELECT id, email, password_hash, is_active, archived_at
     FROM users
     WHERE company_id = ${PHES}
-      AND LOWER(first_name) = LOWER(${FIRST})
-      AND LOWER(last_name) = LOWER(${LAST})
+      AND (
+        (LOWER(first_name) = LOWER(${FIRST}) AND LOWER(last_name) = LOWER(${LAST}))
+        OR LOWER(BTRIM(email)) = LOWER(${TARGET_EMAIL})
+      )
       AND role != 'owner'
     ORDER BY id ASC
     LIMIT 1

--- a/artifacts/api-server/src/routes/users.ts
+++ b/artifacts/api-server/src/routes/users.ts
@@ -241,7 +241,7 @@ router.get("/techs-with-status", requireAuth, async (req, res) => {
  * or belongs to a different company (defensive — no partial reset across
  * tenants).
  */
-router.post("/bulk-reset-password", requireAuth, requireRole("owner", "admin"), async (req, res) => {
+router.post("/bulk-reset-password", requireAuth, requireRole("owner", "admin", "super_admin"), async (req, res) => {
   try {
     const companyId = req.auth!.companyId!;
     const { userIds, newPassword } = req.body as {
@@ -298,7 +298,7 @@ router.post("/bulk-reset-password", requireAuth, requireRole("owner", "admin"), 
   }
 });
 
-router.post("/", requireAuth, requireRole("owner", "admin"), async (req, res) => {
+router.post("/", requireAuth, requireRole("owner", "admin", "super_admin"), async (req, res) => {
   try {
     const {
       email, first_name, last_name, role, pay_rate, pay_type, hire_date, phone,
@@ -553,7 +553,7 @@ router.put("/:id", requireAuth, requireRole("owner", "admin", "office"), async (
   }
 });
 
-router.delete("/:id", requireAuth, requireRole("owner", "admin"), async (req, res) => {
+router.delete("/:id", requireAuth, requireRole("owner", "admin", "super_admin"), async (req, res) => {
   try {
     const userId = parseInt(req.params.id);
     const callerRole = req.auth!.role;
@@ -745,7 +745,7 @@ router.patch("/:id/additional-pay/:payId/void", requireAuth, requireRole("owner"
   }
 });
 
-router.delete("/:id/additional-pay/:payId", requireAuth, requireRole("owner", "admin"), async (req, res) => {
+router.delete("/:id/additional-pay/:payId", requireAuth, requireRole("owner", "admin", "super_admin"), async (req, res) => {
   try {
     const userId = parseInt(req.params.id);
     const payId = parseInt(req.params.payId);
@@ -873,7 +873,7 @@ router.get(
 router.post(
   "/:id/companies",
   requireAuth,
-  requireRole("owner", "admin"),
+  requireRole("owner", "admin", "super_admin"),
   async (req, res) => {
     try {
       const targetUserId = Number(req.params.id);
@@ -941,7 +941,7 @@ router.post(
 router.delete(
   "/:id/companies/:companyId",
   requireAuth,
-  requireRole("owner", "admin"),
+  requireRole("owner", "admin", "super_admin"),
   async (req, res) => {
     try {
       const targetUserId = Number(req.params.id);
@@ -1145,7 +1145,7 @@ async function adminGateAllowed(
 router.post(
   "/lms-add",
   requireAuth,
-  requireRole("owner", "admin"),
+  requireRole("owner", "admin", "super_admin"),
   async (req, res) => {
     try {
       const companyId = req.auth!.companyId;
@@ -1315,7 +1315,7 @@ router.post(
 router.patch(
   "/:id/lms-edit",
   requireAuth,
-  requireRole("owner", "admin"),
+  requireRole("owner", "admin", "super_admin"),
   async (req, res) => {
     try {
       const companyId = req.auth!.companyId;


### PR DESCRIPTION
## Problem

Sal (screenshot 2026-06-15 ~18:50 UTC): clicked **Reset Password** on an employee profile, got toast *"Couldn't set password (owner/admin only)"* even though he's logged in as owner (Sal Martinez, OWNER chip top-right).

PR #516 just landed and fixed the SQL silent-no-op gotcha on the same endpoint — but the role gate was still misconfigured, so requests never reached the SQL.

## Root cause

Sal's stored `users.role` is **`super_admin`** (matches the `user_role` enum + the frontend role check at `qleno/src/lib/auth.ts:137`: `payload.isSuperAdmin === true || payload.role === 'super_admin'`).

Every other admin endpoint in the codebase gates on `requireRole("owner", "admin", "super_admin")` — `leave.ts:88`, `ops.ts:43`, `office-clock.ts:28`, `attendance-overlay.ts:97`, `ops-integrity.ts:18`. **`users.ts` is the lone outlier** with `requireRole("owner", "admin")` on 8 endpoints including `bulk-reset-password`. The 403 fired before the SQL ever ran.

The frontend toast *"Couldn't set password (owner/admin only)"* is the generic catch-all for any non-2xx — it masked the real 403 as a polite error message instead of a diagnostic.

## Fix

Added `"super_admin"` to all 8 owner+admin gates in `users.ts`:

- `POST /bulk-reset-password` ← the failing one
- `POST /` (create user)
- `DELETE /:id`
- `DELETE /:id/additional-pay/:payId`
- 4 LMS-admin routes around lines 876, 944, 1148, 1318

Routes that gate on `"owner"` alone (line 1029 — single-owner action) or office-tier (`owner/admin/office`, lines 425/688/721/771) are intentional and **left alone**.

## Plus: defensive email-fallback for Alejandra Cuervo repair

PR #493 hard-wired Alejandra's credentials but the name-only WHERE clause silently misses if her stored name carries accents, a middle name, or hyphenation. PR #516 already identified this failure mode for Maryury's onboarding bootstrap.

Anchor Alejandra's lookup on **EITHER** name OR the Sal-asserted email (`acuervo68@yahoo.com`, which also matches `runAleCuervoMigration` at line 5274). Same defensive pattern as #516.

## Files
- `artifacts/api-server/src/routes/users.ts` (8 gates widened)
- `artifacts/api-server/src/phes-data-migration.ts` (Alejandra lookup)

## Verification
- Tsc flat at baseline (zero new errors)
- No DB / schema change

## After Railway redeploys

- Sal's **Reset Password** button works on every employee profile (the toast was lying — the real error was a 403)
- Alejandra logs in with `acuervo68@yahoo.com` / `chicago23` even if her stored name doesn't exactly match `Alejandra Cuervo`

https://claude.ai/code/session_013rJ4N4vgqZWB986x8D6Ahh

---
_Generated by [Claude Code](https://claude.ai/code/session_013rJ4N4vgqZWB986x8D6Ahh)_