### PR TITLE
Todd fixes + dispatch board clarity (undo cancel, re-book, grid/zones/legend)

### DIFF
--- a/artifacts/api-server/src/routes/cancellation.ts
+++ b/artifacts/api-server/src/routes/cancellation.ts
@@ -2,7 +2,7 @@ import { Router } from "express";
 import { db } from "@workspace/db";
 import { cancellationLogTable, jobsTable, clientsTable, companiesTable, usersTable } from "@workspace/db/schema";
 import { eq, and, gte, lte, desc, sql, count } from "drizzle-orm";
-import { requireAuth } from "../lib/auth.js";
+import { requireAuth, requireRole } from "../lib/auth.js";
 import {
   resolveCancellationPolicy,
   CANCEL_ACTIONS,
@@ -442,6 +442,109 @@ router.post("/action", requireAuth, async (req, res) => {
     // the toast / log it for debugging.
     rescheduled_to: isReschedule ? { date: body.new_date, time: body.new_time ?? null } : undefined,
   });
+});
+
+/**
+ * POST /api/cancellations/undo — reverse a single-job cancellation.
+ *
+ * Body: { job_id }
+ *
+ * The exact inverse of the charging/free branches of /action:
+ *   - deletes the job's cancellation_log row(s) (cancel/lockout/skip),
+ *   - deletes the PENDING tech cancellation_pay for the job,
+ *   - restores the job: future-dated → 'scheduled' (the visit still happens,
+ *     billed_amount cleared so it bills normally); past-dated → 'cancelled'
+ *     at $0 (a free skip — no charge, no service), per the agreed behavior.
+ *
+ * Guardrails (return 409 instead of touching anything):
+ *   - nothing to undo (no charging/free cancellation row),
+ *   - it was a 'cancel_service' / affects_future_jobs (cascaded to other jobs
+ *     and paused the schedule — must be reversed deliberately, not here),
+ *   - the tech cancellation pay was already PAID (don't silently erase money
+ *     that went out — reverse the pay first).
+ * All in one transaction.
+ */
+router.post("/undo", requireAuth, requireRole("owner", "admin", "office"), async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId!;
+    const jobId = Number(req.body?.job_id);
+    if (!jobId || !Number.isFinite(jobId)) {
+      return res.status(400).json({ error: "Bad Request", message: "job_id required" });
+    }
+
+    const ctx = await db.execute(sql`
+      SELECT j.id,
+             (j.scheduled_date < (now() AT TIME ZONE 'America/Chicago')::date) AS is_past
+        FROM jobs j
+       WHERE j.id = ${jobId} AND j.company_id = ${companyId}
+    `);
+    const job = ctx.rows[0] as any;
+    if (!job) return res.status(404).json({ error: "Not Found", message: "Job not found" });
+
+    const logs = await db.execute(sql`
+      SELECT cancel_action, affects_future_jobs
+        FROM cancellation_log
+       WHERE job_id = ${jobId} AND company_id = ${companyId}
+         AND cancel_action IN ('cancel','lockout','skip','cancel_service')
+    `);
+    const logRows = logs.rows as any[];
+    if (logRows.length === 0) {
+      return res.status(409).json({ error: "Conflict", message: "No cancellation to undo on this job." });
+    }
+    if (logRows.some(r => r.cancel_action === "cancel_service" || r.affects_future_jobs === true)) {
+      return res.status(409).json({
+        error: "Conflict",
+        message: "This was a 'Cancel service' that ended future visits and paused the recurring schedule. Undo it manually so the schedule and future jobs are restored deliberately.",
+      });
+    }
+
+    const paid = await db.execute(sql`
+      SELECT COUNT(*)::int AS n FROM additional_pay
+       WHERE job_id = ${jobId} AND company_id = ${companyId}
+         AND type = 'cancellation_pay' AND status <> 'pending'
+    `);
+    if (Number((paid.rows[0] as any).n) > 0) {
+      return res.status(409).json({
+        error: "Conflict",
+        message: "The cancellation fee was already paid to the tech. Reverse that pay first, then undo.",
+      });
+    }
+
+    const isPast = job.is_past === true;
+    await db.transaction(async (tx) => {
+      await tx.execute(sql`
+        DELETE FROM additional_pay
+         WHERE job_id = ${jobId} AND company_id = ${companyId}
+           AND type = 'cancellation_pay' AND status = 'pending'
+      `);
+      await tx.execute(sql`
+        DELETE FROM cancellation_log
+         WHERE job_id = ${jobId} AND company_id = ${companyId}
+           AND cancel_action IN ('cancel','lockout','skip','cancel_service')
+      `);
+      const undoneNote = sql`COALESCE(notes,'') || (CASE WHEN notes IS NULL OR notes = '' THEN '' ELSE E'\n' END) || '[cancellation_undone]'`;
+      if (isPast) {
+        await tx.execute(sql`
+          UPDATE jobs
+             SET status = 'cancelled'::job_status, billed_amount = 0, locked_at = NULL,
+                 notes = ${undoneNote}
+           WHERE id = ${jobId} AND company_id = ${companyId}
+        `);
+      } else {
+        await tx.execute(sql`
+          UPDATE jobs
+             SET status = 'scheduled'::job_status, billed_amount = NULL, locked_at = NULL,
+                 notes = ${undoneNote}
+           WHERE id = ${jobId} AND company_id = ${companyId}
+        `);
+      }
+    });
+
+    return res.json({ ok: true, restored_status: isPast ? "cancelled" : "scheduled" });
+  } catch (err) {
+    console.error("[cancellations undo]", err);
+    return res.status(500).json({ error: "Server error" });
+  }
 });
 
 export default router;

--- a/artifacts/api-server/src/routes/quotes.ts
+++ b/artifacts/api-server/src/routes/quotes.ts
@@ -488,25 +488,84 @@ router.post("/:id/convert", requireAuth, requireRole("owner", "admin", "office")
 
     const isRecurring = jobFreq !== "on_demand";
     if (isRecurring && clientId) {
-      const [sched] = await db.insert(recurringSchedulesTable).values({
-        company_id: companyId,
-        customer_id: clientId,
-        frequency: jobFreq,
-        day_of_week: null, // cadence anchors on start_date's weekday when null
-        start_date: jobDate,
-        end_date: null,
-        assigned_employee_id: assigned_user_id ? parseInt(String(assigned_user_id)) : null,
-        service_type: serviceType,
-        scheduled_time: scheduled_time || null,
-        duration_minutes: chosenHours != null ? Math.round(chosenHours * 60) : null,
-        base_fee: recurringFee != null ? String(recurringFee) : null,
-        notes: q.internal_memo || null,
-      }).returning();
-
-      // [quote-convert-stickiness 2026-06-10] Persist the quote's add-ons onto
-      // the schedule template (so the edit-job cascade machinery sees them)…
+      // [rebook-preserve 2026-06-20] Re-booking an existing recurring client must
+      // NOT reset them to catalog pricing/timing or spawn a duplicate schedule.
+      // If this client already has an ACTIVE recurring schedule for the SAME
+      // service, reuse it: keep its agreed base_fee + visit length, and only
+      // layer on any NEWLY-sold add-ons (folded into the all-in residential
+      // base). A different service, or a brand-new client, still creates a
+      // fresh schedule at the quoted catalog price. Fixes: re-book dropping
+      // Todd's $220 to the $195 menu, re-book ignoring his real visit length,
+      // and re-book duplicating his recurring schedule.
       const schedAddons = quoteAddonsToJobAddOns(q.addons);
-      for (const a of schedAddons) {
+
+      const priorRows = await db.execute(sql`
+        SELECT id, base_fee, duration_minutes, scheduled_time, assigned_employee_id
+          FROM recurring_schedules
+         WHERE company_id = ${companyId} AND customer_id = ${clientId}
+           AND is_active = true AND service_type = ${serviceType}
+         ORDER BY id DESC LIMIT 1
+      `);
+      const prior = (priorRows.rows as any[])[0];
+      const reusedSchedule = !!prior;
+
+      // Which sold add-ons are genuinely new for this schedule? Idempotent —
+      // re-booking the same add-on twice can never double-charge.
+      let newAddons = schedAddons;
+      if (prior) {
+        const existingAddonRows = await db.execute(sql`
+          SELECT pricing_addon_id FROM recurring_schedule_add_ons WHERE recurring_schedule_id = ${prior.id}
+        `);
+        const have = new Set((existingAddonRows.rows as any[]).map(r => Number(r.pricing_addon_id)));
+        newAddons = schedAddons.filter(a => !have.has(Number(a.pricing_addon_id)));
+      }
+      const newAddonSubtotal = Math.round(newAddons.reduce((s, a) => s + (a.subtotal ?? 0), 0) * 100) / 100;
+
+      let sched: any;
+      let allInBase = 0;
+      if (prior) {
+        // Reuse the existing schedule. Agreed base + visit length stay exactly
+        // as-is; the only money change is folding any new add-ons into the
+        // all-in base going forward.
+        const agreedBase = prior.base_fee != null ? parseFloat(prior.base_fee) : (recurringFee ?? 0);
+        allInBase = Math.round((agreedBase + newAddonSubtotal) * 100) / 100;
+        await db.execute(sql`
+          UPDATE recurring_schedules
+             SET base_fee = ${String(allInBase)},
+                 scheduled_time = COALESCE(${scheduled_time || null}, scheduled_time),
+                 assigned_employee_id = COALESCE(${assigned_user_id ? parseInt(String(assigned_user_id)) : null}, assigned_employee_id)
+           WHERE id = ${prior.id} AND company_id = ${companyId}
+        `);
+        sched = {
+          id: Number(prior.id), company_id: companyId, customer_id: clientId,
+          frequency: jobFreq, day_of_week: null, start_date: jobDate, end_date: null,
+          assigned_employee_id: assigned_user_id ? parseInt(String(assigned_user_id)) : prior.assigned_employee_id,
+          service_type: serviceType,
+          scheduled_time: scheduled_time || prior.scheduled_time || null,
+          duration_minutes: prior.duration_minutes,
+          base_fee: String(allInBase),
+          notes: q.internal_memo || null,
+        };
+      } else {
+        [sched] = await db.insert(recurringSchedulesTable).values({
+          company_id: companyId,
+          customer_id: clientId,
+          frequency: jobFreq,
+          day_of_week: null, // cadence anchors on start_date's weekday when null
+          start_date: jobDate,
+          end_date: null,
+          assigned_employee_id: assigned_user_id ? parseInt(String(assigned_user_id)) : null,
+          service_type: serviceType,
+          scheduled_time: scheduled_time || null,
+          duration_minutes: chosenHours != null ? Math.round(chosenHours * 60) : null,
+          base_fee: recurringFee != null ? String(recurringFee) : null,
+          notes: q.internal_memo || null,
+        }).returning();
+      }
+
+      // [quote-convert-stickiness 2026-06-10] Persist the (new) add-ons onto the
+      // schedule template so the edit-job cascade machinery sees them.
+      for (const a of newAddons) {
         try {
           await db.execute(sql`
             INSERT INTO recurring_schedule_add_ons (recurring_schedule_id, pricing_addon_id, qty)
@@ -526,26 +585,46 @@ router.post("/:id/convert", requireAuth, requireRole("owner", "admin", "office")
         console.warn("[quote convert] recurring generation failed:", genErr?.message ?? genErr);
       }
 
-      // …and onto every occurrence just generated (the engine only stamps the
-      // parking fee at generation time, not schedule add-ons).
-      if (schedAddons.length) {
+      if (reusedSchedule) {
+        // Reused schedule: move every UPCOMING visit to the agreed all-in price
+        // and give it the new add-on line items. Past/completed visits are left
+        // untouched. Setting base_fee = allInBase (not a += delta) is idempotent
+        // — newly generated visits already carry allInBase, existing ones get
+        // corrected up to it, and a repeat re-book is a no-op.
         try {
-          const genRows = await db.execute(sql`SELECT id FROM jobs WHERE recurring_schedule_id = ${sched.id} AND company_id = ${companyId}`);
-          for (const row of (genRows as any).rows) {
-            await persistJobAddOns(db, Number(row.id), companyId, schedAddons);
+          const futureRows = await db.execute(sql`
+            SELECT id FROM jobs
+             WHERE recurring_schedule_id = ${sched.id} AND company_id = ${companyId}
+               AND status = 'scheduled' AND scheduled_date >= CURRENT_DATE`);
+          for (const row of (futureRows.rows as any[])) {
+            if (newAddons.length) { try { await persistJobAddOns(db, Number(row.id), companyId, newAddons); } catch { /* idempotent */ } }
+            await db.execute(sql`UPDATE jobs SET base_fee = ${String(allInBase)} WHERE id = ${Number(row.id)} AND company_id = ${companyId}`);
           }
-        } catch (e) { console.warn("[quote convert] stamping add-ons on generated jobs failed:", e); }
-      }
+        } catch (e) { console.warn("[quote convert] reuse base/add-on stamp failed:", e); }
+      } else {
+        // New schedule: stamp add-ons on every generated occurrence (the engine
+        // only stamps the parking fee at generation time, not schedule add-ons).
+        if (schedAddons.length) {
+          try {
+            const genRows = await db.execute(sql`SELECT id FROM jobs WHERE recurring_schedule_id = ${sched.id} AND company_id = ${companyId}`);
+            for (const row of (genRows as any).rows) {
+              await persistJobAddOns(db, Number(row.id), companyId, schedAddons);
+            }
+          } catch (e) { console.warn("[quote convert] stamping add-ons on generated jobs failed:", e); }
+        }
 
-      // [multi-frequency, decision d] First visit is priced at the one-time
-      // first-visit rate; recurring visits keep the schedule's recurring price.
-      if (firstVisitFee != null && firstVisitFee !== recurringFee) {
-        try {
-          await db.execute(sql`
-            UPDATE jobs SET base_fee = ${String(firstVisitFee)}
-            WHERE id = (SELECT id FROM jobs WHERE recurring_schedule_id = ${sched.id} AND company_id = ${companyId}
-                        ORDER BY scheduled_date ASC, id ASC LIMIT 1)`);
-        } catch (e) { console.warn("[quote convert] first-visit price stamp failed:", e); }
+        // [multi-frequency, decision d] First visit is priced at the one-time
+        // first-visit rate; recurring visits keep the schedule's recurring price.
+        // Only for a genuinely NEW schedule — a reused one keeps the client's
+        // agreed price on every visit.
+        if (firstVisitFee != null && firstVisitFee !== recurringFee) {
+          try {
+            await db.execute(sql`
+              UPDATE jobs SET base_fee = ${String(firstVisitFee)}
+              WHERE id = (SELECT id FROM jobs WHERE recurring_schedule_id = ${sched.id} AND company_id = ${companyId}
+                          ORDER BY scheduled_date ASC, id ASC LIMIT 1)`);
+          } catch (e) { console.warn("[quote convert] first-visit price stamp failed:", e); }
+        }
       }
       logAudit(req, "CONVERTED", "quote", id, null, { status: "booked", recurring_schedule_id: sched.id, jobs_generated: generated.created });
       import("../services/followUpService.js").then(({ stopEnrollmentsForQuote }) => {

--- a/artifacts/qleno/src/components/legend-popover.tsx
+++ b/artifacts/qleno/src/components/legend-popover.tsx
@@ -11,6 +11,14 @@ import { JobVisualStatus, STATUS_VISUALS, ensureJobStatusStyles, mutedFill } fro
 
 const FF = "'Plus Jakarta Sans', sans-serif";
 
+// [legend-zone-clarity 2026-06-20] Real tiles are colored by the job's ZONE,
+// not its status — status shows through the stripe / badge / border / opacity
+// markings ON TOP of the zone color. The legend used each status's own swatch
+// as the tile fill, so it never matched the board ("legend not working"). Use a
+// single neutral zone stand-in here so the markings are what distinguish the
+// rows, and tell the reader the real fill is the zone.
+const ZONE_STANDIN = "#BCC7D6";
+
 // [legend-cohesion 2026-06-18] Only states that ACTUALLY render on the dispatch
 // board. Cancelled + charged-cancel/lockout jobs are excluded from the board
 // (they live on the client-profile calendar), so they're not in this legend —
@@ -36,7 +44,7 @@ function ExampleTile({ status }: { status: JobVisualStatus }) {
     <div style={{
       display: "flex", alignItems: "stretch", gap: 6, width: 96, height: 44,
       borderRadius: 6, padding: 4, position: "relative",
-      backgroundColor: v.fillMuted ? mutedFill(v.swatch) : v.swatch, opacity: v.bodyOpacity,
+      backgroundColor: v.fillMuted ? mutedFill(ZONE_STANDIN) : ZONE_STANDIN, opacity: v.bodyOpacity,
       filter: v.desaturate ? "grayscale(1)" : "none",
       border: v.borderOverride ? `1.5px solid ${v.borderOverride}` : "1px solid rgba(0,0,0,0.08)",
       flexShrink: 0,
@@ -160,6 +168,9 @@ export default function LegendPopover({ open, onClose, mobile, anchorRect }: {
               <X size={18} color="#6B6860" />
             </button>
           </div>
+          <div style={{ fontSize: 12, color: "#9E9B94", marginBottom: 8, lineHeight: 1.45 }}>
+            Each tile's fill color is the job's <strong style={{ color: "#6B6860" }}>zone</strong> (see the Zones filter). The stripe, badge, border, and fading below show its <strong style={{ color: "#6B6860" }}>status</strong>.
+          </div>
           {rows}
         </div>
       </>
@@ -182,8 +193,8 @@ export default function LegendPopover({ open, onClose, mobile, anchorRect }: {
           <X size={14} color="#6B6860" />
         </button>
       </div>
-      <div style={{ fontSize: 11, color: "#9E9B94", marginBottom: 6 }}>
-        How job tiles appear on the dispatch board.
+      <div style={{ fontSize: 11, color: "#9E9B94", marginBottom: 6, lineHeight: 1.45 }}>
+        Each tile's fill color is the job's <strong style={{ color: "#6B6860" }}>zone</strong> (see the Zones filter). The stripe, badge, border, and fading below show its <strong style={{ color: "#6B6860" }}>status</strong>.
       </div>
       {rows}
     </div>

--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -2098,7 +2098,13 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
               <div style={{ display: "flex", gap: 8, marginBottom: 16 }}>
                 <Tile label="Billed" value={fmtUSD(billed)} />
                 <Tile label="Commission" value={hasComm ? fmtUSD(commTotal) : "—"} color="#2D9B83" />
-                <Tile label="Hours" value={allowed != null ? `${allowed.toFixed(1)}h` : "—"} sub={techCount > 1 && perTechAllowed != null ? `${perTechAllowed.toFixed(1)}h/tech · ${techCount} techs` : "allowed"} />
+                {/* [rebook-preserve 2026-06-20] Lead with the time ON THE CLOCK
+                    (allowed ÷ techs) like MaidCentral, not the summed person-
+                    hours — otherwise a 2-tech job reads "5.0h" and looks like
+                    the crew wasn't counted. Total labor moves to the sub-line. */}
+                <Tile label="Hours"
+                  value={allowed != null ? `${(techCount > 1 && perTechAllowed != null ? perTechAllowed : allowed).toFixed(1)}h` : "—"}
+                  sub={techCount > 1 && perTechAllowed != null ? `on clock · ${allowed.toFixed(1)}h total · ${techCount} techs` : "allowed"} />
               </div>
             );
           })()}

--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -5176,7 +5176,10 @@ function EmployeeRow({ employee, onChipClick, nowLine }: { employee: Employee; o
         </div>
       </div>
       <div ref={setNodeRef} style={{ position: "relative", width: TOTAL_SLOTS * SLOT_W, flexShrink: 0, height: rowHeight, backgroundColor: isOver ? "rgba(91,155,213,0.05)" : "transparent", transition: "background-color 0.1s" }}>
-        {TIMES.map((_, i) => <div key={i} style={{ position: "absolute", left: i * SLOT_W, top: 0, bottom: 0, borderRight: i % 2 === 1 ? "1px solid #E5E2DC" : "1px solid #EEECE7" }} />)}
+        {/* [grid-clarity 2026-06-20] Read time at a glance: solid darker line at
+            each hour, faint dotted line at the half-hour, and a subtle tint on
+            alternating hour bands so the eye groups each hour. */}
+        {TIMES.map((_, i) => <div key={i} style={{ position: "absolute", left: i * SLOT_W, top: 0, bottom: 0, width: SLOT_W, pointerEvents: "none", backgroundColor: Math.floor(i / 2) % 2 === 1 ? "rgba(120,110,90,0.045)" : "transparent", borderRight: i % 2 === 1 ? "1px solid #CBC7BF" : "1px dotted #E9E7E2" }} />)}
         {/* Time-off band sits behind job chips (zIndex 0) */}
         {timeOffBg && (
           <div style={{ position: "absolute", left: getBandLeft(), width: getBandWidth(), top: 0, bottom: 0, backgroundColor: timeOffBg, zIndex: 0, pointerEvents: "none" }} />
@@ -5216,7 +5219,7 @@ function UnassignedGanttRow({ jobs, onChipClick, nowLine }: { jobs: DispatchJob[
         </div>
       </div>
       <div style={{ position: "relative", width: TOTAL_SLOTS * SLOT_W, flexShrink: 0, height: rowHeight, backgroundColor: "#FFFBEB88" }}>
-        {TIMES.map((_, i) => <div key={i} style={{ position: "absolute", left: i * SLOT_W, top: 0, bottom: 0, borderRight: i % 2 === 1 ? "1px solid #FDE68A" : "1px solid #FEF3C7" }} />)}
+        {TIMES.map((_, i) => <div key={i} style={{ position: "absolute", left: i * SLOT_W, top: 0, bottom: 0, width: SLOT_W, pointerEvents: "none", backgroundColor: Math.floor(i / 2) % 2 === 1 ? "rgba(180,120,20,0.05)" : "transparent", borderRight: i % 2 === 1 ? "1px solid #F2CE73" : "1px dotted #FCEBB8" }} />)}
         {nowLine >= 0 && nowLine <= TOTAL_SLOTS * SLOT_W && <div style={{ position: "absolute", left: nowLine, top: 0, bottom: 0, width: 2, backgroundColor: "#EF4444", zIndex: 3, pointerEvents: "none" }} />}
         {jobs.map(j => <JobChip key={j.id} job={j} onClick={onChipClick} isUnassigned top={topById.get(j.id) ?? 10} />)}
       </div>
@@ -6226,6 +6229,24 @@ export default function JobsPage() {
   }
   function chipLeft(job: DispatchJob) { return ((timeToMins(job.scheduled_time) - DAY_START) / 30) * SLOT_W; }
 
+  // [zone-branch-grouping 2026-06-20] Zone dropdown options scoped to the
+  // selected branch. With a branch chosen, only that branch's zones show. With
+  // "All Branches", zones are grouped under Oak Lawn / Schaumburg headers (and
+  // an "Other" group for any zone not yet mapped to a branch) so the two
+  // locations aren't mashed into one flat list.
+  const zoneGroups = (() => {
+    const visible = zones.filter(z => selectedBranchFilter === "all" || z.location === selectedBranchFilter);
+    if (selectedBranchFilter !== "all") return [{ label: null as string | null, zones: visible }];
+    const oak = visible.filter(z => z.location === "oak_lawn");
+    const sch = visible.filter(z => z.location === "schaumburg");
+    const other = visible.filter(z => z.location !== "oak_lawn" && z.location !== "schaumburg");
+    const groups: { label: string | null; zones: typeof zones }[] = [];
+    if (oak.length) groups.push({ label: "Oak Lawn", zones: oak });
+    if (sch.length) groups.push({ label: "Schaumburg", zones: sch });
+    if (other.length) groups.push({ label: groups.length ? "Other" : null, zones: other });
+    return groups;
+  })();
+
   // Zone + location filtered dispatch data
   // Zone ids belonging to the selected branch (null = no branch filter).
   const branchZoneIds = selectedBranchFilter === "all"
@@ -6538,11 +6559,16 @@ export default function JobsPage() {
                 {zoneDropdownOpen && (
                   <div style={{ position: "absolute", top: "calc(100% + 4px)", left: 0, zIndex: 200, backgroundColor: "#fff", border: "1px solid #E5E2DC", borderRadius: 8, boxShadow: "0 4px 16px rgba(0,0,0,0.10)", minWidth: 160, overflow: "hidden" }}>
                     <button onClick={() => { setSelectedZoneFilter(null); setZoneDropdownOpen(false); }} style={{ display: "block", width: "100%", textAlign: "left", padding: "8px 12px", border: "none", backgroundColor: selectedZoneFilter === null ? "var(--brand-dim)" : "transparent", color: selectedZoneFilter === null ? "var(--brand)" : "#1A1917", fontSize: 12, fontWeight: 700, cursor: "pointer", fontFamily: FF }}>All Zones</button>
-                    {zones.map(z => (
-                      <button key={z.id} onClick={() => { setSelectedZoneFilter(z.id); setZoneDropdownOpen(false); }} style={{ display: "flex", alignItems: "center", gap: 8, width: "100%", textAlign: "left", padding: "8px 12px", border: "none", backgroundColor: selectedZoneFilter === z.id ? `${z.color}18` : "transparent", color: selectedZoneFilter === z.id ? z.color : "#1A1917", fontSize: 12, fontWeight: 600, cursor: "pointer", fontFamily: FF }}>
-                        <div style={{ width: 8, height: 8, borderRadius: "50%", backgroundColor: z.color, flexShrink: 0 }} />
-                        {z.name}
-                      </button>
+                    {zoneGroups.map((g, gi) => (
+                      <div key={gi}>
+                        {g.label && <div style={{ padding: "6px 12px 3px", fontSize: 9, fontWeight: 800, textTransform: "uppercase", letterSpacing: "0.06em", color: "#9E9B94", backgroundColor: "#FAFAF9", borderTop: gi > 0 ? "1px solid #F0EEE9" : "none" }}>{g.label}</div>}
+                        {g.zones.map(z => (
+                          <button key={z.id} onClick={() => { setSelectedZoneFilter(z.id); setZoneDropdownOpen(false); }} style={{ display: "flex", alignItems: "center", gap: 8, width: "100%", textAlign: "left", padding: "8px 12px", border: "none", backgroundColor: selectedZoneFilter === z.id ? `${z.color}18` : "transparent", color: selectedZoneFilter === z.id ? z.color : "#1A1917", fontSize: 12, fontWeight: 600, cursor: "pointer", fontFamily: FF }}>
+                            <div style={{ width: 8, height: 8, borderRadius: "50%", backgroundColor: z.color, flexShrink: 0 }} />
+                            {z.name}
+                          </button>
+                        ))}
+                      </div>
                     ))}
                   </div>
                 )}
@@ -6888,11 +6914,16 @@ export default function JobsPage() {
                     {zoneDropdownOpen && (
                       <div style={{ position: "absolute", top: "calc(100% + 4px)", right: 0, zIndex: 200, backgroundColor: "#fff", border: "1px solid #E5E2DC", borderRadius: 8, boxShadow: "0 4px 16px rgba(0,0,0,0.10)", minWidth: 160, overflow: "hidden" }}>
                         <button onClick={() => { setSelectedZoneFilter(null); setZoneDropdownOpen(false); }} style={{ display: "block", width: "100%", textAlign: "left", padding: "8px 12px", border: "none", backgroundColor: selectedZoneFilter === null ? "var(--brand-dim)" : "transparent", color: selectedZoneFilter === null ? "var(--brand)" : "#1A1917", fontSize: 12, fontWeight: 700, cursor: "pointer", fontFamily: FF }}>All Zones</button>
-                        {zones.filter(z => selectedBranchFilter === "all" || z.location === selectedBranchFilter).map(z => (
-                          <button key={z.id} onClick={() => { setSelectedZoneFilter(z.id); setZoneDropdownOpen(false); }} style={{ display: "flex", alignItems: "center", gap: 8, width: "100%", textAlign: "left", padding: "8px 12px", border: "none", backgroundColor: selectedZoneFilter === z.id ? `${z.color}18` : "transparent", color: selectedZoneFilter === z.id ? z.color : "#1A1917", fontSize: 12, fontWeight: 600, cursor: "pointer", fontFamily: FF }}>
-                            <div style={{ width: 8, height: 8, borderRadius: "50%", backgroundColor: z.color, flexShrink: 0 }} />
-                            {z.name}
-                          </button>
+                        {zoneGroups.map((g, gi) => (
+                          <div key={gi}>
+                            {g.label && <div style={{ padding: "6px 12px 3px", fontSize: 9, fontWeight: 800, textTransform: "uppercase", letterSpacing: "0.06em", color: "#9E9B94", backgroundColor: "#FAFAF9", borderTop: gi > 0 ? "1px solid #F0EEE9" : "none" }}>{g.label}</div>}
+                            {g.zones.map(z => (
+                              <button key={z.id} onClick={() => { setSelectedZoneFilter(z.id); setZoneDropdownOpen(false); }} style={{ display: "flex", alignItems: "center", gap: 8, width: "100%", textAlign: "left", padding: "8px 12px", border: "none", backgroundColor: selectedZoneFilter === z.id ? `${z.color}18` : "transparent", color: selectedZoneFilter === z.id ? z.color : "#1A1917", fontSize: 12, fontWeight: 600, cursor: "pointer", fontFamily: FF }}>
+                                <div style={{ width: 8, height: 8, borderRadius: "50%", backgroundColor: z.color, flexShrink: 0 }} />
+                                {z.name}
+                              </button>
+                            ))}
+                          </div>
                         ))}
                       </div>
                     )}
@@ -7042,8 +7073,8 @@ export default function JobsPage() {
                     <span style={{ fontSize: 10, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.06em", color: "#9E9B94" }}>Technician</span>
                   </div>
                   {TIMES.map((t, i) => (
-                    <div key={i} style={{ width: SLOT_W, flexShrink: 0, padding: "8px 0 4px 6px", borderRight: i % 2 === 1 ? "1px solid #E5E2DC" : "1px solid #EEECE7" }}>
-                      {i % 2 === 0 && <span style={{ fontSize: 9, fontWeight: 600, color: "#9E9B94", whiteSpace: "nowrap" }}>{t}</span>}
+                    <div key={i} style={{ width: SLOT_W, flexShrink: 0, padding: "8px 0 4px 6px", backgroundColor: Math.floor(i / 2) % 2 === 1 ? "rgba(120,110,90,0.045)" : "transparent", borderRight: i % 2 === 1 ? "1px solid #CBC7BF" : "1px dotted #E9E7E2" }}>
+                      {i % 2 === 0 && <span style={{ fontSize: 10, fontWeight: 700, color: "#6B6860", whiteSpace: "nowrap" }}>{t}</span>}
                     </div>
                   ))}
                 </div>

--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -1909,6 +1909,33 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
     } finally { setBusy(false); }
   }
 
+  async function undoCancellation() {
+    setBusy(true);
+    const API2 = import.meta.env.BASE_URL.replace(/\/$/, "");
+    try {
+      const res = await fetch(`${API2}/api/cancellations/undo`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+        body: JSON.stringify({ job_id: job.id }),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.message || "Undo failed");
+      }
+      const body = await res.json();
+      toast({
+        title: "Cancellation undone",
+        description: body.restored_status === "scheduled"
+          ? "Job restored to scheduled — fee and tech cancellation pay removed."
+          : "Fee removed — job marked a free skip (no charge).",
+      });
+      await onUpdate();
+      onClose();
+    } catch (e) {
+      toast({ title: (e as Error).message || "Error", variant: "destructive" });
+    } finally { setBusy(false); }
+  }
+
   const panelStyle: React.CSSProperties = mobile ? {
     position: "fixed", left: 0, right: 0, bottom: 0, zIndex: 200,
     backgroundColor: "#FFFFFF", borderRadius: "20px 20px 0 0",
@@ -2196,6 +2223,15 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
                 <p style={{ margin: 0, fontSize: 12, color: "#92400E", lineHeight: 1.5 }}>
                   Billed as a {job.cancel_action === "lockout" ? "lockout" : "cancellation"} fee{job.billed_amount != null ? ` of $${Number(job.billed_amount).toFixed(2)}` : ""}, not a service visit. The assigned tech is paid the cancellation fee only (no commission on this job).
                 </p>
+                <button
+                  onClick={() => {
+                    if (window.confirm("Undo this cancellation? This removes the fee and the tech's cancellation pay, and restores the job.")) undoCancellation();
+                  }}
+                  disabled={busy}
+                  style={{ marginTop: 9, height: 28, padding: "0 12px", border: "1px solid #B45309", background: "#fff", color: "#92400E", borderRadius: 6, fontSize: 12, fontWeight: 700, cursor: busy ? "default" : "pointer" }}
+                >
+                  Undo cancellation
+                </button>
               </div>
             </div>
           )}


### PR DESCRIPTION
Several fixes from the Todd Tue / dispatch review. They share a branch so they merge together — happy to split if you'd rather.

## Safe (frontend / additive)

**Undo cancellation** — `POST /api/cancellations/undo` + an "Undo cancellation" button on the job panel. Removes the fee, deletes the tech's pending cancellation pay, restores the job (future → scheduled; past → free skip at $0). Refuses a `cancel_service` cascade or an already-paid fee.

**Dispatch board clarity** (your latest screenshots):
- *Hour grid* — hours now draw a solid darker line, half-hours a faint dotted line, with a subtle band on alternating hours so time reads at a glance.
- *Zones* — "All Branches" no longer dumps every zone into one list; options are grouped under **Oak Lawn / Schaumburg** headers (+ "Other" for unmapped zones). Picking a branch still scopes to it.
- *Legend* — example tiles were colored by status, but real tiles are colored by **zone**, so the legend never matched. Tiles now use a neutral zone stand-in and the legend says plainly: fill = zone, markings (stripe/badge/border/fading) = status.

## ⚠️ Billing logic — test before relying on it

**Re-book preserves the recurring client's real numbers.** Re-booking an existing recurring client rebuilt the job from the generic catalog (wiping the agreed base + visit length) and inserted a duplicate schedule — that's how Todd's $220 dropped to $195 ($245 instead of $270) and his hours read off. Convert now reuses the client's existing active schedule for the same service: keeps the agreed base + duration, folds only newly-sold add-ons in idempotently, updates only upcoming visits, and skips the first-visit catalog stamp. New clients/services still book at the quoted price.

Also: the panel's Hours tile now leads with time **on the clock** (allowed ÷ techs) with total person-hours on the sub-line.

> I could not exercise the re-book/billing path against live data from here — CI confirms it builds. Todd's current visit can be fixed today with **Change price → $270** regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)