### PR TITLE
feat(payroll): one-engine ADP export + in-app Publish/Export/Add-pay

### DIFF
--- a/artifacts/api-server/src/lib/pay-export.ts
+++ b/artifacts/api-server/src/lib/pay-export.ts
@@ -67,6 +67,40 @@ export function buildPayExportCsv(input: PayExportInput): string {
   return lines.join("\n") + "\n";
 }
 
+/**
+ * Shape a single period-pay record (the engine's money breakdown) into the
+ * provider-neutral export row. PURE + DB-free — the ONLY place the engine's
+ * base/tips/overtime/bonus/adjustments buckets map to the export's
+ * regular/OT/adjustments columns, so the export, the on-screen detail, and the
+ * published snapshot can never silently diverge. `gross_cents` is the literal
+ * sum of the three money columns.
+ *
+ * Mapping:
+ *   - regular_pay   = base (commission/hourly base pay from computePayLines)
+ *   - overtime_pay  = overtime additional_pay (this comp model carries OT as a
+ *                     dollar entry, not an hours decomposition, so
+ *                     overtime_hours is 0)
+ *   - adjustments   = tips + bonus + everything else (sick/holiday/mileage/etc.)
+ *   - gross         = base + tips + overtime + bonus + adjustments
+ */
+export function snapshotToExportRow(s: {
+  user_id: number; first_name: string; last_name: string;
+  base: number; hours: number; tips: number; overtime: number; bonus: number; adjustments: number; gross: number;
+}): PayExportRow {
+  const c = (n: number) => Math.round((Number(n) || 0) * 100);
+  return {
+    employee_identifier: String(s.user_id),
+    employee_first_name: s.first_name || "",
+    employee_last_name: s.last_name || "",
+    regular_hours: Number(s.hours) || 0,
+    overtime_hours: 0,
+    regular_pay_cents: c(s.base),
+    overtime_pay_cents: c(s.overtime),
+    adjustments_cents: c(s.tips) + c(s.bonus) + c(s.adjustments),
+    gross_cents: c(s.gross),
+  };
+}
+
 export function buildPayExportFilename(start: string, end: string): string {
   // Provider-neutral. No vendor string. Stable across tenants.
   return `pay-summary-${start}-${end}.csv`;

--- a/artifacts/api-server/src/lib/payroll-snapshot.ts
+++ b/artifacts/api-server/src/lib/payroll-snapshot.ts
@@ -2,6 +2,7 @@ import { db } from "@workspace/db";
 import { sql } from "drizzle-orm";
 import { computePayLines, type PayrollJob, type ClockEntry, type TechCell, type CompanyPayConfig, type HoursBasis } from "./payroll-compute.js";
 import { parseResRatesRow } from "./commission-rates.js";
+import { snapshotToExportRow, type PayExportRow } from "./pay-export.js";
 
 /**
  * Phase 2 — PUBLISH PAYROLL: snapshot each tech's computed pay for a pay period
@@ -122,6 +123,25 @@ export async function computePeriodPay(companyId: number, start: string, end: st
     addlByUser.get(uid)![String(r.type)] = parseFloat(String(r.t || 0));
   }
 
+  // Fold pay_adjustments (the 2B applied-mileage promotion + any office
+  // adjustments) into the SAME per-(user,type) map. GET /payroll/detail counts
+  // these in its grand_total, so the snapshot must too — otherwise the published
+  // number under-reports applied mileage vs. the on-screen detail. Window +
+  // additive merge mirror the /detail route exactly. Raw SQL + try/catch so a
+  // tenant without the table degrades gracefully. [one-engine 2026-06-19]
+  try {
+    for (const r of (await db.execute(sql`
+      SELECT user_id, adjustment_type, COALESCE(SUM(amount), 0) AS t FROM pay_adjustments
+      WHERE company_id = ${companyId}
+        AND created_at >= ${start} AND created_at <= ${end + " 23:59:59"}
+      GROUP BY user_id, adjustment_type`)).rows as any[]) {
+      const uid = Number(r.user_id);
+      if (!addlByUser.has(uid)) addlByUser.set(uid, {});
+      const m = addlByUser.get(uid)!;
+      m[String(r.adjustment_type)] = (m[String(r.adjustment_type)] || 0) + parseFloat(String(r.t || 0));
+    }
+  } catch { /* pay_adjustments absent for this tenant — skip */ }
+
   const byUser = new Map<number, PeriodPay>();
   for (const l of lines) {
     if (!byUser.has(l.user_id)) byUser.set(l.user_id, { user_id: l.user_id, name: userMap.get(l.user_id) || "", gross: 0, base: 0, hours: 0, tips: 0, overtime: 0, bonus: 0, adjustments: 0, jobs: [], additional_pay: {} });
@@ -162,4 +182,58 @@ export async function publishPeriod(companyId: number, start: string, end: strin
         breakdown = EXCLUDED.breakdown, published_at = now(), published_by_user_id = EXCLUDED.published_by_user_id`);
   }
   return { published: pay.length, total_gross: r2(total) };
+}
+
+/**
+ * Build the export rows for a period, ONE ENGINE end to end.
+ *
+ * Prefers the PUBLISHED snapshot (payroll_period_snapshots) so the export
+ * matches exactly what the office locked in. When a period hasn't been
+ * published yet, falls back to a LIVE computePeriodPay run (the same engine the
+ * snapshot is built from and the same one GET /payroll/detail uses) so the
+ * download still works — the returned `source` says which path produced it.
+ */
+export async function buildPeriodExportRows(
+  companyId: number, start: string, end: string,
+): Promise<{ source: "published" | "live"; rows: PayExportRow[] }> {
+  await ensurePayrollSnapshotSetup();
+  const snap = (await db.execute(sql`
+    SELECT s.user_id, u.first_name, u.last_name,
+           s.base, s.hours, s.tips, s.overtime, s.bonus, s.adjustments, s.gross
+    FROM payroll_period_snapshots s
+    LEFT JOIN users u ON u.id = s.user_id
+    WHERE s.company_id = ${companyId} AND s.pay_period_start = ${start} AND s.pay_period_end = ${end}
+    ORDER BY u.first_name, u.last_name`)).rows as any[];
+  if (snap.length) {
+    return {
+      source: "published",
+      rows: snap.map(r => snapshotToExportRow({
+        user_id: Number(r.user_id), first_name: r.first_name ?? "", last_name: r.last_name ?? "",
+        base: parseFloat(String(r.base || 0)), hours: parseFloat(String(r.hours || 0)),
+        tips: parseFloat(String(r.tips || 0)), overtime: parseFloat(String(r.overtime || 0)),
+        bonus: parseFloat(String(r.bonus || 0)), adjustments: parseFloat(String(r.adjustments || 0)),
+        gross: parseFloat(String(r.gross || 0)),
+      })),
+    };
+  }
+  // Not published yet — compute live off the same engine.
+  const pay = await computePeriodPay(companyId, start, end);
+  const nameById = new Map<number, { first: string; last: string }>();
+  const ids = pay.map(p => p.user_id);
+  if (ids.length) {
+    for (const u of (await db.execute(sql`SELECT id, first_name, last_name FROM users WHERE company_id = ${companyId} AND id = ANY(ARRAY[${sql.raw(intList(ids))}]::int[])`)).rows as any[]) {
+      nameById.set(Number(u.id), { first: u.first_name ?? "", last: u.last_name ?? "" });
+    }
+  }
+  return {
+    source: "live",
+    rows: pay
+      .sort((a, b) => (nameById.get(a.user_id)?.first || "").localeCompare(nameById.get(b.user_id)?.first || ""))
+      .map(p => snapshotToExportRow({
+        user_id: p.user_id,
+        first_name: nameById.get(p.user_id)?.first ?? p.name.split(" ")[0] ?? "",
+        last_name: nameById.get(p.user_id)?.last ?? p.name.split(" ").slice(1).join(" ") ?? "",
+        base: p.base, hours: p.hours, tips: p.tips, overtime: p.overtime, bonus: p.bonus, adjustments: p.adjustments, gross: p.gross,
+      })),
+  };
 }

--- a/artifacts/api-server/src/routes/payroll.ts
+++ b/artifacts/api-server/src/routes/payroll.ts
@@ -1348,6 +1348,58 @@ router.post("/publish", requireAuth, requireRole("owner", "admin", "office"), as
   }
 });
 
+// ── [Phase 2] PUBLISH STATUS — has this period been snapshotted? ──────────────
+// Office/admin/owner. Drives the payroll page's Publish button label + the
+// "exporting unpublished" warning. Company-wide (not per-tech). [one-engine 2026-06-19]
+router.get("/publish-status", requireAuth, requireRole("owner", "admin", "office"), async (req, res) => {
+  try {
+    const companyId = (req as any).auth!.companyId;
+    const { pay_period_start, pay_period_end } = req.query;
+    if (!pay_period_start || !pay_period_end) return res.status(400).json({ error: "pay_period_start and pay_period_end are required" });
+    const { ensurePayrollSnapshotSetup } = await import("../lib/payroll-snapshot.js");
+    await ensurePayrollSnapshotSetup();
+    const row = (await db.execute(sql`
+      SELECT COUNT(*)::int AS cnt, COALESCE(SUM(gross), 0) AS total_gross, MAX(published_at) AS published_at
+      FROM payroll_period_snapshots
+      WHERE company_id = ${companyId} AND pay_period_start = ${String(pay_period_start)} AND pay_period_end = ${String(pay_period_end)}`)).rows[0] as any;
+    const cnt = Number(row?.cnt || 0);
+    return res.json({
+      published: cnt > 0,
+      count: cnt,
+      total_gross: parseFloat(String(row?.total_gross || 0)),
+      published_at: row?.published_at ?? null,
+    });
+  } catch (err: any) {
+    console.error("GET /payroll/publish-status:", err);
+    return res.status(500).json({ error: "Internal Server Error", message: err?.message });
+  }
+});
+
+// ── [Phase 2] PAYROLL EXPORT — provider-neutral CSV for the payroll processor ─
+// Office/admin/owner only. ONE ENGINE: rows come from the published snapshot
+// when present, else a live computePeriodPay run (same engine as the on-screen
+// detail and the snapshot). Columns: identifier, name, period, regular hours,
+// OT hours, regular pay, OT pay, adjustments total, gross. [one-engine 2026-06-19]
+router.get("/export", requireAuth, requireRole("owner", "admin", "office"), async (req, res) => {
+  try {
+    const companyId = (req as any).auth!.companyId;
+    const { pay_period_start, pay_period_end } = req.query;
+    if (!pay_period_start || !pay_period_end) return res.status(400).json({ error: "pay_period_start and pay_period_end are required" });
+    const start = String(pay_period_start), end = String(pay_period_end);
+    const { buildPeriodExportRows } = await import("../lib/payroll-snapshot.js");
+    const { buildPayExportCsv, buildPayExportFilename } = await import("../lib/pay-export.js");
+    const { source, rows } = await buildPeriodExportRows(companyId, start, end);
+    const csv = buildPayExportCsv({ period_start: start, period_end: end, rows });
+    res.setHeader("Content-Type", "text/csv; charset=utf-8");
+    res.setHeader("Content-Disposition", `attachment; filename="${buildPayExportFilename(start, end)}"`);
+    res.setHeader("X-Export-Source", source); // "published" | "live" — UI can warn when exporting unpublished
+    return res.send(csv);
+  } catch (err: any) {
+    console.error("GET /payroll/export:", err);
+    return res.status(500).json({ error: "Internal Server Error", message: err?.message });
+  }
+});
+
 // ── [Phase 2] PAY HISTORY — published snapshots for the employee-profile Pay
 // section. ACCESS SCOPING: a technician sees ONLY their own; office/admin/owner
 // may pass ?user_id= to view any tech. A tech who passes someone else's id is

--- a/artifacts/api-server/src/tests/payroll-export-reconcile.test.ts
+++ b/artifacts/api-server/src/tests/payroll-export-reconcile.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Payroll ONE-ENGINE export reconciliation — pure unit tests (no DB).
+ *
+ * Defends the load-bearing promise of the one-engine wiring: the CSV the office
+ * downloads must reconcile to the cent with the published snapshot / on-screen
+ * detail. `snapshotToExportRow` is the single mapping from the engine's money
+ * breakdown to the export's regular/OT/adjustments columns, so these tests pin:
+ *
+ *   A. gross_cents is EXACTLY the sum of regular + overtime + adjustments —
+ *      the column the payroll processor totals can never drift from the parts.
+ *   B. Each engine bucket lands in the right export column (base→regular,
+ *      overtime→overtime, tips+bonus+other→adjustments).
+ *   C. Cent rounding is per-component and stable (no float drift on .005 etc).
+ *   D. The CSV row built from the mapping carries those same cent values.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { snapshotToExportRow, buildPayExportCsv } from "../lib/pay-export.js";
+
+const snap = (over: Partial<Parameters<typeof snapshotToExportRow>[0]> = {}) => ({
+  user_id: 7, first_name: "Juan", last_name: "Salazar",
+  base: 0, hours: 0, tips: 0, overtime: 0, bonus: 0, adjustments: 0, gross: 0,
+  ...over,
+});
+
+describe("snapshotToExportRow — engine→export reconciliation", () => {
+  it("A. gross_cents == regular + overtime + adjustments", () => {
+    const r = snapshotToExportRow(snap({
+      base: 836.94, tips: 45, overtime: 60.5, bonus: 100, adjustments: 12.34,
+      gross: 836.94 + 45 + 60.5 + 100 + 12.34, hours: 38.25,
+    }));
+    assert.equal(r.gross_cents, r.regular_pay_cents + r.overtime_pay_cents + r.adjustments_cents);
+    assert.equal(r.gross_cents, Math.round((836.94 + 45 + 60.5 + 100 + 12.34) * 100));
+  });
+
+  it("B. each bucket maps to the right column", () => {
+    const r = snapshotToExportRow(snap({ base: 500, overtime: 30, tips: 10, bonus: 20, adjustments: 5, gross: 565 }));
+    assert.equal(r.regular_pay_cents, 50000);
+    assert.equal(r.overtime_pay_cents, 3000);
+    assert.equal(r.adjustments_cents, 1000 + 2000 + 500); // tips + bonus + other
+    assert.equal(r.overtime_hours, 0); // OT carried as dollars, not an hours split
+    assert.equal(r.regular_hours, 0);
+  });
+
+  it("C. reconciles exactly for 2dp engine values (what the snapshot stores)", () => {
+    // computePeriodPay r2-rounds every bucket to 2dp and sets gross = sum of
+    // them, so the export's per-component rounding stays penny-exact. Awkward
+    // float values like 0.1+0.2 are the real risk this guards.
+    const base = 33.33, tips = 0.1, overtime = 0.2, bonus = 7.77, adjustments = 1.11;
+    const gross = Math.round((base + tips + overtime + bonus + adjustments) * 100) / 100;
+    const r = snapshotToExportRow(snap({ base, tips, overtime, bonus, adjustments, gross }));
+    assert.equal(r.gross_cents, r.regular_pay_cents + r.overtime_pay_cents + r.adjustments_cents);
+    assert.equal(r.gross_cents, 4251); // 33.33 + 0.10 + 0.20 + 7.77 + 1.11 = 42.51
+  });
+
+  it("D. CSV row carries the reconciled cent values", () => {
+    const r = snapshotToExportRow(snap({ base: 200, overtime: 15, tips: 5, gross: 220, hours: 8 }));
+    const csv = buildPayExportCsv({ period_start: "2026-05-31", period_end: "2026-06-06", rows: [r] });
+    const dataLine = csv.trim().split("\n")[1];
+    // …,8.00,0.00,200.00,15.00,5.00,220.00
+    assert.match(dataLine, /,8\.00,0\.00,200\.00,15\.00,5\.00,220\.00$/);
+    assert.match(dataLine, /^7,Juan,Salazar,2026-05-31,2026-06-06,/);
+  });
+});

--- a/artifacts/qleno/src/pages/payroll.tsx
+++ b/artifacts/qleno/src/pages/payroll.tsx
@@ -146,6 +146,97 @@ function PeriodPicker({ period, onPeriodChange }:
   );
 }
 
+// [one-engine 2026-06-19] Minimal per-tech / per-period entry for tips, OT,
+// bonus, and time-off pay, posting straight to the existing additional_pay
+// endpoint. Stamps created_at to the chosen date so the entry lands in the
+// right pay period (same mechanism employee-profile uses). Lets the office run
+// the whole weekly payroll from this one page instead of hopping to each
+// employee profile. Additive pay types only — deductions stay on the profile
+// where their negative-amount semantics are explicit.
+const ADD_PAY_TYPES = [
+  { v: 'tips', l: 'Tips' },
+  { v: 'overtime', l: 'Overtime' },
+  { v: 'bonus', l: 'Bonus' },
+  { v: 'sick_pay', l: 'Sick Pay' },
+  { v: 'holiday_pay', l: 'Holiday Pay' },
+  { v: 'vacation_pay', l: 'Vacation Pay' },
+  { v: 'mileage', l: 'Mileage' },
+  { v: 'compliment', l: 'Compliment' },
+];
+function AddPayModal({ employees, period, onClose, onSaved }:
+  { employees: any[]; period: { start: string; end: string }; onClose: () => void; onSaved: () => void }) {
+  const [userId, setUserId] = useState<string>('');
+  const [type, setType] = useState('tips');
+  const [amount, setAmount] = useState('');
+  const [date, setDate] = useState(period.end);
+  const [notes, setNotes] = useState('');
+  const [saving, setSaving] = useState(false);
+  const amt = parseFloat(amount);
+  const valid = userId !== '' && Number.isFinite(amt) && amt > 0 && !!date;
+  async function save() {
+    if (!valid) return;
+    setSaving(true);
+    try {
+      await apiFetch(`/users/${userId}/additional-pay`, {
+        method: 'POST',
+        body: JSON.stringify({ amount: amt.toFixed(2), type, notes: notes || null, date }),
+      });
+      onSaved();
+    } catch (e: any) {
+      window.alert(`Could not add pay: ${e?.message || e}`);
+    } finally {
+      setSaving(false);
+    }
+  }
+  const field: React.CSSProperties = { height: 38, padding: '0 12px', border: '1px solid #E5E2DC', borderRadius: 8, fontSize: 13, color: '#1A1917', background: '#fff', outline: 'none', width: '100%', fontFamily: 'inherit' };
+  const lbl: React.CSSProperties = { fontSize: 11, fontWeight: 600, color: '#9E9B94', textTransform: 'uppercase', letterSpacing: '0.06em', display: 'block', marginBottom: 5 };
+  return (
+    <div onClick={onClose} style={{ position: 'fixed', inset: 0, background: 'rgba(10,14,26,.4)', zIndex: 60, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 16 }}>
+      <div onClick={e => e.stopPropagation()} style={{ background: '#fff', borderRadius: 14, width: 420, maxWidth: '100%', boxShadow: '0 24px 70px rgba(10,14,26,.28)', overflow: 'hidden', fontFamily: 'inherit' }}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '16px 20px', borderBottom: '1px solid #EEECE7' }}>
+          <span style={{ fontSize: 15, fontWeight: 700, color: '#1A1917' }}>Add pay adjustment</span>
+          <X size={18} style={{ color: '#9E9B94', cursor: 'pointer' }} onClick={onClose} />
+        </div>
+        <div style={{ padding: 20, display: 'flex', flexDirection: 'column', gap: 14 }}>
+          <div>
+            <label style={lbl}>Employee</label>
+            <select style={field} value={userId} onChange={e => setUserId(e.target.value)}>
+              <option value="">Select employee…</option>
+              {employees.map((e: any) => (
+                <option key={e.id} value={e.id}>{e.first_name} {e.last_name}</option>
+              ))}
+            </select>
+          </div>
+          <div style={{ display: 'flex', gap: 12 }}>
+            <div style={{ flex: 1 }}>
+              <label style={lbl}>Type</label>
+              <select style={field} value={type} onChange={e => setType(e.target.value)}>
+                {ADD_PAY_TYPES.map(t => <option key={t.v} value={t.v}>{t.l}</option>)}
+              </select>
+            </div>
+            <div style={{ flex: 1 }}>
+              <label style={lbl}>Amount ($)</label>
+              <input style={field} type="number" min="0" step="0.01" value={amount} onChange={e => setAmount(e.target.value)} placeholder="0.00" />
+            </div>
+          </div>
+          <div>
+            <label style={lbl}>Effective date <span style={{ textTransform: 'none', fontWeight: 500, color: '#C4C0B8' }}>(determines pay period)</span></label>
+            <input style={field} type="date" value={date} onChange={e => setDate(e.target.value)} />
+          </div>
+          <div>
+            <label style={lbl}>Notes <span style={{ textTransform: 'none', fontWeight: 500, color: '#C4C0B8' }}>(optional)</span></label>
+            <input style={field} value={notes} onChange={e => setNotes(e.target.value)} placeholder="e.g. customer tip, weekend OT" />
+          </div>
+        </div>
+        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 10, padding: '0 20px 20px' }}>
+          <button onClick={onClose} style={{ padding: '9px 16px', border: '1px solid #E5E2DC', borderRadius: 8, background: '#fff', color: '#6B7280', fontSize: 13, fontWeight: 600, cursor: 'pointer', fontFamily: 'inherit' }}>Cancel</button>
+          <button onClick={save} disabled={!valid || saving} style={{ padding: '9px 18px', border: 'none', borderRadius: 8, background: valid && !saving ? 'var(--brand)' : '#C4C0B8', color: '#fff', fontSize: 13, fontWeight: 700, cursor: valid && !saving ? 'pointer' : 'default', fontFamily: 'inherit' }}>{saving ? 'Saving…' : 'Add pay'}</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 // Tenant pay cadence from companies.pay_cadence. Defaults to 'weekly' while
 // loading / when unset (Phes pays weekly; bi-weekly tenants opt in via Settings).
 function useCadence(): string {
@@ -716,8 +807,59 @@ export default function PayrollPage() {
   const totalHours = billableEmployees.reduce((sum: number, e: any) => sum + (payMap[e.id]?.hours ?? 0), 0);
 
   const isOwnerAdmin = ['owner','admin'].includes(getTokenRole() || '');
+  // Publish, Export, and Add-pay are office-grade actions (owner/admin/office) —
+  // same gate as the POST /payroll/publish + /payroll/export routes. [one-engine]
+  const canManagePayroll = ['owner','admin','office'].includes(getTokenRole() || '');
   const [activeView, setActiveView] = useState<'overview' | 'weekly-detail'>('weekly-detail');
   const [expandedOverview, setExpandedOverview] = useState<number[]>([]);
+
+  // ── Publish / Export / Add-pay (run weekly payroll from the app) ────────────
+  const { data: pubStatus, refetch: refetchPub } = useQuery<any>({
+    queryKey: ['payroll-publish-status', payPeriod.start, payPeriod.end],
+    queryFn: () => apiFetch(`/payroll/publish-status?pay_period_start=${payPeriod.start}&pay_period_end=${payPeriod.end}`),
+    enabled: canManagePayroll && !!payPeriod.start && !!payPeriod.end,
+  });
+  const isPublished = !!pubStatus?.published;
+  const [publishing, setPublishing] = useState(false);
+  const [exporting, setExporting] = useState(false);
+  const [showAddPay, setShowAddPay] = useState(false);
+
+  const money2s = (n: number) => Number(n).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+
+  async function handlePublish() {
+    const verb = isPublished ? 'Re-publish' : 'Publish';
+    if (!window.confirm(`${verb} payroll for ${periodLabel}?\n\nThis snapshots each employee's pay as the locked record for this period. Re-publishing overwrites the existing snapshot with current numbers.`)) return;
+    setPublishing(true);
+    try {
+      const r = await apiFetch('/payroll/publish', { method: 'POST', body: JSON.stringify({ pay_period_start: payPeriod.start, pay_period_end: payPeriod.end }) });
+      await refetchPub();
+      window.alert(`Published ${r.published} employee${r.published === 1 ? '' : 's'} for ${periodLabel}.\nTotal gross: $${money2s(r.total_gross)}`);
+    } catch (e: any) {
+      window.alert(`Publish failed: ${e?.message || e}`);
+    } finally {
+      setPublishing(false);
+    }
+  }
+
+  async function handleExport() {
+    if (!isPublished && !window.confirm(`This period hasn't been published yet. Export live (unpublished) numbers?\n\nThey match the on-screen detail but aren't locked. Publish first if you want a fixed record.`)) return;
+    setExporting(true);
+    try {
+      const resp = await fetch(`${API}/api/payroll/export?pay_period_start=${payPeriod.start}&pay_period_end=${payPeriod.end}`, { headers: { ...getAuthHeaders() } });
+      if (!resp.ok) throw new Error(`${resp.status}`);
+      const blob = await resp.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `pay-summary-${payPeriod.start}-${payPeriod.end}.csv`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (e: any) {
+      window.alert(`Export failed: ${e?.message || e}`);
+    } finally {
+      setExporting(false);
+    }
+  }
 
   // Pay Templates removed per Sal (2026-06-08): additional pay is added directly
   // on the employee profile and cascades into the payroll summary by date.
@@ -744,10 +886,46 @@ export default function PayrollPage() {
               </button>
             ))}
           </div>
-          <div style={{ fontSize: 13, color: '#6B7280', fontWeight: 500, fontFamily: 'inherit' }}>
-            Pay period: <span style={{ color: '#1A1917', fontWeight: 700 }}>{periodLabel}</span>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
+            <div style={{ fontSize: 13, color: '#6B7280', fontWeight: 500, fontFamily: 'inherit' }}>
+              Pay period: <span style={{ color: '#1A1917', fontWeight: 700 }}>{periodLabel}</span>
+            </div>
+            {canManagePayroll && (
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                {pubStatus && (
+                  <span title={isPublished && pubStatus.published_at ? `Published ${new Date(pubStatus.published_at).toLocaleString()}` : 'Not yet published'}
+                    style={{ fontSize: 11, fontWeight: 700, padding: '3px 10px', borderRadius: 999, color: isPublished ? '#00A383' : '#9E9B94', background: isPublished ? '#E9FBF5' : '#F4F3F0' }}>
+                    {isPublished ? 'Published' : 'Draft'}
+                  </span>
+                )}
+                <button onClick={() => setShowAddPay(true)}
+                  style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '7px 12px', border: '1px solid #E5E2DC', borderRadius: 8, background: '#fff', color: '#1A1917', fontSize: 13, fontWeight: 600, cursor: 'pointer', fontFamily: 'inherit' }}>
+                  <Plus size={14} strokeWidth={1.8} /> Add pay
+                </button>
+                <button onClick={handlePublish} disabled={publishing}
+                  style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '7px 14px', border: '1px solid #E5E2DC', borderRadius: 8, background: '#fff', color: '#1A1917', fontSize: 13, fontWeight: 600, cursor: publishing ? 'default' : 'pointer', fontFamily: 'inherit' }}>
+                  {publishing ? 'Publishing…' : (isPublished ? 'Re-publish' : 'Publish')}
+                </button>
+                <button onClick={handleExport} disabled={exporting}
+                  style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '7px 14px', border: 'none', borderRadius: 8, background: 'var(--brand)', color: '#fff', fontSize: 13, fontWeight: 700, cursor: exporting ? 'default' : 'pointer', fontFamily: 'inherit' }}>
+                  <Download size={14} strokeWidth={1.8} /> {exporting ? 'Exporting…' : 'Export'}
+                </button>
+              </div>
+            )}
           </div>
         </div>
+        {showAddPay && (
+          <AddPayModal
+            employees={billableEmployees}
+            period={payPeriod}
+            onClose={() => setShowAddPay(false)}
+            onSaved={() => {
+              setShowAddPay(false);
+              qc.invalidateQueries({ queryKey: ['payroll-detail'] });
+              qc.invalidateQueries({ queryKey: ['payroll-overview'] });
+            }}
+          />
+        )}
 
         {activeView === 'weekly-detail' && <WeeklyDetailView period={payPeriod} onPeriodChange={onPeriodChange} />}
 
@@ -758,22 +936,16 @@ export default function PayrollPage() {
             <Calendar size={14} strokeWidth={1.5} />
             {periodLabel}
           </button>
+          {/* One source of truth: routes through the same /payroll/export
+              (published snapshot or live computePeriodPay) as the header
+              Export button, so the CSV can never diverge from the on-screen
+              numbers. [one-engine 2026-06-19] */}
           <button
-            onClick={() => {
-              const csv = ['Employee,Role,Hours,Effective $/hr,Gross Pay',
-                ...billableEmployees.map((e: any) => {
-                  const p = payMap[e.id] || { hours: 0, gross: 0 };
-                  const eff = p.hours > 0 ? (p.gross / p.hours).toFixed(2) : '0.00';
-                  return `${e.first_name} ${e.last_name},${e.role},${p.hours.toFixed(1)},$${eff},$${p.gross.toFixed(2)}`;
-                })
-              ].join('\n');
-              const blob = new Blob([csv], { type: 'text/csv' });
-              const url = URL.createObjectURL(blob);
-              const a = document.createElement('a'); a.href = url; a.download = 'payroll.csv'; a.click();
-            }}
-            style={{ display: 'flex', alignItems: 'center', gap: '8px', padding: '8px 16px', backgroundColor: 'var(--brand)', color: '#FFFFFF', borderRadius: '8px', fontSize: '13px', fontWeight: 600, border: 'none', cursor: 'pointer', fontFamily:'inherit' }}>
+            onClick={handleExport}
+            disabled={exporting}
+            style={{ display: 'flex', alignItems: 'center', gap: '8px', padding: '8px 16px', backgroundColor: 'var(--brand)', color: '#FFFFFF', borderRadius: '8px', fontSize: '13px', fontWeight: 600, border: 'none', cursor: exporting ? 'default' : 'pointer', fontFamily:'inherit' }}>
             <Download size={14} strokeWidth={1.5} />
-            Export CSV
+            {exporting ? 'Exporting…' : 'Export CSV'}
           </button>
         </div>
 


### PR DESCRIPTION
## Goal
Let the office run weekly payroll end-to-end from the app, with the **on-screen detail, the published snapshot, and the export CSV all derived from the same `computePayLines` engine** — identical to the cent.

## What already existed
- `computePayLines` engine (`lib/payroll-compute.ts`) powering `GET /api/payroll/detail`.
- `computePeriodPay` / `publishPeriod` (`lib/payroll-snapshot.ts`) — publish already used the same engine and upserts idempotently into `payroll_period_snapshots`.
- `POST /api/payroll/publish` (owner/admin/office) — but only callable via raw API, no UI.
- `buildPayExportCsv` (`lib/pay-export.ts`) — provider-neutral CSV builder, but only wired to the separate `/api/pay` cutover-1E stack (a different engine), never to the payroll-detail engine.
- Additional-pay CRUD on the **employee profile** page.

## What this PR builds
**1. One engine for the export**
- New `GET /api/payroll/export` (owner/admin/office). Rows come from the **published snapshot** when present, else a **live `computePeriodPay`** run — the same engine as `/detail` and publish. Columns: regular hours, OT hours, regular pay, OT pay, adjustments, gross.
- `snapshotToExportRow()` — single pure/DB-free mapping from the engine's money buckets to the export columns. `gross_cents` is the literal sum of regular+OT+adjustments, so the CSV can't drift from the screen.
- `computePeriodPay` now folds `pay_adjustments` (applied mileage etc.) exactly like `/detail`, so the snapshot gross equals the detail `grand_total` (previously the snapshot under-counted applied mileage).

**2. In-app Publish** — button on the payroll page with confirmation + idempotent re-publish, plus a Draft/Published chip driven by new `GET /api/payroll/publish-status`.

**3. ADP Export route + Download button** — authenticated CSV download; warns when exporting an unpublished period. The legacy Summary-tab client-side export now routes through the same endpoint.

**4. Tips/OT/bonus/sick entry** — a per-tech / per-period **Add pay** modal on the payroll page (the existing employee-profile CRUD remains). Posts to the existing `additional_pay` endpoint; the effective date lands it in the right period.

## Verification (read-only, real co1 data, May 31–Jun 6, 94 completed jobs)
- **engine == export to the cent** for all 11 techs.
- **engine == existing published snapshot** (`MATCH`) for all 10 published techs.
- Total gross **\$8,380.82**.
- New DB-free reconciliation test (`payroll-export-reconcile.test.ts`, 4 cases) pins the export mapping; full pay-export suite stays green (54 tests).

## CI
Local: `typecheck:libs` ✓, api-server esbuild bundle ✓, frontend vite build ✓.

## Scope
No changes to `COMMS_ENABLED`, quote tools, or other branches. Draft — not deployed.