### PR TITLE
June-13 #1 recurrence fan-out + #11 hourly move-in/out (DO NOT MERGE until cleared)

### DIFF
--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -4185,6 +4185,10 @@ export async function runPhesDataMigration(): Promise<void> {
       { name: "Recurring Cleaning",                  method: "sqft",   rate: "55.00", min: "120.00" },
       { name: "Hourly Deep Clean",                   method: "hourly", rate: "70.00", min: "210.00" },
       { name: "Hourly Standard Cleaning",            method: "hourly", rate: "60.00", min: "150.00" },
+      // (#11 2026-06-17) Hourly Move In/Out is its OWN service, distinct from the
+      // flat-rate (sqft) "Move In / Move Out" above — Sal confirmed separate.
+      // method=hourly so it bills hourly_rate × hours like the other hourly scopes.
+      { name: "Hourly Move In / Move Out",           method: "hourly", rate: "70.00", min: "210.00" },
       { name: "Commercial Cleaning",                 method: "hourly", rate: "65.00", min: "200.00" },
       { name: "PPM Turnover",                       method: "sqft",   rate: "65.00", min: "250.00" },
       // Commercial scopes for plain commercial CLIENTS (not the PPM account).

--- a/artifacts/api-server/src/routes/jobs.ts
+++ b/artifacts/api-server/src/routes/jobs.ts
@@ -478,6 +478,88 @@ router.post("/", requireAuth, async (req, res) => {
       }
     }
 
+    // [recurrence-fanout-fix 2026-06-17] (#1) The dispatch "New Job" wizard used
+    // to stamp a recurring `frequency` onto this single job but never create a
+    // recurring_schedules row or generate the rest of the series — so
+    // "scheduling a recurrence" only ever produced the first visit (313
+    // historical jobs carry a recurring frequency with NULL
+    // recurring_schedule_id). Mirror the quote-convert fan-out: build the
+    // schedule, link THIS job as the first occurrence (so the generator's
+    // dedupe skips its date — no duplicate first visit), and synchronously
+    // generate the next 90 days. Calls generateJobsFromSchedule directly, so it
+    // works regardless of the disabled RECURRING_ENGINE cron. Gated by a
+    // FEE-GUARD: never fan out a $0/blank series (the 744-phantom-job incident).
+    const RECURRING_FREQS = new Set(["weekly", "biweekly", "monthly", "weekdays", "every_3_weeks"]);
+    const _feeNum = Number(base_fee);
+    if (
+      client_id &&
+      typeof frequency === "string" && RECURRING_FREQS.has(frequency) &&
+      Number.isFinite(_feeNum) && _feeNum > 0
+    ) {
+      try {
+        const _durationMin = allowed_hours != null && Number(allowed_hours) > 0
+          ? Math.round(Number(allowed_hours) * 60)
+          : (estimated_hours != null && Number(estimated_hours) > 0 ? Math.round(Number(estimated_hours) * 60) : null);
+
+        const [sched] = await db
+          .insert(recurringSchedulesTable)
+          .values({
+            company_id: req.auth!.companyId!,
+            customer_id: client_id,
+            frequency: frequency as any, // narrowed to string; column wants the freq enum union
+            day_of_week: null, // cadence anchors on start_date's weekday when null
+            start_date: scheduled_date,
+            end_date: null,
+            assigned_employee_id: primaryTechId ? Number(primaryTechId) : null,
+            service_type,
+            scheduled_time: scheduled_time || null,
+            duration_minutes: _durationMin,
+            base_fee: String(base_fee),
+            notes: notes || null,
+          })
+          .returning();
+
+        // Link THIS job as the first occurrence so the generator dedupe skips it.
+        await db.update(jobsTable).set({ recurring_schedule_id: sched.id }).where(eq(jobsTable.id, jobId));
+
+        // Carry the wizard's add-ons onto the schedule template so future
+        // occurrences inherit them (the generator only stamps parking itself).
+        const _schedAddons = (Array.isArray(add_ons) ? add_ons : [])
+          .map((a: any) => ({ pricing_addon_id: Number(a?.pricing_addon_id ?? a?.id), qty: Number(a?.qty ?? a?.quantity ?? 1) || 1 }))
+          .filter((a) => Number.isFinite(a.pricing_addon_id) && a.pricing_addon_id > 0);
+        for (const a of _schedAddons) {
+          try {
+            await db.execute(sql`
+              INSERT INTO recurring_schedule_add_ons (recurring_schedule_id, pricing_addon_id, qty)
+              VALUES (${sched.id}, ${a.pricing_addon_id}, ${a.qty})
+            `);
+          } catch (e) { console.warn("[job-create recurrence] schedule add-on insert failed:", e); }
+        }
+
+        const { generateJobsFromSchedule, DAYS_AHEAD } = await import("../lib/recurring-jobs.js");
+        const _today = new Date();
+        const _horizon = new Date(_today.getTime() + DAYS_AHEAD * 24 * 60 * 60 * 1000);
+        const _gen = await generateJobsFromSchedule(sched as any, _today, _horizon, null, geoZip);
+
+        // Stamp schedule add-ons onto the newly-generated occurrences only — the
+        // first job already has its own add-ons (persistJobAddOns above).
+        if (_schedAddons.length) {
+          try {
+            const genRows = await db.execute(sql`SELECT id FROM jobs WHERE recurring_schedule_id = ${sched.id} AND company_id = ${req.auth!.companyId} AND id <> ${jobId}`);
+            for (const row of (genRows as any).rows) {
+              await persistJobAddOns(db, Number(row.id), req.auth!.companyId!, _schedAddons);
+            }
+          } catch (e) { console.warn("[job-create recurrence] stamping add-ons on generated jobs failed:", e); }
+        }
+        newJob[0] = { ...newJob[0], recurring_schedule_id: sched.id } as any;
+        console.log(`[job-create recurrence] job ${jobId} → schedule ${sched.id}, generated ${_gen.created} additional occurrence(s) over ${DAYS_AHEAD} days`);
+      } catch (genErr: any) {
+        // Never fail the job create because the series fan-out hiccuped — the
+        // first visit is already saved and will be returned.
+        console.error("[job-create recurrence] fan-out failed (first visit still created):", genErr?.message ?? genErr);
+      }
+    }
+
     return res.status(201).json({
       ...newJob[0],
       client_name: displayClientName,

--- a/artifacts/api-server/src/routes/quotes.ts
+++ b/artifacts/api-server/src/routes/quotes.ts
@@ -394,6 +394,12 @@ router.post("/:id/convert", requireAuth, requireRole("owner", "admin", "office")
       "recurring cleaning - every 4 weeks": "recurring",
       "hourly deep clean": "deep_clean",
       "hourly standard cleaning": "standard_clean",
+      // (#11) Hourly Move In/Out → move_out enum (the clean TYPE); the hourly
+      // billing is carried by the scope's method + the quote's hours, exactly
+      // like "hourly deep clean" → deep_clean. Without this it fell back to
+      // standard_clean and the office "didn't recognize the hourly option".
+      "hourly move in / move out": "move_out",
+      "hourly move in/move out": "move_out",
       "commercial cleaning": "office_cleaning",
       "ppm turnover": "ppm_turnover",
       "ppm common areas": "common_areas",


### PR DESCRIPTION
**HOLD — do not merge until Sal clears deploy.** Built per Sal's instruction; CI validation only.

## #1 — recurring booking schedules the FULL series
`POST /api/jobs` (dispatch New Job wizard) never created a schedule or fanned out — 313 jobs carry a recurring frequency with NULL `recurring_schedule_id`. Now mirrors the proven quote-convert fan-out: builds the schedule, links the first job (dedupe skips it), generates the next 90 days via `generateJobsFromSchedule` (bypasses the disabled cron). **Fee-guard**: only fans out for a known recurring frequency + client_id + base_fee > 0 (no $0 phantom series). Wrapped so fan-out failure never fails the create.

## #11 — Hourly Move In/Out as its own service
Seeded a new `Hourly Move In / Move Out` pricing_scope (method=hourly) + convert enum map (`→ move_out`). The quote-builder sub-type regex already matches it, so no frontend change.

## Verification
esbuild transforms all files; tsc --noEmit zero new errors vs baseline. Does NOT touch payroll/invoice or the public quote tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)