### PR TITLE
Standardize recurring-frequency labels to plain language everywhere

### DIFF
--- a/artifacts/api-server/src/lib/frequency-labels.ts
+++ b/artifacts/api-server/src/lib/frequency-labels.ts
@@ -1,0 +1,31 @@
+/**
+ * Canonical recurring-frequency display labels (server side).
+ *
+ * MIRRORS artifacts/qleno/src/lib/frequency-labels.ts — the frontend and API
+ * are separate packages so the map is duplicated, but the wording MUST stay
+ * identical. Plain, customer-friendly language everywhere: "Every 2 Weeks" /
+ * "Every 4 Weeks", never "Biweekly"/"Monthly" (Sal's call 2026-06-19). The DB
+ * enum values are unchanged — this is display-only.
+ */
+export const FREQUENCY_LABELS: Record<string, string> = {
+  weekly: "Weekly",
+  biweekly: "Every 2 Weeks",
+  every_2_weeks: "Every 2 Weeks",
+  every_3_weeks: "Every 3 Weeks",
+  monthly: "Every 4 Weeks",
+  every_4_weeks: "Every 4 Weeks",
+  semi_monthly: "Twice a Month",
+  daily: "Daily",
+  weekdays: "Weekdays",
+  custom_days: "Custom Days",
+  custom: "Custom",
+  on_demand: "One-Time",
+  onetime: "One-Time",
+  one_time: "One-Time",
+};
+
+/** Display label for a stored frequency value; falls back to the raw value. */
+export function frequencyLabel(freq?: string | null): string {
+  if (!freq) return "";
+  return FREQUENCY_LABELS[freq] ?? freq;
+}

--- a/artifacts/api-server/src/lib/quote-pricing.ts
+++ b/artifacts/api-server/src/lib/quote-pricing.ts
@@ -1,5 +1,6 @@
 import { db } from "@workspace/db";
 import { sql } from "drizzle-orm";
+import { frequencyLabel } from "./frequency-labels.js";
 
 // [multi-frequency Pass1] Single shared quote-pricing engine + frequency-options
 // builder. Mirrors the authenticated /api/pricing/calculate conventions (the
@@ -110,12 +111,13 @@ export async function computeQuotePricing(opts: {
   };
 }
 
-// The customer-facing tiers, in display order. Labels are generic/multi-tenant.
+// The customer-facing tiers, in display order. Labels via the canonical map
+// (lib/frequency-labels) so they match the quote builder + booking widget.
 const TIERS: Array<{ frequency: string; label: string; recurring: boolean }> = [
-  { frequency: "onetime",  label: "One-time",      recurring: false },
-  { frequency: "weekly",   label: "Weekly",        recurring: true },
-  { frequency: "biweekly", label: "Every 2 weeks", recurring: true },
-  { frequency: "monthly",  label: "Every 4 weeks", recurring: true },
+  { frequency: "onetime",  label: frequencyLabel("onetime"),  recurring: false },
+  { frequency: "weekly",   label: frequencyLabel("weekly"),   recurring: true },
+  { frequency: "biweekly", label: frequencyLabel("biweekly"), recurring: true },
+  { frequency: "monthly",  label: frequencyLabel("monthly"),  recurring: true },
 ];
 
 export type FrequencyOption = {

--- a/artifacts/api-server/src/routes/form-templates.ts
+++ b/artifacts/api-server/src/routes/form-templates.ts
@@ -13,7 +13,7 @@ const PHES_RESIDENTIAL_SCHEMA = [
   { id: "f_city_state_zip", type: "text", label: "City, State, Zip", required: true, variable: "client_city_state_zip" },
   { id: "f_phone", type: "tel", label: "Cell Phone", required: true, variable: "client_phone" },
   { id: "f_email", type: "email", label: "Email Address", required: true, variable: "client_email" },
-  { id: "f_frequency", type: "select", label: "Service Frequency", required: true, variable: "service_frequency", options: ["Weekly", "Bi-Weekly", "Monthly", "One-Time"] },
+  { id: "f_frequency", type: "select", label: "Service Frequency", required: true, variable: "service_frequency", options: ["Weekly", "Every 2 Weeks", "Every 4 Weeks", "One-Time"] },
   { id: "f_entry", type: "select", label: "How do we gain entrance?", required: true, variable: "entry_method", options: ["Client home at time of cleaning", "Garage code", "Key in lockbox", "Key provided to PHES", "Door left unlocked"] },
   { id: "f_contact_tech_change", type: "select", label: "If technician changes, notify via:", required: false, variable: "contact_tech_change", options: ["Text", "Email", "Phone call", "No preference"] },
   { id: "f_contact_during", type: "select", label: "Preferred contact during service:", required: false, variable: "contact_during", options: ["Text", "Phone call", "Do not contact unless emergency"] },
@@ -185,7 +185,7 @@ router.post("/seed-defaults", requireAuth, async (req, res) => {
           { id: "f_address", type: "text", label: "Property Address", required: true, variable: "property_address" },
           { id: "f_phone", type: "tel", label: "Phone", required: true, variable: "contact_phone" },
           { id: "f_email", type: "email", label: "Email", required: true, variable: "contact_email" },
-          { id: "f_frequency", type: "select", label: "Service Frequency", required: true, variable: "service_frequency", options: ["Daily", "Weekly", "Bi-Weekly", "Monthly"] },
+          { id: "f_frequency", type: "select", label: "Service Frequency", required: true, variable: "service_frequency", options: ["Daily", "Weekly", "Every 2 Weeks", "Every 4 Weeks"] },
           { id: "f_scope", type: "textarea", label: "Scope of Work", required: true, variable: "scope_of_work" },
         ] as any,
         terms_body: `COMMERCIAL CLEANING AGREEMENT

--- a/artifacts/qleno/src/components/edit-job-modal.tsx
+++ b/artifacts/qleno/src/components/edit-job-modal.tsx
@@ -19,6 +19,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { X, AlertTriangle, Loader2 } from "lucide-react";
 import { CalendarPopover } from "@/components/calendar-popover";
 import { useAuthStore } from "@/lib/auth";
+import { freqOptions } from "@/lib/frequency-labels";
 import { useToast } from "@/hooks/use-toast";
 
 const FF = "'Plus Jakarta Sans', sans-serif";
@@ -173,13 +174,12 @@ function normalizeTimeStr(t: string | null | undefined): string {
   return `${m[1].padStart(2, "0")}:${m[2]}`;
 }
 
-const FREQUENCIES_STANDARD: Array<{ value: string; label: string }> = [
-  { value: "on_demand", label: "One-time" },
-  { value: "weekly", label: "Weekly" },
-  { value: "biweekly", label: "Biweekly" },
-  { value: "every_3_weeks", label: "Every 3 weeks" },
-  { value: "monthly", label: "Every 4 weeks / Monthly" },
-];
+// Labels come from the canonical map (lib/frequency-labels) so this dropdown
+// stays in sync with dispatch, quotes, and the booking widget.
+const FREQUENCIES_STANDARD = freqOptions([
+  "on_demand", "weekly", "biweekly", "every_3_weeks", "monthly",
+]);
+// Commercial multi-day keeps its parenthetical hints (office-only context).
 const FREQUENCIES_COMMERCIAL_MULTI: Array<{ value: string; label: string }> = [
   { value: "daily",       label: "Daily (every day)" },
   { value: "weekdays",    label: "Weekdays (M–F)" },

--- a/artifacts/qleno/src/components/job-wizard.tsx
+++ b/artifacts/qleno/src/components/job-wizard.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from "react";
 import { CalendarPopover } from "@/components/calendar-popover";
 import { getAuthHeaders } from "@/lib/auth";
+import { frequencyLabel } from "@/lib/frequency-labels";
 import { formatAddress } from "@/lib/format-address";
 import { useAddressAutocomplete } from "@/hooks/use-address-autocomplete";
 import { useBranch } from "@/contexts/branch-context";
@@ -72,15 +73,17 @@ const TIME_OPTIONS = [
 // future tenant needs a custom cadence the right move is to
 // extend the engine, not a DB table.
 type FreqApplies = "residential" | "commercial";
+// Labels via canonical map (lib/frequency-labels); weekdays keeps its (M–F)
+// hint since this dropdown is the commercial scheduling surface.
 const FREQ_OPTIONS: { value: string; label: string; applies_to: FreqApplies[] }[] = [
-  { value: "on_demand",      label: "One Time",         applies_to: ["residential", "commercial"] },
-  { value: "weekly",         label: "Weekly",           applies_to: ["residential", "commercial"] },
-  { value: "biweekly",       label: "Bi-weekly",        applies_to: ["residential", "commercial"] },
-  { value: "every_3_weeks",  label: "Every 3 weeks",    applies_to: ["residential", "commercial"] },
-  { value: "monthly",        label: "Every 4 weeks",    applies_to: ["residential", "commercial"] },
-  { value: "daily",          label: "Daily",            applies_to: ["commercial"] },
-  { value: "weekdays",       label: "Weekdays (M–F)",   applies_to: ["commercial"] },
-  { value: "custom_days",    label: "Custom days",      applies_to: ["commercial"] },
+  { value: "on_demand",      label: frequencyLabel("on_demand"),     applies_to: ["residential", "commercial"] },
+  { value: "weekly",         label: frequencyLabel("weekly"),        applies_to: ["residential", "commercial"] },
+  { value: "biweekly",       label: frequencyLabel("biweekly"),      applies_to: ["residential", "commercial"] },
+  { value: "every_3_weeks",  label: frequencyLabel("every_3_weeks"), applies_to: ["residential", "commercial"] },
+  { value: "monthly",        label: frequencyLabel("monthly"),       applies_to: ["residential", "commercial"] },
+  { value: "daily",          label: frequencyLabel("daily"),         applies_to: ["commercial"] },
+  { value: "weekdays",       label: "Weekdays (M–F)",                applies_to: ["commercial"] },
+  { value: "custom_days",    label: frequencyLabel("custom_days"),   applies_to: ["commercial"] },
 ];
 
 const STATUS_LABELS: Record<string, string> = {

--- a/artifacts/qleno/src/lib/frequency-labels.ts
+++ b/artifacts/qleno/src/lib/frequency-labels.ts
@@ -1,0 +1,68 @@
+/**
+ * Canonical recurring-frequency display labels — single source of truth.
+ *
+ * Sal's rule (2026-06-19): every surface shows recurring cadence in plain,
+ * customer-friendly language. No "Biweekly" (ambiguous — many read it as
+ * twice a week) and no "Monthly" for the 4-week cadence (misleads a customer
+ * into expecting the same calendar date). Online quotes set the standard;
+ * the office screens now match them.
+ *
+ *   weekly        → "Weekly"
+ *   biweekly      → "Every 2 Weeks"
+ *   every_3_weeks → "Every 3 Weeks"
+ *   monthly       → "Every 4 Weeks"   (Phes runs 28-day cycles, not calendar
+ *   every_4_weeks → "Every 4 Weeks"    months; both collapse to one label)
+ *
+ * The DB enum values (weekly / biweekly / every_3_weeks / monthly / …) are
+ * UNCHANGED — this is display-only. Any surface that renders a frequency MUST
+ * route through here. Do NOT inline a new freqMap — that is exactly the drift
+ * (Biweekly vs Every 2 Weeks vs Every 2 weeks) this file exists to kill.
+ */
+export const FREQUENCY_LABELS: Record<string, string> = {
+  weekly: "Weekly",
+  biweekly: "Every 2 Weeks",
+  every_2_weeks: "Every 2 Weeks",
+  every_3_weeks: "Every 3 Weeks",
+  monthly: "Every 4 Weeks",
+  every_4_weeks: "Every 4 Weeks",
+  semi_monthly: "Twice a Month",
+  daily: "Daily",
+  weekdays: "Weekdays",
+  custom_days: "Custom Days",
+  custom: "Custom",
+  on_demand: "One-Time",
+  onetime: "One-Time",
+  one_time: "One-Time",
+};
+
+/** Values that mean "not recurring" — callers can gate on an empty label. */
+const NON_RECURRING = new Set(["on_demand", "onetime", "one_time"]);
+
+/**
+ * Display label for a stored frequency value. Falls back to the raw value
+ * when unknown so a new enum value is still visible (and obviously needs a
+ * label added here) rather than silently blank.
+ */
+export function frequencyLabel(freq?: string | null): string {
+  if (!freq) return "";
+  return FREQUENCY_LABELS[freq] ?? freq;
+}
+
+/**
+ * Like frequencyLabel but returns "" for one-time / on-demand, so dispatch
+ * and list cards can show a recurrence chip only when the job actually
+ * repeats.
+ */
+export function recurrenceLabel(freq?: string | null): string {
+  if (!freq || NON_RECURRING.has(freq)) return "";
+  return frequencyLabel(freq);
+}
+
+/**
+ * Build ordered [{ value, label }] dropdown options from a list of enum
+ * values, each labeled through the canonical map. Keeps every selector's
+ * value set local while guaranteeing the labels stay consistent.
+ */
+export function freqOptions(values: string[]): Array<{ value: string; label: string }> {
+  return values.map((value) => ({ value, label: frequencyLabel(value) }));
+}

--- a/artifacts/qleno/src/pages/book.tsx
+++ b/artifacts/qleno/src/pages/book.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { useRoute } from "wouter";
 import { Phone, Mail, Clock, MapPin, CheckCircle2, AlertCircle, ChevronLeft, ChevronRight, Minus, Plus, Calendar, Tag } from "lucide-react";
 import { CalendarPopover } from "@/components/calendar-popover";
+import { frequencyLabel } from "@/lib/frequency-labels";
 
 // ── API base (public, no auth) ───────────────────────────────────────────────
 const API = import.meta.env.BASE_URL.replace(/\/$/, "");
@@ -991,10 +992,9 @@ export default function BookPage() {
     setUpsellTermsOpen(false); setUpsellCadenceError(false);
   }
 
-  // ── Frequency label helper ────────────────────────────────────────────────
+  // ── Frequency label helper (canonical — lib/frequency-labels) ──────────────
   function wLabel(f: string) {
-    const m: Record<string, string> = { onetime: "One-Time", weekly: "Weekly", biweekly: "Every 2 Weeks", monthly: "Every 4 Weeks" };
-    return m[f] || f;
+    return frequencyLabel(f) || f;
   }
 
   // ── Shared styles ─────────────────────────────────────────────────────────

--- a/artifacts/qleno/src/pages/company/pricing.tsx
+++ b/artifacts/qleno/src/pages/company/pricing.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { getAuthHeaders } from "@/lib/auth";
+import { frequencyLabel } from "@/lib/frequency-labels";
 import { Plus, Trash2, ChevronDown, ChevronRight, Save, ToggleLeft, ToggleRight, Edit2, X, Check, Tag } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { CalendarPopover } from "@/components/calendar-popover";
@@ -139,12 +140,11 @@ interface Addon { id: number; name: string; price: string | null; price_type: st
 interface Discount { id: number; code: string; description: string; discount_type: string; discount_value: string; is_active: boolean; }
 interface FeeRule { id: number; rule_type: string; label: string; charge_percent: string; tech_split_percent: string; window_hours: number | null; is_active: boolean; }
 
-const FREQUENCIES = [
-  { frequency: "onetime", label: "One Time" },
-  { frequency: "weekly", label: "Weekly" },
-  { frequency: "biweekly", label: "Bi-Weekly" },
-  { frequency: "monthly", label: "Monthly" },
-];
+// Labels via canonical map (lib/frequency-labels) for cross-app consistency.
+const FREQUENCIES = ["onetime", "weekly", "biweekly", "monthly"].map((frequency) => ({
+  frequency,
+  label: frequencyLabel(frequency),
+}));
 
 // ── Main Component ─────────────────────────────────────────────────────────────
 

--- a/artifacts/qleno/src/pages/customer-profile.tsx
+++ b/artifacts/qleno/src/pages/customer-profile.tsx
@@ -4,6 +4,7 @@ import { useRoute, useLocation } from "wouter";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { DashboardLayout } from "@/components/layout/dashboard-layout";
 import { getAuthHeaders, getTokenRole } from "@/lib/auth";
+import { FREQUENCY_LABELS, frequencyLabel } from "@/lib/frequency-labels";
 import { formatAddress } from "@/lib/format-address";
 import { CalendarPopover } from "@/components/calendar-popover";
 import {
@@ -861,7 +862,7 @@ function OverviewTab({ client, onUpdate, refetch }: { client: any; onUpdate: (da
     } catch { /* silent */ }
     finally { setVoiding(false); }
   };
-  const cadenceLabel = (c: string) => ({ weekly: "Weekly", biweekly: "Every 2 Weeks", monthly: "Every 4 Weeks" }[c] ?? c);
+  const cadenceLabel = (c: string) => frequencyLabel(c) || c;
   const lockDaysLeft = rateLock?.active && rateLock?.lock_expires_at
     ? Math.max(0, Math.ceil((new Date(rateLock.lock_expires_at).getTime() - Date.now()) / 86400000))
     : null;
@@ -2459,7 +2460,7 @@ function RecurringTab({ clientId }: { clientId: number }) {
     refetch();
   }
 
-  const FREQ_LABELS: Record<string, string> = { weekly: "Every week", biweekly: "Every 2 weeks", monthly: "Monthly", custom: "Custom", semi_monthly: "Twice a month", every_3_weeks: "Every 3 weeks" };
+  const FREQ_LABELS: Record<string, string> = { ...FREQUENCY_LABELS, custom: "Custom" };
   const DAY_LABELS: Record<string, string> = { monday: "Mon", tuesday: "Tue", wednesday: "Wed", thursday: "Thu", friday: "Fri", saturday: "Sat", sunday: "Sun" };
 
   return (
@@ -2964,22 +2965,14 @@ function TechAvatar({ name, size = 24 }: { name: string; size?: number }) {
   );
 }
 
-// [PR #58] Plain-English frequency labels. Operator-facing strings —
-// reads like how you'd describe the cadence to a customer on the phone.
-// Canonical enum values stay the same in DB.
+// Canonical plain-language frequency labels (lib/frequency-labels) so the
+// recurring-schedule dropdown matches dispatch, quotes, and the booking
+// widget. Keep the descriptive hints for custom / weekdays since this is a
+// scheduling dropdown. Canonical enum values stay the same in DB.
 const FREQ_LABELS: Record<string, string> = {
-  weekly: "Every week",
-  biweekly: "Every 2 weeks",
-  every_3_weeks: "Every 3 weeks",
-  monthly: "Monthly",
-  semi_monthly: "Twice a month",
+  ...FREQUENCY_LABELS,
   custom: "Custom (every N weeks)",
-  on_demand: "One-time",
-  // [AI.1] Commercial multi-day frequencies. Surfaced in dropdowns when
-  // the client is commercial; hidden for residential clients.
-  daily: "Daily",
   weekdays: "Weekdays (M–F)",
-  custom_days: "Custom days",
 };
 
 // [PR #58] Frequency options for residential / standard recurring. Order

--- a/artifacts/qleno/src/pages/customers.tsx
+++ b/artifacts/qleno/src/pages/customers.tsx
@@ -3,6 +3,7 @@ import { useIsMobile } from "@/hooks/use-mobile";
 import { useLocation } from "wouter";
 import { DashboardLayout } from "@/components/layout/dashboard-layout";
 import { getAuthHeaders } from "@/lib/auth";
+import { frequencyLabel } from "@/lib/frequency-labels";
 import { useQuery, keepPreviousData } from "@tanstack/react-query";
 import { useBranch } from "@/contexts/branch-context";
 import { toast } from "sonner";
@@ -26,8 +27,7 @@ function fmtDate(d?: string | null) {
 
 function freqLabel(f?: string | null) {
   if (!f) return null;
-  const m: Record<string, string> = { weekly: "Weekly", biweekly: "Bi-weekly", monthly: "Monthly", on_demand: "On Demand" };
-  return m[f] || f;
+  return frequencyLabel(f) || f;
 }
 
 function tierColor(tier: string) {

--- a/artifacts/qleno/src/pages/jobs-list.tsx
+++ b/artifacts/qleno/src/pages/jobs-list.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { useQuery, useQueryClient, useInfiniteQuery } from "@tanstack/react-query";
 import { DashboardLayout } from "@/components/layout/dashboard-layout";
 import { getAuthHeaders } from "@/lib/auth";
+import { FREQUENCY_LABELS } from "@/lib/frequency-labels";
 import { formatAddress } from "@/lib/format-address";
 import { useBranch } from "@/contexts/branch-context";
 import { Link } from "wouter";
@@ -63,10 +64,8 @@ const SERVICE_LABELS: Record<string, string> = {
   medical_office: "Medical", ppm_turnover: "PPM Turnover", post_event: "Post Event",
 };
 
-const FREQ_LABELS: Record<string, string> = {
-  weekly: "Weekly", biweekly: "Biweekly", every_3_weeks: "Every 3 Wks",
-  monthly: "Monthly", on_demand: "One Time",
-};
+// Canonical plain-language labels — see lib/frequency-labels.
+const FREQ_LABELS = FREQUENCY_LABELS;
 
 // ── Period presets ────────────────────────────────────────────────────────────
 function getDateRange(preset: string): { from: string; to: string } {

--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -6,6 +6,7 @@ import { getAuthHeaders, useAuthStore } from "@/lib/auth";
 import { useBranch } from "@/contexts/branch-context";
 import { useToast } from "@/hooks/use-toast";
 import { mapsDirectionsUrl } from "@/lib/format-address";
+import { FREQUENCY_LABELS, frequencyLabel } from "@/lib/frequency-labels";
 import { JobWizard } from "@/components/job-wizard";
 import EditJobModal from "@/components/edit-job-modal";
 import {
@@ -130,18 +131,14 @@ function fmtTime(t: string | null): string {
 }
 function fmtSvc(s: string) { return s.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase()); }
 
-// [freq-consistency 2026-06-08] Canonical recurring-frequency label — ONE source
-// of truth so the Gantt chip, hover card, repeat-badge, and panel header never
-// disagree. monthly AND every_4_weeks both read "Monthly" (Sal's call). Returns
+// [freq-consistency 2026-06-19] Canonical recurring-frequency labels live in
+// lib/frequency-labels (plain language everywhere — "Every 2/4 Weeks", never
+// "Biweekly"/"Monthly"). monthly AND every_4_weeks both read "Every 4 Weeks".
+// Keep the fmtSvc fallback for any value not yet in the shared map; returns
 // "" for non-recurring so callers can gate on it.
-const RECURRENCE_LABELS: Record<string, string> = {
-  weekly: "Weekly", biweekly: "Biweekly", every_2_weeks: "Biweekly",
-  every_3_weeks: "Every 3 Weeks", monthly: "Monthly", every_4_weeks: "Monthly",
-  daily: "Daily", weekdays: "Weekdays", custom_days: "Custom Days",
-};
 function recurrenceLabel(f?: string | null): string {
   if (!f || f === "on_demand") return "";
-  return RECURRENCE_LABELS[f] ?? fmtSvc(f);
+  return FREQUENCY_LABELS[f] ?? fmtSvc(f);
 }
 
 // [hotfix 2026-04-29 / closes #4] Walk up the DOM to find the nearest
@@ -163,17 +160,11 @@ function getScrollParent(el: HTMLElement | null): HTMLElement | null {
 }
 
 // [X] scopeLabel — card-facing "scope" label. Prefers frequency when the
-// job is recurring (Weekly / Biweekly / Every 4 Weeks), falls back to
+// job is recurring (Weekly / Every 2 Weeks / Every 4 Weeks), falls back to
 // service_type when one-off. Matches MC's Job Schedule card convention.
 function scopeLabel(job: { service_type?: string | null; frequency?: string | null }): string {
-  const FREQ: Record<string, string> = {
-    weekly: "Weekly",
-    biweekly: "Biweekly",
-    every_3_weeks: "Every 3 Weeks",
-    monthly: "Monthly",
-    every_4_weeks: "Monthly",
-  };
-  if (job.frequency && FREQ[job.frequency]) return FREQ[job.frequency];
+  const RECURRING_FREQS = ["weekly", "biweekly", "every_3_weeks", "monthly", "every_4_weeks"];
+  if (job.frequency && RECURRING_FREQS.includes(job.frequency)) return frequencyLabel(job.frequency);
   const SVC: Record<string, string> = {
     standard_clean: "Standard Clean",
     deep_clean: "Deep Clean",

--- a/artifacts/qleno/src/pages/my-jobs.tsx
+++ b/artifacts/qleno/src/pages/my-jobs.tsx
@@ -10,6 +10,7 @@ import { ChangePasswordModal } from "@/components/change-password-modal";
 import { useEmployeeView } from "@/contexts/employee-view-context";
 import { getJobVisualStatus, STATUS_VISUALS, ensureJobStatusStyles } from "@/lib/job-status";
 import { formatAddress, mapsDirectionsUrl } from "@/lib/format-address";
+import { FREQUENCY_LABELS as CANONICAL_FREQUENCY_LABELS } from "@/lib/frequency-labels";
 import { VoiceAssistant } from "@/components/voice-assistant";
 import { QlenoMark } from "@/components/brand/QlenoMark";
 import { QuoteAttachments } from "@/components/quote-attachments";
@@ -174,13 +175,10 @@ function formatServiceType(s: string) {
   return s.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
 }
 
-// Cadence labels, MaidCentral-style ("Every Two Weeks"), keyed by the
-// frequency enum. Unknown values title-case as a fallback.
-const FREQUENCY_LABELS: Record<string, string> = {
-  weekly: "Weekly", biweekly: "Every 2 Weeks", every_3_weeks: "Every 3 Weeks",
-  monthly: "Every 4 Weeks", semi_monthly: "Twice a Month", on_demand: "One-Time",
-  daily: "Daily", weekdays: "Weekdays", custom_days: "Custom Days",
-};
+// Cadence labels come from the canonical map (lib/frequency-labels) so the
+// tech view matches dispatch, quotes, and the booking widget. Unknown values
+// title-case as a fallback.
+const FREQUENCY_LABELS = CANONICAL_FREQUENCY_LABELS;
 export function frequencyLabel(f: string | null | undefined): string | null {
   if (!f) return null;
   return FREQUENCY_LABELS[f] ?? f.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());

--- a/artifacts/qleno/src/pages/quote-builder.tsx
+++ b/artifacts/qleno/src/pages/quote-builder.tsx
@@ -25,6 +25,7 @@ import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { calculateCommissionSplit } from "@/lib/commission";
 import { AddonIcon } from "@/lib/addon-icons";
+import { frequencyLabel } from "@/lib/frequency-labels";
 
 const API = import.meta.env.BASE_URL.replace(/\/$/, "");
 const FF = "'Plus Jakarta Sans', sans-serif";
@@ -1575,13 +1576,8 @@ export default function QuoteBuilderPage() {
 
                       {/* Results */}
                       {!clientSearchLoading && clientResults.map(c => {
-                        // Frequency label
-                        const freqMap: Record<string, string> = {
-                          weekly: "Weekly", every_2_weeks: "Biweekly", biweekly: "Biweekly",
-                          every_4_weeks: "Monthly", monthly: "Monthly",
-                          onetime: "One-Time", one_time: "One-Time",
-                        };
-                        const freqLabel = c.frequency ? (freqMap[c.frequency] ?? null) : null;
+                        // Frequency label (canonical — lib/frequency-labels)
+                        const freqLabel = c.frequency ? (frequencyLabel(c.frequency) || null) : null;
 
                         // Last service date
                         const fmtSvcDate = (d: string | null | undefined) => {
@@ -1820,8 +1816,7 @@ export default function QuoteBuilderPage() {
                           return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
                         } catch { return svc.last_date; }
                       })();
-                      const freqMap: Record<string, string> = { weekly: "Weekly", every_2_weeks: "Biweekly", biweekly: "Biweekly", every_4_weeks: "Monthly", monthly: "Monthly", onetime: "One-Time", one_time: "One-Time" };
-                      const freqLabel = svc.frequency ? (freqMap[svc.frequency] ?? svc.frequency) : null;
+                      const freqLabel = svc.frequency ? (frequencyLabel(svc.frequency) || null) : null;
                       return (
                         <div
                           key={i}

--- a/artifacts/qleno/src/pages/recurring-schedules.tsx
+++ b/artifacts/qleno/src/pages/recurring-schedules.tsx
@@ -3,6 +3,7 @@ import { Link } from "wouter";
 import { RefreshCw, Clock, Search, AlertTriangle } from "lucide-react";
 import { DashboardLayout } from "@/components/layout/dashboard-layout";
 import { getAuthHeaders } from "@/lib/auth";
+import { FREQUENCY_LABELS } from "@/lib/frequency-labels";
 import { useToast } from "@/hooks/use-toast";
 import { useIsMobile } from "@/hooks/use-mobile";
 
@@ -22,11 +23,8 @@ type Schedule = {
   is_active: boolean;
 };
 
-const FREQ_LABEL: Record<string, string> = {
-  weekly: "Weekly", biweekly: "Every 2 weeks", every_3_weeks: "Every 3 weeks",
-  monthly: "Monthly", semi_monthly: "Twice a month", custom: "Custom",
-  daily: "Daily", weekdays: "Weekdays", custom_days: "Custom days",
-};
+// Canonical plain-language labels — see lib/frequency-labels.
+const FREQ_LABEL = FREQUENCY_LABELS;
 
 function fmtTime(t: string | null) {
   if (!t) return null;

--- a/artifacts/qleno/src/pages/reports/upsell-conversion.tsx
+++ b/artifacts/qleno/src/pages/reports/upsell-conversion.tsx
@@ -2,13 +2,14 @@ import { useState } from "react";
 import { DashboardLayout } from "@/components/layout/dashboard-layout";
 import { fmt$c, fmtDate, clr, KpiCard, DateRange, ReportHeader, DataTable, useReportData } from "./_shared";
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from "recharts";
+import { frequencyLabel } from "@/lib/frequency-labels";
 
 const FF = "'Plus Jakarta Sans', sans-serif";
 
 function today() { return new Date().toISOString().split("T")[0]; }
 function daysAgo(n: number) { const d = new Date(); d.setDate(d.getDate() - n); return d.toISOString().split("T")[0]; }
 function pct(n: number, d: number) { return d === 0 ? "0%" : `${Math.round(n / d * 100)}%`; }
-function cadenceLabel(c: string) { return ({ weekly: "Weekly", biweekly: "Every 2 Weeks", monthly: "Every 4 Weeks" } as any)[c] ?? c ?? "—"; }
+function cadenceLabel(c: string) { return frequencyLabel(c) || c || "—"; }
 
 interface UpsellRow { id: number; date: string; client_name: string; cadence: string | null; upsell_accepted: boolean; upsell_declined: boolean; upsell_deferred: boolean; locked_rate: string | null; deep_clean_total: string; }
 interface UpsellData { kpi: { total_shown: number; total_accepted: number; total_declined: number; total_deferred: number }; trend: { week_label: string; shown: number; accepted: number }[]; rows: UpsellRow[]; lockHealth: { active_count: number; expiring_30: number; voided_month: number; voided_time_overrun: number; voided_service_gap: number; voided_manual: number; voided_expired: number }; }


### PR DESCRIPTION
## What & why

Recurring cadence wording had drifted across the app — the same frequency showed up three different ways:

- "Every 2 Weeks" vs **"Biweekly"** vs "Every 2 weeks"
- "Every 4 Weeks" vs **"Monthly"** vs "Every 4 weeks / Monthly"

This standardizes **every** surface on plain, customer-friendly language:

| Stored value | Label everywhere |
|---|---|
| `weekly` | Weekly |
| `biweekly` | Every 2 Weeks |
| `every_3_weeks` | Every 3 Weeks |
| `monthly` / `every_4_weeks` | Every 4 Weeks |

Two deliberate calls (Sal, 2026-06-19):
- **No "Biweekly"** — it's ambiguous (many read it as *twice a week*).
- **No "Monthly"** for the 4-week cadence — Phes runs a **28-day cycle**, not a calendar month, so "Monthly" would mislead a customer about when they're cleaned. `monthly` and `every_4_weeks` both collapse to **"Every 4 Weeks"**.

## How

Adds a single canonical source of truth — `lib/frequency-labels` — in **both** packages (frontend + api-server, since they don't share a module). The ~10 surfaces that each hardcoded their own freq→label map now route through it, so this can't drift again.

**DB enum values are unchanged** — this is display-only, no data migration.

## Surfaces updated
Quote builder · booking widget · dispatch/jobs board · jobs list · edit-job modal · job wizard · recurring schedules · customer profile · customers list · my-jobs (tech view) · upsell-conversion report · pricing tab · server quote-pricing tiers · intake form templates.

## Verification
- Frontend `tsc --noEmit`: no new errors from these changes (pre-existing repo-wide errors unrelated to frequency).
- Backend `tsc --noEmit`: touched files (`frequency-labels.ts`, `quote-pricing.ts`) clean; `form-templates.ts` changes are 2 string-literal edits only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY8ue5AhB2THfn3hSsSC4H

---
_Generated by [Claude Code](https://claude.ai/code/session_01XY8ue5AhB2THfn3hSsSC4H)_