### PR TITLE
Audit fixes: commercial job names on time clock + office "view as employee"

### DIFF
--- a/artifacts/api-server/src/routes/jobs.ts
+++ b/artifacts/api-server/src/routes/jobs.ts
@@ -581,7 +581,13 @@ router.get("/my-jobs", requireAuth, async (req, res) => {
     const reqDate = typeof req.query.date === "string" && /^\d{4}-\d{2}-\d{2}$/.test(req.query.date)
       ? req.query.date : today;
     let userId = req.auth!.userId;
-    if (req.auth!.role === "owner" && req.query.employee_id) {
+    // "View as employee" — owner AND office/admin can view a tech's day (the
+    // office team has owner-level tech-management powers, #542). Without office
+    // here, Maribel's "Viewing as Maryury" silently fell back to her own
+    // (empty) job list and showed "No jobs" (Maribel report 2026-06-17).
+    // Techs can never view as someone else.
+    const canViewAsOther = req.auth!.role === "owner" || req.auth!.role === "admin" || req.auth!.role === "office";
+    if (canViewAsOther && req.query.employee_id) {
       userId = parseInt(req.query.employee_id as string);
     }
 

--- a/artifacts/api-server/src/routes/timeclock.ts
+++ b/artifacts/api-server/src/routes/timeclock.ts
@@ -755,10 +755,14 @@ router.get("/day", requireAuth, requireRole("owner", "admin", "office"), async (
              j.job_lat, j.job_lng, j.address_lat, j.address_lng,
              j.account_id, j.base_fee, j.billed_amount, j.allowed_hours, j.branch_id, j.scheduled_date::text AS scheduled_date,
              c.client_type, c.lat AS client_lat, c.lng AS client_lng,
+             -- Commercial jobs carry their customer on account_id (client_id is
+             -- NULL), so fall back to the account name — otherwise the row read
+             -- a useless literal "Client" and the office couldn't reconcile it.
              COALESCE(NULLIF(TRIM(COALESCE(c.first_name,'') || ' ' || COALESCE(c.last_name,'')), ''),
-                      c.company_name, 'Client') AS client_name
+                      a.account_name, c.company_name, 'Client') AS client_name
       FROM jobs j
       LEFT JOIN clients c ON c.id = j.client_id
+      LEFT JOIN accounts a ON a.id = j.account_id
       WHERE j.company_id = ${companyId}
         AND j.scheduled_date::date = ${date}::date
         AND j.status IS DISTINCT FROM 'cancelled'


### PR DESCRIPTION
Two fixes from the live time-clock/My-Jobs audit (both backend-only, api-server builds clean).

## 1. Time clock showed "Client" for commercial jobs
Every commercial (account-based) job row read a literal **"Client"** instead of the customer name, so the office couldn't reconcile it. Commercial jobs store the customer on `account_id` with `client_id` NULL, and the time-clock query joined only `clients`. Fix: join `accounts` and fall back to `account_name` — the same resolution the dispatch board and payroll detail already use.

## 2. "View as employee" returned nothing for office staff
The view-as eye icon routes to `GET /api/jobs/my-jobs?employee_id=…`, but the override was gated to `role === "owner"`. When office staff (Maribel) viewed as a tech (Maryury), the backend ignored `employee_id` and returned the viewer's own empty list — "No jobs / can't see anything." Fix: allow **owner, admin, and office** to view-as (office has owner-level tech-management powers per #542); technicians still cannot view as anyone else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PiXXwFgtNSnzZQy3MTjAj