### PR TITLE
fix(invoices): service date in list/detail, date-range filter, post-completion adjustments

### DIFF
--- a/artifacts/api-server/src/routes/invoices.ts
+++ b/artifacts/api-server/src/routes/invoices.ts
@@ -54,6 +54,14 @@ router.get("/", requireAuth, async (req, res) => {
     if (client_id) conditions.push(eq(invoicesTable.client_id, parseInt(client_id as string)));
     if (branch_id && branch_id !== "all") conditions.push(eq(invoicesTable.branch_id, parseInt(branch_id as string)));
 
+    // [invoice-date-range 2026-06-21] Filter by the invoice's EFFECTIVE service
+    // date = the linked job's scheduled_date, falling back to created_at when the
+    // invoice has no job. Same date the list now displays, so the range filter
+    // matches what the office sees. Inclusive bounds (YYYY-MM-DD).
+    const effDate = sql`COALESCE((SELECT j.scheduled_date FROM jobs j WHERE j.id = ${invoicesTable.job_id}), ${invoicesTable.created_at}::date)`;
+    if (date_from && String(date_from).trim()) conditions.push(sql`${effDate} >= ${String(date_from)}`);
+    if (date_to && String(date_to).trim()) conditions.push(sql`${effDate} <= ${String(date_to)}`);
+
     // [invoice-future-hide 2026-06-20] Maribel: "the invoice tab should only
     // show invoices up to date, not in advance." Recurring/auto draft invoices
     // tied to a not-yet-performed job are billing-in-advance noise that makes

--- a/artifacts/api-server/src/routes/jobs.ts
+++ b/artifacts/api-server/src/routes/jobs.ts
@@ -5300,6 +5300,11 @@ router.post("/:id/rate-mods", requireAuth, async (req, res) => {
     const newBilled = await recomputeJobBilledAmount(jobId, companyId);
     // Time mods extend the job's allowed hours (commercial commission + block).
     const newAllowedHours = mod_type === "time" ? await adjustAllowedHours(jobId, companyId, Number(minutes)) : null;
+    // [post-completion-adjust 2026-06-21] Push the new amount onto the job's
+    // DRAFT invoice if one exists (no-op for sent/paid — those stay immutable;
+    // the office uses "Recalc from Job" to pull an adjustment onto a sent
+    // invoice). Lets a parking/extra fee added to a finished job flow to billing.
+    syncJobInvoiceDraft(jobId, companyId).catch(e => console.error("[rate-mod] invoice draft sync non-fatal:", e));
     logAudit(req, "CREATE", "job_rate_mod", jobId, null, { mod_type, minutes, amount: amt });
     return res.status(201).json({
       mod: insert.rows[0],

--- a/artifacts/qleno/src/pages/invoices.tsx
+++ b/artifacts/qleno/src/pages/invoices.tsx
@@ -464,6 +464,9 @@ export default function InvoicesPage() {
   const isMobile = useIsMobile();
   const [activeTab, setActiveTab] = useState<TabId>("all");
   const [search, setSearch] = useState("");
+  // [invoice-date-range 2026-06-21] Office date-range filter (by service date).
+  const [dateFrom, setDateFrom] = useState("");
+  const [dateTo, setDateTo] = useState("");
   const [showBatch, setShowBatch] = useState(false);
   const [showCloseDay, setShowCloseDay] = useState(false);
   const [showNewInvoice, setShowNewInvoice] = useState(false);
@@ -526,12 +529,14 @@ export default function InvoicesPage() {
     // [invoice-search 2026-06-20] Send search to the server so it spans ALL
     // invoices, not just the 50 rows the page loaded.
     if (search.trim()) params.set("search", search.trim());
+    if (dateFrom) params.set("date_from", dateFrom);
+    if (dateTo) params.set("date_to", dateTo);
     const qs = params.toString();
     return `/api/invoices${qs ? `?${qs}` : ""}`;
   };
 
   const { data, isLoading, refetch } = useQuery({
-    queryKey: ["invoices", activeTab, activeBranchId, search.trim()],
+    queryKey: ["invoices", activeTab, activeBranchId, search.trim(), dateFrom, dateTo],
     queryFn: () => apiFetch(buildInvoicesUrl()),
   });
 
@@ -681,6 +686,16 @@ export default function InvoicesPage() {
                   <input placeholder="Search invoices..." value={search} onChange={e => setSearch(e.target.value)}
                     style={{ paddingLeft: 32, paddingRight: 10, height: 36, width: isMobile ? "100%" : 200, backgroundColor: "#F7F6F3", border: "1px solid #E5E2DC", borderRadius: 8, color: "#1A1917", fontSize: 13, outline: "none", fontFamily: FF }} />
                 </div>
+                {/* [invoice-date-range 2026-06-21] Filter by service date. */}
+                <input type="date" value={dateFrom} max={dateTo || undefined} onChange={e => setDateFrom(e.target.value)} aria-label="From date"
+                  style={{ height: 36, padding: "0 8px", backgroundColor: "#F7F6F3", border: "1px solid #E5E2DC", borderRadius: 8, color: "#1A1917", fontSize: 13, outline: "none", fontFamily: FF }} />
+                <span style={{ color: "#9E9B94", fontSize: 13 }}>–</span>
+                <input type="date" value={dateTo} min={dateFrom || undefined} onChange={e => setDateTo(e.target.value)} aria-label="To date"
+                  style={{ height: 36, padding: "0 8px", backgroundColor: "#F7F6F3", border: "1px solid #E5E2DC", borderRadius: 8, color: "#1A1917", fontSize: 13, outline: "none", fontFamily: FF }} />
+                {(dateFrom || dateTo) && (
+                  <button onClick={() => { setDateFrom(""); setDateTo(""); }} title="Clear dates"
+                    style={{ height: 36, padding: "0 10px", backgroundColor: "transparent", color: "#6B7280", border: "1px solid #E5E2DC", borderRadius: 8, fontSize: 12, fontWeight: 600, cursor: "pointer", fontFamily: FF }}>Clear</button>
+                )}
                 {canAdmin && (
                   <>
                     {!isMobile && <button onClick={() => setShowCloseDay(true)}
@@ -731,7 +746,9 @@ export default function InvoicesPage() {
                         </div>
                         <div style={{ fontSize: 11, color: "#9E9B94", fontFamily: FF }}>
                           {inv.invoice_number || `INV-${String(inv.id).padStart(4, "0")}`}
-                          {inv.due_date ? ` · Due ${new Date(inv.due_date + "T12:00:00").toLocaleDateString("en-US", { month: "short", day: "numeric" })}` : ""}
+                          {inv.service_date
+                            ? ` · ${new Date(inv.service_date + "T12:00:00").toLocaleDateString("en-US", { month: "short", day: "numeric" })}`
+                            : inv.created_at ? ` · ${new Date(inv.created_at).toLocaleDateString("en-US", { month: "short", day: "numeric" })}` : ""}
                         </div>
                       </div>
                       <div style={{ textAlign: "right", flexShrink: 0 }}>
@@ -748,7 +765,7 @@ export default function InvoicesPage() {
             <table style={{ width: "100%", borderCollapse: "collapse" }}>
               <thead>
                 <tr>
-                  {["Invoice #", "Client", "PO #", "Terms", "Amount", "Due Date", "Days Overdue", "Status", ""].map(h => (
+                  {["Invoice #", "Client", "PO #", "Terms", "Amount", "Service Date", "Days Overdue", "Status", ""].map(h => (
                     <th key={h} style={{ ...TH, textAlign: h === "" ? "right" as const : "left" as const }}>{h}</th>
                   ))}
                 </tr>
@@ -788,7 +805,9 @@ export default function InvoicesPage() {
                       </td>
                       <td style={{ padding: "13px 18px", fontSize: 16, fontWeight: 700, color: "#1A1917", fontFamily: FF }}>${(inv.total || 0).toFixed(2)}</td>
                       <td style={{ padding: "13px 18px", fontSize: 12, color: "#6B7280", fontFamily: FF }}>
-                        {inv.due_date ? new Date(inv.due_date + "T12:00:00").toLocaleDateString("en-US", { month: "short", day: "numeric" }) : "—"}
+                        {inv.service_date
+                          ? new Date(inv.service_date + "T12:00:00").toLocaleDateString("en-US", { month: "short", day: "numeric" })
+                          : inv.created_at ? new Date(inv.created_at).toLocaleDateString("en-US", { month: "short", day: "numeric" }) : "—"}
                       </td>
                       <td style={{ padding: "13px 18px" }}>
                         {effectiveStatus === "overdue" && (inv.days_overdue || 0) > 0 ? (

--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -1636,6 +1636,11 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
   // completion isn't a 1-pixel miss.
   const [confirmComplete, setConfirmComplete] = useState(false);
   const isLocked = !!job.locked_at || job.status === "complete" || job.status === "cancelled";
+  // [post-completion-adjust 2026-06-21] The office must be able to add a flat
+  // fee (e.g. +$20 parking) AFTER a job is marked complete — that case is the
+  // norm, not the exception. So adjustments stay editable on COMPLETED jobs;
+  // only a hard lock (paid -> locked_at) or a cancelled job blocks them.
+  const adjUnlocked = !job.locked_at && job.status !== "cancelled";
   const completedAtLabel = (() => {
     const t = job.actual_end_time || job.locked_at;
     if (!t) return null;
@@ -2827,7 +2832,7 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
                             {m.reason}
                           </div>
                         </div>
-                        {!isLocked && (
+                        {adjUnlocked && (
                           <button onClick={() => deleteRateMod(m.id)}
                             style={{ marginLeft: 8, padding: 4, border: "none", background: "transparent", cursor: "pointer", color: "#9E9B94" }}
                             title="Remove adjustment">
@@ -2840,9 +2845,9 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
                 </div>
               )}
               {!modAddOpen ? (
-                <button onClick={() => !isLocked && setModAddOpen(true)}
-                  disabled={isLocked}
-                  style={{ width: "100%", height: 32, display: "flex", alignItems: "center", justifyContent: "center", gap: 6, fontSize: 12, fontWeight: 600, color: isLocked ? "#9E9B94" : "#2D9B83", border: `1px dashed ${isLocked ? "#D1D5DB" : "#2D9B83"}`, borderRadius: 8, background: "transparent", cursor: isLocked ? "not-allowed" : "pointer", fontFamily: FF, opacity: isLocked ? 0.6 : 1 }}>
+                <button onClick={() => adjUnlocked && setModAddOpen(true)}
+                  disabled={!adjUnlocked}
+                  style={{ width: "100%", height: 32, display: "flex", alignItems: "center", justifyContent: "center", gap: 6, fontSize: 12, fontWeight: 600, color: !adjUnlocked ? "#9E9B94" : "#2D9B83", border: `1px dashed ${!adjUnlocked ? "#D1D5DB" : "#2D9B83"}`, borderRadius: 8, background: "transparent", cursor: !adjUnlocked ? "not-allowed" : "pointer", fontFamily: FF, opacity: !adjUnlocked ? 0.6 : 1 }}>
                   <Plus size={12} /> Add Adjustment
                 </button>
               ) : (


### PR DESCRIPTION
Follow-up to #594 — 4 invoice fixes, invoice/billing-scoped only.

1. **Service date in the list & detail** — #594 added `service_date` to the API but the **list still displayed `due_date`**. Now the invoices list (mobile + desktop) and headers show the linked job's **service date** (falls back to `created_at` when no job). Column renamed Due Date → Service Date.
2. **Date-range filter** on the invoices tab — filters by the **effective service date** (`COALESCE(linked job scheduled_date, created_at)`), inclusive bounds, with a Clear button. Matches what the list shows.
3. **Future-draft hide** — confirmed in place (from #594).
4. **Post-completion adjustments unblocked** — the office can add a flat fee (e.g. +$20 parking) to an already-**completed** job; only a hard lock (paid→`locked_at`) or cancelled blocks it. The rate-mod endpoint now `syncJobInvoiceDraft`s so the new amount flows to the job's draft invoice.

Files: `routes/invoices.ts`, `routes/jobs.ts`, `pages/invoices.tsx`, `pages/jobs.tsx`. No lib/*, no secrets.

## Test
4 required checks (dispatch-guard, tsc-check, build-api-server, build-frontend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)