### PR TITLE
fix(lms-admin): completed learners show "Completed" pill, not "X days overdue"

### DIFF
--- a/artifacts/qleno/src/pages/lms-admin.tsx
+++ b/artifacts/qleno/src/pages/lms-admin.tsx
@@ -843,7 +843,7 @@ function RosterTable({
                   </div>
                 </Td>
                 <Td>
-                  <DaysBadge days={r.days_remaining} />
+                  <DaysBadge days={r.days_remaining} status={r.status} />
                 </Td>
                 <Td>
                   <span style={{ color: INK_MUTE, fontSize: 13 }}>
@@ -1679,7 +1679,7 @@ function RosterCards({
               ({r.passed_count}/{r.total_modules})
             </span>
             <span style={{ marginLeft: "auto" }}>
-              <DaysBadge days={r.days_remaining} />
+              <DaysBadge days={r.days_remaining} status={r.status} />
             </span>
           </div>
           <div style={{ fontSize: 12, color: INK_MUTE }}>
@@ -1888,7 +1888,33 @@ function StatusPill({ status }: { status: RosterRow["status"] }) {
   );
 }
 
-function DaysBadge({ days }: { days: number | null }) {
+function DaysBadge({ days, status }: { days: number | null; status?: "active" | "completed" | "expired" }) {
+  // [lms-admin 2026-06-18] Sal report: Jose / Francisco / Maribel show
+  // 100% (13/13) Completed but the days-remaining badge still rendered
+  // "9 days overdue" because the component never read status. Once a
+  // learner is completed the countdown is moot — short-circuit to a
+  // green Completed pill. Same EmojiPill chrome the other states use.
+  if (status === "completed") {
+    return (
+      <span
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 6,
+          background: "#ECFDF5",
+          color: SUCCESS,
+          border: `1px solid #BBF7D0`,
+          padding: "3px 8px",
+          borderRadius: 999,
+          fontSize: 11,
+          fontWeight: 700,
+          whiteSpace: "nowrap",
+        }}
+      >
+        <CircleCheck size={11} /> Completed
+      </span>
+    );
+  }
   let tone = SUCCESS;
   let bg = "#ECFDF5";
   let Icon: typeof CircleCheck = CircleCheck;


### PR DESCRIPTION
## Problem

Sal screenshot 2026-06-18 ~7:16 PM: on `/lms/admin`, three learners with 100% (13/13) Completed still showed an overdue badge:

- **Jose Ardila** — Completed, 100% (13/13), badge says *"6 days overdue"*
- **Francisco Estevez** — Completed, 100% (13/13), badge says *"9 days overdue"*
- **Maribel Castillo** — Completed, 100% (13/13), badge says *"9 days overdue"*

## Root cause

`DaysBadge` (lms-admin.tsx:1891) takes only `days: number | null`. It never reads enrollment status. `days_remaining` stays negative after the deadline passes regardless of whether the learner finished, so the component cheerfully renders "X days overdue" on top of a 100% progress bar.

## Fix

Added optional `status` prop. When `status === "completed"` it short-circuits to a green **Completed** pill (mint background, `CircleCheck` icon — same visual chrome as the other states for consistency). Both call sites (line 846 + 1682) now pass `r.status`.

## Files
- `artifacts/qleno/src/pages/lms-admin.tsx` — `DaysBadge` + 2 call sites

## Verification
- Frontend tsc flat at baseline (zero new errors)
- No backend / schema change

After deploy: Jose / Francisco / Maribel show **"✓ Completed"** in green, no more misleading "9 days overdue."

https://claude.ai/code/session_013rJ4N4vgqZWB986x8D6Ahh

---
_Generated by [Claude Code](https://claude.ai/code/session_013rJ4N4vgqZWB986x8D6Ahh)_