### PR TITLE
feat(comms): mirror MaidCentral customer service cadence — HOLD for confirm

### DIFF
--- a/artifacts/api-server/src/index.ts
+++ b/artifacts/api-server/src/index.ts
@@ -49,6 +49,13 @@ if (criticalMissing) {
   console.error("[Qleno] Missing critical env vars — server may not function correctly");
 }
 
+// [comms-cadence-mirror] MaidCentral sends only a 24-hour (day-before) reminder.
+// Qleno additionally sends a 72-hour (3-day) reminder as an extra customer touch.
+// Default ON (keep the extra touch). Flip to false for an EXACT MaidCentral
+// mirror — that drops the 3-day reminder and keeps only the day-before one.
+// Single switch so the keep-vs-remove call is one line, no code surgery.
+const REMINDER_72H_ENABLED = true;
+
 // ── Notification cron scheduler (CT timezone) ─────────────────────────────
 // Fires reminder_3day at 9 AM CT, reminder_1day at 4 PM CT, review_request hourly
 function startNotificationCron() {
@@ -70,8 +77,9 @@ function startNotificationCron() {
     const ctMonth = ctNow.getUTCMonth(); // 0-indexed; December = 11
     const ctDay   = ctNow.getUTCDate();
 
-    // 9 AM CT → reminder_3day (jobs in 3 days)
-    if (ctH === 9 && fired["reminder_3day"] !== `${ctDate}-9`) {
+    // 9 AM CT → reminder_3day (jobs in 3 days) — gated by REMINDER_72H_ENABLED
+    // so dropping the extra 72h touch for an exact MaidCentral mirror is one flag.
+    if (REMINDER_72H_ENABLED && ctH === 9 && fired["reminder_3day"] !== `${ctDate}-9`) {
       fired["reminder_3day"] = `${ctDate}-9`;
       runReminderCron(3).catch((e: Error) => console.error("[cron] reminder_3day error:", e));
     }

--- a/artifacts/api-server/src/lib/job-lifecycle-notify.ts
+++ b/artifacts/api-server/src/lib/job-lifecycle-notify.ts
@@ -1,0 +1,137 @@
+// [comms-cadence-mirror] Customer-facing lifecycle notifications for a job's
+// START and COMPLETION, fired so Qleno mirrors MaidCentral's service cadence
+// (email + text only — never a phone call).
+//
+// WHY a shared module: the "started" signal arrives from more than one clock
+// path (field tech-clock clock-in, per-house timeclock punch) and "completed"
+// arrives from THREE paths (office PATCH /api/jobs/:id, tech-clock clock_out,
+// timeclock last-tech clock-out). Centralising here keeps one copy of the merge
+// logic and — critically — one IDEMPOTENCY latch so a customer never gets two
+// "started"/"complete" messages when several paths fire for the same job.
+//
+// IDEMPOTENCY: each function CLAIMS the send with a single guarded UPDATE that
+// flips the per-job latch (job_started_sent / job_completed_sent) only if it was
+// still false, returning the row only to the caller that won the race. Everyone
+// else no-ops. completed_at is stamped in the same atomic UPDATE (server NOW(),
+// timestamptz) so the review-request cron has a reliable completion key even if
+// comms are gated off at completion time.
+//
+// GATING is delegated entirely to sendNotification(), which already enforces the
+// global COMMS_ENABLED kill switch AND the per-tenant companies.comms_enabled
+// gate AND resolves the per-tenant Twilio sender. That is what lets Oak Lawn
+// (co1) go live independently of Schaumburg (co4): flip co1.comms_enabled and
+// these fire only for co1's jobs. Nothing here bypasses a gate.
+//
+// Fully non-fatal: any error is swallowed so a notification hiccup can never
+// break a clock punch or a job-completion write.
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+import { sendNotification, labelServiceType } from "../services/notificationService.js";
+
+type JobClientRow = {
+  scheduled_date: string | null;
+  service_type: string | null;
+  address_street: string | null;
+  address_city: string | null;
+  address_state: string | null;
+  address_zip: string | null;
+  first_name: string | null;
+  email: string | null;
+  phone: string | null;
+  client_address: string | null;
+  client_city: string | null;
+  client_state: string | null;
+};
+
+async function loadJobClient(companyId: number, jobId: number): Promise<JobClientRow | null> {
+  const r = await db.execute(sql`
+    SELECT j.scheduled_date, j.service_type,
+           j.address_street, j.address_city, j.address_state, j.address_zip,
+           c.first_name, c.email, c.phone,
+           c.address AS client_address, c.city AS client_city, c.state AS client_state
+      FROM jobs j
+      JOIN clients c ON c.id = j.client_id
+     WHERE j.id = ${jobId} AND j.company_id = ${companyId}
+     LIMIT 1`);
+  return ((r as any).rows?.[0] as JobClientRow) ?? null;
+}
+
+// Canonical address — prefer the per-job address (the override the dispatch/MC
+// import populates), fall back to the client record. zip is included when shown,
+// per the address-display invariant.
+function buildAddress(row: JobClientRow): string {
+  const stateZip = [row.address_state, row.address_zip].filter(Boolean).join(" ");
+  const fromJob = [row.address_street, row.address_city, stateZip].filter(Boolean).join(", ");
+  if (fromJob) return fromJob;
+  const fromClient = [row.client_address, row.client_city, row.client_state].filter(Boolean).join(", ");
+  return fromClient || "On file";
+}
+
+function buildMergeVars(row: JobClientRow): Record<string, string> {
+  return {
+    first_name:       row.first_name || "",
+    appointment_date: row.scheduled_date ? String(row.scheduled_date).slice(0, 10) : "",
+    scope:            labelServiceType(row.service_type),
+    service_address:  buildAddress(row),
+  };
+}
+
+/**
+ * Fire the "your cleaning has started" email + SMS exactly once for this job.
+ * Call on the clock-in / start-job transition. No-op if already sent or if the
+ * job has no client (office events). Gating handled by sendNotification.
+ */
+export async function notifyJobStarted(companyId: number, jobId: number): Promise<void> {
+  try {
+    const claimed = await db.execute(sql`
+      UPDATE jobs
+         SET job_started_sent = true
+       WHERE id = ${jobId}
+         AND company_id = ${companyId}
+         AND COALESCE(job_started_sent, false) = false
+         AND client_id IS NOT NULL
+       RETURNING id`);
+    if (!(claimed as any).rows?.[0]) return; // lost the race / already sent / no client
+
+    const row = await loadJobClient(companyId, jobId);
+    if (!row) return;
+    const mv = buildMergeVars(row);
+    await sendNotification("job_started", "email", companyId, row.email, null, mv).catch(() => {});
+    await sendNotification("job_started", "sms",   companyId, null, row.phone, mv).catch(() => {});
+  } catch (err) {
+    console.error("[job-lifecycle] notifyJobStarted non-fatal:", err);
+  }
+}
+
+/**
+ * Fire the "your cleaning is complete" email + SMS exactly once for this job AND
+ * stamp completed_at (the review-request cron's key). Call alongside
+ * ensureInvoiceForCompletedJob on every completion path. No-op if already sent
+ * or if the job has no client. Gating handled by sendNotification.
+ */
+export async function notifyJobCompleted(companyId: number, jobId: number): Promise<void> {
+  try {
+    // Stamp completion time + claim the send in one atomic write. completed_at is
+    // set regardless of comms gating so the review cron works even if comms were
+    // off at completion and enabled later (the latch still prevents a re-blast).
+    const claimed = await db.execute(sql`
+      UPDATE jobs
+         SET job_completed_sent = true,
+             completed_at = COALESCE(completed_at, NOW())
+       WHERE id = ${jobId}
+         AND company_id = ${companyId}
+         AND COALESCE(job_completed_sent, false) = false
+       RETURNING client_id`);
+    const winner = (claimed as any).rows?.[0];
+    if (!winner) return;          // lost the race / already sent
+    if (!winner.client_id) return; // office event without a customer
+
+    const row = await loadJobClient(companyId, jobId);
+    if (!row) return;
+    const mv = buildMergeVars(row);
+    await sendNotification("job_completed", "email", companyId, row.email, null, mv).catch(() => {});
+    await sendNotification("job_completed", "sms",   companyId, null, row.phone, mv).catch(() => {});
+  } catch (err) {
+    console.error("[job-lifecycle] notifyJobCompleted non-fatal:", err);
+  }
+}

--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -5711,6 +5711,18 @@ async function runNotificationTemplateSeed() {
       ["users.reset_token",                         sql`ALTER TABLE users ADD COLUMN IF NOT EXISTS reset_token TEXT`],
       ["users.reset_token_expires_at",              sql`ALTER TABLE users ADD COLUMN IF NOT EXISTS reset_token_expires_at TIMESTAMP`],
       ["jobs.supply_cost",                          sql`ALTER TABLE jobs ADD COLUMN IF NOT EXISTS supply_cost NUMERIC(8,2) DEFAULT 0.00`],
+      // [comms-cadence-mirror] Lifecycle notification bookkeeping. job_started_sent
+      // / job_completed_sent are per-job idempotency latches so the "cleaning has
+      // started" / "cleaning is complete" texts+emails fire exactly once even
+      // though the start/complete signal arrives from multiple paths (office
+      // PATCH, field tech-clock, per-house timeclock). completed_at is the
+      // server-time (UTC, timestamptz) completion stamp the review-request cron
+      // keys off — replacing the old DATE(created_at) key that never matched
+      // recurring child jobs (generated weeks ahead). NOW() is timestamptz so the
+      // cron's `completed_at vs NOW() - INTERVAL` comparison stays frame-consistent.
+      ["jobs.job_started_sent",                     sql`ALTER TABLE jobs ADD COLUMN IF NOT EXISTS job_started_sent BOOLEAN NOT NULL DEFAULT false`],
+      ["jobs.job_completed_sent",                   sql`ALTER TABLE jobs ADD COLUMN IF NOT EXISTS job_completed_sent BOOLEAN NOT NULL DEFAULT false`],
+      ["jobs.completed_at",                         sql`ALTER TABLE jobs ADD COLUMN IF NOT EXISTS completed_at TIMESTAMPTZ`],
       ["companies.overhead_rate_pct",               sql`ALTER TABLE companies ADD COLUMN IF NOT EXISTS overhead_rate_pct NUMERIC(5,2) DEFAULT 10.00`],
       ["notifications.create_table",                sql`CREATE TABLE IF NOT EXISTS notifications (id uuid PRIMARY KEY DEFAULT gen_random_uuid(), company_id integer NOT NULL, type varchar(50) NOT NULL, title varchar(255) NOT NULL, body text, link varchar(500), meta jsonb, read boolean DEFAULT false, created_at timestamptz DEFAULT now())`],
       ["notifications.idx_company_unread",          sql`CREATE INDEX IF NOT EXISTS idx_notifications_company_unread ON notifications(company_id, read, created_at DESC)`],
@@ -5863,6 +5875,34 @@ async function runNotificationTemplateSeed() {
         subject: null,
         body_html: null,
         body_text: "Hi {{first_name}}, {{technician_name}} from {{company_name}} is on the way \u2014 arriving during your {{appointment_window}} window. Questions? {{company_phone}}.",
+      },
+
+      // ── 3b. JOB STARTED ─────────────────────────────────────────────────
+      // [comms-cadence-mirror] Fires when the cleaner clocks in at the house
+      // (status → in_progress / first timeclock punch). Mirrors MaidCentral's
+      // "your home cleaning has started" touch. Email + SMS.
+      {
+        trigger: "job_started", channel: "email",
+        subject: "Your cleaning has started, {{first_name}}",
+        body_html: `<p style="margin:0 0 20px">Hi {{first_name}},</p>
+<p style="margin:0 0 20px">Good news — your <strong>{{company_name}}</strong> team has arrived and your cleaning is now underway.</p>
+<table width="100%" cellpadding="0" cellspacing="0" style="border:1px solid #E5E2DC;border-radius:6px;background:#FFFFFF;margin:0 0 24px">
+<tr><td style="padding:20px">
+  <p style="margin:0 0 8px;font-size:13px;color:#6B6860;text-transform:uppercase;letter-spacing:.05em">Service</p>
+  <p style="margin:0 0 16px;font-size:15px;color:#1A1917;font-weight:600">{{scope}}</p>
+  <p style="margin:0 0 8px;font-size:13px;color:#6B6860;text-transform:uppercase;letter-spacing:.05em">Address</p>
+  <p style="margin:0;font-size:15px;color:#1A1917">{{service_address}}</p>
+</td></tr>
+</table>
+<p style="margin:0 0 20px;color:#1A1917">You will get a confirmation the moment we finish. If you need to reach the office while we are on-site, call or text <strong>{{company_phone}}</strong>.</p>
+<p style="margin:0">Thank you for trusting {{company_name}}.</p>`,
+        body_text: "Hi {{first_name}}, your {{company_name}} cleaning has started — the team is now on-site at {{service_address}}. We will confirm when we finish. Questions? {{company_phone}}.",
+      },
+      {
+        trigger: "job_started", channel: "sms",
+        subject: null,
+        body_html: null,
+        body_text: "Hi {{first_name}}, your {{company_name}} cleaning has started — the team is now on-site at {{service_address}}. We will confirm when we finish. Questions? {{company_phone}}.",
       },
 
       // ── 4. JOB COMPLETED ────────────────────────────────────────────────

--- a/artifacts/api-server/src/routes/jobs.ts
+++ b/artifacts/api-server/src/routes/jobs.ts
@@ -8,7 +8,7 @@ import { logAudit, logClientActivity } from "../lib/audit.js";
 import { generateJobCompletionPdf } from "../lib/generate-job-pdf.js";
 import { geocodeAddress } from "../lib/geocode.js";
 import { resolveZoneForZip } from "./zones.js";
-import { sendNotification, labelServiceType } from "../services/notificationService.js";
+import { sendNotification } from "../services/notificationService.js";
 import { parseResRatesRow, resolveResidentialPayPct } from "../lib/commission-rates.js";
 import { ensureInvoiceForCompletedJob } from "../lib/ensure-invoice.js";
 import { buildJobLineItems } from "../lib/invoice-line-items.js";
@@ -3641,27 +3641,16 @@ router.post("/:id/complete", requireAuth, async (req, res) => {
       });
     }
 
-    // ── job_completed notification (non-blocking) ─────────────────────────
+    // ── job_completed notification + completion stamp (non-blocking) ──────
+    // [comms-cadence-mirror] Centralised in notifyJobCompleted so the office
+    // PATCH path (here), the field tech-clock clock-out, and the per-house
+    // timeclock last clock-out all send through ONE idempotent helper — no
+    // double-send, and every path stamps completed_at for the review-request
+    // cron. Gating (global + per-tenant comms_enabled) lives in sendNotification.
     const companyId = req.auth!.companyId;
-    if (clientId && jobDetail[0]) {
-      const jd = jobDetail[0];
-      db.select({ email: clientsTable.email, phone: clientsTable.phone,
-                  address: clientsTable.address, city: clientsTable.city, state: clientsTable.state,
-                  first_name: clientsTable.first_name })
-        .from(clientsTable).where(eq(clientsTable.id, clientId)).limit(1)
-        .then(([cl]) => {
-          if (!cl) return;
-          const addr = [cl.address, cl.city, cl.state].filter(Boolean).join(", ");
-          const mv = {
-            first_name:       cl.first_name || "",
-            appointment_date: jd.scheduled_date || new Date().toISOString().slice(0, 10),
-            scope:            labelServiceType(jd.service_type),
-            service_address:  addr,
-          };
-          sendNotification("job_completed", "email", companyId, cl.email, null, mv).catch(() => {});
-          sendNotification("job_completed", "sms",   companyId, null, cl.phone, mv).catch(() => {});
-        }).catch(() => {});
-    }
+    import("../lib/job-lifecycle-notify.js").then(({ notifyJobCompleted }) =>
+      notifyJobCompleted(companyId, jobId).catch(() => {}),
+    ).catch(() => {});
     // ─────────────────────────────────────────────────────────────────────
 
     // ── efficiency auto-compute (non-blocking) ────────────────────────────

--- a/artifacts/api-server/src/routes/tech-clock.ts
+++ b/artifacts/api-server/src/routes/tech-clock.ts
@@ -40,6 +40,7 @@ import { estimateEtaMinutes } from "../lib/eta.js";
 import { sendOnMyWaySms } from "../lib/comms.js";
 import { geocodeAddress } from "../lib/geocode.js";
 import { ensureInvoiceForCompletedJob } from "../lib/ensure-invoice.js";
+import { notifyJobStarted, notifyJobCompleted } from "../lib/job-lifecycle-notify.js";
 
 const router = Router();
 
@@ -495,6 +496,10 @@ async function handleClockEvent(
         .where(
           and(eq(jobsTable.company_id, companyId), eq(jobsTable.id, job.id)),
         );
+      // [comms-cadence-mirror] "Your cleaning has started" — idempotent, gated,
+      // fire-and-forget so it never blocks the clock-in response.
+      notifyJobStarted(companyId, job.id)
+        .catch((e: Error) => console.error("[tech-clock started-notify] non-fatal:", e));
     } else if (eventType === "clock_out" && job.status !== "complete") {
       await db
         .update(jobsTable)
@@ -508,6 +513,9 @@ async function handleClockEvent(
       // is internally non-fatal and skips if an invoice already exists).
       ensureInvoiceForCompletedJob(companyId, job.id, userId)
         .catch((e: Error) => console.error("[tech-clock invoice] non-fatal:", e));
+      // [comms-cadence-mirror] "Your cleaning is complete" + stamp completed_at.
+      notifyJobCompleted(companyId, job.id)
+        .catch((e: Error) => console.error("[tech-clock completed-notify] non-fatal:", e));
     }
 
     return res.json({

--- a/artifacts/api-server/src/routes/timeclock.ts
+++ b/artifacts/api-server/src/routes/timeclock.ts
@@ -6,6 +6,7 @@ import { requireAuth, requireRole } from "../lib/auth.js";
 import { logAudit } from "../lib/audit.js";
 import { computePerTechCommissionRows, type JobTechRow } from "../lib/commission-paytype.js";
 import { ensureInvoiceForCompletedJob } from "../lib/ensure-invoice.js";
+import { notifyJobStarted, notifyJobCompleted } from "../lib/job-lifecycle-notify.js";
 import { parseResRatesRow } from "../lib/commission-rates.js";
 import type { CommissionInputJob } from "../lib/commission-compute.js";
 
@@ -384,6 +385,12 @@ router.post("/clock-in", requireAuth, async (req, res) => {
       console.error("[late_clockin notify] failed:", notifErr);
     }
 
+    // [comms-cadence-mirror] "Your cleaning has started" — fires on the first
+    // clock-in at the house (idempotent latch means later techs on the same job
+    // don't re-send). Gated + fire-and-forget so it never blocks the response.
+    notifyJobStarted(req.auth!.companyId, job_id)
+      .catch((e: Error) => console.error("[timeclock started-notify] non-fatal:", e));
+
     return res.json({
       ...entry,
       distance_from_job_ft: distanceFt,
@@ -547,6 +554,11 @@ router.post("/:id/clock-out", requireAuth, async (req, res) => {
           // never blocks the clock-out response (helper is internally non-fatal).
           ensureInvoiceForCompletedJob(req.auth!.companyId, jobId, req.auth!.userId)
             .catch((e: Error) => console.error("[end-job invoice] non-fatal:", e));
+          // [comms-cadence-mirror] "Your cleaning is complete" + stamp completed_at
+          // (the review-request cron's key). RETURNING guard above means this runs
+          // exactly once, on the transition. Gated + fire-and-forget.
+          notifyJobCompleted(req.auth!.companyId, jobId)
+            .catch((e: Error) => console.error("[end-job completed-notify] non-fatal:", e));
         }
         if (clientId) {
           fetch(`http://localhost:${process.env.PORT || 8080}/api/satisfaction/send`, {

--- a/artifacts/api-server/src/services/notificationService.ts
+++ b/artifacts/api-server/src/services/notificationService.ts
@@ -249,26 +249,37 @@ export async function runReminderCron(daysAhead: number): Promise<void> {
     const targetStr = target.toISOString().slice(0, 10);
     const { sql: drizzleSql } = await import("drizzle-orm");
 
+    // [comms-cadence-mirror] Per-company gate + scope. Reminders previously
+    // gated ONLY on the global COMMS_ENABLED with no company filter, so flipping
+    // the global switch would have blasted EVERY tenant's customers at once. The
+    // `JOIN companies co ... AND co.comms_enabled = true` scopes reminders to
+    // tenants that have explicitly opted in — so Oak Lawn (co1) can go live
+    // independently of Schaumburg (co4). Both gates apply: global COMMS_ENABLED
+    // (checked above) AND per-tenant comms_enabled (here).
     const rows = await db.execute(
       hoursAhead === 72
         ? drizzleSql`
-            SELECT j.id, j.scheduled_date, j.service_type, j.arrival_window,
+            SELECT j.id, j.company_id, j.scheduled_date, j.service_type, j.arrival_window,
                    j.address_street, j.address_city, j.address_state, j.address_zip,
                    c.first_name, c.last_name, c.email, c.phone, c.zip
               FROM jobs j
               JOIN clients c ON c.id = j.client_id
+              JOIN companies co ON co.id = j.company_id
              WHERE j.scheduled_date = ${targetStr}
                AND j.status NOT IN ('cancelled', 'void', 'done', 'complete')
+               AND co.comms_enabled = true
                AND j.reminder_72h_sent = false
           `
         : drizzleSql`
-            SELECT j.id, j.scheduled_date, j.service_type, j.arrival_window,
+            SELECT j.id, j.company_id, j.scheduled_date, j.service_type, j.arrival_window,
                    j.address_street, j.address_city, j.address_state, j.address_zip,
                    c.first_name, c.last_name, c.email, c.phone, c.zip
               FROM jobs j
               JOIN clients c ON c.id = j.client_id
+              JOIN companies co ON co.id = j.company_id
              WHERE j.scheduled_date = ${targetStr}
                AND j.status NOT IN ('cancelled', 'void', 'done', 'complete')
+               AND co.comms_enabled = true
                AND j.reminder_24h_sent = false
           `
     );
@@ -375,15 +386,17 @@ export async function runReviewRequestCron(): Promise<void> {
     return;
   }
   try {
-    const cutoffMs  = 24 * 60 * 60 * 1000;
-    const now       = new Date();
-    const from      = new Date(now.getTime() - cutoffMs - 30 * 60 * 1000); // 24h30m ago
-    const to        = new Date(now.getTime() - cutoffMs + 30 * 60 * 1000); // 23h30m ago
-    const fromStr   = from.toISOString().slice(0, 10);
-
+    // [comms-cadence-mirror] Key off COMPLETION, not creation. The old
+    // `DATE(j.created_at) = ~24h ago` filter never matched recurring child jobs:
+    // the recurring engine generates them weeks ahead, so created_at is the
+    // generation date, not ~24h pre-review — recurring clients silently got no
+    // review request. completed_at (stamped by notifyJobCompleted on every
+    // completion path, server-time timestamptz) fixes that. The 1-hour window
+    // (23h30m–24h30m after completion) lands each job in exactly one hourly run;
+    // the 30-day survey_last_sent throttle is the backstop against any overlap.
     const rows = await db.execute(
       (await import("drizzle-orm")).sql`
-        SELECT j.id, j.company_id, j.client_id, j.created_at, j.scheduled_date, j.service_type,
+        SELECT j.id, j.company_id, j.client_id, j.completed_at, j.scheduled_date, j.service_type,
                c.first_name, c.last_name, c.email, c.phone,
                c.address, c.city, c.state, c.survey_last_sent,
                co.review_link
@@ -391,7 +404,9 @@ export async function runReviewRequestCron(): Promise<void> {
           JOIN clients c ON c.id = j.client_id
           JOIN companies co ON co.id = j.company_id
          WHERE j.status = 'complete'
-           AND DATE(j.created_at) = ${fromStr}
+           AND j.completed_at IS NOT NULL
+           AND j.completed_at >= NOW() - INTERVAL '24 hours 30 minutes'
+           AND j.completed_at <  NOW() - INTERVAL '23 hours 30 minutes'
            AND (c.survey_last_sent IS NULL OR c.survey_last_sent < NOW() - INTERVAL '30 days')
       `
     );


### PR DESCRIPTION
**Status: DRAFT / HOLD.** Built per Sal's green-light to mirror MaidCentral's customer service cadence (email + text only — no phone calls). **Do not deploy until Sal confirms.** `COMMS_ENABLED` is NOT touched — Sal handles env after confirm.

## What this does

| # | Gap | Fix |
|---|-----|-----|
| 1 | **Job started** notification missing | New `job_started` template (email+SMS) + `notifyJobStarted()`, fired on clock-in (field `tech-clock` + per-house `timeclock`) |
| 2 | **Job completed** only sent from office PATCH (field-completed jobs sent nothing) | `notifyJobCompleted()` wired into all 3 completion paths (office PATCH, tech-clock clock-out, timeclock last clock-out) — the same paths `ensureInvoiceForCompletedJob` hooks |
| 3 | **Review request** never fired for recurring clients | Re-keyed off `jobs.completed_at` (~24h after completion) instead of `DATE(created_at)`, which never matched recurring child jobs (generated weeks ahead) |
| 4 | **Reminders** gated on global flag only → flipping it hits all companies | 72h/24h reminder cron now JOINs `companies` + requires `co.comms_enabled`, scoped per company → **co1 (Oak Lawn) goes live independently of co4 (Schaumburg)** |
| 5 | Qleno has a 72h reminder MaidCentral lacks | `REMINDER_72H_ENABLED` flag (default **ON** = keep extra touch). Flip to `false` for an exact MaidCentral mirror. **Sal's keep-vs-remove call.** |

## Design notes
- **Idempotency:** `notifyJobStarted/Completed` claim a per-job latch (`job_started_sent` / `job_completed_sent`) in one atomic guarded UPDATE — multi-path / multi-tech completion never double-sends. `completed_at` stamped in the same write.
- **Gating:** all sends delegate to `sendNotification()` → global `COMMS_ENABLED` + per-tenant `companies.comms_enabled` + per-tenant Twilio sender. Nothing bypasses a gate. All sends are fire-and-forget + non-fatal (never block a clock punch or completion).
- **New columns** (`job_started_sent`, `job_completed_sent`, `completed_at`) added via additive raw-SQL DDL in `phes-data-migration.ts` (same pattern as `reminder_*_sent`). No drizzle schema change.
- Quote/office tools untouched.

## Resulting cadence for co1 (Oak Lawn), once `comms_enabled` is flipped

| Trigger | Offset | Channel | Per-branch gated? |
|---|---|---|---|
| Booking confirmation | on booking | email + SMS | yes |
| 72h reminder *(extra vs MC; flag-toggle)* | 3 days before, 9 AM CT | email + SMS | yes (now per-company) |
| 24h reminder | day before, 4 PM CT | email + SMS | yes (now per-company) |
| On-my-way | tech taps en route | SMS (+email) | yes |
| **Job started** *(new)* | on clock-in | email + SMS | yes |
| **Job completed** *(now all paths)* | on completion | email + SMS | yes |
| **Review request** *(now fires for recurring)* | ~24h after completion | email + SMS | yes |

## Verification
- `pnpm run typecheck:libs` ✓
- `pnpm --filter @workspace/api-server run build` (frontend + server bundle) ✓
- Awaiting GitHub CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)