### PR TITLE
One status vocabulary across dispatch + client-calendar legends

### DIFF
--- a/artifacts/qleno/src/components/legend-popover.tsx
+++ b/artifacts/qleno/src/components/legend-popover.tsx
@@ -11,16 +11,19 @@ import { JobVisualStatus, STATUS_VISUALS, ensureJobStatusStyles, mutedFill } fro
 
 const FF = "'Plus Jakarta Sans', sans-serif";
 
+// [legend-cohesion 2026-06-18] Only states that ACTUALLY render on the dispatch
+// board. Cancelled + charged-cancel/lockout jobs are excluded from the board
+// (they live on the client-profile calendar), so they're not in this legend —
+// the client calendar documents those, using the SAME words (Cancelled,
+// Lockout, Cancel fee) so the team learns one vocabulary, not two.
 const STATUS_ORDER: JobVisualStatus[] = [
   "scheduled",
   "active",
   "en_route",
   "completed",
   "completed_unpaid",
-  "charged_cancel",
   "late_clockin",
   "no_show",
-  "cancelled",
   "unassigned",
 ];
 

--- a/artifacts/qleno/src/pages/customer-profile.tsx
+++ b/artifacts/qleno/src/pages/customer-profile.tsx
@@ -4842,17 +4842,17 @@ function ReferralsCard({ clientId, referrals, refetch, showToast }: {
 
 // ─── Job Calendar ──────────────────────────────────────────────────────────────
 const STATUS_CHIP: Record<string, { bg: string; border: string; text: string; label: string; tooltip: string }> = {
-  scheduled:  { bg: "#DBEAFE", border: "#3B82F6", text: "#1D4ED8", label: "Book",  tooltip: "Booked — Service appointment scheduled" },
+  scheduled:  { bg: "#DBEAFE", border: "#3B82F6", text: "#1D4ED8", label: "Scheduled", tooltip: "Scheduled — service appointment booked" },
   complete:   { bg: "#DCFCE7", border: "#22C55E", text: "#15803D", label: "Done",  tooltip: "Done — Service completed" },
   completed:  { bg: "#DCFCE7", border: "#22C55E", text: "#15803D", label: "Done",  tooltip: "Done — Service completed" },
   invoiced:   { bg: "#DCFCE7", border: "#22C55E", text: "#15803D", label: "Done",  tooltip: "Done — Service completed" },
-  cancelled:  { bg: "#FEE2E2", border: "#EF4444", text: "#DC2626", label: "Cancel", tooltip: "Cancelled — visit cancelled (no fee)" },
+  cancelled:  { bg: "#FEE2E2", border: "#EF4444", text: "#DC2626", label: "Cancelled", tooltip: "Cancelled — visit cancelled (no fee)" },
   bumped:     { bg: "#FED7AA", border: "#F97316", text: "#C2410C", label: "Moved", tooltip: "Moved — Job rescheduled to another date" },
-  skipped:    { bg: "#F3F4F6", border: "#9CA3AF", text: "#6B7280", label: "Skip",  tooltip: "Skip — Client skipped this visit" },
-  lockout:    { bg: "#F3E8E8", border: "#7B2D2D", text: "#7B2D2D", label: "Lock",  tooltip: "Lock Out — Technician could not access the property" },
+  skipped:    { bg: "#F3F4F6", border: "#9CA3AF", text: "#6B7280", label: "Skipped",  tooltip: "Skipped — Client skipped this visit" },
+  lockout:    { bg: "#F3E8E8", border: "#7B2D2D", text: "#7B2D2D", label: "Lockout",  tooltip: "Lockout — Technician could not access the property" },
   // Charged cancel/lockout (job.status stays 'complete' for revenue) — resolved
   // from cancel_action so the calendar reads the truth, not "Done".
-  cancelled_fee: { bg: "#FEF3C7", border: "#F59E0B", text: "#B45309", label: "Cxl Fee", tooltip: "Cancelled — fee charged (not a completed visit)" },
+  cancelled_fee: { bg: "#FEF3C7", border: "#F59E0B", text: "#B45309", label: "Cancel fee", tooltip: "Cancelled — fee charged (not a completed visit)" },
 };
 // A charged cancel/lockout is stored status='complete'; resolve it to the right
 // chip key off cancel_action so the day doesn't read "Done".


### PR DESCRIPTION
The team was learning two legends with different words for the same things (dispatch board vs client-profile Job Calendar). This unifies them onto **one vocabulary**.

- **Client calendar labels now match the dispatch wording:** `Book → Scheduled`, `Cancel → Cancelled`, `Skip → Skipped`, `Lock → Lockout`, `Cxl Fee → Cancel fee`. (Done/Moved already matched.)
- **Dispatch board legend trimmed to what actually renders there** — removed `Cancelled` and `Lockout / Cancel fee`, since #564 took those jobs off the board. They now live only on the client-profile calendar, using the same words.

Net: each legend is a subset of one shared vocabulary, not a separate dialect. Frontend builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PiXXwFgtNSnzZQy3MTjAj

---
_Generated by [Claude Code](https://claude.ai/code/session_019PiXXwFgtNSnzZQy3MTjAj)_