### PR TITLE
feat(pricing): pin grandfathered recurring prices so add-on/discount recalc can't clobber them

### DIFF
--- a/artifacts/api-server/src/lib/recurring-jobs.ts
+++ b/artifacts/api-server/src/lib/recurring-jobs.ts
@@ -208,6 +208,9 @@ export async function insertJobFromSchedule(
       scheduled_time: (schedule.scheduled_time ?? null) as any,
       frequency: mapFrequency(schedule.frequency) as any,
       base_fee: schedule.base_fee ? String(parseFloat(schedule.base_fee).toFixed(2)) : "0.00",
+      // [legacy-pricing-pin 2026-06-20] Carry the schedule's pin onto the job so
+      // a pinned agreed price stays sticky on future occurrences.
+      manual_rate_override: !!schedule.manual_rate_override,
       allowed_hours: schedule.duration_minutes
         ? String((schedule.duration_minutes / 60).toFixed(2))
         : null as any,
@@ -279,6 +282,14 @@ type ScheduleInput = {
   scheduled_time?: string | null;
   duration_minutes: number | null;
   base_fee: string | null;
+  // [legacy-pricing-pin 2026-06-20] When the schedule's agreed price is manually
+  // pinned (grandfathered / unreproducible by the current catalog — e.g. the
+  // MaidCentral import has no sqft, so the sqft-tier engine can't recompute it),
+  // propagate the lock onto every generated occurrence. Without this, generated
+  // jobs default manual_rate_override=false and a later recompute (add-on /
+  // discount edit, or a service-change recalc) can clobber the agreed base_fee.
+  // The locked base itself is already carried by base_fee above.
+  manual_rate_override?: boolean | null;
   notes: string | null;
   // [AI.6] Parking fee per-occurrence config. When enabled, generated jobs
   // for matching weekdays get a job_add_ons row stamped at insertion time.
@@ -374,6 +385,9 @@ export async function computeOccurrencesForSchedule(
       scheduled_time: (schedule.scheduled_time ?? null) as any,
       frequency: mapFrequency(schedule.frequency) as any,
       base_fee: schedule.base_fee ? String(parseFloat(schedule.base_fee).toFixed(2)) : "0.00",
+      // [legacy-pricing-pin 2026-06-20] Carry the schedule's pin onto the job so
+      // a pinned agreed price stays sticky on future occurrences.
+      manual_rate_override: !!schedule.manual_rate_override,
       allowed_hours: schedule.duration_minutes ? String((schedule.duration_minutes / 60).toFixed(2)) : null as any,
       notes: schedule.notes ?? null,
       recurring_schedule_id: schedule.id,

--- a/artifacts/qleno/src/components/edit-job-modal.tsx
+++ b/artifacts/qleno/src/components/edit-job-modal.tsx
@@ -43,6 +43,12 @@ export interface EditableJob {
   duration_minutes: number;
   amount: number;
   base_fee?: number | string | null;
+  // [legacy-pricing-pin 2026-06-20] Stored pin flag. When true the agreed
+  // base_fee is grandfathered/manually locked; the modal opens with the manual
+  // override engaged so it does NOT recompute from the catalog, and round-trips
+  // the flag back on save (without this the modal sent false and silently
+  // unpinned the job). Operator can still "Reset to calculated" to opt in.
+  manual_rate_override?: boolean | null;
   notes: string | null;
   status: string;
   locked_at?: string | null;
@@ -307,7 +313,11 @@ export default function EditJobModal({
   const [clientHourlyRate, setClientHourlyRate] = useState<number | null>(null);
 
   const [baseFee, setBaseFee] = useState<number>(initialBaseFee);
-  const [manualRate, setManualRate] = useState(false);
+  // [legacy-pricing-pin 2026-06-20] Seed from the job's stored pin so an
+  // already-pinned (grandfathered) price is honored on open — recalc effect
+  // bails while this is true (see "honor manual override; no recalc"), and the
+  // save round-trips manual_rate_override=true instead of clobbering it to false.
+  const [manualRate, setManualRate] = useState<boolean>(!!job.manual_rate_override);
   const [manualOpen, setManualOpen] = useState(false);
   const [manualValue, setManualValue] = useState<string>(String(initialBaseFee));
 

--- a/scripts/_legacy_pricing_audit_readonly.mjs
+++ b/scripts/_legacy_pricing_audit_readonly.mjs
@@ -1,0 +1,101 @@
+// READ-ONLY legacy-pricing audit. NO writes. Throwaway diagnostic.
+// Phase 1: residential recurring clients (co1) with a job in May/June 2026,
+// stored agreed price vs current-engine price, flag legacy/custom-priced.
+import pg from '/Users/salvadormartinez/qleno/node_modules/.pnpm/pg@8.20.0/node_modules/pg/lib/index.js';
+import { readFileSync } from 'node:fs';
+
+const env = readFileSync('/Users/salvadormartinez/qleno/.env', 'utf8');
+const url = env.split('\n').find(l => l.startsWith('DATABASE_URL='))?.slice('DATABASE_URL='.length).trim().replace(/^["']|["']$/g, '');
+if (!url) { console.error('no DATABASE_URL'); process.exit(1); }
+const client = new pg.Client({ connectionString: url, ssl: { rejectUnauthorized: false } });
+await client.connect();
+
+const CO1 = 1;
+const q = (text, params) => client.query(text, params).then(r => r.rows);
+
+// 0. sanity: companies
+console.log('=== COMPANIES ===');
+console.table(await q(`SELECT id, name FROM companies ORDER BY id`));
+
+// 1. pricing catalog snapshot for co1
+console.log('\n=== co1 pricing_scopes ===');
+console.table(await q(`SELECT id, name, scope_group, pricing_method, hourly_rate, minimum_bill, is_active FROM pricing_scopes WHERE company_id=$1 ORDER BY id`, [CO1]));
+
+console.log('\n=== co1 pricing_frequencies ===');
+console.table(await q(`SELECT scope_id, frequency, multiplier, rate_override FROM pricing_frequencies WHERE company_id=$1 ORDER BY scope_id, frequency`, [CO1]));
+
+console.log('\n=== co1 pricing_tiers ===');
+console.table(await q(`SELECT scope_id, min_sqft, max_sqft, hours FROM pricing_tiers WHERE company_id=$1 ORDER BY scope_id, min_sqft`, [CO1]));
+
+// 2. distinct service_type values used by co1 residential recurring schedules feeding May/Jun 2026 jobs
+console.log('\n=== distinct recurring service_type (residential, co1) feeding May/Jun 2026 ===');
+console.table(await q(`
+  SELECT rs.service_type, rs.frequency, COUNT(DISTINCT rs.id) schedules
+  FROM recurring_schedules rs
+  WHERE rs.company_id=$1
+    AND EXISTS (
+      SELECT 1 FROM jobs j
+      WHERE j.recurring_schedule_id = rs.id
+        AND j.company_id=$1
+        AND j.account_id IS NULL
+        AND j.scheduled_date BETWEEN '2026-05-01' AND '2026-06-30'
+    )
+  GROUP BY 1,2 ORDER BY 3 DESC`, [CO1]));
+
+// 3. The core dataset: one row per residential recurring schedule with a May/Jun 2026 job.
+console.log('\n=== CORE: residential recurring schedules (co1) with May/Jun 2026 jobs ===');
+const core = await q(`
+  WITH sched AS (
+    SELECT rs.id AS schedule_id, rs.customer_id, rs.service_type, rs.frequency,
+           rs.base_fee::numeric AS sched_base_fee, rs.duration_minutes,
+           rs.manual_rate_override AS sched_override, rs.is_active AS sched_active
+    FROM recurring_schedules rs
+    WHERE rs.company_id=$1
+      AND EXISTS (
+        SELECT 1 FROM jobs j
+        WHERE j.recurring_schedule_id = rs.id AND j.company_id=$1
+          AND j.account_id IS NULL
+          AND j.scheduled_date BETWEEN '2026-05-01' AND '2026-06-30'
+      )
+  ),
+  jobagg AS (
+    SELECT j.recurring_schedule_id,
+           COUNT(*) FILTER (WHERE j.scheduled_date BETWEEN '2026-05-01' AND '2026-06-30') AS mayjun_jobs,
+           MIN(j.base_fee::numeric) FILTER (WHERE j.scheduled_date BETWEEN '2026-05-01' AND '2026-06-30') AS min_job_fee,
+           MAX(j.base_fee::numeric) FILTER (WHERE j.scheduled_date BETWEEN '2026-05-01' AND '2026-06-30') AS max_job_fee,
+           BOOL_OR(j.manual_rate_override) FILTER (WHERE j.scheduled_date BETWEEN '2026-05-01' AND '2026-06-30') AS any_job_override
+    FROM jobs j WHERE j.company_id=$1 AND j.recurring_schedule_id IS NOT NULL
+    GROUP BY 1
+  )
+  SELECT s.schedule_id, s.customer_id,
+         c.first_name, c.last_name, c.client_type,
+         s.service_type, s.frequency, s.sched_base_fee, s.duration_minutes,
+         s.sched_override, s.sched_active,
+         ja.mayjun_jobs, ja.min_job_fee, ja.max_job_fee, ja.any_job_override,
+         ch.sq_footage AS home_sqft, ch.bedrooms, ch.bathrooms, ch.base_fee::numeric AS home_base_fee,
+         c.base_fee::numeric AS client_base_fee, c.hourly_rate::numeric AS client_hourly_rate
+  FROM sched s
+  JOIN clients c ON c.id = s.customer_id AND c.company_id=$1
+  LEFT JOIN LATERAL (
+    SELECT sq_footage, bedrooms, bathrooms, base_fee
+    FROM client_homes ch WHERE ch.client_id = s.customer_id AND ch.company_id=$1
+    ORDER BY ch.is_primary DESC NULLS LAST, ch.id ASC LIMIT 1
+  ) ch ON true
+  JOIN jobagg ja ON ja.recurring_schedule_id = s.schedule_id
+  ORDER BY c.last_name, c.first_name`, [CO1]);
+
+console.log(`rows: ${core.length}`);
+console.table(core.map(r => ({
+  sid: r.schedule_id, name: `${r.first_name||''} ${r.last_name||''}`.trim(),
+  type: r.client_type, svc: r.service_type, freq: r.frequency,
+  sched_fee: r.sched_base_fee, job_fee_min: r.min_job_fee, job_fee_max: r.max_job_fee,
+  sqft: r.home_sqft, dur_min: r.duration_minutes,
+  sched_ovr: r.sched_override, job_ovr: r.any_job_override, jobs: r.mayjun_jobs,
+})));
+
+// 4. dump raw JSON for engine-compute step (next pass)
+console.log('\n=== RAW_JSON_START ===');
+console.log(JSON.stringify(core));
+console.log('=== RAW_JSON_END ===');
+
+await client.end();

--- a/scripts/_legacy_pricing_classify_readonly.mjs
+++ b/scripts/_legacy_pricing_classify_readonly.mjs
@@ -1,0 +1,134 @@
+// READ-ONLY. NO writes. Phase 1 classifier: residential recurring (co1) with
+// May/Jun 2026 jobs → stored agreed price vs current-engine price → legacy flag.
+import pg from '/Users/salvadormartinez/qleno/node_modules/.pnpm/pg@8.20.0/node_modules/pg/lib/index.js';
+import { readFileSync } from 'node:fs';
+const env = readFileSync('/Users/salvadormartinez/qleno/.env','utf8');
+const url = env.split('\n').find(l=>l.startsWith('DATABASE_URL='))?.slice(13).trim().replace(/^["']|["']$/g,'');
+const c = new pg.Client({connectionString:url, ssl:{rejectUnauthorized:false}}); await c.connect();
+const q=(t,p)=>c.query(t,p).then(r=>r.rows);
+const CO1=1, FROM='2026-05-01', TO='2026-06-30';
+const r2=n=>Math.round(n*100)/100;
+
+// ---- load catalog into memory ----
+const scopes = await q(`SELECT id,name,pricing_method,hourly_rate::numeric h,minimum_bill::numeric mb,is_active FROM pricing_scopes WHERE company_id=$1`,[CO1]);
+const freqs  = await q(`SELECT scope_id,frequency,multiplier::numeric mult,rate_override::numeric ro FROM pricing_frequencies WHERE company_id=$1`,[CO1]);
+const tiers  = await q(`SELECT scope_id,min_sqft,max_sqft,hours::numeric hrs FROM pricing_tiers WHERE company_id=$1`,[CO1]);
+
+// service_type text -> scope. Match by name (ci), with known aliases.
+const norm = s => String(s||'').toLowerCase().replace(/[^a-z0-9]/g,'');
+const byName = new Map(scopes.map(s=>[norm(s.name), s]));
+const ALIAS = {
+  standardclean:'Standard Clean', standard_clean:'Standard Clean',
+  recurring:'Standard Clean',
+  deepclean:'Deep Clean',
+  commercialcleaning:'Commercial Cleaning', commercial_cleaning:'Commercial Cleaning',
+  housecleaningdeepcleanormoveinout:'Move In / Move Out',
+};
+function resolveScope(svc){
+  const n = norm(svc);
+  if (byName.has(n)) return byName.get(n);
+  const alias = ALIAS[n] || ALIAS[String(svc||'').toLowerCase().replace(/\s+/g,'')];
+  if (alias) return byName.get(norm(alias));
+  return null;
+}
+// engine price (mirrors computeQuotePricing) — returns {total,detail} or {total:null,reason}
+function enginePrice(scope, sqft, frequency){
+  if(!scope) return {total:null, reason:'no_scope_match'};
+  if((scope.pricing_method||'sqft')!=='sqft') return {total:null, reason:`scope_${scope.pricing_method}_not_sqft`};
+  // freq map: recurring frequencies in catalog use weekly/biweekly/monthly/onetime
+  const fmap = {weekly:'weekly', biweekly:'biweekly', monthly:'monthly', every_3_weeks:'biweekly', custom:'biweekly', weekdays:'weekly', custom_days:'weekly', semi_monthly:'biweekly', onetime:'onetime'};
+  const fk = fmap[frequency] || frequency;
+  const fr = freqs.find(f=>f.scope_id===scope.id && f.frequency===fk);
+  let rate;
+  if(fr && fr.ro!=null) rate=Number(fr.ro);
+  else rate=Number(scope.h)*(fr?Number(fr.mult):1);
+  if(sqft==null) return {total:null, reason:'no_sqft'};
+  const st = tiers.filter(t=>t.scope_id===scope.id).sort((a,b)=>a.min_sqft-b.min_sqft);
+  if(!st.length) return {total:null, reason:'no_tiers'};
+  let tier = st.find(t=>sqft>=t.min_sqft && sqft<=t.max_sqft) ?? (sqft<st[0].min_sqft?st[0]:st[st.length-1]);
+  const base_hours=Number(tier.hrs);
+  let bp=base_hours*rate;
+  const mb=Number(scope.mb||0); let minApplied=false;
+  if(mb>0 && bp<mb){bp=mb; minApplied=true;}
+  return {total:r2(bp), rate:r2(rate), base_hours, freq_used:fk, min_applied:minApplied, reason:'ok'};
+}
+
+// ---- core dataset: residential recurring schedules with May/Jun 2026 jobs ----
+const core = await q(`
+  WITH sched AS (
+    SELECT rs.id schedule_id, rs.customer_id, rs.service_type, rs.frequency,
+           rs.base_fee::numeric sched_fee, rs.duration_minutes, rs.manual_rate_override sched_ovr, rs.is_active sched_active
+    FROM recurring_schedules rs
+    WHERE rs.company_id=$1 AND EXISTS (
+      SELECT 1 FROM jobs j WHERE j.recurring_schedule_id=rs.id AND j.company_id=$1
+        AND j.account_id IS NULL AND j.scheduled_date BETWEEN $2 AND $3)
+  ),
+  jobagg AS (
+    SELECT j.recurring_schedule_id rsid,
+      COUNT(*) FILTER (WHERE j.scheduled_date BETWEEN $2 AND $3) mj,
+      MIN(j.base_fee::numeric) FILTER (WHERE j.scheduled_date BETWEEN $2 AND $3) jmin,
+      MAX(j.base_fee::numeric) FILTER (WHERE j.scheduled_date BETWEEN $2 AND $3) jmax,
+      BOOL_OR(j.manual_rate_override) FILTER (WHERE j.scheduled_date BETWEEN $2 AND $3) job_ovr,
+      COUNT(*) FILTER (WHERE j.scheduled_date BETWEEN $2 AND $3 AND EXISTS(SELECT 1 FROM job_add_ons ja WHERE ja.job_id=j.id)) jobs_with_addons,
+      COUNT(*) FILTER (WHERE j.scheduled_date BETWEEN $2 AND $3 AND EXISTS(SELECT 1 FROM job_discounts jd WHERE jd.job_id=j.id)) jobs_with_disc
+    FROM jobs j WHERE j.company_id=$1 AND j.recurring_schedule_id IS NOT NULL GROUP BY 1
+  )
+  SELECT s.*, c.first_name, c.last_name, c.client_type,
+         ch.sq_footage home_sqft,
+         ja.mj, ja.jmin, ja.jmax, ja.job_ovr, ja.jobs_with_addons, ja.jobs_with_disc
+  FROM sched s
+  JOIN clients c ON c.id=s.customer_id AND c.company_id=$1
+  LEFT JOIN LATERAL (SELECT sq_footage FROM client_homes ch WHERE ch.client_id=s.customer_id AND ch.company_id=$1
+      ORDER BY ch.is_primary DESC NULLS LAST, ch.id ASC LIMIT 1) ch ON true
+  JOIN jobagg ja ON ja.rsid=s.schedule_id
+  WHERE c.client_type='residential'
+  ORDER BY c.last_name, c.first_name`,[CO1,FROM,TO]);
+
+const rows = core.map(r=>{
+  const scope = resolveScope(r.service_type);
+  const eng = enginePrice(scope, r.home_sqft!=null?Number(r.home_sqft):null, r.frequency);
+  const stored = r.sched_fee!=null?Number(r.sched_fee):(r.jmax!=null?Number(r.jmax):null);
+  let cls, delta=null;
+  if(stored==null){ cls='NO_PRICE'; }
+  else if(eng.total==null){ cls='LEGACY_UNREPRODUCIBLE'; }
+  else { delta=r2(stored-eng.total); cls = Math.abs(delta)<=1 ? 'STANDARD_MATCHES' : 'LEGACY_DELTA'; }
+  return {
+    sid:r.schedule_id, name:`${r.first_name||''} ${r.last_name||''}`.trim(),
+    svc:r.service_type, freq:r.frequency, scope:scope?scope.name:'—',
+    sqft:r.home_sqft, stored, engine:eng.total, eng_reason:eng.reason, delta, cls,
+    sched_fee:r.sched_fee!=null?Number(r.sched_fee):null,
+    jmin:r.jmin!=null?Number(r.jmin):null, jmax:r.jmax!=null?Number(r.jmax):null,
+    sched_ovr:r.sched_ovr, job_ovr:r.job_ovr, mj:Number(r.mj),
+    addon_jobs:Number(r.jobs_with_addons), disc_jobs:Number(r.jobs_with_disc),
+    drift: (r.jmin!=null && r.jmax!=null && r.sched_fee!=null && (Number(r.jmin)!==Number(r.sched_fee) || Number(r.jmax)!==Number(r.sched_fee))),
+  };
+});
+
+console.log(`\n=== RESIDENTIAL RECURRING (co1) with May/Jun 2026 jobs: ${rows.length} schedules ===\n`);
+console.table(rows.map(r=>({name:r.name, svc:r.svc, freq:r.freq, scope:r.scope, sqft:r.sqft, stored:r.stored, engine:r.engine, delta:r.delta, why:r.eng_reason, class:r.cls})));
+
+const by = k => rows.filter(r=>r.cls===k);
+console.log('\n=== CLASSIFICATION COUNTS ===');
+console.table([
+  {class:'STANDARD_MATCHES (engine reproduces stored)', n:by('STANDARD_MATCHES').length},
+  {class:'LEGACY_DELTA (engine computes but differs)', n:by('LEGACY_DELTA').length},
+  {class:'LEGACY_UNREPRODUCIBLE (engine cannot compute)', n:by('LEGACY_UNREPRODUCIBLE').length},
+  {class:'NO_PRICE (no stored fee)', n:by('NO_PRICE').length},
+]);
+
+console.log('\n=== reasons engine could not compute ===');
+const reasons={}; for(const r of rows) if(r.engine==null){reasons[r.eng_reason]=(reasons[r.eng_reason]||0)+1;}
+console.table(Object.entries(reasons).map(([reason,n])=>({reason,n})));
+
+console.log('\n=== schedule->job price DRIFT (agreed fee already diverging on generated jobs) ===');
+console.table(rows.filter(r=>r.drift).map(r=>({name:r.name, sched_fee:r.sched_fee, job_min:r.jmin, job_max:r.jmax, job_ovr:r.job_ovr, addon_jobs:r.addon_jobs, disc_jobs:r.disc_jobs})));
+
+console.log('\n=== PROPOSED PIN SET (legacy + no_price; sched_ovr currently false) ===');
+const pin = rows.filter(r=>r.cls!=='STANDARD_MATCHES');
+console.log(`${pin.length} schedules. ${pin.filter(r=>!r.sched_ovr).length} not yet pinned at schedule level.`);
+console.table(pin.map(r=>({sid:r.sid, name:r.name, lock_base:r.stored, class:r.cls, sched_ovr:r.sched_ovr})));
+
+console.log('\n=== currently STANDARD (engine reproduces) — would NOT pin ===');
+console.table(by('STANDARD_MATCHES').map(r=>({name:r.name, stored:r.stored, engine:r.engine})));
+
+await c.end();

--- a/scripts/_legacy_pricing_pin_dryrun_readonly.mjs
+++ b/scripts/_legacy_pricing_pin_dryrun_readonly.mjs
@@ -1,0 +1,146 @@
+// ============================================================================
+// DRY-RUN ONLY — NO WRITES. Legacy-pricing pin plan for co1 (Oak Lawn).
+//
+// Prints EXACTLY what the live pin would do, executes nothing. Live writes are
+// HELD for Sal's confirmation (he is approving pinning all 72).
+//
+// Plan (when approved, run as a separate write script):
+//   1. recurring_schedules.manual_rate_override = true   (base_fee unchanged)
+//   2. future uncompleted jobs of those schedules: manual_rate_override = true
+//      (each job's existing base_fee unchanged — non-destructive)
+//
+// Scope: client_type='residential', co1, with a job in May/Jun 2026.
+// Excludes: Anthony Saguto (NULL agreed price — flag for a real price) and the
+//           6 commercial-typed (client_type='commercial') single-location
+//           clients (out of residential scope).
+// ============================================================================
+import pg from '/Users/salvadormartinez/qleno/node_modules/.pnpm/pg@8.20.0/node_modules/pg/lib/index.js';
+import { readFileSync } from 'node:fs';
+const env = readFileSync('/Users/salvadormartinez/qleno/.env','utf8');
+const url = env.split('\n').find(l=>l.startsWith('DATABASE_URL='))?.slice(13).trim().replace(/^["']|["']$/g,'');
+const c = new pg.Client({connectionString:url, ssl:{rejectUnauthorized:false}}); await c.connect();
+const q=(t,p)=>c.query(t,p).then(r=>r.rows);
+const CO1=1, FROM='2026-05-01', TO='2026-06-30';
+
+console.log('============================================================');
+console.log(' DRY-RUN — legacy-pricing pin plan (co1). NO WRITES EXECUTED.');
+console.log('============================================================\n');
+
+// ---- population: residential recurring schedules with May/Jun 2026 jobs ----
+const pop = await q(`
+  SELECT rs.id schedule_id, rs.customer_id, rs.service_type, rs.frequency,
+         rs.base_fee::numeric agreed_fee, rs.manual_rate_override sched_ovr, rs.is_active,
+         c.first_name, c.last_name, c.client_type
+  FROM recurring_schedules rs
+  JOIN clients c ON c.id=rs.customer_id AND c.company_id=$1
+  WHERE rs.company_id=$1
+    AND c.client_type='residential'
+    AND EXISTS (SELECT 1 FROM jobs j WHERE j.recurring_schedule_id=rs.id AND j.company_id=$1
+                  AND j.account_id IS NULL AND j.scheduled_date BETWEEN $2 AND $3)
+  ORDER BY c.last_name, c.first_name`,[CO1,FROM,TO]);
+
+// exclusions
+const NULL_PRICE = pop.filter(r=>r.agreed_fee==null || Number(r.agreed_fee)===0);
+const pinSet = pop.filter(r=>!(r.agreed_fee==null || Number(r.agreed_fee)===0));
+
+// future-uncompleted job predicate (what we'd pin at job level)
+const FUTURE_PRED = `j.company_id=${CO1} AND j.recurring_schedule_id = $1
+  AND j.status='scheduled' AND j.scheduled_date >= CURRENT_DATE
+  AND j.completed_by_user_id IS NULL AND j.locked_at IS NULL
+  AND j.charge_succeeded_at IS NULL AND j.charge_attempted_at IS NULL
+  AND j.actual_hours IS NULL`;
+
+let totalFutureJobs=0, totalAlreadyPinnedJobs=0;
+const planRows=[]; const driftDetail=[];
+for (const s of pinSet){
+  const fut = await q(`
+    SELECT j.id, j.scheduled_date::text d, j.base_fee::numeric jf, j.manual_rate_override jo
+    FROM jobs j WHERE ${FUTURE_PRED} ORDER BY j.scheduled_date`,[s.schedule_id]);
+  totalFutureJobs += fut.length;
+  totalAlreadyPinnedJobs += fut.filter(j=>j.jo).length;
+  const agreed = Number(s.agreed_fee);
+  const divergent = fut.filter(j=>j.jf!=null && Math.abs(Number(j.jf)-agreed)>0.01);
+  planRows.push({
+    sid:s.schedule_id, name:`${s.first_name||''} ${s.last_name||''}`.trim(),
+    lock_base:agreed, freq:s.frequency, sched_ovr_now:s.sched_ovr,
+    future_jobs:fut.length, jobs_already_pinned:fut.filter(j=>j.jo).length,
+    future_jobs_diverging:divergent.length,
+  });
+  if (divergent.length) driftDetail.push({s, agreed, divergent});
+}
+
+console.log(`-- SCOPE --`);
+console.log(`residential recurring schedules w/ May–Jun 2026 jobs : ${pop.length}`);
+console.log(`  → PIN SET (real agreed price)                       : ${pinSet.length}`);
+console.log(`  → EXCLUDED (null/zero agreed price)                 : ${NULL_PRICE.length}`);
+console.log('');
+
+console.log('================= STEP 1: schedule-level pin =================');
+console.log('WOULD RUN (one statement, parameterized over the pin set):');
+console.log("  UPDATE recurring_schedules SET manual_rate_override = true");
+console.log(`  WHERE company_id = ${CO1} AND id = ANY($1)   -- base_fee untouched`);
+console.log(`  ids = [${pinSet.map(s=>s.schedule_id).join(', ')}]`);
+console.log(`  rows affected (est): ${pinSet.length} (all currently sched_ovr=false)\n`);
+
+console.log('================= STEP 2: future-job pin ====================');
+console.log('WOULD RUN (per schedule, future uncompleted jobs only):');
+console.log("  UPDATE jobs SET manual_rate_override = true");
+console.log("  WHERE company_id=1 AND recurring_schedule_id=$1 AND status='scheduled'");
+console.log("    AND scheduled_date >= CURRENT_DATE AND completed_by_user_id IS NULL");
+console.log("    AND locked_at IS NULL AND charge_succeeded_at IS NULL");
+console.log("    AND charge_attempted_at IS NULL AND actual_hours IS NULL");
+console.log("  -- each job's base_fee is LEFT AS-IS (non-destructive)");
+console.log(`  total future uncompleted jobs to pin: ${totalFutureJobs}`);
+console.log(`  (of which already manual_rate_override=true: ${totalAlreadyPinnedJobs})\n`);
+
+console.log('================= PER-SCHEDULE PIN PLAN =====================');
+console.table(planRows);
+
+console.log('\n================= DRIFT CASES — SAL TO EYEBALL =============');
+console.log('Schedules whose FUTURE jobs have base_fee != agreed schedule price.');
+console.log('Pin locks each job at its CURRENT base_fee. If the current job price is');
+console.log('wrong, realign base_fee to the agreed value BEFORE pinning (needs confirm).\n');
+if (!driftDetail.length) console.log('  (none among future uncompleted jobs)');
+for (const {s, agreed, divergent} of driftDetail){
+  console.log(`• ${s.first_name||''} ${s.last_name||''}`.trim()+` (sid ${s.schedule_id}) — agreed $${agreed.toFixed(2)} / ${s.frequency}`);
+  console.table(divergent.map(j=>({job_id:j.id, date:j.d, job_base_fee:Number(j.jf), agreed, delta:Math.round((Number(j.jf)-agreed)*100)/100, note: Number(j.jf)===0?'likely cancelled/credited occurrence':''})));
+}
+
+// also surface the broader (incl. past) schedule->job drift for context
+console.log('\n================= HISTORICAL DRIFT (all May/Jun jobs, context) ====');
+const histDrift = await q(`
+  SELECT c.first_name, c.last_name, rs.id sid, rs.base_fee::numeric agreed,
+         MIN(j.base_fee::numeric) jmin, MAX(j.base_fee::numeric) jmax,
+         BOOL_OR(j.manual_rate_override) job_ovr
+  FROM recurring_schedules rs
+  JOIN clients c ON c.id=rs.customer_id AND c.company_id=$1 AND c.client_type='residential'
+  JOIN jobs j ON j.recurring_schedule_id=rs.id AND j.company_id=$1 AND j.account_id IS NULL
+       AND j.scheduled_date BETWEEN $2 AND $3
+  WHERE rs.company_id=$1 AND rs.base_fee IS NOT NULL
+  GROUP BY 1,2,3,4
+  HAVING MIN(j.base_fee::numeric) <> rs.base_fee::numeric OR MAX(j.base_fee::numeric) <> rs.base_fee::numeric
+  ORDER BY c.last_name`,[CO1,FROM,TO]);
+console.table(histDrift.map(r=>({name:`${r.first_name||''} ${r.last_name||''}`.trim(), sid:r.sid, agreed:Number(r.agreed), job_min:Number(r.jmin), job_max:Number(r.jmax), job_ovr:r.job_ovr})));
+
+console.log('\n================= EXCLUSIONS ================================');
+console.log('A) NULL/zero agreed price — NOT pinned, needs a real price set:');
+console.table(NULL_PRICE.map(r=>({sid:r.schedule_id, name:`${r.first_name||''} ${r.last_name||''}`.trim(), agreed_fee:r.agreed_fee, svc:r.service_type})));
+
+const commercial = await q(`
+  SELECT rs.id sid, c.first_name, c.last_name, rs.service_type, rs.base_fee::numeric fee
+  FROM recurring_schedules rs
+  JOIN clients c ON c.id=rs.customer_id AND c.company_id=$1
+  WHERE rs.company_id=$1 AND c.client_type='commercial'
+    AND EXISTS (SELECT 1 FROM jobs j WHERE j.recurring_schedule_id=rs.id AND j.company_id=$1
+                  AND j.account_id IS NULL AND j.scheduled_date BETWEEN $2 AND $3)
+  ORDER BY c.last_name`,[CO1,FROM,TO]);
+console.log('\nB) Commercial-typed (client_type=commercial) — OUT OF RESIDENTIAL SCOPE, not touched:');
+console.table(commercial.map(r=>({sid:r.sid, name:`${r.first_name||''} ${r.last_name||''}`.trim(), svc:r.service_type, fee:r.fee})));
+
+console.log('\n============================================================');
+console.log(` SUMMARY: would pin ${pinSet.length} schedules + ${totalFutureJobs} future jobs.`);
+console.log(` Excluded: ${NULL_PRICE.length} null-price (residential), ${commercial.length} commercial-typed.`);
+console.log(` Co4 (Schaumburg) untouched. NOTHING WRITTEN — dry run only.`);
+console.log('============================================================');
+
+await c.end();


### PR DESCRIPTION
## Why

Generalizes the one-off **Todd** fix into durable, root-cause protection.

A read-only audit of **co1 (Oak Lawn)** residential-recurring clients with jobs in **May/June 2026** found that **0 of 73** agreed prices can be reproduced by the current pricing engine:
- **59** have no `sqft` on file (the MaidCentral import never carried it; the engine is sqft-tier → returns null).
- **13** are service-typed "Commercial Cleaning" → hourly-method scope, which the residential engine refuses to price.
- **1** (Ava Martinez, the only client with sqft) computes a **different** number ($195 engine vs $201.50 agreed) — classic Todd delta.

So every residential-recurring price is effectively grandfathered. A recalc — on an add-on/discount edit, or a service-change in the edit modal — silently overwrites the agreed `base_fee`. #572/#582 patched the add-on case at the job level; this makes the protection durable end-to-end.

## Changes (both surgical)

**`recurring-jobs.ts`** — propagate `manual_rate_override` onto every generated occurrence (`insertJobFromSchedule` + `computeOccurrencesForSchedule`). Generated jobs were always born `manual_rate_override=false`, so a pinned schedule's **future** jobs came back unpinned on the next cron run. The locked base (`base_fee`) was already copied; this carries the lock flag with it.

**`edit-job-modal.tsx`** — seed `manualRate` from `job.manual_rate_override`. The modal initialized it to `false` unconditionally, so opening a pinned job and saving any edit sent `manual_rate_override=false` and **silently unpinned it** server-side ([jobs.ts manual_rate_override semantics](../blob/main/artifacts/api-server/src/routes/jobs.ts)). Now a pinned price is honored on open (recalc effect bails — *"honor manual override; no recalc"*) and the flag round-trips on save. Operator can still **Reset to calculated**.

### Verification of the #572/#582 edit-modal protection
- The `priceBaselineRef` "edit-price-preserve" logic **is present on main** — when only add-ons change, it keeps the agreed base sticky + applies the add-on delta. ✓
- Gap found & fixed here: that logic is keyed on the stored `base_fee`, but the hard `manualRate` flag was never seeded from the DB pin, so the pin was dropped on save. Fixed above.

## Out of scope (untouched)
- Quote-builder / booking-widget pricing logic.
- Schaumburg (co4).

## Data writes — HELD for Sal's confirmation
**No production data is written by this PR.** The pins (72 residential-recurring schedules + their **445** future uncompleted jobs → `manual_rate_override=true`, `base_fee` unchanged) ship via a separate, Sal-approved write step. The read-only **dry-run** that prints the exact plan, the drift cases to eyeball, and the exclusions is in [`scripts/_legacy_pricing_pin_dryrun_readonly.mjs`](../blob/feat/legacy-pricing-pin-generator/scripts/_legacy_pricing_pin_dryrun_readonly.mjs).
- **Excluded:** Anthony Saguto (NULL agreed price — flag for a real price) and 6 commercial-typed single-location clients.
- **Drift cases** (future jobs whose `base_fee` diverged from the agreed schedule fee) are listed separately so Sal can decide whether to realign before pinning.

## Follow-up (flagged, optional — root cause)
Backfill `client_homes.sq_footage` for the imported book so the catalog can price these going forward. Until then, manual pins are the protection.

## Test
- `pnpm run typecheck:libs` ✓
- `pnpm --filter @workspace/api-server run build` ✓
- `pnpm --filter @workspace/qleno run build` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)