### PR TITLE
Fix tech reassign: audit/pay can't roll back the change; resync open drawer

### DIFF
--- a/artifacts/api-server/src/routes/jobs.ts
+++ b/artifacts/api-server/src/routes/jobs.ts
@@ -4443,9 +4443,17 @@ router.patch("/:id/reassign-tech", requireAuth, async (req, res) => {
         UPDATE jobs SET assigned_user_id = ${newTechId}
         WHERE id = ${jobId} AND company_id = ${companyId}
       `);
+    });
 
-      // Audit row.
-      const userRows = await tx.execute(sql`
+    // [reassign-resilience 2026-06-18] Audit + pay recompute run AFTER the
+    // commit, each non-fatal. Previously the audit-log INSERT lived INSIDE the
+    // transaction — if it threw (e.g. a missing column on the prod table) the
+    // whole reassignment rolled back, so the office saw a 500 ("it crashed")
+    // and the chip never moved even though the change should have stuck. The
+    // assignment + mirror are the load-bearing writes; audit/pay must never be
+    // able to fail them.
+    try {
+      const userRows = await db.execute(sql`
         SELECT first_name, last_name, email FROM users WHERE id = ${userId} LIMIT 1
       `);
       const u = (userRows.rows[0] as any) ?? {};
@@ -4457,7 +4465,7 @@ router.patch("/:id/reassign-tech", requireAuth, async (req, res) => {
         previous_assigned_user_id: oldAssignedUserId,
         previous_techs: techsBefore.rows,
       };
-      await tx.execute(sql`
+      await db.execute(sql`
         INSERT INTO job_audit_log
           (job_id, company_id, user_id, user_name, user_email,
            field_name, old_value, new_value, cascade_scope, schedule_id)
@@ -4468,9 +4476,14 @@ router.patch("/:id/reassign-tech", requireAuth, async (req, res) => {
            ${JSON.stringify(summary)}::jsonb,
            'this_job', ${null})
       `);
-    });
+    } catch (auditErr) {
+      console.error("reassign-tech audit log failed (non-fatal):", auditErr);
+    }
 
-    const techPay = await calculateTechPay(jobId, companyId);
+    let techPay: Awaited<ReturnType<typeof calculateTechPay>> = [];
+    try { techPay = await calculateTechPay(jobId, companyId); }
+    catch (payErr) { console.error("reassign-tech pay recompute failed (non-fatal):", payErr); }
+
     return res.json({
       data: {
         assigned_user_id: newTechId,

--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -5830,6 +5830,19 @@ export default function JobsPage() {
   const [selectedJob, setSelectedJob] = useState<DispatchJob | null>(null);
   const [showWizard, setShowWizard] = useState(false);
   const [draggingJob, setDraggingJob] = useState<DispatchJob | null>(null);
+  // [panel-resync 2026-06-18] Keep the open drawer in sync with refreshed board
+  // data. After a reassign/edit, load() refetches `data` but selectedJob still
+  // held the pre-save snapshot (old tech), so the drawer showed no change even
+  // though it saved + the chip moved. Re-point selectedJob at the fresh row.
+  useEffect(() => {
+    if (!selectedJob || !data) return;
+    const all: DispatchJob[] = [
+      ...((data.employees ?? []).flatMap((e: any) => e.jobs ?? []) as DispatchJob[]),
+      ...(((data as any).unassigned_jobs ?? []) as DispatchJob[]),
+    ];
+    const fresh = all.find(j => j.id === selectedJob.id);
+    if (fresh) setSelectedJob(fresh);
+  }, [data]); // eslint-disable-line react-hooks/exhaustive-deps
   const [desktopView, setDesktopView] = useState<"timeline" | "list">("timeline");
   // Cutover 3B — Attendance overlay drawer state. Drawer surfaces
   // dispatch-tier proposals (late / short / no_show / missing_clockout)


### PR DESCRIPTION
## Reassigning a tech "saved" but didn't stick (and sometimes crashed)

Changing a job's technician from the drawer dropdown showed a save, but the change didn't take effect "where it matters," and on some jobs it 500'd ("it crashed").

**Backend (`reassign-tech`):** the audit-log `INSERT` ran *inside* the reassign transaction, and the pay recompute ran immediately after. If either threw — e.g. a production schema mismatch on `job_audit_log`, or a pay-calc edge — the **entire reassignment rolled back** (500 → "crash"), or the request errored *after* the commit so the UI never refreshed. Moved both **out of the transaction** and made them non-fatal. The only load-bearing writes are the `job_technicians` swap + the `jobs.assigned_user_id` mirror; those now always commit and return 200, so the board refresh fires.

**Frontend:** the open drawer held the pre-save `selectedJob` snapshot, so even after the board refetched, the drawer still showed the old tech ("nothing changes"). Now the open drawer re-points at the freshly-loaded row whenever board data reloads — so the dropdown and chip both reflect the new tech.

Both the dropdown reassign and the drag-to-reassign path go through this endpoint, so both are covered. Frontend + api-server build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PiXXwFgtNSnzZQy3MTjAj

---
_Generated by [Claude Code](https://claude.ai/code/session_019PiXXwFgtNSnzZQy3MTjAj)_