### PR TITLE
fix(invoices): View crash (line-item coercion) + hide future drafts + live service date

### DIFF
--- a/artifacts/api-server/src/lib/normalize-line-items.ts
+++ b/artifacts/api-server/src/lib/normalize-line-items.ts
@@ -1,0 +1,37 @@
+// [invoice-view-crash 2026-06-20] Pure coercion for invoice line_items.
+//
+// The invoice edit UI binds its qty/rate <input> fields straight to
+// e.target.value, so the saved line_items arrive with `quantity` and
+// `unit_price` as STRINGS ("2", "150"). Persisting those strings into the
+// line_items jsonb is what crashed the invoice "View": the read render does
+// `((item.unit_price ?? item.rate) || 0).toFixed(2)`, and a string has no
+// .toFixed → TypeError → the app's ErrorBoundary shows "Something went wrong".
+//
+// Normalizing on write makes the stored shape always numeric, which protects
+// EVERY reader of line_items (the View render, PDF generation, QuickBooks sync,
+// recalc) — not just the one render path. Kept dependency-free so it is trivial
+// to unit-test without a DB.
+export type NormalizedLineItem = {
+  description: string;
+  quantity: number;
+  unit_price: number;
+  total: number;
+  [k: string]: unknown;
+};
+
+function num(v: unknown): number {
+  const n = typeof v === "number" ? v : parseFloat(String(v));
+  return Number.isFinite(n) ? n : 0;
+}
+
+export function normalizeInvoiceLineItems(lineItems: unknown): NormalizedLineItem[] | undefined {
+  if (!Array.isArray(lineItems)) return undefined;
+  return lineItems.map((item: any) => ({
+    ...item,
+    description: item?.description ?? "",
+    quantity: num(item?.quantity),
+    // accept the legacy `rate` alias the older render falls back to
+    unit_price: num(item?.unit_price ?? item?.rate),
+    total: num(item?.total),
+  }));
+}

--- a/artifacts/api-server/src/routes/clients.ts
+++ b/artifacts/api-server/src/routes/clients.ts
@@ -423,6 +423,24 @@ router.get("/:id/full-profile", requireAuth, async (req, res) => {
       qb_customer_id: qbMap?.qb_customer_id ?? null,
     };
 
+    // [invoice-service-date 2026-06-20] Attach each invoice's LIVE service date
+    // (its linked job's scheduled_date) so the Billing tab shows the real service
+    // date instead of created_at — which is a creation snapshot that goes stale
+    // when a job is rescheduled. One batched lookup; null when job gone/unlinked.
+    const invJobIds = invoices.map((i: any) => i.job_id).filter((x: any) => x != null);
+    const invJobDates = new Map<number, string | null>();
+    if (invJobIds.length) {
+      const jrows = await db
+        .select({ id: jobsTable.id, scheduled_date: jobsTable.scheduled_date })
+        .from(jobsTable)
+        .where(inArray(jobsTable.id, invJobIds));
+      for (const j of jrows) invJobDates.set(j.id, (j.scheduled_date as any) ?? null);
+    }
+    const invoicesWithService = invoices.map((i: any) => ({
+      ...i,
+      service_date: i.job_id ? (invJobDates.get(i.job_id) ?? null) : null,
+    }));
+
     return res.json({
       ...client,
       ...(zoneData || {}),
@@ -431,7 +449,7 @@ router.get("/:id/full-profile", requireAuth, async (req, res) => {
       tech_preferences: preferences,
       notification_settings: notifications,
       scorecards,
-      invoices,
+      invoices: invoicesWithService,
       jobs: jobs.slice(0, 20),
       stats: {
         revenue_all_time,

--- a/artifacts/api-server/src/routes/invoices.ts
+++ b/artifacts/api-server/src/routes/invoices.ts
@@ -112,6 +112,13 @@ router.get("/", requireAuth, async (req, res) => {
         payment_terms: invoicesTable.payment_terms,
         billing_contact_name: invoicesTable.billing_contact_name,
         billing_contact_email: invoicesTable.billing_contact_email,
+        // [invoice-service-date 2026-06-20] Live service date = the linked job's
+        // scheduled_date, read at query time. The invoice has no service-date
+        // column (created_at/due_date are creation snapshots), and a reschedule
+        // moves jobs.scheduled_date WITHOUT touching the invoice — so a snapshot
+        // would go stale (office saw "the 17th" for a job moved to the 19th).
+        // Reading it live can never drift; null when the job is gone/unlinked.
+        service_date: sql<string | null>`(SELECT j.scheduled_date FROM jobs j WHERE j.id = ${invoicesTable.job_id})`,
       })
       .from(invoicesTable)
       .leftJoin(clientsTable, eq(invoicesTable.client_id, clientsTable.id))
@@ -359,6 +366,9 @@ router.get("/:id", requireAuth, async (req, res) => {
         payment_failed: invoicesTable.payment_failed,
         created_at: invoicesTable.created_at,
         paid_at: invoicesTable.paid_at,
+        // [invoice-service-date 2026-06-20] Live service date from the linked job
+        // (see list select). Reschedule-proof; null when job gone/unlinked.
+        service_date: sql<string | null>`(SELECT j.scheduled_date FROM jobs j WHERE j.id = ${invoicesTable.job_id})`,
       })
       .from(invoicesTable)
       .leftJoin(clientsTable, eq(invoicesTable.client_id, clientsTable.id))

--- a/artifacts/api-server/src/routes/invoices.ts
+++ b/artifacts/api-server/src/routes/invoices.ts
@@ -10,6 +10,7 @@ import { appBaseUrl } from "../lib/app-url.js";
 import { generateInvoiceNumber, getNextInvoiceNumber } from "../lib/invoice-number.js";
 import { chargeInvoice } from "../lib/charge-invoice.js";
 import { buildJobLineItems } from "../lib/invoice-line-items.js";
+import { normalizeInvoiceLineItems } from "../lib/normalize-line-items.js";
 
 const router = Router();
 
@@ -52,6 +53,26 @@ router.get("/", requireAuth, async (req, res) => {
     }
     if (client_id) conditions.push(eq(invoicesTable.client_id, parseInt(client_id as string)));
     if (branch_id && branch_id !== "all") conditions.push(eq(invoicesTable.branch_id, parseInt(branch_id as string)));
+
+    // [invoice-future-hide 2026-06-20] Maribel: "the invoice tab should only
+    // show invoices up to date, not in advance." Recurring/auto draft invoices
+    // tied to a not-yet-performed job are billing-in-advance noise that makes
+    // the dates look wrong. Hide DRAFT invoices whose linked job is scheduled
+    // after today from the default view. Only drafts with a future job date are
+    // hidden — sent/paid/overdue/void, manual drafts (no job_id), and drafts for
+    // today-or-earlier jobs all stay. Pass ?include_future=1 to show everything.
+    const includeFuture = String(req.query.include_future || "") === "1";
+    if (!includeFuture) {
+      conditions.push(sql`NOT (
+        ${invoicesTable.status} = 'draft'
+        AND ${invoicesTable.job_id} IS NOT NULL
+        AND EXISTS (
+          SELECT 1 FROM jobs j
+          WHERE j.id = ${invoicesTable.job_id}
+            AND j.scheduled_date > ${today}
+        )
+      )`);
+    }
 
     // [invoice-search 2026-06-20] Server-side search so it works across ALL
     // invoices, not just the 50 the page loaded. Matches the invoice_number,
@@ -371,11 +392,21 @@ router.put("/:id", requireAuth, requireRole("owner", "admin", "office"), async (
       return res.status(409).json({ error: "Conflict", message: `A ${current.status} invoice cannot be edited` });
     }
 
+    // [invoice-view-crash 2026-06-20] Normalize line_items numeric fields to
+    // real numbers before persisting. The edit UI's qty/rate inputs hand back
+    // raw e.target.value STRINGS; storing them as strings in the jsonb is what
+    // crashed the invoice View (the read render called .toFixed() on a string →
+    // TypeError → ErrorBoundary "Something went wrong"). Coercing here is the
+    // durable fix — it protects every reader of line_items (View, PDF, QB sync,
+    // recalc), not just the one render path. The total is still derived from the
+    // (now numeric) line totals, so it can never drift.
+    const normLineItems = normalizeInvoiceLineItems(line_items);
+
     // Total ALWAYS = sum(line items) + tips, so it can never silently drift from
     // the lines. Use the new lines if provided, else the stored subtotal; use
     // the new tip if provided, else the stored tip.
-    const subtotal = line_items
-      ? Math.round(line_items.reduce((s: number, item: any) => s + (Number(item.total) || 0), 0) * 100) / 100
+    const subtotal = normLineItems
+      ? Math.round(normLineItems.reduce((s: number, item: any) => s + (Number(item.total) || 0), 0) * 100) / 100
       : parseFloat(current.subtotal || "0");
     const tipVal = tips !== undefined ? (Number(tips) || 0) : parseFloat(current.tips || "0");
     const total = Math.round((subtotal + tipVal) * 100) / 100;
@@ -384,7 +415,7 @@ router.put("/:id", requireAuth, requireRole("owner", "admin", "office"), async (
       .update(invoicesTable)
       .set({
         ...(status && { status }),
-        ...(line_items && { line_items }),
+        ...(normLineItems && { line_items: normLineItems }),
         tips: tipVal.toFixed(2),
         subtotal: subtotal.toFixed(2),
         total: total.toFixed(2),

--- a/artifacts/api-server/src/tests/invoice-lineitem-normalize.test.ts
+++ b/artifacts/api-server/src/tests/invoice-lineitem-normalize.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Unit tests for normalizeInvoiceLineItems — the fix for the invoice "View"
+ * crash. The edit-save path persisted qty/unit_price as STRINGS, and the View
+ * render called .toFixed() on them → TypeError → ErrorBoundary. The normalizer
+ * guarantees numeric line_items on write.
+ *
+ * Run: tsx --test src/tests/invoice-lineitem-normalize.test.ts   (no DB needed)
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { normalizeInvoiceLineItems } from "../lib/normalize-line-items.js";
+
+describe("normalizeInvoiceLineItems", () => {
+  it("coerces string qty/unit_price/total to numbers (the crash repro)", () => {
+    const out = normalizeInvoiceLineItems([
+      { description: "Deep Clean", quantity: "1", unit_price: "270", total: "270" },
+    ])!;
+    const li = out[0];
+    assert.equal(typeof li.quantity, "number");
+    assert.equal(typeof li.unit_price, "number");
+    assert.equal(typeof li.total, "number");
+    assert.equal(li.unit_price, 270);
+    // The exact thing that threw before: .toFixed on the value must now work.
+    assert.equal(Number(li.unit_price).toFixed(2), "270.00");
+  });
+
+  it("accepts the legacy `rate` alias for unit_price", () => {
+    const out = normalizeInvoiceLineItems([{ description: "x", quantity: 2, rate: "55.5", total: 111 }])!;
+    assert.equal(out[0].unit_price, 55.5);
+  });
+
+  it("defaults missing/garbage numerics to 0, never NaN", () => {
+    const out = normalizeInvoiceLineItems([{ description: "y" }, { quantity: "abc", total: null }])!;
+    assert.equal(out[0].quantity, 0);
+    assert.equal(out[0].unit_price, 0);
+    assert.equal(out[1].quantity, 0);
+    assert.equal(out[1].total, 0);
+    assert.ok(!Number.isNaN(out[1].total));
+  });
+
+  it("preserves real numbers and negative discount lines", () => {
+    const out = normalizeInvoiceLineItems([{ description: "Discount", quantity: 1, unit_price: -25, total: -25 }])!;
+    assert.equal(out[0].total, -25);
+  });
+
+  it("returns undefined for non-array input (so PUT leaves stored lines untouched)", () => {
+    assert.equal(normalizeInvoiceLineItems(undefined), undefined);
+    assert.equal(normalizeInvoiceLineItems(null), undefined);
+    assert.equal(normalizeInvoiceLineItems("nope" as unknown), undefined);
+  });
+});

--- a/artifacts/qleno/src/pages/customer-profile.tsx
+++ b/artifacts/qleno/src/pages/customer-profile.tsx
@@ -1365,7 +1365,7 @@ function BillingTab({ invoices }: { invoices: any[] }) {
               <tr><td colSpan={6} style={{ padding: "48px", textAlign: "center", color: "#9E9B94", fontSize: "13px" }}>No invoices yet</td></tr>
             ) : invoices.map(inv => (
               <tr key={inv.id} style={{ borderBottom: "1px solid #F0EEE9" }}>
-                <td style={{ padding: "12px 16px", fontSize: "13px", color: "#6B7280" }}>{fmtDate(inv.created_at)}</td>
+                <td style={{ padding: "12px 16px", fontSize: "13px", color: "#6B7280" }}>{inv.service_date ? fmtDate(inv.service_date + "T12:00:00") : fmtDate(inv.created_at)}</td>
                 <td style={{ padding: "12px 16px", fontSize: "13px", fontWeight: 600, color: "#1A1917" }}>INV-{String(inv.id).padStart(5, "0")}</td>
                 <td style={{ padding: "12px 16px", fontSize: "13px", fontWeight: 600, color: "#1A1917" }}>{fmtCurrency(inv.total)}</td>
                 <td style={{ padding: "12px 16px", fontSize: "13px", color: inv.paid_at ? "#9E9B94" : "#1A1917" }}>{inv.paid_at ? "$0.00" : fmtCurrency(inv.total)}</td>

--- a/artifacts/qleno/src/pages/invoice-detail.tsx
+++ b/artifacts/qleno/src/pages/invoice-detail.tsx
@@ -367,6 +367,7 @@ export default function InvoiceDetailPage() {
             {[
               { label: "Invoice Number", value: invoice.invoice_number || `INV-${String(invoice.id).padStart(4, "0")}` },
               { label: "Status", value: <StatusBadge status={effectiveStatus} /> },
+              { label: "Service Date", value: invoice.service_date ? new Date(invoice.service_date + "T12:00:00").toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" }) : "—" },
               { label: "Created", value: invoice.created_at ? new Date(invoice.created_at).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" }) : "—" },
               { label: "Due Date", value: invoice.due_date ? new Date(invoice.due_date + "T12:00:00").toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" }) : "—" },
               { label: "Sent", value: invoice.sent_at ? new Date(invoice.sent_at).toLocaleDateString("en-US", { month: "short", day: "numeric" }) : "—" },

--- a/artifacts/qleno/src/pages/invoice-detail.tsx
+++ b/artifacts/qleno/src/pages/invoice-detail.tsx
@@ -216,7 +216,18 @@ export default function InvoiceDetailPage() {
     try {
       await apiFetch(`/api/invoices/${invoiceId}`, {
         method: "PUT",
-        body: JSON.stringify({ line_items: editLines, tips: Number(editTip) || 0 }),
+        body: JSON.stringify({
+          // Coerce every numeric field to a Number — the qty/rate inputs hold
+          // raw e.target.value strings, and persisting them as strings is what
+          // crashed the View render (.toFixed on a string). Send numbers.
+          line_items: editLines.map((l: any) => ({
+            description: l.description || "",
+            quantity: Number(l.quantity) || 0,
+            unit_price: Number(l.unit_price) || 0,
+            total: Number(l.total) || 0,
+          })),
+          tips: Number(editTip) || 0,
+        }),
       });
       toast({ title: "Invoice updated" });
       setEditing(false);
@@ -440,9 +451,9 @@ export default function InvoiceDetailPage() {
                     <td style={{ padding: "10px 0", fontSize: 13, color: "#1A1917", textTransform: "capitalize" }}>
                       {(item.description || "").replace(/_/g, " ")}
                     </td>
-                    <td style={{ padding: "10px 0", fontSize: 13, color: "#6B7280", textAlign: "right" }}>{item.quantity || 1}</td>
-                    <td style={{ padding: "10px 0", fontSize: 13, color: "#6B7280", textAlign: "right" }}>${((item.unit_price ?? item.rate) || 0).toFixed(2)}</td>
-                    <td style={{ padding: "10px 0", fontSize: 13, fontWeight: 700, color: "#1A1917", textAlign: "right" }}>${(item.total || 0).toFixed(2)}</td>
+                    <td style={{ padding: "10px 0", fontSize: 13, color: "#6B7280", textAlign: "right" }}>{Number(item.quantity ?? 1)}</td>
+                    <td style={{ padding: "10px 0", fontSize: 13, color: "#6B7280", textAlign: "right" }}>${Number((item.unit_price ?? item.rate) || 0).toFixed(2)}</td>
+                    <td style={{ padding: "10px 0", fontSize: 13, fontWeight: 700, color: "#1A1917", textAlign: "right" }}>${Number(item.total || 0).toFixed(2)}</td>
                   </tr>
                 ))}
               </tbody>


### PR DESCRIPTION
Three invoice fixes (follow-ups to #591), all verified against the office reports.

## 1. "View" crash — line-item numeric coercion
The edit UI binds qty/rate inputs to raw `e.target.value` **strings**; persisting them into `line_items` jsonb made the View render call `.toFixed()` on a string → TypeError → ErrorBoundary "Something went wrong." New `normalizeInvoiceLineItems` coerces on write (protects View, PDF, QB sync, recalc — every reader), invoice-detail sends numbers, and the render wraps with `Number()`. **Unit tests included** (`invoice-lineitem-normalize.test.ts`).

## 2. Hide future-dated drafts
Maribel: "the invoice tab should only show invoices up to date, not in advance." GET `/api/invoices` now hides **draft** invoices whose linked job is scheduled after today. Sent/paid/overdue/void, manual drafts (no job), and today-or-earlier drafts all stay. `?include_future=1` shows everything.

## 3. Live, reschedule-proof service date
Invoices have no service-date column (`created_at`/`due_date` are creation snapshots that go stale on reschedule — the "Todd shows 6/17 for a 6/19 job" issue). Now the list, detail, and customer Billing tab read the **linked job's `scheduled_date` live** at query time. Null when the job is gone/unlinked.

## Test
4 required CI checks (dispatch-guard, tsc-check, build-api-server, build-frontend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)