### PR TITLE
feat(invoices): "Charge Card on File" button (wired to existing Stripe charge)

### DIFF
--- a/artifacts/api-server/src/routes/invoices.ts
+++ b/artifacts/api-server/src/routes/invoices.ts
@@ -127,6 +127,13 @@ router.get("/", requireAuth, async (req, res) => {
         // would go stale (office saw "the 17th" for a job moved to the 19th).
         // Reading it live can never drift; null when the job is gone/unlinked.
         service_date: sql<string | null>`(SELECT j.scheduled_date FROM jobs j WHERE j.id = ${invoicesTable.job_id})`,
+        // [charge-card 2026-06-21] Card-on-file info so the list/detail can show
+        // a "Charge Card on File" action only when a reusable Stripe PaymentMethod
+        // exists for the client (captured at online booking via SetupIntent).
+        card_last_four: clientsTable.card_last_four,
+        card_brand: clientsTable.card_brand,
+        client_payment_source: clientsTable.payment_source,
+        has_card_on_file: sql<boolean>`(${clientsTable.stripe_payment_method_id} IS NOT NULL AND ${clientsTable.stripe_customer_id} IS NOT NULL)`,
       })
       .from(invoicesTable)
       .leftJoin(clientsTable, eq(invoicesTable.client_id, clientsTable.id))
@@ -377,6 +384,11 @@ router.get("/:id", requireAuth, async (req, res) => {
         // [invoice-service-date 2026-06-20] Live service date from the linked job
         // (see list select). Reschedule-proof; null when job gone/unlinked.
         service_date: sql<string | null>`(SELECT j.scheduled_date FROM jobs j WHERE j.id = ${invoicesTable.job_id})`,
+        // [charge-card 2026-06-21] Card-on-file info (see list select).
+        card_last_four: clientsTable.card_last_four,
+        card_brand: clientsTable.card_brand,
+        client_payment_source: clientsTable.payment_source,
+        has_card_on_file: sql<boolean>`(${clientsTable.stripe_payment_method_id} IS NOT NULL AND ${clientsTable.stripe_customer_id} IS NOT NULL)`,
       })
       .from(invoicesTable)
       .leftJoin(clientsTable, eq(invoicesTable.client_id, clientsTable.id))

--- a/artifacts/qleno/src/pages/invoice-detail.tsx
+++ b/artifacts/qleno/src/pages/invoice-detail.tsx
@@ -352,10 +352,13 @@ export default function InvoiceDetailPage() {
           )}
           {(effectiveStatus === "sent" || effectiveStatus === "overdue") && (
             <>
-              <button onClick={handleCharge} disabled={charging}
-                style={{ display: "flex", alignItems: "center", gap: 6, padding: "9px 16px", backgroundColor: "var(--brand)", color: "#FFFFFF", border: "none", borderRadius: 8, fontSize: 13, fontWeight: 700, cursor: "pointer" }}>
-                <CreditCard size={14} /> {charging ? "Charging..." : "Charge Now"}
-              </button>
+              {invoice.has_card_on_file && (
+                <button onClick={handleCharge} disabled={charging}
+                  title={`Charge the card captured at booking${invoice.card_last_four ? ` (•••• ${invoice.card_last_four})` : ""}`}
+                  style={{ display: "flex", alignItems: "center", gap: 6, padding: "9px 16px", backgroundColor: "var(--brand)", color: "#FFFFFF", border: "none", borderRadius: 8, fontSize: 13, fontWeight: 700, cursor: "pointer" }}>
+                  <CreditCard size={14} /> {charging ? "Charging..." : `Charge Card on File${invoice.card_last_four ? ` •••• ${invoice.card_last_four}` : ""}`}
+                </button>
+              )}
               <button onClick={handleMarkPaidNow} disabled={markingPaid}
                 style={{ display: "flex", alignItems: "center", gap: 6, padding: "9px 16px", backgroundColor: "#16A34A", color: "#FFFFFF", border: "none", borderRadius: 8, fontSize: 13, fontWeight: 700, cursor: "pointer" }}>
                 <DollarSign size={14} /> {markingPaid ? "Marking..." : "Mark Paid"}

--- a/artifacts/qleno/src/pages/invoices.tsx
+++ b/artifacts/qleno/src/pages/invoices.tsx
@@ -536,6 +536,20 @@ export default function InvoicesPage() {
       setPayingInvoiceId(null);
     }
   }
+  async function chargeInvoiceRow(invId: number) {
+    setPayingInvoiceId(invId);
+    try {
+      const r = await apiFetch(`/api/invoices/${invId}/charge`, { method: "POST", body: JSON.stringify({}) });
+      if (r.outcome === "paid") toast({ title: `Charged $${(r.amount || 0).toFixed(2)}` });
+      else if (r.outcome === "needs_manual") toast({ title: r.message });
+      else toast({ title: r.message || "Charge failed", variant: "destructive" });
+      refetch();
+    } catch (err: any) {
+      toast({ title: "Charge failed", description: err?.message || "", variant: "destructive" });
+    } finally {
+      setPayingInvoiceId(null);
+    }
+  }
   async function markInvoiceUnpaid(invId: number) {
     setPayingInvoiceId(invId);
     try {
@@ -849,6 +863,13 @@ export default function InvoicesPage() {
                         </span>
                       </td>
                       <td style={{ padding: "13px 18px", textAlign: "right", whiteSpace: "nowrap" }} onClick={e => e.stopPropagation()}>
+                        {(effectiveStatus === "sent" || effectiveStatus === "overdue") && inv.has_card_on_file && (
+                          <button onClick={() => chargeInvoiceRow(inv.id)} disabled={payingInvoiceId === inv.id}
+                            title={`Charge card on file${inv.card_last_four ? ` (•••• ${inv.card_last_four})` : ""}`}
+                            style={{ marginRight: 8, padding: "5px 10px", border: "none", backgroundColor: "var(--brand)", color: "#FFFFFF", fontSize: 12, fontWeight: 700, borderRadius: 6, cursor: "pointer", fontFamily: FF }}>
+                            {payingInvoiceId === inv.id ? "…" : (inv.card_last_four ? `Charge •••• ${inv.card_last_four}` : "Charge")}
+                          </button>
+                        )}
                         {(effectiveStatus === "sent" || effectiveStatus === "overdue") && (
                           <button onClick={() => markInvoicePaid(inv.id)} disabled={payingInvoiceId === inv.id}
                             title="Mark paid (today)"


### PR DESCRIPTION
Surfaces the off-session Stripe charge in the UI, only when a real card is on file.

## Changes
- **`routes/invoices.ts`** — list + detail SELECTs now return `card_last_four`, `card_brand`, `client_payment_source`, and `has_card_on_file` (= `stripe_payment_method_id IS NOT NULL AND stripe_customer_id IS NOT NULL`).
- **`invoice-detail.tsx`** — the charge button now renders **only when `has_card_on_file`**, labeled **"Charge Card on File •••• NNNN"** → existing `handleCharge` → `POST /api/invoices/:id/charge`.
- **`invoices.tsx`** — list-row **Charge •••• NNNN** action on sent/overdue invoices with a card, calling the same endpoint.

No charge logic changed (`lib/charge-invoice.ts` untouched), no schema change, no secrets. Invoice-scoped.

## Test
4 required checks (dispatch-guard, tsc-check, build-api-server, build-frontend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)