### PR TITLE
Clock times: store + display Central wall-clock consistently (fix +5h drift)

### DIFF
--- a/artifacts/api-server/src/routes/timeclock.ts
+++ b/artifacts/api-server/src/routes/timeclock.ts
@@ -11,6 +11,27 @@ import type { CommissionInputJob } from "../lib/commission-compute.js";
 
 const router = Router();
 
+// [clock-tz 2026-06-17] Clock times are stored as WALL-CLOCK (the office types
+// "4:24 PM" and that's exactly what's stored + shown — see the time-clock UI's
+// design note). Office-typed naive strings already round-trip correctly on a
+// UTC server. But FIELD-app punches use `new Date()` (a real UTC instant), so a
+// 4:24 PM Central punch was stored as 21:24 and the time-clock screen sliced it
+// to "9:24 PM" (+5h). This converts a real instant to the America/Chicago
+// wall-clock and returns a Date whose UTC components equal those wall digits —
+// so it stores into the `timestamp` column as the Central wall-clock, matching
+// the office convention. Phes is single-timezone; when multi-tz lands this
+// takes the tenant's zone instead of the hardcoded America/Chicago.
+const CLOCK_TZ = "America/Chicago";
+function centralWallClock(instant: Date): Date {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: CLOCK_TZ, year: "numeric", month: "2-digit", day: "2-digit",
+    hour: "2-digit", minute: "2-digit", second: "2-digit", hour12: false,
+  }).formatToParts(instant);
+  const g = (t: string) => parts.find(p => p.type === t)!.value;
+  let hh = g("hour"); if (hh === "24") hh = "00"; // Intl can emit 24 at midnight
+  return new Date(`${g("year")}-${g("month")}-${g("day")}T${hh}:${g("minute")}:${g("second")}Z`);
+}
+
 function calculateDistanceFt(lat1: number, lon1: number, lat2: number, lon2: number): number {
   const R = 20902231;
   const dLat = (lat2 - lat1) * Math.PI / 180;
@@ -187,12 +208,15 @@ router.post("/clock-in", requireAuth, async (req, res) => {
     // signal and replays it later. client_clock_in_at carries the REAL on-site
     // time the tech tapped (not the sync time). Accept only a sane past stamp
     // (≤ now + 5 min skew, ≥ 24h ago) so it can't be abused to back/forward-date.
-    let clockInAt: Date | undefined;
+    // Always set the stamp to the Central wall-clock of the real instant (the
+    // DB default now() would store a UTC instant → the +5h bug). Default = now;
+    // offline replay overrides with the queued on-site instant.
+    let clockInAt: Date = centralWallClock(new Date());
     if (req.body?.client_clock_in_at) {
       const d = new Date(req.body.client_clock_in_at);
       const now = Date.now();
       if (!isNaN(d.getTime()) && d.getTime() <= now + 5 * 60 * 1000 && d.getTime() >= now - 24 * 60 * 60 * 1000) {
-        clockInAt = d;
+        clockInAt = centralWallClock(d);
       }
     }
 
@@ -309,7 +333,7 @@ router.post("/clock-in", requireAuth, async (req, res) => {
         user_id: effectiveUserId,
         company_id: req.auth!.companyId,
         branch_id: stampedBranchId,
-        ...(clockInAt ? { clock_in_at: clockInAt } : {}),
+        clock_in_at: clockInAt,
         clock_in_lat: empLat !== null ? String(empLat) : null,
         clock_in_lng: empLng !== null ? String(empLng) : null,
         clock_in_distance_ft: distanceFt !== null ? String(distanceFt) : null,
@@ -380,12 +404,15 @@ router.post("/:id/clock-out", requireAuth, async (req, res) => {
     // [offline-clock 2026-06-11] Queued clock-out replays the REAL on-site time
     // (client_clock_out_at), not the sync time — so a dead-zone job doesn't
     // record a clock-out 30 min late at the tech's house. Same sanity window.
-    let clockOutAt = new Date();
+    // Store the Central wall-clock of the real instant (matches office-typed
+    // times + the time-clock screen's wall-clock display; raw new Date() would
+    // store a UTC instant → the +5h bug).
+    let clockOutAt = centralWallClock(new Date());
     if (req.body?.client_clock_out_at) {
       const d = new Date(req.body.client_clock_out_at);
       const now = Date.now();
       if (!isNaN(d.getTime()) && d.getTime() <= now + 5 * 60 * 1000 && d.getTime() >= now - 24 * 60 * 60 * 1000) {
-        clockOutAt = d;
+        clockOutAt = centralWallClock(d);
       }
     }
 
@@ -610,7 +637,10 @@ router.post("/office/clock-in", requireAuth, requireRole("owner", "admin", "offi
     const job_id = parseInt(String(req.body?.job_id));
     const user_id = parseInt(String(req.body?.user_id));
     if (!job_id || !user_id) return res.status(400).json({ error: "job_id and user_id are required" });
-    const clockInAt = req.body?.clock_in_at ? new Date(req.body.clock_in_at) : new Date();
+    // Typed time = naive wall-clock string, stored as-is (round-trips on a UTC
+    // server). No time given → stamp the Central wall-clock of now (not a raw
+    // UTC instant).
+    const clockInAt = req.body?.clock_in_at ? new Date(req.body.clock_in_at) : centralWallClock(new Date());
     if (isNaN(clockInAt.getTime())) return res.status(400).json({ error: "Invalid clock_in_at" });
 
     const [jobRow] = await db.select({ id: jobsTable.id, branch_id: jobsTable.branch_id })
@@ -648,7 +678,7 @@ router.post("/office/clock-out", requireAuth, requireRole("owner", "admin", "off
     const job_id = parseInt(String(req.body?.job_id));
     const user_id = parseInt(String(req.body?.user_id));
     if (!job_id || !user_id) return res.status(400).json({ error: "job_id and user_id are required" });
-    const clockOutAt = req.body?.clock_out_at ? new Date(req.body.clock_out_at) : new Date();
+    const clockOutAt = req.body?.clock_out_at ? new Date(req.body.clock_out_at) : centralWallClock(new Date());
     if (isNaN(clockOutAt.getTime())) return res.status(400).json({ error: "Invalid clock_out_at" });
 
     const [open] = await db.select().from(timeclockTable).where(and(

--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -320,7 +320,21 @@ function fmtHour(h: number) { if (h === 12) return "12 PM"; if (h === 0) return 
 function fmtMins(mins: number) { const h = Math.floor(mins / 60), m = ((mins % 60) + 60) % 60; const ampm = h % 24 < 12 ? "AM" : "PM"; const hr = h % 12 === 0 ? 12 : h % 12; return `${hr}:${String(m).padStart(2, "0")} ${ampm}`; }
 // [office-clock 2026-06-05] Format an ISO timestamp as wall-clock time and a
 // clock-in -> clock-out span, for the desktop Time Clock panel.
-function fmtClock(iso: string) { const d = new Date(iso); return isNaN(d.getTime()) ? "—" : d.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" }); }
+// [clock-tz 2026-06-17] Clock times are stored WALL-CLOCK (what the tech/office
+// saw on the clock). Slice the HH:MM straight out of the string — never run it
+// through new Date()/toLocaleTimeString(), which re-applies the browser's UTC
+// offset and shifts the displayed time (the dispatch drawer was showing field
+// punches hours off, disagreeing with the Time Clock screen). Mirrors the
+// time-clock page's wall-clock formatter.
+function fmtClock(iso: string | null | undefined) {
+  if (!iso) return "—";
+  const m = String(iso).match(/[T ](\d{2}):(\d{2})/);
+  if (!m) return "—";
+  const h = parseInt(m[1], 10), min = m[2];
+  const ap = h < 12 ? "AM" : "PM";
+  const h12 = ((h + 11) % 12) + 1;
+  return `${h12}:${min} ${ap}`;
+}
 function clockDuration(a: string, b: string) { const ms = new Date(b).getTime() - new Date(a).getTime(); if (isNaN(ms) || ms < 0) return "—"; const mins = Math.round(ms / 60000); const h = Math.floor(mins / 60), m = mins % 60; return h > 0 ? `${h}h ${m}m` : `${m}m`; }
 function slotBg(count: number) { if (count === 0) return "#DCFCE7"; if (count <= 2) return "#FEF3C7"; return "#FEE2E2"; }
 function slotTxt(count: number) { if (count === 0) return "#15803D"; if (count <= 2) return "#92400E"; return "#991B1B"; }
@@ -347,18 +361,21 @@ function ClockEditor({ entry, canEdit, onUpdate }: { entry: ClockEntry; canEdit:
   const [outVal, setOutVal] = useState("");
   const [saving, setSaving] = useState(false);
   const API = import.meta.env.BASE_URL.replace(/\/$/, "");
+  // [clock-tz 2026-06-17] Clock times are WALL-CLOCK. Slice the date+HH:MM
+  // straight out of the stored string (no new Date(), which would re-apply the
+  // browser offset and pre-fill the wrong time); save sends a naive datetime
+  // (no Z) so the server stores exactly what was typed.
   const toLocal = (iso: string | null) => {
     if (!iso) return "";
-    const d = new Date(iso);
-    if (isNaN(d.getTime())) return "";
-    return new Date(d.getTime() - d.getTimezoneOffset() * 60000).toISOString().slice(0, 16);
+    const m = String(iso).match(/(\d{4}-\d{2}-\d{2})[T ](\d{2}:\d{2})/);
+    return m ? `${m[1]}T${m[2]}` : "";
   };
   function open() { setInVal(toLocal(entry.clock_in_at)); setOutVal(toLocal(entry.clock_out_at)); setEditing(true); }
   async function save() {
     if (!inVal) { toast({ title: "Clock-in time is required", variant: "destructive" }); return; }
     setSaving(true);
     try {
-      const body: any = { clock_in_at: new Date(inVal).toISOString(), clock_out_at: outVal ? new Date(outVal).toISOString() : null };
+      const body: any = { clock_in_at: `${inVal}:00`, clock_out_at: outVal ? `${outVal}:00` : null };
       const r = await fetch(`${API}/api/timeclock/${entry.id}`, { method: "PATCH", headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` }, body: JSON.stringify(body) });
       if (!r.ok) { const e = await r.json().catch(() => ({})); throw new Error(e.message || e.error || "Failed"); }
       toast({ title: "Clock updated" });
@@ -2307,8 +2324,8 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
                     value={`${variance > 0 ? "+" : ""}${variance.toFixed(1)}h`}
                     color={variance > 0.25 ? "#D97706" : variance < -0.25 ? "#16A34A" : undefined} />
                 )}
-                {ce?.clock_in_at && <KV label="Clock in" value={new Date(ce.clock_in_at).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })} />}
-                {ce?.clock_out_at && <KV label="Clock out" value={new Date(ce.clock_out_at).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })} />}
+                {ce?.clock_in_at && <KV label="Clock in" value={fmtClock(ce.clock_in_at)} />}
+                {ce?.clock_out_at && <KV label="Clock out" value={fmtClock(ce.clock_out_at)} />}
                 {ce && inDist != null && (
                   <KV label="Distance at clock-in" value={`${Math.round(inDist)} ft${ce.clock_in_outside_geofence ? " (outside)" : ""}`} color={ce.clock_in_outside_geofence ? "#D97706" : undefined} />
                 )}
@@ -3760,7 +3777,7 @@ function MobileJobCard({ job, onClick }: { job: DispatchJob; onClick: () => void
           {job.clock_entry?.clock_in_at && (
             <div style={{ display: "flex", alignItems: "center", gap: 5, fontSize: 11, color: "#16A34A", fontWeight: 600 }}>
               <Clock size={11} />
-              Clocked in {new Date(job.clock_entry.clock_in_at).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
+              Clocked in {fmtClock(job.clock_entry.clock_in_at)}
             </div>
           )}
         </div>
@@ -4322,7 +4339,7 @@ function JobHoverCard({ job, assignedName }: { job: DispatchJob; assignedName?: 
               return (
                 <div>
                   <span style={{ color: "#9E9B94" }}>In:</span>{" "}
-                  {new Date(liveClock.clock_in_at).toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })}
+                  {fmtClock(liveClock.clock_in_at)}
                   {d != null && (
                     <span style={{ color: liveClock.clock_in_outside_geofence ? "#D97706" : "#9E9B94", marginLeft: 6 }}>
                       ({Math.round(d)} ft{liveClock.clock_in_outside_geofence ? " · outside" : ""})
@@ -4334,7 +4351,7 @@ function JobHoverCard({ job, assignedName }: { job: DispatchJob; assignedName?: 
             {liveClock.clock_out_at && (
               <div>
                 <span style={{ color: "#9E9B94" }}>Out:</span>{" "}
-                {new Date(liveClock.clock_out_at).toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })}
+                {fmtClock(liveClock.clock_out_at)}
                 {liveClock.clock_out_distance_ft != null && (
                   <span style={{ color: liveClock.clock_out_outside_geofence ? "#D97706" : "#9E9B94", marginLeft: 6 }}>
                     ({Math.round(liveClock.clock_out_distance_ft)} ft{liveClock.clock_out_outside_geofence ? " · outside" : ""})


### PR DESCRIPTION
## The time-clock "+5h" / screens-disagree bug

Clock times are meant to be **wall-clock** — what the tech punches / the office types is exactly what's stored and shown (the Time Clock UI even documents this). Office-typed times round-trip fine, but the **field app's clock-in/out used `new Date()`** (a real UTC instant). So a **4:24 PM Central** punch was stored as `21:24`, and:
- the **Time Clock screen** sliced it → **"9:24 PM"** (+5h)
- the **dispatch job card** ran it through `new Date().toLocaleTimeString()` → a *different* wrong time

Same punch, two screens, two answers — and it inflated Maryury's hours from ~3.5h to 8.5h and her pay from ~$70 to $170.

## Forward fix (this PR — decision: wall-clock Central everywhere)
- **Storage:** field clock-in/out (and the office "no time given" fallback) now store the **America/Chicago wall-clock** of the real instant via a `centralWallClock()` helper, matching the office-typed convention. Field clock-in no longer falls through to the UTC DB default.
- **Display:** the dispatch drawer/job card now **slice the wall-clock `HH:MM`** (the `fmtClock` formatter, the Job Clocks panel, the "Clocked in" chip, and the Edit-clock-times modal) instead of `new Date()` conversion — so it matches the Time Clock screen exactly.

Single-timezone (Chicago) for now; when multi-tenant timezones land, `centralWallClock` takes the tenant's zone.

## Still to come (separate, you asked to "fix history too")
Field punches **already** stored in UTC will still read their UTC wall time until a follow-up **backfill** corrects them — but with this PR every screen agrees and all *new* punches are right. I'll bring the backfill as a reviewable dry-run before it touches any historical row.

Frontend + api-server build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PiXXwFgtNSnzZQy3MTjAj

---
_Generated by [Claude Code](https://claude.ai/code/session_019PiXXwFgtNSnzZQy3MTjAj)_