### PR TITLE
feat(payroll): per-job pay-basis switch (Allowed vs Hourly) + fix multi-tech overpay

### DIFF
--- a/artifacts/api-server/src/lib/payroll-compute.ts
+++ b/artifacts/api-server/src/lib/payroll-compute.ts
@@ -45,6 +45,9 @@ export interface PayrollJob {
   actual_hours: string | number | null;
   scheduled_date: string;
   branch_id: number | null;
+  // [pay-basis 2026-06-20] 'allowed_hours' (default) | 'hourly'. The office's
+  // per-job switch; governs how clocked techs are paid (see computePayLines).
+  pay_basis?: string | null;
 }
 
 /** Per-employee 4-cell pay matrix (the single source of truth for pay type). */
@@ -160,6 +163,7 @@ export function computePayLines(input: {
   for (const [jobId, jobClocks] of clocksByJob) {
     const job = jobById.get(jobId)!;
     const isComm = jobIsCommercial(job);
+    const jobHourly = job.pay_basis === "hourly";
     const pool = jobPool(job, config);
     // [MC-parity] universal hourly/floor rate ($20). Enhancement B: the
     // commission pool is split across ALL clocked techs by ACTUAL clocked hours
@@ -207,20 +211,41 @@ export function computePayLines(input: {
         continue;
       }
 
-      if (pt === "hourly") {
-        const hasOv = paidOv.has(k);
-        const paidHours = hasOv ? paidOv.get(k)! : basisHours(config.hours_basis, c.clocked_hours, allowed);
+      // [pay-basis 2026-06-20] This tech's share of the job, by clocked hours.
+      const share = totalAllHours > 0 ? c.clocked_hours / totalAllHours : 1 / jobClocks.length;
+
+      // HOURLY job mode (the office's one-off exception): pay each tech their
+      // actual clocked hours × $/hr. An explicit per-tech hours entry was already
+      // applied by the paidOv guard above; this is the no-entry default.
+      if (jobHourly) {
+        const hrlyRate = pt === "hourly" ? rate : config.commercial_hourly_rate;
+        const paidHours = round2(c.clocked_hours);
         lines.push({
           user_id: c.user_id, job_id: jobId, scheduled_date: job.scheduled_date, branch_id: job.branch_id,
           is_commercial: isComm, pay_type: "hourly", basis: "hourly",
-          clocked_hours: round2(c.clocked_hours), paid_hours: round2(paidHours), rate,
-          pool_total: null, pool_share: null, hours_overridden: hasOv,
-          amount: round2(paidHours * rate),
-          // [payroll-label 2026-06-20] Drop the internal hours-basis jargon
-          // ("(greater_of)" etc.) from the per-line label — it's noise to the
-          // office. A manual rate override still shows "(override)" since that
-          // flags a deliberate change worth seeing.
-          pay_basis_label: `$${rate.toFixed(2)}/hr × ${round2(paidHours)}h${hasOv ? " (override)" : ""}`,
+          clocked_hours: round2(c.clocked_hours), paid_hours: paidHours, rate: hrlyRate,
+          pool_total: null, pool_share: null, hours_overridden: false,
+          amount: round2(paidHours * hrlyRate),
+          pay_basis_label: `$${hrlyRate.toFixed(2)}/hr × ${paidHours}h`,
+        });
+        continue;
+      }
+
+      if (pt === "hourly") {
+        // ALLOWED-HOURS default for an hourly-paid tech: pay this tech's SHARE of
+        // the job's allowed budget (hard cap — fast OR slow earns the budget).
+        // This fixes the multi-tech overpay where each tech was paid the WHOLE
+        // job's allowed hours via greater-of (e.g. an 8.2h job paid 8.2h to BOTH
+        // cleaners). To pay actual time on an overrun, the office flips the job
+        // to Hourly.
+        const budgetHours = round2(allowed * share);
+        lines.push({
+          user_id: c.user_id, job_id: jobId, scheduled_date: job.scheduled_date, branch_id: job.branch_id,
+          is_commercial: isComm, pay_type: "hourly", basis: isComm ? "commercial_pool" : "hourly",
+          clocked_hours: round2(c.clocked_hours), paid_hours: budgetHours, rate,
+          pool_total: round2(rate * allowed), pool_share: round2(share), hours_overridden: false,
+          amount: round2(budgetHours * rate),
+          pay_basis_label: `${Math.round(share * 100)}% of $${rate.toFixed(0)}/hr × ${allowed.toFixed(1)}h budget`,
         });
       } else {
         // residential commission tech: GREATER-OF(pool share, hourly floor).

--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -122,6 +122,7 @@ async function runBookingSchemaGuard(): Promise<void> {
     { label: "jobs.last_cleaned_response", stmt: "ALTER TABLE jobs ADD COLUMN IF NOT EXISTS last_cleaned_response TEXT" },
     { label: "jobs.last_cleaned_flag",     stmt: "ALTER TABLE jobs ADD COLUMN IF NOT EXISTS last_cleaned_flag TEXT" },
     { label: "jobs.overage_disclaimer_acknowledged", stmt: "ALTER TABLE jobs ADD COLUMN IF NOT EXISTS overage_disclaimer_acknowledged BOOLEAN DEFAULT false" },
+    { label: "jobs.pay_basis",             stmt: "ALTER TABLE jobs ADD COLUMN IF NOT EXISTS pay_basis TEXT NOT NULL DEFAULT 'allowed_hours'" },
     { label: "jobs.overage_rate",          stmt: "ALTER TABLE jobs ADD COLUMN IF NOT EXISTS overage_rate NUMERIC(10,2)" },
     { label: "jobs.upsell_shown",          stmt: "ALTER TABLE jobs ADD COLUMN IF NOT EXISTS upsell_shown BOOLEAN DEFAULT false" },
     { label: "jobs.upsell_accepted",       stmt: "ALTER TABLE jobs ADD COLUMN IF NOT EXISTS upsell_accepted BOOLEAN DEFAULT false" },

--- a/artifacts/api-server/src/routes/jobs.ts
+++ b/artifacts/api-server/src/routes/jobs.ts
@@ -2,7 +2,7 @@ import { Router } from "express";
 import { db } from "@workspace/db";
 import { jobsTable, clientsTable, usersTable, jobPhotosTable, timeclockTable, invoicesTable, scorecardsTable, serviceZonesTable, serviceZoneEmployeesTable, companiesTable, accountsTable, accountRateCardsTable, accountPropertiesTable, paymentsTable, recurringSchedulesTable, branchesTable, userCompaniesTable, jobDiscountsTable } from "@workspace/db/schema";
 import { eq, and, gte, lte, count, desc, sql, notExists, inArray, isNotNull, isNull, or } from "drizzle-orm";
-import { requireAuth } from "../lib/auth.js";
+import { requireAuth, requireRole } from "../lib/auth.js";
 import { notifyUserAsync } from "../lib/push.js";
 import { logAudit, logClientActivity } from "../lib/audit.js";
 import { generateJobCompletionPdf } from "../lib/generate-job-pdf.js";
@@ -4328,6 +4328,57 @@ router.put("/:id/technicians/:techId/override", requireAuth, async (req, res) =>
     return res.json({ data: result });
   } catch (err) {
     console.error("PUT /jobs/:id/technicians/:techId/override error:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
+// PUT /api/jobs/:id/pay-basis — the office's per-job pay switch.
+//   body: { pay_basis: 'allowed_hours' | 'hourly', hours?: { [user_id]: number } }
+//   - 'allowed_hours' (default): pay the budgeted allowed hours, split across the
+//     job's clocked techs by share. Clears any entered per-tech hours.
+//   - 'hourly': pay each tech the hours in `hours` (blank/omitted → their actual
+//     clocked hours) × rate. Stored as payroll_hours_overrides rows.
+// Owner/admin/office only — it moves money.
+router.put("/:id/pay-basis", requireAuth, requireRole("owner", "admin", "office"), async (req, res) => {
+  try {
+    const jobId = parseInt(req.params.id);
+    const companyId = req.auth!.companyId;
+    const userId = req.auth!.userId;
+    const { pay_basis, hours } = req.body as { pay_basis?: string; hours?: Record<string, unknown> };
+    const basis = pay_basis === "hourly" ? "hourly" : "allowed_hours";
+
+    const jobRows = await db.execute(sql`SELECT id FROM jobs WHERE id = ${jobId} AND company_id = ${companyId} LIMIT 1`);
+    if (!jobRows.rows.length) return res.status(404).json({ error: "Job not found" });
+
+    await db.execute(sql`UPDATE jobs SET pay_basis = ${basis} WHERE id = ${jobId} AND company_id = ${companyId}`);
+
+    if (basis === "hourly") {
+      for (const [uidStr, raw] of Object.entries(hours ?? {})) {
+        const uid = parseInt(uidStr);
+        if (!Number.isFinite(uid)) continue;
+        const h = raw == null || raw === "" ? null : parseFloat(String(raw));
+        if (h == null || !Number.isFinite(h) || h < 0) {
+          // Blank → no override row; the tech falls back to actual clocked hours.
+          await db.execute(sql`DELETE FROM payroll_hours_overrides WHERE company_id = ${companyId} AND job_id = ${jobId} AND user_id = ${uid}`);
+          continue;
+        }
+        await db.execute(sql`
+          INSERT INTO payroll_hours_overrides (company_id, user_id, job_id, paid_hours, created_by_user_id)
+          VALUES (${companyId}, ${uid}, ${jobId}, ${h}, ${userId})
+          ON CONFLICT (company_id, user_id, job_id) DO UPDATE SET
+            paid_hours = EXCLUDED.paid_hours, created_by_user_id = EXCLUDED.created_by_user_id`);
+      }
+    } else {
+      // Back to Allowed hours → drop entered hours so pay recomputes from budget.
+      await db.execute(sql`DELETE FROM payroll_hours_overrides WHERE company_id = ${companyId} AND job_id = ${jobId}`);
+    }
+
+    let result: Awaited<ReturnType<typeof calculateTechPay>> = [];
+    try { result = await calculateTechPay(jobId, companyId); }
+    catch (payErr) { console.error("pay-basis pay recompute failed (non-fatal):", payErr); }
+    return res.json({ ok: true, pay_basis: basis, data: result });
+  } catch (err) {
+    console.error("PUT /jobs/:id/pay-basis error:", err);
     return res.status(500).json({ error: "Internal Server Error" });
   }
 });

--- a/artifacts/api-server/src/routes/payroll.ts
+++ b/artifacts/api-server/src/routes/payroll.ts
@@ -629,6 +629,8 @@ router.get("/detail", requireAuth, async (req, res) => {
         // Commercial CLIENTS (no account_id) are still commercial for pay —
         // never a residential %. Routing below keys on account_id OR this.
         client_type: clientsTable.client_type,
+        // [pay-basis 2026-06-20] Per-job Allowed-hours vs Hourly switch.
+        pay_basis: jobsTable.pay_basis,
       })
       .from(jobsTable)
       .leftJoin(clientsTable, eq(jobsTable.client_id, clientsTable.id))
@@ -820,6 +822,7 @@ router.get("/detail", requireAuth, async (req, res) => {
       service_type: j.service_type, base_fee: j.base_fee, billed_amount: j.billed_amount,
       allowed_hours: j.allowed_hours, actual_hours: j.actual_hours,
       scheduled_date: String(j.scheduled_date), branch_id: (j as any).branch_id ?? null,
+      pay_basis: (j as any).pay_basis ?? "allowed_hours",
     }));
     const payLines = computePayLines({ jobs: jobsForPay, clocks, cellByUser, config: payConfig, paidHoursOverride, finalPayOverride });
 

--- a/lib/db/src/schema/jobs.ts
+++ b/lib/db/src/schema/jobs.ts
@@ -131,6 +131,14 @@ export const jobsTable = pgTable("jobs", {
   // the edit modal. Cleared when scope/freq/add-ons change AND base_fee is
   // omitted from the patch (recalc pulls a fresh value from pricing engine).
   manual_rate_override: boolean("manual_rate_override").notNull().default(false),
+  // [pay-basis 2026-06-20] Per-job pay control (office switch on the job pay
+  // panel). 'allowed_hours' (default) = pay the budgeted allowed hours, split
+  // across the job's clocked techs by their share — fast OR slow, they earn the
+  // budget (hard cap, not greater-of). 'hourly' = pay each tech their entered/
+  // actual hours × rate (the one-off exception). This is the single source of
+  // truth the payroll engine branches on; it also closes the multi-tech
+  // overpay where each tech was paid the WHOLE job's allowed hours.
+  pay_basis: text("pay_basis").notNull().default("allowed_hours"),
   // ── Cutover 1A (data backbone) — additive columns ───────────────────────
   // Scope flags lifted off the MaidCentral worksheet header. 1B (day
   // view) reads these as chips on the job card; 1C (clock-in) doesn't


### PR DESCRIPTION
## What
Adds `jobs.pay_basis` (`allowed_hours` default | `hourly`) — the office's per-job pay switch — and makes the payroll engine honor it. Also fixes a live overpay bug.

## The bug it fixes
`computePayLines` (feeds the `/payroll` screen) paid each hourly tech on a **multi-tech** job the **whole job's** allowed hours (greater-of), not their share.

Example — Richard Nitzsche job 5656: allowed 8.2h, two cleaners each clocked 3.28h → each paid `$20 × 8.2 = $164` instead of their `$82` share. ~16.4 tech-hours billed for an 8.2h budget.

## The model (mirrors MaidCentral's Hourly vs Flat/Allowed job types)
- **Allowed hours (default):** each clocked tech paid their **share** of the job's allowed budget (`allowed × clocked-hour share × rate`) — a hard cap. Fast or slow, they earn the budget; going over doesn't auto-pay more. This implements the default *and* fixes the overpay.
- **Hourly (one-off exception):** each tech paid their entered hours (blank → actual clocked) × rate, stored in `payroll_hours_overrides`.

## Changes
- **Schema + boot DDL:** `jobs.pay_basis TEXT NOT NULL DEFAULT 'allowed_hours'`.
- **`payroll-compute.ts`:** `PayrollJob.pay_basis`; `computePayLines` branches on it and splits allowed hours by tech share.
- **`routes/payroll.ts`:** selects + threads `pay_basis` into the detail compute.
- **`routes/jobs.ts`:** `PUT /:id/pay-basis` (owner/admin/office) sets the switch + per-tech hours; clears entered hours when switched back to Allowed.

## Scope / next
- This lands the **engine, data model, and API**. The **on-screen toggle** on the job pay panel (mockup already approved) is the **next PR** — it'll call this endpoint and read `pay_basis` from the dispatch payload.
- Quote-builder / booking pricing untouched.
- Follow-up: mirror `pay_basis` in the period-lock engine (`commission-paytype.ts`) for parity when payroll is locked.

## Test
- `pnpm run typecheck:libs` ✓
- `pnpm --filter @workspace/api-server run build` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)