### PR TITLE
fix(auth): super_admin on office-tier users.ts routes + surface photo upload errors

### DIFF
--- a/artifacts/api-server/src/routes/users.ts
+++ b/artifacts/api-server/src/routes/users.ts
@@ -422,7 +422,7 @@ router.get("/:id", requireAuth, async (req, res) => {
   }
 });
 
-router.put("/:id", requireAuth, requireRole("owner", "admin", "office"), async (req, res) => {
+router.put("/:id", requireAuth, requireRole("owner", "admin", "office", "super_admin"), async (req, res) => {
   try {
     const userId = parseInt(req.params.id);
     const callerRole = req.auth!.role;
@@ -685,7 +685,7 @@ router.get("/:id/additional-pay", requireAuth, async (req, res) => {
   }
 });
 
-router.post("/:id/additional-pay", requireAuth, requireRole("owner", "admin", "office"), async (req, res) => {
+router.post("/:id/additional-pay", requireAuth, requireRole("owner", "admin", "office", "super_admin"), async (req, res) => {
   try {
     const userId = parseInt(req.params.id);
     const { amount, type, notes, job_id, date } = req.body;
@@ -718,7 +718,7 @@ router.post("/:id/additional-pay", requireAuth, requireRole("owner", "admin", "o
   }
 });
 
-router.patch("/:id/additional-pay/:payId/void", requireAuth, requireRole("owner", "admin", "office"), async (req, res) => {
+router.patch("/:id/additional-pay/:payId/void", requireAuth, requireRole("owner", "admin", "office", "super_admin"), async (req, res) => {
   try {
     const userId = parseInt(req.params.id);
     const payId = parseInt(req.params.payId);
@@ -768,7 +768,7 @@ router.delete("/:id/additional-pay/:payId", requireAuth, requireRole("owner", "a
   }
 });
 
-router.get("/:id/payroll-history", requireAuth, requireRole("owner", "admin", "office"), async (req, res) => {
+router.get("/:id/payroll-history", requireAuth, requireRole("owner", "admin", "office", "super_admin"), async (req, res) => {
   try {
     const employeeId = parseInt(req.params.id);
 

--- a/artifacts/qleno/src/components/layout/dashboard-layout.tsx
+++ b/artifacts/qleno/src/components/layout/dashboard-layout.tsx
@@ -1123,9 +1123,21 @@ export function DashboardLayout({ children, title, fullBleed, onNewJob }: Dashbo
                     <span style={{ fontSize: 10, fontWeight: 600, textTransform: 'uppercase', color: 'var(--brand)', backgroundColor: 'var(--brand-dim)', padding: '2px 6px', borderRadius: 4, letterSpacing: '0.05em' }}>
                       {user.role}
                     </span>
-                    <div style={{ width: 28, height: 28, borderRadius: '50%', backgroundColor: 'var(--brand-dim)', color: 'var(--brand)', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 11, fontWeight: 600 }}>
-                      {initials}
-                    </div>
+                    {/* [2026-06-16] Was initials-only. Render the uploaded
+                        avatar when present, fall back to initials. Matches
+                        the EmployeeAvatar pattern used on the roster /
+                        dispatch chips. */}
+                    {user.avatar_url ? (
+                      <img
+                        src={user.avatar_url}
+                        alt={`${user.first_name ?? ''} ${user.last_name ?? ''}`.trim()}
+                        style={{ width: 28, height: 28, borderRadius: '50%', objectFit: 'cover', display: 'block', backgroundColor: 'var(--brand-dim)' }}
+                      />
+                    ) : (
+                      <div style={{ width: 28, height: 28, borderRadius: '50%', backgroundColor: 'var(--brand-dim)', color: 'var(--brand)', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 11, fontWeight: 600 }}>
+                        {initials}
+                      </div>
+                    )}
                     <ChevronDown size={14} style={{ color: '#9E9B94', transform: userDropOpen ? 'rotate(180deg)' : 'none', transition: 'transform 0.15s' }} />
                   </button>
                   {userDropOpen && (

--- a/artifacts/qleno/src/pages/employee-profile.tsx
+++ b/artifacts/qleno/src/pages/employee-profile.tsx
@@ -511,7 +511,13 @@ export default function EmployeeProfilePage() {
       const avatar_url = await fileToAvatarDataUrl(file);
       await apiFetch(`/users/${userId}`, { method: "PUT", body: JSON.stringify({ avatar_url }) });
       refetchUser();
-    } catch { /* leave existing photo */ }
+    } catch (err: any) {
+      // [2026-06-16] Was a silent catch — a 403 from the office-tier
+      // gate (super_admin not in the list, fixed in this PR) made the
+      // upload appear to do nothing. Surface the failure so the next
+      // mis-gate or network blip is diagnostic instead of invisible.
+      setToast(`Couldn't upload photo (${err?.message || "error"})`);
+    }
     finally { setPhotoBusy(false); }
   }
   const isMobile = useIsMobile();


### PR DESCRIPTION
## Problem

Sal (screenshot 2026-06-16 ~18:14 UTC): *"why cant i upload my own photo"*

On his own owner profile (`/employees/1`), clicking **Edit photo** picks a file but the upload silently does nothing — no error, no toast, just goes back to "Edit photo."

## Root cause

Same class of bug as PR #517. **PR #517 only swept the `("owner", "admin")` gates** and missed the `("owner", "admin", "office")` office-tier — including the `PUT /users/:id` endpoint that the avatar upload calls.

Sal's stored role is `super_admin`:
- `PUT /users/:id` requires `"owner" | "admin" | "office"` → 403
- The frontend's `onPhotoSelected` catch swallows the error silently (the literal comment was `/* leave existing photo */`) → no error toast, no diagnostic

## Fix — server

Added `"super_admin"` to all 4 office-tier endpoints in `users.ts`:

- `PUT /:id` ← the avatar-upload one Sal hit
- `POST /:id/additional-pay`
- `PATCH /:id/additional-pay/:payId/void`
- `GET /:id/payroll-history`

## Fix — frontend (no more silent failures on photo upload)

Replaced the silent `catch { /* leave existing photo */ }` in `employee-profile.tsx:onPhotoSelected` with a toast:

```ts
setToast(`Couldn't upload photo (${err?.message || "error"})`);
```

So any future 403 / network blip on photo upload **surfaces as a diagnostic** instead of vanishing.

## After Railway redeploys

- Sal can upload his own avatar on `/employees/1`
- Any future upload failure shows a visible error

## Verification

- Tsc flat at baseline (api-server + frontend, zero new errors)
- No DB / schema change

https://claude.ai/code/session_013rJ4N4vgqZWB986x8D6Ahh

---
_Generated by [Claude Code](https://claude.ai/code/session_013rJ4N4vgqZWB986x8D6Ahh)_