### PR TITLE
Surface charged cancellations/lockouts (time clock + dispatch) + Fees report

### DIFF
--- a/artifacts/api-server/src/routes/dispatch.ts
+++ b/artifacts/api-server/src/routes/dispatch.ts
@@ -386,6 +386,23 @@ async function buildDispatchPayload(
     const userNameById = new Map<number, string>();
     for (const u of allCompanyUsers) userNameById.set(u.id, `${u.first_name ?? ""} ${u.last_name ?? ""}`.trim());
 
+    // [lockout-visibility 2026-06-17] A charged Cancel/Lockout leaves the job
+    // status='complete' (so it counts as revenue) but it is NOT a real visit.
+    // Surface cancel_action per job so the chip + drawer can badge it as a
+    // fee charge instead of a normal completed clean (Sal: "no indication
+    // this job was saved as a lockout/cancel anywhere").
+    const cancelActionByJob = new Map<number, string>();
+    try {
+      const jobIds = (jobs as any[]).map((j: any) => j.id).filter((x: any) => x != null);
+      if (jobIds.length) {
+        const cc = await db.execute(sql`
+          SELECT DISTINCT job_id, cancel_action FROM cancellation_log
+           WHERE company_id = ${companyId} AND cancel_action IN ('cancel','lockout')
+             AND job_id IN (${sql.join(jobIds.map((n: number) => sql`${n}`), sql`, `)})`);
+        for (const r of cc.rows as any[]) cancelActionByJob.set(Number(r.job_id), String(r.cancel_action));
+      }
+    } catch { /* cancellation_log absent — no badge */ }
+
     // [gps-flag] Tenant toggle — when off, suppress the "GPS unavailable" flag.
     const gpsFlagRow = await db.execute(sql`SELECT flag_missing_gps FROM companies WHERE id = ${companyId} LIMIT 1`);
     const flagMissingGps = (gpsFlagRow.rows[0] as any)?.flag_missing_gps ?? true;
@@ -851,6 +868,9 @@ async function buildDispatchPayload(
         // [AF] Completion / lock state — drawer renders read-only UI when
         // locked_at is set.
         locked_at: j.locked_at ?? null,
+        // 'cancel' | 'lockout' when this completed job is actually a charged
+        // cancellation/lockout (fee billed, not a service visit); else null.
+        cancel_action: cancelActionByJob.get(Number(j.id)) ?? null,
         actual_end_time: j.actual_end_time ?? null,
         completed_by_user_id: j.completed_by_user_id ?? null,
         no_show_marked_by_tech: (j as any).no_show_marked_by_tech ?? null,

--- a/artifacts/api-server/src/routes/reports.ts
+++ b/artifacts/api-server/src/routes/reports.ts
@@ -800,6 +800,59 @@ router.get("/discounts", requireAuth, ROLE, async (req, res) => {
   }
 });
 
+// ─── FEES COLLECTED (cancellation + lockout) ─────────────────────────────────
+// Every charged Cancel/Lockout in the window (from cancellation_log), so the
+// office can see how much was collected in fees — a labeled subset of revenue
+// (the fee already sits in jobs.billed_amount and counts in the Revenue total).
+router.get("/fees", requireAuth, ROLE, async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId!;
+    const now = new Date();
+    const fromStr = (req.query.from as string) || dateStr(new Date(now.getTime() - 30 * 86400000));
+    const toStr   = (req.query.to   as string) || dateStr(now);
+    const rows = await db.execute(sql`
+      SELECT
+        cl.id, cl.cancel_action, cl.customer_charge_amount, cl.cancelled_at,
+        u.first_name AS by_first, u.last_name AS by_last,
+        c.first_name AS client_first, c.last_name AS client_last, c.company_name AS client_company,
+        j.id AS job_id, j.service_type, j.scheduled_date
+      FROM cancellation_log cl
+      JOIN jobs j ON j.id = cl.job_id
+      LEFT JOIN clients c ON c.id = j.client_id
+      LEFT JOIN users u ON u.id = cl.cancelled_by
+      WHERE cl.company_id = ${companyId}
+        AND cl.cancel_action IN ('cancel','lockout')
+        AND j.scheduled_date BETWEEN ${fromStr} AND ${toStr}
+        ${branchFilter(req, "j.branch_id")}
+      ORDER BY j.scheduled_date DESC LIMIT 1000
+    `);
+    const data = (rows.rows as any[]).map(r => ({
+      id: r.id, action: String(r.cancel_action),
+      amount: parseF(r.customer_charge_amount),
+      recorded_at: r.cancelled_at, job_date: r.scheduled_date,
+      recorded_by: r.by_first ? `${r.by_first} ${r.by_last}`.trim() : null,
+      client_name: r.client_first ? `${r.client_first} ${r.client_last}`.trim() : (r.client_company || null),
+      job_id: r.job_id, service_type: r.service_type,
+    }));
+    const lockoutTotal = data.filter(d => d.action === "lockout").reduce((s, r) => s + r.amount, 0);
+    const cancelTotal  = data.filter(d => d.action === "cancel").reduce((s, r) => s + r.amount, 0);
+    return res.json({
+      from: fromStr, to: toStr, data,
+      summary: {
+        total_fees: Math.round((lockoutTotal + cancelTotal) * 100) / 100,
+        lockout_fees: Math.round(lockoutTotal * 100) / 100,
+        cancel_fees: Math.round(cancelTotal * 100) / 100,
+        count: data.length,
+        lockout_count: data.filter(d => d.action === "lockout").length,
+        cancel_count: data.filter(d => d.action === "cancel").length,
+      },
+    });
+  } catch (err) {
+    console.error("Fees report error:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
 // ─── WEEK IN REVIEW ──────────────────────────────────────────────────────────
 router.get("/week-review", requireAuth, ROLE, async (req, res) => {
   try {

--- a/artifacts/api-server/src/routes/timeclock.ts
+++ b/artifacts/api-server/src/routes/timeclock.ts
@@ -857,14 +857,34 @@ router.get("/day", requireAuth, requireRole("owner", "admin", "office"), async (
       // job's normal commission — exclude them from the commission calc so the
       // tech isn't double-paid (commission + cancellation fee).
       const chargedCancelJobIds = new Set<number>();
+      const cancelPayByKey = new Map<string, number>();
+      const cancelActionByJob = new Map<number, string>();
       if (inList) {
         try {
           const cc = await db.execute(sql`
-            SELECT DISTINCT job_id FROM cancellation_log
+            SELECT DISTINCT job_id, cancel_action FROM cancellation_log
              WHERE company_id = ${companyId} AND job_id IN (${inList})
                AND cancel_action IN ('cancel','lockout')`);
-          for (const r of cc.rows as any[]) chargedCancelJobIds.add(Number(r.job_id));
+          for (const r of cc.rows as any[]) {
+            chargedCancelJobIds.add(Number(r.job_id));
+            if (r.cancel_action) cancelActionByJob.set(Number(r.job_id), String(r.cancel_action));
+          }
         } catch { /* cancellation_log absent — no exclusion */ }
+        // The cancellation fee paid to the tech lives in additional_pay
+        // (type 'cancellation_pay'). Surface it per job:tech so the time
+        // clock shows the $X the tech is owed for the lockout/cancel
+        // instead of a blank "—" (Sal: "no indication of the cancel
+        // impacting Hilda's pay"). Keyed by the JOB's date via job_id, not
+        // additional_pay.created_at (which is when the office reclassified).
+        try {
+          const cp = await db.execute(sql`
+            SELECT job_id, user_id, COALESCE(SUM(amount), 0)::float AS amount
+              FROM additional_pay
+             WHERE company_id = ${companyId} AND job_id IN (${inList})
+               AND type = 'cancellation_pay' AND status <> 'voided'
+             GROUP BY job_id, user_id`);
+          for (const r of cp.rows as any[]) cancelPayByKey.set(`${r.job_id}:${r.user_id}`, Number(r.amount));
+        } catch { /* additional_pay absent */ }
       }
       const jobTechsForCalc: JobTechRow[] = techRows
         .filter((t: any) => !chargedCancelJobIds.has(Number(t.job_id)))
@@ -891,6 +911,10 @@ router.get("/day", requireAuth, requireRole("owner", "admin", "office"), async (
                  flagged: boolean; minutes: number | null;
                  pay_type: string | null; hourly_rate: string | null; commission_pct: string | null;
                  pay_deduction_pct: string | null; pay_deduction_flat: string | null; pay: number | null;
+                 // pay_kind tells the UI whether `pay` is normal commission or
+                 // a cancellation/lockout fee (so it can label it and skip the
+                 // pay-type editor). cancel_action is 'cancel' | 'lockout' when set.
+                 pay_kind: "commission" | "cancellation"; cancel_action: string | null;
                  source: string | null;
                  // [gps-on-timeclock 2026-06-11] GPS captured at clock-in/out so
                  // the office can audit field punches right here. has_gps=false
@@ -935,6 +959,15 @@ router.get("/day", requireAuth, requireRole("owner", "admin", "office"), async (
         pay_deduction_flat: p?.pay_deduction_flat != null ? String(p.pay_deduction_flat) : null,
       };
     };
+    // Resolve a row's pay: charged-cancellation jobs are excluded from
+    // commission (above) and instead pay the cancellation fee, so surface that
+    // amount + flag it. Normal jobs use the computed commission.
+    const payRowOf = (jid: number, uid: number): { pay: number | null; pay_kind: "commission" | "cancellation"; cancel_action: string | null } => {
+      if (chargedCancelJobIds.has(jid)) {
+        return { pay: cancelPayByKey.get(`${jid}:${uid}`) ?? 0, pay_kind: "cancellation", cancel_action: cancelActionByJob.get(jid) ?? "cancel" };
+      }
+      return { pay: payByKey.get(`${jid}:${uid}`) ?? null, pay_kind: "commission", cancel_action: null };
+    };
     const emp = new Map<number, { user_id: number; name: string; rows: Row[] }>();
     const ensureEmp = (uid: number) => {
       if (!emp.has(uid)) emp.set(uid, { user_id: uid, name: nameByUser.get(uid) || "Tech", rows: [] });
@@ -956,7 +989,7 @@ router.get("/day", requireAuth, requireRole("owner", "admin", "office"), async (
           job_id: jid, client_name: j.client_name, service_type: j.service_type, scheduled_time: j.scheduled_time ?? null,
           entry_id: e ? Number(e.id) : null, clock_in_at: e?.clock_in_at ?? null, clock_out_at: e?.clock_out_at ?? null,
           flagged: !!e?.flagged, minutes: e ? minutesOf(e.clock_in_at, e.clock_out_at) : null,
-          ...payOf(jid, t.user_id), pay: payByKey.get(`${jid}:${t.user_id}`) ?? null, source: e?.source ?? null,
+          ...payOf(jid, t.user_id), ...payRowOf(jid, t.user_id), source: e?.source ?? null,
           ...gpsOf(e), ...coordsOf(j),
         });
       }
@@ -969,7 +1002,7 @@ router.get("/day", requireAuth, requireRole("owner", "admin", "office"), async (
         job_id: Number(e.job_id), client_name: j?.client_name ?? "Client", service_type: j?.service_type ?? "",
         scheduled_time: j?.scheduled_time ?? null, entry_id: Number(e.id), clock_in_at: e.clock_in_at ?? null,
         clock_out_at: e.clock_out_at ?? null, flagged: !!e.flagged, minutes: minutesOf(e.clock_in_at, e.clock_out_at),
-        ...payOf(Number(e.job_id), Number(e.user_id)), pay: payByKey.get(`${e.job_id}:${e.user_id}`) ?? null, source: e.source ?? null,
+        ...payOf(Number(e.job_id), Number(e.user_id)), ...payRowOf(Number(e.job_id), Number(e.user_id)), source: e.source ?? null,
         ...gpsOf(e), ...coordsOf(j),
       });
     }
@@ -1005,6 +1038,7 @@ router.get("/day", requireAuth, requireRole("owner", "admin", "office"), async (
         FROM additional_pay
         WHERE company_id = ${companyId}
           AND status <> 'voided'
+          AND type <> 'cancellation_pay'
           AND created_at::date = ${date}::date
       `);
       additionalPayTotal = Math.round(Number((ap.rows[0] as any)?.total ?? 0) * 100) / 100;

--- a/artifacts/qleno/src/App.tsx
+++ b/artifacts/qleno/src/App.tsx
@@ -45,6 +45,7 @@ const PayrollReportPage   = lazy(() => import("@/pages/reports/payroll"));
 const EmployeeStatsPage   = lazy(() => import("@/pages/reports/employee-stats"));
 const TipsReportPage      = lazy(() => import("@/pages/reports/tips"));
 const DiscountsReportPage = lazy(() => import("@/pages/reports/discounts"));
+const FeesReportPage      = lazy(() => import("@/pages/reports/fees"));
 const ReceivablesPage     = lazy(() => import("@/pages/reports/receivables"));
 const JobCostingPage      = lazy(() => import("@/pages/reports/job-costing"));
 const PayrollToRevenuePage= lazy(() => import("@/pages/reports/payroll-to-revenue"));
@@ -238,6 +239,7 @@ function Router() {
         <Route path="/reports/employee-stats" component={EmployeeStatsPage} />
         <Route path="/reports/tips" component={TipsReportPage} />
         <Route path="/reports/discounts" component={DiscountsReportPage} />
+        <Route path="/reports/fees" component={FeesReportPage} />
         <Route path="/reports/receivables" component={ReceivablesPage} />
         <Route path="/reports/job-costing" component={JobCostingPage} />
         <Route path="/reports/payroll-to-revenue" component={PayrollToRevenuePage} />

--- a/artifacts/qleno/src/components/legend-popover.tsx
+++ b/artifacts/qleno/src/components/legend-popover.tsx
@@ -17,6 +17,7 @@ const STATUS_ORDER: JobVisualStatus[] = [
   "en_route",
   "completed",
   "completed_unpaid",
+  "charged_cancel",
   "late_clockin",
   "no_show",
   "cancelled",
@@ -67,6 +68,11 @@ function ExampleTile({ status }: { status: JobVisualStatus }) {
       {v.showNoShowBadge && (
         <div style={{ position: "absolute", top: 3, right: 3, fontSize: 8, fontWeight: 800, color: "#FFFFFF", backgroundColor: "#991B1B", padding: "1px 4px", borderRadius: 3 }}>
           NO SHOW
+        </div>
+      )}
+      {v.showFeeBadge && (
+        <div style={{ position: "absolute", top: 3, right: 3, fontSize: 8, fontWeight: 800, color: "#FFFFFF", backgroundColor: "#B45309", padding: "1px 4px", borderRadius: 3, letterSpacing: "0.05em" }}>
+          FEE
         </div>
       )}
       {/* [job-card-redesign] UNPAID badge mirrors the chip pill so the

--- a/artifacts/qleno/src/lib/job-status.ts
+++ b/artifacts/qleno/src/lib/job-status.ts
@@ -68,6 +68,7 @@ export type JobVisualStatus =
   | "active"
   | "completed"
   | "completed_unpaid"
+  | "charged_cancel"
   | "en_route"
   | "late_clockin"
   | "no_show"
@@ -96,6 +97,12 @@ export interface JobStatusInput {
    *  (customer accountability). The button doesn't exist yet — until
    *  it ships this field stays null and no_show never fires. */
   no_show_marked_by_tech?: string | null;
+  /** [lockout-visibility 2026-06-17] 'cancel' | 'lockout' when this job,
+   *  though status='complete', is actually a charged cancellation/lockout
+   *  (fee billed, no real visit). Set from the dispatch payload's
+   *  cancel_action. Takes precedence over the plain "completed" visual so
+   *  the office can tell a fee charge apart from a finished clean. */
+  cancel_action?: string | null;
 }
 
 // [phes-lifecycle 2026-04-29] Phes-specific thresholds. Multi-tenant
@@ -156,6 +163,9 @@ function isUnpaidOnlineJob(job: JobStatusInput): boolean {
 export function getJobVisualStatus(job: JobStatusInput, now: Date = new Date()): JobVisualStatus {
   if (job.status === "cancelled") return "cancelled";
   if (job.status === "complete") {
+    // A charged Cancel/Lockout keeps status='complete' (so it counts as
+    // revenue) but it's a fee, not a finished clean — surface it distinctly.
+    if (job.cancel_action === "cancel" || job.cancel_action === "lockout") return "charged_cancel";
     return isUnpaidOnlineJob(job) ? "completed_unpaid" : "completed";
   }
 
@@ -228,6 +238,10 @@ export interface StatusVisual {
   showCheckmark: boolean;
   /** Whether to render a "NO SHOW" text badge. */
   showNoShowBadge: boolean;
+  /** [lockout-visibility] Whether to render a "LOCKOUT / FEE" text badge
+   *  (charged_cancel). The consumer picks the exact word from the job's
+   *  cancel_action; this flag is just the trigger. */
+  showFeeBadge?: boolean;
   /** Whether to apply strikethrough to the title text (cancelled). */
   strikethrough: boolean;
   /** Whether to desaturate the body via grayscale filter (cancelled). */
@@ -323,6 +337,21 @@ export const STATUS_VISUALS: Record<JobVisualStatus, StatusVisual> = {
     strikethrough: false,
     desaturate: false,
     borderOverride: "#BA7517",
+    showCarIcon: false,
+  },
+  charged_cancel: {
+    label: "Lockout / Cancel fee",
+    description: "Marked complete as a charged cancellation or lockout — a fee was billed, not a service visit.",
+    swatch: "#B45309",
+    stripe: null,
+    bodyOpacity: 1,
+    fillMuted: true,
+    showCheckmark: false,
+    showNoShowBadge: false,
+    showFeeBadge: true,
+    strikethrough: true,
+    desaturate: false,
+    borderOverride: "#B45309",
     showCarIcon: false,
   },
   late_clockin: {

--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -78,7 +78,7 @@ const STATUS: Record<string, { bg: string; border: string; text: string; dot: st
 interface ClockEntry { id: number; clock_in_at: string | null; clock_out_at: string | null; distance_from_job_ft: number | null; is_flagged: boolean; clock_in_distance_ft?: number | null; clock_out_distance_ft?: number | null; clock_in_outside_geofence?: boolean; clock_out_outside_geofence?: boolean; gps_missing?: boolean; }
 interface JobTechCommission { user_id: number; name: string; is_primary: boolean; est_hours: number; calc_pay: number; final_pay: number; pay_override: number | null; /* [pay-matrix 2026-04-29] surface the per-tech matrix cell so JobPanel can render "Hourly $20/hr × 6h" or "Commission 35%" without re-deriving */ pay_type?: "commission" | "hourly"; pay_rate?: number; }
 interface JobAddOn { name: string; quantity: number; unit_price: number; subtotal: number; }
-interface DispatchJob { id: number; client_id: number; client_name: string; /* [scheduling-engine 2026-04-29] display_name = "Company - Contact" for commercial clients with company_name set; falls back to client_name otherwise. Use this on every chip/header/hover surface so the composition rule lives server-side. */ display_name?: string; client_company_name?: string | null; client_phone?: string | null; client_zip?: string | null; client_notes?: string | null; client_payment_method?: string | null; /* [tile redesign] residential or commercial badge; commercial when account_id is set OR client_type === 'commercial' */ client_type?: "residential" | "commercial" | null; address: string | null; /* [inline-edit] raw fields for address editor mode detection */ job_address_street?: string | null; job_address_city?: string | null; job_address_state?: string | null; job_address_zip?: string | null; client_address?: string | null; client_city?: string | null; client_state?: string | null; client_address_zip?: string | null; assigned_user_id: number | null; assigned_user_name?: string; job_lat?: number | null; job_lng?: number | null; service_type: string; status: string; scheduled_date: string; scheduled_time: string | null; frequency: string; amount: number; duration_minutes: number; notes: string | null; office_notes?: string | null; office_notes_updated_at?: string | null; office_notes_updated_by_name?: string | null; before_photo_count: number; after_photo_count: number; clock_entry: ClockEntry | null; zone_id?: number | null; zone_color?: string | null; zone_name?: string | null; branch_id?: number | null; branch_name?: string | null; last_service_date?: string | null; account_id?: number | null; account_name?: string | null; billing_method?: string | null; hourly_rate?: number | null; estimated_hours?: number | null; actual_hours?: number | null; billed_hours?: number | null; billed_amount?: number | null; /* [commercial-revenue 2026-06-04] allowed_hours drives the "$50/hr × 8h" card display; manual_rate_override distinguishes a flat pinned price from rate×hours billing */ allowed_hours?: number | null; manual_rate_override?: boolean | null; charge_failed_at?: string | null; charge_succeeded_at?: string | null; property_access_notes?: string | null; booking_location?: string | null; technicians?: JobTechCommission[]; est_hours_per_tech?: number | null; est_pay_per_tech?: number | null; company_res_pct?: number | null; /* [AI.7.4] Commission routing — 'commercial_hourly' or 'residential_pool' */ commission_basis?: "commercial_hourly" | "residential_pool" | null; commercial_hourly_rate?: number | null; /* [AF] completion lock state */ locked_at?: string | null; actual_end_time?: string | null; completed_by_user_id?: number | null; /* [job-card-redesign] Add-ons drive the +N pill on the chip and the full list in the popover. is_new_client = first-ever residential job (no prior completed). en_route_at scaffolds the "On My Way" status; column doesn't exist yet, so the field is always undefined until the SMS engine lands. */ add_ons?: JobAddOn[]; is_new_client?: boolean; en_route_at?: string | null; /* [phes-lifecycle 2026-04-29] Manual no-show flag set by the field app's "No Show" button. Drives the NO_SHOW visual state via getJobVisualStatus. Until the field-app button ships, both fields stay null. */ no_show_marked_by_tech?: string | null; no_show_marked_by_user_id?: number | null; /* [BUG-3F2 / 2026-06-02] Multi-tech fan-out fields. team_role identifies whether this card renders for the primary or a team member, so the FE can style team-member cards differently. revenue_share is the per-tech weighted share of the job amount; the badge sums revenue_share (when present) instead of amount so per-row totals don't double-count shared jobs across the company. */ team_role?: "primary" | "team"; revenue_share?: number; }
+interface DispatchJob { id: number; client_id: number; client_name: string; /* [scheduling-engine 2026-04-29] display_name = "Company - Contact" for commercial clients with company_name set; falls back to client_name otherwise. Use this on every chip/header/hover surface so the composition rule lives server-side. */ display_name?: string; client_company_name?: string | null; client_phone?: string | null; client_zip?: string | null; client_notes?: string | null; client_payment_method?: string | null; /* [tile redesign] residential or commercial badge; commercial when account_id is set OR client_type === 'commercial' */ client_type?: "residential" | "commercial" | null; address: string | null; /* [inline-edit] raw fields for address editor mode detection */ job_address_street?: string | null; job_address_city?: string | null; job_address_state?: string | null; job_address_zip?: string | null; client_address?: string | null; client_city?: string | null; client_state?: string | null; client_address_zip?: string | null; assigned_user_id: number | null; assigned_user_name?: string; job_lat?: number | null; job_lng?: number | null; service_type: string; status: string; scheduled_date: string; scheduled_time: string | null; frequency: string; amount: number; duration_minutes: number; notes: string | null; office_notes?: string | null; office_notes_updated_at?: string | null; office_notes_updated_by_name?: string | null; before_photo_count: number; after_photo_count: number; clock_entry: ClockEntry | null; zone_id?: number | null; zone_color?: string | null; zone_name?: string | null; branch_id?: number | null; branch_name?: string | null; last_service_date?: string | null; account_id?: number | null; account_name?: string | null; billing_method?: string | null; hourly_rate?: number | null; estimated_hours?: number | null; actual_hours?: number | null; billed_hours?: number | null; billed_amount?: number | null; /* [commercial-revenue 2026-06-04] allowed_hours drives the "$50/hr × 8h" card display; manual_rate_override distinguishes a flat pinned price from rate×hours billing */ allowed_hours?: number | null; manual_rate_override?: boolean | null; charge_failed_at?: string | null; charge_succeeded_at?: string | null; property_access_notes?: string | null; booking_location?: string | null; technicians?: JobTechCommission[]; est_hours_per_tech?: number | null; est_pay_per_tech?: number | null; company_res_pct?: number | null; /* [AI.7.4] Commission routing — 'commercial_hourly' or 'residential_pool' */ commission_basis?: "commercial_hourly" | "residential_pool" | null; commercial_hourly_rate?: number | null; /* [AF] completion lock state */ locked_at?: string | null; /* [lockout-visibility 2026-06-17] 'cancel'|'lockout' when this completed job is a charged cancellation/lockout (fee billed, not a visit); drives the charged_cancel visual + fee badge */ cancel_action?: string | null; actual_end_time?: string | null; completed_by_user_id?: number | null; /* [job-card-redesign] Add-ons drive the +N pill on the chip and the full list in the popover. is_new_client = first-ever residential job (no prior completed). en_route_at scaffolds the "On My Way" status; column doesn't exist yet, so the field is always undefined until the SMS engine lands. */ add_ons?: JobAddOn[]; is_new_client?: boolean; en_route_at?: string | null; /* [phes-lifecycle 2026-04-29] Manual no-show flag set by the field app's "No Show" button. Drives the NO_SHOW visual state via getJobVisualStatus. Until the field-app button ships, both fields stay null. */ no_show_marked_by_tech?: string | null; no_show_marked_by_user_id?: number | null; /* [BUG-3F2 / 2026-06-02] Multi-tech fan-out fields. team_role identifies whether this card renders for the primary or a team member, so the FE can style team-member cards differently. revenue_share is the per-tech weighted share of the job amount; the badge sums revenue_share (when present) instead of amount so per-row totals don't double-count shared jobs across the company. */ team_role?: "primary" | "team"; revenue_share?: number; }
 interface Employee { id: number; name: string; role: string; jobs: DispatchJob[]; zone?: { zone_id: number; zone_color: string; zone_name: string } | null; time_off?: 'pto' | 'sick' | 'absent' | null; commission_rate?: number | null; avatar_url?: string | null; }
 interface DispatchData { employees: Employee[]; unassigned_jobs: DispatchJob[]; }
 
@@ -2160,6 +2160,23 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
             );
           })()}
 
+          {/* [lockout-visibility 2026-06-17] This completed job is actually a
+              charged cancellation/lockout — make that unmistakable in the
+              drawer (it was the surface Sal opened and saw "no indication"). */}
+          {(job.cancel_action === "cancel" || job.cancel_action === "lockout") && (
+            <div style={{ background: "#FEF3C7", border: "1px solid #FCD34D", borderRadius: 8, padding: "10px 14px", display: "flex", alignItems: "flex-start", gap: 8, marginBottom: 14 }}>
+              <AlertTriangle size={14} style={{ color: "#B45309", flexShrink: 0, marginTop: 1 }} />
+              <div>
+                <p style={{ fontSize: 10, fontWeight: 700, color: "#92400E", textTransform: "uppercase", letterSpacing: "0.06em", margin: "0 0 3px" }}>
+                  {job.cancel_action === "lockout" ? "Lockout — fee charged" : "Cancellation — fee charged"}
+                </p>
+                <p style={{ margin: 0, fontSize: 12, color: "#92400E", lineHeight: 1.5 }}>
+                  Billed as a {job.cancel_action === "lockout" ? "lockout" : "cancellation"} fee{job.billed_amount != null ? ` of $${Number(job.billed_amount).toFixed(2)}` : ""}, not a service visit. The assigned tech is paid the cancellation fee only (no commission on this job).
+                </p>
+              </div>
+            </div>
+          )}
+
           {job.property_access_notes && (
             <div style={{ background: "#FFFBEB", border: "1px solid #FDE68A", borderRadius: 8, padding: "10px 14px", display: "flex", alignItems: "flex-start", gap: 8, marginBottom: 14 }}>
               <AlertTriangle size={14} style={{ color: "#D97706", flexShrink: 0, marginTop: 1 }} />
@@ -3655,6 +3672,11 @@ function MobileJobCard({ job, onClick }: { job: DispatchJob; onClick: () => void
           NO SHOW
         </div>
       )}
+      {visual.showFeeBadge && (
+        <div style={{ position: "absolute", top: 8, right: 8, fontSize: 9, fontWeight: 800, color: "#FFFFFF", backgroundColor: "#B45309", padding: "3px 7px", borderRadius: 4, letterSpacing: "0.05em", zIndex: 2 }}>
+          {job.cancel_action === "lockout" ? "LOCKOUT" : "CANCEL FEE"}
+        </div>
+      )}
       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", marginBottom: 8 }}>
         <div style={{ flex: 1, minWidth: 0 }}>
           <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 2, flexWrap: "wrap" }}>
@@ -4593,6 +4615,11 @@ function JobChip({
             NO SHOW
           </div>
         )}
+        {visual.showFeeBadge && (
+          <div style={{ position: "absolute", top: 8, right: 8, fontSize: 9, fontWeight: 800, color: "#FFFFFF", backgroundColor: "#B45309", padding: "3px 7px", borderRadius: 4, letterSpacing: "0.05em", zIndex: 3 }}>
+            {job.cancel_action === "lockout" ? "LOCKOUT" : "CANCEL FEE"}
+          </div>
+        )}
         <div style={{ paddingLeft: visual.stripe ? 8 : 0 }}>
           {body}
         </div>
@@ -4649,6 +4676,11 @@ function JobChip({
             <Check size={10} color="#FFFFFF" strokeWidth={3} />
           </div>
         )}
+        {visual.showFeeBadge && (
+          <div style={{ position: "absolute", top: -6, right: -2, fontSize: 8, fontWeight: 800, color: "#FFFFFF", backgroundColor: "#B45309", padding: "2px 5px", borderRadius: 3, letterSpacing: "0.05em", zIndex: 3, boxShadow: "0 1px 3px rgba(0,0,0,0.2)" }}>
+            {job.cancel_action === "lockout" ? "LOCKOUT" : "CANCEL FEE"}
+          </div>
+        )}
       </div>
     );
   }
@@ -4699,6 +4731,11 @@ function JobChip({
       {visual.showNoShowBadge && (
         <div style={{ position: "absolute", top: -6, right: -2, fontSize: 8, fontWeight: 800, color: "#FFFFFF", backgroundColor: "#991B1B", padding: "2px 5px", borderRadius: 3, letterSpacing: "0.05em", zIndex: 3, boxShadow: "0 1px 3px rgba(0,0,0,0.2)" }}>
           NO SHOW
+        </div>
+      )}
+      {visual.showFeeBadge && (
+        <div style={{ position: "absolute", top: -6, right: -2, fontSize: 8, fontWeight: 800, color: "#FFFFFF", backgroundColor: "#B45309", padding: "2px 5px", borderRadius: 3, letterSpacing: "0.05em", zIndex: 3, boxShadow: "0 1px 3px rgba(0,0,0,0.2)" }}>
+          {job.cancel_action === "lockout" ? "LOCKOUT" : "CANCEL FEE"}
         </div>
       )}
       {hovered && !dnd.isDragging && <JobHoverCard job={job} assignedName={assignedName} />}

--- a/artifacts/qleno/src/pages/reports/fees.tsx
+++ b/artifacts/qleno/src/pages/reports/fees.tsx
@@ -1,0 +1,65 @@
+import { useState } from "react";
+import { DashboardLayout } from "@/components/layout/dashboard-layout";
+import { fmt$c, fmtDate, fmtSvc, clr, KpiCard, DateRange, ReportHeader, DataTable, useReportData } from "./_shared";
+
+function today() { return new Date().toISOString().split("T")[0]; }
+function daysAgo(n: number) { const d = new Date(); d.setDate(d.getDate() - n); return d.toISOString().split("T")[0]; }
+
+interface FeeRow {
+  id: number; action: string; amount: number; recorded_at: string; job_date: string | null;
+  recorded_by: string | null; client_name: string | null; service_type: string | null; job_id: number;
+}
+interface FeesData {
+  from: string; to: string; data: FeeRow[];
+  summary: {
+    total_fees: number; lockout_fees: number; cancel_fees: number;
+    count: number; lockout_count: number; cancel_count: number;
+  };
+}
+
+export default function FeesReportPage() {
+  const [from, setFrom] = useState(daysAgo(30));
+  const [to, setTo] = useState(today());
+
+  const { data, loading } = useReportData<FeesData>(`/reports/fees?from=${from}&to=${to}`);
+  const rows = data?.data ?? [];
+  const s = data?.summary;
+
+  const cols = [
+    { header: "Job Date", render: (r: FeeRow) => r.job_date ? fmtDate(r.job_date) : "—" },
+    { header: "Client", render: (r: FeeRow) => r.client_name ?? "—" },
+    { header: "Service", render: (r: FeeRow) => r.service_type ? fmtSvc(r.service_type) : "—" },
+    {
+      header: "Type",
+      render: (r: FeeRow) => (
+        <span style={{ fontSize: 11, fontWeight: 800, letterSpacing: "0.04em", textTransform: "uppercase" as const, color: "#B45309", background: "#FEF3C7", border: "1px solid #FCD34D", borderRadius: 999, padding: "2px 8px" }}>
+          {r.action === "lockout" ? "Lockout" : "Cancellation"}
+        </span>
+      ),
+    },
+    { header: "Fee Collected", render: (r: FeeRow) => <span style={{ fontWeight: 700, color: clr.green }}>{fmt$c(r.amount)}</span>, align: "right" as const },
+    { header: "Recorded By", render: (r: FeeRow) => r.recorded_by ?? "—" },
+  ];
+
+  return (
+    <DashboardLayout title="Fees Collected">
+      <div style={{ padding: "24px 28px", maxWidth: 1000 }}>
+        <ReportHeader
+          title="Fees Collected"
+          subtitle="Cancellation and lockout fees billed in the selected date range. These are already counted inside total revenue — this report breaks out how much of it is fees."
+          printable
+          filters={<DateRange from={from} to={to} onChange={(f, t) => { setFrom(f); setTo(t); }} />}
+        />
+
+        <div style={{ display: "flex", gap: 14, flexWrap: "wrap", marginBottom: 24 }}>
+          <KpiCard label="Total Fees Collected" value={fmt$c(s?.total_fees ?? 0)} color={clr.green} />
+          <KpiCard label="Lockout Fees" value={fmt$c(s?.lockout_fees ?? 0)} sub={`${s?.lockout_count ?? 0} lockouts`} color={clr.amber} />
+          <KpiCard label="Cancellation Fees" value={fmt$c(s?.cancel_fees ?? 0)} sub={`${s?.cancel_count ?? 0} cancellations`} color={clr.amber} />
+          <KpiCard label="Total Charges" value={String(s?.count ?? 0)} color={clr.secondary} />
+        </div>
+
+        <DataTable cols={cols} rows={rows} loading={loading} emptyMsg="No cancellation or lockout fees in this date range." />
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/artifacts/qleno/src/pages/reports/index.tsx
+++ b/artifacts/qleno/src/pages/reports/index.tsx
@@ -17,6 +17,7 @@ const REPORT_GROUPS = [
       { title: "Job Costing",          desc: "Revenue vs labor cost with gross profit margins.",       url: "/reports/job-costing",       icon: Clipboard },
       { title: "Payroll % Revenue",    desc: "Payroll-to-revenue ratio tracked week over week.",       url: "/reports/payroll-to-revenue",icon: Activity },
       { title: "Discounts",            desc: "Every discount applied to a job — code, amount, and who applied it.", url: "/reports/discounts", icon: Percent },
+      { title: "Fees Collected",       desc: "Cancellation and lockout fees billed in a period — labeled subset of revenue.", url: "/reports/fees", icon: Banknote },
     ],
   },
   {
@@ -60,7 +61,7 @@ export default function ReportsIndexPage() {
       <div style={{ padding: '24px 28px', maxWidth: 1200 }}>
         <div style={{ marginBottom: 28 }}>
           <h1 style={{ margin: 0, fontSize: 22, fontWeight: 700, color: '#1A1917' }}>Reports</h1>
-          <p style={{ margin: '6px 0 0', fontSize: 14, color: '#6B7280' }}>18 reports covering financials, operations, client quality, and growth.</p>
+          <p style={{ margin: '6px 0 0', fontSize: 14, color: '#6B7280' }}>19 reports covering financials, operations, client quality, and growth.</p>
         </div>
 
         {REPORT_GROUPS.map(group => (

--- a/artifacts/qleno/src/pages/time-clock.tsx
+++ b/artifacts/qleno/src/pages/time-clock.tsx
@@ -86,7 +86,8 @@ type Row = {
   entry_id: number | null; clock_in_at: string | null; clock_out_at: string | null; flagged: boolean; minutes: number | null;
   pay_type: string | null; hourly_rate: string | null; commission_pct: string | null;
   pay_deduction_pct: string | null; pay_deduction_flat: string | null;
-  pay?: number | null; source?: string | null;
+  pay?: number | null; pay_kind?: "commission" | "cancellation"; cancel_action?: string | null;
+  source?: string | null;
   gps_in_ft?: number | null; gps_out_ft?: number | null;
   gps_in_outside?: boolean | null; gps_out_outside?: boolean | null; has_gps?: boolean;
   gps_in_lat?: number | null; gps_in_lng?: number | null;
@@ -136,6 +137,24 @@ function PayEditor({ emp, row, onChanged, toastFn }: {
       toastFn({ title: "Pay saved" });
     } catch (e: any) { toastFn({ title: e.message || "Pay save failed" }); }
     finally { setBusy(false); }
+  }
+
+  // Charged cancellation/lockout: the tech is paid the cancellation fee, not
+  // commission, so the pay-type editor doesn't apply. Show a clear static
+  // label instead of the (misleading) Fee Split / Allowed Hours dropdown.
+  if (row.pay_kind === "cancellation") {
+    const isLockout = row.cancel_action === "lockout";
+    return (
+      <div style={{ display: "flex", alignItems: "center", gap: 8, padding: "0 14px 9px 14px", flexWrap: "wrap" }}>
+        <span style={{ fontSize: 10, color: "#9E9B94", fontWeight: 700, minWidth: 28 }}>PAY</span>
+        <span style={{ fontSize: 11, fontWeight: 800, letterSpacing: "0.04em", textTransform: "uppercase", color: "#B45309", background: "#FEF3C7", border: "1px solid #FCD34D", borderRadius: 999, padding: "3px 10px" }}>
+          {isLockout ? "Lockout fee" : "Cancellation fee"}
+        </span>
+        <span style={{ fontSize: 11, color: "#9E9B94" }}>
+          Paid as a flat {isLockout ? "lockout" : "cancellation"} fee — no commission on this job.
+        </span>
+      </div>
+    );
   }
 
   return (
@@ -284,8 +303,10 @@ function RowEditor({ emp, row, dateStr, onChanged, toastFn }: {
       <div style={{ width: 56, textAlign: "right", fontSize: 12, fontWeight: 700, color: liveMins != null ? "#1A1917" : "#C4C0BB" }}>
         {liveMins != null ? fmtHrs(liveMins) : (parsedIn && !parsedOut ? "open" : "—")}
       </div>
-      <div style={{ width: 70, textAlign: "right", fontSize: 13, fontWeight: 800, color: row.pay != null && row.pay > 0 ? "#0A7C66" : "#C4C0BB" }}
-        title="Commission for this timesheet (same engine as Payroll)">
+      <div style={{ width: 70, textAlign: "right", fontSize: 13, fontWeight: 800, color: row.pay_kind === "cancellation" ? "#B45309" : (row.pay != null && row.pay > 0 ? "#0A7C66" : "#C4C0BB") }}
+        title={row.pay_kind === "cancellation"
+          ? `${row.cancel_action === "lockout" ? "Lockout" : "Cancellation"} fee paid to this tech (not commission)`
+          : "Commission for this timesheet (same engine as Payroll)"}>
         {row.pay != null ? `$${row.pay.toFixed(2)}` : "—"}
       </div>
       <button onClick={save} disabled={busy || !dirty}


### PR DESCRIPTION
Fixes the "no indication anywhere" problem Sal hit after marking Alex Jorgensen's job a lockout/cancel, and adds the fee reporting requested.

## The bugs (charged cancellation was invisible)
A charged Cancel/Lockout keeps the job `status='complete'` so the fee counts as revenue — but nothing surfaced it.

**Time clock** — the tech's cancellation fee lives in `additional_pay` (`cancellation_pay`) and the job is excluded from commission, so Hilda's row showed `$0`/`—` with the $60 invisible. Now:
- The fee is surfaced per job:tech (keyed by the job's date), shown in amber with a **Lockout fee / Cancellation fee** badge.
- The pay-type dropdown (meaningless for a flat fee) is replaced with a static fee label.
- `cancellation_pay` is excluded from the day-level additional-pay total so it isn't double-counted.

**Dispatch board + drawer** — the chip looked identical to a normal completed clean. Now:
- The dispatch payload exposes `cancel_action` per job.
- A new `charged_cancel` visual state (amber border, muted fill, strikethrough, **LOCKOUT / CANCEL FEE** badge) renders across every chip layout, plus the Legend.
- The job drawer shows a **"Lockout/Cancellation — fee charged"** banner explaining the tech is paid the fee only (no commission).

## Reporting (your "fees as revenue + reports" ask)
- **New "Fees Collected" report** (`/reports/fees`): cancellation + lockout fees billed in a period, with line items and lockout/cancel totals — a labeled subset of revenue (fees already sit in `billed_amount` and count in the Revenue total, per your "counted in total, but labeled" choice).
- The **Revenue Summary** report already breaks out a "Cancellation Fees" line, and a **Discounts** report already exists and is linked under Reports → Financial — so discount tracking per month is already available there.

Frontend (`vite`) and api-server (`esbuild`) both build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PiXXwFgtNSnzZQy3MTjAj

---
_Generated by [Claude Code](https://claude.ai/code/session_019PiXXwFgtNSnzZQy3MTjAj)_