### PR TITLE
Time clock: job address, clickable client/employee names, clock-out GPS

### DIFF
--- a/artifacts/api-server/src/routes/timeclock.ts
+++ b/artifacts/api-server/src/routes/timeclock.ts
@@ -783,8 +783,25 @@ router.get("/day", requireAuth, requireRole("owner", "admin", "office"), async (
       SELECT j.id AS job_id, j.scheduled_time, j.assigned_user_id,
              j.service_type::text AS service_type, j.address_street,
              j.job_lat, j.job_lng, j.address_lat, j.address_lng,
-             j.account_id, j.base_fee, j.billed_amount, j.allowed_hours, j.branch_id, j.scheduled_date::text AS scheduled_date,
+             j.account_id, j.client_id, j.base_fee, j.billed_amount, j.allowed_hours, j.branch_id, j.scheduled_date::text AS scheduled_date,
              c.client_type, c.lat AS client_lat, c.lng AS client_lng,
+             -- Service address so the office can tell apart multiple jobs for the
+             -- same client/account on one day (e.g. several PPM units) without
+             -- opening the schedule. Prefer the job's own address, then the
+             -- account property (with its unit/property name), then the client.
+             COALESCE(
+               NULLIF(TRIM(
+                 COALESCE(j.address_street,'') ||
+                 CASE WHEN NULLIF(j.address_city,'')  IS NOT NULL THEN ', ' || j.address_city  ELSE '' END ||
+                 CASE WHEN NULLIF(j.address_state,'') IS NOT NULL THEN ', ' || j.address_state ELSE '' END ||
+                 CASE WHEN NULLIF(j.address_zip,'')   IS NOT NULL THEN ' '  || j.address_zip   ELSE '' END
+               ), ''),
+               NULLIF(TRIM(
+                 COALESCE(ap.address,'') ||
+                 CASE WHEN NULLIF(ap.property_name,'') IS NOT NULL THEN ' (' || ap.property_name || ')' ELSE '' END
+               ), ''),
+               NULLIF(TRIM(c.address), '')
+             ) AS address,
              -- Commercial jobs carry their customer on account_id (client_id is
              -- NULL), so fall back to the account name — otherwise the row read
              -- a useless literal "Client" and the office couldn't reconcile it.
@@ -793,6 +810,7 @@ router.get("/day", requireAuth, requireRole("owner", "admin", "office"), async (
       FROM jobs j
       LEFT JOIN clients c ON c.id = j.client_id
       LEFT JOIN accounts a ON a.id = j.account_id
+      LEFT JOIN account_properties ap ON ap.id = j.account_property_id
       WHERE j.company_id = ${companyId}
         AND j.scheduled_date::date = ${date}::date
         AND j.status IS DISTINCT FROM 'cancelled'
@@ -944,6 +962,9 @@ router.get("/day", requireAuth, requireRole("owner", "admin", "office"), async (
     } catch (e) { console.error("[TC-DAY] pay compute error:", e); }
 
     type Row = { job_id: number; client_name: string; service_type: string; scheduled_time: string | null;
+                 // address + ids so the office can tell apart same-client jobs and
+                 // click through to the customer/account + employee profiles.
+                 address: string | null; client_id: number | null; account_id: number | null;
                  entry_id: number | null; clock_in_at: string | null; clock_out_at: string | null;
                  flagged: boolean; minutes: number | null;
                  pay_type: string | null; hourly_rate: string | null; commission_pct: string | null;
@@ -1024,6 +1045,7 @@ router.get("/day", requireAuth, requireRole("owner", "admin", "office"), async (
         const e = entryByJobUser.get(key) || null;
         ensureEmp(t.user_id).rows.push({
           job_id: jid, client_name: j.client_name, service_type: j.service_type, scheduled_time: j.scheduled_time ?? null,
+          address: j.address ?? null, client_id: j.client_id != null ? Number(j.client_id) : null, account_id: j.account_id != null ? Number(j.account_id) : null,
           entry_id: e ? Number(e.id) : null, clock_in_at: e?.clock_in_at ?? null, clock_out_at: e?.clock_out_at ?? null,
           flagged: !!e?.flagged, minutes: e ? minutesOf(e.clock_in_at, e.clock_out_at) : null,
           ...payOf(jid, t.user_id), ...payRowOf(jid, t.user_id), source: e?.source ?? null,
@@ -1037,6 +1059,7 @@ router.get("/day", requireAuth, requireRole("owner", "admin", "office"), async (
       const j = jobById.get(Number(e.job_id));
       ensureEmp(Number(e.user_id)).rows.push({
         job_id: Number(e.job_id), client_name: j?.client_name ?? "Client", service_type: j?.service_type ?? "",
+        address: j?.address ?? null, client_id: j?.client_id != null ? Number(j.client_id) : null, account_id: j?.account_id != null ? Number(j.account_id) : null,
         scheduled_time: j?.scheduled_time ?? null, entry_id: Number(e.id), clock_in_at: e.clock_in_at ?? null,
         clock_out_at: e.clock_out_at ?? null, flagged: !!e.flagged, minutes: minutesOf(e.clock_in_at, e.clock_out_at),
         ...payOf(Number(e.job_id), Number(e.user_id)), ...payRowOf(Number(e.job_id), Number(e.user_id)), source: e.source ?? null,

--- a/artifacts/qleno/src/pages/time-clock.tsx
+++ b/artifacts/qleno/src/pages/time-clock.tsx
@@ -5,6 +5,7 @@ import { useToast } from "@/hooks/use-toast";
 import { ChevronLeft, ChevronRight, Clock, Trash2, AlertTriangle, Check, CalendarDays } from "lucide-react";
 import { PunchMapModal } from "@/components/punch-map-modal";
 import { CalendarPopover } from "@/components/calendar-popover";
+import { Link } from "wouter";
 
 // [time-clock-portal 2026-06-05] Office Time Clock portal. The office reconciles
 // Qleno's per-job clock times against MaidCentral so commission (proportional by
@@ -83,6 +84,7 @@ function fmtSchedTime(t: string | null) {
 
 type Row = {
   job_id: number; client_name: string; service_type: string; scheduled_time: string | null;
+  address?: string | null; client_id?: number | null; account_id?: number | null;
   entry_id: number | null; clock_in_at: string | null; clock_out_at: string | null; flagged: boolean; minutes: number | null;
   pay_type: string | null; hourly_rate: string | null; commission_pct: string | null;
   pay_deduction_pct: string | null; pay_deduction_flat: string | null;
@@ -260,7 +262,19 @@ function RowEditor({ emp, row, dateStr, onChanged, toastFn }: {
     <div style={{ borderTop: "1px solid #F4F3F0" }}>
     <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "9px 14px 4px 14px" }}>
       <div style={{ flex: 1, minWidth: 0 }}>
-        <div style={{ fontSize: 13, fontWeight: 600, color: "#1A1917", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{row.client_name}</div>
+        {/* Client/account name links to the profile (residential → customer,
+            commercial → account), like MaidCentral. Falls back to plain text
+            when neither id is present. */}
+        <div style={{ fontSize: 13, fontWeight: 600, color: "#1A1917", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+          {row.account_id ? (
+            <Link href={`/accounts/${row.account_id}`} onClick={e => e.stopPropagation()} style={{ color: "#1A1917", textDecoration: "none" }}><span style={{ borderBottom: "1px solid #D4D1CB" }}>{row.client_name}</span></Link>
+          ) : row.client_id ? (
+            <Link href={`/customers/${row.client_id}`} onClick={e => e.stopPropagation()} style={{ color: "#1A1917", textDecoration: "none" }}><span style={{ borderBottom: "1px solid #D4D1CB" }}>{row.client_name}</span></Link>
+          ) : row.client_name}
+        </div>
+        {row.address && (
+          <div style={{ fontSize: 11, color: "#9E9B94", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{row.address}</div>
+        )}
         <div style={{ fontSize: 11, color: "#9E9B94" }}>
           {fmtSvc(row.service_type)}{row.scheduled_time ? ` · sched ${fmtSchedTime(row.scheduled_time)}` : ""}
           {!row.entry_id && <span style={{ color: "#9E9B94", marginLeft: 6, fontWeight: 700 }}>· not clocked in</span>}
@@ -286,6 +300,21 @@ function RowEditor({ emp, row, dateStr, onChanged, toastFn }: {
               })()
             : <span title="This punch carried no location — phone location was off/denied, or it was entered here as an office correction." style={{ marginLeft: 6, fontWeight: 700, color: "#9E9B94" }}>· no GPS</span>
           )}
+          {/* Clock-out location, mirroring the clock-in pill — the office needs
+              to see WHERE the tech punched out (on-site vs at home). Only when
+              the clock-out punch carried coordinates. */}
+          {row.entry_id && row.clock_out_at && row.gps_out_lat != null && row.gps_out_lng != null && (() => {
+            const lat = row.gps_out_lat!, lng = row.gps_out_lng!;
+            const label = `out ${row.gps_out_ft != null ? `${row.gps_out_ft} ft` : "GPS"}${row.gps_out_outside ? " (outside zone)" : ""}`;
+            const color = row.gps_out_outside ? "#B45309" : "#0A7C66";
+            const tip = `Clock-out location: ${lat.toFixed(5)}, ${lng.toFixed(5)}${row.gps_out_ft != null ? ` · ${row.gps_out_ft} ft from job` : " · job not geocoded, distance unavailable"}. Tap to see it on the map.`;
+            return (
+              <button type="button" title={tip} onClick={e => { e.stopPropagation(); setGpsOpen(true); }}
+                style={{ marginLeft: 6, fontWeight: 700, color, textDecoration: "underline", background: "none", border: "none", padding: 0, cursor: "pointer", fontFamily: "inherit", fontSize: "inherit" }}>
+                · {label} ▸
+              </button>
+            );
+          })()}
         </div>
       </div>
       <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
@@ -444,7 +473,11 @@ export default function TimeClockPage() {
             return (
               <div key={emp.user_id} style={{ background: "#fff", border: "0.5px solid #E5E2DC", borderRadius: 12, marginBottom: 12, overflow: "hidden" }}>
                 <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", padding: "11px 16px", background: "#FAFAF8", borderBottom: "1px solid #EEECE7" }}>
-                  <div style={{ fontSize: 14, fontWeight: 800, color: "#1A1917" }}>{emp.name}</div>
+                  <div style={{ fontSize: 14, fontWeight: 800, color: "#1A1917" }}>
+                    <Link href={`/employees/${emp.user_id}`} style={{ color: "#1A1917", textDecoration: "none" }}>
+                      <span style={{ borderBottom: "1px solid #D4D1CB" }}>{emp.name}</span>
+                    </Link>
+                  </div>
                   <div style={{ display: "flex", alignItems: "center", gap: 14, fontSize: 12, color: "#6B6860" }}>
                     {emp.day_start && <span>{fmtClock(emp.day_start)} – {emp.open ? "on clock" : fmtClock(emp.day_end)}</span>}
                     <span style={{ color: punched < emp.rows.length ? "#B45309" : "#16A34A", fontWeight: 700 }}>{punched}/{emp.rows.length} punched</span>


### PR DESCRIPTION
Usability pass on the Time Clock screen for the reconciliation audit (Sal's requests).

- **Job address per row** — each row now shows the service address (job address → account property with its unit/property name → client address). Multiple PPM units or several same-client jobs on one day are now distinguishable without opening the schedule.
- **Clickable names** — the client/account name links to its profile (residential → `/customers/:id`, commercial → `/accounts/:id`), and the employee name links to `/employees/:id`, like MaidCentral.
- **Clock-out GPS pill** — added next to the existing clock-in pill (the clock-out coordinates were already returned and on the map modal, just not surfaced inline), so the office can see *where* the tech punched out, not only where they punched in.

Frontend + api-server build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PiXXwFgtNSnzZQy3MTjAj

---
_Generated by [Claude Code](https://claude.ai/code/session_019PiXXwFgtNSnzZQy3MTjAj)_