### PR TITLE
Recurring horizon 365→90 days to curb Postgres volume growth

### DIFF
--- a/artifacts/api-server/src/lib/recurring-jobs.ts
+++ b/artifacts/api-server/src/lib/recurring-jobs.ts
@@ -11,12 +11,15 @@ import {
 
 // [scheduling-engine 2026-04-29] Rolling generation window.
 // [recurring-perpetual 2026-06-17] Extended 90 → 365 so a recurring schedule
-// always has ~1 year of visits on the books from "today" — set-it-and-forget-it,
-// the way HCP perpetuates. The nightly 2 AM cron re-runs with this horizon and
-// the idempotent dedupe in generateJobsFromSchedule only adds the new days that
-// rolled into range, so the year-ahead window slides forward daily and never
-// runs out (until the schedule's end_date or cancellation).
-export const DAYS_AHEAD = 365;
+// always has ~1 year of visits on the books from "today".
+// [recurring-horizon-trim 2026-06-19] Back to 90. The 365-day horizon
+// materialized ~260 weekday jobs PER recurring client at once (+ technician /
+// add-on rows + per-edit cascade audit rows), which filled the Postgres volume
+// to 98% in production. 90 days is still perpetual — the nightly 2 AM cron
+// slides the window forward daily and the idempotent dedupe only adds the new
+// days that rolled into range, so a schedule never runs out — but it keeps ~75%
+// fewer future rows on disk at any moment.
+export const DAYS_AHEAD = 90;
 
 function mapServiceType(raw: string | null): string {
   if (!raw) return "recurring";


### PR DESCRIPTION
Production Postgres volume hit 98% full (Railway alert). The most likely driver is the 1-year recurring horizon (#540), which pre-creates ~260 weekday jobs **per recurring client** at once, plus technician/add-on rows and per-edit cascade audit rows.

This drops the rolling materialization window **365 → 90 days**. Still perpetual — the nightly 2 AM cron slides the window forward daily and the idempotent dedupe only adds newly-in-range days, so schedules never run out — but it keeps **~75% fewer future job rows** on disk at any moment, stopping the runaway growth.

Note: this does **not** delete already-materialized far-future jobs (out to 365). That's a separate, reviewed cleanup I'll do once we confirm the table sizes — see the diagnostic SQL in the chat.

api-server builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PiXXwFgtNSnzZQy3MTjAj

---
_Generated by [Claude Code](https://claude.ai/code/session_019PiXXwFgtNSnzZQy3MTjAj)_