### PR TITLE
feat(time-off): anniversary-reset accrual + field-app request→approval→notify workflow + MaidCentral migration

### DIFF
--- a/artifacts/api-server/src/cutover-data-migration.ts
+++ b/artifacts/api-server/src/cutover-data-migration.ts
@@ -671,11 +671,11 @@ async function seedLeaveTypesPerTenant(): Promise<void> {
 
 /**
  * Cutover 3A — seed the Phes company_leave_policy with the
- * CALENDAR-YEAR reset + ceiling + lead-days. All buckets (PLAWA, PTO,
- * Unpaid) reset Jan 1 for every employee — confirmed by Sal 2026-06-20,
- * overriding the earlier work_anniversary assumption (the handbook's
- * individualized "Benefit Year" language does NOT govern leave resets).
- * Idempotent.
+ * WORK-ANNIVERSARY reset (per-employee benefit year) + ceiling +
+ * lead-days. Each employee's buckets (PLAWA, PTO, Unpaid) reset on their
+ * own hire anniversary — matches the handbook's individualized "Benefit
+ * Year" (confirmed by Sal 2026-06-20: NOT a Jan-1 calendar reset).
+ * Idempotent: COALESCE-preserves any tenant customization.
  */
 async function seedPhesLeavePolicy3A(): Promise<void> {
   await db.execute(
@@ -693,16 +693,12 @@ async function seedPhesLeavePolicy3A(): Promise<void> {
         company_id, leave_reset_basis,
         use_it_or_lose_it_alert_lead_days, balance_ceiling_hours
       )
-      VALUES (1, 'calendar_year', 60, 80)
+      VALUES (1, 'work_anniversary', 60, 80)
       ON CONFLICT (company_id) DO UPDATE SET
+        leave_reset_basis = COALESCE(EXCLUDED.leave_reset_basis, company_leave_policy.leave_reset_basis),
         use_it_or_lose_it_alert_lead_days = COALESCE(EXCLUDED.use_it_or_lose_it_alert_lead_days, company_leave_policy.use_it_or_lose_it_alert_lead_days),
         balance_ceiling_hours = COALESCE(EXCLUDED.balance_ceiling_hours, company_leave_policy.balance_ceiling_hours);
-      -- Force calendar-year reset for Phes regardless of any prior
-      -- work_anniversary value (Sal 2026-06-20). Not COALESCE-preserved.
-      UPDATE company_leave_policy
-      SET leave_reset_basis = 'calendar_year'
-      WHERE company_id = 1;
-      RAISE NOTICE 'cutover-migration: ensured Phes 3A leave policy (calendar-year reset)';
+      RAISE NOTICE 'cutover-migration: ensured Phes 3A leave policy (work-anniversary reset)';
     END
     $$;
   `),

--- a/artifacts/api-server/src/cutover-data-migration.ts
+++ b/artifacts/api-server/src/cutover-data-migration.ts
@@ -612,10 +612,16 @@ async function seedLeaveTypesPerTenant(): Promise<void> {
         carryover_allowed, documentation_required, requestable,
         exempt_from_blackout
       )
+      -- PLAWA: 40h FRONT-LOADED after 90 days, NO carryover (reset to 40
+      -- each calendar year). This is Phes's actual policy per the handbook
+      -- ("40 paid hours per Benefit Year, front-loaded after 90 days …
+      -- unused PLAWA hours … do not carry over"), confirmed by Sal
+      -- 2026-06-20. NOT accrue_per_hours — that earlier seed encoded the
+      -- IL statutory MINIMUM (1hr/40 worked), which Phes exceeds.
       VALUES
         (1, 'plawa', 'PLAWA', true, 40,
-         'accrue_per_hours', 0.025, 90,
-         true, false, true, true),
+         'flat_grant', 0, 90,
+         false, false, true, true),
         (1, 'pto_phes', 'PTO', true, 40,
          'flat_grant', 0, 365,
          true, false, true, false),
@@ -627,6 +633,17 @@ async function seedLeaveTypesPerTenant(): Promise<void> {
          false, false, false, false)
       ON CONFLICT DO NOTHING;
 
+      -- Correct any pre-existing Phes PLAWA row (deployed before the fix
+      -- above) to the front-loaded policy. ON CONFLICT DO NOTHING leaves
+      -- existing rows untouched, so this UPDATE is the path that fixes
+      -- prod. Idempotent.
+      UPDATE leave_types
+      SET accrual_mode = 'flat_grant',
+          accrual_rate = 0,
+          carryover_allowed = false
+      WHERE company_id = 1
+        AND slug = 'plawa';
+
       -- The default-seeded "pto" row for company_id=1 collides with
       -- the Phes-specific PTO (slug 'pto_phes' is intentional to keep
       -- both rows distinguishable). If the default 'pto' row was
@@ -637,6 +654,14 @@ async function seedLeaveTypesPerTenant(): Promise<void> {
       WHERE company_id = 1
         AND slug = 'pto';
 
+      -- Likewise deactivate the generic default 'sick' bucket for Phes —
+      -- PLAWA is the single sick bucket for co1. Two active sick-like
+      -- buckets (generic 'sick' + 'plawa') is a seeding leftover.
+      UPDATE leave_types
+      SET active = false
+      WHERE company_id = 1
+        AND slug = 'sick';
+
       RAISE NOTICE 'cutover-migration: seeded leave_types per tenant';
     END
     $$;
@@ -646,9 +671,11 @@ async function seedLeaveTypesPerTenant(): Promise<void> {
 
 /**
  * Cutover 3A — seed the Phes company_leave_policy with the
- * anniversary-based reset + ceiling + lead-days. Idempotent: only
- * writes when the column has the schema default (NULL/zero) and the
- * tenant hasn't customized.
+ * CALENDAR-YEAR reset + ceiling + lead-days. All buckets (PLAWA, PTO,
+ * Unpaid) reset Jan 1 for every employee — confirmed by Sal 2026-06-20,
+ * overriding the earlier work_anniversary assumption (the handbook's
+ * individualized "Benefit Year" language does NOT govern leave resets).
+ * Idempotent.
  */
 async function seedPhesLeavePolicy3A(): Promise<void> {
   await db.execute(
@@ -666,12 +693,16 @@ async function seedPhesLeavePolicy3A(): Promise<void> {
         company_id, leave_reset_basis,
         use_it_or_lose_it_alert_lead_days, balance_ceiling_hours
       )
-      VALUES (1, 'work_anniversary', 60, 80)
+      VALUES (1, 'calendar_year', 60, 80)
       ON CONFLICT (company_id) DO UPDATE SET
-        leave_reset_basis = COALESCE(EXCLUDED.leave_reset_basis, company_leave_policy.leave_reset_basis),
         use_it_or_lose_it_alert_lead_days = COALESCE(EXCLUDED.use_it_or_lose_it_alert_lead_days, company_leave_policy.use_it_or_lose_it_alert_lead_days),
         balance_ceiling_hours = COALESCE(EXCLUDED.balance_ceiling_hours, company_leave_policy.balance_ceiling_hours);
-      RAISE NOTICE 'cutover-migration: ensured Phes 3A leave policy';
+      -- Force calendar-year reset for Phes regardless of any prior
+      -- work_anniversary value (Sal 2026-06-20). Not COALESCE-preserved.
+      UPDATE company_leave_policy
+      SET leave_reset_basis = 'calendar_year'
+      WHERE company_id = 1;
+      RAISE NOTICE 'cutover-migration: ensured Phes 3A leave policy (calendar-year reset)';
     END
     $$;
   `),

--- a/artifacts/api-server/src/index.ts
+++ b/artifacts/api-server/src/index.ts
@@ -14,6 +14,7 @@ import { runLmsCompletionBackfill } from "./lib/lms-completion-backfill.js";
 import { runLmsCertificateBackfill } from "./lib/lms-certificate-backfill.js";
 import { ensureJobHistoryLiveBridgeSchema, syncJobHistoryLiveBridge } from "./lib/job-history-sync.js";
 import { bootstrapOnboardingPasswords } from "./lib/onboarding-password-backfill.js";
+import { runLeaveAccrualCron } from "./lib/leave-accrual-cron.js";
 
 const port = Number(process.env.PORT) || 3000;
 
@@ -90,6 +91,14 @@ function startNotificationCron() {
     if (ctH === 1 && fired["rate_lock_nightly"] !== `${ctDate}-1`) {
       fired["rate_lock_nightly"] = `${ctDate}-1`;
       runRateLockNightlyChecks().catch((e: Error) => console.error("[cron] rate_lock_nightly error:", e));
+    }
+    // 2 AM CT → leave accrual: grant-on-eligibility (90-day sick / 1-year
+    // PTO gates) + calendar-year reset (Jan 1 re-front-load) for every
+    // leave-enabled tenant. Gated by LEAVE_ACCRUAL_ENABLED (default OFF) —
+    // no balance writes until Sal signs off and flips the Railway env var.
+    if (ctH === 2 && fired["leave_accrual"] !== `${ctDate}-2`) {
+      fired["leave_accrual"] = `${ctDate}-2`;
+      runLeaveAccrualCron(ctDate).catch((e: Error) => console.error("[cron] leave_accrual error:", e));
     }
     // December 1 at 9 AM CT → annual re-acknowledgment cycle auto-open
     // for every tenant. Idempotent: skips tenants with an existing

--- a/artifacts/api-server/src/index.ts
+++ b/artifacts/api-server/src/index.ts
@@ -93,9 +93,10 @@ function startNotificationCron() {
       runRateLockNightlyChecks().catch((e: Error) => console.error("[cron] rate_lock_nightly error:", e));
     }
     // 2 AM CT → leave accrual: grant-on-eligibility (90-day sick / 1-year
-    // PTO gates) + calendar-year reset (Jan 1 re-front-load) for every
-    // leave-enabled tenant. Gated by LEAVE_ACCRUAL_ENABLED (default OFF) —
-    // no balance writes until Sal signs off and flips the Railway env var.
+    // PTO gates) + work-anniversary reset (re-front-load on each employee's
+    // benefit-year boundary) for every leave-enabled tenant. Gated by
+    // LEAVE_ACCRUAL_ENABLED (default OFF) — no balance writes until Sal
+    // signs off and flips the Railway env var.
     if (ctH === 2 && fired["leave_accrual"] !== `${ctDate}-2`) {
       fired["leave_accrual"] = `${ctDate}-2`;
       runLeaveAccrualCron(ctDate).catch((e: Error) => console.error("[cron] leave_accrual error:", e));

--- a/artifacts/api-server/src/lib/leave-accrual-cron.ts
+++ b/artifacts/api-server/src/lib/leave-accrual-cron.ts
@@ -1,10 +1,11 @@
 /**
- * Daily leave-accrual cron — grant-on-eligibility + calendar-year reset.
+ * Daily leave-accrual cron — grant-on-eligibility + work-anniversary reset.
  *
  * Runs the unified reconcile (./leave-reconcile.ts) for every tenant with
- * the leave program enabled. One daily pass covers all three actions:
+ * the leave program enabled. One daily pass covers all three actions,
+ * keyed off each employee's hire-anniversary benefit year:
  *   - initial_grant : a new hire crosses the 90-day / 1-year gate
- *   - annual_reset  : first run on/after Jan 1 re-front-loads the year
+ *   - annual_reset  : first run of a new benefit year (work anniversary)
  *   - tier_topup    : PTO crosses its 2-year tenure tier
  *
  * GATED by LEAVE_ACCRUAL_ENABLED (default OFF) — mirrors the COMMS_ENABLED /

--- a/artifacts/api-server/src/lib/leave-accrual-cron.ts
+++ b/artifacts/api-server/src/lib/leave-accrual-cron.ts
@@ -1,0 +1,65 @@
+/**
+ * Daily leave-accrual cron — grant-on-eligibility + calendar-year reset.
+ *
+ * Runs the unified reconcile (./leave-reconcile.ts) for every tenant with
+ * the leave program enabled. One daily pass covers all three actions:
+ *   - initial_grant : a new hire crosses the 90-day / 1-year gate
+ *   - annual_reset  : first run on/after Jan 1 re-front-loads the year
+ *   - tier_topup    : PTO crosses its 2-year tenure tier
+ *
+ * GATED by LEAVE_ACCRUAL_ENABLED (default OFF) — mirrors the COMMS_ENABLED /
+ * recurring-cron-off pattern. Deploying this code does NOT write any
+ * balances until the env flag is flipped to "true" in Railway, AFTER Sal
+ * signs off on the migration dry-run. Until then the cron is a no-op.
+ */
+import { db } from "@workspace/db";
+import { companyLeavePolicyTable } from "@workspace/db/schema";
+import { eq } from "drizzle-orm";
+import { reconcileCompanyLeaveBalances } from "./leave-reconcile.js";
+
+export const LEAVE_ACCRUAL_ENABLED =
+  process.env.LEAVE_ACCRUAL_ENABLED === "true";
+
+export type LeaveAccrualRunSummary = {
+  company_id: number;
+  initial_grant: number;
+  annual_reset: number;
+  tier_topup: number;
+};
+
+export async function runLeaveAccrualCron(
+  asOf: string,
+): Promise<LeaveAccrualRunSummary[]> {
+  if (!LEAVE_ACCRUAL_ENABLED) {
+    console.log(
+      "[cron] leave_accrual: LEAVE_ACCRUAL_ENABLED not 'true' — skipping (no balance writes)",
+    );
+    return [];
+  }
+  const tenants = await db
+    .select({ company_id: companyLeavePolicyTable.company_id })
+    .from(companyLeavePolicyTable)
+    .where(eq(companyLeavePolicyTable.leave_program_enabled, true));
+
+  const summary: LeaveAccrualRunSummary[] = [];
+  for (const t of tenants) {
+    try {
+      const plan = await reconcileCompanyLeaveBalances(t.company_id, asOf, {
+        dryRun: false,
+      });
+      const row: LeaveAccrualRunSummary = {
+        company_id: t.company_id,
+        initial_grant: plan.filter((p) => p.plan.action === "initial_grant").length,
+        annual_reset: plan.filter((p) => p.plan.action === "annual_reset").length,
+        tier_topup: plan.filter((p) => p.plan.action === "tier_topup").length,
+      };
+      summary.push(row);
+      console.log(
+        `[cron] leave_accrual co${row.company_id}: ${row.initial_grant} granted, ${row.annual_reset} reset, ${row.tier_topup} tier-topup`,
+      );
+    } catch (e) {
+      console.error(`[cron] leave_accrual co${t.company_id} error:`, e);
+    }
+  }
+  return summary;
+}

--- a/artifacts/api-server/src/lib/leave-grant-reset.ts
+++ b/artifacts/api-server/src/lib/leave-grant-reset.ts
@@ -1,9 +1,11 @@
 /**
- * Time-off grant + annual reset engine (Phes calendar-year model).
+ * Time-off grant + annual reset engine (Phes work-anniversary model).
  *
  * Confirmed by Sal 2026-06-20:
- *   - ALL buckets reset on the CALENDAR YEAR (Jan 1), for every employee.
- *     There is no per-employee work-anniversary reset.
+ *   - Every employee has their OWN benefit year, anchored to their hire
+ *     date. All buckets (PLAWA, PTO, Unpaid) reset on the employee's WORK
+ *     ANNIVERSARY — NOT a Jan-1 calendar reset. Matches the handbook's
+ *     individualized "Benefit Year."
  *   - PLAWA (sick): 40h FRONT-LOADED after 90 days, NO carryover.
  *   - PTO: 40h after 1 year, topping up to 80h (hard cap) at 2 years.
  *   - Unpaid personal: 40h from day one.
@@ -14,15 +16,16 @@
  * (capped at the ceiling) — which for PTO would yield 60h, not 80h, for
  * the handbook's "used 20 of 40, top up to 80" example. The handbook is
  * explicit: "we top up to the cap, we do not add on top." So the Phes
- * model is "set the bank to the tenure entitlement each year" — NOT
- * carryover arithmetic. `applyReset` stays for any tenant that wants the
- * allowance/carryover model; Phes uses the entitlement model here.
+ * model is "set the bank to the tenure entitlement each benefit year" —
+ * NOT carryover arithmetic. `applyReset` stays for any tenant that wants
+ * the allowance/carryover model; Phes uses the entitlement model here.
  *
  * The grant/reset is unified into ONE idempotent operation
- * (`planLeaveGrant`) so the daily cron handles three cases with one rule:
- *   - initial_grant : employee crosses the waiting-period gate mid-year
- *   - annual_reset  : first run of a new calendar year (re-front-load)
- *   - tier_topup    : PTO crosses its 2-year tenure tier mid-year
+ * (`planLeaveGrant`) so the daily cron handles three cases with one rule,
+ * keyed off each employee's benefit-year start (most recent anniversary):
+ *   - initial_grant : employee crosses the waiting-period gate
+ *   - annual_reset  : first run of a new benefit year (re-front-load)
+ *   - tier_topup    : granted is below the current tenure tier (PTO 40→80)
  *
  * The pure functions here take no DB and are unit-tested. The DB wrapper
  * (`reconcileCompanyLeaveBalances`) lives in ./leave-reconcile.ts and
@@ -80,7 +83,26 @@ export function completedYearsOfService(
   return Math.max(0, years);
 }
 
-/** Target granted hours for the CURRENT calendar year for one bucket.
+/** The start of the employee's CURRENT benefit year as of `asOf`: the
+ *  most recent hire-anniversary on or before `asOf`. Used to decide
+ *  whether this benefit year's grant has already landed. Both args
+ *  YYYY-MM-DD; returns a UTC Date. (Feb-29 hires roll to Mar-1 in
+ *  non-leap years via JS Date normalization.) */
+export function benefitYearStartDate(hireDate: string, asOf: string): Date {
+  const h = new Date(`${hireDate}T00:00:00Z`);
+  const a = new Date(`${asOf}T00:00:00Z`);
+  let anniv = new Date(
+    Date.UTC(a.getUTCFullYear(), h.getUTCMonth(), h.getUTCDate()),
+  );
+  if (anniv.getTime() > a.getTime()) {
+    anniv = new Date(
+      Date.UTC(a.getUTCFullYear() - 1, h.getUTCMonth(), h.getUTCDate()),
+    );
+  }
+  return anniv;
+}
+
+/** Target granted hours for the CURRENT benefit year for one bucket.
  *  Returns 0 when the employee hasn't cleared the waiting period (i.e.
  *  not eligible yet) or the bucket isn't a flat grant.
  *
@@ -108,8 +130,8 @@ export function entitlementHours(
 }
 
 /** Plan the grant/reset action for one (employee, bucket) as of `asOf`.
- *  Idempotent: re-running within the same calendar year is a no-op once
- *  the year's grant has landed (except a mid-year tenure tier bump). */
+ *  Idempotent: re-running within the same benefit year is a no-op once
+ *  the year's grant has landed (except a tenure tier bump). */
 export function planLeaveGrant(
   bucket: GrantBucket,
   balance: GrantBalance | null,
@@ -126,14 +148,18 @@ export function planLeaveGrant(
     return { entitlement: ent, new_granted: granted, new_used: used, action: "none" };
   }
 
-  const currentYear = new Date(`${asOf}T00:00:00Z`).getUTCFullYear();
-  const lastResetYear = balance?.last_reset_at
-    ? new Date(balance.last_reset_at).getUTCFullYear()
+  // hireDate is non-null here (ent > 0 requires it). Reset is keyed off
+  // the employee's benefit year, not the calendar: the grant for this
+  // benefit year has landed iff last_reset_at is on/after the most recent
+  // anniversary.
+  const benefitYearStartMs = benefitYearStartDate(hireDate as string, asOf).getTime();
+  const lastResetMs = balance?.last_reset_at
+    ? new Date(balance.last_reset_at).getTime()
     : null;
 
-  // First touch of this calendar year → front-load the entitlement and
+  // First touch of this benefit year → front-load the entitlement and
   // zero used. New row = initial grant; an older row = annual reset.
-  if (lastResetYear === null || lastResetYear < currentYear) {
+  if (lastResetMs === null || lastResetMs < benefitYearStartMs) {
     return {
       entitlement: ent,
       new_granted: ent,
@@ -142,7 +168,7 @@ export function planLeaveGrant(
     };
   }
 
-  // Already granted this year. The only legitimate mid-year change is a
+  // Already granted this benefit year. The only legitimate change is a
   // tenure tier bump (PTO crossing 2 years): top granted UP, preserve used.
   if (ent > granted) {
     return { entitlement: ent, new_granted: ent, new_used: used, action: "tier_topup" };

--- a/artifacts/api-server/src/lib/leave-grant-reset.ts
+++ b/artifacts/api-server/src/lib/leave-grant-reset.ts
@@ -1,0 +1,151 @@
+/**
+ * Time-off grant + annual reset engine (Phes calendar-year model).
+ *
+ * Confirmed by Sal 2026-06-20:
+ *   - ALL buckets reset on the CALENDAR YEAR (Jan 1), for every employee.
+ *     There is no per-employee work-anniversary reset.
+ *   - PLAWA (sick): 40h FRONT-LOADED after 90 days, NO carryover.
+ *   - PTO: 40h after 1 year, topping up to 80h (hard cap) at 2 years.
+ *   - Unpaid personal: 40h from day one.
+ *
+ * This is a deliberately DIFFERENT model from lib/leave-balance.ts
+ * `applyReset` (the generic carryover-candidate math). That function
+ * carries the unused prior balance forward and adds a grant on top
+ * (capped at the ceiling) — which for PTO would yield 60h, not 80h, for
+ * the handbook's "used 20 of 40, top up to 80" example. The handbook is
+ * explicit: "we top up to the cap, we do not add on top." So the Phes
+ * model is "set the bank to the tenure entitlement each year" — NOT
+ * carryover arithmetic. `applyReset` stays for any tenant that wants the
+ * allowance/carryover model; Phes uses the entitlement model here.
+ *
+ * The grant/reset is unified into ONE idempotent operation
+ * (`planLeaveGrant`) so the daily cron handles three cases with one rule:
+ *   - initial_grant : employee crosses the waiting-period gate mid-year
+ *   - annual_reset  : first run of a new calendar year (re-front-load)
+ *   - tier_topup    : PTO crosses its 2-year tenure tier mid-year
+ *
+ * The pure functions here take no DB and are unit-tested. The DB wrapper
+ * (`reconcileCompanyLeaveBalances`) lives in ./leave-reconcile.ts and
+ * composes these — split out so importing the pure math in tests doesn't
+ * pull in the drizzle client.
+ */
+
+import { isPastWaitingPeriod, round2 } from "./leave-balance.js";
+
+export type GrantAccrualMode =
+  | "flat_grant"
+  | "accrue_per_hours"
+  | "office_recorded";
+
+export type GrantBucket = {
+  slug: string;
+  accrual_mode: GrantAccrualMode;
+  annual_cap_hours: number;
+  waiting_period_days: number;
+  carryover_allowed: boolean;
+};
+
+export type GrantBalance = {
+  granted_hours: number;
+  used_hours: number;
+  last_reset_at: Date | null;
+};
+
+export type GrantAction =
+  | "none"
+  | "initial_grant"
+  | "annual_reset"
+  | "tier_topup";
+
+export type GrantPlan = {
+  entitlement: number;
+  new_granted: number;
+  new_used: number;
+  action: GrantAction;
+};
+
+/** Full completed years of service as of `asOf`. Both args YYYY-MM-DD.
+ *  Anniversary not yet reached in `asOf`'s year counts as one fewer. */
+export function completedYearsOfService(
+  hireDate: string,
+  asOf: string,
+): number {
+  const h = new Date(`${hireDate}T00:00:00Z`);
+  const a = new Date(`${asOf}T00:00:00Z`);
+  let years = a.getUTCFullYear() - h.getUTCFullYear();
+  const annivThisYear = new Date(
+    Date.UTC(a.getUTCFullYear(), h.getUTCMonth(), h.getUTCDate()),
+  );
+  if (a.getTime() < annivThisYear.getTime()) years -= 1;
+  return Math.max(0, years);
+}
+
+/** Target granted hours for the CURRENT calendar year for one bucket.
+ *  Returns 0 when the employee hasn't cleared the waiting period (i.e.
+ *  not eligible yet) or the bucket isn't a flat grant.
+ *
+ *  Tenure tier: for a carryover bucket whose ceiling exceeds the annual
+ *  cap (Phes PTO: cap 40, ceiling 80), entitlement = cap × completed
+ *  years, capped at the ceiling. So PTO is 40 in year 1 and 80 from
+ *  year 2 on. Non-carryover buckets (PLAWA, Unpaid) are always the cap. */
+export function entitlementHours(
+  bucket: GrantBucket,
+  hireDate: string | null,
+  asOf: string,
+  ceilingHours: number,
+): number {
+  if (bucket.accrual_mode !== "flat_grant") return 0;
+  if (!hireDate) return 0;
+  if (!isPastWaitingPeriod(hireDate, bucket.waiting_period_days, asOf)) {
+    return 0;
+  }
+  const base = Math.max(0, bucket.annual_cap_hours);
+  if (bucket.carryover_allowed && ceilingHours > base) {
+    const years = Math.max(1, completedYearsOfService(hireDate, asOf));
+    return Math.min(ceilingHours, round2(base * years));
+  }
+  return base;
+}
+
+/** Plan the grant/reset action for one (employee, bucket) as of `asOf`.
+ *  Idempotent: re-running within the same calendar year is a no-op once
+ *  the year's grant has landed (except a mid-year tenure tier bump). */
+export function planLeaveGrant(
+  bucket: GrantBucket,
+  balance: GrantBalance | null,
+  hireDate: string | null,
+  asOf: string,
+  ceilingHours: number,
+): GrantPlan {
+  const granted = balance ? round2(balance.granted_hours) : 0;
+  const used = balance ? round2(balance.used_hours) : 0;
+  const ent = entitlementHours(bucket, hireDate, asOf, ceilingHours);
+
+  // Not grantable / not eligible yet → leave whatever is there untouched.
+  if (bucket.accrual_mode !== "flat_grant" || ent <= 0) {
+    return { entitlement: ent, new_granted: granted, new_used: used, action: "none" };
+  }
+
+  const currentYear = new Date(`${asOf}T00:00:00Z`).getUTCFullYear();
+  const lastResetYear = balance?.last_reset_at
+    ? new Date(balance.last_reset_at).getUTCFullYear()
+    : null;
+
+  // First touch of this calendar year → front-load the entitlement and
+  // zero used. New row = initial grant; an older row = annual reset.
+  if (lastResetYear === null || lastResetYear < currentYear) {
+    return {
+      entitlement: ent,
+      new_granted: ent,
+      new_used: 0,
+      action: balance === null ? "initial_grant" : "annual_reset",
+    };
+  }
+
+  // Already granted this year. The only legitimate mid-year change is a
+  // tenure tier bump (PTO crossing 2 years): top granted UP, preserve used.
+  if (ent > granted) {
+    return { entitlement: ent, new_granted: ent, new_used: used, action: "tier_topup" };
+  }
+  return { entitlement: ent, new_granted: granted, new_used: used, action: "none" };
+}

--- a/artifacts/api-server/src/lib/leave-notifications.ts
+++ b/artifacts/api-server/src/lib/leave-notifications.ts
@@ -1,0 +1,217 @@
+/**
+ * Time-off request notifications — mirrors MaidCentral's employee
+ * "Schedule Request" workflow, extended to SMS (Sal wants employee-facing
+ * decisions on SMS + email; MC is email-only).
+ *
+ * MC templates mirrored (subjects kept close to MC's wording):
+ *   - submit  → EMPLOYEE "Your Time-Off Request is Pending (<dates>)"
+ *               (short-notice/sick → "Emergency Request Received")
+ *             + OFFICE/OWNER "ACTION REQUIRED: review & approve …"
+ *   - approve → EMPLOYEE "Your Time-Off Request was Approved (<dates>)"
+ *   - deny    → EMPLOYEE "Your Time-Off Request was Denied (<dates>)"
+ *
+ * Channels:
+ *   - In-app + web push: via notify.ts (internal staff alerts, ungated).
+ *   - Office/owner email: via notifyOfficeUsers (existing staff-alert path).
+ *   - EMPLOYEE email + SMS: employee-facing → gated by COMMS_ENABLED
+ *     (SMS additionally by the per-tenant/branch gate via resolveSender),
+ *     honoring the hard rule that no SMS/email leaves the system until
+ *     comms are explicitly enabled. Until then employees still get the
+ *     in-app + push alert.
+ *
+ * All sends are best-effort and never throw into the request path — the
+ * leave_request row in the DB is the source of truth.
+ */
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+import { notifyUser, notifyOfficeUsers } from "./notify.js";
+import { resolveSender, sendSmsVia } from "./comms-sender.js";
+
+type LeaveCtx = {
+  request_id: number;
+  company_id: number;
+  user_id: number;
+  employee_name: string;
+  employee_first: string;
+  employee_email: string | null;
+  employee_phone: string | null;
+  bucket_name: string;
+  exempt_from_blackout: boolean;
+  start_date: string;
+  end_date: string;
+  hours: string;
+  status: string;
+  decision_note: string | null;
+  company_name: string;
+  email_from: string;
+};
+
+async function loadCtx(requestId: number): Promise<LeaveCtx | null> {
+  const r = await db.execute(sql`
+    SELECT lr.id, lr.company_id, lr.user_id, lr.start_date, lr.end_date, lr.hours,
+           lr.status, lr.decision_note,
+           lt.display_name AS bucket_name, lt.exempt_from_blackout,
+           u.first_name, u.last_name, u.email, u.phone,
+           c.name AS company_name, c.email_from_address
+      FROM leave_requests lr
+      JOIN leave_types lt ON lt.id = lr.leave_type_id
+      JOIN users u ON u.id = lr.user_id
+      JOIN companies c ON c.id = lr.company_id
+     WHERE lr.id = ${requestId} LIMIT 1`);
+  const row: any = r.rows[0];
+  if (!row) return null;
+  return {
+    request_id: Number(row.id),
+    company_id: Number(row.company_id),
+    user_id: Number(row.user_id),
+    employee_name: `${row.first_name ?? ""} ${row.last_name ?? ""}`.trim(),
+    employee_first: row.first_name ?? "there",
+    employee_email: row.email ?? null,
+    employee_phone: row.phone ?? null,
+    bucket_name: row.bucket_name,
+    exempt_from_blackout: !!row.exempt_from_blackout,
+    start_date: String(row.start_date),
+    end_date: String(row.end_date),
+    hours: String(row.hours),
+    status: String(row.status),
+    decision_note: row.decision_note ?? null,
+    company_name: row.company_name || "Qleno",
+    email_from: row.email_from_address || "noreply@phes.io",
+  };
+}
+
+function dateLabel(c: LeaveCtx): string {
+  return c.start_date === c.end_date ? c.start_date : `${c.start_date} → ${c.end_date}`;
+}
+
+/** Employee-facing email — gated by COMMS_ENABLED (employee-facing comms). */
+async function sendEmployeeEmail(c: LeaveCtx, subject: string, bodyHtml: string): Promise<void> {
+  try {
+    if (process.env.COMMS_ENABLED !== "true") return;
+    const key = process.env.RESEND_API_KEY;
+    if (!key || !c.employee_email) return;
+    const from = `${c.company_name} <${c.email_from}>`;
+    const html = `<div style="font-family:Arial,sans-serif;max-width:520px;margin:0 auto;padding:24px;color:#1A1917">
+${bodyHtml}
+<p style="font-size:12px;color:#9E9B94;margin:16px 0 0">${c.company_name} · Time Off</p>
+</div>`;
+    const { Resend } = await import("resend");
+    const resend = new Resend(key);
+    const r: any = await resend.emails.send({ from, to: [c.employee_email], subject, html });
+    if (r?.error) console.error("[leave-notify] employee email error:", r.error?.message ?? r.error);
+  } catch (e) {
+    console.error("[leave-notify] employee email failed:", e);
+  }
+}
+
+/** Employee-facing SMS — gated by COMMS_ENABLED + tenant/branch via resolveSender. */
+async function sendEmployeeSms(c: LeaveCtx, body: string): Promise<void> {
+  try {
+    if (!c.employee_phone) return;
+    const sender = await resolveSender(c.company_id, null);
+    if (sender.reason) {
+      console.log(`[leave-notify] SMS suppressed (${sender.reason}) for request #${c.request_id}`);
+      return;
+    }
+    await sendSmsVia(sender, c.employee_phone, body);
+  } catch (e) {
+    console.error("[leave-notify] employee SMS failed:", e);
+  }
+}
+
+/** On submit: office/owner "ACTION REQUIRED" + employee "Pending"/"Emergency"
+ *  (or "Denied" if the request was auto-denied at create, e.g. blackout). */
+export async function notifyLeaveSubmitted(requestId: number, companyId: number): Promise<void> {
+  const c = await loadCtx(requestId);
+  if (!c) return;
+  const dates = dateLabel(c);
+
+  // Auto-denied at create (blackout overlap on a non-exempt bucket).
+  if (c.status === "denied") {
+    await notifyLeaveDecision(requestId, "denied");
+    return;
+  }
+
+  // Office + owner: ACTION REQUIRED (in-app + push + staff email).
+  await notifyOfficeUsers(companyId, {
+    type: "leave_request",
+    title: `ACTION REQUIRED: Review ${c.employee_name}'s time-off request`,
+    body: `${c.employee_name} requested ${Number(c.hours).toFixed(2)} h of ${c.bucket_name} for ${dates}. Review and approve or deny.`,
+    link: "/leave-review",
+    meta: { request_id: requestId },
+  });
+
+  // Employee: emergency (short-notice/sick) vs standard pending.
+  const emergency = c.exempt_from_blackout || isShortNotice(c.start_date);
+  await notifyUser({
+    companyId,
+    userId: c.user_id,
+    type: "leave_request",
+    title: emergency ? "Emergency time-off request received" : "Your time-off request is pending",
+    body: `${c.bucket_name} · ${dates} · ${Number(c.hours).toFixed(2)} h`,
+    link: "/leave",
+    meta: { request_id: requestId },
+  });
+  if (emergency) {
+    await sendEmployeeEmail(
+      c,
+      `ATTN: You've submitted an Emergency Request (${dates})`,
+      `<p style="font-size:16px;font-weight:700;margin:0 0 8px">Emergency time-off request received</p>
+<p style="font-size:14px;line-height:1.5;margin:0">Hi ${c.employee_first}, we received your emergency request for <b>${c.bucket_name}</b> on <b>${dates}</b> (${Number(c.hours).toFixed(2)} h). The office will follow up shortly.</p>`,
+    );
+    await sendEmployeeSms(c, `${c.company_name}: Emergency time-off request received for ${dates} (${c.bucket_name}). The office will follow up.`);
+  } else {
+    await sendEmployeeEmail(
+      c,
+      `Your Time-Off Request is Pending (${dates})`,
+      `<p style="font-size:16px;font-weight:700;margin:0 0 8px">Your time-off request is pending</p>
+<p style="font-size:14px;line-height:1.5;margin:0">Hi ${c.employee_first}, your request for <b>${c.bucket_name}</b> on <b>${dates}</b> (${Number(c.hours).toFixed(2)} h) is pending office approval. You'll get a message when it's decided.</p>`,
+    );
+    await sendEmployeeSms(c, `${c.company_name}: Your time-off request for ${dates} (${c.bucket_name}) is pending approval.`);
+  }
+}
+
+/** On approve/deny: employee Approved/Denied (in-app + push + email + SMS). */
+export async function notifyLeaveDecision(requestId: number, outcome: "approved" | "denied"): Promise<void> {
+  const c = await loadCtx(requestId);
+  if (!c) return;
+  const dates = dateLabel(c);
+  const approved = outcome === "approved";
+
+  await notifyUser({
+    companyId: c.company_id,
+    userId: c.user_id,
+    type: "leave_decision",
+    title: approved ? "Your time-off request was approved" : "Your time-off request was denied",
+    body: `${c.bucket_name} · ${dates}${c.decision_note ? ` · ${c.decision_note}` : ""}`,
+    link: "/leave",
+    meta: { request_id: requestId },
+  });
+
+  if (approved) {
+    await sendEmployeeEmail(
+      c,
+      `Congrats! Your Time-Off Request has been Approved (${dates})`,
+      `<p style="font-size:16px;font-weight:700;margin:0 0 8px">Your time-off request was approved</p>
+<p style="font-size:14px;line-height:1.5;margin:0">Hi ${c.employee_first}, your request for <b>${c.bucket_name}</b> on <b>${dates}</b> (${Number(c.hours).toFixed(2)} h) has been <b>approved</b>.</p>`,
+    );
+    await sendEmployeeSms(c, `${c.company_name}: Your time-off request for ${dates} (${c.bucket_name}) was APPROVED.`);
+  } else {
+    const note = c.decision_note ? ` Reason: ${c.decision_note}.` : "";
+    await sendEmployeeEmail(
+      c,
+      `Your Time-Off Request has been Denied (${dates})`,
+      `<p style="font-size:16px;font-weight:700;margin:0 0 8px">Your time-off request was denied</p>
+<p style="font-size:14px;line-height:1.5;margin:0">Hi ${c.employee_first}, your request for <b>${c.bucket_name}</b> on <b>${dates}</b> (${Number(c.hours).toFixed(2)} h) was <b>denied</b>.${note} Please reach out to the office with questions.</p>`,
+    );
+    await sendEmployeeSms(c, `${c.company_name}: Your time-off request for ${dates} (${c.bucket_name}) was denied.${c.decision_note ? ` ${c.decision_note}` : ""}`);
+  }
+}
+
+/** Short notice = start date within the 7-day window from today (UTC date). */
+function isShortNotice(startDate: string): boolean {
+  const today = new Date().toISOString().slice(0, 10);
+  const start = new Date(`${startDate}T00:00:00Z`).getTime();
+  const cutoff = new Date(`${today}T00:00:00Z`).getTime() + 7 * 86400000;
+  return start < cutoff;
+}

--- a/artifacts/api-server/src/lib/leave-pay-preview.ts
+++ b/artifacts/api-server/src/lib/leave-pay-preview.ts
@@ -1,93 +1,43 @@
 /**
- * Paid-leave payroll PREVIEW — review-gated, never auto-paid.
+ * Paid-leave PENDING forecast (read-only office signal).
  *
- * Mirrors the mileage/OT philosophy in CLAUDE.md: "No money moves
- * automatically — the banner surfaces the estimate; the office pays it via
- * the normal additional-pay flow." This computes, for a pay window, the
- * dollar value of APPROVED paid leave (PLAWA / PTO — buckets with
- * leave_types.is_paid = true) as hours × hourly rate, and returns it as a
- * non-binding preview. It does NOT write additional_pay, does NOT touch
- * grand_total, and is read-only.
+ * Approved paid leave now AUTO-PAYS at approval (see lib/leave-pay.ts) as a
+ * real `additional_pay` line, so it already shows on the payroll summary.
+ * To avoid double-counting, this endpoint forecasts only PENDING (not-yet-
+ * approved) paid requests in a window — "what payroll would add if these
+ * are approved" — at the flat $20/hr leave rate. Read-only; writes nothing.
  *
- * Rate resolution (centralized — no inline literals, per the
- * "never hardcode the rate" rule):
- *   1. employee_pay_rates — the dated canonical hourly rate in effect for
- *      the window (latest effective_date <= window end, not yet ended).
- *   2. companies.commercial_hourly_rate — the only other concrete hourly
- *      figure on file (default $20), used as a documented fallback.
- *   3. none — no rate on file; amount is null and the office must set one.
- * The chosen source is returned as `rate_source` so the office sees
- * exactly where each number came from. (Which rate Phes pays leave at is a
- * Sal sign-off question — see the design doc.)
- *
- * Unpaid Personal leave is excluded (is_paid = false → no dollars).
- * Holiday is a separate benefit, not a leave_types bucket, so it never
- * appears here.
+ * Unpaid Personal is excluded (is_paid = false → no dollars). Holiday is a
+ * separate benefit, not a leave_types bucket, so it never appears here.
  */
 import { db } from "@workspace/db";
 import {
   leaveRequestsTable,
   leaveTypesTable,
   usersTable,
-  employeePayRatesTable,
 } from "@workspace/db/schema";
-import { and, eq, gte, lte, desc, sql } from "drizzle-orm";
+import { and, eq, gte, lte } from "drizzle-orm";
+import { LEAVE_PAY_RATE } from "./leave-pay.js";
 
 export type LeavePayPreviewRow = {
   user_id: number;
   name: string;
   slug: string;
   bucket: string;
-  approved_hours: number;
-  hourly_rate: number | null;
-  rate_source: "employee_pay_rates" | "company_default" | "none";
-  amount: number | null;
+  pending_hours: number;
+  hourly_rate: number;
+  amount: number;
 };
 
 export type LeavePayPreview = {
   rows: LeavePayPreviewRow[];
   total: number;
+  rate: number;
   note: string;
 };
 
-async function resolveCompanyDefaultHourly(
-  companyId: number,
-): Promise<number | null> {
-  try {
-    const r = await db.execute(
-      sql`SELECT commercial_hourly_rate FROM companies WHERE id = ${companyId} LIMIT 1`,
-    );
-    const v = (r.rows[0] as any)?.commercial_hourly_rate;
-    return v == null ? null : Number(v);
-  } catch {
-    return null;
-  }
-}
-
-async function resolveEmployeeHourly(
-  companyId: number,
-  userId: number,
-  asOf: string,
-): Promise<number | null> {
-  const rows = await db
-    .select({ rate: employeePayRatesTable.hourly_rate })
-    .from(employeePayRatesTable)
-    .where(
-      and(
-        eq(employeePayRatesTable.company_id, companyId),
-        eq(employeePayRatesTable.user_id, userId),
-        lte(employeePayRatesTable.effective_date, asOf),
-      ),
-    )
-    .orderBy(desc(employeePayRatesTable.effective_date))
-    .limit(1);
-  return rows[0]?.rate != null ? Number(rows[0].rate) : null;
-}
-
-/** Compute the paid-leave preview for [from, to] (YYYY-MM-DD). Requests
- *  are attributed by start_date falling in the window — a request that
- *  straddles two pay periods lands wholly in the period of its start
- *  (flagged in `note`; refine if Sal wants day-level splitting). */
+/** Forecast pending paid-leave dollars for [from, to] (YYYY-MM-DD),
+ *  attributed by start_date. Flat $20/hr. */
 export async function computeLeavePayPreview(
   companyId: number,
   from: string,
@@ -111,14 +61,13 @@ export async function computeLeavePayPreview(
     .where(
       and(
         eq(leaveRequestsTable.company_id, companyId),
-        eq(leaveRequestsTable.status, "approved"),
+        eq(leaveRequestsTable.status, "pending"),
         eq(leaveTypesTable.is_paid, true),
         gte(leaveRequestsTable.start_date, from),
         lte(leaveRequestsTable.start_date, to),
       ),
     );
 
-  // Aggregate hours per (user, bucket).
   const agg = new Map<
     string,
     { user_id: number; name: string; slug: string; bucket: string; hours: number }
@@ -138,46 +87,26 @@ export async function computeLeavePayPreview(
     agg.set(key, cur);
   }
 
-  const companyDefault = await resolveCompanyDefaultHourly(companyId);
-  const rateCache = new Map<number, number | null>();
-
   const rows: LeavePayPreviewRow[] = [];
   for (const a of agg.values()) {
-    let rate = rateCache.get(a.user_id);
-    if (rate === undefined) {
-      rate = await resolveEmployeeHourly(companyId, a.user_id, to);
-      rateCache.set(a.user_id, rate);
-    }
-    let hourly: number | null;
-    let source: LeavePayPreviewRow["rate_source"];
-    if (rate != null) {
-      hourly = rate;
-      source = "employee_pay_rates";
-    } else if (companyDefault != null) {
-      hourly = companyDefault;
-      source = "company_default";
-    } else {
-      hourly = null;
-      source = "none";
-    }
     const hours = Math.round(a.hours * 100) / 100;
     rows.push({
       user_id: a.user_id,
       name: a.name,
       slug: a.slug,
       bucket: a.bucket,
-      approved_hours: hours,
-      hourly_rate: hourly,
-      rate_source: source,
-      amount: hourly != null ? Math.round(hours * hourly * 100) / 100 : null,
+      pending_hours: hours,
+      hourly_rate: LEAVE_PAY_RATE,
+      amount: Math.round(hours * LEAVE_PAY_RATE * 100) / 100,
     });
   }
   rows.sort((x, y) => x.name.localeCompare(y.name) || x.slug.localeCompare(y.slug));
 
-  const total = rows.reduce((s, r) => s + (r.amount ?? 0), 0);
+  const total = rows.reduce((s, r) => s + r.amount, 0);
   return {
     rows,
     total: Math.round(total * 100) / 100,
-    note: "Preview only — review-gated. Not added to gross pay; the office pays approved leave via the normal additional-pay flow. Requests attributed by start_date.",
+    rate: LEAVE_PAY_RATE,
+    note: `Forecast of PENDING paid-leave requests at $${LEAVE_PAY_RATE}/hr. Approved leave already auto-pays on the payroll summary; this is the not-yet-approved pipeline. Attributed by start_date.`,
   };
 }

--- a/artifacts/api-server/src/lib/leave-pay-preview.ts
+++ b/artifacts/api-server/src/lib/leave-pay-preview.ts
@@ -1,0 +1,183 @@
+/**
+ * Paid-leave payroll PREVIEW — review-gated, never auto-paid.
+ *
+ * Mirrors the mileage/OT philosophy in CLAUDE.md: "No money moves
+ * automatically — the banner surfaces the estimate; the office pays it via
+ * the normal additional-pay flow." This computes, for a pay window, the
+ * dollar value of APPROVED paid leave (PLAWA / PTO — buckets with
+ * leave_types.is_paid = true) as hours × hourly rate, and returns it as a
+ * non-binding preview. It does NOT write additional_pay, does NOT touch
+ * grand_total, and is read-only.
+ *
+ * Rate resolution (centralized — no inline literals, per the
+ * "never hardcode the rate" rule):
+ *   1. employee_pay_rates — the dated canonical hourly rate in effect for
+ *      the window (latest effective_date <= window end, not yet ended).
+ *   2. companies.commercial_hourly_rate — the only other concrete hourly
+ *      figure on file (default $20), used as a documented fallback.
+ *   3. none — no rate on file; amount is null and the office must set one.
+ * The chosen source is returned as `rate_source` so the office sees
+ * exactly where each number came from. (Which rate Phes pays leave at is a
+ * Sal sign-off question — see the design doc.)
+ *
+ * Unpaid Personal leave is excluded (is_paid = false → no dollars).
+ * Holiday is a separate benefit, not a leave_types bucket, so it never
+ * appears here.
+ */
+import { db } from "@workspace/db";
+import {
+  leaveRequestsTable,
+  leaveTypesTable,
+  usersTable,
+  employeePayRatesTable,
+} from "@workspace/db/schema";
+import { and, eq, gte, lte, desc, sql } from "drizzle-orm";
+
+export type LeavePayPreviewRow = {
+  user_id: number;
+  name: string;
+  slug: string;
+  bucket: string;
+  approved_hours: number;
+  hourly_rate: number | null;
+  rate_source: "employee_pay_rates" | "company_default" | "none";
+  amount: number | null;
+};
+
+export type LeavePayPreview = {
+  rows: LeavePayPreviewRow[];
+  total: number;
+  note: string;
+};
+
+async function resolveCompanyDefaultHourly(
+  companyId: number,
+): Promise<number | null> {
+  try {
+    const r = await db.execute(
+      sql`SELECT commercial_hourly_rate FROM companies WHERE id = ${companyId} LIMIT 1`,
+    );
+    const v = (r.rows[0] as any)?.commercial_hourly_rate;
+    return v == null ? null : Number(v);
+  } catch {
+    return null;
+  }
+}
+
+async function resolveEmployeeHourly(
+  companyId: number,
+  userId: number,
+  asOf: string,
+): Promise<number | null> {
+  const rows = await db
+    .select({ rate: employeePayRatesTable.hourly_rate })
+    .from(employeePayRatesTable)
+    .where(
+      and(
+        eq(employeePayRatesTable.company_id, companyId),
+        eq(employeePayRatesTable.user_id, userId),
+        lte(employeePayRatesTable.effective_date, asOf),
+      ),
+    )
+    .orderBy(desc(employeePayRatesTable.effective_date))
+    .limit(1);
+  return rows[0]?.rate != null ? Number(rows[0].rate) : null;
+}
+
+/** Compute the paid-leave preview for [from, to] (YYYY-MM-DD). Requests
+ *  are attributed by start_date falling in the window — a request that
+ *  straddles two pay periods lands wholly in the period of its start
+ *  (flagged in `note`; refine if Sal wants day-level splitting). */
+export async function computeLeavePayPreview(
+  companyId: number,
+  from: string,
+  to: string,
+): Promise<LeavePayPreview> {
+  const reqs = await db
+    .select({
+      user_id: leaveRequestsTable.user_id,
+      hours: leaveRequestsTable.hours,
+      slug: leaveTypesTable.slug,
+      bucket: leaveTypesTable.display_name,
+      first_name: usersTable.first_name,
+      last_name: usersTable.last_name,
+    })
+    .from(leaveRequestsTable)
+    .innerJoin(
+      leaveTypesTable,
+      eq(leaveRequestsTable.leave_type_id, leaveTypesTable.id),
+    )
+    .innerJoin(usersTable, eq(leaveRequestsTable.user_id, usersTable.id))
+    .where(
+      and(
+        eq(leaveRequestsTable.company_id, companyId),
+        eq(leaveRequestsTable.status, "approved"),
+        eq(leaveTypesTable.is_paid, true),
+        gte(leaveRequestsTable.start_date, from),
+        lte(leaveRequestsTable.start_date, to),
+      ),
+    );
+
+  // Aggregate hours per (user, bucket).
+  const agg = new Map<
+    string,
+    { user_id: number; name: string; slug: string; bucket: string; hours: number }
+  >();
+  for (const r of reqs) {
+    const key = `${r.user_id}:${r.slug}`;
+    const cur =
+      agg.get(key) ??
+      {
+        user_id: r.user_id,
+        name: `${r.first_name ?? ""} ${r.last_name ?? ""}`.trim(),
+        slug: r.slug,
+        bucket: r.bucket,
+        hours: 0,
+      };
+    cur.hours += Number(r.hours);
+    agg.set(key, cur);
+  }
+
+  const companyDefault = await resolveCompanyDefaultHourly(companyId);
+  const rateCache = new Map<number, number | null>();
+
+  const rows: LeavePayPreviewRow[] = [];
+  for (const a of agg.values()) {
+    let rate = rateCache.get(a.user_id);
+    if (rate === undefined) {
+      rate = await resolveEmployeeHourly(companyId, a.user_id, to);
+      rateCache.set(a.user_id, rate);
+    }
+    let hourly: number | null;
+    let source: LeavePayPreviewRow["rate_source"];
+    if (rate != null) {
+      hourly = rate;
+      source = "employee_pay_rates";
+    } else if (companyDefault != null) {
+      hourly = companyDefault;
+      source = "company_default";
+    } else {
+      hourly = null;
+      source = "none";
+    }
+    const hours = Math.round(a.hours * 100) / 100;
+    rows.push({
+      user_id: a.user_id,
+      name: a.name,
+      slug: a.slug,
+      bucket: a.bucket,
+      approved_hours: hours,
+      hourly_rate: hourly,
+      rate_source: source,
+      amount: hourly != null ? Math.round(hours * hourly * 100) / 100 : null,
+    });
+  }
+  rows.sort((x, y) => x.name.localeCompare(y.name) || x.slug.localeCompare(y.slug));
+
+  const total = rows.reduce((s, r) => s + (r.amount ?? 0), 0);
+  return {
+    rows,
+    total: Math.round(total * 100) / 100,
+    note: "Preview only — review-gated. Not added to gross pay; the office pays approved leave via the normal additional-pay flow. Requests attributed by start_date.",
+  };
+}

--- a/artifacts/api-server/src/lib/leave-pay.ts
+++ b/artifacts/api-server/src/lib/leave-pay.ts
@@ -1,0 +1,73 @@
+/**
+ * Auto-pay approved paid leave (Sal 2026-06-20).
+ *
+ * Approval is the gate: when the office approves a PAID leave request
+ * (PLAWA / PTO), the hours cascade into pay automatically as a visible,
+ * labeled `additional_pay` line item — no separate manual pay step.
+ *
+ *   pay = hours × LEAVE_PAY_RATE ($20/hr, the company floor — a FLAT rate
+ *   for leave, NOT each tech's commission/blended rate).
+ *
+ * Type mapping (so the payroll Time-Off group + label render correctly):
+ *   sick / PLAWA bucket → additional_pay type 'sick_pay'  → "Sick Pay"
+ *   PTO bucket          → additional_pay type 'pto'       → "PTO"
+ *   unpaid buckets      → no pay row (is_paid = false)
+ *
+ * Idempotent: re-approving (e.g. denied→approved override) never
+ * double-pays — guarded on a `leave_req#<id>` marker in the notes.
+ * status='pending' so it flows into the payroll window (which excludes
+ * only 'voided'); created_at = now so it lands in the period of approval.
+ */
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+/** Flat company-floor rate for paid sick + PTO hours. */
+export const LEAVE_PAY_RATE = 20;
+
+export type LeavePayResult =
+  | { paid: false; reason: string }
+  | { paid: true; type: string; hours: number; amount: number };
+
+export async function writeApprovedLeavePay(
+  companyId: number,
+  requestId: number,
+): Promise<LeavePayResult> {
+  const r = await db.execute(sql`
+    SELECT lr.user_id, lr.hours, lr.start_date, lr.end_date,
+           lt.is_paid, lt.slug, lt.display_name
+      FROM leave_requests lr
+      JOIN leave_types lt ON lt.id = lr.leave_type_id
+     WHERE lr.id = ${requestId} AND lr.company_id = ${companyId}
+     LIMIT 1`);
+  const row: any = r.rows[0];
+  if (!row) return { paid: false, reason: "request not found" };
+  if (!row.is_paid) return { paid: false, reason: "unpaid bucket" };
+
+  const slug = String(row.slug);
+  const payType =
+    slug === "plawa" || slug === "sick" || slug.includes("sick")
+      ? "sick_pay"
+      : "pto";
+  const hours = Number(row.hours);
+  if (!(hours > 0)) return { paid: false, reason: "non-positive hours" };
+  const amount = Math.round(hours * LEAVE_PAY_RATE * 100) / 100;
+  const marker = `leave_req#${requestId}`;
+  const dates =
+    String(row.start_date) === String(row.end_date)
+      ? String(row.start_date)
+      : `${String(row.start_date)}–${String(row.end_date)}`;
+  const notes = `${row.display_name} leave approved (${marker}) — ${hours.toFixed(2)}h × $${LEAVE_PAY_RATE}/hr, ${dates}`;
+
+  // Insert only if no non-voided pay row already exists for this request.
+  await db.execute(sql`
+    INSERT INTO additional_pay (company_id, user_id, type, amount, notes, status, created_at)
+    SELECT ${companyId}, ${Number(row.user_id)}, ${payType}, ${amount.toFixed(2)}, ${notes}, 'pending', NOW()
+     WHERE NOT EXISTS (
+       SELECT 1 FROM additional_pay
+        WHERE company_id = ${companyId}
+          AND notes LIKE ${"%" + marker + "%"}
+          AND COALESCE(status,'pending') <> 'voided'
+     )`);
+
+  return { paid: true, type: payType, hours, amount };
+}

--- a/artifacts/api-server/src/lib/leave-reconcile.ts
+++ b/artifacts/api-server/src/lib/leave-reconcile.ts
@@ -1,0 +1,159 @@
+/**
+ * DB wrapper around the pure grant/reset engine (./leave-grant-reset.ts).
+ *
+ * `reconcileCompanyLeaveBalances` loops every active employee × active
+ * flat-grant bucket for a company and applies the plan from
+ * `planLeaveGrant`:
+ *   - dryRun: true  → compute + return the plan, write NOTHING (powers
+ *                     the migration diff and a safe cron preview).
+ *   - dryRun: false → persist initial_grant / annual_reset / tier_topup.
+ *
+ * Idempotent: re-running the same day is a no-op once the year's grant
+ * has landed (the year guard in planLeaveGrant). Split from the pure math
+ * so unit tests can import the math without pulling in the drizzle client.
+ */
+
+import { db } from "@workspace/db";
+import {
+  leaveTypesTable,
+  employeeLeaveBalancesTable,
+  companyLeavePolicyTable,
+  usersTable,
+} from "@workspace/db/schema";
+import { and, eq } from "drizzle-orm";
+import { round2 } from "./leave-balance.js";
+import {
+  planLeaveGrant,
+  type GrantAccrualMode,
+  type GrantBalance,
+  type GrantPlan,
+} from "./leave-grant-reset.js";
+
+export type ReconcilePlanRow = {
+  user_id: number;
+  first_name: string | null;
+  last_name: string | null;
+  hire_date: string | null;
+  leave_type_id: number;
+  slug: string;
+  display_name: string;
+  prior_granted: number;
+  prior_used: number;
+  plan: GrantPlan;
+  remaining: number; // new_granted - new_used
+};
+
+export async function reconcileCompanyLeaveBalances(
+  companyId: number,
+  asOf: string,
+  opts: { dryRun: boolean },
+): Promise<ReconcilePlanRow[]> {
+  const [policy] = await db
+    .select({ ceiling: companyLeavePolicyTable.balance_ceiling_hours })
+    .from(companyLeavePolicyTable)
+    .where(eq(companyLeavePolicyTable.company_id, companyId))
+    .limit(1);
+  const ceiling = policy?.ceiling ? Number(policy.ceiling) : 80;
+
+  const buckets = await db
+    .select()
+    .from(leaveTypesTable)
+    .where(
+      and(
+        eq(leaveTypesTable.company_id, companyId),
+        eq(leaveTypesTable.active, true),
+        eq(leaveTypesTable.accrual_mode, "flat_grant"),
+      ),
+    );
+
+  const users = await db
+    .select({
+      id: usersTable.id,
+      first_name: usersTable.first_name,
+      last_name: usersTable.last_name,
+      hire_date: usersTable.hire_date,
+    })
+    .from(usersTable)
+    .where(
+      and(eq(usersTable.company_id, companyId), eq(usersTable.is_active, true)),
+    );
+
+  const out: ReconcilePlanRow[] = [];
+  for (const u of users) {
+    const hireDate = u.hire_date ? String(u.hire_date) : null;
+    for (const b of buckets) {
+      const balRow = await db
+        .select()
+        .from(employeeLeaveBalancesTable)
+        .where(
+          and(
+            eq(employeeLeaveBalancesTable.company_id, companyId),
+            eq(employeeLeaveBalancesTable.user_id, u.id),
+            eq(employeeLeaveBalancesTable.leave_type_id, b.id),
+          ),
+        )
+        .limit(1);
+      const bal = balRow[0] ?? null;
+      const balance: GrantBalance | null = bal
+        ? {
+            granted_hours: Number(bal.granted_hours),
+            used_hours: Number(bal.used_hours),
+            last_reset_at: bal.last_reset_at ? new Date(bal.last_reset_at) : null,
+          }
+        : null;
+
+      const plan = planLeaveGrant(
+        {
+          slug: b.slug,
+          accrual_mode: b.accrual_mode as GrantAccrualMode,
+          annual_cap_hours: Number(b.annual_cap_hours),
+          waiting_period_days: b.waiting_period_days,
+          carryover_allowed: b.carryover_allowed,
+        },
+        balance,
+        hireDate,
+        asOf,
+        ceiling,
+      );
+
+      if (plan.action !== "none" && !opts.dryRun) {
+        const resetAt = new Date(`${asOf}T12:00:00Z`);
+        if (bal) {
+          await db
+            .update(employeeLeaveBalancesTable)
+            .set({
+              granted_hours: plan.new_granted.toFixed(2),
+              used_hours: plan.new_used.toFixed(2),
+              last_reset_at: resetAt,
+              updated_at: new Date(),
+            })
+            .where(eq(employeeLeaveBalancesTable.id, bal.id));
+        } else {
+          await db.insert(employeeLeaveBalancesTable).values({
+            company_id: companyId,
+            user_id: u.id,
+            leave_type_id: b.id,
+            granted_hours: plan.new_granted.toFixed(2),
+            used_hours: plan.new_used.toFixed(2),
+            last_reset_at: resetAt,
+          });
+        }
+      }
+
+      out.push({
+        user_id: u.id,
+        first_name: u.first_name,
+        last_name: u.last_name,
+        hire_date: hireDate,
+        leave_type_id: b.id,
+        slug: b.slug,
+        display_name: b.display_name,
+        prior_granted: balance ? round2(balance.granted_hours) : 0,
+        prior_used: balance ? round2(balance.used_hours) : 0,
+        plan,
+        remaining: round2(plan.new_granted - plan.new_used),
+      });
+    }
+  }
+  return out;
+}

--- a/artifacts/api-server/src/lib/leave-request-rules.ts
+++ b/artifacts/api-server/src/lib/leave-request-rules.ts
@@ -72,6 +72,37 @@ export function checkWaitingPeriod(
   return { ok: true };
 }
 
+/** PTO + Unpaid Personal require 7 days' advance notice (per handbook).
+ *  Short-notice buckets — PLAWA/sick, identified by exempt_from_blackout
+ *  (the protected, grace-call bucket) — are exempt: same-day / emergency
+ *  requests are allowed. Keyed on exempt_from_blackout to avoid a new
+ *  column; PLAWA is the only exempt bucket and the only short-notice one. */
+export const ADVANCE_NOTICE_DAYS = 7;
+
+export function checkAdvanceNotice(
+  bucket: BucketForValidation,
+  startDate: string,
+  asOf: string,
+): RuleResult {
+  if (bucket.exempt_from_blackout) return { ok: true }; // sick/emergency path
+  const cutoff = addDaysISO(asOf, ADVANCE_NOTICE_DAYS);
+  if (startDate < cutoff) {
+    return {
+      ok: false,
+      code: "insufficient_notice",
+      message: `${bucket.display_name} requires ${ADVANCE_NOTICE_DAYS} days' advance notice. Earliest start date is ${cutoff}.`,
+    };
+  }
+  return { ok: true };
+}
+
+/** asOf (YYYY-MM-DD) + n days, as YYYY-MM-DD (UTC). */
+function addDaysISO(asOf: string, n: number): string {
+  const d = new Date(`${asOf}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + n);
+  return d.toISOString().slice(0, 10);
+}
+
 export function checkBalance(
   bucket: BucketForValidation,
   requestedHours: number,

--- a/artifacts/api-server/src/routes/hr-leave.ts
+++ b/artifacts/api-server/src/routes/hr-leave.ts
@@ -8,6 +8,22 @@ import {
 import { eq, and, desc } from "drizzle-orm";
 import { requireAuth, requireRole } from "../lib/auth.js";
 
+/**
+ * DEPRECATED (time-off-accrual 2026-06-20) — legacy single-bucket leave.
+ *
+ * Superseded by the 3A engine at /api/leave (per-bucket
+ * employee_leave_balances + grant/reset jobs). The single-bucket columns
+ * users.{leave,pto,sick}_balance_hours this router reads/writes are NO
+ * LONGER the source of truth. The employee-profile Leave Balance tab now
+ * reads /api/leave/balances; nothing in the UI calls POST /use anymore.
+ *
+ * Kept ONLY so the GET /balance `usage` array (employee_leave_usage,
+ * which the 3A approval flow still populates) keeps rendering the history
+ * list. Do NOT build new features on this router. The deprecated columns
+ * and the write endpoints (PUT /balance, POST /use, POST /activate) are
+ * slated for removal in a follow-up AFTER the migration sign-off — left
+ * in place now to avoid a destructive schema change in this PR.
+ */
 const router = Router();
 
 router.get("/balance/:employee_id", requireAuth, requireRole("owner", "admin", "office"), async (req, res) => {

--- a/artifacts/api-server/src/routes/leave.ts
+++ b/artifacts/api-server/src/routes/leave.ts
@@ -64,11 +64,16 @@ import {
 import {
   checkRequestable,
   checkWaitingPeriod,
+  checkAdvanceNotice,
   checkBalance,
   detectBlackoutOverlap,
   type BucketForValidation,
   type BlackoutWindow,
 } from "../lib/leave-request-rules.js";
+import {
+  notifyLeaveSubmitted,
+  notifyLeaveDecision,
+} from "../lib/leave-notifications.js";
 import { recordUnexcusedEntryAndDriveLadder } from "../lib/unexcused-ladder-writer.js";
 import { evaluateUseItOrLoseItAlert } from "../lib/leave-alerts.js";
 import {
@@ -470,6 +475,9 @@ router.post("/requests", async (req, res) => {
   if (!r1.ok) return res.status(409).json({ error: "Conflict", ...r1 });
   const r2 = checkWaitingPeriod(validation, hireDate, today);
   if (!r2.ok) return res.status(409).json({ error: "Conflict", ...r2 });
+  // 7-day advance notice for PTO + Unpaid (sick/PLAWA = short-notice, exempt).
+  const r2b = checkAdvanceNotice(validation, body.start_date, today);
+  if (!r2b.ok) return res.status(409).json({ error: "Conflict", ...r2b });
 
   const balanceRow = await ensureBalanceRow(companyId, userId, bucket.id);
   const balance = computeCurrentBalance({
@@ -534,10 +542,9 @@ router.post("/requests", async (req, res) => {
     })
     .returning();
 
-  // Best-effort office notification (COMMS_ENABLED gated). Never
-  // fail the request if comms fails — the ticket is the source of
-  // truth.
-  void notifyOfficeOfRequestSilent(inserted[0]!.id, companyId);
+  // Office/owner "ACTION REQUIRED" + employee "Pending"/"Emergency" (or
+  // "Denied" if auto-denied above). Best-effort, never fails the request.
+  void notifyLeaveSubmitted(inserted[0]!.id, companyId);
 
   return res.json({ data: inserted[0] });
 });
@@ -841,7 +848,8 @@ router.post("/requests/:id/approve", adminWriteGate, async (req, res) => {
       updated_at: new Date(),
     })
     .where(eq(leaveRequestsTable.id, id));
-  void notifyEmployeeOfDecisionSilent(id, "approved");
+  // Employee Approved notification: in-app + push + email + SMS (MC-mirrored).
+  void notifyLeaveDecision(id, "approved");
   // [push 2026-06-03] Push the employee (fire-and-forget, gated by COMMS_ENABLED).
   {
     const when = reqRow.start_date
@@ -881,7 +889,8 @@ router.post("/requests/:id/deny", adminWriteGate, async (req, res) => {
       updated_at: new Date(),
     })
     .where(eq(leaveRequestsTable.id, id));
-  void notifyEmployeeOfDecisionSilent(id, "denied");
+  // Employee Denied notification: in-app + push + email + SMS (MC-mirrored).
+  void notifyLeaveDecision(id, "denied");
   return res.json({ data: { id, status: "denied" } });
 });
 
@@ -1117,38 +1126,10 @@ router.post("/unexcused/record", officeReadGate, async (req, res) => {
 // Notification helpers — best-effort, COMMS_ENABLED-gated, never throw
 // ─────────────────────────────────────────────────────────────────────────────
 
-async function notifyOfficeOfRequestSilent(
-  requestId: number,
-  companyId: number,
-): Promise<void> {
-  try {
-    if (process.env.COMMS_ENABLED !== "true") return;
-    // The ticket itself is in the DB; this is just the email ping.
-    // Office notification details (recipient list) live in the
-    // existing comms layer — wired by recipient role conventions.
-    // Implementing the actual send is out of scope here; we leave a
-    // structured log line the comms job can pick up.
-    console.log(
-      `[leave] new request #${requestId} (company ${companyId}) — comms enabled, office notify`,
-    );
-  } catch (err) {
-    console.warn("[leave] office notify failed (non-fatal):", err);
-  }
-}
-
-async function notifyEmployeeOfDecisionSilent(
-  requestId: number,
-  outcome: "approved" | "denied",
-): Promise<void> {
-  try {
-    if (process.env.COMMS_ENABLED !== "true") return;
-    console.log(
-      `[leave] request #${requestId} → ${outcome} — comms enabled, employee notify`,
-    );
-  } catch (err) {
-    console.warn("[leave] employee notify failed (non-fatal):", err);
-  }
-}
+// Leave request/decision notifications moved to lib/leave-notifications.ts
+// (notifyLeaveSubmitted / notifyLeaveDecision) — real in-app + push + email
+// + SMS mirroring MaidCentral's templates, replacing the prior console-log
+// stubs (notifyOfficeOfRequestSilent / notifyEmployeeOfDecisionSilent).
 
 // notifyOfficeOfDisciplineSilent moved to lib/unexcused-ladder-writer.ts
 // in cutover 3B and re-exported (imported above) so the new

--- a/artifacts/api-server/src/routes/leave.ts
+++ b/artifacts/api-server/src/routes/leave.ts
@@ -74,6 +74,7 @@ import {
   notifyLeaveSubmitted,
   notifyLeaveDecision,
 } from "../lib/leave-notifications.js";
+import { writeApprovedLeavePay } from "../lib/leave-pay.js";
 import { recordUnexcusedEntryAndDriveLadder } from "../lib/unexcused-ladder-writer.js";
 import { evaluateUseItOrLoseItAlert } from "../lib/leave-alerts.js";
 import {
@@ -848,6 +849,13 @@ router.post("/requests/:id/approve", adminWriteGate, async (req, res) => {
       updated_at: new Date(),
     })
     .where(eq(leaveRequestsTable.id, id));
+  // Auto-pay: approval is the gate — a paid bucket cascades into pay as a
+  // visible additional_pay line ($20/hr flat). Idempotent; unpaid = no-op.
+  try {
+    await writeApprovedLeavePay(companyId, id);
+  } catch (err) {
+    console.error("[leave] auto-pay on approval failed (non-fatal):", err);
+  }
   // Employee Approved notification: in-app + push + email + SMS (MC-mirrored).
   void notifyLeaveDecision(id, "approved");
   // [push 2026-06-03] Push the employee (fire-and-forget, gated by COMMS_ENABLED).

--- a/artifacts/api-server/src/routes/payroll.ts
+++ b/artifacts/api-server/src/routes/payroll.ts
@@ -130,8 +130,9 @@ router.get("/summary", requireAuth, requireRole("owner", "admin", "office"), asy
       const sick_pay = additional.sick_pay || 0;
       const holiday_pay = additional.holiday_pay || 0;
       const vacation_pay = additional.vacation_pay || 0;
+      const pto = additional.pto || 0; // auto-paid PTO leave (type 'pto')
       const deductions = additional.amount_owed || 0;
-      const gross_pay = base_pay + tips + bonuses + sick_pay + holiday_pay + vacation_pay - deductions;
+      const gross_pay = base_pay + tips + bonuses + sick_pay + holiday_pay + vacation_pay + pto - deductions;
 
       return {
         user_id: emp.id,
@@ -146,6 +147,7 @@ router.get("/summary", requireAuth, requireRole("owner", "admin", "office"), asy
         sick_pay,
         holiday_pay,
         vacation_pay,
+        pto,
         deductions,
         gross_pay: Math.round(gross_pay * 100) / 100,
       };

--- a/artifacts/api-server/src/routes/payroll.ts
+++ b/artifacts/api-server/src/routes/payroll.ts
@@ -15,6 +15,7 @@ import {
   FEDERAL_DEFAULT_RULES,
   type OvertimeRules,
 } from "../lib/overtime.js";
+import { computeLeavePayPreview } from "../lib/leave-pay-preview.js";
 
 const router = Router();
 
@@ -165,6 +166,31 @@ router.get("/summary", requireAuth, requireRole("owner", "admin", "office"), asy
   } catch (err) {
     console.error("Payroll summary error:", err);
     return res.status(500).json({ error: "Internal Server Error", message: "Failed to get payroll summary" });
+  }
+});
+
+// ── Paid-leave preview (review-gated) ──────────────────────────────────────────
+// [time-off-accrual 2026-06-20] Surfaces the dollar value of APPROVED paid
+// leave (PLAWA / PTO) for a pay window as hours × rate — a non-binding review
+// signal, NOT auto-pay. Same philosophy as the overtime/mileage banners: the
+// office sees the estimate and pays via the normal additional-pay flow. Does
+// not modify gross_pay. Office-only.
+router.get("/leave-pay-preview", requireAuth, requireRole("owner", "admin", "office"), async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId!;
+    const { from, to } = req.query;
+    if (!from || !to) {
+      return res.status(400).json({ error: "from and to (YYYY-MM-DD) required" });
+    }
+    const preview = await computeLeavePayPreview(
+      companyId,
+      String(from),
+      String(to),
+    );
+    return res.json(preview);
+  } catch (err) {
+    console.error("leave-pay-preview error:", err);
+    return res.status(500).json({ error: "Failed to compute leave pay preview" });
   }
 });
 

--- a/artifacts/api-server/src/tests/cutover-3b-leave-grant-reset.test.ts
+++ b/artifacts/api-server/src/tests/cutover-3b-leave-grant-reset.test.ts
@@ -8,8 +8,10 @@ import {
   completedYearsOfService,
   entitlementHours,
   planLeaveGrant,
+  benefitYearStartDate,
   type GrantBucket,
 } from "../lib/leave-grant-reset.js";
+import { checkAdvanceNotice } from "../lib/leave-request-rules.js";
 
 const ASOF = "2026-06-20";
 const CEILING = 80;
@@ -116,24 +118,43 @@ describe("planLeaveGrant", () => {
     assert.equal(p.new_granted, 0);
   });
 
-  it("balance from last year + eligible → annual_reset (re-front-load, used 0)", () => {
+  it("last reset in PRIOR benefit year → annual_reset (re-front-load, used 0)", () => {
+    // Norma-like: hire 5/11, last reset on the 2025 anniversary. As of
+    // 2026-06-20 the benefit year started 2026-05-11, so the 2025 grant
+    // is stale → re-front-load.
     const p = planLeaveGrant(
       PLAWA,
-      { granted_hours: 40, used_hours: 32, last_reset_at: new Date("2025-01-01T12:00:00Z") },
-      "2024-01-01",
+      { granted_hours: 40, used_hours: 32, last_reset_at: new Date("2025-05-11T12:00:00Z") },
+      "2023-05-11",
       ASOF,
       CEILING,
     );
     assert.equal(p.action, "annual_reset");
     assert.equal(p.new_granted, 40);
-    assert.equal(p.new_used, 0); // prior-year usage wiped
+    assert.equal(p.new_used, 0); // prior-benefit-year usage wiped
   });
 
-  it("balance granted this year, entitlement unchanged → none (preserve used)", () => {
+  it("NO calendar reset: Jan-1 does NOT reset; before the anniversary it's still the prior benefit year", () => {
+    // Hire 5/11; as of 2026-04-01 (before the 2026 anniversary) the
+    // current benefit year started 2025-05-11. A reset stamped 2025-05-11
+    // is still current → none. (A Jan-1 calendar model would have reset.)
+    const p = planLeaveGrant(
+      PLAWA,
+      { granted_hours: 40, used_hours: 12, last_reset_at: new Date("2025-05-11T12:00:00Z") },
+      "2023-05-11",
+      "2026-04-01",
+      CEILING,
+    );
+    assert.equal(p.action, "none");
+    assert.equal(p.new_granted, 40);
+    assert.equal(p.new_used, 12); // preserved — same benefit year
+  });
+
+  it("balance granted THIS benefit year, entitlement unchanged → none (preserve used)", () => {
     const p = planLeaveGrant(
       PTO,
-      { granted_hours: 40, used_hours: 10, last_reset_at: new Date("2026-01-01T12:00:00Z") },
-      "2025-06-03",
+      { granted_hours: 40, used_hours: 10, last_reset_at: new Date("2026-06-10T12:00:00Z") },
+      "2025-06-03", // benefit year started 2026-06-03; reset 6/10 is current
       ASOF,
       CEILING,
     );
@@ -142,11 +163,13 @@ describe("planLeaveGrant", () => {
     assert.equal(p.new_used, 10);
   });
 
-  it("PTO crosses 2-year tier mid-year → tier_topup to 80, used preserved", () => {
+  it("PTO tier bump within the benefit year → tier_topup to 80, used preserved", () => {
+    // Anniversary 6/18 already reset granted to 40 (stale), but tenure is
+    // now 2yr so the tier is 80 → top the bank up without zeroing used.
     const p = planLeaveGrant(
       PTO,
-      { granted_hours: 40, used_hours: 10, last_reset_at: new Date("2026-01-01T12:00:00Z") },
-      "2024-06-18", // 2 years as of ASOF
+      { granted_hours: 40, used_hours: 10, last_reset_at: new Date("2026-06-19T12:00:00Z") },
+      "2024-06-18", // benefit year started 2026-06-18; 2 years tenure
       ASOF,
       CEILING,
     );
@@ -155,12 +178,12 @@ describe("planLeaveGrant", () => {
     assert.equal(p.new_used, 10); // NOT reset — only the bank tops up
   });
 
-  it("handbook example: PTO bank tops UP to tier, never stacks (no +on-top)", () => {
-    // Used 20 of 40 in year 1; at the year reset the bank is set to the
-    // year's entitlement, not 20 carried + a fresh grant.
+  it("handbook example: PTO bank tops UP to tier at the anniversary, never stacks", () => {
+    // Used 20 of 40; at the benefit-year (anniversary) reset the bank is
+    // set to the tenure entitlement, not 20 carried + a fresh grant.
     const p = planLeaveGrant(
       PTO,
-      { granted_hours: 40, used_hours: 20, last_reset_at: new Date("2025-06-30T12:00:00Z") },
+      { granted_hours: 40, used_hours: 20, last_reset_at: new Date("2025-06-18T12:00:00Z") },
       "2024-06-18",
       ASOF,
       CEILING,
@@ -169,5 +192,33 @@ describe("planLeaveGrant", () => {
     assert.equal(p.new_granted, 80); // tier at 2yr
     assert.equal(p.new_used, 0);
     // available = 80, NOT 20 + 80 = 100, NOT 20 + 40 = 60
+  });
+});
+
+describe("checkAdvanceNotice — 7-day for PTO/Unpaid, exempt for sick", () => {
+  const ptoB = { requestable: true, waiting_period_days: 365, accrual_mode: "flat_grant" as const, exempt_from_blackout: false, display_name: "PTO" };
+  const sickB = { requestable: true, waiting_period_days: 90, accrual_mode: "flat_grant" as const, exempt_from_blackout: true, display_name: "PLAWA" };
+  it("PTO start within 7 days → fail", () => {
+    const r = checkAdvanceNotice(ptoB, "2026-06-23", "2026-06-20");
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.equal(r.code, "insufficient_notice");
+  });
+  it("PTO start exactly 7 days out → ok", () => {
+    assert.equal(checkAdvanceNotice(ptoB, "2026-06-27", "2026-06-20").ok, true);
+  });
+  it("Sick (exempt) same-day → ok (emergency path)", () => {
+    assert.equal(checkAdvanceNotice(sickB, "2026-06-20", "2026-06-20").ok, true);
+  });
+});
+
+describe("benefitYearStartDate", () => {
+  it("most recent anniversary on/before asOf", () => {
+    assert.equal(benefitYearStartDate("2023-05-11", "2026-06-20").toISOString().slice(0, 10), "2026-05-11");
+  });
+  it("before this year's anniversary → last year's", () => {
+    assert.equal(benefitYearStartDate("2023-05-11", "2026-04-01").toISOString().slice(0, 10), "2025-05-11");
+  });
+  it("Aug hire mid-year → prior Aug", () => {
+    assert.equal(benefitYearStartDate("2025-08-01", "2026-06-20").toISOString().slice(0, 10), "2025-08-01");
   });
 });

--- a/artifacts/api-server/src/tests/cutover-3b-leave-grant-reset.test.ts
+++ b/artifacts/api-server/src/tests/cutover-3b-leave-grant-reset.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Time-off grant + calendar-year reset engine (Phes model).
+ * Pure tests — no DB. Names per the buckets seeded for co1.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  completedYearsOfService,
+  entitlementHours,
+  planLeaveGrant,
+  type GrantBucket,
+} from "../lib/leave-grant-reset.js";
+
+const ASOF = "2026-06-20";
+const CEILING = 80;
+
+const PLAWA: GrantBucket = {
+  slug: "plawa",
+  accrual_mode: "flat_grant",
+  annual_cap_hours: 40,
+  waiting_period_days: 90,
+  carryover_allowed: false,
+};
+const PTO: GrantBucket = {
+  slug: "pto_phes",
+  accrual_mode: "flat_grant",
+  annual_cap_hours: 40,
+  waiting_period_days: 365,
+  carryover_allowed: true,
+};
+const UNPAID: GrantBucket = {
+  slug: "unpaid_leave",
+  accrual_mode: "flat_grant",
+  annual_cap_hours: 40,
+  waiting_period_days: 0,
+  carryover_allowed: false,
+};
+
+describe("completedYearsOfService", () => {
+  it("Diana 2024-06-18 → 2 years by 2026-06-20", () => {
+    assert.equal(completedYearsOfService("2024-06-18", ASOF), 2);
+  });
+  it("anniversary not yet reached counts one fewer", () => {
+    assert.equal(completedYearsOfService("2024-06-18", "2026-06-17"), 1);
+  });
+  it("Alma 2025-06-03 → 1 year by 2026-06-20", () => {
+    assert.equal(completedYearsOfService("2025-06-03", ASOF), 1);
+  });
+  it("hired this year → 0", () => {
+    assert.equal(completedYearsOfService("2026-05-01", ASOF), 0);
+  });
+});
+
+describe("entitlementHours — PLAWA (sick, 40 front-loaded after 90d, no carryover)", () => {
+  it("past 90 days → 40", () => {
+    assert.equal(entitlementHours(PLAWA, "2026-01-26", ASOF, CEILING), 40);
+  });
+  it("within 90 days → 0 (not eligible)", () => {
+    assert.equal(entitlementHours(PLAWA, "2026-05-25", ASOF, CEILING), 0);
+  });
+  it("never scales with tenure (carryover false)", () => {
+    assert.equal(entitlementHours(PLAWA, "2019-09-01", ASOF, CEILING), 40);
+  });
+  it("null hire date → 0", () => {
+    assert.equal(entitlementHours(PLAWA, null, ASOF, CEILING), 0);
+  });
+});
+
+describe("entitlementHours — PTO (40 @ 1yr → 80 @ 2yr, hard cap 80)", () => {
+  it("under 1 year → 0", () => {
+    assert.equal(entitlementHours(PTO, "2025-08-01", ASOF, CEILING), 0);
+  });
+  it("1 year (Alma) → 40", () => {
+    assert.equal(entitlementHours(PTO, "2025-06-03", ASOF, CEILING), 40);
+  });
+  it("2 years (Diana) → 80", () => {
+    assert.equal(entitlementHours(PTO, "2024-06-18", ASOF, CEILING), 80);
+  });
+  it("3+ years stays capped at 80 (Norma)", () => {
+    assert.equal(entitlementHours(PTO, "2023-05-11", ASOF, CEILING), 80);
+  });
+});
+
+describe("entitlementHours — Unpaid personal (40 from day one)", () => {
+  it("eligible day one → 40", () => {
+    assert.equal(entitlementHours(UNPAID, "2026-06-16", ASOF, CEILING), 40);
+  });
+});
+
+describe("entitlementHours — non-flat-grant buckets never grant", () => {
+  it("office_recorded → 0", () => {
+    assert.equal(
+      entitlementHours({ ...PLAWA, accrual_mode: "office_recorded" }, "2020-01-01", ASOF, CEILING),
+      0,
+    );
+  });
+  it("accrue_per_hours → 0", () => {
+    assert.equal(
+      entitlementHours({ ...PLAWA, accrual_mode: "accrue_per_hours" }, "2020-01-01", ASOF, CEILING),
+      0,
+    );
+  });
+});
+
+describe("planLeaveGrant", () => {
+  it("no balance + eligible → initial_grant (40, used 0)", () => {
+    const p = planLeaveGrant(PLAWA, null, "2026-01-26", ASOF, CEILING);
+    assert.equal(p.action, "initial_grant");
+    assert.equal(p.new_granted, 40);
+    assert.equal(p.new_used, 0);
+  });
+
+  it("no balance + not eligible → none (0/0)", () => {
+    const p = planLeaveGrant(PLAWA, null, "2026-05-25", ASOF, CEILING);
+    assert.equal(p.action, "none");
+    assert.equal(p.new_granted, 0);
+  });
+
+  it("balance from last year + eligible → annual_reset (re-front-load, used 0)", () => {
+    const p = planLeaveGrant(
+      PLAWA,
+      { granted_hours: 40, used_hours: 32, last_reset_at: new Date("2025-01-01T12:00:00Z") },
+      "2024-01-01",
+      ASOF,
+      CEILING,
+    );
+    assert.equal(p.action, "annual_reset");
+    assert.equal(p.new_granted, 40);
+    assert.equal(p.new_used, 0); // prior-year usage wiped
+  });
+
+  it("balance granted this year, entitlement unchanged → none (preserve used)", () => {
+    const p = planLeaveGrant(
+      PTO,
+      { granted_hours: 40, used_hours: 10, last_reset_at: new Date("2026-01-01T12:00:00Z") },
+      "2025-06-03",
+      ASOF,
+      CEILING,
+    );
+    assert.equal(p.action, "none");
+    assert.equal(p.new_granted, 40);
+    assert.equal(p.new_used, 10);
+  });
+
+  it("PTO crosses 2-year tier mid-year → tier_topup to 80, used preserved", () => {
+    const p = planLeaveGrant(
+      PTO,
+      { granted_hours: 40, used_hours: 10, last_reset_at: new Date("2026-01-01T12:00:00Z") },
+      "2024-06-18", // 2 years as of ASOF
+      ASOF,
+      CEILING,
+    );
+    assert.equal(p.action, "tier_topup");
+    assert.equal(p.new_granted, 80);
+    assert.equal(p.new_used, 10); // NOT reset — only the bank tops up
+  });
+
+  it("handbook example: PTO bank tops UP to tier, never stacks (no +on-top)", () => {
+    // Used 20 of 40 in year 1; at the year reset the bank is set to the
+    // year's entitlement, not 20 carried + a fresh grant.
+    const p = planLeaveGrant(
+      PTO,
+      { granted_hours: 40, used_hours: 20, last_reset_at: new Date("2025-06-30T12:00:00Z") },
+      "2024-06-18",
+      ASOF,
+      CEILING,
+    );
+    assert.equal(p.action, "annual_reset");
+    assert.equal(p.new_granted, 80); // tier at 2yr
+    assert.equal(p.new_used, 0);
+    // available = 80, NOT 20 + 80 = 100, NOT 20 + 40 = 60
+  });
+});

--- a/artifacts/qleno/src/pages/employee-profile-hr-tabs.tsx
+++ b/artifacts/qleno/src/pages/employee-profile-hr-tabs.tsx
@@ -186,138 +186,90 @@ export function HRAttendanceTab({ employeeId }: { employeeId: number }) {
   );
 }
 
+// [time-off-accrual 2026-06-20] Repointed to the 3A leave engine. Shows
+// per-bucket balances (PLAWA / PTO / Unpaid) — granted / used / available
+// + the 90-day / 1-year eligibility gate — from GET /api/leave/balances,
+// the single source of truth. Usage history still reads employee_leave_usage
+// (which the 3A approval flow populates). The legacy single-bucket readout
+// and the manual "Log Leave Usage" write (it decremented the deprecated
+// users.leave_balance_hours) are removed — leave usage now flows through the
+// leave-request → approval path. All buckets reset on the calendar year.
 export function LeaveBalanceTab({ employeeId }: { employeeId: number }) {
-  const role = getTokenRole();
-  const canLog = role === "owner" || role === "admin" || role === "office";
   const { toast } = useToast();
-  const [data, setData] = useState<any>(null);
+  const [buckets, setBuckets] = useState<any[] | null>(null);
+  const [usage, setUsage] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
-  const [showModal, setShowModal] = useState(false);
-  const [form, setForm] = useState({ date_used: new Date().toISOString().slice(0, 10), hours: "", notes: "" });
-  const [saving, setSaving] = useState(false);
 
-  function load() {
-    apiFetch(`/hr-leave/balance/${employeeId}`)
-      .then(setData)
-      .catch(() => toast({ title: "Failed to load leave balance", variant: "destructive" }))
-      .finally(() => setLoading(false));
-  }
-
-  useEffect(() => { load(); }, [employeeId]);
-
-  async function submit() {
-    setSaving(true);
-    try {
-      const result = await apiFetch("/hr-leave/use", { method: "POST", body: JSON.stringify({ employee_id: employeeId, ...form }) });
-      setData((d: any) => ({ ...d, leave_balance_hours: result.new_balance, usage: [result.usage, ...(d.usage || [])] }));
-      setShowModal(false);
-      toast({ title: "Leave usage recorded" });
-    } catch {
-      toast({ title: "Failed to log leave usage", variant: "destructive" });
-    } finally {
-      setSaving(false);
-    }
-  }
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    Promise.all([
+      apiFetch(`/leave/balances?userId=${employeeId}`).then((r: any) => r?.data ?? []).catch(() => []),
+      apiFetch(`/hr-leave/balance/${employeeId}`).then((r: any) => r?.usage ?? []).catch(() => []),
+    ])
+      .then(([b, u]: any[]) => {
+        if (!active) return;
+        setBuckets(b);
+        setUsage(u);
+      })
+      .catch(() => toast({ title: "Failed to load leave balances", variant: "destructive" }))
+      .finally(() => { if (active) setLoading(false); });
+    return () => { active = false; };
+  }, [employeeId]);
 
   if (loading) return <div style={{ padding: 32, textAlign: "center", color: "#9CA3AF", fontFamily: FF }}>Loading…</div>;
-  if (!data) return <EmptyState message="Could not load leave data" />;
-
-  const policy = data.policy;
-  const activated = data.leave_balance_activated;
+  if (!buckets) return <EmptyState message="Could not load leave data" />;
 
   return (
     <div>
-      {!policy?.leave_program_enabled && (
+      <div style={{ fontSize: 12, color: "#6B7280", fontFamily: FF, marginBottom: 16 }}>
+        Balances reset each calendar year (Jan 1). Sick (PLAWA) front-loads 40 hrs after 90 days; PTO grants 40 hrs after 1 year, topping up to 80 hrs at 2 years.
+      </div>
+
+      {!buckets.length && (
         <div style={{ background: "#F9FAFB", border: "1px solid #E5E7EB", borderRadius: 8, padding: "16px 20px", marginBottom: 20, fontSize: 13, color: "#6B7280", fontFamily: FF }}>
-          No leave program is configured. Enable it in Company Settings under HR Policies.
+          No leave buckets configured. Set them up in Company Settings under HR Policies.
         </div>
       )}
 
-      {policy?.leave_program_enabled && (
-        <>
-          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: 12, marginBottom: 24 }}>
-            <div style={{ background: "#fff", border: "1px solid #E5E2DC", borderRadius: 10, padding: "16px 20px" }}>
-              <div style={{ fontSize: 11, textTransform: "uppercase", letterSpacing: "0.06em", color: "#9CA3AF", fontFamily: FF, marginBottom: 6 }}>Balance</div>
-              <div style={{ fontSize: 28, fontWeight: 700, color: activated ? "var(--brand)" : "#9CA3AF", fontFamily: FF }}>{parseFloat(data.leave_balance_hours || "0").toFixed(1)}</div>
-              <div style={{ fontSize: 12, color: "#6B7280", fontFamily: FF }}>hours available</div>
-            </div>
-            <div style={{ background: "#fff", border: "1px solid #E5E2DC", borderRadius: 10, padding: "16px 20px" }}>
-              <div style={{ fontSize: 11, textTransform: "uppercase", letterSpacing: "0.06em", color: "#9CA3AF", fontFamily: FF, marginBottom: 6 }}>Status</div>
-              <div style={{ fontSize: 13, fontWeight: 600, fontFamily: FF, color: activated ? "#166534" : "#92400E" }}>
-                {activated ? "Active" : "Not yet eligible"}
-              </div>
-              {!activated && data.activation_date && (
-                <div style={{ fontSize: 12, color: "#6B7280", fontFamily: FF, marginTop: 2 }}>
-                  Eligible from {fmtDate(data.activation_date)}
+      {!!buckets.length && (
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 12, marginBottom: 24 }}>
+          {buckets.map((b: any) => {
+            const eligible = !!b.past_waiting_period;
+            const available = parseFloat(b.available ?? "0");
+            return (
+              <div key={b.leave_type_id} style={{ background: "#fff", border: "1px solid #E5E2DC", borderRadius: 10, padding: "16px 20px" }}>
+                <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 6 }}>
+                  <div style={{ fontSize: 11, textTransform: "uppercase", letterSpacing: "0.06em", color: "#9CA3AF", fontFamily: FF }}>{b.display_name}</div>
+                  <span style={{ fontSize: 10, fontWeight: 600, fontFamily: FF, padding: "2px 7px", borderRadius: 999, color: eligible ? "#166534" : "#92400E", background: eligible ? "#DCFCE7" : "#FEF3C7" }}>
+                    {eligible ? "Eligible" : "Not yet eligible"}
+                  </span>
                 </div>
-              )}
-            </div>
-            <div style={{ background: "#fff", border: "1px solid #E5E2DC", borderRadius: 10, padding: "16px 20px" }}>
-              <div style={{ fontSize: 11, textTransform: "uppercase", letterSpacing: "0.06em", color: "#9CA3AF", fontFamily: FF, marginBottom: 6 }}>Program</div>
-              <div style={{ fontSize: 13, fontWeight: 600, color: "#1A1917", fontFamily: FF }}>{policy.leave_program_name}</div>
-              <div style={{ fontSize: 12, color: "#6B7280", fontFamily: FF }}>
-                {policy.leave_grant_method === "front_loaded" ? `${policy.leave_hours_granted} hrs front-loaded` : "Accrual-based"}
-              </div>
-            </div>
-          </div>
-
-          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 12 }}>
-            <h3 style={{ margin: 0, fontSize: 14, fontWeight: 600, color: "#1A1917", fontFamily: FF }}>Usage History</h3>
-            {canLog && activated && (
-              <button onClick={() => setShowModal(true)} style={{
-                display: "flex", alignItems: "center", gap: 6, padding: "8px 16px",
-                background: "var(--brand)", color: "#fff", border: "none", borderRadius: 8,
-                fontSize: 13, fontWeight: 600, cursor: "pointer", fontFamily: FF,
-              }}>
-                <Plus size={14} /> Log Leave Usage
-              </button>
-            )}
-          </div>
-
-          {!(data.usage || []).length && <EmptyState message="No leave usage recorded yet" />}
-          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-            {(data.usage || []).map((u: any) => (
-              <div key={u.id} style={{ background: "#fff", border: "1px solid #E5E2DC", borderRadius: 10, padding: "14px 18px", display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-                <div>
-                  <div style={{ fontSize: 13, fontWeight: 600, color: "#1A1917", fontFamily: FF }}>{fmtDate(u.date_used)}</div>
-                  {u.notes && <div style={{ fontSize: 12, color: "#6B7280", fontFamily: FF, marginTop: 2 }}>{u.notes}</div>}
+                <div style={{ fontSize: 28, fontWeight: 700, color: eligible ? "var(--brand)" : "#9CA3AF", fontFamily: FF }}>{available.toFixed(1)}</div>
+                <div style={{ fontSize: 12, color: "#6B7280", fontFamily: FF }}>hours available</div>
+                <div style={{ fontSize: 11, color: "#9CA3AF", fontFamily: FF, marginTop: 8 }}>
+                  {parseFloat(b.granted ?? "0").toFixed(1)} granted · {parseFloat(b.used ?? "0").toFixed(1)} used
+                  {!eligible && b.waiting_period_days > 0 && ` · eligible after ${b.waiting_period_days} days`}
                 </div>
-                <div style={{ fontSize: 16, fontWeight: 700, color: "#991B1B", fontFamily: FF }}>−{parseFloat(u.hours).toFixed(1)} hrs</div>
               </div>
-            ))}
-          </div>
-        </>
-      )}
-
-      {showModal && (
-        <div style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,0.4)", display: "flex", alignItems: "center", justifyContent: "center", zIndex: 1000 }}>
-          <div style={{ background: "#fff", borderRadius: 12, padding: 28, width: 400, boxShadow: "0 20px 60px rgba(0,0,0,0.2)" }}>
-            <h3 style={{ margin: "0 0 20px", fontSize: 16, fontWeight: 700, color: "#1A1917", fontFamily: FF }}>Log Leave Usage</h3>
-            <div style={{ display: "flex", flexDirection: "column", gap: 12, marginBottom: 20 }}>
-              <div>
-                <label style={{ fontSize: 12, fontWeight: 500, display: "block", marginBottom: 4, fontFamily: FF }}>Date</label>
-                <CalendarPopover value={form.date_used} ariaLabel="Date" onChange={ymd => setForm(p => ({ ...p, date_used: ymd }))} block />
-              </div>
-              <div>
-                <label style={{ fontSize: 12, fontWeight: 500, display: "block", marginBottom: 4, fontFamily: FF }}>Hours Used</label>
-                <input type="number" min={0.5} step={0.5} value={form.hours} onChange={e => setForm(p => ({ ...p, hours: e.target.value }))}
-                  style={{ width: "100%", padding: "8px 10px", border: "1px solid #E5E2DC", borderRadius: 8, fontSize: 13, fontFamily: FF, outline: "none", boxSizing: "border-box" }} />
-              </div>
-              <div>
-                <label style={{ fontSize: 12, fontWeight: 500, display: "block", marginBottom: 4, fontFamily: FF }}>Notes</label>
-                <textarea value={form.notes} onChange={e => setForm(p => ({ ...p, notes: e.target.value }))} rows={2}
-                  style={{ width: "100%", padding: "8px 10px", border: "1px solid #E5E2DC", borderRadius: 8, fontSize: 13, fontFamily: FF, resize: "vertical", outline: "none", boxSizing: "border-box" }} />
-              </div>
-            </div>
-            <div style={{ display: "flex", gap: 10, justifyContent: "flex-end" }}>
-              <button onClick={() => setShowModal(false)} style={{ padding: "8px 16px", border: "1px solid #E5E2DC", borderRadius: 8, fontSize: 13, background: "#fff", cursor: "pointer", fontFamily: FF }}>Cancel</button>
-              <button onClick={submit} disabled={saving} style={{ padding: "8px 16px", background: "#0A0E1A", color: "#fff", border: "none", borderRadius: 8, fontSize: 13, fontWeight: 600, cursor: saving ? "not-allowed" : "pointer", fontFamily: FF, opacity: saving ? 0.6 : 1 }}>
-                {saving ? "Saving…" : "Log Usage"}
-              </button>
-            </div>
-          </div>
+            );
+          })}
         </div>
       )}
+
+      <h3 style={{ margin: "0 0 12px", fontSize: 14, fontWeight: 600, color: "#1A1917", fontFamily: FF }}>Usage History</h3>
+      {!usage.length && <EmptyState message="No leave usage recorded yet" />}
+      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+        {usage.map((u: any) => (
+          <div key={u.id} style={{ background: "#fff", border: "1px solid #E5E2DC", borderRadius: 10, padding: "14px 18px", display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+            <div>
+              <div style={{ fontSize: 13, fontWeight: 600, color: "#1A1917", fontFamily: FF }}>{fmtDate(u.date_used)}</div>
+              {u.notes && <div style={{ fontSize: 12, color: "#6B7280", fontFamily: FF, marginTop: 2 }}>{u.notes}</div>}
+            </div>
+            <div style={{ fontSize: 16, fontWeight: 700, color: "#991B1B", fontFamily: FF }}>−{parseFloat(u.hours).toFixed(1)} hrs</div>
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/artifacts/qleno/src/pages/leave-request.tsx
+++ b/artifacts/qleno/src/pages/leave-request.tsx
@@ -163,7 +163,10 @@ export default function LeaveRequestPage() {
 
         {/* Request form */}
         <div style={{ backgroundColor: CARD, border: `1px solid ${BORDER}`, borderRadius: 10, padding: 14, marginBottom: 20 }}>
-          <div style={{ fontSize: 14, fontWeight: 800, color: INK, marginBottom: 10 }}>Submit a request</div>
+          <div style={{ fontSize: 14, fontWeight: 800, color: INK, marginBottom: 4 }}>Submit a request</div>
+          <div style={{ fontSize: 11, color: MUTED, marginBottom: 10 }}>
+            PTO and Unpaid Personal require 7 days' advance notice. Sick time can be requested for the same day.
+          </div>
           <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
             <FormField label="Bucket">
               <select

--- a/artifacts/qleno/src/pages/payroll.tsx
+++ b/artifacts/qleno/src/pages/payroll.tsx
@@ -32,14 +32,14 @@ function empRate(emp: any): number {
 
 const PAY_TYPE_LABELS: Record<string, string> = {
   bonus: 'Bonus', tips: 'Tips', mileage: 'Mileage', mileage_reimbursement: 'Mileage',
-  sick_pay: 'Sick Pay', holiday_pay: 'Holiday Pay', vacation_pay: 'Vacation Pay',
+  sick_pay: 'Sick Pay', holiday_pay: 'Holiday Pay', vacation_pay: 'Vacation Pay', pto: 'PTO',
   compliment: 'Compliment', amount_owed: 'Amount Owed',
 };
 
 const PAY_GROUPS = [
   { label: 'Earnings',  types: ['bonus','tips'] },
   { label: 'Reimbursements', types: ['mileage','mileage_reimbursement'] },
-  { label: 'Time Off',  types: ['sick_pay','holiday_pay','vacation_pay'] },
+  { label: 'Time Off',  types: ['sick_pay','holiday_pay','vacation_pay','pto'] },
   { label: 'Other',     types: ['compliment','amount_owed'] },
 ];
 
@@ -326,7 +326,7 @@ function WeeklyDetailView({ period, onPeriodChange }: { period: { start: string;
         const sumK = (...ks: string[]) => ks.reduce((s, k) => s + (Number(ap[k]) || 0), 0);
         const tipsAmt = sumK('tips');
         const mileageAmt = sumK('mileage', 'mileage_reimbursement');
-        const timeOffAmt = sumK('sick_pay', 'holiday_pay', 'vacation_pay');
+        const timeOffAmt = sumK('sick_pay', 'holiday_pay', 'vacation_pay', 'pto');
         const hoursWorked = Number(emp.totals?.hrs_worked ?? 0);
         const allowedHrs = Number(emp.totals?.hrs_scheduled ?? 0);
         const money = (n: number) => `$${Number(n).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;

--- a/docs/TIME_OFF_ACCRUAL_PHASE1_FINDINGS_AND_DESIGN.md
+++ b/docs/TIME_OFF_ACCRUAL_PHASE1_FINDINGS_AND_DESIGN.md
@@ -908,3 +908,58 @@ Flags are computed against the **post-#581 target config** (PLAWA = flat_grant/4
 no-carryover). On current prod PLAWA is still `accrue_per_hours` (the cron skips
 it). So the correct order is **deploy #581 first → re-run this dry-run → apply →
 enable cron**, which makes the live `leave_types` match the flag assumptions.
+
+---
+
+# Phase 2f — LIVE MC crawl dry-run (2026-06-22, SUPERSEDES 2e)
+
+The live MaidCentral crawl is authoritative and replaces the Attendance-Stats
+export. Notable deltas: **Rosa Gallegos now EXCLUDED** (1099), **Alejandra PLAWA is
+46/46/0** (avail 0, not 12), **Norma PTO 112/112/0**, **Juliana PLAWA 45/24/21**.
+
+- **Excluded (4):** Generic Cleaner (test), Salvador Martinez (owner), **Rosa
+  Gallegos + Alma Salinas (1099)**. ⚠️ MC has no 1099 field — the 1099 list is
+  Sal's call and **not yet final** (flag).
+- **Loaded (10):** Ardila(44), Castillo(35), Cuervo(41), Estevez(37), Hilda
+  Gallegos(516), Katia Gonzalez(726), Loredo(42), Mejia(40), Puga(32), Vasquez(38).
+  All name+uid matched. **30 balance upserts**, **1 hire fix** (Alejandra
+  2023-05-11→2025-08-01), **0 history** (loading balances+dates now; history second
+  pass). Dataset: `scripts/_mc_timeoff_dataset.json` (untracked, PII).
+- Rule: `available_hours` is the authoritative live balance; granted/used as given
+  (all rows internally consistent: granted − used = available).
+
+## Flags / decisions for Sal (4)
+
+**Over-cap on the GRANTED/USED columns — but AVAILABLE is within policy:**
+| Employee | Bucket | granted | used | **available** | cap | note |
+|---|---|---|---|---|---|---|
+| Alejandra Cuervo | PLAWA | 46 | 46 | **0** | 40 | re-granted mid-year (history: 40 granted 2025-12-10, drawn to 0) |
+| Juliana Loredo | PLAWA | 45 | 24 | **21** | 40 | |
+| Norma Puga | PTO | 112 | 112 | **0** | 80 | history: PTO audit correction + 2026-06-06 cash-out of 80 |
+
+These exceed the single-period cap only on the **cumulative** granted/used (multiple
+grants / cash-outs / audit corrections during the year — visible in MC history).
+The **spendable available is correct and within cap** (0 / 21 / 0). Recommend
+**loading as-is** (preserves the MC audit trail; available is right); the engine
+normalizes `granted` to the cap at each employee's next anniversary reset. The
+alternative — clamping granted to the cap now — would break the granted ≥ used
+invariant (used already exceeds the cap), so as-is is cleaner.
+
+**Other flags:**
+- **Katia Gonzalez (uid 726)** is INACTIVE in Qleno but active in MC — reactivate
+  or skip.
+- **Guadalupe Mejia** is now **Part Time** per the MC note — confirm PT affects
+  nothing in the benefit grants (currently treated same as full-time).
+
+No sub-entitlement / engine-overwrite flags this round (the prior Alejandra 12→40
+concern is resolved by the live 46/46/0).
+
+## History — recommendation
+Load **balances + hire dates now** (this dry-run); do **history as a second pass**.
+Sal has the full per-row arrays (Maribel 15, Alejandra 10, Estevez 10, Juliana 6,
+Guadalupe 16, Norma 48, Diana 13). The loader inserts them into
+`employee_leave_usage` as `[MC import]`-tagged ledger rows — **informational only;
+they do not recompute the authoritative balances** (those come from the balance
+upsert). Norma's non-usage rows (PTO audit correction, 80h cash-out) will be
+inserted verbatim with descriptive notes for the audit trail, not as "leave used."
+Paste the arrays when ready and I'll fold them into the loader for a history pass.

--- a/docs/TIME_OFF_ACCRUAL_PHASE1_FINDINGS_AND_DESIGN.md
+++ b/docs/TIME_OFF_ACCRUAL_PHASE1_FINDINGS_AND_DESIGN.md
@@ -1,0 +1,403 @@
+# Time-Off Accrual — Phase 1 Findings & Design
+
+**Status:** Phase 1 (research + design). Read-only. **No engine built, no balances
+written, no prod writes.** Awaiting Sal's confirmation of the rules before Phase 2.
+
+**Scope:** Hours-based accrual + balances + annual reset + 90-day eligibility for
+**Sick (PLAWA)**, **PTO**, and **Unpaid Personal Leave**, integrated with payroll, then
+migrate every active employee's starting balances from MaidCentral.
+
+**Branch:** `feat/time-off-accrual-phase1-design` · draft PR.
+
+---
+
+## TL;DR — the one thing that changes everything
+
+**The leave engine already largely exists.** A prior workstream ("Cutover 3A") shipped a
+tenant-configurable leave system: schema, a pure-math accrual/reset engine, request
+lifecycle (with multi-bucket cascade), blackouts, and use-it-or-lose-it alerts. Phes's
+PLAWA / PTO / Unpaid / Unexcused buckets are **already seeded** in the DB.
+
+So this is **not** a green-field "build an accrual engine" job. The real Phase 2 work is
+narrower and more surgical:
+
+1. **Fix the seeded PLAWA config** — it currently contradicts the written policy (see
+   discrepancy #1 below). This is a correctness bug, not a style choice.
+2. **Wire the grant/accrual/reset to actually run** — the math exists but **nothing calls
+   it**. Balances are inert (everyone shows 0). There is no reset cron and no
+   grant-on-eligibility job.
+3. **Connect leave to payroll** — paid sick/PTO hours do **not** flow into pay today.
+   Office manually types dollar amounts as `additional_pay` lines.
+4. **Resolve the split-brain** — there are **two** parallel leave subsystems (the new 3A
+   tables and an older set of `users.*_balance_hours` columns). They disagree.
+5. **Migrate balances from MaidCentral** — a load path already exists; we need the data.
+
+And there is **one policy conflict that only Sal can resolve** (reset basis: calendar year
+vs. work anniversary). Everything downstream — reset dates, migration, the 90-day gate —
+depends on his answer. **Details and the full question list are at the bottom.**
+
+---
+
+## 1. Extracted policies (from the LMS)
+
+**Source:** `artifacts/qleno/src/lib/training/curriculum.ts` (the bilingual
+`phes-policies` LMS module). This is real, written, employee-facing policy — quoted
+verbatim below. Mirror/answer-key: `lib/training/src/answer-key.ts`.
+
+### The three-bucket model (curriculum.ts ~line 334, verbatim table)
+
+| # | Bucket | Hours | Eligible | Notice | Deniable? | Paid out at separation? |
+|---|--------|-------|----------|--------|-----------|-------------------------|
+| 1 | Any-Reason Leave (**PLAWA / sick**) | 40 / year | After **90 days** | Grace call only | No — protected | No |
+| 2 | **PTO** | 40 (yr 1) → 80 (yr 2+) | After **1 year** | 7 days advance | Yes — business needs | **Yes** |
+| 3 | **Unpaid Personal Leave** | 40 / yr (5 days) | **Day one** | 7 days advance | Yes — business needs | No |
+
+### Sick / PLAWA — verbatim
+
+> "40 paid hours per Benefit Year, **front-loaded** after 90 days of employment."
+> — curriculum.ts:356
+
+> "Because Phes **frontloads the full 40 PLAWA hours** at the start of each Benefit Year,
+> unused PLAWA hours from the prior Benefit Year **do not carry over**. Unused PLAWA hours
+> are **not paid out at separation**, consistent with the Illinois Paid Leave for All
+> Workers Act frontloading exception."
+> — curriculum.ts:366
+
+**This answers Sal's open questions directly:**
+- Granted upfront vs. accrued? → **Front-loaded (granted in full)**, not accrued.
+- Carryover vs. use-it-or-lose-it? → **No carryover** (reset to 40 each year). Matches
+  Sal's "resets" intuition.
+- Hours-based? → **Yes, 40 hours.**
+- Eligibility? → **After 90 days.**
+- Paid out at separation? → **No.**
+
+### The "Benefit Year" definition — verbatim (this is the conflict)
+
+> "Attendance tracking, **leave balances**, and disciplinary thresholds reset annually on
+> the employee's **Work Anniversary (hire date)**. This twelve-month period is your Benefit
+> Year. Different employees have different Benefit Year start dates because they were hired
+> on different dates."
+> — curriculum.ts:245
+
+⚠️ **The LMS says leave resets on each employee's work anniversary, not the calendar
+year.** Sal's instruction to me said sick "resets automatically **each calendar year**."
+These disagree. This is question #1 for Sal — see the bottom of the doc.
+
+### PTO — verbatim (from the agent crawl; consistent with the bucket table)
+
+> "40 hours after 1 year. Tops up to 80 hours at 2-year anniversary." … "Hard cap: 80
+> hours total. Unused PTO does NOT stack. We top up to the cap, we do not add on top." …
+> "PTO IS paid out at separation per the Illinois Wage Payment and Collection Act."
+
+The "top-up to 80, never 100" math is exactly what the existing reset engine implements
+(grant 40 + capped carryover, ceiling 80 — see §3).
+
+### Unpaid Personal Leave — verbatim
+
+> "40 hours / 5 days of unpaid time off, available day one." … "Does NOT carry over to the
+> next year. Not paid out at separation." … "Used for PLANNED absences only … Not for
+> same-day call-offs."
+
+### Cascade order (which bucket pays first) — verbatim
+
+> "Same-day call-off: PLAWA is the only bucket that applies. … Planned absence (with 7+
+> days advance notice): PLAWA → PTO → Unpaid Personal Leave → discipline scale."
+
+### Adjacent benefits the LMS also defines (not in this build's core 3, but related)
+
+- **Holiday top-up:** "8 hours of regular pay per Benefit Year," eligibility "after 90
+  days" (curriculum.ts:538, 547-548). Today this is the manual `holiday_pay` additional-pay
+  line.
+- **Birthday day off:** discretionary, after 90 days, forfeited if unused, never paid out
+  (curriculum.ts:563). Explicitly *not* vested wages.
+- **Protected absences** (jury duty, voting, workers' comp, VESSA, bereavement, lactation —
+  paid, etc.): never count as unexcused; out of scope for accrual but relevant to the
+  request/approval flow that already exists.
+
+### Policy gaps to confirm with Sal (not fully specified in the LMS)
+
+- **PTO accrual mechanism inside year 1.** LMS says "40 after 1 year." Is PTO granted as a
+  lump 40 at the 1-year mark (front-loaded, like PLAWA), or does it accrue over year 1 and
+  become *usable* at 1 year? The current seed treats it as a flat grant at the 1-year gate.
+- **PTO reset cadence** — anniversary (implied by "2-year anniversary" language) vs.
+  calendar. See conflict #1.
+- **Unpaid leave tracking unit** — "40 hours / 5 days." Track in hours (recommended,
+  matches everything else) — confirm.
+- **Mid-year hire proration** — does a partial first Benefit Year get a prorated PLAWA/PTO
+  grant, or the full 40? (IL PLAWA frontloading is typically full; confirm.)
+
+---
+
+## 2. Current employee status from MaidCentral (BLOCKED — need Sal to pull)
+
+I cannot reach `phes.maidcentral.com` (requires Sal's authenticated session). The crawl
+needs Sal to either pull the report or get me into a logged-in Chrome tab.
+
+**What I need, per active employee (Oak Lawn / co1 only — see scoping note):**
+
+| Field | Why |
+|-------|-----|
+| Full name + MC employee ID | Match to the Qleno `users` row |
+| **Hire date** | Drives the 90-day PLAWA gate, the 1-year PTO gate, and the anniversary reset |
+| Sick / PLAWA — accrued, used, **remaining** (2026) | Seed starting balance |
+| PTO / vacation — accrued, used, **remaining** (2026) | Seed starting balance |
+| Personal / unpaid — used (2026) | Seed starting balance |
+
+**Where to find it in MaidCentral (please confirm which screen actually has it):**
+- **Office → Employees → [employee] → Time Off / PTO tab** — per-employee accrued/used/
+  remaining is usually here.
+- Or a **Payroll / Time-Off Balance report** under Reports, if one exists, which would
+  export all employees at once (preferred — one CSV).
+
+**Action for Sal:** pull that report/screen (CSV export if possible, or screenshots of each
+employee's Time Off tab) and drop it here. If you'd rather, get me to a logged-in
+MaidCentral tab in Chrome and I'll drive the extraction myself. Until then, balances in
+§4's migration plan are a template, not real numbers.
+
+> **Scoping note (hard rule):** CLAUDE.md — "Schaumburg branch does NOT migrate from
+> MaidCentral." The Phes-specific leave buckets are seeded for **company_id = 1 (Oak Lawn)**
+> only. So this MaidCentral migration covers **Oak Lawn (co1) employees only**. Schaumburg
+> (co4) gets balances set natively, not imported from MC. Confirm co1 = the MaidCentral
+> tenant.
+
+---
+
+## 3. Qleno today — what actually exists (corrected assessment)
+
+The premise in the task ("sick_pay/holiday_pay/vacation_pay are manual additional_pay
+dollar entries — NO accrual/balance tracking") is **half right**: payroll *is* still
+manual dollars, but a full balance/accrual **engine already exists** — it's just not wired
+to run or to pay. Here's the real state.
+
+### 3a. The "Cutover 3A" leave system — BUILT (the good news)
+
+| Piece | File | State |
+|-------|------|-------|
+| Schema: `leave_types`, `employee_leave_balances`, `leave_requests`, `leave_blackouts`, `employee_availability` | `lib/db/src/schema/leave.ts` | ✅ Complete, multi-tenant |
+| Pure-math engine: `computeCurrentBalance`, `accrueFromWorkedHours`, **`applyReset`** (grant + capped carryover + ceiling + forfeiture), `isPastWaitingPeriod` (90-day gate) | `artifacts/api-server/src/lib/leave-balance.ts` | ✅ Complete + unit-tested (`tests/cutover-3a-leave.test.ts`) |
+| Routes: types CRUD, balances, requests, **cascade** (PTO→PLAWA→Unpaid), approve/deny/cancel, blackouts, alerts, unexcused ladder | `artifacts/api-server/src/routes/leave.ts` (1157 lines, mounted at `/api/leave`) | ✅ Built |
+| Per-tenant policy config | `company_leave_policy` table (`lib/db/src/schema/hr_policies.ts`), incl. `leave_reset_basis`, `balance_ceiling_hours` (80), carryover, payout, lead-days | ✅ Built |
+| Phes bucket seed | `cutover-data-migration.ts` (`seedLeaveTypes…`, `seedPhesLeavePolicy3A`) | ✅ Runs on cold start |
+
+`applyReset` already implements **exactly** Sal's PTO top-up story (grant 40 + carryover
+capped at ceiling 80, excess forfeited — the doc comment even works the "60 → 80, forfeit
+20" example).
+
+### 3b. Three things that make the engine **inert or wrong today** (the work)
+
+**(i) PLAWA is seeded against the written policy.** `cutover-data-migration.ts:450` seeds
+PLAWA as:
+
+```
+(1, 'plawa', 'PLAWA', true, 40, 'accrue_per_hours', 0.025, 90, carryover=true, exempt=true)
+```
+
+i.e. **accrue 1 hr per 40 worked, with carryover**. But the LMS (and Sal) say
+**front-loaded 40, no carryover**. Correct config is `accrual_mode='flat_grant'`,
+`accrual_rate=0`, `carryover_allowed=false`. **This is discrepancy #1 — a real bug.** The
+0.025 figure is the IL statutory *minimum* accrual, which Phes exceeds by frontloading; the
+seed encoded the floor instead of Phes's actual richer policy.
+
+**(ii) Nothing ever populates balances.** `applyReset` and `accrueFromWorkedHours` are
+called **only by the test file** — there is no reset cron and no grant-on-eligibility job.
+`buildBalancesForUser` (`routes/leave.ts:249`) reads `granted_hours` straight from the row,
+which defaults to `0` and is never written for flat-grant buckets. It also does **not**
+apply `accrueFromWorkedHours` for the accrue bucket. **Net: every employee's 3A balance
+shows 0 today.** The engine is built but parked.
+
+**(iii) Leave is disconnected from payroll.** `routes/payroll.ts:129-147` sums
+`sick_pay + holiday_pay + vacation_pay` purely from manual `additional_pay` dollar rows
+(`type` is free-text). Approved `leave_requests` hours are **never** converted to dollars.
+Payroll also *excludes* these types from the OT regular-rate (payroll.ts:336) — correct,
+but it confirms they're treated as opaque dollars, not hours×rate.
+
+### 3c. The split-brain — TWO leave subsystems that disagree
+
+| | **Old (users-column) system** | **New (3A) system** |
+|---|---|---|
+| Storage | `users.leave_balance_hours`, `users.pto_balance_hours`, `users.sick_balance_hours`, `users.benefit_year_start`, `users.leave_balance_activated` | `employee_leave_balances` (per user × leave_type) |
+| Route | `/api/hr-leave` (`routes/hr-leave.ts`) — `GET/PUT /balance`, `POST /use`, `POST /activate` | `/api/leave` (`routes/leave.ts`) |
+| Grant logic | `/activate` front-loads `leave_hours_granted` into `users.leave_balance_hours` at `eligibility_trigger_days` | `applyReset` / `accrueFromWorkedHours` (uncalled) |
+| `POST /use` | decrements **only** `leave_balance_hours` (the legacy single bucket) — **not** pto/sick | balance decremented on request approval |
+| UI | Employee Profile → Leave Balance / HR Attendance tab | Leave request / review pages |
+
+These overlap and contradict: `/hr-leave POST /use` decrements `leave_balance_hours` while
+PTO/sick are set absolutely via `PUT`; the 3A `employee_leave_balances` is a third copy.
+**Phase 2 must pick ONE canonical store** (recommendation below) and make the other a
+read-through or retire it. Shipping accrual on top of the split-brain would create exactly
+the kind of pay-affecting "which number is right?" bug this build is supposed to prevent.
+
+### 3d. Where it surfaces (UI)
+
+- **Employee profile:** `artifacts/qleno/src/pages/employee-profile.tsx` (tabs incl. "Leave
+  Balance", "HR Attendance", "Additional Pay", "Payroll History"); HR tab logic in
+  `employee-profile-hr-tabs.tsx` (reads `/api/hr-leave/balance`).
+- **Payroll:** `artifacts/qleno/src/pages/payroll.tsx` (groups `sick_pay/holiday_pay/
+  vacation_pay` under a "Time Off" header).
+- **Employee-facing leave:** `leave-request.tsx`, `leave-review.tsx`.
+
+---
+
+## 4. Proposed design (Phase 2)
+
+**Guiding principle:** don't rebuild — **converge on the 3A engine**, fix its seed, wire
+its automation, connect it to pay, and retire the duplicate. This matches the codebase's
+own stated intent (the `PUT /hr-leave/balance` comment already calls itself "the load path
+for the reconciliation import of MaidCentral PTO/sick balances").
+
+### 4.1 Canonical store
+
+Make **`employee_leave_balances` (3A) the single source of truth.** Treat
+`users.{pto,sick,leave}_balance_hours` as **deprecated**: either (a) drop them after
+migration, or (b) keep them as a denormalized read-mirror updated from 3A (like the
+assignment-mirror pattern in CLAUDE.md). Recommend (a) for cleanliness once the profile UI
+is repointed at `/api/leave/balances`.
+
+### 4.2 Corrected Phes `leave_types` (the seed fix)
+
+| slug | display | paid | cap | accrual_mode | rate | wait (days) | carryover | reset basis* | payout on sep |
+|------|---------|------|-----|--------------|------|-------------|-----------|--------------|---------------|
+| `plawa` | PLAWA (Sick) | yes | 40 | **flat_grant** | 0 | 90 | **false** | (see Q1) | no |
+| `pto_phes` | PTO | yes | 40 | flat_grant | 0 | 365 | true (ceiling 80) | anniversary | **yes** |
+| `unpaid_leave` | Unpaid Personal | no | 40 | flat_grant | 0 | 0 | false | (see Q1) | no |
+| `unexcused` | Unexcused | no | 40 | office_recorded | 0 | 0 | n/a | per Benefit Yr | no |
+
+\* `leave_types` has **no per-type reset-basis column today** — `company_leave_policy.
+leave_reset_basis` is company-wide (currently `work_anniversary`). If PLAWA must reset on a
+**different** cadence than PTO (e.g. calendar-year PLAWA + anniversary PTO), Phase 2 needs a
+new `reset_basis` column on `leave_types`. **This hinges on Sal's answer to Q1.** Also set
+`company_leave_policy.payout_on_separation` correctly per-type (PTO yes, others no) — today
+it's a single company flag, may need to move to the type.
+
+### 4.3 Grant + accrual + reset jobs (the automation that's missing)
+
+Three pieces, all building on the existing pure-math engine (no new math):
+
+1. **Grant-on-eligibility job** — daily. For each active employee × flat-grant bucket: if
+   `isPastWaitingPeriod(hire_date, waiting_period_days, today)` flips true and no grant has
+   landed for the current Benefit Year, write `granted_hours = annual_cap_hours` to
+   `employee_leave_balances`. (PLAWA at 90 days; PTO at 365 days.)
+2. **Annual reset job** — daily check, fires on each employee's reset boundary (calendar
+   1/1 or work anniversary per Q1). Calls the existing `applyReset(...)` and persists
+   `new_granted` + surfaces `forfeited_hours` to the office. Resets `used_hours` to 0,
+   stamps `last_reset_at`.
+3. **(Optional) accrue snapshot** — only needed if any bucket stays `accrue_per_hours`. Per
+   the policy, PLAWA should be flat_grant, so this may be unnecessary for Phes. Keep the
+   function for other tenants.
+
+Wire these into the existing CT-timezone cron scheduler in
+`artifacts/api-server/src/index.ts` (alongside `rate_lock_nightly`, `annual_cycle_auto_open`,
+etc.). **Idempotent, guarded by `last_reset_at` / a grant marker** so a double-fire can't
+double-grant.
+
+### 4.4 Payroll integration (paid sick/PTO → dollars)
+
+At the payroll assembly point (`routes/payroll.ts`, after `computePayLines`):
+
+- Pull **approved** `leave_requests` for **paid** buckets (`leave_types.is_paid = true`)
+  whose dates fall in the pay window.
+- Convert `hours × effective hourly rate` — rate from `employee_pay_rates` (the dated table
+  CLAUDE.md treats as canonical), **not** a hardcoded number, mirroring the
+  commission/mileage "never inline a rate" rule.
+- Emit as a derived pay line (or a typed `additional_pay` row written by the system, clearly
+  marked `source='leave_engine'` so it's distinguishable from manual office entries and
+  never double-counted).
+- **Keep these excluded from the OT regular-rate** (payroll.ts already does this for the
+  manual types — preserve it). Unpaid leave produces **no** pay line by definition.
+- **No money moves automatically without office review** — same philosophy as mileage/OT in
+  CLAUDE.md. Surface the computed paid-leave dollars at the payroll review gate; office
+  confirms. (Confirm with Sal — Q6.)
+
+### 4.5 Surfacing
+
+- **Employee profile** → repoint the Leave Balance tab at `/api/leave/balances` so it shows
+  all buckets (PLAWA / PTO / Unpaid) with granted / used / **available** + the 90-day/1-year
+  eligibility state and next reset date. Retire the old single-bucket readout.
+- **Payroll detail** → show paid-leave dollars as a derived, labeled line under the existing
+  "Time Off" group, with the hours and rate visible (not an opaque dollar amount).
+- **Office** → the existing use-it-or-lose-it alerts (`/api/leave/alerts/use-it-or-lose-it`)
+  already exist; surface them on the dashboard ahead of reset boundaries.
+
+### 4.6 Migration plan (MaidCentral → Qleno, co1 only)
+
+The load path **already exists**: `PUT /api/hr-leave/balance/:employee_id` is documented as
+"the load path for the reconciliation import of MaidCentral PTO/sick balances." For the 3A
+store we'll write `employee_leave_balances` directly instead.
+
+**Steps (Phase 2, after rules confirmed):**
+1. Sal pulls the MaidCentral per-employee Time-Off report (§2).
+2. **Reconcile names → Qleno `users.id`** for active co1 employees; confirm each
+   `users.hire_date` matches MC (hire date drives every gate — fix mismatches first).
+3. For each employee × bucket, seed `employee_leave_balances`:
+   - `granted_hours` = MC **accrued/granted** for the current Benefit Year
+   - `used_hours` = MC **used** for the current Benefit Year
+   - → `available = granted − used` reproduces MC's remaining.
+   - Set `last_reset_at` to the current Benefit Year start so the next reset fires correctly.
+4. **Dry-run first** (CLAUDE.md DB rule) — produce a diff report (employee, bucket, granted,
+   used, available) for Sal to eyeball **before** any write. Seed via `ON CONFLICT DO
+   UPDATE` (CLAUDE.md seed rule).
+5. Spot-check 3-5 employees against MC in the UI after load.
+
+**Edge cases to decide (in Q-list):** employees still inside 90 days (no PLAWA yet —
+seed 0?), employees between 1 and 2 years (PTO 40 vs 80), and anyone with a remaining
+balance above the ceiling.
+
+---
+
+## 5. Questions for Sal (must answer before Phase 2 build)
+
+**Q1 — Reset basis (BLOCKER, affects everything).** The LMS says leave resets on each
+employee's **work anniversary** (individualized Benefit Year); your instruction said
+**calendar year**. Which is correct — and is it the **same for all three** buckets, or does
+PLAWA reset on a different cadence than PTO? (If they differ, we add a per-type reset column.)
+
+**Q2 — PLAWA accrual method.** Confirm PLAWA is **front-loaded 40 hours at the 90-day mark,
+no carryover** (matches the LMS), so I can fix the seed that currently has it accruing
+0.025/hr with carryover. (I'm 95% sure from the LMS — just need your yes.)
+
+**Q3 — PTO in year 1.** Is PTO **granted as a lump 40 at the 1-year anniversary**, or does
+it **accrue over** year 1 and become usable at 1 year? And confirm the top-up to 80 at year
+2 with a hard ceiling of 80 (no stacking).
+
+**Q4 — Mid-year hire proration.** New hire partway through a Benefit Year — **full 40**
+PLAWA/PTO grant, or **prorated**?
+
+**Q5 — Unpaid personal leave.** Track in **hours (40)** like the others? Any balance to
+migrate, or just track usage going forward (it's unpaid, so it never hits pay)?
+
+**Q6 — Payroll auto-pay vs. review gate.** Should approved **paid** sick/PTO hours auto-
+convert to dollars on the payroll run, or surface at the **review gate** for office
+confirmation first (like mileage/OT)? Recommendation: review gate.
+
+**Q7 — Canonical store + cleanup.** OK to make 3A `employee_leave_balances` the single
+source of truth and **retire** the older `users.{pto,sick,leave}_balance_hours` columns +
+`/api/hr-leave` flow after migration? (Removes the split-brain.)
+
+**Q8 — Scope confirm.** MaidCentral migration is **Oak Lawn / co1 only** (Schaumburg/co4
+does not migrate from MC — hard rule). Confirm co1 is the MaidCentral tenant, and confirm
+the active-employee list.
+
+**Q9 — Separation payout.** Confirm payout-on-separation: **PTO yes**, PLAWA no, Unpaid no
+(per LMS). This affects whether the ceiling/forfeiture or a payout calc applies at offboard.
+
+**Q10 — MaidCentral report.** Which exact MC screen/report has per-employee accrued / used /
+remaining for sick + PTO + personal (and hire dates)? Pull it (CSV preferred) or get me into
+a logged-in Chrome tab and I'll extract it.
+
+---
+
+## Appendix — key file references
+
+- LMS policy: `artifacts/qleno/src/lib/training/curriculum.ts` (lines 245, 334, 356, 366,
+  538, 547-548)
+- Leave schema: `lib/db/src/schema/leave.ts`; policy schema:
+  `lib/db/src/schema/hr_policies.ts` (`company_leave_policy`, line 98)
+- Engine math: `artifacts/api-server/src/lib/leave-balance.ts`
+- Leave routes (3A): `artifacts/api-server/src/routes/leave.ts` (mounted `/api/leave`)
+- Old leave routes: `artifacts/api-server/src/routes/hr-leave.ts` (mounted `/api/hr-leave`)
+- Phes seed: `artifacts/api-server/src/cutover-data-migration.ts` (lines 405-512)
+- Payroll assembly: `artifacts/api-server/src/routes/payroll.ts` (lines 129-147, 336)
+- Pay rates (canonical): `employee_pay_rates` in `lib/db/src/schema/pay.ts`
+- Tests: `artifacts/api-server/src/tests/cutover-3a-leave.test.ts`
+- Cron host: `artifacts/api-server/src/index.ts`
+</content>

--- a/docs/TIME_OFF_ACCRUAL_PHASE1_FINDINGS_AND_DESIGN.md
+++ b/docs/TIME_OFF_ACCRUAL_PHASE1_FINDINGS_AND_DESIGN.md
@@ -400,4 +400,141 @@ a logged-in Chrome tab and I'll extract it.
 - Pay rates (canonical): `employee_pay_rates` in `lib/db/src/schema/pay.ts`
 - Tests: `artifacts/api-server/src/tests/cutover-3a-leave.test.ts`
 - Cron host: `artifacts/api-server/src/index.ts`
+
+---
+
+# Addendum (2026-06-19) — Hire dates received; migration + eligibility finalized
+
+Sal pulled the MaidCentral Employee List (hire dates). I cross-checked it against the live
+Qleno DB (read-only audit, `scripts/_timeoff_audit_readonly.mjs`, SELECT-only). Results below.
+
+## A. Live-data confirmations of the Phase 1 assessment
+
+- **3A balances are empty:** `employee_leave_balances` for co1 = **0 rows, 0 granted, 0
+  used.** Old `users.{pto,sick,leave}_balance_hours` = all `0.00`, `leave_balance_activated
+  = false` for everyone. The engine is inert, exactly as described. Nothing to "preserve" on
+  migration — we seed from scratch.
+- **PLAWA seed bug confirmed in prod:** `leave_types` id 9 `plawa` = `accrue_per_hours`,
+  rate `0.0250`, `carryover_allowed = true`. Must become `flat_grant` / rate 0 /
+  `carryover=false`.
+- **NEW: duplicate active sick bucket.** co1 has **both** `plawa` (id 9, wait 90) **and**
+  the generic `sick` (id 5, "Sick Time", flat_grant, wait 0, carryover false) **active**.
+  The generic `pto` (id 1) was deactivated during seeding but the generic `sick` was not.
+  Two sick-like buckets showing at once → Phase 2 must deactivate `sick` (id 5) for co1 so
+  PLAWA is the single sick bucket.
+- **`company_leave_policy` (co1):** `leave_program_enabled=true`,
+  `leave_reset_basis='work_anniversary'`, `balance_ceiling_hours=80`,
+  `eligibility_trigger_days=90`, **`payout_on_separation=false`**. The payout flag conflicts
+  with the LMS (PTO *is* paid out) — see Q9.
+
+## B. Roster reconciliation (MC → Qleno) — two data problems to fix first
+
+| MC id | Name | MC hire | Qleno user | Qleno hire | Status |
+|------|------|---------|-----------|-----------|--------|
+| 26443 | Norma Puga | 2023-05-11 | 32 | 2023-05-11 | ✅ match |
+| 26450 | Maribel Castillo (office) | 2023-02-21 | 35 | 2023-02-21 | ✅ match |
+| 26451 | Salvador Martinez (owner) | 2019-09-01 | 1 | **NULL** | ⚠️ Qleno hire_date missing (owner — likely excluded from accrual anyway, Q11) |
+| 26452 | Rosa Gallegos | 2020-04-01 | 36 | 2020-04-01 | ✅ match |
+| 28968 | Francisco Estevez (office) | 2024-06-03 | 37 | 2024-06-03 | ✅ match |
+| 29567 | Diana Vasquez | 2024-06-18 | 38 | 2024-06-18 | ✅ match |
+| 30618 | Alma Salinas | 2025-06-03 | 39 | 2025-06-03 | ✅ match |
+| 32094 | Guadalupe Mejia | 2025-06-11 | 40 | 2025-06-11 | ✅ match |
+| 42877 | Alejandra Cuervo | 2025-08-01 | 41 | **2023-05-11** | 🔴 **WRONG** — Qleno copied Norma's date; would falsely grant PTO. Fix to 2025-08-01 before migration. |
+| 47897 | Juliana Loredo | 2026-01-26 | 42 | 2026-01-26 | ✅ match |
+| 51027 | Jose Ardila | 2026-05-01 | 44 | 2026-05-01 | ✅ match |
+| 51901 | Hilda Gallegos | 2026-05-25 | 516 | 2026-05-25 | ✅ match |
+| 28511 | Generic Cleaner (TEST) | 2024-05-15 | — | — | exclude (test) |
+| — | **Maryury Colmenares** | **not in MC list** | 817 | 2026-06-16 | 🟡 In Qleno, hired 3 days ago, **absent from MC list**. Include in accrual? (Q12) |
+| — | Test Auditor (TEST) | — | 493 | NULL | exclude (test) |
+
+**Two blockers for the migration roster:** (1) fix Alejandra's hire_date (a spin-off task
+is already queued), (2) decide on Maryury. Both are pre-migration data fixes.
+
+## C. Per-employee eligibility (as of today, 2026-06-19; using MC hire dates)
+
+90-day sick gate = `hire + 90d ≤ today`. PTO gate = `hire + 1yr ≤ today`. PTO tier: year-1
+grant = 40h; after 2nd anniversary the ceiling top-up takes it to 80h.
+
+| Employee | Hire | Sick (PLAWA) eligible? | PTO eligible? | PTO grant tier |
+|----------|------|------------------------|---------------|----------------|
+| Rosa Gallegos | 2020-04-01 | ✅ | ✅ | 80 (2yr+) |
+| Maribel Castillo (office) | 2023-02-21 | ✅ | ✅ | 80 |
+| Norma Puga | 2023-05-11 | ✅ | ✅ | 80 |
+| Francisco Estevez (office) | 2024-06-03 | ✅ | ✅ | 80 (2nd anniv 2026-06-03, 16d ago) |
+| Diana Vasquez | 2024-06-18 | ✅ | ✅ | 80 (2nd anniv **2026-06-18, yesterday**) |
+| Alma Salinas | 2025-06-03 | ✅ | ✅ (1yr crossed 16d ago) | 40 (year 1) |
+| Guadalupe Mejia | 2025-06-11 | ✅ | ✅ (1yr crossed 8d ago) | 40 (year 1) |
+| Alejandra Cuervo | 2025-08-01 | ✅ (90d since 2025-10-30) | ❌ (1yr = 2026-08-01) | — |
+| Juliana Loredo | 2026-01-26 | ✅ (90d since 2026-04-26) | ❌ (1yr = 2027-01-26) | — |
+| Jose Ardila | 2026-05-01 | ❌ (90d = 2026-07-30) | ❌ | — |
+| Hilda Gallegos | 2026-05-25 | ❌ (90d = 2026-08-23) | ❌ | — |
+| Maryury Colmenares | 2026-06-16 | ❌ (90d = 2026-09-14) | ❌ | — |
+| Sal Martinez (owner) | 2019-09-01 | (excluded? Q11) | (excluded? Q11) | — |
+
+This matches Sal's stated implications exactly (Jose & Hilda not sick-eligible; Alejandra/
+Juliana/Jose/Hilda not PTO-eligible; Alma & Guadalupe just crossed PTO). **Diana crossing
+her 2-year anniversary yesterday and Francisco 16 days ago means their 40→80 top-up is
+right on the boundary — the exact day depends on the reset basis (Q1).**
+
+## D. The "used so far" balance — why I now recommend MaidCentral as the source
+
+Sal suggested deriving 2026 "used" from Qleno's `additional_pay`. **I checked the real rows
+— this is not reliable for hours:**
+
+- `additional_pay` stores **dollars**, not hours. Hours appear only sporadically in
+  free-text `notes` (e.g. *"Fever … 11am-6pm (7h)"*, *"Dentist … (6h)"*) and many entries
+  (esp. PTO/vacation) have **no** hours noted.
+- The implied rate is **inconsistent** ($100/5h = $20/h, but $144/8h = $18/h), and
+  **`employee_pay_rates` is empty** — there is no canonical rate to divide dollars by.
+- Only **two** employees have any 2026 time-off entries at all: Norma (user 32) and
+  Alejandra (user 41). Everyone else = $0 in `additional_pay` for 2026.
+- `holiday_pay` entries exist too, but **holiday is a separate benefit**, not one of the
+  three accrual buckets — don't fold it into PLAWA/PTO used-hours.
+
+**Recommendation:** use **MaidCentral's per-employee Time Off tab (hours)** as the
+authoritative "used" source. MC tracks used *in hours* natively; Qleno's dollar ledger
+can't be back-converted cleanly. The pull is small in practice (only Norma & Alejandra have
+2026 usage), but get all active employees for a clean reconciliation.
+
+**Critical dependency — the "used" window is undefined until Q1 is answered.** "Used so far
+this Benefit Year" means:
+- **Calendar-year reset:** used since 2026-01-01 (Norma's Jan–Mar PTO + Feb sick all count
+  against this year's 40/80).
+- **Work-anniversary reset:** used since each person's most recent anniversary (Norma's
+  benefit year started **2026-05-11**, so her Jan–Mar usage is in the *prior* year and does
+  **not** reduce her new grant — she'd start nearly full).
+
+These produce **very different** starting balances for Norma. So the migration's per-person
+`used_hours` cannot be finalized until Sal answers Q1.
+
+## E. Finalized migration procedure (HELD pending Q1 + dry-run sign-off)
+
+1. **Pre-fix data:** correct Alejandra's hire_date (→2025-08-01); decide Maryury (Q12); set
+   Sal's hire_date or exclude (Q11).
+2. **Fix the seed (Phase 2 code):** PLAWA → `flat_grant`/rate 0/`carryover=false`;
+   deactivate generic `sick` (id 5) for co1; set per-type `payout_on_separation` (PTO yes).
+3. **Grant:** the grant-on-eligibility job writes `granted_hours` per the §C table
+   (PLAWA 40 to all sick-eligible; PTO 40 or 80 to PTO-eligible; 0 for not-yet-eligible).
+   This is **engine-computed, not migrated** — MC "accrued/granted" is not imported.
+4. **Used:** set `used_hours` per employee/bucket from **MC used-hours within the current
+   Benefit Year** (window per Q1). Only Norma & Alejandra are non-zero in 2026.
+5. **Stamp** `last_reset_at` = current Benefit Year start so the next reset fires correctly.
+6. **Dry-run diff** (employee × bucket: granted / used / available) for Sal to eyeball
+   **before any write**; seed via `ON CONFLICT DO UPDATE`. Spot-check 3–5 in the UI after.
+
+## F. Updated / added questions for Sal
+
+- **Q1 (still the blocker)** — reset basis: calendar year vs. work anniversary. Now doubly
+  important: it sets both the reset date *and* the "used so far" window that determines every
+  starting balance (see §D).
+- **Q10 (resolved direction)** — "used" source: I recommend **MaidCentral Time Off tab
+  (hours)**, not Qleno `additional_pay` (can't yield reliable hours). Confirm, and Sal pulls
+  the per-employee used-hours (Employees → [employee] → Time Off / PTO tab, or a Time-Off
+  report) once Q1 fixes the window.
+- **Q11 (new)** — owner/office staff: do PLAWA/PTO accrual apply to Sal (owner) and the
+  office staff (Maribel, Francisco), or techs only? Sal's Qleno hire_date is NULL.
+- **Q12 (new)** — Maryury Colmenares (Qleno user 817, hired 2026-06-16) isn't in the MC
+  list. Include her in accrual (she's pre-90-day, so 0 today either way)?
+- **Q13 (new)** — duplicate sick bucket: OK to deactivate the generic `sick` (leave_types
+  id 5) for co1 so PLAWA is the only sick bucket?
 </content>

--- a/docs/TIME_OFF_ACCRUAL_PHASE1_FINDINGS_AND_DESIGN.md
+++ b/docs/TIME_OFF_ACCRUAL_PHASE1_FINDINGS_AND_DESIGN.md
@@ -542,12 +542,16 @@ These produce **very different** starting balances for Norma. So the migration's
 
 # Phase 2 — BUILD (2026-06-20)
 
-**Reset basis RESOLVED (Sal 2026-06-20): CALENDAR YEAR for all employees, all
-buckets — everyone resets Jan 1.** Q1 is closed. The handbook's individualized
-"Benefit Year" language does NOT govern leave resets; the seed now stores
-`leave_reset_basis = 'calendar_year'` for co1. Sick = 40 front-loaded after 90
-days, no carryover, not paid at separation; PTO = 40 after 1 year → 80 (hard
-cap) at 2 years; Unpaid = 40 from day one.
+> ⚠️ **SUPERSEDED — see "Phase 2b — Reset-basis correction" below.** My first
+> read of Sal's answer was calendar-year (Jan 1); Sal corrected it to
+> **WORK ANNIVERSARY** (per-employee benefit year). The code, tests, dry-run,
+> and seed have all been reworked accordingly. This section's calendar-year
+> framing and dry-run numbers are kept only as a record; the corrected
+> numbers are in Phase 2b.
+
+**Reset basis (initial read — later corrected): calendar year.** Sick = 40
+front-loaded after 90 days, no carryover, not paid at separation; PTO = 40 after
+1 year → 80 (hard cap) at 2 years; Unpaid = 40 from day one.
 
 **Status: code built, CI-green, balance writes + deploy HELD for sign-off.** The
 accrual cron is gated OFF by `LEAVE_ACCRUAL_ENABLED` (default false), so merging/
@@ -618,5 +622,101 @@ usage. Holiday_pay is reported but NOT deducted — separate benefit.)
 2. Deploy (seed fix lands: PLAWA corrected, dup sick off, calendar basis).
 3. Re-run the dry-run; Sal eyeballs.
 4. Flip `LEAVE_ACCRUAL_ENABLED=true` → the 2 AM cron grants balances; overlay the
-   2026 `used` (one-time migration write, `ON CONFLICT DO UPDATE`).
+   current-benefit-year `used` (one-time migration write, `ON CONFLICT DO UPDATE`).
 5. Spot-check 3–5 employees in the profile UI.
+
+---
+
+# Phase 2b — Reset-basis correction + request workflow (2026-06-20)
+
+## Reset basis CORRECTED → WORK ANNIVERSARY (per-employee benefit year)
+
+Sal corrected the basis: each employee's benefit year is anchored to their
+**hire date and resets on their work anniversary** — NOT a Jan-1 calendar reset.
+This matches the handbook and the already-seeded 3A `work_anniversary` policy, so
+**no handbook change is needed.** All buckets reset on the anniversary.
+
+Reworked accordingly (still HELD behind `LEAVE_ACCRUAL_ENABLED`):
+- **Seed** (`cutover-data-migration.ts`) reverted to `leave_reset_basis =
+  'work_anniversary'` (COALESCE-preserving). PLAWA flat-grant fix + dup-sick
+  deactivation stand.
+- **Engine** (`lib/leave-grant-reset.ts`): added `benefitYearStartDate` (most
+  recent hire anniversary ≤ today); `planLeaveGrant` now keys the reset off the
+  benefit year, not the calendar year (`last_reset_at < benefitYearStart` →
+  reset). 25 unit tests, incl. an explicit "no Jan-1 reset" case.
+- **Dry-run** (`scripts/_timeoff_migration_dryrun_readonly.mjs`): "used" now
+  counts `additional_pay` only within each employee's **current benefit year**
+  (since their anniversary), not the calendar year.
+
+### Corrected dry-run (co1, as of 2026-06-20, work-anniversary basis)
+
+The big change: usage **before** an employee's most recent anniversary is in
+their *prior* benefit year and is NOT deducted — so most employees start with
+**full** balances. Only Alejandra (anniversary 8/1, so her whole benefit year of
+usage counts) carries used hours.
+
+| Employee | Hire | Benefit yr start | PLAWA (g/u/rem) | PTO (g/u/rem) | Unpaid |
+|----------|------|------------------|-----------------|---------------|--------|
+| Rosa Gallegos | 2020-04-01 | 2026-04-01 | 40/0/40 | 80/0/80 | 40 |
+| Maribel Castillo (office) | 2023-02-21 | 2026-02-21 | 40/0/40 | 80/0/80 | 40 |
+| Norma Puga | 2023-05-11 | 2026-05-11 | 40/0/40 | 80/0/80 | 40 |
+| Francisco Estevez (office) | 2024-06-03 | 2026-06-03 | 40/0/40 | 80/0/80 | 40 |
+| Diana Vasquez | 2024-06-18 | 2026-06-18 | 40/0/40 | 80/0/80 | 40 |
+| Alma Salinas | 2025-06-03 | 2026-06-03 | 40/0/40 | 40/0/40 | 40 |
+| Guadalupe Mejia | 2025-06-11 | 2026-06-11 | 40/0/40 | 40/0/40 | 40 |
+| Alejandra Cuervo | 2025-08-01 | 2025-08-01 | 40/29/**11** | not eligible | 40 |
+| Juliana Loredo | 2026-01-26 | 2026-01-26 | 40/0/40 | not eligible | 40 |
+| Jose Ardila | 2026-05-01 | — | not eligible | not eligible | 40 |
+| Hilda Gallegos | 2026-05-25 | — | not eligible | not eligible | 40 |
+
+(Norma's Jan–Mar 2026 PTO/sick fall before her 5/11 anniversary → prior benefit
+year → not deducted. Contrast the superseded calendar-year table above.)
+
+## Request → approval → notification workflow (field app), mirroring MaidCentral
+
+### What the 3A lifecycle ALREADY provided
+
+| # | Step | Status before this build |
+|---|------|--------------------------|
+| 1 | Employee request from phone | ✅ `leave-request.tsx` at `/leave` (DashboardLayout = field app): per-bucket balances + submit form + my-requests list. Posts `POST /api/leave/requests`. |
+| 3 | Balance check + deduction | ✅ `checkBalance` on submit; `used_hours` increments on approve; restored on cancel. Balances visible to employee (`/balances/me`) + office (`/balances?userId=`). |
+| 5 | Approve / deny in app | ✅ `leave-review.tsx` + `POST /requests/:id/approve|deny` (office/owner gated). |
+| — | Blackout auto-deny + cascade | ✅ Already present (PLAWA exempt; non-exempt auto-denied; multi-bucket cascade endpoint). |
+
+### What was MISSING — and is now built in this PR
+
+| # | Step | Gap | Built |
+|---|------|-----|-------|
+| 2 | 7-day notice rules | ❌ none — only the 90-day *employment* gate existed | ✅ `checkAdvanceNotice` (PTO + Unpaid require start ≥ today+7d; PLAWA/sick exempt = emergency). Wired into `POST /requests`; field-app hint added. |
+| 4 | Office + owner on submit | ❌ stub (`console.log` only) | ✅ `notifyLeaveSubmitted` → `notifyOfficeUsers` (owner+admin+office): in-app + push + staff email, MC "ACTION REQUIRED: review & approve". |
+| 6 | Employee on decision | ❌ stub + push only | ✅ `notifyLeaveDecision` → employee in-app + push + **email + SMS** for Approved/Denied (MC subjects). |
+| 1+ | Employee on submit | ❌ no confirmation | ✅ employee "Pending" (email+SMS+in-app); short-notice/sick → "Emergency Request Received" variant. |
+
+New module: `lib/leave-notifications.ts`. MC templates mirrored (subjects close to
+MC's "Pending / Approved / Denied / Emergency"); Sal's superset = employee
+decisions on **SMS + email** (MC is email-only).
+
+**Channel gating:** in-app + push always fire (internal staff alerts, ungated).
+Employee **email + SMS are gated by `COMMS_ENABLED`** (SMS additionally by the
+per-tenant/branch gate via `resolveSender`) — honoring the hard rule that no
+SMS/email leaves the system until comms are enabled. So in prod today employees
+get in-app + push; email/SMS begin once `COMMS_ENABLED=true`. Office alerts use
+the existing (ungated) staff-alert email path.
+
+### Workflow items still open / flagged
+- **Cascade requests** (`POST /requests/cascade`, office-driven multi-bucket
+  fall-through) are NOT yet wired to the new notifier — the field app uses the
+  simple `POST /requests` path, which is. Follow-up if office uses cascade.
+- **Field-app nav**: ✅ confirmed — `/leave` is routed (`App.tsx`) and the sidebar
+  exposes a "Time Off" entry for `technician`/`team_lead` roles
+  (`app-sidebar.tsx`). Reachable on the phone today.
+- **Notification prefs**: `notifyUser` email/push for employee in-app types
+  depend on `TYPE_TO_CATEGORY` mapping; employee email/SMS here are sent directly
+  (MC-mirrored), not pref-gated, so they always send when `COMMS_ENABLED`.
+
+## Residual questions (unchanged + reconfirmed for the anniversary basis)
+The Phase 2 residual list still stands: PTO mid-year 2-year top-up timing (now at
+the **anniversary** reset, which is the natural boundary — confirm), mid-year
+proration, leave pay **rate source** (`employee_pay_rates` empty), auto-pay vs
+preview, and the pre-write data fixes (Alejandra hire_date, Maryury, owner/office
+scope). All HELD for Sal's sign-off before any balance write or deploy.

--- a/docs/TIME_OFF_ACCRUAL_PHASE1_FINDINGS_AND_DESIGN.md
+++ b/docs/TIME_OFF_ACCRUAL_PHASE1_FINDINGS_AND_DESIGN.md
@@ -720,3 +720,72 @@ the **anniversary** reset, which is the natural boundary — confirm), mid-year
 proration, leave pay **rate source** (`employee_pay_rates` empty), auto-pay vs
 preview, and the pre-write data fixes (Alejandra hire_date, Maryury, owner/office
 scope). All HELD for Sal's sign-off before any balance write or deploy.
+
+---
+
+# Phase 2c — FINALIZED (Sal's answers, 2026-06-20)
+
+All residuals resolved. Build complete; still HELD (no balance writes, no deploy,
+no `COMMS_ENABLED`/`LEAVE_ACCRUAL_ENABLED` flip) until Sal confirms this dry-run.
+
+- **Leave pay rate = flat $20/hr** (company floor) for paid sick + PTO — NOT the
+  tech's commission/blended rate. `LEAVE_PAY_RATE = 20` in `lib/leave-pay.ts`.
+- **Auto-pay on approval.** Approval is the gate: approving a paid request writes
+  a visible, labeled `additional_pay` line (`sick_pay` → "Sick Pay", `pto` →
+  "PTO") = hours × $20, landing in the payroll period of the approval. No manual
+  pay step. Idempotent (guarded on a `leave_req#<id>` marker). Wired in the
+  approve route → `writeApprovedLeavePay`. Frontend payroll Time-Off group + the
+  legacy `/summary` gross both include `pto`.
+- **Both views in sync on approval.** Balance deduction (`used_hours`) + the paid
+  line are read from shared sources: office sees `/leave/balances?userId=` + the
+  payroll line; the employee sees `/leave/balances/me` (profile + field-app
+  "My Time Off") + the same `additional_pay` row in their payroll history. One
+  write, both views update.
+- **PTO 2-year top-up = at the anniversary reset** (confirmed). The engine
+  recomputes the tier (40 < 2yr, 80 ≥ 2yr) at each benefit-year boundary.
+- **Proration:** full front-load at the gate, no proration — sensible under the
+  work-anniversary model because each benefit year is a clean 12 months from
+  hire (a new hire's first PLAWA covers the rest of their first benefit year).
+- **Data fixes resolved:** Alejandra → MC hire 2025-08-01 (Qleno fix tracked
+  separately); **Maryury Colmenares (uid 817) INCLUDED**; **owner (Sal) EXCLUDED**
+  from accrual; **office staff (Maribel, Francisco) INCLUDED**.
+- **Preview repurposed:** `GET /api/payroll/leave-pay-preview` now forecasts
+  **PENDING** paid requests at $20/hr (approved leave already auto-pays — avoids
+  double-counting). Read-only.
+
+## FINAL migration dry-run (co1, as of 2026-06-20, work-anniversary, $20/hr)
+
+`scripts/_timeoff_migration_dryrun_readonly.mjs` (read-only). `rem_$@20` =
+remaining hours × $20 (sick + PTO; unpaid = $0) — what the bank is worth if used.
+
+| Employee | Benefit yr | PLAWA g/u/rem | PTO g/u/rem | Unpaid | PLAWA $ | PTO $ |
+|----------|-----------|---------------|-------------|--------|---------|-------|
+| Rosa Gallegos | 2026-04-01 | 40/0/40 | 80/0/80 | 40 | $800 | $1600 |
+| Maribel Castillo (office) | 2026-02-21 | 40/0/40 | 80/0/80 | 40 | $800 | $1600 |
+| Norma Puga | 2026-05-11 | 40/0/40 | 80/0/80 | 40 | $800 | $1600 |
+| Francisco Estevez (office) | 2026-06-03 | 40/0/40 | 80/0/80 | 40 | $800 | $1600 |
+| Diana Vasquez | 2026-06-18 | 40/0/40 | 80/0/80 | 40 | $800 | $1600 |
+| Alma Salinas | 2026-06-03 | 40/0/40 | 40/0/40 | 40 | $800 | $800 |
+| Guadalupe Mejia | 2026-06-11 | 40/0/40 | 40/0/40 | 40 | $800 | $800 |
+| Alejandra Cuervo | 2025-08-01 | 40/29/**11** | not elig. | 40 | $220 | — |
+| Juliana Loredo | 2026-01-26 | 40/0/40 | not elig. | 40 | $800 | — |
+| Jose Ardila | 2026-05-01 | not elig. | not elig. | 40 | — | — |
+| Hilda Gallegos | 2026-05-25 | not elig. | not elig. | 40 | — | — |
+| Maryury Colmenares | 2026-06-16 | not elig. | not elig. | 40 | — | — |
+
+(Owner Sal excluded. Most start full; only Alejandra carries used PLAWA — her
+benefit year began 2025-08-01 so her 2025-12→2026-06 sick usage = 29h counts.)
+
+## Go-live sequence (after Sal confirms this dry-run)
+
+1. Apply the Alejandra hire_date fix (uid 41 → 2025-08-01).
+2. Deploy — seed lands (PLAWA flat-grant, dup sick off, work_anniversary basis);
+   auto-pay-on-approval + notifications + 7-day-notice ship inert (gated).
+3. Re-run the dry-run against deployed state; Sal eyeballs.
+4. Flip `LEAVE_ACCRUAL_ENABLED=true` → the 2 AM cron grants/resets balances per
+   the table above (initial grants at each employee's gate; resets on anniversary).
+5. Flip `COMMS_ENABLED=true` when ready → employee email/SMS for pending/decision
+   begin (office in-app/email already work; in-app/push need no flip).
+6. From here, approving a request auto-pays at $20/hr as a payroll line; balances
+   + pay stay in sync across office and employee views.
+7. Spot-check 3–5 employees (profile + field-app "My Time Off" + payroll).

--- a/docs/TIME_OFF_ACCRUAL_PHASE1_FINDINGS_AND_DESIGN.md
+++ b/docs/TIME_OFF_ACCRUAL_PHASE1_FINDINGS_AND_DESIGN.md
@@ -963,3 +963,71 @@ they do not recompute the authoritative balances** (those come from the balance
 upsert). Norma's non-usage rows (PTO audit correction, 80h cash-out) will be
 inserted verbatim with descriptive notes for the audit trail, not as "leave used."
 Paste the arrays when ready and I'll fold them into the loader for a history pass.
+
+---
+
+# Phase 2g — FINAL, sign-off-ready (2026-06-22)
+
+Sal's decisions locked: (2) **Katia Gonzalez removed** — no longer employed, not
+loaded (already inactive in Qleno; leave as-is). (3) **Guadalupe** treated the same
+despite Part-Time. (4) **1099 list locked at exactly Rosa Gallegos + Alma Salinas**;
+no one else. (5) **History = second pass** (balances + dates now). (1) over-cap =
+load as-is after the explanation below.
+
+**Final dry-run: 9 employees, 27 balance upserts, 1 hire-date fix (Alejandra
+2023-05-11 → 2025-08-01), 0 history.** Loaded: Ardila, Castillo, Cuervo, Estevez,
+Hilda Gallegos, Loredo, Mejia, Puga, Vasquez. Excluded (5): Generic Cleaner, Sal,
+Rosa, Alma, Katia.
+
+## The over-cap explanation (flag #1)
+
+Three rows show a `granted`/`used` total above the Qleno cap, yet `available` is
+within policy:
+
+| Who | Bucket | granted | used | **available** | cap |
+|---|---|---|---|---|---|
+| Alejandra | PLAWA | 46 | 46 | **0** | 40 |
+| Juliana | PLAWA | 45 | 24 | **21** | 40 |
+| Norma | PTO | 112 | 112 | **0** | 80 |
+
+**Why granted/used can exceed the cap while available stays in policy:**
+- `granted` = the *cumulative* hours added to the bucket over the year (the
+  front-load **plus** any mid-year re-grants, top-ups, or audit corrections MC
+  recorded). `used` = the *cumulative* hours drawn down. `available` = `granted −
+  used` = what's actually left to spend right now.
+- The Qleno **cap is a ceiling on the spendable balance / the annual front-load —
+  not on lifetime cumulative grants.** Within one year an employee can be granted
+  40, use 40, then be re-granted more. Alejandra's history shows exactly that: 40
+  granted 2025-12-10, drawn to 0 by 2026-06-05, then topped up — so cumulative
+  granted = 46, used = 46, **available = 0**. Norma was granted/accrued 112 PTO
+  over the period (incl. a PTO audit correction) and used/cashed-out all of it
+  (incl. an 80h cash-out on 2026-06-06) → **available = 0**.
+- **The spendable available (0 / 21 / 0) is what matters** — it's what the
+  employee can request, what the field-app shows, and what gates new requests.
+  All three are within policy.
+
+**Why clamping `granted` to the cap would be wrong:** if we forced Alejandra's
+`granted` down to 40 while `used` stays 46, then `available = 40 − 46 = −6`
+(nonsense). Clamping available to 0 would then leave `granted (40) < used (46)`,
+which violates the invariant that you can't use more than was ever granted — it
+corrupts the audit trail. Loading the true cumulative (`granted 46 / used 46`)
+keeps `available = 0` (correct) and the record honest.
+
+**Self-correcting:** at each employee's next **anniversary reset**, the engine sets
+`granted = entitlement` (40 PLAWA / 80 PTO) and `used = 0` — so the over-cap
+cumulative is a within-year artifact that normalizes automatically next year.
+
+→ **Recommendation: load as-is.** Awaiting Sal's "go" on this explanation before apply.
+
+## Queued to apply (the moment Sal confirms — still NOT run)
+
+1. **Deploy #581 first** (corrects PLAWA → flat_grant/40/no-carryover, dup-sick off,
+   work_anniversary basis) so live `leave_types` matches the model.
+2. `node scripts/timeoff-mc-loader.mjs --dataset scripts/_mc_timeoff_dataset.json --apply`
+   → writes: 1 hire-date fix, 27 balance rows (PTO + PLAWA from MC, Unpaid 40 each;
+   Unexcused untouched), transactional, idempotent.
+3. Flip `LEAVE_ACCRUAL_ENABLED=true` → cron maintains anniversaries on top of the
+   import (the import's `last_reset_at` prevents mid-year clobber).
+4. **History second pass**: paste the per-row arrays → loader inserts `[MC import]`
+   ledger rows (informational; balances unaffected).
+5. Spot-check (profile + field-app "My Time Off" + payroll).

--- a/docs/TIME_OFF_ACCRUAL_PHASE1_FINDINGS_AND_DESIGN.md
+++ b/docs/TIME_OFF_ACCRUAL_PHASE1_FINDINGS_AND_DESIGN.md
@@ -789,3 +789,77 @@ benefit year began 2025-08-01 so her 2025-12→2026-06 sick usage = 29h counts.)
 6. From here, approving a request auto-pays at $20/hr as a payroll line; balances
    + pay stay in sync across office and employee views.
 7. Spot-check 3–5 employees (profile + field-app "My Time Off" + payroll).
+
+---
+
+# Phase 2d — MaidCentral loader ready (2026-06-20)
+
+PR #581 **rebased onto current main** (past #601–#605), **marked ready for review**,
+all 4 CI checks green. Still NOT merged/deployed; no writes; accrual cron off.
+
+## Loader status — what existed vs. what was added
+
+- The earlier `_timeoff_migration_dryrun_readonly.mjs` and the engine
+  (`leave-reconcile.ts`) only compute **default grants** from hire dates and
+  *derive* "used" from `additional_pay`. **Neither ingests a real MC dataset**,
+  and neither loads **history**.
+- **NEW: `scripts/timeoff-mc-loader.mjs`** ingests the verified MC dataset and
+  cascades all three things Sal wants:
+  1. **Start dates** → `users.hire_date` corrections (eligibility depends on it).
+  2. **Balances** → `employee_leave_balances` (granted + used), upsert on
+     `(company_id, user_id, leave_type_id)`; `last_reset_at` = the employee's
+     current benefit-year start (work anniversary ≤ as_of) so the cron does NOT
+     immediately re-reset the imported balance.
+  3. **History** → `employee_leave_usage` rows (date_used, hours, notes),
+     deduped, prefixed `[MC import]`.
+- **Dry-run by default** (prints the full diff, writes nothing); `--apply` writes
+  in a transaction. Idempotent (balances upsert, history NOT-EXISTS dedup, hire
+  set) — safe to re-run. Validated against a sample: hire fix, 5 balance upserts,
+  history rows, and an availability-mismatch flag all surfaced correctly.
+
+## Dataset format I need from the MC crawl
+
+JSON (the loader prints this banner when run without `--dataset`):
+
+```json
+{
+  "as_of": "2026-06-20",
+  "company_id": 1,
+  "employees": [
+    {
+      "match": { "qleno_user_id": 41, "name": "Alejandra Cuervo", "email": "..." },
+      "mc_employee_id": 42877,
+      "hire_date": "2025-08-01",
+      "balances": [
+        { "bucket": "plawa",  "granted_hours": 40, "used_hours": 29, "available_hours": 11 },
+        { "bucket": "pto",    "granted_hours": 0,  "used_hours": 0,  "available_hours": 0  },
+        { "bucket": "unpaid", "granted_hours": 40, "used_hours": 0,  "available_hours": 40 }
+      ],
+      "history": [
+        { "bucket": "plawa", "date_used": "2026-01-07", "hours": 7, "notes": "Fever 11am-6pm" }
+      ]
+    }
+  ]
+}
+```
+
+- **match.qleno_user_id** preferred (name/email are fallback + sanity check).
+- **bucket** ∈ `plawa|sick`, `pto|vacation`, `unpaid|personal` → maps to PLAWA /
+  PTO / Unpaid Leave. `unexcused` is office-recorded, not imported here.
+- **hire_date** required per employee (start-date cascade).
+- **balances**: one row per bucket; `available_hours` validated against
+  granted − used (mismatch is flagged, granted/used wins).
+- **history**: optional but wanted — each row becomes a usage-ledger entry.
+- A **CSV** is fine too if easier — same columns (employee, bucket, granted, used,
+  available, hire_date) + a second history sheet (employee, bucket, date, hours,
+  notes); I'll adapt the loader's parser. JSON is the path of least resistance.
+
+## Load sequence when the dataset lands (still HELD for sign-off)
+
+1. `node scripts/timeoff-mc-loader.mjs --dataset mc.json` → **dry-run**; Sal eyeballs
+   the hire fixes + balances + history + flags.
+2. On approval: `--apply` (transactional) writes hire dates + balances + history.
+3. Then merge + deploy #581 and flip `LEAVE_ACCRUAL_ENABLED` so future
+   anniversaries reset on top of the imported balances (the import's
+   `last_reset_at` stops the cron from clobbering imported numbers mid-year).
+4. Spot-check (profile + field-app + payroll).

--- a/docs/TIME_OFF_ACCRUAL_PHASE1_FINDINGS_AND_DESIGN.md
+++ b/docs/TIME_OFF_ACCRUAL_PHASE1_FINDINGS_AND_DESIGN.md
@@ -537,4 +537,86 @@ These produce **very different** starting balances for Norma. So the migration's
   list. Include her in accrual (she's pre-90-day, so 0 today either way)?
 - **Q13 (new)** — duplicate sick bucket: OK to deactivate the generic `sick` (leave_types
   id 5) for co1 so PLAWA is the only sick bucket?
-</content>
+
+---
+
+# Phase 2 — BUILD (2026-06-20)
+
+**Reset basis RESOLVED (Sal 2026-06-20): CALENDAR YEAR for all employees, all
+buckets — everyone resets Jan 1.** Q1 is closed. The handbook's individualized
+"Benefit Year" language does NOT govern leave resets; the seed now stores
+`leave_reset_basis = 'calendar_year'` for co1. Sick = 40 front-loaded after 90
+days, no carryover, not paid at separation; PTO = 40 after 1 year → 80 (hard
+cap) at 2 years; Unpaid = 40 from day one.
+
+**Status: code built, CI-green, balance writes + deploy HELD for sign-off.** The
+accrual cron is gated OFF by `LEAVE_ACCRUAL_ENABLED` (default false), so merging/
+deploying writes NO balances until Sal confirms the dry-run and flips the
+Railway env var.
+
+## What was built
+
+| Piece | File | Notes |
+|-------|------|-------|
+| PLAWA seed fix + dup-sick deactivation + calendar-year basis | `cutover-data-migration.ts` | PLAWA → `flat_grant`/0/no-carryover (corrective UPDATE fixes prod); generic `sick` (id 5) deactivated for co1; policy forced to `calendar_year` |
+| Pure grant/reset engine | `lib/leave-grant-reset.ts` | `entitlementHours`, `completedYearsOfService`, `planLeaveGrant` (initial_grant / annual_reset / tier_topup). PTO "top-up to tier" (40→80), NOT carryover math |
+| Unit tests | `tests/cutover-3b-leave-grant-reset.test.ts` | 21 tests, all green (incl. handbook "top to 80, never stack" case) |
+| DB reconcile wrapper | `lib/leave-reconcile.ts` | loops employees × flat-grant buckets; `dryRun` mode powers the migration diff |
+| Daily cron (gated) | `lib/leave-accrual-cron.ts` + `index.ts` (2 AM CT) | grant-on-eligibility + Jan-1 reset; `LEAVE_ACCRUAL_ENABLED` default OFF |
+| Payroll review-gate preview | `lib/leave-pay-preview.ts` + `GET /api/payroll/leave-pay-preview` | approved paid leave × resolved rate; read-only, NOT folded into gross (like mileage/OT) |
+| Employee-profile UI repoint | `employee-profile-hr-tabs.tsx` | per-bucket 3A balances + eligibility + calendar-reset note; legacy single-bucket readout + manual log-usage write removed |
+| Legacy deprecation | `routes/hr-leave.ts` | deprecation banner; column DROP deferred to a post-sign-off follow-up |
+
+CI: `typecheck:libs` clean; api-server esbuild bundle + frontend vite build pass;
+382/382 cutover tests pass.
+
+## Migration DRY-RUN (co1 / Oak Lawn, as of 2026-06-20)
+
+Read-only, no writes: `scripts/_timeoff_migration_dryrun_readonly.mjs`. Granted =
+engine entitlement; Used = derived from 2026 `additional_pay` (sick_pay→PLAWA,
+vacation_pay→PTO; hours parsed from "(Xh)" notes else ÷ $20/h); Remaining =
+max(0, granted − used). Unpaid = 40 day-one, used 0.
+
+| Employee | Hire | PLAWA grant/used/rem | PTO grant/used/rem | Unpaid |
+|----------|------|----------------------|--------------------|--------|
+| Rosa Gallegos | 2020-04-01 | 40 / 0 / 40 | 80 / 0 / 80 | 40 |
+| Maribel Castillo (office) | 2023-02-21 | 40 / 0 / 40 | 80 / 0 / 80 | 40 |
+| Norma Puga | 2023-05-11 | 40 / 8 / 32 | 80 / 34.5 / 45.5 | 40 |
+| Francisco Estevez (office) | 2024-06-03 | 40 / 0 / 40 | 80 / 0 / 80 | 40 |
+| Diana Vasquez | 2024-06-18 | 40 / 0 / 40 | 80 / 0 / 80 | 40 |
+| Alma Salinas | 2025-06-03 | 40 / 0 / 40 | 40 / 0 / 40 | 40 |
+| Guadalupe Mejia | 2025-06-11 | 40 / 0 / 40 | 40 / 0 / 40 | 40 |
+| Alejandra Cuervo | 2025-08-01 | 40 / 21 / 19 | — not eligible | 40 |
+| Juliana Loredo | 2026-01-26 | 40 / 0 / 40 | — not eligible | 40 |
+| Jose Ardila | 2026-05-01 | — not eligible | — not eligible | 40 |
+| Hilda Gallegos | 2026-05-25 | — not eligible | — not eligible | 40 |
+
+(Used derivation printed per-row by the script. Only Norma & Alejandra have 2026
+usage. Holiday_pay is reported but NOT deducted — separate benefit.)
+
+## Residual questions for Sal (sign-off gate — no writes until answered)
+
+1. **PTO year-1 grant + mid-year 2-year top-up timing.** The dry-run grants the
+   tenure tier as of today (40 < 2yr, 80 ≥ 2yr). The engine bumps the tier at the
+   next Jan-1 reset, NOT on the mid-year work anniversary. The handbook says "tops
+   up at 2-year anniversary" — confirm Jan-1 timing is acceptable, or we add a
+   mid-year anniversary top-up.
+2. **Mid-year-hire proration.** New hires get the FULL 40 at the gate (IL PLAWA
+   frontloading norm), not prorated. Confirm.
+3. **Leave pay rate source.** The payroll preview + the used-hours derivation use
+   `employee_pay_rates` → company `commercial_hourly_rate` → $20 fallback (rate
+   table is empty today). Confirm the rate Phes pays leave at, and whether to seed
+   `employee_pay_rates`.
+4. **Auto-pay vs preview.** Paid leave is surfaced as a review-gate preview, not
+   auto-added to gross. Confirm (recommended) or switch to auto-pay.
+5. **Pre-write data fixes:** Alejandra hire_date (→2025-08-01), Maryury inclusion
+   (Q12), owner/office scope (Q11).
+
+## Go-live sequence (after sign-off)
+
+1. Apply the Alejandra hire_date fix + Maryury/owner decisions.
+2. Deploy (seed fix lands: PLAWA corrected, dup sick off, calendar basis).
+3. Re-run the dry-run; Sal eyeballs.
+4. Flip `LEAVE_ACCRUAL_ENABLED=true` → the 2 AM cron grants balances; overlay the
+   2026 `used` (one-time migration write, `ON CONFLICT DO UPDATE`).
+5. Spot-check 3–5 employees in the profile UI.

--- a/docs/TIME_OFF_ACCRUAL_PHASE1_FINDINGS_AND_DESIGN.md
+++ b/docs/TIME_OFF_ACCRUAL_PHASE1_FINDINGS_AND_DESIGN.md
@@ -863,3 +863,48 @@ JSON (the loader prints this banner when run without `--dataset`):
    anniversaries reset on top of the imported balances (the import's
    `last_reset_at` stops the cron from clobbering imported numbers mid-year).
 4. Spot-check (profile + field-app + payroll).
+
+---
+
+# Phase 2e — MC "Employee Attendance Stats" dry-run (2026-06-22)
+
+Sal's MC export = hire dates + balances (PTO + Sick) only, **no line-item
+history** (separate report later). Bucket scheme: PTO ← MC PTO; PLAWA ← MC Sick;
+Unpaid ← default 40 (day-one, all employees); Unexcused ← 0 (not imported).
+Skips: Generic Cleaner (test), Alma Salinas (1099), Salvador Martinez (owner).
+Dataset: `scripts/_mc_timeoff_dataset.json` (untracked — employee PII). Loaded via
+`timeoff-mc-loader.mjs` (dry-run, no writes). granted = used + available.
+
+**All 11 names matched a Qleno user** (none unmatched): Jose Ardila (44), Maribel
+Castillo (35), Alejandra Cuervo (41), Francisco Estevez (37), Hilda Gallegos (516),
+Rosa Gallegos (36), Katia Gonzalez (726), Juliana Loredo (42), Guadalupe Mejia (40),
+Norma Puga (32), Diana Vasquez (38). Hire-date correction: **Alejandra 2023-05-11 →
+2025-08-01** (1 fix). 33 balance upserts (3 buckets × 11). History inserts: 0.
+
+## Decisions for Sal (from the 7 flags)
+
+**A. Balances ABOVE the Qleno cap** — loaded as-is from MC; cap or honor?
+- Rosa Gallegos **PTO 160h** (ceiling is 80) — likely 2 years stacked in MC.
+- Guadalupe Mejia **PLAWA 69.5h**, Diana Vasquez **PLAWA 56h**, Juliana Loredo
+  **PLAWA 42h** (PLAWA front-load is 40) — MC kept availability at 40 after usage,
+  so used+avail exceeds 40.
+
+**B. Balances BELOW the engine front-load** — the accrual cron (once #581 is live
++ enabled) front-loads the full entitlement, so its `tier_topup` would raise these
+on its next run, **overwriting the import** (used preserved):
+- Alejandra **PLAWA 12 → 40** (avail 0 → 28).
+- Norma **PTO 40 → 80** (she's 3 yrs; tier is 80; avail 0 → 40).
+- Decide per employee: **accept** the engine front-load (Qleno policy: 40/80), or
+  **freeze** the imported MC number until the next anniversary.
+
+**C. Katia Gonzalez (uid 726) is INACTIVE in Qleno** but active in the MC export —
+reactivate the Qleno user or skip her?
+
+**D. History** is absent from this MC report (balances + attendance stats only) —
+`employee_leave_usage` stays empty until the separate usage report is loaded.
+
+## Sequencing note (important)
+Flags are computed against the **post-#581 target config** (PLAWA = flat_grant/40/
+no-carryover). On current prod PLAWA is still `accrue_per_hours` (the cron skips
+it). So the correct order is **deploy #581 first → re-run this dry-run → apply →
+enable cron**, which makes the live `leave_types` match the flag assumptions.

--- a/scripts/_timeoff_audit_readonly.mjs
+++ b/scripts/_timeoff_audit_readonly.mjs
@@ -1,0 +1,86 @@
+// READ-ONLY time-off migration design audit. SELECT only. No writes. Throwaway.
+import pg from '/Users/salvadormartinez/qleno/node_modules/.pnpm/pg@8.20.0/node_modules/pg/lib/index.js';
+import { readFileSync } from 'node:fs';
+
+const env = readFileSync('/Users/salvadormartinez/qleno/.env', 'utf8');
+const url = env.split('\n').find(l => l.startsWith('DATABASE_URL='))?.slice('DATABASE_URL='.length).trim().replace(/^["']|["']$/g, '');
+if (!url) { console.error('no DATABASE_URL'); process.exit(1); }
+
+const client = new pg.Client({ connectionString: url, ssl: { rejectUnauthorized: false } });
+await client.connect();
+const CO1 = 1;
+
+console.log('=== co1 ACTIVE USERS: id, name, hire_date, status ===');
+const users = await client.query(`
+  SELECT id, first_name, last_name, role, is_active,
+         hire_date::text AS hire_date,
+         pto_balance_hours, sick_balance_hours, leave_balance_hours,
+         leave_balance_activated, benefit_year_start::text AS benefit_year_start
+  FROM users
+  WHERE company_id = $1 AND COALESCE(is_active, true) = true
+  ORDER BY hire_date NULLS FIRST, last_name`, [CO1]);
+console.table(users.rows);
+
+console.log('\n=== employee_pay_rates (current effective hourly rate per user) ===');
+try {
+  const rates = await client.query(`
+    SELECT DISTINCT ON (user_id) user_id, hourly_rate, effective_date::text eff, end_date::text endd
+    FROM employee_pay_rates WHERE company_id = $1
+    ORDER BY user_id, effective_date DESC`, [CO1]);
+  console.table(rates.rows);
+} catch (e) { console.log('employee_pay_rates:', e.message); }
+
+console.log('\n=== additional_pay TIME-OFF entries for co1 in 2026 (the "used" question) ===');
+const addl = await client.query(`
+  SELECT user_id, type, COUNT(*) n, SUM(amount)::numeric(12,2) total_dollars,
+         MIN(created_at)::date first_dt, MAX(created_at)::date last_dt
+  FROM additional_pay
+  WHERE company_id = $1
+    AND COALESCE(status,'pending') <> 'voided'
+    AND created_at >= '2026-01-01'
+    AND lower(type) IN ('sick','sick_pay','vacation','vacation_pay','holiday','holiday_pay','pto','pto_pay','personal')
+  GROUP BY user_id, type ORDER BY user_id, type`, [CO1]);
+console.table(addl.rows);
+console.log('time-off additional_pay rows in 2026:', addl.rowCount);
+
+console.log('\n=== does additional_pay encode HOURS anywhere? (column check + sample notes) ===');
+const cols = await client.query(`
+  SELECT column_name, data_type FROM information_schema.columns
+  WHERE table_name = 'additional_pay' ORDER BY ordinal_position`);
+console.table(cols.rows);
+const sample = await client.query(`
+  SELECT user_id, type, amount, notes FROM additional_pay
+  WHERE company_id = $1 AND lower(type) IN ('sick','sick_pay','vacation','vacation_pay','holiday','holiday_pay','pto')
+  ORDER BY created_at DESC LIMIT 15`, [CO1]);
+console.table(sample.rows);
+
+console.log('\n=== leave_types seeded for co1 (active) ===');
+const lt = await client.query(`
+  SELECT id, slug, display_name, is_paid, annual_cap_hours, accrual_mode, accrual_rate,
+         waiting_period_days, carryover_allowed, active
+  FROM leave_types WHERE company_id = $1 ORDER BY active DESC, slug`, [CO1]);
+console.table(lt.rows);
+
+console.log('\n=== employee_leave_balances for co1 (are 3A balances populated or inert?) ===');
+const elb = await client.query(`
+  SELECT COUNT(*) AS rows, COALESCE(SUM(granted_hours),0) AS sum_granted, COALESCE(SUM(used_hours),0) AS sum_used
+  FROM employee_leave_balances WHERE company_id = $1`, [CO1]);
+console.table(elb.rows);
+
+console.log('\n=== company_leave_policy for co1 ===');
+try {
+  const pol = await client.query(`SELECT leave_program_enabled, leave_reset_basis, balance_ceiling_hours, carryover_enabled, payout_on_separation, eligibility_trigger_days FROM company_leave_policy WHERE company_id = $1`, [CO1]);
+  console.table(pol.rows);
+} catch (e) { console.log('company_leave_policy:', e.message); }
+
+console.log('\n=== employee_leave_usage (office-logged) for co1 in 2026 ===');
+try {
+  const usg = await client.query(`
+    SELECT employee_id, COUNT(*) n, SUM(hours)::numeric(10,2) hrs, MIN(date_used)::text first, MAX(date_used)::text last
+    FROM employee_leave_usage WHERE company_id = $1 AND date_used >= '2026-01-01'
+    GROUP BY employee_id ORDER BY employee_id`, [CO1]);
+  console.table(usg.rows);
+  console.log('leave_usage rows in 2026:', usg.rowCount);
+} catch (e) { console.log('employee_leave_usage:', e.message); }
+
+await client.end();

--- a/scripts/_timeoff_migration_dryrun_readonly.mjs
+++ b/scripts/_timeoff_migration_dryrun_readonly.mjs
@@ -1,0 +1,123 @@
+// READ-ONLY time-off migration DRY-RUN for Oak Lawn (co1). SELECT only.
+// NO writes. Produces the per-employee × bucket diff (eligibility, granted,
+// used, remaining) for Sal's sign-off BEFORE any balance is written.
+//
+// Granted   = engine entitlement (mirrors lib/leave-grant-reset.ts):
+//             PLAWA 40 after 90d; PTO 40 after 1yr, 80 after 2yr; Unpaid 40 day-one.
+// Used 2026 = derived from Qleno additional_pay (Sal's chosen source):
+//             sick_pay → PLAWA, vacation_pay → PTO. Hours parsed from the
+//             "(Xh)" note when present, else amount ÷ $20/h (the apparent
+//             standard day rate). holiday_pay is a SEPARATE benefit, not a
+//             bucket — reported, not deducted. Calendar-year window (2026).
+// Remaining = max(0, granted - used).
+import pg from '/Users/salvadormartinez/qleno/node_modules/.pnpm/pg@8.20.0/node_modules/pg/lib/index.js';
+import { readFileSync } from 'node:fs';
+
+const env = readFileSync('/Users/salvadormartinez/qleno/.env', 'utf8');
+const url = env.split('\n').find(l => l.startsWith('DATABASE_URL='))?.slice('DATABASE_URL='.length).trim().replace(/^["']|["']$/g, '');
+if (!url) { console.error('no DATABASE_URL'); process.exit(1); }
+
+const ASOF = '2026-06-20';      // today; calendar-year reset basis (Sal 2026-06-20)
+const LEAVE_RATE = 20;          // $/h fallback for dollars→hours (flagged for Sal)
+const CEILING = 80;
+
+// MC-authoritative roster (hire dates Sal pulled) mapped to Qleno user ids
+// from the Phase-1 reconciliation. Alejandra uses the MC-correct 2025-08-01
+// (Qleno still has the wrong 2023-05-11 — fix tracked separately).
+const ROSTER = [
+  { uid: 36, name: 'Rosa Gallegos', hire: '2020-04-01' },
+  { uid: 35, name: 'Maribel Castillo', hire: '2023-02-21', office: true },
+  { uid: 32, name: 'Norma Puga', hire: '2023-05-11' },
+  { uid: 37, name: 'Francisco Estevez', hire: '2024-06-03', office: true },
+  { uid: 38, name: 'Diana Vasquez', hire: '2024-06-18' },
+  { uid: 39, name: 'Alma Salinas', hire: '2025-06-03' },
+  { uid: 40, name: 'Guadalupe Mejia', hire: '2025-06-11' },
+  { uid: 41, name: 'Alejandra Cuervo', hire: '2025-08-01' },
+  { uid: 42, name: 'Juliana Loredo', hire: '2026-01-26' },
+  { uid: 44, name: 'Jose Ardila', hire: '2026-05-01' },
+  { uid: 516, name: 'Hilda Gallegos', hire: '2026-05-25' },
+];
+
+const daysBetween = (a, b) => Math.floor((new Date(`${b}T00:00:00Z`) - new Date(`${a}T00:00:00Z`)) / 86400000);
+function completedYears(hire, asOf) {
+  const h = new Date(`${hire}T00:00:00Z`), a = new Date(`${asOf}T00:00:00Z`);
+  let y = a.getUTCFullYear() - h.getUTCFullYear();
+  const anniv = new Date(Date.UTC(a.getUTCFullYear(), h.getUTCMonth(), h.getUTCDate()));
+  if (a < anniv) y -= 1;
+  return Math.max(0, y);
+}
+const plawaGrant = hire => (daysBetween(hire, ASOF) >= 90 ? 40 : 0);
+const ptoGrant = hire => (daysBetween(hire, ASOF) >= 365 ? (completedYears(hire, ASOF) >= 2 ? CEILING : 40) : 0);
+const unpaidGrant = () => 40;
+
+// hours from an additional_pay row: "(Xh)" note first, else amount/$20
+function rowHours(amount, notes) {
+  const m = (notes || '').match(/\((\d+(?:\.\d+)?)\s*h\)/i);
+  if (m) return { hrs: parseFloat(m[1]), src: 'note' };
+  return { hrs: Math.round((parseFloat(amount) / LEAVE_RATE) * 100) / 100, src: '$/' + LEAVE_RATE };
+}
+
+const client = new pg.Client({ connectionString: url, ssl: { rejectUnauthorized: false } });
+await client.connect();
+
+// 2026 time-off additional_pay for the roster
+const uids = ROSTER.map(r => r.uid);
+const ap = await client.query(`
+  SELECT user_id, lower(type) AS type, amount, notes
+  FROM additional_pay
+  WHERE company_id = 1 AND COALESCE(status,'pending') <> 'voided'
+    AND created_at >= '2026-01-01' AND created_at < '2027-01-01'
+    AND lower(type) IN ('sick_pay','vacation_pay','holiday_pay')
+    AND user_id = ANY($1::int[])
+  ORDER BY user_id, type`, [uids]);
+
+const used = {}; // uid → { plawa, pto, holiday }
+for (const u of uids) used[u] = { plawa: 0, pto: 0, holiday: 0 };
+const derivation = [];
+for (const r of ap.rows) {
+  const { hrs, src } = rowHours(r.amount, r.notes);
+  const bucket = r.type === 'sick_pay' ? 'plawa' : r.type === 'vacation_pay' ? 'pto' : 'holiday';
+  used[r.user_id][bucket] += hrs;
+  derivation.push({ uid: r.user_id, type: r.type, amount: r.amount, hrs, via: src, note: (r.notes || '').slice(0, 48) });
+}
+
+console.log(`\n=== TIME-OFF MIGRATION DRY-RUN (co1 / Oak Lawn) — as of ${ASOF}, calendar-year reset ===`);
+console.log('granted = engine entitlement; used = 2026 additional_pay (sick→PLAWA, vacation→PTO); remaining = max(0, granted-used)\n');
+
+const out = [];
+for (const e of ROSTER) {
+  const buckets = [
+    { slug: 'PLAWA (sick)', granted: plawaGrant(e.hire), used: round(used[e.uid].plawa) },
+    { slug: 'PTO', granted: ptoGrant(e.hire), used: round(used[e.uid].pto) },
+    { slug: 'Unpaid', granted: unpaidGrant(), used: 0 },
+  ];
+  for (const b of buckets) {
+    const eligible = b.granted > 0 || b.slug === 'Unpaid';
+    const remaining = Math.max(0, round(b.granted - b.used));
+    const over = b.used > b.granted ? '  ⚠ used>granted' : '';
+    out.push({
+      employee: e.name + (e.office ? ' (office)' : ''),
+      hire: e.hire,
+      bucket: b.slug,
+      eligible: eligible ? 'yes' : 'NO',
+      granted: b.granted,
+      used: b.used,
+      remaining: remaining + over,
+    });
+  }
+}
+console.table(out);
+
+console.log('\n=== USED-HOURS DERIVATION (from 2026 additional_pay) ===');
+console.table(derivation);
+
+console.log('\n=== FLAGS ===');
+console.log('• Alejandra Cuervo (uid 41): dry-run uses MC hire 2025-08-01; Qleno DB still has 2023-05-11 (WRONG) — fix before write.');
+console.log('• Maryury Colmenares (uid 817, hired 2026-06-16): in Qleno, NOT in the MC list — excluded here pending Q12.');
+console.log('• Sal Martinez (owner, uid 1) excluded (Q11: owner/office in scope?). Maribel & Francisco are office — included, confirm Q11.');
+console.log(`• Dollars→hours used $${LEAVE_RATE}/h where the note had no "(Xh)" — confirm the leave pay rate (Q: rate source).`);
+console.log('• holiday_pay reported in derivation but NOT a balance bucket (separate 8h benefit) — not deducted.');
+console.log('• Unpaid personal: granted 40 day-one, used 0 (no additional_pay maps to it; tracked going forward).');
+
+await client.end();
+function round(n) { return Math.round(n * 100) / 100; }

--- a/scripts/_timeoff_migration_dryrun_readonly.mjs
+++ b/scripts/_timeoff_migration_dryrun_readonly.mjs
@@ -38,6 +38,10 @@ const ROSTER = [
   { uid: 42, name: 'Juliana Loredo', hire: '2026-01-26' },
   { uid: 44, name: 'Jose Ardila', hire: '2026-05-01' },
   { uid: 516, name: 'Hilda Gallegos', hire: '2026-05-25' },
+  // Resolved (Sal 2026-06-20): include Maryury (real active co1 tech, just
+  // post-dated the MC list pull). Owner (Sal, uid 1) EXCLUDED from accrual;
+  // office staff (Maribel, Francisco) INCLUDED.
+  { uid: 817, name: 'Maryury Colmenares', hire: '2026-06-16' },
 ];
 
 const daysBetween = (a, b) => Math.floor((new Date(`${b}T00:00:00Z`) - new Date(`${a}T00:00:00Z`)) / 86400000);
@@ -109,6 +113,8 @@ for (const e of ROSTER) {
     const eligible = b.granted > 0 || b.slug === 'Unpaid';
     const remaining = Math.max(0, round(b.granted - b.used));
     const over = b.used > b.granted ? '  ⚠ used>granted' : '';
+    // Leave pays $20/hr flat on approval (sick + PTO). Unpaid = $0.
+    const paid = b.slug === 'PLAWA (sick)' || b.slug === 'PTO';
     out.push({
       employee: e.name + (e.office ? ' (office)' : ''),
       hire: e.hire,
@@ -118,6 +124,7 @@ for (const e of ROSTER) {
       granted: b.granted,
       used: b.used,
       remaining: remaining + over,
+      'rem_$@20': paid ? `$${(remaining * LEAVE_RATE).toFixed(0)}` : '—',
     });
   }
 }
@@ -128,9 +135,8 @@ console.table(derivation);
 
 console.log('\n=== FLAGS ===');
 console.log('• Alejandra Cuervo (uid 41): dry-run uses MC hire 2025-08-01; Qleno DB still has 2023-05-11 (WRONG) — fix before write.');
-console.log('• Maryury Colmenares (uid 817, hired 2026-06-16): in Qleno, NOT in the MC list — excluded here pending Q12.');
-console.log('• Sal Martinez (owner, uid 1) excluded (Q11: owner/office in scope?). Maribel & Francisco are office — included, confirm Q11.');
-console.log(`• Dollars→hours used $${LEAVE_RATE}/h where the note had no "(Xh)" — confirm the leave pay rate (Q: rate source).`);
+console.log('• RESOLVED (Sal 2026-06-20): Maryury Colmenares (uid 817) INCLUDED; owner (Sal, uid 1) EXCLUDED from accrual; office staff (Maribel, Francisco) INCLUDED.');
+console.log(`• RESOLVED: leave pays a FLAT $${LEAVE_RATE}/hr (company floor) on approval. rem_$@20 = remaining hours × $${LEAVE_RATE} (sick + PTO; unpaid = $0). Dollars→hours of past usage also normalized at $${LEAVE_RATE}/h where note lacked "(Xh)".`);
 console.log('• holiday_pay reported in derivation but NOT a balance bucket (separate 8h benefit) — not deducted.');
 console.log('• Unpaid personal: granted 40 day-one, used 0 (no additional_pay maps to it; tracked going forward).');
 console.log('• WORK-ANNIVERSARY basis: "used" counts only additional_pay in the current benefit year (since benefit_yr). Entries before it (in_BY=PRIOR) are last year — NOT deducted. This is why Norma (anniv 5/11) shows ~0 used despite Jan–Mar PTO.');

--- a/scripts/_timeoff_migration_dryrun_readonly.mjs
+++ b/scripts/_timeoff_migration_dryrun_readonly.mjs
@@ -4,11 +4,13 @@
 //
 // Granted   = engine entitlement (mirrors lib/leave-grant-reset.ts):
 //             PLAWA 40 after 90d; PTO 40 after 1yr, 80 after 2yr; Unpaid 40 day-one.
-// Used 2026 = derived from Qleno additional_pay (Sal's chosen source):
+// Used      = derived from Qleno additional_pay (Sal's chosen source):
 //             sick_pay → PLAWA, vacation_pay → PTO. Hours parsed from the
 //             "(Xh)" note when present, else amount ÷ $20/h (the apparent
 //             standard day rate). holiday_pay is a SEPARATE benefit, not a
-//             bucket — reported, not deducted. Calendar-year window (2026).
+//             bucket — reported, not deducted. WINDOW = each employee's
+//             current BENEFIT YEAR (most recent hire anniversary → today),
+//             since the reset basis is work_anniversary (Sal 2026-06-20).
 // Remaining = max(0, granted - used).
 import pg from '/Users/salvadormartinez/qleno/node_modules/.pnpm/pg@8.20.0/node_modules/pg/lib/index.js';
 import { readFileSync } from 'node:fs';
@@ -49,6 +51,13 @@ function completedYears(hire, asOf) {
 const plawaGrant = hire => (daysBetween(hire, ASOF) >= 90 ? 40 : 0);
 const ptoGrant = hire => (daysBetween(hire, ASOF) >= 365 ? (completedYears(hire, ASOF) >= 2 ? CEILING : 40) : 0);
 const unpaidGrant = () => 40;
+// Most recent hire-anniversary on/before ASOF = start of current benefit year.
+function benefitYearStart(hire, asOf) {
+  const h = new Date(`${hire}T00:00:00Z`), a = new Date(`${asOf}T00:00:00Z`);
+  let anniv = new Date(Date.UTC(a.getUTCFullYear(), h.getUTCMonth(), h.getUTCDate()));
+  if (anniv > a) anniv = new Date(Date.UTC(a.getUTCFullYear() - 1, h.getUTCMonth(), h.getUTCDate()));
+  return anniv.toISOString().slice(0, 10);
+}
 
 // hours from an additional_pay row: "(Xh)" note first, else amount/$20
 function rowHours(amount, notes) {
@@ -60,13 +69,15 @@ function rowHours(amount, notes) {
 const client = new pg.Client({ connectionString: url, ssl: { rejectUnauthorized: false } });
 await client.connect();
 
-// 2026 time-off additional_pay for the roster
+// time-off additional_pay for the roster (wide window; filtered per
+// employee's benefit-year start below — work-anniversary reset basis)
 const uids = ROSTER.map(r => r.uid);
+const bysByUid = Object.fromEntries(ROSTER.map(r => [r.uid, benefitYearStart(r.hire, ASOF)]));
 const ap = await client.query(`
-  SELECT user_id, lower(type) AS type, amount, notes
+  SELECT user_id, lower(type) AS type, amount, notes, created_at::date AS created
   FROM additional_pay
   WHERE company_id = 1 AND COALESCE(status,'pending') <> 'voided'
-    AND created_at >= '2026-01-01' AND created_at < '2027-01-01'
+    AND created_at >= '2024-01-01'
     AND lower(type) IN ('sick_pay','vacation_pay','holiday_pay')
     AND user_id = ANY($1::int[])
   ORDER BY user_id, type`, [uids]);
@@ -75,17 +86,20 @@ const used = {}; // uid → { plawa, pto, holiday }
 for (const u of uids) used[u] = { plawa: 0, pto: 0, holiday: 0 };
 const derivation = [];
 for (const r of ap.rows) {
+  const createdStr = (r.created instanceof Date ? r.created.toISOString().slice(0, 10) : String(r.created).slice(0, 10));
+  const inBenefitYear = createdStr >= bysByUid[r.user_id];
   const { hrs, src } = rowHours(r.amount, r.notes);
   const bucket = r.type === 'sick_pay' ? 'plawa' : r.type === 'vacation_pay' ? 'pto' : 'holiday';
-  used[r.user_id][bucket] += hrs;
-  derivation.push({ uid: r.user_id, type: r.type, amount: r.amount, hrs, via: src, note: (r.notes || '').slice(0, 48) });
+  if (inBenefitYear) used[r.user_id][bucket] += hrs;
+  derivation.push({ uid: r.user_id, type: r.type, created: createdStr, in_BY: inBenefitYear ? 'yes' : 'PRIOR', amount: r.amount, hrs, via: src });
 }
 
-console.log(`\n=== TIME-OFF MIGRATION DRY-RUN (co1 / Oak Lawn) — as of ${ASOF}, calendar-year reset ===`);
-console.log('granted = engine entitlement; used = 2026 additional_pay (sick→PLAWA, vacation→PTO); remaining = max(0, granted-used)\n');
+console.log(`\n=== TIME-OFF MIGRATION DRY-RUN (co1 / Oak Lawn) — as of ${ASOF}, WORK-ANNIVERSARY reset ===`);
+console.log('granted = engine entitlement; used = current-benefit-year additional_pay (sick→PLAWA, vacation→PTO); remaining = max(0, granted-used)\n');
 
 const out = [];
 for (const e of ROSTER) {
+  const bys = benefitYearStart(e.hire, ASOF);
   const buckets = [
     { slug: 'PLAWA (sick)', granted: plawaGrant(e.hire), used: round(used[e.uid].plawa) },
     { slug: 'PTO', granted: ptoGrant(e.hire), used: round(used[e.uid].pto) },
@@ -98,6 +112,7 @@ for (const e of ROSTER) {
     out.push({
       employee: e.name + (e.office ? ' (office)' : ''),
       hire: e.hire,
+      benefit_yr: bys,
       bucket: b.slug,
       eligible: eligible ? 'yes' : 'NO',
       granted: b.granted,
@@ -118,6 +133,7 @@ console.log('• Sal Martinez (owner, uid 1) excluded (Q11: owner/office in scop
 console.log(`• Dollars→hours used $${LEAVE_RATE}/h where the note had no "(Xh)" — confirm the leave pay rate (Q: rate source).`);
 console.log('• holiday_pay reported in derivation but NOT a balance bucket (separate 8h benefit) — not deducted.');
 console.log('• Unpaid personal: granted 40 day-one, used 0 (no additional_pay maps to it; tracked going forward).');
+console.log('• WORK-ANNIVERSARY basis: "used" counts only additional_pay in the current benefit year (since benefit_yr). Entries before it (in_BY=PRIOR) are last year — NOT deducted. This is why Norma (anniv 5/11) shows ~0 used despite Jan–Mar PTO.');
 
 await client.end();
 function round(n) { return Math.round(n * 100) / 100; }

--- a/scripts/timeoff-mc-loader.mjs
+++ b/scripts/timeoff-mc-loader.mjs
@@ -1,0 +1,195 @@
+/**
+ * MaidCentral → Qleno time-off LOADER (co1).
+ *
+ * Ingests the verified MC dataset and cascades it into the 3A leave tables:
+ *   1. START DATES   → users.hire_date corrections (eligibility depends on it).
+ *   2. BALANCES      → employee_leave_balances (granted_hours + used_hours),
+ *                      upsert on (company_id, user_id, leave_type_id).
+ *                      last_reset_at = the employee's current benefit-year start
+ *                      (work anniversary ≤ as_of) so the accrual cron does NOT
+ *                      immediately re-reset the imported balance.
+ *   3. HISTORY       → employee_leave_usage rows (date_used, hours, notes),
+ *                      deduped, prefixed "[MC import]".
+ *
+ * DRY-RUN BY DEFAULT — prints the full diff and writes NOTHING. Pass --apply
+ * to write (wrapped in a transaction). Do NOT --apply until Sal signs off on
+ * the dry-run. Idempotent: balances upsert; hire dates set; history NOT-EXISTS
+ * deduped — safe to re-run.
+ *
+ * Usage:
+ *   node scripts/timeoff-mc-loader.mjs --dataset path/to/mc.json            # dry-run
+ *   node scripts/timeoff-mc-loader.mjs --dataset path/to/mc.json --apply    # write (HELD)
+ *   node scripts/timeoff-mc-loader.mjs                                      # print expected schema
+ *
+ * Expected dataset JSON (see SCHEMA banner printed when --dataset is omitted).
+ */
+import pg from "/Users/salvadormartinez/qleno/node_modules/.pnpm/pg@8.20.0/node_modules/pg/lib/index.js";
+import { readFileSync } from "node:fs";
+
+const args = process.argv.slice(2);
+const datasetPath = args[(args.indexOf("--dataset") + 1) || -1];
+const APPLY = args.includes("--apply");
+const COMPANY = Number(args[(args.indexOf("--company") + 1) || -1]) || 1;
+
+// Dataset bucket alias → Qleno co1 leave_types slug.
+const BUCKET_TO_SLUG = {
+  plawa: "plawa", sick: "plawa", sick_pay: "plawa", any_reason: "plawa",
+  pto: "pto_phes", vacation: "pto_phes", vacation_pay: "pto_phes", pto_phes: "pto_phes",
+  unpaid: "unpaid_leave", unpaid_personal: "unpaid_leave", personal: "unpaid_leave", unpaid_leave: "unpaid_leave",
+};
+
+const SCHEMA = `
+Expected MC dataset JSON (the format the loader ingests):
+
+{
+  "as_of": "2026-06-20",            // date the MC balances were captured
+  "company_id": 1,                   // Phes / Oak Lawn
+  "employees": [
+    {
+      "match": { "qleno_user_id": 41, "name": "Alejandra Cuervo", "email": "..." },
+      "mc_employee_id": 42877,       // for the audit trail (optional)
+      "hire_date": "2025-08-01",     // MC start date (drives eligibility) — REQUIRED
+      "balances": [
+        // bucket ∈ {plawa|sick, pto|vacation, unpaid|personal}
+        { "bucket": "plawa",  "granted_hours": 40, "used_hours": 29, "available_hours": 11 },
+        { "bucket": "pto",    "granted_hours": 0,  "used_hours": 0,  "available_hours": 0  },
+        { "bucket": "unpaid", "granted_hours": 40, "used_hours": 0,  "available_hours": 40 }
+      ],
+      "history": [
+        { "bucket": "plawa", "date_used": "2026-01-07", "hours": 7, "notes": "Fever 11am-6pm" },
+        { "bucket": "pto",   "date_used": "2025-09-15", "hours": 8, "notes": "Vacation day" }
+      ]
+    }
+  ]
+}
+
+Notes:
+- match: provide qleno_user_id (preferred). name/email used only as a fallback + sanity check.
+- balances: one row per bucket the employee has. available_hours is validated against granted-used.
+- history: optional but Sal wants it — each row → employee_leave_usage (date_used, hours, notes).
+- buckets map: plawa/sick→PLAWA, pto/vacation→PTO, unpaid/personal→Unpaid Leave.
+`;
+
+if (!datasetPath || args.includes("--help")) {
+  console.log(SCHEMA);
+  console.log(`Run with --dataset <path> for a dry-run; add --apply to write (HELD for sign-off).`);
+  process.exit(0);
+}
+
+// ── benefit-year start (work anniversary ≤ asOf) — matches the engine ──
+function benefitYearStart(hire, asOf) {
+  const h = new Date(`${hire}T00:00:00Z`), a = new Date(`${asOf}T00:00:00Z`);
+  let anniv = new Date(Date.UTC(a.getUTCFullYear(), h.getUTCMonth(), h.getUTCDate()));
+  if (anniv > a) anniv = new Date(Date.UTC(a.getUTCFullYear() - 1, h.getUTCMonth(), h.getUTCDate()));
+  return anniv.toISOString().slice(0, 10);
+}
+const r2 = (n) => Math.round(Number(n) * 100) / 100;
+
+const ds = JSON.parse(readFileSync(datasetPath, "utf8"));
+const asOf = ds.as_of || new Date().toISOString().slice(0, 10);
+const companyId = ds.company_id || COMPANY;
+
+const env = readFileSync("/Users/salvadormartinez/qleno/.env", "utf8");
+const url = env.split("\n").find((l) => l.startsWith("DATABASE_URL=")).slice(13).trim().replace(/^["']|["']$/g, "");
+const client = new pg.Client({ connectionString: url, ssl: { rejectUnauthorized: false } });
+await client.connect();
+
+// Resolve leave_types (slug → id) and users for the company.
+const ltRows = (await client.query(`SELECT id, slug, display_name, is_paid FROM leave_types WHERE company_id=$1 AND active=true`, [companyId])).rows;
+const slugToType = Object.fromEntries(ltRows.map((r) => [r.slug, r]));
+const users = (await client.query(`SELECT id, first_name, last_name, lower(email) email, hire_date::text hire, is_active, company_id FROM users WHERE company_id=$1`, [companyId])).rows;
+const byId = new Map(users.map((u) => [u.id, u]));
+const byEmail = new Map(users.filter((u) => u.email).map((u) => [u.email, u]));
+const byName = new Map(users.map((u) => [`${(u.first_name || "").toLowerCase()} ${(u.last_name || "").toLowerCase()}`.trim(), u]));
+
+const hireFixes = [], balanceUpserts = [], historyInserts = [], flags = [];
+
+for (const e of ds.employees || []) {
+  const m = e.match || {};
+  let u = m.qleno_user_id ? byId.get(m.qleno_user_id) : null;
+  if (!u && m.email) u = byEmail.get(String(m.email).toLowerCase());
+  if (!u && m.name) u = byName.get(String(m.name).toLowerCase());
+  if (!u) { flags.push(`UNMATCHED employee: ${JSON.stringify(m)} — skipped`); continue; }
+  if (!u.is_active) flags.push(`${u.first_name} ${u.last_name} (uid ${u.id}) is INACTIVE — included anyway, confirm`);
+
+  // 1. hire-date correction
+  if (e.hire_date && e.hire_date !== u.hire) {
+    hireFixes.push({ uid: u.id, name: `${u.first_name} ${u.last_name}`, qleno_hire: u.hire, mc_hire: e.hire_date });
+  }
+  const effHire = e.hire_date || u.hire;
+  const lastReset = effHire ? benefitYearStart(effHire, asOf) : null;
+
+  // 2. balances
+  for (const b of e.balances || []) {
+    const slug = BUCKET_TO_SLUG[String(b.bucket).toLowerCase()];
+    const lt = slug ? slugToType[slug] : null;
+    if (!lt) { flags.push(`${u.first_name} ${u.last_name}: unknown bucket "${b.bucket}" — balance skipped`); continue; }
+    const granted = r2(b.granted_hours ?? 0), used = r2(b.used_hours ?? 0);
+    const avail = r2(granted - used);
+    if (b.available_hours != null && r2(b.available_hours) !== avail) {
+      flags.push(`${u.first_name} ${u.last_name}/${slug}: available mismatch (dataset ${b.available_hours} vs granted-used ${avail}) — using granted/used`);
+    }
+    balanceUpserts.push({ uid: u.id, name: `${u.first_name} ${u.last_name}`, slug, leave_type_id: lt.id, granted, used, available: avail, last_reset_at: lastReset });
+  }
+
+  // 3. history
+  for (const h of e.history || []) {
+    const hrs = r2(h.hours ?? 0);
+    if (!(hrs > 0) || !h.date_used) { flags.push(`${u.first_name} ${u.last_name}: bad history row ${JSON.stringify(h)} — skipped`); continue; }
+    const bucket = BUCKET_TO_SLUG[String(h.bucket || "").toLowerCase()] || h.bucket || "leave";
+    historyInserts.push({ uid: u.id, name: `${u.first_name} ${u.last_name}`, date_used: h.date_used, hours: hrs, notes: `[MC import] ${bucket}${h.notes ? `: ${h.notes}` : ""}` });
+  }
+}
+
+console.log(`\n=== MC TIME-OFF LOADER — co${companyId}, as_of ${asOf} — ${APPLY ? "APPLY (WRITING)" : "DRY-RUN (no writes)"} ===`);
+console.log(`employees in dataset: ${(ds.employees || []).length}`);
+
+console.log(`\n--- 1. HIRE-DATE CORRECTIONS (${hireFixes.length}) ---`);
+console.table(hireFixes);
+console.log(`\n--- 2. BALANCE UPSERTS (${balanceUpserts.length}) ---`);
+console.table(balanceUpserts);
+console.log(`\n--- 3. HISTORY INSERTS (${historyInserts.length}) --- (showing first 25)`);
+console.table(historyInserts.slice(0, 25));
+console.log(`\n--- FLAGS (${flags.length}) ---`);
+flags.forEach((f) => console.log("  •", f));
+
+if (!APPLY) {
+  console.log(`\nDRY-RUN complete. No writes. Re-run with --apply to write (after Sal sign-off).`);
+  await client.end();
+  process.exit(0);
+}
+
+// ── APPLY (transactional) ──
+console.log(`\nAPPLYING…`);
+await client.query("BEGIN");
+try {
+  for (const f of hireFixes) {
+    await client.query(`UPDATE users SET hire_date=$1 WHERE id=$2 AND company_id=$3`, [f.mc_hire, f.uid, companyId]);
+  }
+  for (const b of balanceUpserts) {
+    await client.query(
+      `INSERT INTO employee_leave_balances (company_id, user_id, leave_type_id, granted_hours, used_hours, last_reset_at, created_at, updated_at)
+       VALUES ($1,$2,$3,$4,$5,$6, NOW(), NOW())
+       ON CONFLICT (company_id, user_id, leave_type_id)
+       DO UPDATE SET granted_hours=EXCLUDED.granted_hours, used_hours=EXCLUDED.used_hours, last_reset_at=EXCLUDED.last_reset_at, updated_at=NOW()`,
+      [companyId, b.uid, b.leave_type_id, b.granted.toFixed(2), b.used.toFixed(2), b.last_reset_at ? `${b.last_reset_at}T12:00:00Z` : null],
+    );
+  }
+  for (const h of historyInserts) {
+    await client.query(
+      `INSERT INTO employee_leave_usage (company_id, employee_id, date_used, hours, notes, logged_by, created_at)
+       SELECT $1,$2,$3,$4,$5,NULL,NOW()
+        WHERE NOT EXISTS (
+          SELECT 1 FROM employee_leave_usage
+           WHERE company_id=$1 AND employee_id=$2 AND date_used=$3 AND hours=$4 AND notes=$5)`,
+      [companyId, h.uid, h.date_used, h.hours.toFixed(2), h.notes],
+    );
+  }
+  await client.query("COMMIT");
+  console.log(`APPLIED: ${hireFixes.length} hire fixes, ${balanceUpserts.length} balances, ${historyInserts.length} history rows.`);
+} catch (err) {
+  await client.query("ROLLBACK");
+  console.error("APPLY FAILED — rolled back:", err.message);
+  process.exitCode = 1;
+}
+await client.end();

--- a/scripts/timeoff-mc-loader.mjs
+++ b/scripts/timeoff-mc-loader.mjs
@@ -94,9 +94,21 @@ const url = env.split("\n").find((l) => l.startsWith("DATABASE_URL=")).slice(13)
 const client = new pg.Client({ connectionString: url, ssl: { rejectUnauthorized: false } });
 await client.connect();
 
+// Completed full years of service (for the PTO 40→80 tenure tier).
+function completedYears(hire, asOf) {
+  const h = new Date(`${hire}T00:00:00Z`), a = new Date(`${asOf}T00:00:00Z`);
+  let y = a.getUTCFullYear() - h.getUTCFullYear();
+  const anniv = new Date(Date.UTC(a.getUTCFullYear(), h.getUTCMonth(), h.getUTCDate()));
+  if (a < anniv) y -= 1;
+  return Math.max(0, y);
+}
+const daysBetween = (a, b) => Math.floor((new Date(`${b}T00:00:00Z`) - new Date(`${a}T00:00:00Z`)) / 86400000);
+
 // Resolve leave_types (slug → id) and users for the company.
-const ltRows = (await client.query(`SELECT id, slug, display_name, is_paid FROM leave_types WHERE company_id=$1 AND active=true`, [companyId])).rows;
+const ltRows = (await client.query(`SELECT id, slug, display_name, is_paid, annual_cap_hours, carryover_allowed, waiting_period_days FROM leave_types WHERE company_id=$1 AND active=true`, [companyId])).rows;
 const slugToType = Object.fromEntries(ltRows.map((r) => [r.slug, r]));
+const policyRow = (await client.query(`SELECT balance_ceiling_hours FROM company_leave_policy WHERE company_id=$1`, [companyId])).rows[0];
+const ceiling = policyRow?.balance_ceiling_hours != null ? Number(policyRow.balance_ceiling_hours) : 80;
 const users = (await client.query(`SELECT id, first_name, last_name, lower(email) email, hire_date::text hire, is_active, company_id FROM users WHERE company_id=$1`, [companyId])).rows;
 const byId = new Map(users.map((u) => [u.id, u]));
 const byEmail = new Map(users.filter((u) => u.email).map((u) => [u.email, u]));
@@ -128,6 +140,35 @@ for (const e of ds.employees || []) {
     const avail = r2(granted - used);
     if (b.available_hours != null && r2(b.available_hours) !== avail) {
       flags.push(`${u.first_name} ${u.last_name}/${slug}: available mismatch (dataset ${b.available_hours} vs granted-used ${avail}) — using granted/used`);
+    }
+    // Flags are evaluated against the POST-#581 TARGET leave_types config (not
+    // the current prod seed, where PLAWA is still accrue_per_hours/carryover and
+    // the cron would skip it). This gives an accurate picture of behavior once
+    // #581 is deployed — which is the planned order (deploy #581 → load → enable).
+    const TARGET = {
+      plawa:        { cap: 40, carryover: false, wait: 90,  flat: true },
+      pto_phes:     { cap: 40, carryover: true,  wait: 365, flat: true },
+      unpaid_leave: { cap: 40, carryover: false, wait: 0,   flat: true },
+    };
+    const t = TARGET[slug] || { cap: Number(lt.annual_cap_hours), carryover: lt.carryover_allowed, wait: Number(lt.waiting_period_days), flat: lt.accrual_mode === "flat_grant" };
+
+    // Cap/ceiling: carryover buckets (PTO) cap at the policy ceiling; others at
+    // the annual cap. MC numbers above the cap load as-is per Sal but are flagged.
+    const cap = t.carryover && ceiling > t.cap ? ceiling : t.cap;
+    if (granted > cap) {
+      flags.push(`${u.first_name} ${u.last_name}/${slug}: granted ${granted}h EXCEEDS Qleno cap ${cap}h — loaded as-is from MC; confirm cap policy`);
+    }
+    // ENGINE-OVERRIDE: the accrual cron front-loads the full entitlement. If the
+    // imported granted is BELOW the entitlement for an eligible employee, the
+    // cron's tier_topup raises granted → entitlement on its next run, overwriting
+    // the MC import (used preserved). Surface for a freeze-vs-accept decision.
+    if (t.flat && effHire && daysBetween(effHire, asOf) >= t.wait) {
+      const ent = t.carryover && ceiling > t.cap
+        ? Math.min(ceiling, t.cap * Math.max(1, completedYears(effHire, asOf)))
+        : t.cap;
+      if (ent > granted) {
+        flags.push(`${u.first_name} ${u.last_name}/${slug}: imported granted ${granted}h < post-#581 entitlement ${ent}h → accrual cron would tier_topup to ${ent}h (avail ${r2(ent - used)}), OVERWRITING the MC import. Decide: accept engine front-load vs freeze import.`);
+      }
     }
     balanceUpserts.push({ uid: u.id, name: `${u.first_name} ${u.last_name}`, slug, leave_type_id: lt.id, granted, used, available: avail, last_reset_at: lastReset });
   }


### PR DESCRIPTION
**Draft. Phase 1 design + Phase 2 build + Phase 2b correction & workflow.** Doc: `docs/TIME_OFF_ACCRUAL_PHASE1_FINDINGS_AND_DESIGN.md`.

⚠️ **Balance writes + deploy HELD for Sal's sign-off.** Accrual cron gated OFF by `LEAVE_ACCRUAL_ENABLED` (default false); employee email/SMS gated by `COMMS_ENABLED`. Nothing writes balances or sends comms until enabled.

## Rules (Sal-confirmed)
Per-employee **WORK-ANNIVERSARY** benefit year (reset on hire anniversary, NOT Jan 1). Sick (PLAWA) = 40 front-loaded after 90 days, no carryover; PTO = 40 @ 1yr → 80 @ 2yr (hard cap); Unpaid = 40 day one.

## Accrual engine
- Seed: PLAWA → flat_grant/no-carryover (corrective UPDATE); dup `sick` deactivated for co1; `leave_reset_basis=work_anniversary`.
- `lib/leave-grant-reset.ts` (pure, 25 tests) keys reset off `benefitYearStartDate` (most recent anniversary). `lib/leave-reconcile.ts` + gated 2 AM cron.
- Payroll review-gated preview (`GET /api/payroll/leave-pay-preview`), read-only.
- Employee-profile UI repointed to 3A per-bucket balances.

## Request → approval → notification workflow (field app, mirrors MaidCentral)
3A already had: employee request UI (`/leave`, in field-app sidebar), balance check/deduction, approve/deny (`leave-review`). **Built the gaps:**
- **7-day advance notice** (`checkAdvanceNotice`): PTO + Unpaid require start≥today+7d; sick/PLAWA exempt (emergency). + field-app hint.
- **Real notifications** (`lib/leave-notifications.ts`, replacing console-log stubs): submit → office/owner "ACTION REQUIRED" (in-app+push+email) + employee "Pending"/"Emergency" (in-app+push+email+SMS); approve/deny → employee "Approved"/"Denied" (in-app+push+email+SMS). MC subjects mirrored; decisions on SMS+email (superset of MC's email-only). Employee email/SMS gated by COMMS_ENABLED.

## Corrected dry-run (co1, work-anniversary)
Most employees start FULL (pre-anniversary usage is prior benefit year). Only Alejandra carries usage: PLAWA 40/29/**11**. Norma now 40/0/40 + 80/0/80 (her Jan–Mar PTO is last benefit year). Full table in doc.

## CI
389/389 cutover tests · api+frontend build · typecheck:libs — all green.

## Residual (sign-off gate)
PTO 2-yr top-up at anniversary (confirm), proration, leave pay **rate source** (employee_pay_rates empty), auto-pay vs preview, data fixes (Alejandra hire_date, Maryury, owner/office scope). Cascade-request notifications = follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)