### PR TITLE
Hotfix: time-clock 500 (chargedCancelJobIds scope)

### DIFF
--- a/artifacts/api-server/src/routes/timeclock.ts
+++ b/artifacts/api-server/src/routes/timeclock.ts
@@ -826,6 +826,12 @@ router.get("/day", requireAuth, requireRole("owner", "admin", "office"), async (
     // Payroll screen by construction. Pay flows: clock + pay-type here →
     // computePerTechCommissionRows → shown here AND applied at period-lock.
     const payByKey = new Map<string, number>();
+    // Declared in the outer scope (not inside the try) because payRowOf below
+    // reads them when building each row — a try-local const would be out of
+    // scope there (the "chargedCancelJobIds is not defined" 500).
+    const chargedCancelJobIds = new Set<number>();
+    const cancelPayByKey = new Map<string, number>();
+    const cancelActionByJob = new Map<number, string>();
     try {
       let comp: any = { res_tech_pay_pct: 0.35, deep_clean_pay_pct: 0.32, move_in_out_pay_pct: 0.32, commercial_hourly_rate: 20, commercial_comp_mode: "allowed_hours" };
       try {
@@ -856,9 +862,6 @@ router.get("/day", requireAuth, requireRole("owner", "admin", "office"), async (
       // the cancellation fee (an additional_pay 'cancellation_pay' row), NOT the
       // job's normal commission — exclude them from the commission calc so the
       // tech isn't double-paid (commission + cancellation fee).
-      const chargedCancelJobIds = new Set<number>();
-      const cancelPayByKey = new Map<string, number>();
-      const cancelActionByJob = new Map<number, string>();
       if (inList) {
         try {
           const cc = await db.execute(sql`


### PR DESCRIPTION
## Hotfix: Time Clock 500 on every date

The lockout-visibility change (#555) declared `chargedCancelJobIds`, `cancelPayByKey`, and `cancelActionByJob` **inside** the pay-compute `try` block, but the `payRowOf` helper that reads them runs **outside** that block. At runtime every `GET /api/timeclock/day` threw `chargedCancelJobIds is not defined`, so the Time Clock screen showed *"server error: chargedCancelJobIds is not defined"* on every date.

Fix: move the three declarations to the outer scope (next to `payByKey`); the `try` block now only populates them. api-server builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PiXXwFgtNSnzZQy3MTjAj

---
_Generated by [Claude Code](https://claude.ai/code/session_019PiXXwFgtNSnzZQy3MTjAj)_