### PR TITLE
fix(dispatch): storage-audit 500 (date+unknown cast) + early disk alert

### DIFF
--- a/artifacts/api-server/src/index.ts
+++ b/artifacts/api-server/src/index.ts
@@ -14,6 +14,7 @@ import { runLmsCompletionBackfill } from "./lib/lms-completion-backfill.js";
 import { runLmsCertificateBackfill } from "./lib/lms-certificate-backfill.js";
 import { ensureJobHistoryLiveBridgeSchema, syncJobHistoryLiveBridge } from "./lib/job-history-sync.js";
 import { bootstrapOnboardingPasswords } from "./lib/onboarding-password-backfill.js";
+import { startDiskUsageAlertCron } from "./lib/disk-usage-alert.js";
 
 const port = Number(process.env.PORT) || 3000;
 
@@ -356,6 +357,9 @@ async function startup() {
   }, 5000); // 5s delay to let migrations finish
   startNotificationCron();
   startFollowUpCron();
+  // [disk-alert 2026-06-19] Early-warning before the Postgres volume fills
+  // (the 365-day recurring backlog hit 98% with no prior warning).
+  startDiskUsageAlertCron();
 
   // [revenue-connect 2026-06-12] Hourly job_history re-sync — keeps the
   // revenue ledger current so yesterday's completions appear in the

--- a/artifacts/api-server/src/lib/disk-usage-alert.ts
+++ b/artifacts/api-server/src/lib/disk-usage-alert.ts
@@ -1,0 +1,143 @@
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+// [disk-alert 2026-06-19] Early-warning for the Postgres volume.
+//
+// Context: the 365-day recurring horizon (since trimmed to 90, see
+// recurring-jobs.ts) materialized a far-future job backlog that filled the
+// production Postgres volume to 98% and caused a boot outage. There was no
+// warning before the cliff. This cron is that warning: a daily check that
+// logs the database size and raises a WARN + in-app notification once usage
+// crosses a configurable threshold (default ~72%), well before the volume
+// fills.
+//
+// Capacity can't be read from inside Postgres (Railway's Postgres data lives
+// on a separate service's volume), so the percentage path needs the volume
+// size supplied via env. Two modes:
+//   - DB_VOLUME_LIMIT_BYTES set  → percentage mode: WARN at
+//     used / limit >= DB_ALERT_THRESHOLD_PCT (default 0.72).
+//   - DB_VOLUME_LIMIT_BYTES unset → absolute mode: WARN when the database
+//     size exceeds DB_ALERT_ABS_BYTES (default 768 MiB) — a sane pre-cliff
+//     number so the alert still fires out of the box.
+// The absolute database size is logged every run either way, so the trend is
+// always visible even before the env is configured.
+
+const DEFAULT_ALERT_THRESHOLD_PCT = 0.72;
+const DEFAULT_ALERT_ABS_BYTES = 768 * 1024 * 1024; // 768 MiB
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+function num(envVal: string | undefined): number | null {
+  const n = Number(envVal);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+function thresholdPct(): number {
+  const p = num(process.env.DB_ALERT_THRESHOLD_PCT);
+  return p != null && p < 1 ? p : DEFAULT_ALERT_THRESHOLD_PCT;
+}
+
+export type DiskUsageResult = {
+  usedBytes: number;
+  limitBytes: number | null;
+  pct: number | null;
+  over: boolean;
+  mode: "percentage" | "absolute";
+};
+
+const fmtGiB = (b: number) => (b / 1024 ** 3).toFixed(2);
+const fmtMiB = (b: number) => (b / 1024 ** 2).toFixed(0);
+
+export async function checkDiskUsageOnce(): Promise<DiskUsageResult> {
+  const sizeRes = await db.execute(
+    sql`SELECT pg_database_size(current_database()) AS bytes`
+  );
+  const usedBytes = Number((sizeRes.rows[0] as any)?.bytes ?? 0);
+
+  const limitBytes = num(process.env.DB_VOLUME_LIMIT_BYTES);
+  const mode: "percentage" | "absolute" = limitBytes != null ? "percentage" : "absolute";
+
+  let pct: number | null = null;
+  let over = false;
+  if (limitBytes != null) {
+    pct = usedBytes / limitBytes;
+    over = pct >= thresholdPct();
+  } else {
+    const absLimit = num(process.env.DB_ALERT_ABS_BYTES) ?? DEFAULT_ALERT_ABS_BYTES;
+    over = usedBytes >= absLimit;
+  }
+
+  const headline =
+    mode === "percentage"
+      ? `${((pct ?? 0) * 100).toFixed(1)}% (${fmtGiB(usedBytes)}/${fmtGiB(limitBytes!)} GiB)`
+      : `${fmtGiB(usedBytes)} GiB used (no DB_VOLUME_LIMIT_BYTES set — absolute-threshold mode)`;
+
+  if (!over) {
+    console.log(`[disk-alert] OK: Postgres volume ${headline}.`);
+    return { usedBytes, limitBytes, pct, over, mode };
+  }
+
+  // Over threshold — gather the largest tables so the WARN is actionable.
+  let topTables = "";
+  try {
+    const t = await db.execute(sql`
+      SELECT c.relname AS name, pg_total_relation_size(c.oid) AS bytes
+      FROM pg_class c
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = 'public' AND c.relkind = 'r'
+      ORDER BY pg_total_relation_size(c.oid) DESC
+      LIMIT 5
+    `);
+    topTables = (t.rows as any[])
+      .map((r) => `${r.name}=${fmtMiB(Number(r.bytes))}MB`)
+      .join(", ");
+  } catch (e) {
+    console.error("[disk-alert] top-table lookup failed:", e);
+  }
+
+  console.warn(
+    `[disk-alert] WARNING: Postgres volume ${headline} — over threshold. ` +
+      `Top tables: ${topTables}. ` +
+      `Reclaim space: GET /api/dispatch/storage-audit then ` +
+      `POST /api/dispatch/prune-far-future {"confirm":true}.`
+  );
+
+  // Surface in-app for the office, deduped to once per 24h per company so the
+  // daily cron doesn't pile up notifications. Mirrors the job_unassigned
+  // pattern in recurring-jobs.ts.
+  const pctLabel = mode === "percentage" ? `${((pct ?? 0) * 100).toFixed(1)}% used` : `${fmtGiB(usedBytes)} GiB used`;
+  const title = `Storage warning — ${pctLabel}`;
+  const body =
+    mode === "percentage"
+      ? `Database volume is at ${((pct ?? 0) * 100).toFixed(1)}% (${fmtGiB(usedBytes)}/${fmtGiB(limitBytes!)} GiB). Prune far-future recurring jobs to reclaim space before the cliff.`
+      : `Database is at ${fmtGiB(usedBytes)} GiB and past the alert threshold. Prune far-future recurring jobs to reclaim space.`;
+  try {
+    await db.execute(sql`
+      INSERT INTO notifications (company_id, type, title, body, link, meta)
+      SELECT co.id, 'disk_warning', ${title}, ${body}, ${"/dispatch"},
+             ${JSON.stringify({ used_bytes: usedBytes, limit_bytes: limitBytes, pct, mode })}::jsonb
+      FROM companies co
+      WHERE NOT EXISTS (
+        SELECT 1 FROM notifications n
+        WHERE n.company_id = co.id
+          AND n.type = 'disk_warning'
+          AND n.created_at > now() - interval '24 hours'
+      )
+    `);
+  } catch (e) {
+    console.error("[disk-alert] notification insert failed:", e);
+  }
+
+  return { usedBytes, limitBytes, pct, over, mode };
+}
+
+// Daily disk-usage check. Fires once ~60s after boot (so a volume already
+// near the cliff is flagged immediately on deploy) then every 24h.
+export function startDiskUsageAlertCron() {
+  const tick = () =>
+    void checkDiskUsageOnce().catch((e) =>
+      console.error("[disk-alert] check failed:", e?.message || e)
+    );
+  setTimeout(tick, 60_000);
+  setInterval(tick, ONE_DAY_MS);
+  console.log("[disk-alert] Daily Postgres volume check scheduled");
+}

--- a/artifacts/api-server/src/routes/dispatch.ts
+++ b/artifacts/api-server/src/routes/dispatch.ts
@@ -1338,11 +1338,18 @@ router.get("/zone-coverage-audit", requireAuth, dispatchOfficeGate, async (req, 
 //   - no clock punches (timeclock / job_clock_events) and no invoice
 // Because deletion runs in a transaction, any unexpected FK child rolls the
 // whole thing back rather than leaving a half-deleted job.
+//
+// NOTE: cutoffDays MUST be cast `::int` in the SQL. Drizzle binds the JS
+// number as an untyped parameter ($1), so a bare `CURRENT_DATE + ${cutoffDays}`
+// makes Postgres throw `operator is not unique: date + unknown` (42725) — it
+// can't choose between date+int / date+interval for an unknown-typed operand.
+// The cast pins it to `date + int` → date. (This 500'd the live storage-audit
+// endpoint; the error is NOT an enum issue despite the surface symptom.)
 const prunableFarFutureWhere = (companyId: number, cutoffDays: number) => sql`
   j.company_id = ${companyId}
   AND j.status = 'scheduled'
   AND j.recurring_schedule_id IS NOT NULL
-  AND j.scheduled_date > (CURRENT_DATE + ${cutoffDays})
+  AND j.scheduled_date > (CURRENT_DATE + ${cutoffDays}::int)
   AND j.manual_rate_override = false
   AND j.charge_succeeded_at IS NULL
   AND j.charge_attempted_at IS NULL
@@ -1367,7 +1374,7 @@ router.get("/storage-audit", requireAuth, dispatchOfficeGate, async (req, res) =
         COUNT(*) FILTER (
           WHERE j.status = 'scheduled'
             AND j.recurring_schedule_id IS NOT NULL
-            AND j.scheduled_date > (CURRENT_DATE + ${cutoffDays})
+            AND j.scheduled_date > (CURRENT_DATE + ${cutoffDays}::int)
         ) AS far_future_recurring_total,
         COUNT(*) FILTER (WHERE (${prunableFarFutureWhere(companyId, cutoffDays)})) AS prunable
       FROM jobs j
@@ -1406,8 +1413,16 @@ router.get("/storage-audit", requireAuth, dispatchOfficeGate, async (req, res) =
       })),
     });
   } catch (err) {
+    const cause: any = (err as any)?.cause ?? err;
     console.error("Storage audit error:", err);
-    return res.status(500).json({ error: "Internal Server Error", message: err instanceof Error ? err.message : "Failed to run audit" });
+    return res.status(500).json({
+      error: "Internal Server Error",
+      message: err instanceof Error ? err.message : "Failed to run audit",
+      // [outage-diagnostic 2026-06-19] Surface the underlying Postgres error so
+      // a future failure (bad cast, missing relation/column) is visible without
+      // direct DB access.
+      pg: { message: cause?.message, code: cause?.code, detail: cause?.detail, table: cause?.table, column: cause?.column, routine: cause?.routine },
+    });
   }
 });
 
@@ -1444,8 +1459,14 @@ router.post("/prune-far-future", requireAuth, requireRole("owner", "super_admin"
 
     return res.json({ dry_run: false, deleted: ids.length, cutoff_days: cutoffDays });
   } catch (err) {
+    const cause: any = (err as any)?.cause ?? err;
     console.error("Prune far-future error:", err);
-    return res.status(500).json({ error: "Internal Server Error", message: err instanceof Error ? err.message : "Failed to prune" });
+    return res.status(500).json({
+      error: "Internal Server Error",
+      message: err instanceof Error ? err.message : "Failed to prune",
+      // [outage-diagnostic 2026-06-19] Surface the underlying Postgres error.
+      pg: { message: cause?.message, code: cause?.code, detail: cause?.detail, table: cause?.table, column: cause?.column, routine: cause?.routine },
+    });
   }
 });
 


### PR DESCRIPTION
## Summary
Fixes the production `storage-audit` / `prune-far-future` 500s and adds the missing early-warning before the Postgres volume fills.

### 1. storage-audit / prune-far-future 500 — root cause
The shared prunable predicate did `CURRENT_DATE + ${cutoffDays}`. Drizzle binds the JS number as an **untyped** bind parameter (`$1`), so Postgres throws `operator is not unique: date + unknown` (SQLSTATE **42725**) — it cannot choose `date + int` vs `date + interval` for an unknown-typed operand.

**Fix:** cast `${cutoffDays}::int` → resolves to `date + int` → date.

Verified against prod: the exact totals query with `$2::int` returns rows (1315 far-future recurring for co1); the bare-parameter form 500s. The reported `enum_in` symptom was a red herring — ground truth from the live endpoint was the `date + unknown` error (`params: 90,1,90,1`).

Also surfaces the underlying Postgres error (`code`/`detail`/`routine`) in the 500 body for future diagnosis. **Supersedes** `fix/storage-audit-error-surface` (that branch added only the diagnostic surfacing, not the root-cause fix).

### 2. Early disk alert
`lib/disk-usage-alert.ts` — a daily cron that logs `pg_database_size` every run and raises a `WARN` log + in-app `notifications` row once usage crosses a threshold. This is the warning that was absent when the 365-day recurring backlog filled the volume to 98%.

- **Percentage mode** when `DB_VOLUME_LIMIT_BYTES` is set → WARN at `DB_ALERT_THRESHOLD_PCT` (default `0.72`).
- **Absolute fallback** when unset → WARN at `DB_ALERT_ABS_BYTES` (default 768 MiB), so it fires out of the box.
- Notification deduped to once/24h per company (mirrors the `job_unassigned` pattern). `notifications.type` is `varchar`, so no enum change needed.

**Recommended follow-up (env):** set `DB_VOLUME_LIMIT_BYTES` to the real Railway Postgres volume size for percentage-accurate alerting.

## Testing
- `tsc` clean on all three changed files (pre-existing repo type errors unrelated).
- Root-cause fix verified against prod DB read-only (`$2::int` returns 1315).
- Diff scoped to 3 files; no payroll-branch code included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)