### PR TITLE
feat(invoicing): edit invoices from UI + add-ons flow correctly

### DIFF
--- a/artifacts/api-server/src/lib/ensure-invoice.ts
+++ b/artifacts/api-server/src/lib/ensure-invoice.ts
@@ -31,10 +31,11 @@
 // (per-visit 'sent'); batch 'pending' drafts do NOT push — only their
 // consolidated parent does (Scope 2/5).
 import { db } from "@workspace/db";
-import { jobsTable, invoicesTable, accountsTable, companiesTable, clientsTable, jobDiscountsTable, jobAddOnsTable, addOnsTable } from "@workspace/db/schema";
+import { jobsTable, invoicesTable, accountsTable, companiesTable, clientsTable } from "@workspace/db/schema";
 import { eq, and, ne } from "drizzle-orm";
 import { getNextInvoiceNumber } from "./invoice-number.js";
 import { derivePaymentSource } from "./payment-source.js";
+import { buildJobLineItems } from "./invoice-line-items.js";
 
 // [cutover-guard 2026-06-17] Qleno go-live date. Jobs scheduled before this are
 // billed in MaidCentral; the completion engine never auto-invoices them. Single
@@ -174,56 +175,12 @@ export async function ensureInvoiceForCompletedJob(
       termsDays === 15 ? "net_15" :
       termsDays === 7  ? "net_7"  : "due_on_receipt";
 
-    // ── Build line items from LOCKED job pricing ─────────────────────────────
-    // Scope line: hourly jobs bill billed_amount (qty=hours × hourly_rate);
-    // flat jobs bill base_fee.
-    const scopeAmount = job.billed_amount
-      ? parseFloat(String(job.billed_amount))
-      : parseFloat(String(job.base_fee ?? "0"));
-    const svcLabel = (job.service_type ?? "Cleaning Service")
-      .split("_").map((w: string) => w.charAt(0).toUpperCase() + w.slice(1)).join(" ");
-    const scopeQty = job.billed_hours ? parseFloat(String(job.billed_hours)) : 1;
-    const scopeUnit = job.hourly_rate ? parseFloat(String(job.hourly_rate)) : scopeAmount;
-
-    const lineItems: any[] = [{ description: svcLabel, quantity: scopeQty, unit_price: scopeUnit, total: scopeAmount }];
-    let runningTotal = scopeAmount;
-
-    // Add-on / fee-rule lines (job_add_ons holds both add-ons and fees like
-    // parking). One line each, named from add_ons. Skipped for hourly jobs whose
-    // billed_amount already rolls everything into the metered total.
-    if (!job.billed_amount) {
-      const addons = await db
-        .select({
-          name: addOnsTable.name,
-          quantity: jobAddOnsTable.quantity,
-          unit_price: jobAddOnsTable.unit_price,
-          subtotal: jobAddOnsTable.subtotal,
-        })
-        .from(jobAddOnsTable)
-        .leftJoin(addOnsTable, eq(jobAddOnsTable.add_on_id, addOnsTable.id))
-        .where(eq(jobAddOnsTable.job_id, jobId));
-      for (const a of addons) {
-        const lineTotal = parseFloat(String(a.subtotal ?? "0"));
-        runningTotal += lineTotal;
-        lineItems.push({
-          description: a.name || "Add-on",
-          quantity: a.quantity ?? 1,
-          unit_price: parseFloat(String(a.unit_price ?? "0")),
-          total: lineTotal,
-        });
-      }
-    }
-
-    // Discount lines (negative) so the total nets out.
-    const jobDisc = await db.select().from(jobDiscountsTable)
-      .where(and(eq(jobDiscountsTable.job_id, jobId), eq(jobDiscountsTable.company_id, companyId)));
-    for (const d of jobDisc) {
-      const amt = parseFloat(String(d.amount));
-      runningTotal -= amt;
-      const label = `Discount${d.code ? ` ${d.code}` : (d.type === "percent" ? ` ${parseFloat(String(d.value))}%` : "")}${d.reason && d.reason !== d.code ? ` — ${d.reason}` : ""}`;
-      lineItems.push({ description: label, quantity: 1, unit_price: -amt, total: -amt });
-    }
-    const netAmount = Math.max(0, Math.round(runningTotal * 100) / 100);
+    // Build line items from the job's LOCKED pricing via the shared builder
+    // (scope + ALL add-ons + ALL discounts) — same code the draft re-sync and
+    // the office recalc use, so they can never diverge.
+    const built = await buildJobLineItems(companyId, jobId);
+    const lineItems = built?.lineItems ?? [];
+    const netAmount = built?.subtotal ?? 0;
 
     const [newInv] = await db
       .insert(invoicesTable)

--- a/artifacts/api-server/src/lib/invoice-line-items.ts
+++ b/artifacts/api-server/src/lib/invoice-line-items.ts
@@ -1,0 +1,86 @@
+// [invoice-line-items 2026-06-17] Single source of truth for building an
+// invoice's line items from a job's LOCKED pricing. Used by:
+//   - ensureInvoiceForCompletedJob (creation on completion)
+//   - syncJobInvoiceDraft (re-sync a draft when the job is edited in dispatch)
+//   - POST /api/invoices/:id/recalc (office "recalc from job" action)
+// Previously the draft-sync rebuilt scope + discounts only and DROPPED add-ons;
+// centralizing here makes all three identical so they can never diverge again.
+//
+// Composition (never recomputed from the pricing engine — uses stored values):
+//   scope line  — hourly jobs bill billed_amount (qty = billed_hours,
+//                 unit = hourly_rate); flat jobs bill base_fee (qty 1).
+//   add-on lines — one per job_add_ons row (covers add-ons AND fee rules like
+//                 parking), named from add_ons. Skipped for hourly jobs whose
+//                 billed_amount already rolls everything into the metered total.
+//   discount lines — each job_discounts row as a negative line so the total nets.
+import { db } from "@workspace/db";
+import { jobsTable, jobAddOnsTable, addOnsTable, jobDiscountsTable } from "@workspace/db/schema";
+import { eq, and } from "drizzle-orm";
+
+export type InvoiceLineItem = { description: string; quantity: number; unit_price: number; total: number };
+
+export async function buildJobLineItems(
+  companyId: number,
+  jobId: number,
+): Promise<{ lineItems: InvoiceLineItem[]; subtotal: number } | null> {
+  const [job] = await db
+    .select({
+      service_type: jobsTable.service_type,
+      base_fee: jobsTable.base_fee,
+      billed_amount: jobsTable.billed_amount,
+      billed_hours: jobsTable.billed_hours,
+      hourly_rate: jobsTable.hourly_rate,
+    })
+    .from(jobsTable)
+    .where(and(eq(jobsTable.id, jobId), eq(jobsTable.company_id, companyId)))
+    .limit(1);
+  if (!job) return null;
+
+  const scopeAmount = job.billed_amount
+    ? parseFloat(String(job.billed_amount))
+    : parseFloat(String(job.base_fee ?? "0"));
+  const svcLabel = (job.service_type ?? "Cleaning Service")
+    .split("_").map((w: string) => w.charAt(0).toUpperCase() + w.slice(1)).join(" ");
+  const scopeQty = job.billed_hours ? parseFloat(String(job.billed_hours)) : 1;
+  const scopeUnit = job.hourly_rate ? parseFloat(String(job.hourly_rate)) : scopeAmount;
+
+  const lineItems: InvoiceLineItem[] = [
+    { description: svcLabel, quantity: scopeQty, unit_price: scopeUnit, total: scopeAmount },
+  ];
+  let runningTotal = scopeAmount;
+
+  if (!job.billed_amount) {
+    const addons = await db
+      .select({
+        name: addOnsTable.name,
+        quantity: jobAddOnsTable.quantity,
+        unit_price: jobAddOnsTable.unit_price,
+        subtotal: jobAddOnsTable.subtotal,
+      })
+      .from(jobAddOnsTable)
+      .leftJoin(addOnsTable, eq(jobAddOnsTable.add_on_id, addOnsTable.id))
+      .where(eq(jobAddOnsTable.job_id, jobId));
+    for (const a of addons) {
+      const lineTotal = parseFloat(String(a.subtotal ?? "0"));
+      runningTotal += lineTotal;
+      lineItems.push({
+        description: a.name || "Add-on",
+        quantity: a.quantity ?? 1,
+        unit_price: parseFloat(String(a.unit_price ?? "0")),
+        total: lineTotal,
+      });
+    }
+  }
+
+  const jobDisc = await db.select().from(jobDiscountsTable)
+    .where(and(eq(jobDiscountsTable.job_id, jobId), eq(jobDiscountsTable.company_id, companyId)));
+  for (const d of jobDisc) {
+    const amt = parseFloat(String(d.amount));
+    runningTotal -= amt;
+    const label = `Discount${d.code ? ` ${d.code}` : (d.type === "percent" ? ` ${parseFloat(String(d.value))}%` : "")}${d.reason && d.reason !== d.code ? ` — ${d.reason}` : ""}`;
+    lineItems.push({ description: label, quantity: 1, unit_price: -amt, total: -amt });
+  }
+
+  const subtotal = Math.max(0, Math.round(runningTotal * 100) / 100);
+  return { lineItems, subtotal };
+}

--- a/artifacts/api-server/src/routes/invoices.ts
+++ b/artifacts/api-server/src/routes/invoices.ts
@@ -9,6 +9,7 @@ import { sendNotification } from "../services/notificationService.js";
 import { appBaseUrl } from "../lib/app-url.js";
 import { generateInvoiceNumber, getNextInvoiceNumber } from "../lib/invoice-number.js";
 import { chargeInvoice } from "../lib/charge-invoice.js";
+import { buildJobLineItems } from "../lib/invoice-line-items.js";
 
 const router = Router();
 
@@ -336,27 +337,41 @@ router.get("/:id", requireAuth, async (req, res) => {
   }
 });
 
-router.put("/:id", requireAuth, async (req, res) => {
+router.put("/:id", requireAuth, requireRole("owner", "admin", "office"), async (req, res) => {
   try {
     const invoiceId = parseInt(req.params.id);
     const { status, line_items, tips } = req.body;
 
-    let subtotal: number | undefined;
-    let total: number | undefined;
-
-    if (line_items) {
-      subtotal = line_items.reduce((s: number, item: any) => s + (item.total || 0), 0);
-      total = subtotal + (tips || 0);
+    // Edit guard: a paid or void invoice is immutable. Editing happens on
+    // draft / sent / overdue (overdue is a display-derivation of sent). Paid →
+    // reverse via refund flow; void → already inert. Keeps the books honest.
+    const [current] = await db
+      .select({ status: invoicesTable.status, subtotal: invoicesTable.subtotal, tips: invoicesTable.tips })
+      .from(invoicesTable)
+      .where(and(eq(invoicesTable.id, invoiceId), eq(invoicesTable.company_id, req.auth!.companyId)))
+      .limit(1);
+    if (!current) return res.status(404).json({ error: "Not Found", message: "Invoice not found" });
+    if (current.status === "paid" || current.status === "void" || current.status === "superseded") {
+      return res.status(409).json({ error: "Conflict", message: `A ${current.status} invoice cannot be edited` });
     }
+
+    // Total ALWAYS = sum(line items) + tips, so it can never silently drift from
+    // the lines. Use the new lines if provided, else the stored subtotal; use
+    // the new tip if provided, else the stored tip.
+    const subtotal = line_items
+      ? Math.round(line_items.reduce((s: number, item: any) => s + (Number(item.total) || 0), 0) * 100) / 100
+      : parseFloat(current.subtotal || "0");
+    const tipVal = tips !== undefined ? (Number(tips) || 0) : parseFloat(current.tips || "0");
+    const total = Math.round((subtotal + tipVal) * 100) / 100;
 
     const [updated] = await db
       .update(invoicesTable)
       .set({
         ...(status && { status }),
         ...(line_items && { line_items }),
-        ...(tips !== undefined && { tips: tips.toString() }),
-        ...(subtotal !== undefined && { subtotal: subtotal.toString() }),
-        ...(total !== undefined && { total: total.toString() }),
+        tips: tipVal.toFixed(2),
+        subtotal: subtotal.toFixed(2),
+        total: total.toFixed(2),
         ...(status === "sent" && { sent_at: new Date() }),
         ...(status === "paid" && { paid_at: new Date() }),
       })
@@ -365,7 +380,9 @@ router.put("/:id", requireAuth, async (req, res) => {
 
     if (!updated) return res.status(404).json({ error: "Not Found", message: "Invoice not found" });
 
-    // QB sync on update (fire and forget)
+    logAudit(req, "UPDATE", "invoice", invoiceId, { status: current.status }, { line_items, tips: tipVal, total });
+
+    // QB re-push on edit (fire and forget, one-way; no-op when not connected).
     queueSync(() => syncInvoice(req.auth!.companyId, invoiceId));
     if (status === "paid") {
       queueSync(() => syncPayment(req.auth!.companyId, invoiceId));
@@ -628,6 +645,53 @@ router.post("/:id/void", requireAuth, requireRole("owner", "admin", "office"), a
   } catch (err) {
     console.error("Void invoice error:", err);
     return res.status(500).json({ error: "Internal Server Error", message: "Failed to void invoice" });
+  }
+});
+
+// ── Recalc from job (Fix 2) ─────────────────────────────────────────────────
+// Rebuild an invoice's line items from its job's CURRENT locked pricing (scope +
+// ALL add-ons + ALL discounts) via the shared builder. This is how the office
+// pulls a post-completion dispatch change (e.g. an add-on added after the
+// per-visit invoice already went 'sent') onto the invoice — since sent invoices
+// are not auto-resynced. Preserves any manually-entered tip. Blocked on
+// paid/void/superseded. Re-pushes to QB.
+router.post("/:id/recalc", requireAuth, requireRole("owner", "admin", "office"), async (req, res) => {
+  try {
+    const invoiceId = parseInt(req.params.id);
+    if (isNaN(invoiceId)) return res.status(400).json({ error: "Bad Request", message: "Invalid invoice id" });
+
+    const [inv] = await db
+      .select({ id: invoicesTable.id, status: invoicesTable.status, job_id: invoicesTable.job_id, tips: invoicesTable.tips })
+      .from(invoicesTable)
+      .where(and(eq(invoicesTable.id, invoiceId), eq(invoicesTable.company_id, req.auth!.companyId)))
+      .limit(1);
+    if (!inv) return res.status(404).json({ error: "Not Found", message: "Invoice not found" });
+    if (inv.status === "paid" || inv.status === "void" || inv.status === "superseded") {
+      return res.status(409).json({ error: "Conflict", message: `A ${inv.status} invoice cannot be recalculated` });
+    }
+    if (!inv.job_id) {
+      return res.status(400).json({ error: "Bad Request", message: "This invoice is not linked to a job — edit its line items directly" });
+    }
+
+    const built = await buildJobLineItems(req.auth!.companyId, inv.job_id);
+    if (!built) return res.status(404).json({ error: "Not Found", message: "Linked job not found" });
+
+    const tipVal = parseFloat(inv.tips || "0");
+    const total = Math.round((built.subtotal + tipVal) * 100) / 100;
+
+    const [updated] = await db
+      .update(invoicesTable)
+      .set({ line_items: built.lineItems, subtotal: built.subtotal.toFixed(2), total: total.toFixed(2) })
+      .where(and(eq(invoicesTable.id, invoiceId), eq(invoicesTable.company_id, req.auth!.companyId)))
+      .returning();
+
+    logAudit(req, "UPDATE", "invoice", invoiceId, null, { action: "recalc_from_job", job_id: inv.job_id, total });
+    queueSync(() => syncInvoice(req.auth!.companyId, invoiceId));
+
+    return res.json(formatInvoice({ ...updated, client_name: null }));
+  } catch (err) {
+    console.error("Recalc invoice error:", err);
+    return res.status(500).json({ error: "Internal Server Error", message: "Failed to recalc invoice" });
   }
 });
 

--- a/artifacts/api-server/src/routes/jobs.ts
+++ b/artifacts/api-server/src/routes/jobs.ts
@@ -11,15 +11,19 @@ import { resolveZoneForZip } from "./zones.js";
 import { sendNotification, labelServiceType } from "../services/notificationService.js";
 import { parseResRatesRow, resolveResidentialPayPct } from "../lib/commission-rates.js";
 import { ensureInvoiceForCompletedJob } from "../lib/ensure-invoice.js";
+import { buildJobLineItems } from "../lib/invoice-line-items.js";
 
 const router = Router();
 
 // [invoice-sync 2026-06-11] Keep a job's existing DRAFT invoice in lockstep with
-// its price + applied discounts. Discounts render as their own negative line
-// items so the invoice total nets them out. NEVER touches a sent/paid invoice
+// its price + add-ons + applied discounts. NEVER touches a sent/paid invoice
 // (QB is write-only + sent invoices are immutable) and never creates one — only
 // syncs a draft that already exists. Fully non-fatal: an invoice hiccup must
 // never break the underlying job write.
+// [2026-06-17] Rebuilds via the shared buildJobLineItems (scope + ALL add-ons +
+// ALL discounts) — the prior version omitted add-ons and would DROP them from a
+// draft on re-sync. Same code the creation engine + office recalc use, so a job
+// edit in dispatch now reflects correctly on its draft invoice.
 async function syncJobInvoiceDraft(jobId: number, companyId: number): Promise<void> {
   try {
     const [existing] = await db
@@ -29,35 +33,11 @@ async function syncJobInvoiceDraft(jobId: number, companyId: number): Promise<vo
       .limit(1);
     if (!existing || existing.status !== "draft") return;
 
-    const [job] = await db
-      .select({
-        service_type: jobsTable.service_type, base_fee: jobsTable.base_fee,
-        billed_amount: jobsTable.billed_amount, hourly_rate: jobsTable.hourly_rate, billed_hours: jobsTable.billed_hours,
-      })
-      .from(jobsTable)
-      .where(and(eq(jobsTable.id, jobId), eq(jobsTable.company_id, companyId)))
-      .limit(1);
-    if (!job) return;
-
-    const service = job.billed_amount ? parseFloat(String(job.billed_amount)) : parseFloat(String(job.base_fee ?? "0"));
-    const svcLabel = (job.service_type ?? "Cleaning Service").split("_").map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(" ");
-    const qty = job.billed_hours ? parseFloat(String(job.billed_hours)) : 1;
-    const unitPrice = job.hourly_rate ? parseFloat(String(job.hourly_rate)) : service;
-
-    const discounts = await db.select().from(jobDiscountsTable)
-      .where(and(eq(jobDiscountsTable.job_id, jobId), eq(jobDiscountsTable.company_id, companyId)));
-    const discountTotal = discounts.reduce((s, d) => s + parseFloat(String(d.amount)), 0);
-    const net = Math.max(0, Math.round((service - discountTotal) * 100) / 100);
-
-    const lineItems: any[] = [{ description: svcLabel, quantity: qty, unit_price: unitPrice, total: service }];
-    for (const d of discounts) {
-      const amt = parseFloat(String(d.amount));
-      const label = `Discount${d.code ? ` ${d.code}` : (d.type === "percent" ? ` ${parseFloat(String(d.value))}%` : "")}${d.reason && d.reason !== d.code ? ` — ${d.reason}` : ""}`;
-      lineItems.push({ description: label, quantity: 1, unit_price: -amt, total: -amt });
-    }
+    const built = await buildJobLineItems(companyId, jobId);
+    if (!built) return;
 
     await db.update(invoicesTable)
-      .set({ line_items: lineItems, subtotal: net.toFixed(2), total: net.toFixed(2) })
+      .set({ line_items: built.lineItems, subtotal: built.subtotal.toFixed(2), total: built.subtotal.toFixed(2) })
       .where(eq(invoicesTable.id, existing.id));
 
     // Re-push to QuickBooks (no-op for non-connected tenants). Accounting, not

--- a/artifacts/qleno/src/pages/invoice-detail.tsx
+++ b/artifacts/qleno/src/pages/invoice-detail.tsx
@@ -117,6 +117,11 @@ export default function InvoiceDetailPage() {
   const [sendingInvoice, setSendingInvoice] = useState(false);
   const [charging, setCharging] = useState(false);
   const [voiding, setVoiding] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [editLines, setEditLines] = useState<any[]>([]);
+  const [editTip, setEditTip] = useState(0);
+  const [savingEdit, setSavingEdit] = useState(false);
+  const [recalcing, setRecalcing] = useState(false);
 
   const { data: invoice, isLoading } = useQuery({
     queryKey: ["invoice", invoiceId],
@@ -181,6 +186,60 @@ export default function InvoiceDetailPage() {
       toast({ title: e?.message || "Failed to void invoice", variant: "destructive" });
     }
     setVoiding(false);
+  }
+
+  // ── Edit invoice (line items / amounts / tip / discount) ──
+  function startEdit() {
+    const lines = Array.isArray(invoice?.line_items) ? invoice.line_items : [];
+    setEditLines(lines.map((l: any) => ({
+      description: l.description || "",
+      quantity: Number(l.quantity ?? 1),
+      unit_price: Number(l.unit_price ?? l.rate ?? 0),
+      total: Number(l.total ?? 0),
+    })));
+    setEditTip(Number(invoice?.tips || 0));
+    setEditing(true);
+  }
+  function setLine(i: number, patch: any) {
+    setEditLines(prev => prev.map((l, idx) => {
+      if (idx !== i) return l;
+      const next = { ...l, ...patch };
+      next.total = Math.round((Number(next.quantity) || 0) * (Number(next.unit_price) || 0) * 100) / 100;
+      return next;
+    }));
+  }
+  const editSubtotal = Math.round(editLines.reduce((s, l) => s + (Number(l.total) || 0), 0) * 100) / 100;
+  const editTotal = Math.round((editSubtotal + (Number(editTip) || 0)) * 100) / 100;
+
+  async function handleSaveEdit() {
+    setSavingEdit(true);
+    try {
+      await apiFetch(`/api/invoices/${invoiceId}`, {
+        method: "PUT",
+        body: JSON.stringify({ line_items: editLines, tips: Number(editTip) || 0 }),
+      });
+      toast({ title: "Invoice updated" });
+      setEditing(false);
+      qc.invalidateQueries({ queryKey: ["invoice", invoiceId] });
+      qc.invalidateQueries({ queryKey: ["invoices"] });
+    } catch (e: any) {
+      toast({ title: e?.message || "Failed to save invoice", variant: "destructive" });
+    }
+    setSavingEdit(false);
+  }
+
+  async function handleRecalc() {
+    if (!window.confirm("Rebuild this invoice's line items from the job's current add-ons, discounts and price? This replaces the current lines (your tip is kept).")) return;
+    setRecalcing(true);
+    try {
+      await apiFetch(`/api/invoices/${invoiceId}/recalc`, { method: "POST" });
+      toast({ title: "Invoice recalculated from job" });
+      qc.invalidateQueries({ queryKey: ["invoice", invoiceId] });
+      qc.invalidateQueries({ queryKey: ["invoices"] });
+    } catch (e: any) {
+      toast({ title: e?.message || "Failed to recalc invoice", variant: "destructive" });
+    }
+    setRecalcing(false);
   }
 
   const CARD: React.CSSProperties = {
@@ -272,6 +331,18 @@ export default function InvoiceDetailPage() {
               {voiding ? "Voiding..." : "Void"}
             </button>
           )}
+          {!["paid", "void", "superseded"].includes(invoice.status) && !editing && (
+            <button onClick={startEdit}
+              style={{ display: "flex", alignItems: "center", gap: 6, padding: "9px 16px", backgroundColor: "transparent", color: "#1A1917", border: "1px solid #E5E2DC", borderRadius: 8, fontSize: 13, fontWeight: 700, cursor: "pointer" }}>
+              Edit
+            </button>
+          )}
+          {!["paid", "void", "superseded"].includes(invoice.status) && invoice.job_id && !editing && (
+            <button onClick={handleRecalc} disabled={recalcing}
+              style={{ display: "flex", alignItems: "center", gap: 6, padding: "9px 16px", backgroundColor: "transparent", color: "#1A1917", border: "1px solid #E5E2DC", borderRadius: 8, fontSize: 13, fontWeight: 700, cursor: "pointer" }}>
+              {recalcing ? "Recalculating..." : "Recalc from Job"}
+            </button>
+          )}
         </div>
         {invoice.payment_failed && (effectiveStatus === "sent" || effectiveStatus === "overdue") && (
           <div style={{ marginBottom: 20, padding: "10px 14px", backgroundColor: "#FEF2F2", border: "1px solid #FECACA", borderRadius: 8, fontSize: 13, color: "#991B1B", display: "flex", alignItems: "center", gap: 8 }}>
@@ -307,7 +378,50 @@ export default function InvoiceDetailPage() {
 
         <div style={CARD}>
           <h3 style={{ margin: "0 0 16px", fontSize: 14, fontWeight: 700, color: "#1A1917" }}>Line Items</h3>
-          {lineItems.length === 0 ? (
+
+          {editing ? (
+            <div>
+              {editLines.map((l, i) => (
+                <div key={i} style={{ display: "flex", gap: 8, alignItems: "center", marginBottom: 8 }}>
+                  <input value={l.description} placeholder="Description"
+                    onChange={e => setLine(i, { description: e.target.value })}
+                    style={{ flex: 1, padding: "7px 10px", border: "1px solid #E5E2DC", borderRadius: 6, fontSize: 13, fontFamily: FF }} />
+                  <input type="number" step="0.01" value={l.quantity} title="Qty"
+                    onChange={e => setLine(i, { quantity: e.target.value })}
+                    style={{ width: 60, padding: "7px 8px", border: "1px solid #E5E2DC", borderRadius: 6, fontSize: 13, textAlign: "right", fontFamily: FF }} />
+                  <input type="number" step="0.01" value={l.unit_price} title="Rate (negative = discount)"
+                    onChange={e => setLine(i, { unit_price: e.target.value })}
+                    style={{ width: 90, padding: "7px 8px", border: "1px solid #E5E2DC", borderRadius: 6, fontSize: 13, textAlign: "right", fontFamily: FF }} />
+                  <span style={{ width: 80, textAlign: "right", fontSize: 13, fontWeight: 700, color: l.total < 0 ? "#991B1B" : "#1A1917" }}>${Number(l.total || 0).toFixed(2)}</span>
+                  <button onClick={() => setEditLines(prev => prev.filter((_, idx) => idx !== i))}
+                    title="Remove line" style={{ background: "none", border: "none", color: "#9E9B94", cursor: "pointer", fontSize: 16, lineHeight: 1 }}>×</button>
+                </div>
+              ))}
+              <div style={{ display: "flex", gap: 8, marginTop: 4, marginBottom: 14 }}>
+                <button onClick={() => setEditLines(prev => [...prev, { description: "", quantity: 1, unit_price: 0, total: 0 }])}
+                  style={{ padding: "6px 12px", border: "1px solid #E5E2DC", borderRadius: 6, background: "transparent", fontSize: 12, fontWeight: 600, cursor: "pointer", fontFamily: FF }}>+ Add line</button>
+                <button onClick={() => setEditLines(prev => [...prev, { description: "Discount", quantity: 1, unit_price: 0, total: 0 }])}
+                  style={{ padding: "6px 12px", border: "1px solid #E5E2DC", borderRadius: 6, background: "transparent", fontSize: 12, fontWeight: 600, cursor: "pointer", fontFamily: FF }}>+ Add discount</button>
+              </div>
+              <div style={{ display: "flex", justifyContent: "flex-end", alignItems: "center", gap: 10, marginBottom: 6 }}>
+                <span style={{ fontSize: 13, color: "#6B7280" }}>Tip</span>
+                <input type="number" step="0.01" value={editTip} onChange={e => setEditTip(Number(e.target.value) || 0)}
+                  style={{ width: 100, padding: "7px 8px", border: "1px solid #E5E2DC", borderRadius: 6, fontSize: 13, textAlign: "right", fontFamily: FF }} />
+              </div>
+              <div style={{ display: "flex", justifyContent: "flex-end", gap: 24, borderTop: "2px solid #EEECE7", paddingTop: 10, marginTop: 6 }}>
+                <span style={{ fontSize: 13, color: "#6B7280" }}>Subtotal ${editSubtotal.toFixed(2)}</span>
+                <span style={{ fontSize: 16, fontWeight: 800, color: "#1A1917" }}>Total ${editTotal.toFixed(2)}</span>
+              </div>
+              <div style={{ display: "flex", justifyContent: "flex-end", gap: 10, marginTop: 16 }}>
+                <button onClick={() => setEditing(false)}
+                  style={{ padding: "9px 16px", border: "1px solid #E5E2DC", borderRadius: 8, background: "transparent", color: "#6B7280", fontSize: 13, fontWeight: 700, cursor: "pointer", fontFamily: FF }}>Cancel</button>
+                <button onClick={handleSaveEdit} disabled={savingEdit}
+                  style={{ padding: "9px 20px", border: "none", borderRadius: 8, backgroundColor: "var(--brand)", color: "#FFFFFF", fontSize: 13, fontWeight: 700, cursor: "pointer", fontFamily: FF }}>
+                  {savingEdit ? "Saving..." : "Save changes"}
+                </button>
+              </div>
+            </div>
+          ) : lineItems.length === 0 ? (
             <p style={{ fontSize: 13, color: "#9E9B94", margin: 0 }}>No line items recorded.</p>
           ) : (
             <table style={{ width: "100%", borderCollapse: "collapse" }}>
@@ -327,7 +441,7 @@ export default function InvoiceDetailPage() {
                       {(item.description || "").replace(/_/g, " ")}
                     </td>
                     <td style={{ padding: "10px 0", fontSize: 13, color: "#6B7280", textAlign: "right" }}>{item.quantity || 1}</td>
-                    <td style={{ padding: "10px 0", fontSize: 13, color: "#6B7280", textAlign: "right" }}>${(item.rate || 0).toFixed(2)}</td>
+                    <td style={{ padding: "10px 0", fontSize: 13, color: "#6B7280", textAlign: "right" }}>${((item.unit_price ?? item.rate) || 0).toFixed(2)}</td>
                     <td style={{ padding: "10px 0", fontSize: 13, fontWeight: 700, color: "#1A1917", textAlign: "right" }}>${(item.total || 0).toFixed(2)}</td>
                   </tr>
                 ))}


### PR DESCRIPTION
Two office-requested fixes (Maribel). Cutover guard untouched.

## Fix 1 — Edit invoices from the UI
- Invoice detail page **Edit mode**: add/remove line items, change qty/rate, add a tip, add a discount line; live subtotal/total. Saves via `PUT /api/invoices/:id` and **re-pushes to QuickBooks** (one-way).
- **Safe rule:** editing allowed on **draft / sent / overdue**; **blocked on paid / void / superseded** (409). Total is always recomputed as `sum(lines) + tip` so it can't silently drift. Office role-gated, audit-logged.
- Fixed read-only rate display (was reading `item.rate`; engine lines use `unit_price`).

## Fix 2 — Add-ons/discounts flow + stop dropping add-ons
- New shared `lib/invoice-line-items.ts` (`buildJobLineItems` = scope + ALL add-ons + ALL discounts), used by the creation engine, the draft re-sync, and recalc — so they can never diverge.
- `syncJobInvoiceDraft` previously **omitted add-ons and dropped them** on any draft re-sync; now mirrors the builder.
- New `POST /api/invoices/:id/recalc` + "Recalc from Job" button — rebuilds an invoice's lines from the job's current locked pricing (keeps tip), for pulling a post-completion dispatch change onto an already-sent invoice. Blocked on paid/void/superseded; re-pushes QB.

## Resulting behavior per invoice state (after a dispatch add-on/discount change)
- **Draft** (batch clients / manual): auto-re-syncs on the job edit — add-ons now included.
- **Sent / overdue** (per-visit default): not auto-resynced; office clicks **Recalc from Job** (or edits directly). 
- **Paid / void / superseded**: immutable — edit + recalc both blocked.

Verified: tsc clean on touched files, server bundles clean, invoice-detail transpiles clean. Live E2E to follow before deploy.