### PR TITLE
fix(payroll): exclude sandbox/test employees from detail + publish

### DIFF
--- a/artifacts/api-server/src/lib/payroll-snapshot.ts
+++ b/artifacts/api-server/src/lib/payroll-snapshot.ts
@@ -92,9 +92,16 @@ export async function computePeriodPay(companyId: number, start: string, end: st
   const clockedUserIds = [...new Set(clocks.map(c => c.user_id))];
   const cellByUser = new Map<number, TechCell>();
   const userMap = new Map<number, string>();
+  // [sandbox-exclude 2026-06-20] Test/sandbox fixtures (is_sandbox=true) never
+  // belong in a payroll run — must match GET /payroll/detail exactly. Excluded
+  // at the OUTPUT (folds below skip them) so real techs' pool shares don't move.
+  // is_sandbox, NOT is_active: a deactivated-but-real tech (is_active=false,
+  // is_sandbox=false) is still owed clocked pay and stays in.
+  const sandboxUserIds = new Set<number>();
   if (clockedUserIds.length) {
-    const us = (await db.execute(sql`SELECT id, first_name, last_name, residential_pay_type, residential_pay_rate, commercial_pay_type, commercial_pay_rate FROM users WHERE company_id = ${companyId} AND id = ANY(ARRAY[${sql.raw(intList(clockedUserIds))}]::int[])`)).rows as any[];
+    const us = (await db.execute(sql`SELECT id, first_name, last_name, is_sandbox, residential_pay_type, residential_pay_rate, commercial_pay_type, commercial_pay_rate FROM users WHERE company_id = ${companyId} AND id = ANY(ARRAY[${sql.raw(intList(clockedUserIds))}]::int[])`)).rows as any[];
     for (const u of us) {
+      if (u.is_sandbox === true) { sandboxUserIds.add(Number(u.id)); continue; }
       userMap.set(Number(u.id), `${u.first_name ?? ""} ${u.last_name ?? ""}`.trim());
       cellByUser.set(Number(u.id), {
         residential_pay_type: u.residential_pay_type === "hourly" ? "hourly" : "commission",
@@ -144,6 +151,7 @@ export async function computePeriodPay(companyId: number, start: string, end: st
 
   const byUser = new Map<number, PeriodPay>();
   for (const l of lines) {
+    if (sandboxUserIds.has(l.user_id)) continue; // [sandbox-exclude] drop test fixtures
     if (!byUser.has(l.user_id)) byUser.set(l.user_id, { user_id: l.user_id, name: userMap.get(l.user_id) || "", gross: 0, base: 0, hours: 0, tips: 0, overtime: 0, bonus: 0, adjustments: 0, jobs: [], additional_pay: {} });
     const p = byUser.get(l.user_id)!;
     p.base = r2(p.base + l.amount);
@@ -152,6 +160,7 @@ export async function computePeriodPay(companyId: number, start: string, end: st
   }
   // fold additional_pay
   for (const [uid, types] of addlByUser) {
+    if (sandboxUserIds.has(uid)) continue; // [sandbox-exclude] a test fixture earns no additional_pay either
     if (!byUser.has(uid)) byUser.set(uid, { user_id: uid, name: userMap.get(uid) || "", gross: 0, base: 0, hours: 0, tips: 0, overtime: 0, bonus: 0, adjustments: 0, jobs: [], additional_pay: {} });
     const p = byUser.get(uid)!;
     p.additional_pay = types;

--- a/artifacts/api-server/src/routes/payroll.ts
+++ b/artifacts/api-server/src/routes/payroll.ts
@@ -756,11 +756,21 @@ router.get("/detail", requireAuth, async (req, res) => {
     const clockedUserIds = [...new Set(clocks.map(c => c.user_id))];
     const cellByUser = new Map<number, TechCell>();
     const userMap = new Map<number, { first_name: string; last_name: string }>();
+    // [sandbox-exclude 2026-06-20] Test/sandbox fixtures (is_sandbox=true) must
+    // NEVER appear in payroll — the "Generic Cleaner" ghost computed $130 and
+    // landed in the published May 31 snapshot as a phantom 11th tech. Exclude
+    // them at the OUTPUT (drop their pay lines below), NOT by filtering clocks,
+    // so a real tech's commission-pool share can never shift. is_sandbox — NOT
+    // is_active — is the discriminator: real but deactivated techs (e.g. a
+    // terminated employee still owed for clocked work) are is_active=false yet
+    // is_sandbox=false and MUST still be paid.
+    const sandboxUserIds = new Set<number>();
     if (clockedUserIds.length) {
       const urows = await db.execute(sql`
-        SELECT id, first_name, last_name, residential_pay_type, residential_pay_rate, commercial_pay_type, commercial_pay_rate
+        SELECT id, first_name, last_name, is_sandbox, residential_pay_type, residential_pay_rate, commercial_pay_type, commercial_pay_rate
         FROM users WHERE company_id = ${companyId} AND id = ANY(ARRAY[${sql.raw(intList(clockedUserIds))}]::int[])`);
       for (const u of urows.rows as any[]) {
+        if (u.is_sandbox === true) { sandboxUserIds.add(Number(u.id)); continue; }
         userMap.set(Number(u.id), { first_name: u.first_name ?? "", last_name: u.last_name ?? "" });
         cellByUser.set(Number(u.id), {
           residential_pay_type: u.residential_pay_type === "hourly" ? "hourly" : "commission",
@@ -816,6 +826,7 @@ router.get("/detail", requireAuth, async (req, res) => {
     // group lines by tech (filterUserId applied here — techs see only their own)
     const linesByUser = new Map<number, typeof payLines>();
     for (const l of payLines) {
+      if (sandboxUserIds.has(l.user_id)) continue; // [sandbox-exclude] drop test fixtures
       if (filterUserId && l.user_id !== filterUserId) continue;
       if (!linesByUser.has(l.user_id)) linesByUser.set(l.user_id, []);
       linesByUser.get(l.user_id)!.push(l);


### PR DESCRIPTION
## Problem
Re-publishing the May 31 week surfaced a ghost: the **"Generic Cleaner" test fixture** (`u517`, `is_sandbox=true`) had clocked 3 solo test jobs and computed **\$130**, landing in the published snapshot as a phantom 11th tech. Test/sandbox employees must never appear in payroll.

## Fix
Drop `is_sandbox=true` users from **both** pay-computation surfaces, at the **output** layer (after `computePayLines`) rather than by filtering clock entries — so a real tech's commission-pool share can never shift:
- `GET /api/payroll/detail` (on-screen): skip sandbox lines when grouping by tech.
- `computePeriodPay` (publish snapshot): skip sandbox in the pay-line fold **and** the additional_pay fold.

## Why `is_sandbox`, not `is_active`
The instruction proposed `is_active=false`, but the data showed that would be wrong: **Juan Salazar** (`u43`) is `is_active=false` **but `is_sandbox=false`** — a real, deactivated tech still owed **\$669.99** for clocked work in the period. Filtering on `is_active` would have dropped him too, leaving **9** techs instead of the **10 real** ones. `is_sandbox=true` is the precise test-fixture signal (only Generic Cleaner among the 11). Deactivated-but-real techs stay in and get paid.

## Verification plan (post-deploy)
Re-publish the May 31 week and confirm: **10 techs**, total **\$8,250.82**, Generic Cleaner gone, Juan Salazar still present at \$669.99, on-screen detail == published snapshot to the cent.

## CI / scope
Server bundle + lib typecheck via CI. No changes to `COMMS_ENABLED` or quote tools. Low risk — no real pay run until July.