### PR TITLE
June-13 punch-list: Tier 1 bugs + Tier 2 pricing (#3 #6 #8 #15 #2 #13 #14)

### DIFF
--- a/artifacts/api-server/scripts/j6_reschedule_dedupe_fix.ts
+++ b/artifacts/api-server/scripts/j6_reschedule_dedupe_fix.ts
@@ -1,0 +1,86 @@
+/**
+ * J6 — Fix reschedule-onto-voided-date failure (#6, June-13 punch-list).
+ *
+ * Problem: rescheduling a recurring job onto a date that already holds a
+ * VOIDED/cancelled occurrence of the SAME schedule returns
+ * {"error":"Failed to reschedule job"}. Root cause: the partial unique index
+ * `jobs_recurring_dedupe_idx` is
+ *     ON jobs (company_id, recurring_schedule_id, scheduled_date)
+ *   WHERE recurring_schedule_id IS NOT NULL
+ * with NO status exclusion. A cancelled occurrence still occupies its
+ * (company_id, recurring_schedule_id, scheduled_date) slot, so moving another
+ * occurrence onto that date violates the unique index (SQLSTATE 23505) and the
+ * reschedule handler's catch-all returns the generic error.
+ *
+ * Fix: recreate the index with `AND status <> 'cancelled'` so a cancelled
+ * occupant no longer reserves the slot. This matches the (now-dropped)
+ * `uq_jobs_no_double_book` constraint, which deliberately carried
+ * `WHERE status NOT IN ('cancelled')` exactly so cancel+rebook worked.
+ *
+ * The dedupe purpose (stop the recurring engine from generating duplicate LIVE
+ * occurrences) is preserved — two live occupants on the same slot are still
+ * rejected; only cancelled ones stop blocking.
+ *
+ * CONCURRENTLY cannot run inside a transaction; run at session level.
+ * Idempotent: skips if the index already carries the status predicate.
+ *
+ *   tsx scripts/j6_reschedule_dedupe_fix.ts
+ */
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+const IDX = "jobs_recurring_dedupe_idx";
+
+async function main() {
+  console.log("=== J6 — reschedule dedupe index fix (exclude cancelled) ===\n");
+
+  const cur = await db.execute(sql`
+    SELECT indexdef FROM pg_indexes
+     WHERE schemaname = 'public' AND tablename = 'jobs' AND indexname = ${IDX}
+  `);
+  const curDef = (cur.rows[0] as any)?.indexdef as string | undefined;
+  console.log("Current definition:", curDef ?? "(index does not exist)");
+
+  if (curDef && /status\b/i.test(curDef)) {
+    console.log("\nIndex already excludes cancelled. Nothing to do.");
+    process.exit(0);
+  }
+
+  // Pre-flight: would the new (stricter-on-live, looser-on-cancelled) index
+  // have any duplicate LIVE tuples? If so, abort — data needs cleanup first.
+  const dupes = await db.execute(sql`
+    SELECT company_id, recurring_schedule_id, scheduled_date, COUNT(*)::int AS n
+      FROM jobs
+     WHERE recurring_schedule_id IS NOT NULL AND status <> 'cancelled'
+     GROUP BY company_id, recurring_schedule_id, scheduled_date
+    HAVING COUNT(*) > 1
+  `);
+  if ((dupes.rowCount ?? 0) > 0) {
+    console.log(`!! ${dupes.rowCount} duplicate LIVE tuples remain — aborting.`);
+    console.log(dupes.rows);
+    process.exit(1);
+  }
+  console.log("Pre-flight: zero duplicate live tuples. Safe to rebuild.\n");
+
+  if (curDef) {
+    console.log("Dropping old index (CONCURRENTLY)...");
+    await db.execute(sql`DROP INDEX CONCURRENTLY IF EXISTS ${sql.raw(IDX)}`);
+  }
+
+  console.log("Creating index with status exclusion (CONCURRENTLY)...");
+  await db.execute(sql`
+    CREATE UNIQUE INDEX CONCURRENTLY ${sql.raw(IDX)}
+        ON jobs (company_id, recurring_schedule_id, scheduled_date)
+     WHERE recurring_schedule_id IS NOT NULL AND status <> 'cancelled'
+  `);
+  console.log("Index recreated.");
+
+  const after = await db.execute(sql`
+    SELECT indexdef FROM pg_indexes
+     WHERE schemaname = 'public' AND tablename = 'jobs' AND indexname = ${IDX}
+  `);
+  console.log("\nPost-verify:", (after.rows[0] as any)?.indexdef);
+  process.exit(0);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/artifacts/api-server/src/routes/clients.ts
+++ b/artifacts/api-server/src/routes/clients.ts
@@ -2234,9 +2234,25 @@ router.patch("/:clientId/jobs/:jobId/reschedule", requireAuth, async (req, res) 
       return res.status(400).json({ error: "Cannot reschedule a completed or invoiced job" });
     }
 
-    await db.execute(sql`
-      UPDATE jobs SET scheduled_date = ${new_date}::date WHERE id = ${jobId}
-    `);
+    // [reschedule-dedupe-fix 2026-06-16] (#6) Moving a recurring job onto a
+    // date that holds a CANCELLED occurrence of the same schedule used to throw
+    // a generic 500 ("Failed to reschedule job"). The real fix is the
+    // jobs_recurring_dedupe_idx rebuild (scripts/j6_reschedule_dedupe_fix.ts)
+    // which excludes cancelled rows from the unique slot. Until/if that index
+    // is in place, catch the unique-violation (SQLSTATE 23505) explicitly and
+    // return an actionable 409 instead of the opaque generic error.
+    try {
+      await db.execute(sql`
+        UPDATE jobs SET scheduled_date = ${new_date}::date WHERE id = ${jobId}
+      `);
+    } catch (updErr: any) {
+      if (String(updErr?.code) === "23505") {
+        return res.status(409).json({
+          error: "That date already has another occurrence of this recurring service. Cancel or move the existing one first.",
+        });
+      }
+      throw updErr;
+    }
 
     try {
       await db.execute(sql`

--- a/artifacts/api-server/src/routes/dispatch.ts
+++ b/artifacts/api-server/src/routes/dispatch.ts
@@ -783,11 +783,20 @@ router.get("/", requireAuth, dispatchOfficeGate, async (req, res) => {
             return base + mods;
           }
           // Residential: unchanged. An explicit billed price (e.g. manual
-          // "Change price") wins; otherwise base_fee + add-ons + rate-mods.
+          // "Change price") wins; otherwise base_fee + rate-mods.
+          // [addon-doublecount-fix 2026-06-16] (#2/#14) base_fee is the all-in
+          // residential total — it ALREADY includes the add-on subtotals (the
+          // wizard/quote/edit-modal convention; jobs.ts:388, and
+          // recomputeJobBilledAmount residential = base + mods, no add-ons).
+          // job_add_ons rows are the itemized breakdown of money already inside
+          // base_fee, so re-adding `addOns` here double-counted every
+          // residential add-on job (e.g. converted job 6805: 744.80 base + 248.80
+          // add-ons shown as 993.60). Do NOT re-add add-ons; match the stored
+          // base_fee convention and the recompute helper.
           const billed = (j as any).billed_amount != null ? parseFloat(String((j as any).billed_amount)) : null;
           if (billed != null && billed > 0) return billed;
           const base = j.base_fee ? parseFloat(j.base_fee) : 0;
-          return base + mods + addOns;
+          return base + mods;
         })(),
         duration_minutes: durationMinutes,
         notes: j.notes,

--- a/artifacts/api-server/src/routes/pricing.ts
+++ b/artifacts/api-server/src/routes/pricing.ts
@@ -655,23 +655,38 @@ router.post("/calculate", requireAuth, async (req, res) => {
            GROUP BY ab.id, ab.name, ab.discount_type, ab.discount_value
         `);
         const bundles = (bundleResult as any).rows ?? [];
-        for (const bundle of bundles) {
-          const rawRequired: number[] = (bundle.required_ids ?? []).map((x: any) => parseInt(String(x))).filter((n: number) => !isNaN(n));
-          const required: number[] = [...new Set(rawRequired)];
+        // [combo-discount-fix 2026-06-16] (#13) Previously EVERY bundle whose
+        // required add-ons were all present was applied and summed, so two
+        // bundles covering the same add-ons stacked — e.g. "Appliance Combo"
+        // (-$20) AND "Oven + Refrigerator Combo" (-$15), both = {Oven,
+        // Refrigerator}, hit the same quote (-$35 instead of one). Select a
+        // NON-OVERLAPPING set: prefer the most specific bundle (largest required
+        // set), tie-broken by the larger discount, and never let two bundles
+        // claim the same add-on. Disjoint bundles (e.g. an appliance combo + a
+        // window combo) still stack — only same-add-on overlaps are collapsed.
+        const candidates = bundles.map((bundle: any) => {
+          const required: number[] = [...new Set((bundle.required_ids ?? []).map((x: any) => parseInt(String(x))).filter((n: number) => !isNaN(n)))] as number[];
           const matched = required.filter(rid => validIdsForBundles.includes(rid));
-          if (required.length > 0 && matched.length === required.length) {
-            const dv = parseFloat(String(bundle.discount_value));
-            let disc = 0;
-            if (bundle.discount_type === "flat_per_item") {
-              disc = dv * matched.length;
-            } else if (bundle.discount_type === "flat" || bundle.discount_type === "flat_total") {
-              disc = dv;
-            } else if (bundle.discount_type === "percentage") {
-              disc = (dv / 100) * base_price;
-            }
-            bundle_discount += disc;
-            bundle_breakdown.push({ name: bundle.name, discount: Math.round(disc * 100) / 100 });
+          if (required.length === 0 || matched.length !== required.length) return null;
+          const dv = parseFloat(String(bundle.discount_value));
+          let disc = 0;
+          if (bundle.discount_type === "flat_per_item") {
+            disc = dv * matched.length;
+          } else if (bundle.discount_type === "flat" || bundle.discount_type === "flat_total") {
+            disc = dv;
+          } else if (bundle.discount_type === "percentage") {
+            disc = (dv / 100) * base_price;
           }
+          return { name: String(bundle.name), required, disc };
+        }).filter(Boolean) as Array<{ name: string; required: number[]; disc: number }>;
+        // Most specific first; equal specificity → larger discount wins.
+        candidates.sort((a, b) => (b.required.length - a.required.length) || (b.disc - a.disc));
+        const consumedAddons = new Set<number>();
+        for (const c of candidates) {
+          if (c.required.some(rid => consumedAddons.has(rid))) continue; // overlaps a higher-priority bundle
+          c.required.forEach(rid => consumedAddons.add(rid));
+          bundle_discount += c.disc;
+          bundle_breakdown.push({ name: c.name, discount: Math.round(c.disc * 100) / 100 });
         }
       }
     }

--- a/artifacts/api-server/src/routes/quotes.ts
+++ b/artifacts/api-server/src/routes/quotes.ts
@@ -449,14 +449,25 @@ router.post("/:id/convert", requireAuth, requireRole("owner", "admin", "office")
     // choice on a lead-only quote creates a schedule (not a one-off) and the
     // booking confirmation has contact info. Find by email/phone, else create.
     let clientId: number | null = q.client_id || null;
-    if (!clientId && ((q as any).lead_email || (q as any).lead_phone)) {
+    // [convert-client-fix 2026-06-16] (#3) Previously a client was only
+    // materialized when the quote had an email OR phone. The office form does
+    // not require either — a new lead can convert with just a name and/or
+    // address. In that case clientId stayed null, the job was inserted with
+    // client_id=null and the address as raw text, and the customer's
+    // name/address/email were never saved as a client. Broaden the gate to any
+    // identifying field (name or address too); email/phone still drive dedupe,
+    // and a name-only lead falls through to a fresh insert.
+    const _hasIdentity = (q as any).lead_email || (q as any).lead_phone || (q as any).lead_name || (q as any).address;
+    if (!clientId && _hasIdentity) {
       const emailLc = (q as any).lead_email ? String((q as any).lead_email).toLowerCase().trim() : null;
       const phone10 = String((q as any).lead_phone || "").replace(/\D/g, "").slice(-10) || null;
-      const match = await db.execute(sql`
+      // Dedupe only when we have an email or phone to match on; a name-only
+      // lead has no reliable key, so it always inserts a fresh client.
+      const match = (emailLc || phone10) ? await db.execute(sql`
         SELECT id FROM clients WHERE company_id = ${companyId} AND (
           (${emailLc}::text IS NOT NULL AND lower(email) = ${emailLc}) OR
           (${phone10}::text IS NOT NULL AND right(regexp_replace(coalesce(phone,''),'\\D','','g'),10) = ${phone10})
-        ) ORDER BY id DESC LIMIT 1`);
+        ) ORDER BY id DESC LIMIT 1`) : { rows: [] as any[] };
       clientId = (match.rows[0] as any)?.id ?? null;
       if (!clientId) {
         const np = String((q as any).lead_name ?? "").trim().split(/\s+/).filter(Boolean);

--- a/artifacts/qleno/src/components/edit-job-modal.tsx
+++ b/artifacts/qleno/src/components/edit-job-modal.tsx
@@ -2163,11 +2163,12 @@ export default function EditJobModal({
             </div>
           </div>
 
-          {/* Section 6 — Instructions */}
+          {/* Section 6 — Cleaner Notes (#15: was "Instructions"; this field is
+              jobs.notes, the note the technician sees in the field app). */}
           <div style={SECTION}>
-            <span style={LABEL}>Instructions</span>
+            <span style={LABEL}>Cleaner Notes (tech sees this)</span>
             <textarea value={instructions} onChange={e => setInstructions(e.target.value)}
-              placeholder="Notes for technicians on this job…"
+              placeholder="Notes the cleaner sees on this job…"
               rows={4}
               style={{ ...INPUT, height: "auto", padding: "10px 12px", lineHeight: 1.5, resize: "vertical" }} />
           </div>

--- a/artifacts/qleno/src/components/edit-job-modal.tsx
+++ b/artifacts/qleno/src/components/edit-job-modal.tsx
@@ -281,6 +281,11 @@ export default function EditJobModal({
   // of the tenant default.
   const [addonPriceOverrides, setAddonPriceOverrides] = useState<Map<number, number>>(new Map());
   const [initialAddonPriceOverrides, setInitialAddonPriceOverrides] = useState<Map<number, number>>(new Map());
+  // [deletable-addons-fix 2026-06-16] (#14B) Name/subtotal for the job's
+  // existing add-ons, so an add-on that ISN'T in the current scope's catalog
+  // (e.g. a quote-originated add-on from another scope) can still be rendered
+  // as a removable row. Without this it had no catalog row and no way to delete.
+  const [existingAddonInfo, setExistingAddonInfo] = useState<Map<number, { name: string; subtotal: number }>>(new Map());
 
   // [W2] Client property sqft. Pre-filled from GET /api/jobs/:id which now
   // joins client_homes and surfaces sq_footage. Operator can edit inline;
@@ -572,6 +577,7 @@ export default function EditJobModal({
         const existing = Array.isArray(d.existing_add_ons) ? d.existing_add_ons : [];
         const addonMap = new Map<number, number>();
         const priceMap = new Map<number, number>();
+        const infoMap = new Map<number, { name: string; subtotal: number }>();
         for (const a of existing) {
           if (a.pricing_addon_id != null) {
             const pid = Number(a.pricing_addon_id);
@@ -580,12 +586,15 @@ export default function EditJobModal({
             // input pre-fills with what's actually on the job (not the
             // tenant default). User can then tweak or leave alone.
             if (a.unit_price != null) priceMap.set(pid, Number(a.unit_price));
+            // (#14B) Keep name/subtotal so a non-catalog add-on still renders.
+            infoMap.set(pid, { name: String(a.name ?? "Add-on"), subtotal: Number(a.subtotal ?? 0) });
           }
         }
         setSelectedAddons(addonMap);
         setInitialSelectedAddons(addonMap);
         setAddonPriceOverrides(priceMap);
         setInitialAddonPriceOverrides(priceMap);
+        setExistingAddonInfo(infoMap);
 
         // [W2] sqft pre-fill. The route returns null for legacy MC-imported
         // homes. We set both current + initial to the same value so the
@@ -1874,6 +1883,56 @@ export default function EditJobModal({
                 })}
               </div>
             )}
+
+            {/* [deletable-addons-fix 2026-06-16] (#14B) Add-ons on the job that
+                are NOT in the current scope's catalog (e.g. carried over from
+                the original quote under a different scope) had no row and could
+                not be removed. Render them here as removable rows. Removing one
+                shrinks selectedAddons, which re-fires the price recalc so
+                base_fee drops accordingly. */}
+            {(() => {
+              const catalogIds = new Set(availableAddons.map(a => a.id));
+              const orphans = Array.from(selectedAddons.keys()).filter(id => !catalogIds.has(id));
+              if (orphans.length === 0) return null;
+              return (
+                <div style={{ display: "flex", flexDirection: "column", gap: 6, marginTop: 6 }}>
+                  <span style={{ fontSize: 11, color: "#9E9B94", fontFamily: FF }}>From the original quote</span>
+                  {orphans.map(id => {
+                    const info = existingAddonInfo.get(id);
+                    const name = info?.name || "Add-on";
+                    const amt = info?.subtotal ?? 0;
+                    return (
+                      <div key={`orphan-${id}`} style={{
+                        display: "flex", alignItems: "center", gap: 8,
+                        padding: "8px 10px", borderRadius: 8,
+                        border: "1px solid var(--brand, #00C9A0)",
+                        backgroundColor: "rgba(0,201,160,0.05)", fontFamily: FF,
+                      }}>
+                        <span style={{ flex: 1, fontSize: 13, color: "#1A1917" }}>{name}</span>
+                        <span style={{ fontSize: 12, color: "#6B6860" }}>${Number(amt).toFixed(0)}</span>
+                        <button type="button" aria-label={`Remove ${name}`}
+                          onClick={() => {
+                            setSelectedAddons(prev => {
+                              const next = new Map(prev);
+                              next.delete(id);
+                              return next;
+                            });
+                            setAddonPriceOverrides(prev => {
+                              if (!prev.has(id)) return prev;
+                              const next = new Map(prev);
+                              next.delete(id);
+                              return next;
+                            });
+                          }}
+                          style={{ border: "none", background: "none", cursor: "pointer", color: "#B91C1C", fontSize: 16, lineHeight: 1, padding: "0 4px", fontFamily: FF }}>
+                          ×
+                        </button>
+                      </div>
+                    );
+                  })}
+                </div>
+              );
+            })()}
 
             {/* [AI.7.1] Parking-fee day picker. Renders when commercial +
                 recurring + parking is checked. Default = schedule's

--- a/artifacts/qleno/src/components/job-wizard.tsx
+++ b/artifacts/qleno/src/components/job-wizard.tsx
@@ -166,6 +166,12 @@ export function JobWizard({ open, onClose, onCreated, preselectedClient, presetD
   const [clientResults, setClientResults] = useState<any[]>([]);
   const [selectedClient, setSelectedClient] = useState<any>(null);
   const [clientRecentJobs, setClientRecentJobs] = useState<any[]>([]);
+  // [rebook-fix 2026-06-16] (#8) Feedback after clicking a "re-book" row.
+  // Clicking used to silently set Step-2 state with no confirmation, and a
+  // legacy/MC-imported service_type that isn't in the active grid highlighted
+  // nothing — so the click read as a no-op. Surface a banner; warn when the
+  // past service type is no longer selectable so the operator re-picks one.
+  const [rebookNotice, setRebookNotice] = useState<{ kind: "ok" | "warn"; msg: string } | null>(null);
   const clientDebounce = useRef<ReturnType<typeof setTimeout>>();
 
   // Step 1 — New Customer Inline Form
@@ -453,16 +459,23 @@ export function JobWizard({ open, onClose, onCreated, preselectedClient, presetD
 
   // Re-book: pre-fill Step 2 details from a past job
   function rebookFromPastJob(pastJob: any) {
+    // Is the past job's service type still an active, selectable type? Legacy /
+    // MC-imported slugs aren't rendered in the grid (AI.4), so setting one would
+    // highlight nothing and confuse the operator.
+    const row = pastJob.service_type
+      ? apiServiceTypes.find(s => s.slug === pastJob.service_type)
+      : undefined;
+    const slugSelectable = !!(row && row.is_active);
     if (pastJob.service_type) {
-      setServiceType(pastJob.service_type);
       // Flip the Job Type toggle to match the past job's parent. Without this,
       // re-booking a commercial past job on a hybrid client left the grid on
       // Residential, so the picked service never showed — looked like the
       // button did nothing ("no pasa nada").
-      const row = apiServiceTypes.find(s => s.slug === pastJob.service_type);
       if (row?.parent_slug === "residential" || row?.parent_slug === "commercial") {
         setHybridParentOverride(row.parent_slug);
       }
+      // Only pre-select the type when it's actually selectable in the grid.
+      if (slugSelectable) setServiceType(pastJob.service_type);
     }
     const mins = pastJob.duration_minutes
       ?? (pastJob.allowed_hours ? Math.round(parseFloat(pastJob.allowed_hours) * 60) : null);
@@ -472,6 +485,11 @@ export function JobWizard({ open, onClose, onCreated, preselectedClient, presetD
       if (!isNaN(n) && n > 0) { setPrice(n); setPriceOverridden(true); }
     }
     if (pastJob.frequency) setFrequency(pastJob.frequency);
+    setRebookNotice(
+      slugSelectable
+        ? { kind: "ok", msg: "Pre-filled from the past job — review the details below." }
+        : { kind: "warn", msg: "Pre-filled hours, price and frequency. The previous service type is no longer available — pick a current one below." }
+    );
   }
 
   // Load the most recent job at the selected commercial property. When the
@@ -1278,20 +1296,45 @@ export function JobWizard({ open, onClose, onCreated, preselectedClient, presetD
               {preselectedClient && clientRecentJobs.length > 0 && (
                 <div>
                   <p style={{ fontSize: 11, fontWeight: 700, color: "#9E9B94", textTransform: "uppercase", letterSpacing: "0.06em", margin: "0 0 8px" }}>Last 3 Jobs — click to re-book</p>
+                  {/* #8: confirmation/feedback after a re-book click. */}
+                  {rebookNotice && (
+                    <div style={{ fontSize: 11, fontWeight: 600, lineHeight: 1.4, padding: "8px 10px", borderRadius: 8, marginBottom: 8,
+                      color: rebookNotice.kind === "warn" ? "#92400E" : "#166534",
+                      background: rebookNotice.kind === "warn" ? "#FEF3C7" : "#DCFCE7",
+                      border: `1px solid ${rebookNotice.kind === "warn" ? "#FDE68A" : "#BBF7D0"}` }}>
+                      {rebookNotice.msg}
+                    </div>
+                  )}
                   <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-                    {clientRecentJobs.map((j: any) => (
+                    {clientRecentJobs.map((j: any) => {
+                      // #8: surface the hours and cleaner from each past visit.
+                      const hrs = j.actual_hours != null && parseFloat(String(j.actual_hours)) > 0
+                        ? `${parseFloat(String(j.actual_hours)).toFixed(1)}h`
+                        : (j.allowed_hours != null && parseFloat(String(j.allowed_hours)) > 0
+                          ? `${parseFloat(String(j.allowed_hours)).toFixed(1)}h allowed`
+                          : null);
+                      const cleaner = j.assigned_user_name && String(j.assigned_user_name).trim()
+                        ? String(j.assigned_user_name).trim() : "Unassigned";
+                      return (
                       <button key={j.id} onClick={() => rebookFromPastJob(j)} type="button"
-                        style={{ display: "flex", justifyContent: "space-between", alignItems: "center", padding: "9px 12px", background: "#F9F9F9", borderRadius: 8, border: "1px solid #E5E2DC", cursor: "pointer", fontFamily: "inherit", textAlign: "left" }}
+                        style={{ display: "flex", flexDirection: "column", gap: 3, padding: "9px 12px", background: "#F9F9F9", borderRadius: 8, border: "1px solid #E5E2DC", cursor: "pointer", fontFamily: "inherit", textAlign: "left" }}
                         onMouseEnter={e => (e.currentTarget.style.background = "#F0FDFB")}
                         onMouseLeave={e => (e.currentTarget.style.background = "#F9F9F9")}>
-                        <span style={{ fontSize: 12, color: "#1A1917", fontWeight: 600 }}>{String(j.service_type || "").replace(/_/g, " ")}</span>
-                        <div style={{ display: "flex", gap: 10, alignItems: "center" }}>
-                          <span style={{ fontSize: 11, color: "#9E9B94" }}>{String(j.scheduled_date || "")}</span>
-                          {j.base_fee != null && <span style={{ fontSize: 11, color: "#6B6860", fontWeight: 600 }}>${parseFloat(String(j.base_fee)).toFixed(0)}</span>}
-                          <span style={{ fontSize: 10, color: "#2D9B83", fontWeight: 700 }}>Re-book ▸</span>
+                        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", width: "100%" }}>
+                          <span style={{ fontSize: 12, color: "#1A1917", fontWeight: 600 }}>{String(j.service_type || "").replace(/_/g, " ")}</span>
+                          <div style={{ display: "flex", gap: 10, alignItems: "center" }}>
+                            <span style={{ fontSize: 11, color: "#9E9B94" }}>{String(j.scheduled_date || "")}</span>
+                            {j.base_fee != null && <span style={{ fontSize: 11, color: "#6B6860", fontWeight: 600 }}>${parseFloat(String(j.base_fee)).toFixed(0)}</span>}
+                            <span style={{ fontSize: 10, color: "#2D9B83", fontWeight: 700 }}>Re-book ▸</span>
+                          </div>
+                        </div>
+                        <div style={{ display: "flex", gap: 8, alignItems: "center", fontSize: 11, color: "#9E9B94" }}>
+                          <span>{cleaner}</span>
+                          {hrs && <><span style={{ color: "#D8D4CC" }}>·</span><span>{hrs}</span></>}
                         </div>
                       </button>
-                    ))}
+                      );
+                    })}
                   </div>
                 </div>
               )}

--- a/artifacts/qleno/src/pages/customer-profile.tsx
+++ b/artifacts/qleno/src/pages/customer-profile.tsx
@@ -768,7 +768,9 @@ function EditProfileDrawer({ client, onClose, onSave, onToast }: { client: any; 
                 )}
               </div>
               <div>{lbl("Client Since")}<input value={form.client_since} onChange={upd("client_since")} type="date" style={inp} /></div>
-              <div>{lbl("Internal Notes")}<textarea value={form.notes} onChange={upd("notes")} rows={3} style={{ ...inp, resize: "vertical" as const }} /></div>
+              {/* #15: clients.notes is shown to the cleaner every visit ("Client
+                  Notes — every visit" in the field app), not internal-only. */}
+              <div>{lbl("Client Notes (cleaner sees)")}<textarea value={form.notes} onChange={upd("notes")} rows={3} style={{ ...inp, resize: "vertical" as const }} /></div>
             </div>
           </div>
           {/* Cancellation policy overrides — both blank means "use the

--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -1425,6 +1425,14 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
   const [officeNotes, setOfficeNotes] = useState(job.office_notes || "");
   const [officeNotesSaving, setOfficeNotesSaving] = useState(false);
   const [officeNotesSaved, setOfficeNotesSaved] = useState(false);
+  // [cleaner-notes-fix 2026-06-16] (#15) job.notes is the note the CLEANER sees
+  // in the field app ("Today's Job Notes"). It used to render read-only here,
+  // editable only behind the modal's unobvious "Instructions" label. Make it
+  // inline-editable from the panel (office/owner/admin), mirroring office-notes
+  // auto-save. Saves via PUT { notes } — already accepted by the route.
+  const [cleanerNotes, setCleanerNotes] = useState(job.notes || "");
+  const [cleanerNotesSaving, setCleanerNotesSaving] = useState(false);
+  const [cleanerNotesSaved, setCleanerNotesSaved] = useState(false);
 
   // Rate mods state — per-job time and fee adjustments. Owner/admin/office
   // can manage. The backend recomputes billed_amount = base_fee + SUM(mods)
@@ -1530,6 +1538,27 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
     }, 2000);
     return () => clearTimeout(delay);
   }, [officeNotes, job.id, job.office_notes, token]);
+
+  // [cleaner-notes-fix 2026-06-16] (#15) Debounced auto-save for the
+  // cleaner-visible job note (job.notes). Same pattern as office notes.
+  useEffect(() => {
+    const delay = setTimeout(async () => {
+      if (cleanerNotes === (job.notes || "")) return; // no change
+      setCleanerNotesSaving(true);
+      setCleanerNotesSaved(false);
+      try {
+        await fetch(`${_API3}/api/jobs/${job.id}`, {
+          method: "PUT",
+          headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+          body: JSON.stringify({ notes: cleanerNotes || null }),
+        });
+        setCleanerNotesSaved(true);
+        setTimeout(() => setCleanerNotesSaved(false), 3000);
+      } catch {}
+      finally { setCleanerNotesSaving(false); }
+    }, 2000);
+    return () => clearTimeout(delay);
+  }, [cleanerNotes, job.id, job.notes, token]);
 
   async function saveOverride(techId: number) {
     setOverrideBusy(true);
@@ -2155,11 +2184,41 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
             </div>
           )}
 
-          {job.notes && (
-            <PS label="Notes">
-              <p style={{ margin: 0, fontSize: 13, color: "#6B7280", lineHeight: 1.6 }}>{job.notes}</p>
-              <TranslateNote text={job.notes} />
-            </PS>
+          {/* Cleaner Notes — the note the technician sees in the field app.
+              Inline-editable for office/owner/admin (#15); read-only otherwise. */}
+          {canEditOfficeNotes ? (
+            <div style={{ marginBottom: 16 }}>
+              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 8 }}>
+                <div style={{ display: "flex", alignItems: "center", gap: 5 }}>
+                  <span style={{ fontSize: 10, fontWeight: 700, textTransform: "uppercase" as const, letterSpacing: "0.08em", color: "#9E9B94" }}>Cleaner Notes (tech sees this)</span>
+                </div>
+                {cleanerNotesSaving && <span style={{ fontSize: 10, color: "#9E9B94" }}>Saving...</span>}
+                {!cleanerNotesSaving && cleanerNotesSaved && <span style={{ fontSize: 10, color: "#16A34A", fontWeight: 600 }}>✓ Saved</span>}
+              </div>
+              <textarea
+                value={cleanerNotes}
+                onChange={e => { setCleanerNotes(e.target.value); setCleanerNotesSaved(false); }}
+                placeholder="Instructions the cleaner sees on this job…"
+                rows={4}
+                style={{
+                  width: "100%", boxSizing: "border-box" as const, resize: "vertical" as const,
+                  border: "1px solid #E5E2DC", borderRadius: 8, padding: "8px 10px",
+                  fontSize: 12, fontFamily: FF, color: "#1A1917", lineHeight: 1.6,
+                  outline: "none", background: "#FAFAF8",
+                }}
+                onFocus={e => (e.target.style.borderColor = "var(--brand)")}
+                onBlur={e => (e.target.style.borderColor = "#E5E2DC")}
+              />
+              <p style={{ fontSize: 10, color: "#C0BDB8", marginTop: 4, fontFamily: FF }}>Auto-saves 2 s after you stop typing</p>
+              {cleanerNotes && <TranslateNote text={cleanerNotes} />}
+            </div>
+          ) : (
+            job.notes && (
+              <PS label="Cleaner Notes (tech sees this)">
+                <p style={{ margin: 0, fontSize: 13, color: "#6B7280", lineHeight: 1.6 }}>{job.notes}</p>
+                <TranslateNote text={job.notes} />
+              </PS>
+            )
           )}
 
           {/* Office Notes — editable, office/owner/admin only */}


### PR DESCRIPTION
Approved by Sal for deploy. Branch off origin/main, two scoped commits.

## Tier 1 (clear bugs)
- **#6** reschedule onto a date holding a VOIDED occurrence: handler catches 23505 → 409; **migration `scripts/j6_reschedule_dedupe_fix.ts`** rebuilds `jobs_recurring_dedupe_idx` with `AND status <> 'cancelled'` (run separately against prod).
- **#3** office quote convert now saves a new client from name/address (was email/phone-only gate); email/phone still dedupe.
- **#15** `jobs.notes` (cleaner-visible) now inline-editable in JobPanel; relabel "Instructions"→"Cleaner Notes (tech sees this)", "Internal Notes"→"Client Notes (cleaner sees)".
- **#8** rebook only pre-selects selectable service types, shows ok/warn banner, surfaces past-visit hours + cleaner.

## Tier 2 (pricing)
- **#2/#14** residential add-on double-count: dispatch amount `base + mods + addOns` → `base + mods` (base_fee is all-in; verified all 127 residential add-on jobs have base_fee ≥ add-on sum; commission/revenue read base_fee, unaffected; **no overcharge — 0 residential payments exist**).
- **#13** office combo-discount stacking: `POST /pricing/calculate` now picks a non-overlapping bundle set (most-specific, tie→larger discount). **Public/online twin in `public.ts` intentionally NOT touched (Sal deciding).**
- **#14B** deletable quote-originated add-ons in the edit-job modal.

## Verification
tsc --build (libs) passes; esbuild transforms all touched files; tsc --noEmit introduces zero new errors vs baseline. Full rollup bundle validated by CI.

Does NOT touch payroll/invoice work or the public quote tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)