### PR TITLE
feat(invoicing): cutover-date guard — never auto-invoice pre-July-1 jobs [READY, awaiting go]

### DIFF
--- a/artifacts/api-server/src/lib/ensure-invoice.ts
+++ b/artifacts/api-server/src/lib/ensure-invoice.ts
@@ -36,6 +36,12 @@ import { eq, and, ne } from "drizzle-orm";
 import { getNextInvoiceNumber } from "./invoice-number.js";
 import { derivePaymentSource } from "./payment-source.js";
 
+// [cutover-guard 2026-06-17] Qleno go-live date. Jobs scheduled before this are
+// billed in MaidCentral; the completion engine never auto-invoices them. Single
+// hardcoded constant for Phes go-live; move to tenant_settings when multi-tenant
+// cutovers arrive (mirrors the LATE_THRESHOLD_MINUTES pattern in job-status.ts).
+const INVOICE_CUTOVER_DATE = "2026-07-01";
+
 export type EnsureInvoiceResult = {
   created: boolean;
   skipped: boolean;
@@ -81,11 +87,20 @@ export async function ensureInvoiceForCompletedJob(
         billed_hours: jobsTable.billed_hours,
         hourly_rate: jobsTable.hourly_rate,
         charge_succeeded_at: jobsTable.charge_succeeded_at,
+        scheduled_date: jobsTable.scheduled_date,
       })
       .from(jobsTable)
       .where(and(eq(jobsTable.id, jobId), eq(jobsTable.company_id, companyId)))
       .limit(1);
     if (!job) return NO_OP;
+
+    // [cutover-guard 2026-06-17] Pre-cutover jobs are billed in MaidCentral, NOT
+    // Qleno. Never auto-invoice a job scheduled before the Qleno go-live date —
+    // otherwise a stale June job closed out in Qleno after July 1 would double-bill
+    // a customer already invoiced in MC. Scoped to the completion engine only;
+    // the office can still manually invoice a pre-cutover job if it ever needs it.
+    const sched = job.scheduled_date ? String(job.scheduled_date).slice(0, 10) : null;
+    if (sched && sched < INVOICE_CUTOVER_DATE) return NO_OP;
 
     // Skip jobs already charged — money already moved, so an invoice would be a
     // duplicate AR artifact (spec §1 idempotency).


### PR DESCRIPTION
## Why
The per-visit engine keys on the **completion event, not the job's scheduled date.** So if a stale **June** job (billed in MaidCentral) is closed out in Qleno *after* July 1 go-live, it would auto-generate a Qleno invoice → **double-bill** a customer already invoiced in MC.

## What
`ensureInvoiceForCompletedJob` now skips any job with `scheduled_date < INVOICE_CUTOVER_DATE` (`'2026-07-01'`). Makes June double-billing **structurally impossible** regardless of when stale June jobs get closed.

- Scoped to the **completion engine only** — the office can still manually invoice a pre-cutover job via `POST /api/invoices` if ever needed.
- Single hardcoded constant (mirrors `LATE_THRESHOLD_MINUTES`); easy to move to `tenant_settings` for future multi-tenant cutovers.

## Verification
- tsc clean on the file; server entry esbuild-bundles clean.
- Behavior: a `scheduled_date='2026-06-..'` job completed in Qleno → engine returns NO_OP (no invoice). A `'2026-07-..'` job → invoices normally (validated by today's E2E, which used July-dated test jobs and passed).

**Ready — holding for your go before merge/deploy.** Pairs with the standing decision to not pre-invoice not-completed June jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)