### PR TITLE
feat(invoices): Mark Paid / Mark Unpaid + finalize≠notify lifecycle docs

### DIFF
--- a/artifacts/api-server/src/lib/ensure-invoice.ts
+++ b/artifacts/api-server/src/lib/ensure-invoice.ts
@@ -196,7 +196,14 @@ export async function ensureInvoiceForCompletedJob(
         job_id: jobId,
         client_id: job.client_id ?? null,
         account_id: job.account_id ?? null,
-        // per_visit issues immediately (sent); batch stays a pending draft.
+        // [invoice-lifecycle 2026-06-21] per_visit completions are FINALIZED
+        // immediately as 'sent' = issued / awaiting payment, so the Invoices
+        // "Outstanding" KPI (status IN ('sent','overdue')) picks them up the
+        // moment a job is completed. NOTE: 'sent' here means FINALIZED, NOT
+        // "notification emailed" — this path never calls sendNotification, so
+        // finalizing a completed job never messages the customer (decoupled by
+        // design; the only customer send is the explicit POST /:id/send route).
+        // batch_invoice clients stay a pending draft for month-end consolidation.
         status: isBatch ? "draft" : "sent",
         batch_status: isBatch ? "pending" : null,
         sent_at: isBatch ? null : today,

--- a/artifacts/api-server/src/routes/invoices.ts
+++ b/artifacts/api-server/src/routes/invoices.ts
@@ -647,6 +647,60 @@ router.post("/:id/mark-paid", requireAuth, requireRole("owner", "admin", "office
   }
 });
 
+// ── Mark UNPAID (undo a manual Mark Paid) ───────────────────────────────────
+// Office-only. Reverts a manually-marked-paid invoice back to the finalized,
+// outstanding ('sent') state and clears paid_at so the KPIs move it back out of
+// Paid/YTD into Outstanding. Removes the manual payment record(s) created by
+// Mark Paid. Refuses to touch an invoice that carries a real processor payment
+// (Stripe/Square) — that must be reversed via a refund, not an unmark.
+router.post("/:id/mark-unpaid", requireAuth, requireRole("owner", "admin", "office"), async (req, res) => {
+  try {
+    const invoiceId = parseInt(req.params.id);
+    if (isNaN(invoiceId)) return res.status(400).json({ error: "Bad Request", message: "Invalid invoice id" });
+
+    const [invoice] = await db
+      .select({
+        id: invoicesTable.id,
+        status: invoicesTable.status,
+        stripe_payment_intent_id: invoicesTable.stripe_payment_intent_id,
+        square_payment_id: invoicesTable.square_payment_id,
+      })
+      .from(invoicesTable)
+      .where(and(eq(invoicesTable.id, invoiceId), eq(invoicesTable.company_id, req.auth!.companyId)))
+      .limit(1);
+
+    if (!invoice) return res.status(404).json({ error: "Not Found", message: "Invoice not found" });
+    if (invoice.status !== "paid") {
+      return res.status(409).json({ error: "Conflict", message: "Only a paid invoice can be marked unpaid" });
+    }
+    if (invoice.stripe_payment_intent_id || invoice.square_payment_id) {
+      return res.status(409).json({ error: "Conflict", message: "This invoice has a processor payment — issue a refund instead of marking it unpaid" });
+    }
+
+    // Back to finalized/outstanding so the Outstanding KPI picks it up again.
+    const [updated] = await db
+      .update(invoicesTable)
+      .set({ status: "sent", paid_at: null })
+      .where(and(eq(invoicesTable.id, invoiceId), eq(invoicesTable.company_id, req.auth!.companyId)))
+      .returning();
+
+    // Drop the manual payment record(s) the Mark Paid action inserted. (Guarded
+    // above against processor payments, so these are office manual marks only.)
+    await db.delete(paymentsTable)
+      .where(and(eq(paymentsTable.invoice_id, invoiceId), eq(paymentsTable.company_id, req.auth!.companyId)));
+
+    logAudit(req, "UPDATE", "invoice", invoiceId, { status: "paid" }, { status: "sent", unmarked_paid: true });
+
+    // Reflect the reversal in QuickBooks (one-way push; no-op when not connected).
+    queueSync(() => syncInvoice(req.auth!.companyId, invoiceId));
+
+    return res.json(formatInvoice({ ...updated, client_name: null }));
+  } catch (err) {
+    console.error("Mark unpaid error:", err);
+    return res.status(500).json({ error: "Internal Server Error", message: "Failed to mark invoice unpaid" });
+  }
+});
+
 // ── Office-triggered charge (Scope 3) ──────────────────────────────────────
 // Routes by the invoice's effective payment_source. Office-only. Charges at most
 // once — NO auto-retry. stripe → off-session charge; square → Square (when

--- a/artifacts/qleno/src/pages/invoice-detail.tsx
+++ b/artifacts/qleno/src/pages/invoice-detail.tsx
@@ -117,6 +117,8 @@ export default function InvoiceDetailPage() {
   const [sendingInvoice, setSendingInvoice] = useState(false);
   const [charging, setCharging] = useState(false);
   const [voiding, setVoiding] = useState(false);
+  const [markingPaid, setMarkingPaid] = useState(false);
+  const [markingUnpaid, setMarkingUnpaid] = useState(false);
   const [editing, setEditing] = useState(false);
   const [editLines, setEditLines] = useState<any[]>([]);
   const [editTip, setEditTip] = useState(0);
@@ -186,6 +188,36 @@ export default function InvoiceDetailPage() {
       toast({ title: e?.message || "Failed to void invoice", variant: "destructive" });
     }
     setVoiding(false);
+  }
+
+  // One-click "Mark Paid = now". Payment is collected externally (Square); this
+  // just records the manual mark and sets paid_at so the Paid(30d)/YTD KPIs fill.
+  async function handleMarkPaidNow() {
+    setMarkingPaid(true);
+    try {
+      await apiFetch(`/api/invoices/${invoiceId}/mark-paid`, { method: "POST", body: JSON.stringify({}) });
+      toast({ title: "Marked paid" });
+      qc.invalidateQueries({ queryKey: ["invoice", invoiceId] });
+      qc.invalidateQueries({ queryKey: ["invoices"] });
+    } catch (e: any) {
+      toast({ title: e?.message || "Failed to mark paid", variant: "destructive" });
+    }
+    setMarkingPaid(false);
+  }
+
+  // Undo a manual Mark Paid — reverts to outstanding and clears paid_at.
+  async function handleMarkUnpaid() {
+    if (!window.confirm("Mark this invoice unpaid? It returns to Outstanding and the recorded payment is removed.")) return;
+    setMarkingUnpaid(true);
+    try {
+      await apiFetch(`/api/invoices/${invoiceId}/mark-unpaid`, { method: "POST" });
+      toast({ title: "Marked unpaid" });
+      qc.invalidateQueries({ queryKey: ["invoice", invoiceId] });
+      qc.invalidateQueries({ queryKey: ["invoices"] });
+    } catch (e: any) {
+      toast({ title: e?.message || "Failed to mark unpaid", variant: "destructive" });
+    }
+    setMarkingUnpaid(false);
   }
 
   // ── Edit invoice (line items / amounts / tip / discount) ──
@@ -324,9 +356,13 @@ export default function InvoiceDetailPage() {
                 style={{ display: "flex", alignItems: "center", gap: 6, padding: "9px 16px", backgroundColor: "var(--brand)", color: "#FFFFFF", border: "none", borderRadius: 8, fontSize: 13, fontWeight: 700, cursor: "pointer" }}>
                 <CreditCard size={14} /> {charging ? "Charging..." : "Charge Now"}
               </button>
+              <button onClick={handleMarkPaidNow} disabled={markingPaid}
+                style={{ display: "flex", alignItems: "center", gap: 6, padding: "9px 16px", backgroundColor: "#16A34A", color: "#FFFFFF", border: "none", borderRadius: 8, fontSize: 13, fontWeight: 700, cursor: "pointer" }}>
+                <DollarSign size={14} /> {markingPaid ? "Marking..." : "Mark Paid"}
+              </button>
               <button onClick={() => setShowMarkPaid(true)}
                 style={{ display: "flex", alignItems: "center", gap: 6, padding: "9px 16px", backgroundColor: "#DCFCE7", color: "#166534", border: "1px solid #BBF7D0", borderRadius: 8, fontSize: 13, fontWeight: 700, cursor: "pointer" }}>
-                <DollarSign size={14} /> Mark as Paid
+                Record payment…
               </button>
               {effectiveStatus === "overdue" && (
                 <button onClick={handleSendReminder} disabled={sendingReminder}
@@ -340,6 +376,12 @@ export default function InvoiceDetailPage() {
             <button onClick={handleVoid} disabled={voiding}
               style={{ display: "flex", alignItems: "center", gap: 6, padding: "9px 16px", backgroundColor: "transparent", color: "#991B1B", border: "1px solid #FECACA", borderRadius: 8, fontSize: 13, fontWeight: 700, cursor: "pointer" }}>
               {voiding ? "Voiding..." : "Void"}
+            </button>
+          )}
+          {invoice.status === "paid" && (
+            <button onClick={handleMarkUnpaid} disabled={markingUnpaid}
+              style={{ display: "flex", alignItems: "center", gap: 6, padding: "9px 16px", backgroundColor: "transparent", color: "#92400E", border: "1px solid #FDE68A", borderRadius: 8, fontSize: 13, fontWeight: 700, cursor: "pointer" }}>
+              {markingUnpaid ? "Updating..." : "Mark Unpaid"}
             </button>
           )}
           {!["paid", "void", "superseded"].includes(invoice.status) && !editing && (

--- a/artifacts/qleno/src/pages/invoices.tsx
+++ b/artifacts/qleno/src/pages/invoices.tsx
@@ -486,6 +486,7 @@ export default function InvoicesPage() {
   const [readyExpanded, setReadyExpanded] = useState(true);
   const [failedExpanded, setFailedExpanded] = useState(true);
   const [chargingJobId, setChargingJobId] = useState<number | null>(null);
+  const [payingInvoiceId, setPayingInvoiceId] = useState<number | null>(null);
 
   const { data: readyData, refetch: refetchReady } = useQuery({
     queryKey: ["ready-to-charge"],
@@ -519,6 +520,32 @@ export default function InvoicesPage() {
       toast({ title: "Charge failed", description: err.message, variant: "destructive" });
     } finally {
       setChargingJobId(null);
+    }
+  }
+
+  // [invoice-lifecycle 2026-06-21] One-click Mark Paid / Unmark from the list.
+  async function markInvoicePaid(invId: number) {
+    setPayingInvoiceId(invId);
+    try {
+      await apiFetch(`/api/invoices/${invId}/mark-paid`, { method: "POST", body: JSON.stringify({}) });
+      toast({ title: "Marked paid" });
+      refetch();
+    } catch (err: any) {
+      toast({ title: "Failed to mark paid", description: err?.message || "", variant: "destructive" });
+    } finally {
+      setPayingInvoiceId(null);
+    }
+  }
+  async function markInvoiceUnpaid(invId: number) {
+    setPayingInvoiceId(invId);
+    try {
+      await apiFetch(`/api/invoices/${invId}/mark-unpaid`, { method: "POST" });
+      toast({ title: "Marked unpaid" });
+      refetch();
+    } catch (err: any) {
+      toast({ title: "Failed to mark unpaid", description: err?.message || "", variant: "destructive" });
+    } finally {
+      setPayingInvoiceId(null);
     }
   }
 
@@ -821,7 +848,21 @@ export default function InvoicesPage() {
                           {effectiveStatus}
                         </span>
                       </td>
-                      <td style={{ padding: "13px 18px", textAlign: "right" }} onClick={e => e.stopPropagation()}>
+                      <td style={{ padding: "13px 18px", textAlign: "right", whiteSpace: "nowrap" }} onClick={e => e.stopPropagation()}>
+                        {(effectiveStatus === "sent" || effectiveStatus === "overdue") && (
+                          <button onClick={() => markInvoicePaid(inv.id)} disabled={payingInvoiceId === inv.id}
+                            title="Mark paid (today)"
+                            style={{ marginRight: 8, padding: "5px 10px", border: "none", backgroundColor: "#16A34A", color: "#FFFFFF", fontSize: 12, fontWeight: 700, borderRadius: 6, cursor: "pointer", fontFamily: FF }}>
+                            {payingInvoiceId === inv.id ? "…" : "Mark Paid"}
+                          </button>
+                        )}
+                        {inv.status === "paid" && (
+                          <button onClick={() => markInvoiceUnpaid(inv.id)} disabled={payingInvoiceId === inv.id}
+                            title="Mark unpaid"
+                            style={{ marginRight: 8, padding: "5px 10px", border: "1px solid #FDE68A", backgroundColor: "transparent", color: "#92400E", fontSize: 12, fontWeight: 700, borderRadius: 6, cursor: "pointer", fontFamily: FF }}>
+                            {payingInvoiceId === inv.id ? "…" : "Unmark"}
+                          </button>
+                        )}
                         <button style={{ padding: 5, border: "none", backgroundColor: "transparent", color: "#9E9B94", cursor: "pointer", borderRadius: 4 }}>
                           <Download size={14} strokeWidth={1.5} />
                         </button>


### PR DESCRIPTION
Lets the office record payment in Qleno (collection stays in Square) so the Paid(30d)/YTD KPIs fill, and undo it.

## Changes
- **`routes/invoices.ts`** — new `POST /:id/mark-unpaid` (owner/admin/office): reverts a *manually* marked-paid invoice to `sent` + clears `paid_at`, deletes the manual payment record(s). **Refuses** invoices with a real Stripe/Square payment (refund instead).
- **`invoice-detail.tsx`** — one-click **Mark Paid** (now), **Record payment…** (dated modal, existing), and **Mark Unpaid** (shown when paid).
- **`invoices.tsx`** — list-row **Mark Paid** (on sent/overdue) and **Unmark** (on paid).
- **`ensure-invoice.ts`** — **comment only**: documents that per-visit completions finalize as `'sent'` = issued/outstanding, and that `'sent'` means FINALIZED, **not** "notification emailed" (the only customer send is `POST /:id/send`). No logic change.

Files: `lib/ensure-invoice.ts` (comment), `routes/invoices.ts`, `pages/invoice-detail.tsx`, `pages/invoices.tsx`. No secrets, invoice-scoped.

## Test
4 required checks (dispatch-guard, tsc-check, build-api-server, build-frontend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)