### PR TITLE
fix(payroll): publish prunes orphan snapshot rows for dropped techs

### DIFF
--- a/artifacts/api-server/src/lib/payroll-snapshot.ts
+++ b/artifacts/api-server/src/lib/payroll-snapshot.ts
@@ -179,6 +179,20 @@ export async function computePeriodPay(companyId: number, start: string, end: st
 export async function publishPeriod(companyId: number, start: string, end: string, byUserId: number): Promise<{ published: number; total_gross: number }> {
   await ensurePayrollSnapshotSetup();
   const pay = await computePeriodPay(companyId, start, end);
+  // [prune-stale 2026-06-20] Publish was upsert-only, so a tech who drops out of
+  // a period between publishes (a now-excluded sandbox fixture, or a tech who
+  // lost all their jobs) left an ORPHAN snapshot row behind — re-publishing the
+  // May 31 week recomputed 10 techs but the phantom "Generic Cleaner" row from a
+  // prior publish survived, so the locked snapshot still read 11. Delete any
+  // existing rows for this (company, period) that aren't in the freshly computed
+  // set BEFORE upserting, so the snapshot always reflects exactly the current
+  // computation.
+  const keepIds = pay.map(p => p.user_id);
+  if (keepIds.length) {
+    await db.execute(sql`DELETE FROM payroll_period_snapshots WHERE company_id = ${companyId} AND pay_period_start = ${start} AND pay_period_end = ${end} AND user_id <> ALL(ARRAY[${sql.raw(intList(keepIds))}]::int[])`);
+  } else {
+    await db.execute(sql`DELETE FROM payroll_period_snapshots WHERE company_id = ${companyId} AND pay_period_start = ${start} AND pay_period_end = ${end}`);
+  }
   let total = 0;
   for (const p of pay) {
     total += p.gross;


### PR DESCRIPTION
## Problem
Follow-up to #584. After excluding sandbox techs from the computation, re-publishing the May 31 week **recomputed 10 techs ($8,250.82)** but `publish-status` still read **11 / $8,380.82** with "Generic Cleaner" present.

Root cause: `publishPeriod` was **upsert-only**. A tech who drops out of a period between publishes (a now-excluded sandbox fixture, or a tech who lost all their jobs) left an **orphan snapshot row** behind — the upsert never deletes it.

## Fix
Before upserting, delete any existing `payroll_period_snapshots` rows for the `(company, period)` whose `user_id` isn't in the freshly computed set. The published snapshot now always reflects exactly the current computation. Empty computation deletes all rows for the period.

## Verify (post-deploy)
Re-publish May 31 → `publish-status` reads **10 / $8,250.82**, Generic Cleaner gone, Juan Salazar still present, detail == snapshot to the cent.

## Scope
No `COMMS_ENABLED` / quote-tool changes. Low risk.