### PR TITLE
fix(auth): hard-wire Maryury Colmenares access on cold start

### DIFF
--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -2698,6 +2698,108 @@ async function runAlejandraCuervoAccessRepair(): Promise<void> {
 }
 
 /**
+ * Maryury Colmenares access repair (2026-06-16, ad-hoc).
+ *
+ * Same pattern as the Diana / Juliana / Alejandra repairs. PR #516
+ * landed a more generic bootstrapOnboardingPasswords() that also
+ * targets Maryury, but it gates on `COMMS_ENABLED !== 'true'` and
+ * Sal asked for an unconditional hard-wire so she works regardless of
+ * the comms-gate state.
+ *
+ * On every cold start (idempotent, scoped to company_id=1):
+ *   1. Resolve Maryury Colmenares by name OR email OR id=817.
+ *   2. Set email = 'marjuryj@gmail.com' (Sal-asserted; matches the
+ *      login email visible in the LMS admin profile).
+ *   3. Ensure password_hash = bcrypt('chicago23'). bcrypt.compare
+ *      guards make every subsequent boot a no-op SELECT once correct.
+ *   4. Ensure is_active = true and archived_at = NULL.
+ *   5. Stamp password_reset_to_chicago23_at = NOW().
+ *
+ * Lookup is broad on purpose — name OR canonical email OR id=817
+ * (the value documented in PR #516's notes). If any of the three
+ * matches, the function runs against her row.
+ */
+async function runMaryuryColmenaresAccessRepair(): Promise<void> {
+  const PHES = 1;
+  const FIRST = "Maryury";
+  const LAST = "Colmenares";
+  const TARGET_EMAIL = "marjuryj@gmail.com";
+  const KNOWN_USER_ID = 817;
+  const TARGET_PASSWORD = "chicago23";
+
+  const rows = await db.execute<{
+    id: number;
+    email: string;
+    password_hash: string;
+    is_active: boolean;
+    archived_at: Date | null;
+  }>(sql`
+    SELECT id, email, password_hash, is_active, archived_at
+    FROM users
+    WHERE company_id = ${PHES}
+      AND (
+        (LOWER(first_name) = LOWER(${FIRST}) AND LOWER(last_name) = LOWER(${LAST}))
+        OR LOWER(BTRIM(email)) = LOWER(${TARGET_EMAIL})
+        OR id = ${KNOWN_USER_ID}
+      )
+      AND role != 'owner'
+    ORDER BY id ASC
+    LIMIT 1
+  `);
+  const row = ((rows as any).rows ?? rows)[0] as
+    | {
+        id: number;
+        email: string;
+        password_hash: string;
+        is_active: boolean;
+        archived_at: Date | null;
+      }
+    | undefined;
+
+  if (!row) {
+    console.log(
+      `[maryury-colmenares-access-repair] no Maryury Colmenares row in company_id=${PHES}; skipping`,
+    );
+    return;
+  }
+
+  const hashMatches = await bcrypt
+    .compare(TARGET_PASSWORD, row.password_hash)
+    .catch(() => false);
+  const emailMatches = row.email === TARGET_EMAIL;
+  const activeOk = row.is_active === true;
+  const unarchivedOk = row.archived_at === null;
+
+  if (hashMatches && emailMatches && activeOk && unarchivedOk) {
+    console.log(
+      `[maryury-colmenares-access-repair] user_id=${row.id} already in target state; no-op`,
+    );
+    return;
+  }
+
+  const newHash = hashMatches
+    ? row.password_hash
+    : await bcrypt.hash(TARGET_PASSWORD, 10);
+
+  await db.execute(sql`
+    UPDATE users
+    SET
+      email = ${TARGET_EMAIL},
+      password_hash = ${newHash},
+      is_active = true,
+      archived_at = NULL,
+      password_reset_to_chicago23_at = NOW()
+    WHERE id = ${row.id}
+  `);
+
+  console.log(
+    `[maryury-colmenares-access-repair] user_id=${row.id} updated: ` +
+      `email_changed=${!emailMatches} hash_rewritten=${!hashMatches} ` +
+      `reactivated=${!activeOk} unarchived=${!unarchivedOk}`,
+  );
+}
+
+/**
  * QA sandbox account repurpose (2026-05-15 sprint, pre-sprint task).
  *
  * Dispatch created an audit fixture user during Phase 6 — repurpose it
@@ -3449,6 +3551,12 @@ export async function runPhesDataMigration(): Promise<void> {
     await runAlejandraCuervoAccessRepair();
   } catch (err: any) {
     console.warn("[phes-migration] alejandra-cuervo-access-repair — non-fatal:", err?.message ?? err);
+  }
+
+  try {
+    await runMaryuryColmenaresAccessRepair();
+  } catch (err: any) {
+    console.warn("[phes-migration] maryury-colmenares-access-repair — non-fatal:", err?.message ?? err);
   }
 
   try {


### PR DESCRIPTION
## Why a dedicated function

Sal: *"No claude i dont want to reset password just fix her account with the password chicago23"*

PR #516 already lands a broader `bootstrapOnboardingPasswords()` that targets Maryury — **but it gates on `COMMS_ENABLED !== 'true'`**, which silently bails if comms have been flipped on for go-live. Sal wants her hard-wired the same way Diana (#351) / Juliana (#363) / Alejandra (#493) are, so the cold-start migration guarantees access regardless of the comms-gate state.

## What this does

Adds `runMaryuryColmenaresAccessRepair()` to the `runPhesDataMigration()` chain. On every cold start (idempotent, scoped to `company_id = 1`):

1. Resolve Maryury Colmenares by **name OR email OR id=817** — three overlapping match clauses, so the function fires even if one attribute drifts (the failure mode #516 documented).
2. Set `email = 'marjuryj@gmail.com'` (Sal-asserted; matches the login email visible on her LMS admin profile).
3. Ensure `password_hash = bcrypt('chicago23', 10)`. `bcrypt.compare` guard keeps subsequent boots a no-op SELECT + compare.
4. Ensure `is_active = true` and `archived_at = NULL`.
5. Stamp `password_reset_to_chicago23_at = NOW()`.

## After Railway redeploys

Maryury logs in with:
- **Email:** `marjuryj@gmail.com`
- **Password:** `chicago23`

Boot-log confirmation line:
```
[maryury-colmenares-access-repair] user_id=X updated: email_changed=... hash_rewritten=... reactivated=... unarchived=...
```

## Scope / safety

- One file changed: `artifacts/api-server/src/phes-data-migration.ts`
- Scoped to `company_id = 1`
- No COMMS gate — runs unconditionally (point of this PR)
- Idempotent: bcrypt-compare + string-equality guards make subsequent boots a no-op
- Tsc flat at baseline (zero new errors)
- Non-fatal `try/catch` wrap so a bad-state-on-boot can't block deploy

https://claude.ai/code/session_013rJ4N4vgqZWB986x8D6Ahh

---
_Generated by [Claude Code](https://claude.ai/code/session_013rJ4N4vgqZWB986x8D6Ahh)_