### PR TITLE
[DRAFT] Payroll MC-parity engine: hourly floor + all-techs pool denominator

### DIFF
--- a/artifacts/api-server/src/index.ts
+++ b/artifacts/api-server/src/index.ts
@@ -203,6 +203,12 @@ async function startup() {
   } catch (err: any) {
     console.error("[startup] ensurePayrollP0Setup — non-fatal:", err?.message ?? err);
   }
+  try {
+    const { ensurePayrollSnapshotSetup } = await import("./lib/payroll-snapshot.js");
+    await ensurePayrollSnapshotSetup();
+  } catch (err: any) {
+    console.error("[startup] ensurePayrollSnapshotSetup — non-fatal:", err?.message ?? err);
+  }
   // [revenue-connect 2026-06-12] job_history live bridge — mirrors completed
   // jobs into the revenue ledger past each tenant's MC-import end date, so
   // the dashboard forecast / business health / client history stay live

--- a/artifacts/api-server/src/lib/payroll-compute.ts
+++ b/artifacts/api-server/src/lib/payroll-compute.ts
@@ -76,7 +76,7 @@ export interface PayLine {
   branch_id: number | null;
   is_commercial: boolean;
   pay_type: PayType;
-  basis: "hourly" | "residential_pool" | "commercial_pool" | "manual_override";
+  basis: "hourly" | "residential_pool" | "commercial_pool" | "hourly_floor" | "manual_override";
   clocked_hours: number;
   paid_hours: number;       // hourly lines only (else 0)
   rate: number | null;      // $/hr for hourly, pct for commission
@@ -161,10 +161,12 @@ export function computePayLines(input: {
     const job = jobById.get(jobId)!;
     const isComm = jobIsCommercial(job);
     const pool = jobPool(job, config);
-
-    // Partition clocked techs into commission vs hourly for THIS job's type.
-    const commissionTechs = jobClocks.filter(c => payTypeFor(cellFor(c.user_id), isComm) === "commission");
-    const totalCommMinutes = commissionTechs.reduce((s, c) => s + c.clocked_hours, 0);
+    // [MC-parity] universal hourly/floor rate ($20). Enhancement B: the
+    // commission pool is split across ALL clocked techs by ACTUAL clocked hours
+    // (hourly techs occupy the denominator and take hourly — their pool share is
+    // forgone, matching MaidCentral on mixed crews).
+    const floorRate = config.commercial_hourly_rate;
+    const totalAllHours = jobClocks.reduce((s, c) => s + c.clocked_hours, 0);
 
     for (const c of jobClocks) {
       const cell = cellFor(c.user_id);
@@ -185,6 +187,26 @@ export function computePayLines(input: {
         continue;
       }
 
+      // Per-job HOURS override pays this line HOURLY at the company rate,
+      // regardless of the job's commission routing. It's an hours lever (not a
+      // dollar one): the office marks "this job was paid $/hr × N hours" — which
+      // is how MaidCentral hand-assigns certain jobs to hourly (incl. jobs a
+      // commission tech would otherwise pool). Commission-pool jobs carry no
+      // override and flow through the pool logic below.
+      if (paidOv.has(k)) {
+        const oh = paidOv.get(k)!;
+        const ovRate = config.commercial_hourly_rate;
+        lines.push({
+          user_id: c.user_id, job_id: jobId, scheduled_date: job.scheduled_date, branch_id: job.branch_id,
+          is_commercial: isComm, pay_type: "hourly", basis: "hourly",
+          clocked_hours: round2(c.clocked_hours), paid_hours: round2(oh), rate: ovRate,
+          pool_total: null, pool_share: null, hours_overridden: true,
+          amount: round2(oh * ovRate),
+          pay_basis_label: `$${ovRate.toFixed(2)}/hr × ${round2(oh)}h (override)`,
+        });
+        continue;
+      }
+
       if (pt === "hourly") {
         const hasOv = paidOv.has(k);
         const paidHours = hasOv ? paidOv.get(k)! : basisHours(config.hours_basis, c.clocked_hours, allowed);
@@ -197,19 +219,26 @@ export function computePayLines(input: {
           pay_basis_label: `$${rate.toFixed(2)}/hr × ${round2(paidHours)}h${hasOv ? " (override)" : ` (${config.hours_basis})`}`,
         });
       } else {
-        // commission: weighted share of the job pool among clocked commission techs
-        const share = totalCommMinutes > 0 ? c.clocked_hours / totalCommMinutes : (commissionTechs.length ? 1 / commissionTechs.length : 0);
+        // residential commission tech: GREATER-OF(pool share, hourly floor).
+        // Enhancement A: floor = clocked actual hrs × $20 (long low-fee job still
+        // clears minimum wage). Enhancement B: pool share weighted by clocked
+        // hours across ALL techs on the job.
+        const shareFrac = totalAllHours > 0 ? c.clocked_hours / totalAllHours : 1;
+        const shareAmt = round2(pool.total * shareFrac);
+        const floorAmt = round2(c.clocked_hours * floorRate);
+        const useFloor = floorAmt > shareAmt;
         lines.push({
           user_id: c.user_id, job_id: jobId, scheduled_date: job.scheduled_date, branch_id: job.branch_id,
           is_commercial: isComm, pay_type: "commission",
-          basis: isComm ? "commercial_pool" : "residential_pool",
-          clocked_hours: round2(c.clocked_hours), paid_hours: 0, rate: isComm ? null : rate,
-          pool_total: pool.total, pool_share: round2(share),
+          basis: useFloor ? "hourly_floor" : (isComm ? "commercial_pool" : "residential_pool"),
+          clocked_hours: round2(c.clocked_hours), paid_hours: useFloor ? round2(c.clocked_hours) : 0,
+          rate: useFloor ? floorRate : rate,
+          pool_total: pool.total, pool_share: round2(shareFrac),
           hours_overridden: false,
-          amount: round2(pool.total * share),
-          pay_basis_label: commissionTechs.length > 1
-            ? `${(share * 100).toFixed(0)}% of ${pool.basisLabel}`
-            : pool.basisLabel,
+          amount: Math.max(shareAmt, floorAmt),
+          pay_basis_label: useFloor
+            ? `$${floorRate.toFixed(2)}/hr × ${round2(c.clocked_hours)}h (floor)`
+            : `${Math.round(shareFrac * 100)}% of ${pool.basisLabel}`,
         });
       }
     }

--- a/artifacts/api-server/src/lib/payroll-snapshot.ts
+++ b/artifacts/api-server/src/lib/payroll-snapshot.ts
@@ -1,0 +1,165 @@
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+import { computePayLines, type PayrollJob, type ClockEntry, type TechCell, type CompanyPayConfig, type HoursBasis } from "./payroll-compute.js";
+import { parseResRatesRow } from "./commission-rates.js";
+
+/**
+ * Phase 2 — PUBLISH PAYROLL: snapshot each tech's computed pay for a pay period
+ * into a locked per-(period, tech) record, and read it back for the
+ * employee-profile Pay section. Idempotent: re-publishing a period upserts.
+ *
+ * The snapshot is the SOURCE OF TRUTH for what a tech is shown — once published
+ * it doesn't drift if jobs/clocks change later. Breakdown columns mirror the
+ * MaidCentral grid the team is used to (base / hours / tips / OT / bonus /
+ * adjustments) plus a per-job JSON for the expandable detail.
+ */
+export async function ensurePayrollSnapshotSetup(): Promise<void> {
+  try {
+    await db.execute(sql`
+      CREATE TABLE IF NOT EXISTS payroll_period_snapshots (
+        id serial PRIMARY KEY,
+        company_id integer NOT NULL,
+        pay_period_start date NOT NULL,
+        pay_period_end date NOT NULL,
+        user_id integer NOT NULL,
+        gross numeric(10,2) NOT NULL DEFAULT 0,
+        base numeric(10,2) NOT NULL DEFAULT 0,
+        hours numeric(8,2) NOT NULL DEFAULT 0,
+        tips numeric(10,2) NOT NULL DEFAULT 0,
+        overtime numeric(10,2) NOT NULL DEFAULT 0,
+        bonus numeric(10,2) NOT NULL DEFAULT 0,
+        adjustments numeric(10,2) NOT NULL DEFAULT 0,
+        breakdown jsonb NOT NULL DEFAULT '[]'::jsonb,
+        published_at timestamptz NOT NULL DEFAULT now(),
+        published_by_user_id integer,
+        CONSTRAINT payroll_snap_uniq UNIQUE (company_id, pay_period_start, pay_period_end, user_id)
+      )`);
+    await db.execute(sql`CREATE INDEX IF NOT EXISTS idx_payroll_snap_user ON payroll_period_snapshots (company_id, user_id, pay_period_start DESC)`);
+    console.log("[payroll-snapshot] schema ready");
+  } catch (err) {
+    console.error("[payroll-snapshot] ensure setup error (non-fatal):", err);
+  }
+}
+
+const r2 = (n: number) => Math.round(n * 100) / 100;
+const intList = (a: number[]) => a.map(Number).filter(Number.isFinite).join(",");
+
+export interface PeriodPay {
+  user_id: number;
+  name: string;
+  gross: number;
+  base: number;
+  hours: number;
+  tips: number;
+  overtime: number;
+  bonus: number;
+  adjustments: number; // sick + other adjustment-type additional_pay
+  jobs: Array<{ job_id: number; date: string; client: string; amount: number; hours: number; basis: string }>;
+  additional_pay: Record<string, number>;
+}
+
+/**
+ * Compute each tech's pay for a period using the MC-parity engine + additional_pay.
+ * Same inputs/rules as GET /payroll/detail; returned in snapshot shape.
+ */
+export async function computePeriodPay(companyId: number, start: string, end: string): Promise<PeriodPay[]> {
+  const co = (await db.execute(sql`SELECT res_tech_pay_pct, deep_clean_pay_pct, move_in_out_pay_pct, commercial_hourly_rate, commercial_comp_mode, payroll_hours_basis FROM companies WHERE id = ${companyId} LIMIT 1`)).rows[0] as any;
+  const resRates = parseResRatesRow(co);
+  const hb = co?.payroll_hours_basis;
+  const config: CompanyPayConfig = {
+    resRates,
+    commercial_hourly_rate: parseFloat(String(co?.commercial_hourly_rate ?? 20)),
+    commercial_comp_mode: co?.commercial_comp_mode === "actual_hours" ? "actual_hours" : "allowed_hours",
+    hours_basis: (hb === "actual_clocked" || hb === "allowed_hours" || hb === "greater_of" ? hb : "greater_of") as HoursBasis,
+  };
+  const jr = (await db.execute(sql`
+    SELECT j.id, j.account_id, cl.client_type, cl.first_name, cl.last_name, a.account_name, j.service_type,
+           j.base_fee, j.billed_amount, j.allowed_hours, j.actual_hours, j.scheduled_date::text AS scheduled_date, j.branch_id
+    FROM jobs j LEFT JOIN clients cl ON cl.id = j.client_id LEFT JOIN accounts a ON a.id = j.account_id
+    WHERE j.company_id = ${companyId} AND j.status = 'complete'
+      AND j.scheduled_date >= ${start} AND j.scheduled_date <= ${end}`)).rows as any[];
+  const jobs: PayrollJob[] = jr.map(j => ({ id: j.id, account_id: j.account_id, client_type: j.client_type, service_type: j.service_type, base_fee: j.base_fee, billed_amount: j.billed_amount, allowed_hours: j.allowed_hours, actual_hours: j.actual_hours, scheduled_date: j.scheduled_date, branch_id: j.branch_id }));
+  const nameOfJob = new Map<number, string>(jr.map(j => [j.id, (`${j.first_name ?? ""} ${j.last_name ?? ""}`.trim() || j.account_name || "")]));
+  const ids = jobs.map(j => j.id);
+  if (!ids.length) return [];
+
+  const clocks: ClockEntry[] = ((await db.execute(sql`
+    SELECT user_id, job_id, ROUND(SUM(EXTRACT(EPOCH FROM (clock_out_at - clock_in_at)) / 3600.0)::numeric, 2) AS hrs
+    FROM timeclock WHERE company_id = ${companyId} AND job_id = ANY(ARRAY[${sql.raw(intList(ids))}]::int[]) AND clock_out_at IS NOT NULL
+    GROUP BY user_id, job_id`)).rows as any[]).map(r => ({ user_id: Number(r.user_id), job_id: Number(r.job_id), clocked_hours: parseFloat(String(r.hrs || 0)) }));
+
+  const clockedUserIds = [...new Set(clocks.map(c => c.user_id))];
+  const cellByUser = new Map<number, TechCell>();
+  const userMap = new Map<number, string>();
+  if (clockedUserIds.length) {
+    const us = (await db.execute(sql`SELECT id, first_name, last_name, residential_pay_type, residential_pay_rate, commercial_pay_type, commercial_pay_rate FROM users WHERE company_id = ${companyId} AND id = ANY(ARRAY[${sql.raw(intList(clockedUserIds))}]::int[])`)).rows as any[];
+    for (const u of us) {
+      userMap.set(Number(u.id), `${u.first_name ?? ""} ${u.last_name ?? ""}`.trim());
+      cellByUser.set(Number(u.id), {
+        residential_pay_type: u.residential_pay_type === "hourly" ? "hourly" : "commission",
+        residential_pay_rate: parseFloat(String(u.residential_pay_rate ?? resRates.res_tech_pay_pct)),
+        commercial_pay_type: u.commercial_pay_type === "commission" ? "commission" : "hourly",
+        commercial_pay_rate: parseFloat(String(u.commercial_pay_rate ?? config.commercial_hourly_rate)),
+      });
+    }
+  }
+  const paidOv = new Map<string, number>();
+  try { for (const r of (await db.execute(sql`SELECT user_id, job_id, paid_hours FROM payroll_hours_overrides WHERE company_id = ${companyId} AND job_id = ANY(ARRAY[${sql.raw(intList(ids))}]::int[])`)).rows as any[]) if (r.paid_hours != null) paidOv.set(`${r.user_id}:${r.job_id}`, parseFloat(String(r.paid_hours))); } catch { /* table absent */ }
+  const finalOv = new Map<string, number>();
+  try { for (const r of (await db.execute(sql`SELECT user_id, job_id, final_pay FROM job_technicians WHERE job_id = ANY(ARRAY[${sql.raw(intList(ids))}]::int[]) AND final_pay IS NOT NULL`)).rows as any[]) if (r.final_pay != null) finalOv.set(`${r.user_id}:${r.job_id}`, parseFloat(String(r.final_pay))); } catch { /* */ }
+
+  const lines = computePayLines({ jobs, clocks, cellByUser, config, paidHoursOverride: paidOv, finalPayOverride: finalOv });
+
+  // additional_pay by user + type, bucketed by created_at in the window
+  const addlByUser = new Map<number, Record<string, number>>();
+  for (const r of (await db.execute(sql`
+    SELECT user_id, type, COALESCE(SUM(amount), 0) AS t FROM additional_pay
+    WHERE company_id = ${companyId} AND status <> 'voided'
+      AND created_at >= ${start + "T00:00:00Z"} AND created_at <= ${end + "T23:59:59Z"}
+    GROUP BY user_id, type`)).rows as any[]) {
+    const uid = Number(r.user_id);
+    if (!addlByUser.has(uid)) addlByUser.set(uid, {});
+    addlByUser.get(uid)![String(r.type)] = parseFloat(String(r.t || 0));
+  }
+
+  const byUser = new Map<number, PeriodPay>();
+  for (const l of lines) {
+    if (!byUser.has(l.user_id)) byUser.set(l.user_id, { user_id: l.user_id, name: userMap.get(l.user_id) || "", gross: 0, base: 0, hours: 0, tips: 0, overtime: 0, bonus: 0, adjustments: 0, jobs: [], additional_pay: {} });
+    const p = byUser.get(l.user_id)!;
+    p.base = r2(p.base + l.amount);
+    p.hours = r2(p.hours + (l.paid_hours > 0 ? l.paid_hours : l.clocked_hours));
+    p.jobs.push({ job_id: l.job_id, date: l.scheduled_date, client: nameOfJob.get(l.job_id) || "", amount: l.amount, hours: l.paid_hours > 0 ? l.paid_hours : l.clocked_hours, basis: l.pay_basis_label });
+  }
+  // fold additional_pay
+  for (const [uid, types] of addlByUser) {
+    if (!byUser.has(uid)) byUser.set(uid, { user_id: uid, name: userMap.get(uid) || "", gross: 0, base: 0, hours: 0, tips: 0, overtime: 0, bonus: 0, adjustments: 0, jobs: [], additional_pay: {} });
+    const p = byUser.get(uid)!;
+    p.additional_pay = types;
+    for (const [t, amt] of Object.entries(types)) {
+      if (t === "tips") p.tips = r2(p.tips + amt);
+      else if (t === "overtime" || t === "overtime_pay") p.overtime = r2(p.overtime + amt);
+      else if (t === "bonus") p.bonus = r2(p.bonus + amt);
+      else p.adjustments = r2(p.adjustments + amt); // sick_pay, holiday_pay, adjustment, mileage, etc.
+    }
+  }
+  for (const p of byUser.values()) p.gross = r2(p.base + p.tips + p.overtime + p.bonus + p.adjustments);
+  return [...byUser.values()];
+}
+
+/** Publish (idempotent upsert) a period's snapshots. Returns the published rows. */
+export async function publishPeriod(companyId: number, start: string, end: string, byUserId: number): Promise<{ published: number; total_gross: number }> {
+  await ensurePayrollSnapshotSetup();
+  const pay = await computePeriodPay(companyId, start, end);
+  let total = 0;
+  for (const p of pay) {
+    total += p.gross;
+    await db.execute(sql`
+      INSERT INTO payroll_period_snapshots (company_id, pay_period_start, pay_period_end, user_id, gross, base, hours, tips, overtime, bonus, adjustments, breakdown, published_at, published_by_user_id)
+      VALUES (${companyId}, ${start}, ${end}, ${p.user_id}, ${p.gross}, ${p.base}, ${p.hours}, ${p.tips}, ${p.overtime}, ${p.bonus}, ${p.adjustments}, ${JSON.stringify(p.jobs)}::jsonb, now(), ${byUserId})
+      ON CONFLICT (company_id, pay_period_start, pay_period_end, user_id)
+      DO UPDATE SET gross = EXCLUDED.gross, base = EXCLUDED.base, hours = EXCLUDED.hours, tips = EXCLUDED.tips,
+        overtime = EXCLUDED.overtime, bonus = EXCLUDED.bonus, adjustments = EXCLUDED.adjustments,
+        breakdown = EXCLUDED.breakdown, published_at = now(), published_by_user_id = EXCLUDED.published_by_user_id`);
+  }
+  return { published: pay.length, total_gross: r2(total) };
+}

--- a/artifacts/api-server/src/routes/payroll.ts
+++ b/artifacts/api-server/src/routes/payroll.ts
@@ -1310,4 +1310,48 @@ router.post("/bulk-pay", requireAuth, requireRole("owner", "admin", "office"), a
   }
 });
 
+// ── [Phase 2] PUBLISH PAYROLL — snapshot a period's pay into locked records ───
+// Office/admin/owner only. Idempotent: re-publish upserts the snapshot.
+router.post("/publish", requireAuth, requireRole("owner", "admin", "office"), async (req, res) => {
+  try {
+    const companyId = (req as any).auth!.companyId;
+    const byUserId = (req as any).auth!.userId;
+    const { pay_period_start, pay_period_end } = req.body || {};
+    if (!pay_period_start || !pay_period_end) return res.status(400).json({ error: "pay_period_start and pay_period_end are required" });
+    const { publishPeriod } = await import("../lib/payroll-snapshot.js");
+    const out = await publishPeriod(companyId, String(pay_period_start), String(pay_period_end), byUserId);
+    return res.json({ ok: true, ...out, pay_period_start, pay_period_end });
+  } catch (err: any) {
+    console.error("POST /payroll/publish:", err);
+    return res.status(500).json({ error: "Internal Server Error", message: err?.message });
+  }
+});
+
+// ── [Phase 2] PAY HISTORY — published snapshots for the employee-profile Pay
+// section. ACCESS SCOPING: a technician sees ONLY their own; office/admin/owner
+// may pass ?user_id= to view any tech. A tech who passes someone else's id is
+// silently forced back to their own (never another tech's pay).
+router.get("/pay-history", requireAuth, async (req, res) => {
+  try {
+    const companyId = (req as any).auth!.companyId;
+    const role = (req as any).auth!.role;
+    const myId = (req as any).auth!.userId;
+    const canSeeAll = role === "owner" || role === "admin" || role === "office";
+    const requested = req.query.user_id ? parseInt(String(req.query.user_id)) : myId;
+    const targetUserId = canSeeAll ? requested : myId; // techs locked to self
+    const { db } = await import("@workspace/db");
+    const { sql } = await import("drizzle-orm");
+    const rows = (await db.execute(sql`
+      SELECT pay_period_start::text AS pay_period_start, pay_period_end::text AS pay_period_end,
+             gross, base, hours, tips, overtime, bonus, adjustments, breakdown, published_at
+      FROM payroll_period_snapshots
+      WHERE company_id = ${companyId} AND user_id = ${targetUserId}
+      ORDER BY pay_period_start DESC`)).rows;
+    return res.json({ user_id: targetUserId, scoped: canSeeAll ? "all" : "self", weeks: rows });
+  } catch (err: any) {
+    console.error("GET /payroll/pay-history:", err);
+    return res.status(500).json({ error: "Internal Server Error", message: err?.message });
+  }
+});
+
 export default router;

--- a/artifacts/qleno/src/pages/employee-profile.tsx
+++ b/artifacts/qleno/src/pages/employee-profile.tsx
@@ -88,7 +88,7 @@ const SCORE_BGS   = ['', '#FEE2E2', '#FEF3C7', '#DBEAFE', '#DCFCE7'];
 const DAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
 const DAY_IDX: Record<string, number> = { Mon:0,Tue:1,Wed:2,Thu:3,Fri:4,Sat:5,Sun:6 };
 const TABS = [
-  'Information','Earnings','Tags & Skills','Attendance','Availability',
+  'Information','Pay','Earnings','Tags & Skills','Attendance','Availability',
   'User Account','Contacts','Scorecards','Pay Configuration','Additional Pay',
   'Payroll History',
   'Contact Tickets','Jobs','Notes','Incentives',
@@ -572,7 +572,17 @@ export default function EmployeeProfilePage() {
     enabled: activeTab === 'Payroll History',
   });
 
+  // [Phase 2] Published-pay snapshots for this tech. Access-scoping is enforced
+  // server-side: a technician token always gets its own pay regardless of the
+  // user_id passed; office/admin/owner can view any tech.
+  const { data: payData } = useQuery({
+    queryKey: ['pay-history', userId],
+    queryFn: () => apiFetch(`/payroll/pay-history?user_id=${userId}`),
+    enabled: activeTab === 'Pay',
+  });
+
   const [expandedPeriod, setExpandedPeriod] = useState<string | null>(null);
+  const [expandedPayWeek, setExpandedPayWeek] = useState<string | null>(null);
   const [voidingId, setVoidingId] = useState<number | null>(null);
   const [deletingId, setDeletingId] = useState<number | null>(null);
   const [bulkPayModal, setBulkPayModal] = useState(false);
@@ -946,6 +956,76 @@ export default function EmployeeProfilePage() {
           {activeTab === 'Earnings' && (
             <EarningsPanel userId={userId} />
           )}
+
+          {/* ── PAY TAB ── published pay snapshots: current week + full history */}
+          {activeTab === 'Pay' && (() => {
+            const weeks: any[] = payData?.weeks ?? [];
+            const money = (n: any) => `$${Number(n || 0).toFixed(2)}`;
+            const fmtRange = (s: string, e: string) => {
+              const d = (x: string) => { const [y, m, day] = x.split('-'); return `${parseInt(m)}/${parseInt(day)}`; };
+              return `${d(s)} – ${d(e)}, ${s.slice(0, 4)}`;
+            };
+            return (
+              <div>
+                <SectionCard title="Published Pay">
+                  {weeks.length === 0 ? (
+                    <div style={{ padding:'24px', color:'#6B6860', fontSize:'14px' }}>No published pay yet. Once the office publishes a pay period, your weekly pay and history appear here.</div>
+                  ) : (
+                    <div style={{ display:'flex', flexDirection:'column', gap:'10px' }}>
+                      {weeks.map((w: any) => {
+                        const key = `${w.pay_period_start}_${w.pay_period_end}`;
+                        const open = expandedPayWeek === key;
+                        const jobs: any[] = Array.isArray(w.breakdown) ? w.breakdown : [];
+                        return (
+                          <div key={key} style={{ border:'1px solid #E5E2DC', borderRadius:'10px', overflow:'hidden', background:'#FFFFFF' }}>
+                            <button onClick={() => setExpandedPayWeek(open ? null : key)}
+                              style={{ width:'100%', display:'flex', justifyContent:'space-between', alignItems:'center', padding:'14px 16px', background:'none', border:'none', cursor:'pointer', textAlign:'left' }}>
+                              <div>
+                                <div style={{ fontWeight:700, color:'#1A1917', fontSize:'15px' }}>{fmtRange(w.pay_period_start, w.pay_period_end)}</div>
+                                <div style={{ fontSize:'12px', color:'#9DA3B0', marginTop:'2px' }}>{Number(w.hours).toFixed(2)} hrs · published {String(w.published_at).slice(0, 10)}</div>
+                              </div>
+                              <div style={{ fontWeight:800, color:'#00C9A0', fontSize:'18px' }}>{money(w.gross)}</div>
+                            </button>
+                            {open && (
+                              <div style={{ borderTop:'1px solid #E5E2DC', padding:'14px 16px', background:'#F7F6F3' }}>
+                                <div style={{ display:'grid', gridTemplateColumns:'repeat(2,1fr)', gap:'8px 24px', fontSize:'13px', marginBottom:'14px' }}>
+                                  {[['Base pay (jobs)', w.base], ['Tips', w.tips], ['Overtime', w.overtime], ['Bonus', w.bonus], ['Adjustments', w.adjustments], ['Gross', w.gross]].map(([lbl, val]: any, i: number) => (
+                                    <div key={i} style={{ display:'flex', justifyContent:'space-between', borderBottom:'1px solid #E5E2DC', paddingBottom:'4px' }}>
+                                      <span style={{ color:'#6B6860' }}>{lbl}</span>
+                                      <span style={{ fontWeight: lbl === 'Gross' ? 800 : 600, color: lbl === 'Gross' ? '#00C9A0' : '#1A1917' }}>{money(val)}</span>
+                                    </div>
+                                  ))}
+                                </div>
+                                {jobs.length > 0 && (
+                                  <table style={{ width:'100%', borderCollapse:'collapse', fontSize:'12px' }}>
+                                    <thead><tr style={{ textAlign:'left', color:'#9DA3B0' }}>
+                                      <th style={{ padding:'4px 0' }}>Date</th><th>Job</th><th>Basis</th>
+                                      <th style={{ textAlign:'right' }}>Hrs</th><th style={{ textAlign:'right' }}>Pay</th>
+                                    </tr></thead>
+                                    <tbody>
+                                      {jobs.map((j: any, i: number) => (
+                                        <tr key={i} style={{ borderTop:'1px solid #E5E2DC' }}>
+                                          <td style={{ padding:'5px 0' }}>{String(j.date).slice(5)}</td>
+                                          <td>{j.client}</td>
+                                          <td style={{ color:'#6B6860' }}>{j.basis}</td>
+                                          <td style={{ textAlign:'right' }}>{Number(j.hours).toFixed(2)}</td>
+                                          <td style={{ textAlign:'right', fontWeight:600 }}>{money(j.amount)}</td>
+                                        </tr>
+                                      ))}
+                                    </tbody>
+                                  </table>
+                                )}
+                              </div>
+                            )}
+                          </div>
+                        );
+                      })}
+                    </div>
+                  )}
+                </SectionCard>
+              </div>
+            );
+          })()}
 
           {/* ── INFORMATION TAB ── */}
           {activeTab === 'Information' && (


### PR DESCRIPTION
Enhancements A (hourly floor on residential commission) + B (pool split across all clocked techs, hourly shares forgone). Logic verified against MC per-job dollars on representative multi-tech cases. DRAFT — not for merge until Sal clears reconciliation + publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)