### PR TITLE
Payroll: drop internal "(greater_of)" jargon from pay line labels

### DIFF
--- a/artifacts/api-server/src/lib/payroll-compute.ts
+++ b/artifacts/api-server/src/lib/payroll-compute.ts
@@ -216,7 +216,11 @@ export function computePayLines(input: {
           clocked_hours: round2(c.clocked_hours), paid_hours: round2(paidHours), rate,
           pool_total: null, pool_share: null, hours_overridden: hasOv,
           amount: round2(paidHours * rate),
-          pay_basis_label: `$${rate.toFixed(2)}/hr × ${round2(paidHours)}h${hasOv ? " (override)" : ` (${config.hours_basis})`}`,
+          // [payroll-label 2026-06-20] Drop the internal hours-basis jargon
+          // ("(greater_of)" etc.) from the per-line label — it's noise to the
+          // office. A manual rate override still shows "(override)" since that
+          // flags a deliberate change worth seeing.
+          pay_basis_label: `$${rate.toFixed(2)}/hr × ${round2(paidHours)}h${hasOv ? " (override)" : ""}`,
         });
       } else {
         // residential commission tech: GREATER-OF(pool share, hourly floor).


### PR DESCRIPTION
## Why

On the payroll per-client breakdown, each hourly line read like `$20.00/hr × 3h (greater_of)`. The `(greater_of)` parenthetical is the internal hours-basis enum — it means nothing to the office and is just noise on nearly every line.

## What

Removed the `(greater_of)` / hours-basis suffix from the per-line pay label (`pay_basis_label` in `payroll-compute.ts`). A manual **`(override)`** still shows, since that flags a deliberate rate change worth seeing.

One-line backend change at the label source, so it cleans up the live detail and future published snapshots without touching the payroll frontend (which is being actively changed in parallel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019PiXXwFgtNSnzZQy3MTjAj)_