### PR TITLE
Client-profile UX: sane last/next cleaning, Cancel legend, lighter LTV box; drop PHES badge

### DIFF
--- a/artifacts/api-server/src/routes/clients.ts
+++ b/artifacts/api-server/src/routes/clients.ts
@@ -276,9 +276,23 @@ router.get("/:id/full-profile", requireAuth, async (req, res) => {
       .filter(i => i.paid_at && new Date(i.paid_at) >= twelve_months_ago)
       .reduce((s, i) => s + parseFloat(i.total || "0"), 0);
     const completed_jobs = jobs.filter(j => j.status === "complete");
-    const last_cleaning = completed_jobs[0]?.scheduled_date || null;
-    const upcoming_jobs = jobs.filter(j => ["scheduled","in_progress"].includes(j.status || "") && j.scheduled_date && j.scheduled_date >= now.toISOString().split("T")[0]);
-    const next_cleaning = upcoming_jobs[0]?.scheduled_date || null;
+    // [last-next-fix 2026-06-18] Compute via direct SQL, not the 50-most-recent
+    // in-memory `jobs` slice — a client with hundreds of future jobs could push
+    // the real last-completed out of the window, and the old next picked the
+    // LATEST future job (desc order) instead of the soonest, even surfacing a
+    // stale past 'scheduled' job. Last = most recent completed on/before today;
+    // Next = soonest scheduled on/after today.
+    const lastNextRes = await db.execute(sql`
+      SELECT
+        (SELECT MAX(scheduled_date) FROM jobs
+           WHERE client_id = ${clientId} AND company_id = ${companyId}
+             AND status = 'complete' AND scheduled_date <= CURRENT_DATE) AS last_cleaning,
+        (SELECT MIN(scheduled_date) FROM jobs
+           WHERE client_id = ${clientId} AND company_id = ${companyId}
+             AND status::text IN ('scheduled','in_progress') AND scheduled_date >= CURRENT_DATE) AS next_cleaning
+    `);
+    const last_cleaning = (lastNextRes.rows[0] as any)?.last_cleaning ? String((lastNextRes.rows[0] as any).last_cleaning) : null;
+    const next_cleaning = (lastNextRes.rows[0] as any)?.next_cleaning ? String((lastNextRes.rows[0] as any).next_cleaning) : null;
     const avg_bill_completed = completed_jobs.length ? revenue_all_time / completed_jobs.length : 0;
     const avg_bill = invoices.length ? revenue_all_time / invoices.length : 0;
 
@@ -293,7 +307,7 @@ router.get("/:id/full-profile", requireAuth, async (req, res) => {
 
     // ACTIVE if any job in the last 60 days; otherwise INACTIVE.
     const client_status: "active" | "inactive" =
-      last_cleaning_ms >= sixty_days_ago_ms || upcoming_jobs.length > 0 ? "active" : "inactive";
+      last_cleaning_ms >= sixty_days_ago_ms || next_cleaning != null ? "active" : "inactive";
 
     // RECURRING if the client has any active recurring_schedules row.
     // [hotfix 2026-04-29] Column is `is_active`, not `active`. The bad
@@ -1213,19 +1227,24 @@ router.get("/:id/job-history", requireAuth, async (req, res) => {
       service_type: string | null; technician: string | null; notes: string | null;
     }>;
 
-    // Last cleaning from job_history
-    const last_cleaning: string | null = records.length > 0 ? records[0].job_date : null;
-
-    // Next cleaning from jobs table (nearest scheduled job in the future)
-    const nextJobRes = await db.execute(sql`
-      SELECT scheduled_date FROM jobs
+    // [last-next-fix 2026-06-18] Last = most recent COMPLETED job on/before
+    // today (records[0] could be a future or non-completed row → showed a
+    // nonsensical "Next before Last"); Next = soonest scheduled on/after today.
+    const lastJobRes = await db.execute(sql`
+      SELECT MAX(scheduled_date) AS d FROM jobs
       WHERE client_id = ${clientId} AND company_id = ${companyId}
-        AND status = 'scheduled' AND scheduled_date >= CURRENT_DATE
-      ORDER BY scheduled_date ASC LIMIT 1
+        AND status = 'complete' AND scheduled_date <= CURRENT_DATE
     `);
-    const next_cleaning: string | null = nextJobRes.rows.length > 0
-      ? String((nextJobRes.rows[0] as any).scheduled_date)
-      : null;
+    const last_cleaning: string | null = (lastJobRes.rows[0] as any)?.d
+      ? String((lastJobRes.rows[0] as any).d) : null;
+
+    const nextJobRes = await db.execute(sql`
+      SELECT MIN(scheduled_date) AS d FROM jobs
+      WHERE client_id = ${clientId} AND company_id = ${companyId}
+        AND status::text IN ('scheduled','in_progress') AND scheduled_date >= CURRENT_DATE
+    `);
+    const next_cleaning: string | null = (nextJobRes.rows[0] as any)?.d
+      ? String((nextJobRes.rows[0] as any).d) : null;
 
     // Is this client on an active recurring schedule?
     const recurrRes = await db.execute(sql`

--- a/artifacts/qleno/src/pages/customer-profile.tsx
+++ b/artifacts/qleno/src/pages/customer-profile.tsx
@@ -4840,7 +4840,7 @@ const STATUS_CHIP: Record<string, { bg: string; border: string; text: string; la
   complete:   { bg: "#DCFCE7", border: "#22C55E", text: "#15803D", label: "Done",  tooltip: "Done — Service completed" },
   completed:  { bg: "#DCFCE7", border: "#22C55E", text: "#15803D", label: "Done",  tooltip: "Done — Service completed" },
   invoiced:   { bg: "#DCFCE7", border: "#22C55E", text: "#15803D", label: "Done",  tooltip: "Done — Service completed" },
-  cancelled:  { bg: "#FEE2E2", border: "#EF4444", text: "#DC2626", label: "Void",  tooltip: "Void — Appointment cancelled" },
+  cancelled:  { bg: "#FEE2E2", border: "#EF4444", text: "#DC2626", label: "Cancel", tooltip: "Cancelled — visit cancelled (no fee)" },
   bumped:     { bg: "#FED7AA", border: "#F97316", text: "#C2410C", label: "Moved", tooltip: "Moved — Job rescheduled to another date" },
   skipped:    { bg: "#F3F4F6", border: "#9CA3AF", text: "#6B7280", label: "Skip",  tooltip: "Skip — Client skipped this visit" },
   lockout:    { bg: "#F3E8E8", border: "#7B2D2D", text: "#7B2D2D", label: "Lock",  tooltip: "Lock Out — Technician could not access the property" },
@@ -5070,7 +5070,7 @@ function JobCalendar({ clientId, clientName, onScheduleOnDate }: { clientId: num
   }
 
   const statusLegend = Object.entries(STATUS_CHIP).filter(([k]) =>
-    ["scheduled","complete","cancelled","bumped","skipped","lockout"].includes(k)
+    ["scheduled","complete","cancelled","cancelled_fee","bumped","skipped","lockout"].includes(k)
   );
 
   return (
@@ -5543,27 +5543,22 @@ export default function CustomerProfilePage() {
             <span>Next: <strong style={{ color: nextCleaning ? "var(--brand)" : "#9E9B94" }}>{nextCleaning ? fmtDate(nextCleaning) : "Not scheduled"}</strong></span>
           </div>
         </div>
-        <div style={{ background: "#0A0E1A", borderRadius: 10, padding: "7px 14px", textAlign: "center" as const, flexShrink: 0 }}>
-          <div style={{ fontSize: 19, fontWeight: 900, color: "#00C9A0", lineHeight: 1 }}>${ltv.toLocaleString("en-US", { maximumFractionDigits: 0 })}</div>
-          <div style={{ fontSize: 9, fontWeight: 700, color: "#9CA3AF", textTransform: "uppercase" as const, letterSpacing: "0.07em", marginTop: 2 }}>Lifetime Value</div>
-          {/* [scheduling-engine 2026-04-29] Subtitle pins "since
-              when" — first-job date if available, else client
-              created_at. Removes the ambiguity of an unlabeled
-              dollar number that could be misread as YTD or this
-              month. */}
-          {(() => {
-            const since = jhStats?.first_cleaning ?? profile.created_at ?? null;
-            if (!since) return null;
-            return (
-              <div style={{ fontSize: 8, fontWeight: 600, color: "#6B7280", marginTop: 1 }}>
-                Since {fmtDate(since)}
-              </div>
-            );
-          })()}
+        {/* [ltv-restyle 2026-06-18] Was a dark navy box that clashed with the
+            light card UI. Now an on-brand light card: ink value, muted label,
+            mint YTD chip — matches the rest of the profile. */}
+        <div style={{ background: "#FFFFFF", border: "1px solid #E5E2DC", borderRadius: 12, padding: "10px 16px", flexShrink: 0, display: "flex", alignItems: "center", gap: 16 }}>
+          <div>
+            <div style={{ fontSize: 9, fontWeight: 700, color: "#9E9B94", textTransform: "uppercase" as const, letterSpacing: "0.07em" }}>Lifetime Value</div>
+            <div style={{ fontSize: 22, fontWeight: 800, color: "#0A0E1A", lineHeight: 1.1, marginTop: 2 }}>${ltv.toLocaleString("en-US", { maximumFractionDigits: 0 })}</div>
+            {(() => {
+              const since = jhStats?.first_cleaning ?? profile.created_at ?? null;
+              return since ? <div style={{ fontSize: 10, fontWeight: 500, color: "#9E9B94", marginTop: 1 }}>Since {fmtDate(since)}</div> : null;
+            })()}
+          </div>
           {jhStats?.ytd_revenue != null && (
-            <div style={{ marginTop: 5, paddingTop: 5, borderTop: "1px solid rgba(255,255,255,0.12)" }}>
-              <div style={{ fontSize: 13, fontWeight: 800, color: "#86EFAC", lineHeight: 1 }}>${(jhStats.ytd_revenue as number).toLocaleString("en-US", { maximumFractionDigits: 0 })}</div>
-              <div style={{ fontSize: 8, fontWeight: 700, color: "#9CA3AF", textTransform: "uppercase" as const, letterSpacing: "0.07em", marginTop: 1 }}>{new Date().getFullYear()} YTD</div>
+            <div style={{ paddingLeft: 16, borderLeft: "1px solid #EEECE7" }}>
+              <div style={{ fontSize: 9, fontWeight: 700, color: "#9E9B94", textTransform: "uppercase" as const, letterSpacing: "0.07em" }}>{new Date().getFullYear()} YTD</div>
+              <div style={{ fontSize: 17, fontWeight: 800, color: "var(--brand, #00A383)", lineHeight: 1.1, marginTop: 2 }}>${(jhStats.ytd_revenue as number).toLocaleString("en-US", { maximumFractionDigits: 0 })}</div>
             </div>
           )}
         </div>

--- a/artifacts/qleno/src/pages/my-jobs.tsx
+++ b/artifacts/qleno/src/pages/my-jobs.tsx
@@ -852,26 +852,8 @@ export function JobCard({ job, empPos, onRefresh, isPreviewMode, actingForUserId
             Commercial
           </span>
         )}
-        {/* For cross-tenant techs the BUSINESS chip is the important one
-            (Phes vs PHES Schaumburg). Branch is intra-tenant and only
-            shows when there's no company chip to avoid double-tagging. */}
-        {job.company_name ? (
-          <span style={{
-            fontSize: 10, fontWeight: 700, padding: "2px 8px", borderRadius: 20,
-            background: "#F4F3F0", color: "#6B6860", letterSpacing: "0.02em",
-            textTransform: "uppercase",
-          }}>
-            {job.company_name}
-          </span>
-        ) : job.branch_name ? (
-          <span style={{
-            fontSize: 10, fontWeight: 700, padding: "2px 8px", borderRadius: 20,
-            background: "#F4F3F0", color: "#6B6860", letterSpacing: "0.02em",
-            textTransform: "uppercase",
-          }}>
-            {job.branch_name}
-          </span>
-        ) : null}
+        {/* [card-cleanup 2026-06-18] The company/branch chip ("PHES") was noise
+            on the tech card — they know where they work. Removed per Sal. */}
         {/* Zone chip — color dot + name so the tech knows which area they're
             headed to. A zoneless job is a data error (see zone-resolution rule). */}
         {job.zone_name && (
@@ -1644,13 +1626,6 @@ export default function MyJobsPage() {
                       style={{ opacity: 0.55, backgroundColor: "#FFFFFF", border: `1px solid ${job.zone_color || "#E5E2DC"}`, borderLeft: `3px solid ${job.zone_color || "var(--brand)"}`, borderRadius: 12, padding: 18, marginBottom: 10, cursor: "pointer" }}>
                       <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 4, flexWrap: "wrap" }}>
                         <p style={{ fontSize: 16, fontWeight: 700, color: "#1A1917", margin: 0 }}>{job.client_name}</p>
-                        {(job.company_name || job.branch_name) && (
-                          <span style={{
-                            fontSize: 10, fontWeight: 700, padding: "2px 8px", borderRadius: 20,
-                            background: "#F4F3F0", color: "#6B6860", letterSpacing: "0.02em",
-                            textTransform: "uppercase",
-                          }}>{job.company_name ?? job.branch_name}</span>
-                        )}
                       </div>
                       <p style={{ fontSize: 11, color: "var(--brand)", textTransform: "uppercase", fontWeight: 600, margin: "0 0 4px" }}>{formatServiceType(job.service_type)}</p>
                       {job.scheduled_time && <p style={{ fontSize: 12, color: "#6B6860", margin: 0 }}>{formatTime(job.scheduled_time)}</p>}
@@ -1676,9 +1651,6 @@ export default function MyJobsPage() {
                         <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 4, flexWrap: "wrap" }}>
                           <Check size={15} color="var(--brand, #2D9B83)" style={{ flexShrink: 0 }} />
                           <p style={{ fontSize: 16, fontWeight: 700, color: "#1A1917", margin: 0 }}>{job.client_name}</p>
-                          {(job.company_name || job.branch_name) && (
-                            <span style={{ fontSize: 10, fontWeight: 700, padding: "2px 8px", borderRadius: 20, background: "#F4F3F0", color: "#6B6860", letterSpacing: "0.02em", textTransform: "uppercase" }}>{job.company_name ?? job.branch_name}</span>
-                          )}
                         </div>
                         <p style={{ fontSize: 11, color: "var(--brand)", textTransform: "uppercase", fontWeight: 600, margin: "0 0 4px" }}>{formatServiceType(job.service_type)}</p>
                         {job.address && <p style={{ fontSize: 12, color: "#6B6860", margin: "2px 0 0" }}>{formatAddress(job.address, job.city, job.state, job.zip)}</p>}


### PR DESCRIPTION
## Client profile
- **Last / Next cleaning made no sense** (Next showed a date *before* Last). Both the profile and job-history endpoints now compute these with direct SQL: **Last** = most recent COMPLETE job on/before today; **Next** = soonest scheduled job on/after today. The old code derived them from a 50-row, desc-ordered in-memory slice, so a stale past `scheduled` job (or a client with many future jobs) produced a past/incorrect "Next."
- **Job Calendar legend:** `Void` → **`Cancel`** (clearer, matches the action), and the charged-cancel **`Cxl Fee`** chip is now shown in the legend.
- **Lifetime Value box restyled** from the dark navy box (which clashed with the light card UI) to an on-brand light card — ink value, muted label, mint YTD.

## Tech job card
- Removed the company/branch (**"PHES"**) chip — noise; the tech knows where they work. Dropped from the main card and the Up Next / Completed Today rows.

Frontend + api-server build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PiXXwFgtNSnzZQy3MTjAj

---
_Generated by [Claude Code](https://claude.ai/code/session_019PiXXwFgtNSnzZQy3MTjAj)_