### PR TITLE
Cancellations off the board + labeled in client profile; plain-English activity log

### DIFF
--- a/artifacts/api-server/src/routes/clients.ts
+++ b/artifacts/api-server/src/routes/clients.ts
@@ -2192,7 +2192,13 @@ router.get("/:id/calendar-jobs", requireAuth, async (req, res) => {
         j.billed_amount, j.estimated_hours, j.actual_hours,
         j.scheduled_time, j.address_street, j.address_city,
         u.first_name || ' ' || u.last_name AS technician_name,
-        u.id AS technician_id
+        u.id AS technician_id,
+        -- Charged cancel/lockout keeps status='complete' so the calendar must
+        -- not show it as "Done" — surface the action so the chip reads
+        -- "Cancelled (fee)" / "Lockout" instead.
+        (SELECT cl.cancel_action FROM cancellation_log cl
+          WHERE cl.job_id = j.id AND cl.cancel_action IN ('cancel','lockout')
+          ORDER BY cl.cancelled_at DESC LIMIT 1) AS cancel_action
       FROM jobs j
       LEFT JOIN users u ON u.id = j.assigned_user_id
       WHERE j.client_id = ${clientId}

--- a/artifacts/api-server/src/routes/dispatch.ts
+++ b/artifacts/api-server/src/routes/dispatch.ts
@@ -245,6 +245,13 @@ async function buildDispatchPayload(
         eq(jobsTable.company_id, companyId),
         eq(jobsTable.scheduled_date, date),
         sql`${jobsTable.status} != 'cancelled'`,
+        // [cancel-off-board 2026-06-18] A charged Cancel/Lockout keeps
+        // status='complete' (so the fee counts as revenue + shows in the Fees
+        // report + client profile), but it is NOT work on the schedule — keep
+        // it OFF the dispatch board so a cancelled visit doesn't sit in a tech's
+        // lane (Sal: "it's still on the job board, I need it off"). The fee is
+        // still tracked everywhere else.
+        sql`NOT EXISTS (SELECT 1 FROM cancellation_log cl WHERE cl.job_id = ${jobsTable.id} AND cl.cancel_action IN ('cancel','lockout'))`,
         // [quote-convert-branch 2026-06-08] Untagged (NULL-branch) jobs must NOT
         // vanish under a location filter. Quote→job convert never set branch_id,
         // so converted jobs "didn't stick" on the board when the office viewed a

--- a/artifacts/qleno/src/pages/customer-profile.tsx
+++ b/artifacts/qleno/src/pages/customer-profile.tsx
@@ -4844,7 +4844,17 @@ const STATUS_CHIP: Record<string, { bg: string; border: string; text: string; la
   bumped:     { bg: "#FED7AA", border: "#F97316", text: "#C2410C", label: "Moved", tooltip: "Moved — Job rescheduled to another date" },
   skipped:    { bg: "#F3F4F6", border: "#9CA3AF", text: "#6B7280", label: "Skip",  tooltip: "Skip — Client skipped this visit" },
   lockout:    { bg: "#F3E8E8", border: "#7B2D2D", text: "#7B2D2D", label: "Lock",  tooltip: "Lock Out — Technician could not access the property" },
+  // Charged cancel/lockout (job.status stays 'complete' for revenue) — resolved
+  // from cancel_action so the calendar reads the truth, not "Done".
+  cancelled_fee: { bg: "#FEF3C7", border: "#F59E0B", text: "#B45309", label: "Cxl Fee", tooltip: "Cancelled — fee charged (not a completed visit)" },
 };
+// A charged cancel/lockout is stored status='complete'; resolve it to the right
+// chip key off cancel_action so the day doesn't read "Done".
+function chipKeyFor(j: any): string {
+  if (j?.cancel_action === "lockout") return "lockout";
+  if (j?.cancel_action === "cancel") return "cancelled_fee";
+  return String(j?.status);
+}
 const RESCHEDULE_REASONS = [
   "Client Request", "Tech Unavailable", "Weather", "Holiday / Observed Holiday",
   "Emergency", "Client Traveling", "Schedule Optimization", "Other",
@@ -5017,7 +5027,7 @@ function JobCalendar({ clientId, clientName, onScheduleOnDate }: { clientId: num
             textAlign: "right", marginBottom: 1, lineHeight: "16px",
           }}>{d}</div>
           {jobs.map(j => {
-            const chip = STATUS_CHIP[String(j.status)] || STATUS_CHIP.scheduled;
+            const chip = STATUS_CHIP[chipKeyFor(j)] || STATUS_CHIP.scheduled;
             const ro = isReadOnly(j);
             return (
               <div
@@ -5110,7 +5120,7 @@ function JobCalendar({ clientId, clientName, onScheduleOnDate }: { clientId: num
           <div style={{ background: "#FFFFFF", borderRadius: 12, padding: 24, width: 420, maxWidth: "90vw", fontFamily: FF, boxShadow: "0 16px 48px rgba(0,0,0,0.18)" }}>
             {(() => {
               const j = modal.job;
-              const chip = STATUS_CHIP[String(j.status)] || STATUS_CHIP.scheduled;
+              const chip = STATUS_CHIP[chipKeyFor(j)] || STATUS_CHIP.scheduled;
               const ro = isReadOnly(j);
               const origDate = String(j.scheduled_date).split("T")[0];
               return (
@@ -5253,19 +5263,71 @@ function ActivityTab({ clientId }: { clientId: number }) {
     communication:   { label: "Message",        color: "#374151", bg: "#F3F4F6" },
   };
   const label = (f: string | null) => (f ? f.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase()) : "");
-  const fmtVal = (v: any) => (v == null ? "—" : typeof v === "object" ? JSON.stringify(v) : String(v));
+  // [audit-plain-english 2026-06-18] The activity feed read like code (raw JSON
+  // dumps, "[unknown — see X history]", field names). These helpers turn each
+  // entry into one plain sentence the office can read at a glance.
+  const isNum = (v: any) => v != null && v !== "" && Number.isFinite(Number(v));
+  const money = (v: any) => `$${Number(v).toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+  const truthy = (v: any) => v === true || v === "true";
+  const time12 = (t: any) => {
+    const m = String(t).match(/^(\d{1,2}):(\d{2})/);
+    if (!m) return String(t);
+    const h = parseInt(m[1], 10); const ap = h < 12 ? "AM" : "PM";
+    return `${((h + 11) % 12) + 1}:${m[2]} ${ap}`;
+  };
+  // A readable scalar; objects/arrays/empties we can't summarize → null (caller
+  // falls back to a generic phrase rather than printing JSON).
+  const valText = (v: any): string | null => {
+    if (v == null || v === "") return null;
+    if (typeof v === "object") return Array.isArray(v) ? (v.length ? null : null) : null;
+    if (typeof v === "boolean") return v ? "yes" : "no";
+    if (typeof v === "string" && /unknown — see/i.test(v)) return null;
+    return String(v);
+  };
+  const describeEdit = (e: any): string => {
+    const nv = e.new_value ?? {}, ov = e.old_value ?? {};
+    const f = e.field_name as string;
+    const n = (nv && typeof nv === "object" && "value" in nv) ? (nv as any).value : nv;
+    const o = (ov && typeof ov === "object" && "value" in ov) ? (ov as any).value : ov;
+    switch (f) {
+      case "cascade_summary": {
+        const upd = Number(nv?.future_jobs_updated ?? 0), ins = Number(nv?.future_jobs_inserted ?? 0), del = Number(nv?.future_jobs_deleted ?? 0);
+        const parts: string[] = [];
+        if (upd) parts.push(`${upd} future visit${upd === 1 ? "" : "s"} updated`);
+        if (ins) parts.push(`${ins} added`);
+        if (del) parts.push(`${del} removed`);
+        return parts.length ? `Recurring schedule changed — ${parts.join(", ")}` : "Recurring schedule changed";
+      }
+      case "base_fee":      return `Price changed${isNum(o) ? ` from ${money(o)}` : ""} to ${money(n)}`;
+      case "billed_amount": return `Billed amount changed${isNum(o) ? ` from ${money(o)}` : ""} to ${money(n)}`;
+      case "hourly_rate":   return `Hourly rate set to ${money(n)}/hr`;
+      case "allowed_hours": return `Allowed hours set to ${n}`;
+      case "scheduled_time": return `Start time changed to ${time12(n)}`;
+      case "scheduled_date": return `Date changed to ${n}`;
+      case "manual_rate_override": return `Manual price override turned ${truthy(n) ? "on" : "off"}`;
+      case "team_user_ids": return "Team reassigned";
+      case "add_ons":       return "Add-ons updated";
+      case "service_type":  return `Service changed to ${label(String(n))}`;
+      case "notes": case "office_notes": return "Notes updated";
+      default: {
+        const nt = valText(n), ot = valText(o);
+        if (nt) return `${label(f)} changed${ot ? ` from ${ot}` : ""} to ${nt}`;
+        return `${label(f)} updated`;
+      }
+    }
+  };
   const describe = (e: any): string => {
     const nv = e.new_value || {}, ov = e.old_value || {};
     switch (e.event_type) {
-      case "job_edit":        return `${label(e.field_name)}: ${fmtVal(ov?.value ?? ov)} → ${fmtVal(nv?.value ?? nv)}`;
-      case "job_rescheduled": return `${label(e.field_name)}${nv.reason ? ` · ${nv.reason}` : ""}`;
-      case "job_cancelled":   return `${label(e.field_name) || "Cancelled"}${nv.reason ? ` · ${nv.reason}` : ""}${nv.charge ? ` · charged $${Number(nv.charge).toFixed(2)}` : ""}`;
-      case "job_deleted":     return `Job #${ov.job_id ?? ""}${ov.service_type ? ` · ${label(ov.service_type)}` : ""}${ov.scheduled_date ? ` · ${ov.scheduled_date}` : ""}`;
-      case "communication":   return `${nv.direction === "inbound" ? "Received" : "Sent"} ${e.field_name || ""}${nv.summary ? ` · ${nv.summary}` : nv.subject ? ` · ${nv.subject}` : ""}`;
-      case "client_edit":     return `${label(e.field_name)}: ${fmtVal(ov)} → ${fmtVal(nv)}`;
-      case "job_created":     return `Job #${e.related_job_id ?? ""} created`;
+      case "job_edit":        return describeEdit(e);
+      case "job_rescheduled": return `Rescheduled${nv.reason ? ` — ${nv.reason}` : ""}`;
+      case "job_cancelled":   return `Cancelled${nv.reason ? ` — ${String(nv.reason).replace(/_/g, " ")}` : ""}${nv.charge != null ? ` · fee ${money(nv.charge)}` : ""}`;
+      case "job_deleted":     return `Job deleted${ov.service_type ? ` · ${label(ov.service_type)}` : ""}${ov.scheduled_date ? ` · ${ov.scheduled_date}` : ""}`;
+      case "communication":   return `${nv.direction === "inbound" ? "Received" : "Sent"} ${e.field_name || "message"}${nv.summary ? ` — ${nv.summary}` : nv.subject ? ` — ${nv.subject}` : ""}`;
+      case "client_edit":     { const nt = valText(nv?.value ?? nv); return nt ? `${label(e.field_name)} changed to ${nt}` : `${label(e.field_name)} updated`; }
+      case "job_created":     return "Job created";
       case "client_created":  return "Client created";
-      default:                return label(e.field_name);
+      default:                return label(e.field_name) || "Updated";
     }
   };
   return (


### PR DESCRIPTION
Three fixes around charged cancellations and the client profile.

## 1. Cancelled jobs off the dispatch board
A charged Cancel/Lockout keeps `status='complete'` so the fee still counts as revenue (and shows in the Fees report + client profile), but a cancelled visit isn't work — it was still sitting in a tech's lane on the board. The dispatch board now **excludes** charged cancel/lockout jobs ("it's still on the job board, I need it off"). Tracked everywhere else, just not on the schedule.

## 2. Client profile no longer marks a cancellation as "Done"
The Job Calendar mapped `status='complete' → Done`, so a charged cancellation showed green/Done. `calendar-jobs` now returns `cancel_action`, and the chip resolves to **"Cancelled (fee)"** (or Lockout) instead. The "Cancellations & Reschedules" section already showed it correctly; now the calendar agrees.

## 3. Activity (audit) log in plain English
It was dumping raw JSON and field names:
> Cascade Summary: {} → {"values":{"add_ons":[...]}}
> Team User Ids: [unknown — see job_technicians history] → [39]
> Manual Rate Override: true → {}

Now each entry is one readable sentence:
> Price changed from $400.00 to $420.00 · Start time changed to 6:00 AM · Team reassigned · Manual price override turned off · Recurring schedule changed — 64 future visits updated

Frontend + api-server build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PiXXwFgtNSnzZQy3MTjAj

---
_Generated by [Claude Code](https://claude.ai/code/session_019PiXXwFgtNSnzZQy3MTjAj)_