### PR TITLE
Tech My Jobs: reopen completed jobs for photos; hide past-visit tech names

### DIFF
--- a/artifacts/api-server/src/routes/jobs.ts
+++ b/artifacts/api-server/src/routes/jobs.ts
@@ -844,11 +844,8 @@ router.get("/my-jobs/:id/history", requireAuth, async (req, res) => {
       SELECT j2.id, j2.scheduled_date, j2.service_type,
         (SELECT ROUND(GREATEST(EXTRACT(EPOCH FROM (MAX(tc.clock_out_at) - MIN(tc.clock_in_at))) / 3600.0, 0)::numeric, 1)
            FROM timeclock tc WHERE tc.job_id = j2.id AND tc.clock_out_at IS NOT NULL) AS hours,
-        COALESCE(
-          (SELECT string_agg(DISTINCT u.first_name, ', ')
-             FROM job_technicians jt JOIN users u ON u.id = jt.user_id WHERE jt.job_id = j2.id),
-          (SELECT u2.first_name FROM users u2 WHERE u2.id = j2.assigned_user_id)
-        ) AS techs,
+        -- [no-prev-tech 2026-06-17] WHO did the past visit is intentionally NOT
+        -- returned to the tech-facing detail — Sal: avoid tech-vs-tech conflict.
         (SELECT string_agg(tn.body, ' · ' ORDER BY tn.created_at)
            FROM technician_notes tn WHERE tn.job_id = j2.id) AS tech_notes
       FROM jobs j2

--- a/artifacts/qleno/src/pages/my-job-detail.tsx
+++ b/artifacts/qleno/src/pages/my-job-detail.tsx
@@ -175,8 +175,11 @@ export default function MyJobDetailPage() {
                           <span style={{ fontSize: 12, color: "#6B6860", fontWeight: 600, flexShrink: 0 }}>{Number(v.hours).toFixed(1)} hrs</span>
                         )}
                       </div>
+                      {/* [no-prev-tech 2026-06-17] Deliberately do NOT show who
+                          did past visits — Sal: avoid tech-vs-tech conflict over
+                          "who left it dirty". Date + service type only. */}
                       <p style={{ fontSize: 12, color: "#6B6860", margin: "3px 0 0" }}>
-                        {formatServiceType(v.service_type)}{v.techs ? ` · ${v.techs}` : ""}
+                        {formatServiceType(v.service_type)}
                       </p>
                       {v.tech_notes && (
                         <div style={{ backgroundColor: "#F7F6F3", borderRadius: 8, padding: "8px 10px", marginTop: 8 }}>

--- a/artifacts/qleno/src/pages/my-jobs.tsx
+++ b/artifacts/qleno/src/pages/my-jobs.tsx
@@ -4,7 +4,7 @@ import { useAuthStore, getTokenRole } from "@/lib/auth";
 import { InlinePriceEdit } from "@/components/inline-price-edit";
 import { EarningsPanel } from "@/components/earnings-panel";
 import { useToast } from "@/hooks/use-toast";
-import { Check, Eye, Navigation, Phone, GraduationCap, DollarSign, Users, MapPin, Sun, Cloud, CloudSun, CloudRain, CloudSnow, CloudDrizzle, CloudLightning, Plane, Bell, KeyRound, LogOut } from "lucide-react";
+import { Check, Eye, Navigation, Phone, GraduationCap, DollarSign, Users, MapPin, Sun, Cloud, CloudSun, CloudRain, CloudSnow, CloudDrizzle, CloudLightning, Plane, Bell, KeyRound, LogOut, Camera } from "lucide-react";
 import { Link, useLocation } from "wouter";
 import { ChangePasswordModal } from "@/components/change-password-modal";
 import { useEmployeeView } from "@/contexts/employee-view-context";
@@ -1658,6 +1658,36 @@ export default function MyJobsPage() {
                       <DistanceBadge jobLat={job.job_lat} jobLng={job.job_lng} empPos={empPos} />
                     </div>
                   ))}
+                </div>
+              )}
+              {/* [reopen-completed 2026-06-17] Completed jobs were dropped from
+                  the list entirely once clocked out, so the tech could never get
+                  back in to add before/after photos ("all the info disappears").
+                  Keep them as tappable rows → the detail page's photo upload.
+                  Tech name of past visits is hidden separately (no conflict). */}
+              {completedToday.length > 0 && (
+                <div style={{ marginTop: 20 }}>
+                  <p style={{ fontSize: 11, color: "#9E9B94", textTransform: "uppercase", letterSpacing: "0.06em", margin: "0 0 10px 4px" }}>Completed Today</p>
+                  {completedToday.map(job => {
+                    const needsPhotos = (job.before_photo_count ?? 0) === 0 || (job.after_photo_count ?? 0) === 0;
+                    return (
+                      <div key={job.id} onClick={() => navigate(`/my-jobs/${job.id}?date=${selectedDate}`)}
+                        style={{ backgroundColor: "#FFFFFF", border: `1px solid ${job.zone_color || "#E5E2DC"}`, borderLeft: `3px solid var(--brand, #2D9B83)`, borderRadius: 12, padding: 18, marginBottom: 10, cursor: "pointer" }}>
+                        <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 4, flexWrap: "wrap" }}>
+                          <Check size={15} color="var(--brand, #2D9B83)" style={{ flexShrink: 0 }} />
+                          <p style={{ fontSize: 16, fontWeight: 700, color: "#1A1917", margin: 0 }}>{job.client_name}</p>
+                          {(job.company_name || job.branch_name) && (
+                            <span style={{ fontSize: 10, fontWeight: 700, padding: "2px 8px", borderRadius: 20, background: "#F4F3F0", color: "#6B6860", letterSpacing: "0.02em", textTransform: "uppercase" }}>{job.company_name ?? job.branch_name}</span>
+                          )}
+                        </div>
+                        <p style={{ fontSize: 11, color: "var(--brand)", textTransform: "uppercase", fontWeight: 600, margin: "0 0 4px" }}>{formatServiceType(job.service_type)}</p>
+                        {job.address && <p style={{ fontSize: 12, color: "#6B6860", margin: "2px 0 0" }}>{formatAddress(job.address, job.city, job.state, job.zip)}</p>}
+                        <p style={{ fontSize: 12, fontWeight: 700, color: needsPhotos ? "#B45309" : "#2D9B83", margin: "8px 0 0", display: "flex", alignItems: "center", gap: 5 }}>
+                          <Camera size={13} /> {needsPhotos ? "Tap to add before/after photos" : "Photos added — tap to review"}
+                        </p>
+                      </div>
+                    );
+                  })}
                 </div>
               )}
             </>


### PR DESCRIPTION
Two field-tech fixes from Sal/Maribel.

## 1. Reopen completed jobs to upload before/after photos
Once a tech clocked out, the completed job was dropped from the My Jobs list entirely — it isn't "active" and isn't "upcoming," and nothing else rendered it, so only the "Day complete" summary remained. The tech had **no way back into the job to add before/after photos** ("all the info disappears / can't see an option to upload the pictures").

Added a **"Completed Today"** section: tappable rows that open the job detail (where the before/after photo upload already lives), with a "Tap to add before/after photos" prompt when photos are still missing.

## 2. Hide who did past visits
The "Previous Visits Here" list showed the tech who did each past visit (e.g. "Recurring · Diana"). Removed it to **avoid tech-vs-tech conflict** over who left a unit dirty — dropped from the UI *and* from the tech-facing `/my-jobs/:id/history` API (now date + service type + notes only).

Frontend + api-server build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PiXXwFgtNSnzZQy3MTjAj

---
_Generated by [Claude Code](https://claude.ai/code/session_019PiXXwFgtNSnzZQy3MTjAj)_