### PR TITLE
feat(booking): abandoned-booking follow-up drip (5 steps, co1+co4)

### DIFF
--- a/artifacts/api-server/src/cutover-data-migration.ts
+++ b/artifacts/api-server/src/cutover-data-migration.ts
@@ -115,6 +115,122 @@ export async function runCutoverDataMigration(): Promise<void> {
       err,
     );
   }
+  try {
+    await ensureAbandonedBookingFollowup();
+  } catch (err) {
+    console.error(
+      "[cutover-migration] abandoned_booking follow-up seed failed (non-fatal):",
+      err,
+    );
+  }
+}
+
+/**
+ * Abandoned-booking follow-up drip — mirrors the quote_followup /
+ * post_job_retention sequences. Two parts, both idempotent:
+ *
+ *   1. Add follow_up_enrollments.abandoned_booking_id (FK → abandoned_bookings,
+ *      ON DELETE SET NULL) so an enrollment can hang off an abandoned booking
+ *      the same way others hang off quote_id / client_id / lead_id. SET NULL so
+ *      the /book/confirm cleanup DELETE of the abandoned row doesn't block.
+ *   2. Seed an 'abandoned_booking' sequence + its 5 steps for every company that
+ *      already has follow-up sequences but not this one yet. Runs for co1 + co4
+ *      identically (same content), matching how the other sequences are shaped.
+ *
+ * Step-1 timing (+20 min) is set by enrollForAbandonedBooking() at enroll time
+ * (delay_hours is integer-hours and can't express 20 min); steps 2–5 advance via
+ * delay_hours from the prior step (2h, 22h, 48h, 72h ≈ +2h, +1d, +3d, +6d from
+ * abandon). Seeded is_active=true to match the other sequences — note co4 has
+ * comms ON, so enrollments there will fire once deployed (gate via is_active if
+ * a hold is wanted).
+ */
+async function ensureAbandonedBookingFollowup(): Promise<void> {
+  // Part 1 — link column (no-op if follow_up_enrollments or abandoned_bookings
+  // isn't present yet; both are created earlier / by phes-data-migration).
+  await db.execute(
+    sql.raw(`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema='public' AND table_name='follow_up_enrollments'
+      ) THEN
+        RAISE NOTICE 'cutover-migration: follow_up_enrollments not present, skipping abandoned_booking_id add';
+        RETURN;
+      END IF;
+      IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema='public' AND table_name='follow_up_enrollments'
+          AND column_name='abandoned_booking_id'
+      ) THEN
+        ALTER TABLE follow_up_enrollments
+          ADD COLUMN abandoned_booking_id integer
+            REFERENCES abandoned_bookings(id) ON DELETE SET NULL;
+      END IF;
+    END
+    $$;
+  `),
+  );
+
+  // Part 2 — seed the sequence + steps per company (idempotent: only companies
+  // that have follow-up sequences but lack an 'abandoned_booking' one).
+  const companies = await db.execute(
+    sql`
+      SELECT DISTINCT company_id FROM follow_up_sequences
+      WHERE company_id NOT IN (
+        SELECT company_id FROM follow_up_sequences WHERE sequence_type = 'abandoned_booking'
+      )
+    `,
+  );
+
+  const step2Email =
+    `<h2 style="font-size:22px;color:#1A1917;margin:0 0 12px;">Still want that cleaning, {{first_name}}?</h2>` +
+    `<p style="font-size:15px;color:#1A1917;line-height:1.6;margin:0 0 16px;">You started booking with {{company_name}} but didn't quite finish. No worries — your details are saved and you can pick up right where you left off.</p>` +
+    `<p style="text-align:center;margin:24px 0;"><a href="{{resume_link}}" style="background:#00C9A0;color:#0A0E1A;text-decoration:none;font-weight:700;padding:14px 28px;border-radius:8px;display:inline-block;font-size:15px;">Finish my booking</a></p>` +
+    `<p style="font-size:14px;color:#1A1917;line-height:1.6;margin:0;">Why customers choose us: every cleaner is vetted and background-checked, every clean is backed by our satisfaction guarantee (if we miss a spot, we come back and re-clean for free), and rescheduling is always easy.</p>` +
+    `<p style="font-size:14px;color:#1A1917;line-height:1.6;margin:16px 0 0;">Questions? Call or text {{office_phone}} or just reply to this email.</p>` +
+    `<p style="font-size:14px;color:#1A1917;margin:16px 0 0;">The {{company_name}} Team</p>`;
+
+  const step4Email =
+    `<h2 style="font-size:22px;color:#1A1917;margin:0 0 12px;">Here's 10% off to finish up, {{first_name}}</h2>` +
+    `<p style="font-size:15px;color:#1A1917;line-height:1.6;margin:0 0 16px;">We'd love to get your home on the schedule — so here's <strong>10% off your first clean</strong> when you complete your booking. Your saved details are ready to go.</p>` +
+    `<p style="text-align:center;margin:24px 0;"><a href="{{resume_link}}" style="background:#00C9A0;color:#0A0E1A;text-decoration:none;font-weight:700;padding:14px 28px;border-radius:8px;display:inline-block;font-size:15px;">Finish my booking &amp; save 10%</a></p>` +
+    `<p style="font-size:14px;color:#1A1917;line-height:1.6;margin:0;">Offer applies to your first clean. Questions? Call or text {{office_phone}} or reply to this email.</p>` +
+    `<p style="font-size:14px;color:#1A1917;margin:16px 0 0;">The {{company_name}} Team</p>`;
+
+  const steps = [
+    { n: 1, h: 0, ch: "sms", subj: null,
+      body: "Hi {{first_name}}, looks like you started booking your {{company_name}} cleaning but didn't finish — want me to hold your spot? Pick up where you left off: {{resume_link}}" },
+    { n: 2, h: 2, ch: "email", subj: "Still want that cleaning, {{first_name}}?", body: step2Email },
+    { n: 3, h: 22, ch: "sms", subj: null,
+      body: "Hi {{first_name}}, your {{company_name}} booking is still saved and we have openings this week. Want me to get you on the schedule? {{resume_link}}" },
+    { n: 4, h: 48, ch: "email", subj: "Here's 10% to finish up", body: step4Email },
+    { n: 5, h: 72, ch: "sms", subj: null,
+      body: "Hi {{first_name}}, I'll close out your booking for now — reply anytime and we'll pick right back up. Thanks from the {{company_name}} team." },
+  ];
+
+  for (const row of companies.rows as any[]) {
+    const companyId = row.company_id;
+    const seq = await db.execute(
+      sql`
+        INSERT INTO follow_up_sequences (company_id, sequence_type, name, is_active)
+        VALUES (${companyId}, 'abandoned_booking', 'Abandoned Booking Follow-Up', true)
+        RETURNING id
+      `,
+    );
+    const seqId = (seq.rows[0] as any).id;
+    for (const s of steps) {
+      await db.execute(
+        sql`
+          INSERT INTO follow_up_steps (sequence_id, step_number, delay_hours, channel, subject, message_template)
+          VALUES (${seqId}, ${s.n}, ${s.h}, ${s.ch}, ${s.subj}, ${s.body})
+        `,
+      );
+    }
+    console.log(
+      `[cutover-migration] seeded abandoned_booking sequence ${seqId} (5 steps) for company ${companyId}`,
+    );
+  }
 }
 
 /**

--- a/artifacts/api-server/src/routes/public.ts
+++ b/artifacts/api-server/src/routes/public.ts
@@ -11,6 +11,7 @@ import { companiesTable } from "@workspace/db/schema";
 import { eq, and } from "drizzle-orm";
 import { getBranchByZip } from "../lib/branchRouter";
 import { buildClientConfirmationEmail, buildOfficeNotificationEmail } from "../lib/emailTemplates";
+import { enrollForAbandonedBooking, stopEnrollmentsForAbandonedBooking } from "../services/followUpService.js";
 
 const router = Router();
 
@@ -872,7 +873,10 @@ router.post("/book/confirm", rateLimit, async (req, res) => {
           ${scopeLabel}, 'booking_widget', 'booked', ${jobId}, NOW(), NOW(), NOW()
         )
       `);
-      // Remove any abandoned booking for this email
+      // Booking finished — stop any abandoned-booking drip first (FK is
+      // ON DELETE SET NULL, so the delete below only nulls an already-stopped
+      // enrollment), then remove the abandoned booking for this email.
+      await stopEnrollmentsForAbandonedBooking(company_id, email, "booking_completed");
       await db.execute(drizzleSql`
         DELETE FROM abandoned_bookings WHERE company_id = ${company_id} AND email = ${email}
       `);
@@ -1337,6 +1341,7 @@ router.post("/book/abandon-track", rateLimit, async (req, res) => {
         drizzleSql`SELECT id FROM abandoned_bookings WHERE company_id = ${company_id} AND email = ${email} LIMIT 1`
       );
       if (existing.rows.length > 0) {
+        const abId = (existing.rows[0] as any).id;
         await db.execute(drizzleSql`
           UPDATE abandoned_bookings SET
             first_name = COALESCE(${first_name || null}, first_name),
@@ -1349,14 +1354,19 @@ router.post("/book/abandon-track", rateLimit, async (req, res) => {
             updated_at = NOW()
           WHERE company_id = ${company_id} AND email = ${email}
         `);
+        // Idempotent enroll (no-ops if already enrolled or sequence inactive).
+        await enrollForAbandonedBooking(company_id, abId);
         return res.json({ ok: true, action: "updated" });
       }
     }
-    await db.execute(drizzleSql`
+    const inserted = await db.execute(drizzleSql`
       INSERT INTO abandoned_bookings (company_id, first_name, last_name, email, phone, address, zip, scope, step_abandoned, created_at, updated_at)
       VALUES (${company_id}, ${first_name || null}, ${last_name || null}, ${email || null}, ${phone || null},
               ${address || null}, ${zip || null}, ${scope || null}, ${step_abandoned}, NOW(), NOW())
+      RETURNING id
     `);
+    const newAbId = (inserted.rows[0] as any)?.id;
+    if (newAbId) await enrollForAbandonedBooking(company_id, newAbId);
     return res.json({ ok: true, action: "created" });
   } catch (err: any) {
     console.error("POST /public/book/abandon-track:", err);

--- a/artifacts/api-server/src/services/followUpService.ts
+++ b/artifacts/api-server/src/services/followUpService.ts
@@ -268,6 +268,44 @@ export async function enrollForJobComplete(
   }
 }
 
+// ── Enroll for abandoned-booking follow-up ─────────────────────────────────────
+// Fired from POST /api/public/book/abandon-track after the abandoned_bookings
+// upsert. Step 1 fires +20 min (set explicitly here; delay_hours is integer
+// hours so it can't hold 20 min). Dedupes on the abandoned_booking row.
+export async function enrollForAbandonedBooking(
+  companyId: number,
+  abandonedBookingId: number,
+): Promise<void> {
+  try {
+    const seqRows = await db.execute(sql`
+      SELECT id FROM follow_up_sequences
+      WHERE company_id = ${companyId} AND sequence_type = 'abandoned_booking' AND is_active = true
+      LIMIT 1
+    `);
+    if (!seqRows.rows.length) return;
+    const sequenceId = (seqRows.rows[0] as any).id;
+
+    // Deduplicate: one active enrollment per abandoned booking
+    const existing = await db.execute(sql`
+      SELECT id FROM follow_up_enrollments
+      WHERE sequence_id = ${sequenceId} AND abandoned_booking_id = ${abandonedBookingId}
+        AND completed_at IS NULL AND stopped_at IS NULL
+      LIMIT 1
+    `);
+    if (existing.rows.length > 0) return;
+
+    await db.execute(sql`
+      INSERT INTO follow_up_enrollments
+        (company_id, sequence_id, abandoned_booking_id, current_step, next_fire_at)
+      VALUES
+        (${companyId}, ${sequenceId}, ${abandonedBookingId}, 1, NOW() + INTERVAL '20 minutes')
+    `);
+    console.log(`[follow-up] Enrolled abandoned_booking ${abandonedBookingId} in abandoned_booking sequence ${sequenceId}`);
+  } catch (err) {
+    console.error("[follow-up] enrollForAbandonedBooking error (non-fatal):", err);
+  }
+}
+
 // ── Stop enrollments for a client (rebooked / booked) ─────────────────────────
 export async function stopEnrollmentsForClient(
   clientId: number,
@@ -313,6 +351,32 @@ export async function stopEnrollmentsForQuote(
   }
 }
 
+// ── Stop abandoned-booking enrollments (the customer finished booking) ──────────
+// Keyed by email since /book/confirm knows the email, not the abandoned row id.
+// Run BEFORE the confirm-time DELETE of the abandoned_bookings row (the FK is
+// ON DELETE SET NULL, so a delete only nulls the link on an already-stopped row).
+export async function stopEnrollmentsForAbandonedBooking(
+  companyId: number,
+  email: string,
+  reason: string,
+): Promise<void> {
+  try {
+    await db.execute(sql`
+      UPDATE follow_up_enrollments fe
+      SET stopped_at = NOW(), stopped_reason = ${reason}
+      FROM abandoned_bookings ab
+      WHERE fe.abandoned_booking_id = ab.id
+        AND ab.company_id = ${companyId}
+        AND lower(ab.email) = lower(${email})
+        AND fe.completed_at IS NULL
+        AND fe.stopped_at IS NULL
+    `);
+    console.log(`[follow-up] Stopped abandoned_booking enrollments for ${email} — reason: ${reason}`);
+  } catch (err) {
+    console.error("[follow-up] stopEnrollmentsForAbandonedBooking error (non-fatal):", err);
+  }
+}
+
 // ── Process due enrollments (cron body) ───────────────────────────────────────
 export async function processDueEnrollments(): Promise<void> {
   if (process.env.COMMS_ENABLED !== "true") {
@@ -323,7 +387,7 @@ export async function processDueEnrollments(): Promise<void> {
     const due = await db.execute(sql`
       SELECT
         fe.id, fe.company_id, fe.sequence_id, fe.quote_id, fe.client_id, fe.lead_id,
-        fe.current_step,
+        fe.abandoned_booking_id, fe.current_step,
         fs.name AS sequence_name, fs.sequence_type
       FROM follow_up_enrollments fe
       JOIN follow_up_sequences fs ON fs.id = fe.sequence_id
@@ -404,6 +468,17 @@ async function processEnrollment(enr: any): Promise<void> {
       recipientPhone = l.phone || null;
       zip = l.zip || null;
     }
+  } else if (enr.abandoned_booking_id) {
+    const abRows = await db.execute(sql`
+      SELECT first_name, email, phone, zip FROM abandoned_bookings WHERE id = ${enr.abandoned_booking_id} LIMIT 1
+    `);
+    if (abRows.rows.length) {
+      const a = abRows.rows[0] as any;
+      firstName = a.first_name || "";
+      recipientEmail = a.email || null;
+      recipientPhone = a.phone || null;
+      zip = a.zip || null;
+    }
   }
 
   // Per-branch routing — every comm goes through getBranchByZip (CLAUDE.md).
@@ -435,6 +510,15 @@ async function processEnrollment(enr: any): Promise<void> {
   // Quote-tied enrollments (the quote email/SMS) get the full quote merge set:
   // public estimate link, total, itemized line items, address, contact, brand.
   if (enr.quote_id) Object.assign(mergeVars, await buildQuoteMergeVars(enr.company_id, enr.quote_id));
+  // Abandoned-booking enrollments get {{resume_link}} (the company booking page)
+  // + {{office_phone}} (the steps reference both).
+  if (enr.abandoned_booking_id) {
+    const slugRows = await db.execute(sql`SELECT slug FROM companies WHERE id = ${enr.company_id} LIMIT 1`);
+    const slug = (slugRows.rows[0] as any)?.slug;
+    const base = appBaseUrl();
+    mergeVars.resume_link = slug ? `${base}/book/${slug}` : `${base}/book`;
+    mergeVars.office_phone = mergeVars.company_phone;
+  }
   const body    = resolveMergeFields(rawBody, mergeVars);
   const subject = rawSubject ? resolveMergeFields(rawSubject, mergeVars) : "";
   const emailBrand: EmailBrand = { companyName: mergeVars.company_name, phone: mergeVars.company_phone, email: mergeVars.company_email };


### PR DESCRIPTION
## What
New **Abandoned Booking Follow-Up** sequence — when a customer starts the online booking widget but doesn't finish, they get a 5-touch drip to bring them back. Mirrors the existing `quote_followup` / `post_job_retention` sequences.

## Steps
| # | Timing | Channel | Content |
|---|---|---|---|
| 1 | +20 min | SMS | hold-your-spot + `{{resume_link}}` |
| 2 | +2 h | Email | reassurance (vetted/background-checked, satisfaction guarantee, easy reschedule) + "Finish my booking" button |
| 3 | +1 day | SMS | still saved, openings this week + link |
| 4 | +3 days | Email | 10% off first clean + finish button |
| 5 | +6 days | SMS | closing out, reply anytime |

(Step 1 timing set at enroll time — `delay_hours` is integer-hours; steps 2–5 advance via `delay_hours` 2/22/48/72 ≈ +2h/+1d/+3d/+6d from abandon.)

## Wiring
- **Migration** (`cutover-data-migration.ts`): adds `follow_up_enrollments.abandoned_booking_id` (FK → `abandoned_bookings`, `ON DELETE SET NULL`), then seeds the sequence + 5 steps for every company that has follow-up sequences but not this one (**co1 + co4 identical**). Idempotent.
- **`followUpService.ts`**: `enrollForAbandonedBooking` (step 1 +20 min, deduped per abandoned row), recipient resolution from `abandoned_bookings`, `{{resume_link}}`/`{{office_phone}}` merge vars, and `stopEnrollmentsForAbandonedBooking`.
- **`public.ts`**: enroll on `/book/abandon-track` (both upsert paths); `/book/confirm` stops the drip before deleting the abandoned row.

## Guards (standard, unchanged)
`COMMS_ENABLED` + company + branch gating; one enrollment per abandon; stop on completed booking; per-branch routing via `getBranchByZip`.

## ⚠️ Deploy note (why merge is held)
Seeded `is_active=true` to match the other sequences. **co4 (Schaumburg) has comms ON**, so its abandoned-booking enrollments will start firing once deployed. If you want to hold co4, set that sequence's `is_active=false` (or hold deploy). co1 stays inert until `COMMS_ENABLED` flips.

`{{resume_link}}` currently points to the company booking page (`/book/<slug>`); a true token-based resume is a future enhancement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)