### PR TITLE
fix(invoices): View button, server-side search, stop $0 auto-invoices

### DIFF
--- a/artifacts/api-server/src/lib/ensure-invoice.ts
+++ b/artifacts/api-server/src/lib/ensure-invoice.ts
@@ -182,6 +182,13 @@ export async function ensureInvoiceForCompletedJob(
     const lineItems = built?.lineItems ?? [];
     const netAmount = built?.subtotal ?? 0;
 
+    // [invoice-zero-guard 2026-06-20] Never auto-create a $0 invoice. A cancelled/
+    // credited occurrence or a $0-priced job (e.g. a split-billed sibling) would
+    // otherwise spawn a $0 draft that clutters AR and confuses the office
+    // ("are we invoicing $0 jobs??"). The office can still invoice manually if a
+    // genuine $0 document is ever needed.
+    if (netAmount <= 0) return NO_OP;
+
     const [newInv] = await db
       .insert(invoicesTable)
       .values({

--- a/artifacts/api-server/src/routes/invoices.ts
+++ b/artifacts/api-server/src/routes/invoices.ts
@@ -37,7 +37,7 @@ function formatInvoice(inv: any) {
 
 router.get("/", requireAuth, async (req, res) => {
   try {
-    const { status, client_id, date_from, date_to, page = "1", limit = "50", branch_id } = req.query;
+    const { status, client_id, date_from, date_to, page = "1", limit = "50", branch_id, search } = req.query;
     const offset = (parseInt(page as string) - 1) * parseInt(limit as string);
 
     const today = new Date().toISOString().split("T")[0];
@@ -52,6 +52,21 @@ router.get("/", requireAuth, async (req, res) => {
     }
     if (client_id) conditions.push(eq(invoicesTable.client_id, parseInt(client_id as string)));
     if (branch_id && branch_id !== "all") conditions.push(eq(invoicesTable.branch_id, parseInt(branch_id as string)));
+
+    // [invoice-search 2026-06-20] Server-side search so it works across ALL
+    // invoices, not just the 50 the page loaded. Matches the invoice_number,
+    // the client name, AND the displayed "INV-00622" id form (the UI pads the
+    // numeric id, so "INV-00622" / "00622" / "622" all resolve to id 622).
+    if (search && String(search).trim()) {
+      const s = String(search).trim();
+      const like = `%${s}%`;
+      const digits = s.replace(/\D/g, "");
+      const idMatch = digits ? sql` OR ${invoicesTable.id} = ${parseInt(digits, 10)}` : sql``;
+      conditions.push(sql`(
+        ${invoicesTable.invoice_number} ILIKE ${like}
+        OR concat(${clientsTable.first_name}, ' ', ${clientsTable.last_name}) ILIKE ${like}${idMatch}
+      )`);
+    }
 
     const invoices = await db
       .select({
@@ -87,6 +102,7 @@ router.get("/", requireAuth, async (req, res) => {
     const totalResult = await db
       .select({ count: count() })
       .from(invoicesTable)
+      .leftJoin(clientsTable, eq(invoicesTable.client_id, clientsTable.id))
       .where(and(...conditions));
 
     const compCond = eq(invoicesTable.company_id, req.auth!.companyId);

--- a/artifacts/qleno/src/pages/customer-profile.tsx
+++ b/artifacts/qleno/src/pages/customer-profile.tsx
@@ -1344,6 +1344,7 @@ function HomesTab({ clientId, homes, refetch, zoneColor, zoneName }: { clientId:
 
 // ─── Billing Tab ──────────────────────────────────────────────────────────────
 function BillingTab({ invoices }: { invoices: any[] }) {
+  const [, navigate] = useLocation();
   const statusStyle: Record<string, React.CSSProperties> = {
     paid: { background: "#DCFCE7", color: "#166534", border: "1px solid #BBF7D0" },
     overdue: { background: "#FEE2E2", color: "#991B1B", border: "1px solid #FECACA" },
@@ -1374,7 +1375,7 @@ function BillingTab({ invoices }: { invoices: any[] }) {
                   </span>
                 </td>
                 <td style={{ padding: "12px 16px" }}>
-                  <button style={{ fontSize: "12px", color: "var(--brand)", background: "none", border: "none", cursor: "pointer", fontWeight: 600 }}>View</button>
+                  <button onClick={() => navigate(`/invoices/${inv.id}`)} style={{ fontSize: "12px", color: "var(--brand)", background: "none", border: "none", cursor: "pointer", fontWeight: 600 }}>View</button>
                 </td>
               </tr>
             ))}

--- a/artifacts/qleno/src/pages/invoices.tsx
+++ b/artifacts/qleno/src/pages/invoices.tsx
@@ -523,12 +523,15 @@ export default function InvoicesPage() {
     const params = new URLSearchParams();
     if (activeTab !== "all") params.set("status", activeTab);
     if (activeBranchId !== "all") params.set("branch_id", String(activeBranchId));
+    // [invoice-search 2026-06-20] Send search to the server so it spans ALL
+    // invoices, not just the 50 rows the page loaded.
+    if (search.trim()) params.set("search", search.trim());
     const qs = params.toString();
     return `/api/invoices${qs ? `?${qs}` : ""}`;
   };
 
   const { data, isLoading, refetch } = useQuery({
-    queryKey: ["invoices", activeTab, activeBranchId],
+    queryKey: ["invoices", activeTab, activeBranchId, search.trim()],
     queryFn: () => apiFetch(buildInvoicesUrl()),
   });
 


### PR DESCRIPTION
Fixes three invoice bugs the office reported (Maribel):

## 1. "View" did nothing
The invoice **View** button on the customer profile had **no `onClick`** — a styled button wired to nothing. Now navigates to `/invoices/:id` (route + detail page already existed). [customer-profile.tsx]

## 2. Search didn't work (INV-00622 / 00622 / client name)
The invoices page filtered **client-side over only the 50 loaded rows**, so anything past the first page was unfindable. Added **server-side search** to `GET /api/invoices`:
- matches `invoice_number`, **client name**, and the displayed padded id (`INV-00622` / `00622` / `622` → id 622)
- page now sends `?search=`; count query joins clients so the predicate resolves.

## 3. $0 invoices auto-created
`ensureInvoiceForCompletedJob` had no zero guard → a cancelled/credited occurrence or a $0 split-billed job spawned a $0 draft. Added `if (netAmount <= 0) return NO_OP`. Office can still invoice manually if a real $0 doc is needed.

## Diagnosed but NOT in this PR (need your call — see chat)
- **28 existing $0 drafts** already in the table → cleanup (void) is a data op.
- **All KPI stats show $0** — root cause: every invoice is stuck as **draft** (568 draft / 80 paid / **0 sent**), and the 80 paid rows have **no `paid_at`**, so Paid/YTD compute to $0. That's a workflow/data decision, not a pure code bug.
- **"Won't show more than 50"** — list has no pagination/load-more yet.

## Test
- `pnpm --filter @workspace/api-server run build` ✓
- `pnpm --filter @workspace/qleno run build` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)