### PR TITLE
Allow adding/editing techs on completed jobs (payroll reconciliation)

### DIFF
--- a/artifacts/api-server/src/routes/jobs.ts
+++ b/artifacts/api-server/src/routes/jobs.ts
@@ -1629,13 +1629,17 @@ router.patch("/:id", requireAuth, async (req, res) => {
     // down (audit-trail preserved), so the heads-up was just friction.
 
     // ── In-progress guard: open timeclock blocks date/time/team edits ──────
+    // Only for jobs still in flight. A COMPLETED job must stay editable (the
+    // office reconciles tech assignments + times after the fact for payroll —
+    // CLAUDE.md), and such jobs can carry a dangling open clock entry that
+    // would otherwise wrongly block "add a tech to a completed job" (Sal).
     const tcRows = await db.execute(sql`
       SELECT user_id FROM timeclock
       WHERE job_id = ${jobId} AND clock_out_at IS NULL
       LIMIT 1
     `);
     const isClockedIn = tcRows.rows.length > 0;
-    if (isClockedIn) {
+    if (isClockedIn && !isCompleted) {
       const blockedFields: string[] = [];
       if (scheduled_date !== undefined && scheduled_date !== before.scheduled_date) blockedFields.push("scheduled_date");
       if (scheduled_time !== undefined && scheduled_time !== before.scheduled_time) blockedFields.push("scheduled_time");

--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -2125,9 +2125,9 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
                     </span>
                   ))}
                   {canManageCommission && (
-                    <button onClick={() => !isLocked && setAddTechOpen(true)}
-                      disabled={isLocked}
-                      style={{ display: "inline-flex", alignItems: "center", gap: 4, padding: "3px 9px", fontSize: 11, fontWeight: 700, color: isLocked ? "#9E9B94" : "#2D9B83", border: `1px dashed ${isLocked ? "#D1D5DB" : "#2D9B83"}`, borderRadius: 999, background: "transparent", cursor: isLocked ? "not-allowed" : "pointer", fontFamily: FF, opacity: isLocked ? 0.6 : 1 }}>
+                    <button onClick={() => job.status !== "cancelled" && setAddTechOpen(true)}
+                      disabled={job.status === "cancelled"}
+                      style={{ display: "inline-flex", alignItems: "center", gap: 4, padding: "3px 9px", fontSize: 11, fontWeight: 700, color: job.status === "cancelled" ? "#9E9B94" : "#2D9B83", border: `1px dashed ${job.status === "cancelled" ? "#D1D5DB" : "#2D9B83"}`, borderRadius: 999, background: "transparent", cursor: job.status === "cancelled" ? "not-allowed" : "pointer", fontFamily: FF, opacity: job.status === "cancelled" ? 0.6 : 1 }}>
                       <Plus size={11} /> Add tech
                     </button>
                   )}
@@ -2467,9 +2467,13 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
                   return `${label} job · ${t === "hourly" ? "hourly pay per tech" : "commission % per tech"}`;
                 })()}
               </div>
-              <button onClick={() => !isLocked && setAddTechOpen(true)}
-                disabled={isLocked}
-                style={{ marginTop: 8, width: "100%", height: 32, display: "flex", alignItems: "center", justifyContent: "center", gap: 6, fontSize: 12, fontWeight: 600, color: isLocked ? "#9E9B94" : "#2D9B83", border: `1px dashed ${isLocked ? "#D1D5DB" : "#2D9B83"}`, borderRadius: 8, background: "transparent", cursor: isLocked ? "not-allowed" : "pointer", fontFamily: FF, opacity: isLocked ? 0.6 : 1 }}>
+              {/* [add-tech-on-complete 2026-06-18] Team is editable on completed
+                  jobs — the office reconciles who actually worked, for payroll
+                  (Sal: "job is complete but I can't add another tech"). Only a
+                  cancelled job blocks it. */}
+              <button onClick={() => job.status !== "cancelled" && setAddTechOpen(true)}
+                disabled={job.status === "cancelled"}
+                style={{ marginTop: 8, width: "100%", height: 32, display: "flex", alignItems: "center", justifyContent: "center", gap: 6, fontSize: 12, fontWeight: 600, color: job.status === "cancelled" ? "#9E9B94" : "#2D9B83", border: `1px dashed ${job.status === "cancelled" ? "#D1D5DB" : "#2D9B83"}`, borderRadius: 8, background: "transparent", cursor: job.status === "cancelled" ? "not-allowed" : "pointer", fontFamily: FF, opacity: job.status === "cancelled" ? 0.6 : 1 }}>
                 <Plus size={12} /> Add tech
               </button>
             </PS>


### PR DESCRIPTION
## "Job is complete but I can't add another tech, and I need to"
A completed job couldn't take an additional tech — the panel's **+ Add tech** was greyed out and the edit-modal team save was blocked — even though the office legitimately needs to record who actually worked, after the fact, for payroll.

- **Frontend:** the panel's **+ Add tech** buttons are now enabled on completed jobs; only a **cancelled** job blocks team edits.
- **Backend:** the in-progress guard (an open timeclock blocks date/time/team edits) now applies **only to non-completed jobs**. A completed job can carry a dangling open clock entry, which was wrongly tripping the guard and 409'ing the team save. Completed jobs stay editable for reconciliation (matches the codebase's own rule about fixing tech/clock data post-completion).

## The "makes no sense" data on that job
The screenshots show a split-brain: the **panel** lists **Hilda Gallegos** (from `jobs.assigned_user_id`) while the **edit modal** shows **Maryury Colmenares** as Primary (from `job_technicians`), and it claims **"2 techs"** while only one is actually assigned. This PR gives the office the tool to fix it: re-saving the team on the (now-editable) completed job replaces `job_technicians` and re-mirrors `assigned_user_id`, reconciling both sides. Add the tech who actually worked and Save — the counts and primary will line up.

Frontend + api-server build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PiXXwFgtNSnzZQy3MTjAj

---
_Generated by [Claude Code](https://claude.ai/code/session_019PiXXwFgtNSnzZQy3MTjAj)_