### PR TITLE
feat(auth): read-only "accountant" role for the CPA (view-only)

### DIFF
--- a/artifacts/api-server/src/lib/auth.ts
+++ b/artifacts/api-server/src/lib/auth.ts
@@ -53,6 +53,14 @@ export function requireAuth(req: Request, res: Response, next: NextFunction): vo
   try {
     const payload = verifyToken(token);
     req.auth = payload;
+    // [accountant-readonly 2026-06-20] The 'accountant' role (external CPA) is
+    // VIEW-ONLY across the entire app: permit safe read methods, reject every
+    // mutation no matter which endpoint it targets. Enforced here at the single
+    // auth choke point so no write path can ever be missed.
+    if (payload.role === "accountant" && !["GET", "HEAD", "OPTIONS"].includes(req.method)) {
+      res.status(403).json({ error: "Forbidden", message: "Accountant access is view-only" });
+      return;
+    }
     next();
   } catch {
     res.status(401).json({ error: "Unauthorized", message: "Invalid or expired token" });

--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -706,6 +706,10 @@ async function runBookingSchemaGuard(): Promise<void> {
     //
     // jobs.frequency — three new values for the multi-day case. Child jobs
     // mirror their parent recurring_schedules.frequency.
+    // [accountant-readonly 2026-06-20] External view-only role (CPA). Read-only
+    // is enforced globally in requireAuth; this just lets the role value exist.
+    { label: "user_role.accountant",
+      stmt: `ALTER TYPE user_role ADD VALUE IF NOT EXISTS 'accountant'` },
     { label: "frequency.daily",
       stmt: `ALTER TYPE frequency ADD VALUE IF NOT EXISTS 'daily'` },
     { label: "frequency.weekdays",

--- a/artifacts/qleno/src/components/layout/app-sidebar.tsx
+++ b/artifacts/qleno/src/components/layout/app-sidebar.tsx
@@ -63,7 +63,7 @@ const NAV_SECTIONS = [
       // Gantt as the default view. Active-highlight covers all 3 urls via
       // MULTI_URL_HIGHLIGHT below.
       { title: "Jobs",      url: "/dispatch",  icon: Briefcase, roles: ["owner", "admin", "office", "super_admin"] },
-      { title: "Customers", url: "/customers", icon: Users, roles: ["owner", "admin", "office", "super_admin"] },
+      { title: "Customers", url: "/customers", icon: Users, roles: ["owner", "admin", "office", "super_admin", "accountant"] },
       { title: "Messages",  url: "/messages",  icon: MessageSquare, roles: ["owner", "admin", "office", "super_admin"] },
       { title: "Accounts",  url: "/accounts",  icon: Building2, roles: ["owner", "admin", "office", "super_admin"] },
     ],
@@ -87,7 +87,7 @@ const NAV_SECTIONS = [
   {
     label: "Money",
     items: [
-      { title: "Invoices", url: "/invoices", icon: FileText, roles: ["owner", "admin", "office", "super_admin"] },
+      { title: "Invoices", url: "/invoices", icon: FileText, roles: ["owner", "admin", "office", "super_admin", "accountant"] },
       { title: "Batch Invoicing", url: "/admin/batch-invoicing", icon: Layers, roles: ["owner", "admin", "office", "super_admin"] },
     ],
   },

--- a/artifacts/qleno/src/pages/login.tsx
+++ b/artifacts/qleno/src/pages/login.tsx
@@ -52,6 +52,10 @@ export default function Login() {
             setLocation("/admin");
           } else if (res.user.role === 'technician' || res.user.role === 'team_lead') {
             setLocation("/my-jobs");
+          } else if (res.user.role === 'accountant') {
+            // [accountant-readonly 2026-06-20] CPA lands on Invoices (their main
+            // surface) — Customers + Invoices are the read-only v1 nav.
+            setLocation("/invoices");
           } else {
             setLocation("/dashboard");
           }

--- a/lib/db/src/schema/users.ts
+++ b/lib/db/src/schema/users.ts
@@ -5,7 +5,11 @@ import { companiesTable } from "./companies";
 import { branchesTable } from "./branches";
 
 export const userRoleEnum = pgEnum("user_role", [
-  "owner", "admin", "office", "technician", "team_lead", "super_admin"
+  "owner", "admin", "office", "technician", "team_lead", "super_admin",
+  // [accountant-readonly 2026-06-20] External view-only role (e.g. the company
+  // CPA). Read-everything, edit-nothing — enforced globally in requireAuth
+  // (every non-GET request from this role is rejected).
+  "accountant",
 ]);
 
 export const payTypeEnum = pgEnum("pay_type", [


### PR DESCRIPTION
Adds an **`accountant`** role for an outside CPA — sees data, **edits nothing**.

## How read-only is guaranteed
Enforced at the **single auth choke point**: `requireAuth` rejects **any non-GET request** from an `accountant` (403). So every write path — current or future, on any endpoint — is blocked, without relying on per-endpoint role lists. Safe by construction.

## Changes
- **Schema + boot DDL:** `accountant` added to the `user_role` enum.
- **`auth.ts`:** `requireAuth` blocks non-GET/HEAD/OPTIONS for the role.
- **Login:** accountant lands on `/invoices`.
- **Sidebar:** accountant sees **Customers + Invoices** (their list/detail GETs are open to any authed user → work read-only with zero risk).

## v1 scope
**Customers + Invoices** are fully functional read-only today. **Accounts / Reports / Payroll** are role-gated GETs — exposing them is a quick follow-up (add `accountant` to those read endpoints; writes stay blocked by the choke-point guard regardless).

## Not included (by design / boundary)
- **No account or password is created here.** The office adds the CPA via the normal Add-User flow and sets the password there (comms are off, so invite links don't apply). I can't create logins or handle passwords.

## Test
- `pnpm run typecheck:libs` ✓
- api-server build ✓ · frontend build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)