### PR TITLE
fix(access): block techs from desktop office surfaces (route guard + sidebar + API)

### DIFF
--- a/artifacts/api-server/src/routes/dashboard.ts
+++ b/artifacts/api-server/src/routes/dashboard.ts
@@ -2,17 +2,24 @@ import { Router } from "express";
 import { db } from "@workspace/db";
 import { jobsTable, clientsTable, usersTable, invoicesTable, timeclockTable, scorecardsTable, accountsTable, accountPropertiesTable, quotesTable, recurringSchedulesTable } from "@workspace/db/schema";
 import { eq, and, or, gte, lte, lt, isNull, count, sum, avg, desc, sql, isNotNull, ne, notInArray } from "drizzle-orm";
-import { requireAuth } from "../lib/auth.js";
+import { requireAuth, requireRole } from "../lib/auth.js";
 import { jobRevenueExpr } from "../lib/job-revenue-sql.js";
 import { computeCommissionRows, type CommissionInputJob } from "../lib/commission-compute.js";
 import { parseResRatesRow } from "../lib/commission-rates.js";
 
 const router = Router();
 
+// [tech-boundary 2026-06-17] All /api/dashboard routes are office-tier
+// only. Was zero requireRole calls before this PR — a tech with the
+// URL could pull /metrics, /today, /kpis, /revenue-chart, etc. The
+// payload includes per-employee performance and company financials
+// that techs should never see.
+const officeGate = requireRole("owner", "admin", "office", "super_admin");
+
 // ── Weekly forecast in-memory cache (5 min TTL, keyed by companyId + week start) ──
 const wfCache = new Map<string, { data: unknown; ts: number }>();
 
-router.get("/metrics", requireAuth, async (req, res) => {
+router.get("/metrics", requireAuth, officeGate, async (req, res) => {
   try {
     const { period = "week", branch_id } = req.query;
     const branchFilter = branch_id && branch_id !== "all" ? parseInt(branch_id as string) : null;
@@ -160,7 +167,7 @@ router.get("/metrics", requireAuth, async (req, res) => {
   }
 });
 
-router.get("/today", requireAuth, async (req, res) => {
+router.get("/today", requireAuth, officeGate, async (req, res) => {
   try {
     const companyId = req.auth!.companyId!;
     const now = new Date();
@@ -350,7 +357,7 @@ router.get("/today", requireAuth, async (req, res) => {
   }
 });
 
-router.get("/kpis", requireAuth, async (req, res) => {
+router.get("/kpis", requireAuth, officeGate, async (req, res) => {
   try {
     const companyId = req.auth!.companyId!;
     const now = new Date();
@@ -796,7 +803,7 @@ router.get("/kpis", requireAuth, async (req, res) => {
   }
 });
 
-router.get("/revenue-chart", requireAuth, async (req, res) => {
+router.get("/revenue-chart", requireAuth, officeGate, async (req, res) => {
   try {
     const companyId = req.auth!.companyId!;
 
@@ -867,7 +874,7 @@ router.get("/revenue-chart", requireAuth, async (req, res) => {
   }
 });
 
-router.get("/techs-today", requireAuth, async (req, res) => {
+router.get("/techs-today", requireAuth, officeGate, async (req, res) => {
   try {
     const companyId = req.auth!.companyId!;
     const now = new Date();
@@ -928,7 +935,7 @@ router.get("/techs-today", requireAuth, async (req, res) => {
   }
 });
 
-router.get("/commercial-alerts", requireAuth, async (req, res) => {
+router.get("/commercial-alerts", requireAuth, officeGate, async (req, res) => {
   try {
     const companyId = req.auth!.companyId;
     const todayStr = new Date().toISOString().split("T")[0];
@@ -1020,7 +1027,7 @@ router.get("/commercial-alerts", requireAuth, async (req, res) => {
 });
 
 // ── GET /api/dashboard/weekly-forecast ──────────────────────────────────────
-router.get("/weekly-forecast", requireAuth, async (req, res) => {
+router.get("/weekly-forecast", requireAuth, officeGate, async (req, res) => {
   try {
     const companyId = req.auth!.companyId!;
     const now = new Date();
@@ -1381,7 +1388,7 @@ async function computeLastWeekPayrollPct(companyId: number): Promise<{ payroll_p
 }
 
 // Desktop BUSINESS HEALTH section. Same source-of-truth helpers as mobile.
-router.get("/business-health", requireAuth, async (req, res) => {
+router.get("/business-health", requireAuth, officeGate, async (req, res) => {
   try {
     const companyId = req.auth!.companyId;
     const [bh, pay] = await Promise.all([computeBusinessHealth(companyId), computeLastWeekPayrollPct(companyId)]);
@@ -1398,7 +1405,7 @@ router.get("/business-health", requireAuth, async (req, res) => {
 // Branch-aware for job/client-based cards (jobs.branch_id / clients.branch_id);
 // leads + quotes are company-wide (quotes has no reliable branch_id column).
 // Desktop endpoints are untouched.
-router.get("/mobile-cards", requireAuth, async (req, res) => {
+router.get("/mobile-cards", requireAuth, officeGate, async (req, res) => {
   try {
     const companyId = req.auth!.companyId;
     const branchRaw = req.query.branch_id;
@@ -1556,7 +1563,7 @@ router.get("/mobile-cards", requireAuth, async (req, res) => {
 // Per-user mobile dashboard card preference (selected cards + order).
 // Reuses user_column_preferences with page='mobile_dashboard' — no schema change.
 // No rows = user hasn't customized → frontend shows the role default.
-router.get("/card-prefs", requireAuth, async (req, res) => {
+router.get("/card-prefs", requireAuth, officeGate, async (req, res) => {
   try {
     const userId = req.auth!.userId;
     const companyId = req.auth!.companyId;
@@ -1617,7 +1624,7 @@ router.delete("/card-prefs", requireAuth, async (req, res) => {
 // reads like "what happened to my jobs/quotes/invoices/clients lately", with a
 // link back to each record. Raw fields go to the client; the dashboard maps
 // them to a friendly label + route (the frontend owns the route table).
-router.get("/recent-activity", requireAuth, async (req, res) => {
+router.get("/recent-activity", requireAuth, officeGate, async (req, res) => {
   try {
     const companyId = req.auth!.companyId!;
     const limit = Math.min(parseInt(String(req.query.limit ?? "15")) || 15, 50);

--- a/artifacts/api-server/src/routes/dispatch.ts
+++ b/artifacts/api-server/src/routes/dispatch.ts
@@ -2,13 +2,22 @@ import { Router } from "express";
 import { db } from "@workspace/db";
 import { jobsTable, usersTable, clientsTable, timeclockTable, jobPhotosTable, serviceZonesTable, serviceZoneEmployeesTable, accountsTable, accountPropertiesTable, employeeAttendanceLogTable, employeeLeaveUsageTable, branchesTable, recurringSchedulesTable } from "@workspace/db/schema";
 import { eq, and, count, sql, inArray } from "drizzle-orm";
-import { requireAuth } from "../lib/auth.js";
+import { requireAuth, requireRole } from "../lib/auth.js";
 import { parseResRatesRow, resolveResidentialPayPct } from "../lib/commission-rates.js";
 import { jobRevenueExpr } from "../lib/job-revenue-sql.js";
 
 const router = Router();
 
-router.get("/", requireAuth, async (req, res) => {
+// [tech-boundary 2026-06-17] All /api/dispatch routes are office-tier
+// only — techs have no business reading the full company dispatch
+// payload (every other tech's name, every client, every job). Was a
+// real leak: dispatch.ts had ZERO requireRole calls before this PR
+// even though every other office route in the codebase gated. A tech
+// with the URL could hit GET /api/dispatch?date=... via devtools/curl
+// and pull the entire day's office data.
+const dispatchOfficeGate = requireRole("owner", "admin", "office", "super_admin");
+
+router.get("/", requireAuth, dispatchOfficeGate, async (req, res) => {
   try {
     const companyId = req.auth!.companyId;
     const date = (req.query.date as string) || new Date().toISOString().split("T")[0];
@@ -1006,7 +1015,7 @@ router.get("/", requireAuth, async (req, res) => {
 // day's full data on demand.
 //
 // Window defaults to current Sunday–Saturday when from/to omitted.
-router.get("/week-summary", requireAuth, async (req, res) => {
+router.get("/week-summary", requireAuth, dispatchOfficeGate, async (req, res) => {
   try {
     const companyId = req.auth!.companyId;
     const branch_id = req.query.branch_id as string | undefined;
@@ -1110,7 +1119,7 @@ router.get("/week-summary", requireAuth, async (req, res) => {
 //       c_other:            { count, samples: [...] },
 //     },
 //   }
-router.get("/zone-coverage-audit", requireAuth, async (req, res) => {
+router.get("/zone-coverage-audit", requireAuth, dispatchOfficeGate, async (req, res) => {
   try {
     const companyId = (req as any).auth!.companyId;
     const today = new Date();

--- a/artifacts/qleno/src/App.tsx
+++ b/artifacts/qleno/src/App.tsx
@@ -1,11 +1,12 @@
-import { lazy, Suspense } from "react";
-import { Switch, Route, Router as WouterRouter, Redirect } from "wouter";
+import { lazy, Suspense, useEffect } from "react";
+import { Switch, Route, Router as WouterRouter, Redirect, useLocation } from "wouter";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { ErrorBoundary } from "@/components/error-boundary";
 import { BranchProvider } from "@/contexts/branch-context";
 import { EmployeeViewProvider } from "@/contexts/employee-view-context";
+import { useAuthStore } from "@/lib/auth";
 
 const Login               = lazy(() => import("@/pages/login"));
 const Dashboard           = lazy(() => import("@/pages/dashboard"));
@@ -126,9 +127,71 @@ function PageLoader() {
   );
 }
 
+// [tech-boundary 2026-06-17] Sal report: techs could log in on desktop
+// and view office surfaces (dispatch, payroll, customers, etc.). The
+// login flow already routes techs to /my-jobs after sign-in, but a
+// tech who knows a URL — or hits "/" — sees the full office page.
+//
+// This guard runs at the Router level. When the authenticated user is
+// role=technician or team_lead and the current path is NOT in the tech
+// allowlist below, redirect to /my-jobs. Owner / admin / office /
+// super_admin pass through to the full route.
+//
+// Allowlist (not denylist) so a forgotten future office route can
+// only cost a tech UX bug — never a data leak.
+const TECH_ALLOWED_PREFIXES = [
+  "/login",
+  "/accept-invite",
+  "/my-jobs",
+  "/my-day",
+  "/training",
+  "/leave",
+  "/notifications",
+  "/pay/",        // token-based payment link
+  "/sign/",       // token-based document sign
+  "/sign-doc/",   // token-based document sign
+  "/onboard/",    // token-based onboarding
+  "/book/",       // token-based booking
+  "/survey/",     // token-based survey
+  "/portal/",     // public client portal
+];
+
+function isTechAllowedPath(pathname: string): boolean {
+  // /lms is allowed but /lms/admin* is owner/admin only.
+  if (pathname.startsWith("/lms/admin")) return false;
+  if (pathname === "/lms" || pathname.startsWith("/lms/")) return true;
+  // /employees/:id — let techs view their OWN profile only (they hit
+  // this via the avatar menu). The page itself self-gates on whether
+  // the viewed userId matches the auth userId. Allowing the path here
+  // is consistent with how the LMS routes a tech to their own LMS
+  // profile page via /lms/admin/employee/:id (admin-only — blocked
+  // above) vs the regular /employees/:id (their own self-view).
+  // For now, BLOCK /employees/:id on desktop for techs — they can
+  // change their password / avatar from the avatar menu modal, which
+  // doesn't need the full profile page.
+  return TECH_ALLOWED_PREFIXES.some(
+    (p) => pathname === p.replace(/\/$/, "") || pathname.startsWith(p),
+  );
+}
+
+function TechRouteGuard({ children }: { children: React.ReactNode }) {
+  const role = useAuthStore((s) => s.user?.role);
+  const [location, navigate] = useLocation();
+  const isTech = role === "technician" || role === "team_lead";
+  const blocked = isTech && !isTechAllowedPath(location);
+
+  useEffect(() => {
+    if (blocked) navigate("/my-jobs");
+  }, [blocked, navigate]);
+
+  if (blocked) return null;
+  return <>{children}</>;
+}
+
 function Router() {
   return (
     <Suspense fallback={<PageLoader />}>
+      <TechRouteGuard>
       <Switch>
         <Route path="/" component={Dashboard} />
         <Route path="/login" component={Login} />
@@ -251,6 +314,7 @@ function Router() {
 
         <Route component={NotFound} />
       </Switch>
+      </TechRouteGuard>
     </Suspense>
   );
 }

--- a/artifacts/qleno/src/components/layout/app-sidebar.tsx
+++ b/artifacts/qleno/src/components/layout/app-sidebar.tsx
@@ -44,65 +44,85 @@ function useNeedsContactedCount(role: string | undefined) {
 // no longer surfaces a missing-zip badge; the data layer fixes
 // itself.
 
+// [tech-boundary 2026-06-17] Office-side sections. Items without a
+// `roles` array previously fell through and rendered for techs too —
+// that's why Maryury saw Dashboard / Jobs / Customers / Employees /
+// Invoices in her sidebar even though she had no business being on any
+// of them. Added the office-tier `roles` allowlist on every item that
+// was missing one. Techs (`technician` / `team_lead`) now see ZERO
+// items from these sections — the per-item filter drops them all.
 const NAV_SECTIONS = [
   {
     label: "Operations",
     items: [
-      { title: "Dashboard", url: "/dashboard", icon: LayoutDashboard },
+      { title: "Dashboard", url: "/dashboard", icon: LayoutDashboard, roles: ["owner", "admin", "office", "super_admin"] },
       // [2026-04-22] Consolidated "Dispatch Board" + "Jobs" → single "Jobs"
       // entry pointing at /dispatch (the Gantt). /jobs and /jobs/list still
       // resolve to JobsListPage via direct URL; the sidebar just prefers the
       // Gantt as the default view. Active-highlight covers all 3 urls via
       // MULTI_URL_HIGHLIGHT below.
-      { title: "Jobs",      url: "/dispatch",  icon: Briefcase },
-      { title: "Customers", url: "/customers", icon: Users },
-      { title: "Messages",  url: "/messages",  icon: MessageSquare, roles: ["owner", "admin", "office"] },
-      { title: "Accounts",  url: "/accounts",  icon: Building2, roles: ["owner", "admin", "office"] },
+      { title: "Jobs",      url: "/dispatch",  icon: Briefcase, roles: ["owner", "admin", "office", "super_admin"] },
+      { title: "Customers", url: "/customers", icon: Users, roles: ["owner", "admin", "office", "super_admin"] },
+      { title: "Messages",  url: "/messages",  icon: MessageSquare, roles: ["owner", "admin", "office", "super_admin"] },
+      { title: "Accounts",  url: "/accounts",  icon: Building2, roles: ["owner", "admin", "office", "super_admin"] },
     ],
   },
   {
     label: "Sales",
     items: [
-      { title: "Leads",  url: "/leads",  icon: UserPlus,   roles: ["owner", "admin", "office"], badge: "needs_contacted" },
-      { title: "Quotes", url: "/quotes", icon: FileTextIcon, roles: ["owner", "admin", "office"] },
-      { title: "Estimates", url: "/estimates", icon: Calculator, roles: ["owner", "admin", "office"] },
+      { title: "Leads",  url: "/leads",  icon: UserPlus,   roles: ["owner", "admin", "office", "super_admin"], badge: "needs_contacted" },
+      { title: "Quotes", url: "/quotes", icon: FileTextIcon, roles: ["owner", "admin", "office", "super_admin"] },
+      { title: "Estimates", url: "/estimates", icon: Calculator, roles: ["owner", "admin", "office", "super_admin"] },
     ],
   },
   {
     label: "Team",
     items: [
-      { title: "Employees", url: "/employees", icon: UserCheck },
-      { title: "Time Clock", url: "/time-clock", icon: Clock, roles: ["owner", "admin", "office"] },
-      { title: "Payroll",   url: "/payroll",   icon: DollarSign, roles: ["owner", "admin"] },
+      { title: "Employees", url: "/employees", icon: UserCheck, roles: ["owner", "admin", "office", "super_admin"] },
+      { title: "Time Clock", url: "/time-clock", icon: Clock, roles: ["owner", "admin", "office", "super_admin"] },
+      { title: "Payroll",   url: "/payroll",   icon: DollarSign, roles: ["owner", "admin", "super_admin"] },
     ],
   },
   {
     label: "Money",
     items: [
-      { title: "Invoices", url: "/invoices", icon: FileText },
+      { title: "Invoices", url: "/invoices", icon: FileText, roles: ["owner", "admin", "office", "super_admin"] },
     ],
   },
   {
     label: "Insights",
     items: [
-      { title: "Reports",        url: "/reports",                icon: BarChart2,     roles: ["owner", "admin", "office"] },
-      { title: "Core KPIs",      url: "/reports/insights",       icon: TrendingUp,    roles: ["owner", "admin", "office"] },
-      { title: "Churn Board",    url: "/intelligence/churn",     icon: AlertTriangle, roles: ["owner", "admin"] },
-      { title: "Tech Retention", url: "/intelligence/retention", icon: HeartPulse,    roles: ["owner", "admin"] },
+      { title: "Reports",        url: "/reports",                icon: BarChart2,     roles: ["owner", "admin", "office", "super_admin"] },
+      { title: "Core KPIs",      url: "/reports/insights",       icon: TrendingUp,    roles: ["owner", "admin", "office", "super_admin"] },
+      { title: "Churn Board",    url: "/intelligence/churn",     icon: AlertTriangle, roles: ["owner", "admin", "super_admin"] },
+      { title: "Tech Retention", url: "/intelligence/retention", icon: HeartPulse,    roles: ["owner", "admin", "super_admin"] },
     ],
   },
   {
     label: "Learning",
     items: [
+      // Cleancyclopedia + Training are reference / training surfaces —
+      // techs DO get these. No roles array → visible to everyone.
       { title: "Cleancyclopedia", url: "/cleancyclopedia", icon: BookOpen },
       { title: "Training",        url: "/training",        icon: GraduationCap },
       { title: "Training Admin",  url: "/lms/admin",       icon: GraduationCap, roles: ["owner", "admin", "super_admin", "office"] },
     ],
   },
   {
+    label: "My Day",
+    items: [
+      // Tech-facing sidebar entries. Office tiers don't need these (they
+      // navigate via Dashboard / Jobs above), so cap on technician /
+      // team_lead. Without these the tech sidebar was just Training and
+      // Cleancyclopedia, with no quick path back to their schedule.
+      { title: "My Jobs",   url: "/my-jobs",   icon: Briefcase,    roles: ["technician", "team_lead"] },
+      { title: "Leave",     url: "/leave",     icon: FileText,     roles: ["technician", "team_lead"] },
+    ],
+  },
+  {
     label: "Admin",
     items: [
-      { title: "Settings", url: "/company", icon: Settings, roles: ["owner", "admin"] },
+      { title: "Settings", url: "/company", icon: Settings, roles: ["owner", "admin", "super_admin"] },
     ],
   },
 ];
@@ -250,7 +270,17 @@ export function AppSidebar({ mobile = false, open = false, onClose }: AppSidebar
 
       {/* Nav */}
       <nav style={{ flex: 1, overflowY: 'auto', overflowX: 'hidden', padding: '8px 0 12px' }}>
-        {NAV_SECTIONS.map(section => (
+        {NAV_SECTIONS.map(section => {
+          // [tech-boundary 2026-06-17] Pre-filter items by role. When
+          // every item in a section is filtered out for this user
+          // (e.g. a tech viewing an office-only "Operations" / "Sales"
+          // / "Insights" / etc. section) skip the section entirely so
+          // we don't render an orphan label with nothing under it.
+          const visibleItems = section.items.filter(
+            (item: any) => !item.roles || (userInfo && item.roles.includes(userInfo.role)),
+          );
+          if (visibleItems.length === 0) return null;
+          return (
           <div key={section.label}>
             {/* Section label — only when expanded */}
             {expanded && (
@@ -264,8 +294,7 @@ export function AppSidebar({ mobile = false, open = false, onClose }: AppSidebar
               </p>
             )}
             {!expanded && <div style={{ height: 12 }} />}
-            {section.items
-              .filter(item => !item.roles || (userInfo && item.roles.includes(userInfo.role)))
+            {visibleItems
               .map(item => {
                 const active = isActive(item.url);
                 const Icon = item.icon;
@@ -346,7 +375,8 @@ export function AppSidebar({ mobile = false, open = false, onClose }: AppSidebar
                 );
               })}
           </div>
-        ))}
+          );
+        })}
       </nav>
 
       <div style={{ borderTop: '1px solid #EEECE7' }} />


### PR DESCRIPTION
## Problem

Sal: *"on desktop techs can be logged in and view the system just like office staff can. This cannot happen."*

Three layers of leak today, fixed in this PR:

| Layer | Today | After |
|---|---|---|
| Frontend routes | No role check. Tech hits `/dispatch` URL → sees full office page | Redirected to `/my-jobs` |
| Sidebar | Half the items lacked `roles` array; tech saw Dashboard / Jobs / Customers / Employees / Invoices | Tech sees only Cleancyclopedia, Training, My Jobs, Leave |
| Backend | `routes/dispatch.ts` and `routes/dashboard.ts` had **0** `requireRole` calls. Tech could `curl /api/dispatch?date=...` and get full company payload | 403 Forbidden |

## Fix

### Frontend route guard — allowlist (App.tsx)

New `<TechRouteGuard>` wraps the Router. When the authenticated user is `technician` or `team_lead` and the current path is NOT in the tech allowlist (my-jobs, my-day, training, lms (not lms/admin), leave, notifications, token-based pages like `/sign/`, `/pay/`, `/portal/`, `/onboard/`, `/book/`, `/survey/`, `/accept-invite`), redirect to `/my-jobs`. Owner / admin / office / super_admin pass through unchanged.

**Allowlist, not denylist** — a future office route added without a guard can only cost a tech UX bug, never a data leak.

### Sidebar (app-sidebar.tsx)

- Added the office-tier `roles` array to every `NAV_SECTIONS` item missing one (Dashboard, Jobs, Customers, Messages, Accounts, Employees, Invoices, all Reports)
- Pre-filter at the **section** level: when all items in a section are filtered out, skip the section entirely so we don't render an orphan "Operations" / "Sales" / "Insights" label with nothing under it
- Added a "My Day" section with **My Jobs** + **Leave** links visible only to technician / team_lead

### Backend (dispatch.ts + dashboard.ts)

- `dispatch.ts` — added `dispatchOfficeGate = requireRole("owner", "admin", "office", "super_admin")` to all 3 routes (`/`, `/week-summary`, `/zone-coverage-audit`)
- `dashboard.ts` — added `officeGate` to every `router.get` / `router.post` (10 routes: `/metrics`, `/today`, `/kpis`, `/revenue-chart`, `/techs-today`, `/commercial-alerts`, `/weekly-forecast`, `/business-health`, `/mobile-cards`, `/card-prefs`)

## Files
- `artifacts/qleno/src/App.tsx` — TechRouteGuard + imports
- `artifacts/qleno/src/components/layout/app-sidebar.tsx` — roles arrays + section-skip + tech My Day
- `artifacts/api-server/src/routes/dispatch.ts` — officeGate on 3 routes
- `artifacts/api-server/src/routes/dashboard.ts` — officeGate on 10 routes

## Verification
- Api-server tsc flat at baseline (zero new errors)
- Frontend tsc flat at baseline (zero new errors)
- No DB / schema change

## After Railway redeploys

- Tech who types `/dispatch` / `/payroll` / `/employees` in the URL bar → redirected to `/my-jobs` instantly
- Tech sidebar shows only: Cleancyclopedia, Training, My Jobs, Leave
- Tech hitting `GET /api/dispatch?date=...` via curl/devtools gets 403

## Known follow-up (not in this PR)

Many other office routes (payroll, reports, clients, accounts, invoices, etc.) still lack `requireRole` at the API layer — the frontend guard catches them in the UI, but a curl-savvy tech could still hit them directly. Should be swept in a separate audit PR, but this PR closes the biggest leak (dispatch, which exposes the full company payload) and the most visible UI leak.

https://claude.ai/code/session_013rJ4N4vgqZWB986x8D6Ahh

---
_Generated by [Claude Code](https://claude.ai/code/session_013rJ4N4vgqZWB986x8D6Ahh)_