### PR TITLE
Payroll Allowed+Worked hours per tech; remove dead Flag action

### DIFF
--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -2801,7 +2801,7 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
 
         {/* [AF] Action footer. When isLocked (status=complete/cancelled or
             locked_at set), Mark Complete is replaced with a muted "Completed
-            at ..." label and Reschedule / Cancel / Flag are disabled. */}
+            at ..." label and Reschedule / Cancel are disabled. */}
         <div style={{ padding: "12px 20px 20px", borderTop: "1px solid #EEECE7", display: "flex", gap: 8, flexShrink: 0, flexWrap: "wrap" }}>
           {isLocked ? (
             <div style={{ flex: 1, minWidth: 100, padding: "10px 12px", border: "1px solid #E5E2DC", borderRadius: 8, backgroundColor: "#F8F7F4", color: "#6B6860", fontSize: 12, fontWeight: 600, fontFamily: FF, display: "flex", alignItems: "center", justifyContent: "center", gap: 6 }}>
@@ -2831,12 +2831,6 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
             <button onClick={() => setStatus("in_progress")} disabled={busy}
               style={{ flex: 1, minWidth: 100, padding: "10px 12px", border: "1px solid #FCD34D", borderRadius: 8, backgroundColor: "#FEF3C7", color: "#92400E", fontSize: 13, fontWeight: 700, cursor: "pointer", fontFamily: FF }}>
               Start Job
-            </button>
-          )}
-          {!isLocked && job.status !== "flagged" && !confirmComplete && (
-            <button onClick={() => setStatus("flagged")} disabled={busy}
-              style={{ padding: "10px 12px", border: "1px solid #FCA5A5", borderRadius: 8, backgroundColor: "#FEE2E2", color: "#991B1B", fontSize: 13, fontWeight: 700, cursor: "pointer", fontFamily: FF }}>
-              Flag
             </button>
           )}
           {/* Charge Client — owner/admin only, completed Stripe jobs not yet charged */}

--- a/artifacts/qleno/src/pages/payroll.tsx
+++ b/artifacts/qleno/src/pages/payroll.tsx
@@ -237,13 +237,18 @@ function WeeklyDetailView({ period, onPeriodChange }: { period: { start: string;
         const mileageAmt = sumK('mileage', 'mileage_reimbursement');
         const timeOffAmt = sumK('sick_pay', 'holiday_pay', 'vacation_pay');
         const hoursWorked = Number(emp.totals?.hrs_worked ?? 0);
+        const allowedHrs = Number(emp.totals?.hrs_scheduled ?? 0);
         const money = (n: number) => `$${Number(n).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
         const eff = Number(emp.totals?.hrs_worked) > 0 ? Math.round((Number(emp.totals?.hrs_scheduled || 0) / Number(emp.totals.hrs_worked)) * 100) : null;
         const effRate = emp.totals?.effective_rate;
         const billedTotal = Number(emp.totals?.job_total ?? 0);
         const laborPct = billedTotal > 0 ? Math.round((emp.totals.commission / billedTotal) * 100) : null;
         const rollup: any[] = [
-          { label: 'Hours', value: hoursWorked.toFixed(1) },
+          // Allowed + Worked hrs side by side per tech — mirrors the team
+          // header so the office reads budget-vs-actual on each row, not just
+          // in the aggregate (Sal request 2026-06-17).
+          { label: 'Allowed', value: allowedHrs.toFixed(1) },
+          { label: 'Worked', value: hoursWorked.toFixed(1) },
           ...(eff != null ? [{ label: 'Eff', value: `${eff}%` }] : []),
           { label: 'Billed', value: money(billedTotal) },
           { label: 'Total Pay', value: money(emp.totals.grand_total), strong: true, accent: true },


### PR DESCRIPTION
Two small dispatch/payroll tweaks from Sal:

## 1. Per-tech Allowed + Worked hours on the payroll list
The payroll team-summary header shows **Allowed hrs** and **Worked hrs**, but each collapsed technician row only showed a single **Hours** (worked) figure. This adds an **Allowed** stat next to **Worked** on every tech row, so the office reads budget-vs-actual per person at a glance — the same view Sal likes in the header, now at the individual level. Numbers were already in the `/payroll/detail` payload (`totals.hrs_scheduled` / `totals.hrs_worked`); display-only.

## 2. Remove the Flag action from the job card
The **Flag** button set `jobs.status` to `'flagged'`, which isn't a value in the `job_status` enum (`scheduled | in_progress | complete | cancelled`) — so it was effectively dead and served no purpose. Removed from the job panel footer.

Frontend builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PiXXwFgtNSnzZQy3MTjAj