### PR TITLE
fix(my-jobs): include job_technicians team members on /my-jobs and /api/tech/today

### DIFF
--- a/artifacts/api-server/src/routes/jobs.ts
+++ b/artifacts/api-server/src/routes/jobs.ts
@@ -1,7 +1,7 @@
 import { Router } from "express";
 import { db } from "@workspace/db";
 import { jobsTable, clientsTable, usersTable, jobPhotosTable, timeclockTable, invoicesTable, scorecardsTable, serviceZonesTable, serviceZoneEmployeesTable, companiesTable, accountsTable, accountRateCardsTable, accountPropertiesTable, paymentsTable, recurringSchedulesTable, branchesTable, userCompaniesTable, jobDiscountsTable } from "@workspace/db/schema";
-import { eq, and, gte, lte, count, desc, sql, notExists, inArray, isNotNull, isNull } from "drizzle-orm";
+import { eq, and, gte, lte, count, desc, sql, notExists, inArray, isNotNull, isNull, or } from "drizzle-orm";
 import { requireAuth } from "../lib/auth.js";
 import { notifyUserAsync } from "../lib/push.js";
 import { logAudit, logClientActivity } from "../lib/audit.js";
@@ -638,7 +638,19 @@ router.get("/my-jobs", requireAuth, async (req, res) => {
       .leftJoin(companiesTable, eq(jobsTable.company_id, companiesTable.id))
       .where(and(
         inArray(jobsTable.company_id, tenantIds),
-        eq(jobsTable.assigned_user_id, userId),
+        // [2026-06-17] Was eq(assigned_user_id, userId) only — missed
+        // helpers/teammates because the dispatch read path uses
+        // job_technicians as truth (the primary tech is one row there
+        // among possibly several). A tech added via Add Team Member as
+        // a non-primary helper would have nothing on jobs.assigned_user_id
+        // and the my-jobs query would return zero. Sal report 2026-06-17:
+        // Maryury "cannot see her assigned schedule" — she was added as
+        // a helper. Match the dispatch invariant: a tech sees a job if
+        // they are either the primary OR on the team.
+        or(
+          eq(jobsTable.assigned_user_id, userId),
+          sql`EXISTS (SELECT 1 FROM job_technicians jt WHERE jt.job_id = ${jobsTable.id} AND jt.user_id = ${userId})`,
+        ),
         eq(jobsTable.scheduled_date, reqDate),
       ))
       .orderBy(jobsTable.scheduled_time);

--- a/artifacts/api-server/src/routes/tech.ts
+++ b/artifacts/api-server/src/routes/tech.ts
@@ -22,7 +22,7 @@ import {
   serviceZonesTable,
   timeclockTable,
 } from "@workspace/db/schema";
-import { and, asc, eq, sql } from "drizzle-orm";
+import { and, asc, eq, or, sql } from "drizzle-orm";
 import { requireAuth } from "../lib/auth.js";
 
 const router = Router();
@@ -120,7 +120,16 @@ router.get("/today", requireAuth, async (req, res) => {
       .where(
         and(
           eq(jobsTable.company_id, companyId),
-          eq(jobsTable.assigned_user_id, userId),
+          // [2026-06-17] Was assigned_user_id only — missed helpers/teammates
+          // (same fix as /api/jobs/my-jobs). Dispatch reads job_technicians
+          // as truth; this read path must match or a tech added via Add Team
+          // Member as a non-primary helper sees nothing on /my-day. The
+          // privacy rule from the 1B spec ("tech sees only their own day")
+          // is preserved — we still anchor on req.auth!.userId.
+          or(
+            eq(jobsTable.assigned_user_id, userId),
+            sql`EXISTS (SELECT 1 FROM job_technicians jt WHERE jt.job_id = ${jobsTable.id} AND jt.user_id = ${userId})`,
+          ),
           eq(jobsTable.scheduled_date, date),
         ),
       )


### PR DESCRIPTION
## Problem

Sal screenshot 2026-06-17 ~7:18 AM CDT: *"user has access now but cannot see her assigned schedule"* — Maryury logs in fine, but `/my-jobs` shows "No jobs today" even when she's been added to a job's team via "Add Team Member" as a helper (not the primary).

## Root cause

Two tech-facing endpoints filter by `assigned_user_id` only, missing every helper/teammate:

- **`GET /api/jobs/my-jobs`** (`jobs.ts:641`) — feeds the `/my-jobs` page
- **`GET /api/tech/today`** (`tech.ts:123`) — feeds the `/my-day` page

The **dispatch** read path treats `job_technicians` as the source of truth (PR #381 closed the inverse half — dispatch surfaces the chip even when the primary mirror gets stale). These two tech-facing surfaces never made the same correction. A tech added as a non-primary helper has nothing on `jobs.assigned_user_id` and the query returned zero rows → invisible schedule.

This is exactly the assignment-mirror class CLAUDE.md flagged. The dispatch direction got fixed; the tech-view direction was still broken.

## Fix

Extend both WHERE clauses to OR-match against `job_technicians`:

```ts
WHERE (
  jobs.assigned_user_id = $userId
  OR EXISTS (
    SELECT 1 FROM job_technicians jt
    WHERE jt.job_id = jobs.id AND jt.user_id = $userId
  )
)
```

The privacy rule from the 1B spec ("a tech sees only their own day") is preserved — we still anchor on `req.auth.userId`, never a user-controlled parameter.

## Files
- `artifacts/api-server/src/routes/jobs.ts` — `/my-jobs` WHERE + `or` import
- `artifacts/api-server/src/routes/tech.ts` — `/today` WHERE + `or` import

## Verification
- Tsc flat at baseline (zero new errors)
- No DB / schema change

## After Railway redeploys

- Maryury sees every job she's a helper on (not just jobs where she's primary)
- Same fix for every tech ever added via "Add Team Member" as a non-primary

https://claude.ai/code/session_013rJ4N4vgqZWB986x8D6Ahh

---
_Generated by [Claude Code](https://claude.ai/code/session_013rJ4N4vgqZWB986x8D6Ahh)_