### PR TITLE
Fix removed tech lingering on dispatch board; guard last/next cleaning dates

### DIFF
--- a/artifacts/api-server/src/routes/jobs.ts
+++ b/artifacts/api-server/src/routes/jobs.ts
@@ -4218,6 +4218,14 @@ router.delete("/:id/technicians/:techId", requireAuth, async (req, res) => {
       && Boolean((removingRow.rows[0] as any).is_primary);
 
     let newPrimary: number | null = null;
+    // [remove-mirror-fix 2026-06-18] Re-point assigned_user_id whenever the
+    // removed tech IS the job's current primary — keyed on assigned_user_id, NOT
+    // only the job_technicians.is_primary flag. A split-brain row (assigned to
+    // the tech but is_primary=false) otherwise left assigned_user_id pointing at
+    // the removed tech, so the dispatch board's assigned_user_id fallback kept
+    // the chip in their row even after a successful remove (Sal: "removed
+    // Alejandra, still in her bar").
+    const removingCurrentPrimary = wasRemovingPrimary || techId === Number(oldAssignedUserId);
 
     await db.transaction(async (tx) => {
       await tx.execute(sql`
@@ -4225,12 +4233,12 @@ router.delete("/:id/technicians/:techId", requireAuth, async (req, res) => {
         WHERE job_id = ${jobId} AND user_id = ${techId} AND company_id = ${companyId}
       `);
 
-      if (wasRemovingPrimary) {
+      if (removingCurrentPrimary) {
         // Promote next remaining tech (oldest by row id). Could be no rows left.
         const remaining = await tx.execute(sql`
           SELECT user_id FROM job_technicians
           WHERE job_id = ${jobId}
-          ORDER BY id ASC LIMIT 1
+          ORDER BY is_primary DESC, id ASC LIMIT 1
         `);
         if (remaining.rows.length > 0) {
           newPrimary = Number((remaining.rows[0] as any).user_id);
@@ -4245,9 +4253,14 @@ router.delete("/:id/technicians/:techId", requireAuth, async (req, res) => {
           WHERE id = ${jobId} AND company_id = ${companyId}
         `);
       }
+    });
 
-      // Audit row.
-      const userRows = await tx.execute(sql`
+    // [remove-resilience 2026-06-18] Audit + pay recompute AFTER commit, each
+    // non-fatal — same hardening as reassign-tech (#563). The removal + mirror
+    // are the load-bearing writes; an audit/pay hiccup must never roll them back
+    // (which would 500 and leave the chip stuck).
+    try {
+      const userRows = await db.execute(sql`
         SELECT first_name, last_name, email FROM users WHERE id = ${userId} LIMIT 1
       `);
       const u = (userRows.rows[0] as any) ?? {};
@@ -4256,25 +4269,29 @@ router.delete("/:id/technicians/:techId", requireAuth, async (req, res) => {
       const summary = {
         action: "tech_removed",
         removed_user_id: techId,
-        was_primary: wasRemovingPrimary,
+        was_primary: removingCurrentPrimary,
         new_primary_user_id: newPrimary,
-        mirrored_to_assigned_user_id: wasRemovingPrimary,
+        mirrored_to_assigned_user_id: removingCurrentPrimary,
         previous_assigned_user_id: oldAssignedUserId,
       };
-      await tx.execute(sql`
+      await db.execute(sql`
         INSERT INTO job_audit_log
           (job_id, company_id, user_id, user_name, user_email,
            field_name, old_value, new_value, cascade_scope, schedule_id)
         VALUES
           (${jobId}, ${companyId}, ${userId}, ${actorName}, ${actorEmail},
            'tech_removed',
-           ${JSON.stringify({ removed_user_id: techId, was_primary: wasRemovingPrimary, assigned_user_id: oldAssignedUserId })}::jsonb,
+           ${JSON.stringify({ removed_user_id: techId, was_primary: removingCurrentPrimary, assigned_user_id: oldAssignedUserId })}::jsonb,
            ${JSON.stringify(summary)}::jsonb,
            'this_job', ${null})
       `);
-    });
+    } catch (auditErr) {
+      console.error("remove-technician audit log failed (non-fatal):", auditErr);
+    }
 
-    const result = await calculateTechPay(jobId, companyId);
+    let result: Awaited<ReturnType<typeof calculateTechPay>> = [];
+    try { result = await calculateTechPay(jobId, companyId); }
+    catch (payErr) { console.error("remove-technician pay recompute failed (non-fatal):", payErr); }
     return res.json({ data: result });
   } catch (err) {
     console.error("DELETE /jobs/:id/technicians/:techId error:", err);

--- a/artifacts/qleno/src/pages/customer-profile.tsx
+++ b/artifacts/qleno/src/pages/customer-profile.tsx
@@ -3114,8 +3114,14 @@ function ProfileHero({ client, stats, jhStats, recurringSchedule, onSchedule, on
   const isRecurring = jhStats?.is_recurring ?? (client.service_type === "recurring" || (client.frequency && client.frequency !== "on_demand"));
   const freqBadge = recurringSchedule?.frequency ? (FREQ_LABELS[recurringSchedule.frequency] || recurringSchedule.frequency) : (client.frequency ? (FREQ_LABELS[client.frequency] || freqLabel(client.frequency)) : null);
   const ltv = jhStats ? jhStats.total_revenue : (stats?.revenue_all_time || 0);
-  const lastCleaning = jhStats?.last_cleaning ?? stats?.last_cleaning;
-  const nextCleaning = jhStats?.next_cleaning ?? stats?.next_cleaning;
+  // [last-next-clamp 2026-06-18] A "next cleaning" can never be in the past and
+  // "last" never in the future — guard the display regardless of what the stats
+  // endpoints return (stale/odd rows otherwise produced "Next: yesterday").
+  const _todayStr = (() => { const d = new Date(); return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`; })();
+  const _rawLast = jhStats?.last_cleaning ?? stats?.last_cleaning;
+  const _rawNext = jhStats?.next_cleaning ?? stats?.next_cleaning;
+  const lastCleaning = _rawLast && String(_rawLast).slice(0, 10) <= _todayStr ? _rawLast : null;
+  const nextCleaning = _rawNext && String(_rawNext).slice(0, 10) >= _todayStr ? _rawNext : null;
   const initials = `${client.first_name?.[0] || ""}${client.last_name?.[0] || ""}`;
 
   return (
@@ -5445,8 +5451,13 @@ export default function CustomerProfilePage() {
 
   const jhStats = jhData?.stats || null;
   const ltv = jhStats?.total_revenue ?? profile.stats?.revenue_all_time ?? 0;
-  const lastCleaning = jhStats?.last_cleaning ?? profile.stats?.last_cleaning;
-  const nextCleaning = jhStats?.next_cleaning ?? profile.stats?.next_cleaning;
+  // [last-next-clamp 2026-06-18] Last ≤ today, Next ≥ today — never show a past
+  // "next" or a future "last" no matter what the stats endpoints return.
+  const _todayStr = (() => { const d = new Date(); return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`; })();
+  const _rawLast = jhStats?.last_cleaning ?? profile.stats?.last_cleaning;
+  const _rawNext = jhStats?.next_cleaning ?? profile.stats?.next_cleaning;
+  const lastCleaning = _rawLast && String(_rawLast).slice(0, 10) <= _todayStr ? _rawLast : null;
+  const nextCleaning = _rawNext && String(_rawNext).slice(0, 10) >= _todayStr ? _rawNext : null;
   const initials = `${profile.first_name?.[0] || ""}${profile.last_name?.[0] || ""}`.toUpperCase();
   const isRecurring = jhStats?.is_recurring ?? (profile.service_type === "recurring" || (profile.frequency && profile.frequency !== "on_demand"));
   const freqBadge = recurringSchedule?.frequency


### PR DESCRIPTION
## Removed tech still showing on the board
Removing a tech who was the job's `assigned_user_id` but whose `job_technicians` row was flagged `is_primary=false` (a split-brain) deleted the row but **left `assigned_user_id` pointing at them** — so the dispatch board's `assigned_user_id` fallback kept the chip in their lane even after a successful remove ("removed Alejandra, still in her bar").

Fix: re-point `assigned_user_id` (promote next remaining tech, or NULL) whenever the removed tech is the current primary **by `assigned_user_id`**, not only by the `is_primary` flag. Also moved the audit insert + pay recompute **out of the transaction** (non-fatal), the same hardening applied to reassign-tech in #563, so an audit/pay hiccup can't roll back the removal.

## Last / Next cleaning dates
Guard the display so **Next** is never a past date and **Last** never a future one, regardless of what the stats endpoints return — a stale row was surfacing "Next: yesterday." (The backend now computes these correctly too, from #566; this is the belt-and-suspenders on the display.)

Frontend + api-server build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PiXXwFgtNSnzZQy3MTjAj

---
_Generated by [Claude Code](https://claude.ai/code/session_019PiXXwFgtNSnzZQy3MTjAj)_