### PR TITLE
fix(dispatch): surface real Postgres error in storage-audit/prune (#574 follow-up)

### DIFF
--- a/artifacts/api-server/src/routes/dispatch.ts
+++ b/artifacts/api-server/src/routes/dispatch.ts
@@ -1406,8 +1406,15 @@ router.get("/storage-audit", requireAuth, dispatchOfficeGate, async (req, res) =
       })),
     });
   } catch (err) {
+    const cause: any = (err as any)?.cause ?? err;
     console.error("Storage audit error:", err);
-    return res.status(500).json({ error: "Internal Server Error", message: err instanceof Error ? err.message : "Failed to run audit" });
+    return res.status(500).json({
+      error: "Internal Server Error",
+      message: err instanceof Error ? err.message : "Failed to run audit",
+      // [outage-diagnostic 2026-06-19] Surface the underlying Postgres error so
+      // a missing relation/column is visible without direct DB access.
+      pg: { message: cause?.message, code: cause?.code, detail: cause?.detail, table: cause?.table, column: cause?.column, routine: cause?.routine },
+    });
   }
 });
 
@@ -1444,8 +1451,14 @@ router.post("/prune-far-future", requireAuth, requireRole("owner", "super_admin"
 
     return res.json({ dry_run: false, deleted: ids.length, cutoff_days: cutoffDays });
   } catch (err) {
+    const cause: any = (err as any)?.cause ?? err;
     console.error("Prune far-future error:", err);
-    return res.status(500).json({ error: "Internal Server Error", message: err instanceof Error ? err.message : "Failed to prune" });
+    return res.status(500).json({
+      error: "Internal Server Error",
+      message: err instanceof Error ? err.message : "Failed to prune",
+      // [outage-diagnostic 2026-06-19] Surface the underlying Postgres error.
+      pg: { message: cause?.message, code: cause?.code, detail: cause?.detail, table: cause?.table, column: cause?.column, routine: cause?.routine },
+    });
   }
 });
 


### PR DESCRIPTION
Follow-up to #574 (Track C storage reclamation). The `storage-audit` query fails against the production schema, but the endpoint only returns Drizzle's generic `Failed query` wrapper — hiding which relation/column prod is missing. Direct prod DB introspection is out of scope for this session, so this surfaces the underlying Postgres error (`message/code/detail/table/column/routine`) in the 500 response + logs, to pinpoint the gap before running the destructive prune.

Diagnostic-only; no query logic changed. Once the real cause is known, the precise fix lands on this same branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)