### PR TITLE
feat(promos): auto-applied 15% off 2nd recurring visit + any deep clean

### DIFF
--- a/artifacts/api-server/package.json
+++ b/artifacts/api-server/package.json
@@ -11,7 +11,8 @@
     "test:bundle": "tsx --test src/tests/bundle-discount.test.ts",
     "test:parking": "DATABASE_URL=postgres://stub@stub/stub tsx --test src/tests/parking-waterfall.test.ts",
     "test:lms": "DATABASE_URL=postgres://stub@stub/stub tsx --test src/tests/lms-*.test.ts",
-    "test:cutover": "DATABASE_URL=postgres://stub@stub/stub tsx --test src/tests/cutover-*.test.ts"
+    "test:cutover": "DATABASE_URL=postgres://stub@stub/stub tsx --test src/tests/cutover-*.test.ts",
+    "test:promos": "DATABASE_URL=postgres://stub@stub/stub tsx --test src/tests/auto-promos.test.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.71.0",

--- a/artifacts/api-server/src/index.ts
+++ b/artifacts/api-server/src/index.ts
@@ -225,6 +225,15 @@ async function startup() {
   } catch (err: any) {
     console.error("[startup] runCutoverDataMigration — non-fatal:", err?.message ?? err);
   }
+  // [auto-promos 2026-06-21] auto_promos table + seed 15% offers for co1/co4.
+  try {
+    await withBootTimeout("runAutoPromosMigration", SCHEMA_TIMEOUT_MS, async () => {
+      const { runAutoPromosMigration } = await import("./lib/auto-promos.js");
+      await runAutoPromosMigration([1, 4]);
+    });
+  } catch (err: any) {
+    console.error("[startup] runAutoPromosMigration — non-fatal:", err?.message ?? err);
+  }
   // [booking-confirmation GAP1] token column + job_scheduled SMS template (all tenants)
   try {
     await withBootTimeout("ensureBookingConfirmationSetup", SCHEMA_TIMEOUT_MS, async () => {

--- a/artifacts/api-server/src/lib/auto-promos-core.ts
+++ b/artifacts/api-server/src/lib/auto-promos-core.ts
@@ -1,0 +1,53 @@
+// [auto-promos 2026-06-21] PURE promo logic — math + the rule selector. Kept in
+// its own module with NO `@workspace/db` import so unit tests can import it
+// without triggering the Drizzle connection init (same pattern as
+// recurring-cadences.ts). The DB-backed helpers live in auto-promos.ts and
+// re-export everything here.
+
+export const SECOND_RECURRING = "second_recurring";
+export const DEEP_CLEAN = "deep_clean";
+
+export type ActivePromo = { kind: string; pct: number; label: string };
+
+const r2 = (n: number) => Math.round(n * 100) / 100;
+
+// Default labels when a tenant row doesn't set one. Kept here so the invoice
+// reads cleanly regardless of how the auto_promos row was seeded.
+export function defaultPromoLabel(kind: string, pct: number): string {
+  const p = Number.isInteger(pct) ? String(pct) : pct.toFixed(2);
+  if (kind === SECOND_RECURRING) return `Second Visit Promo (${p}% off)`;
+  if (kind === DEEP_CLEAN) return `Deep Clean Promo (${p}% off)`;
+  return `Promo (${p}% off)`;
+}
+
+// The job_discounts.code stamped for a kind — stable per kind so re-stamping is
+// idempotent and the rows are easy to find/clean.
+export function promoCode(kind: string): string {
+  return `AUTO_${kind.toUpperCase()}`;
+}
+
+// Pure: dollars off for a percent against a base. Clamps junk to 0.
+export function promoAmount(pct: number, base: number): number {
+  if (!(pct > 0) || !(base > 0)) return 0;
+  return r2((pct / 100) * base);
+}
+
+// Pure: pick the single applicable promo for a job context. NON-STACKING by
+// design — a job gets at most ONE auto-promo (the highest-percent applicable
+// one), so a 2nd-visit deep clean is 15% off, never 30%. Returns null when none
+// apply.
+export function selectAutoPromo(ctx: {
+  serviceType: string | null;
+  isSecondRecurringVisit: boolean;
+  active: ActivePromo[];
+}): ActivePromo | null {
+  const applicable: ActivePromo[] = [];
+  for (const p of ctx.active) {
+    if (!(p.pct > 0)) continue;
+    if (p.kind === DEEP_CLEAN && ctx.serviceType === "deep_clean") applicable.push(p);
+    if (p.kind === SECOND_RECURRING && ctx.isSecondRecurringVisit) applicable.push(p);
+  }
+  if (!applicable.length) return null;
+  applicable.sort((a, b) => b.pct - a.pct);
+  return applicable[0];
+}

--- a/artifacts/api-server/src/lib/auto-promos.ts
+++ b/artifacts/api-server/src/lib/auto-promos.ts
@@ -1,0 +1,222 @@
+// [auto-promos 2026-06-21] Engine for tenant-scoped, automatically-applied
+// promotional discounts. Two offers ship initially:
+//   second_recurring — 15% off the SECOND visit of a customer's recurring plan.
+//   deep_clean       — 15% off ANY deep clean, year-round.
+//
+// Design (single source of truth = job_discounts):
+//   * The realized discount ALWAYS lands as a job_discounts row (code prefixed
+//     'AUTO_'), so the existing invoice builder itemizes it automatically and
+//     every paid dollar is auditable. No new "discount" surface is invented.
+//   * `ensureAutoPromosForJob` is the ONE chokepoint — called from
+//     buildJobLineItems, so EVERY invoice surface (completion, draft re-sync,
+//     office recalc) reflects the promo with no per-call-site wiring. Idempotent:
+//     it deletes any prior AUTO_ rows for the job and re-stamps the current one,
+//     so a changed rate / re-edit can never duplicate or go stale.
+//   * `computeCheckoutPromo` lets runCalculate surface the deep-clean promo at
+//     online-booking time so the advertised price is honored at checkout too.
+//
+// Pure helpers (promoAmount / selectAutoPromo) carry the math + the rule and are
+// unit-tested without a DB.
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+import {
+  SECOND_RECURRING,
+  DEEP_CLEAN,
+  defaultPromoLabel,
+  promoCode,
+  promoAmount,
+  selectAutoPromo,
+  type ActivePromo,
+} from "./auto-promos-core.js";
+
+// Re-export the pure surface so existing importers of this module are unchanged.
+export {
+  SECOND_RECURRING,
+  DEEP_CLEAN,
+  defaultPromoLabel,
+  promoCode,
+  promoAmount,
+  selectAutoPromo,
+};
+export type { ActivePromo };
+
+// ── DB-backed helpers ────────────────────────────────────────────────────────
+//
+// Each DB helper takes an optional `exec` executor (the global pool by default).
+// Pass a Drizzle transaction to run the whole flow atomically — used by the
+// transactional verification harness so the real code can be exercised against
+// production data and then rolled back, mutating nothing. Mirrors the recurring
+// engine's `txOrDb` convention.
+
+// Load a tenant's active auto-promos. Returns [] when the table doesn't exist
+// yet (fresh deploy before the boot migration) or the tenant has none — callers
+// then no-op, so this can never break a job/invoice flow.
+export async function loadActivePromos(companyId: number, exec: any = db): Promise<ActivePromo[]> {
+  try {
+    const rows = (await exec.execute(sql`
+      SELECT kind, discount_pct, label
+        FROM auto_promos
+       WHERE company_id = ${companyId} AND is_active = true
+    `)).rows as any[];
+    return rows.map((r) => {
+      const pct = parseFloat(String(r.discount_pct));
+      const kind = String(r.kind);
+      return { kind, pct, label: r.label || defaultPromoLabel(kind, pct) };
+    });
+  } catch {
+    return [];
+  }
+}
+
+// 1-based ordinal of a job within its recurring schedule, ordered by the cadence
+// slot (occurrence_date, falling back to scheduled_date for legacy rows). The
+// 2nd visit is ordinal 2. Counts every prior occurrence row for the schedule
+// (regardless of status) so a cancelled-but-present first visit still anchors
+// the count. Returns null when the job isn't part of a recurring schedule.
+export async function getRecurringOrdinal(companyId: number, jobId: number, exec: any = db): Promise<number | null> {
+  const [job] = (await exec.execute(sql`
+    SELECT recurring_schedule_id, COALESCE(occurrence_date, scheduled_date)::text AS occ
+      FROM jobs WHERE id = ${jobId} AND company_id = ${companyId} LIMIT 1
+  `)).rows as any[];
+  if (!job || job.recurring_schedule_id == null || !job.occ) return null;
+  const [cnt] = (await exec.execute(sql`
+    SELECT count(*)::int AS n
+      FROM jobs
+     WHERE company_id = ${companyId}
+       AND recurring_schedule_id = ${job.recurring_schedule_id}
+       AND COALESCE(occurrence_date, scheduled_date) < ${job.occ}::date
+  `)).rows as any[];
+  return Number(cnt?.n ?? 0) + 1;
+}
+
+// THE chokepoint. Ensures a job carries exactly the auto-promo it's entitled to
+// (or none) as a job_discounts row, so the invoice builder itemizes it. Returns
+// the stamped promo (with computed amount) or null. Idempotent + self-healing:
+// always clears prior AUTO_ rows first, so re-running on an edited job re-derives
+// the correct discount and never duplicates. Manual (non-AUTO_) discounts are
+// never touched.
+export async function ensureAutoPromosForJob(
+  companyId: number,
+  jobId: number,
+  exec: any = db,
+): Promise<{ kind: string; code: string; pct: number; amount: number; base: number } | null> {
+  let job: any;
+  try {
+    [job] = (await exec.execute(sql`
+      SELECT service_type, base_fee, billed_amount, recurring_schedule_id
+        FROM jobs WHERE id = ${jobId} AND company_id = ${companyId} LIMIT 1
+    `)).rows as any[];
+  } catch {
+    return null;
+  }
+  if (!job) return null;
+
+  const active = await loadActivePromos(companyId, exec);
+
+  // Clear any prior auto-promo rows so a re-stamp is always clean.
+  try {
+    await exec.execute(sql`
+      DELETE FROM job_discounts
+       WHERE company_id = ${companyId} AND job_id = ${jobId} AND code LIKE 'AUTO\\_%'
+    `);
+  } catch {
+    // job_discounts must exist in any real deploy; if the delete fails we bail
+    // rather than risk a partial state.
+    return null;
+  }
+
+  if (!active.length) return null;
+
+  // Is this the 2nd visit of a recurring plan?
+  let isSecond = false;
+  if (job.recurring_schedule_id != null && active.some((p) => p.kind === SECOND_RECURRING)) {
+    const ordinal = await getRecurringOrdinal(companyId, jobId, exec);
+    isSecond = ordinal === 2;
+  }
+
+  const chosen = selectAutoPromo({
+    serviceType: job.service_type ?? null,
+    isSecondRecurringVisit: isSecond,
+    active,
+  });
+  if (!chosen) return null;
+
+  // Base = the job's main service-line amount as it appears on the invoice
+  // (billed_amount for metered/hourly jobs, else base_fee). This is "the
+  // per-visit / deep-clean price" — add-on lines (parking, etc.) are NOT
+  // discounted.
+  const base = job.billed_amount != null
+    ? parseFloat(String(job.billed_amount))
+    : parseFloat(String(job.base_fee ?? "0"));
+  const amount = promoAmount(chosen.pct, base);
+  if (!(amount > 0)) return null;
+
+  const code = promoCode(chosen.kind);
+  await exec.execute(sql`
+    INSERT INTO job_discounts (company_id, job_id, code, type, value, amount, reason)
+    VALUES (${companyId}, ${jobId}, ${code}, 'percent', ${chosen.pct}, ${amount}, ${chosen.label})
+  `);
+  return { kind: chosen.kind, code, pct: chosen.pct, amount, base };
+}
+
+// Checkout-time promo for the online booking widget / quote calculator. Only the
+// deep-clean promo is determinable from a single quote (the 2nd-recurring promo
+// is contextual to a schedule occurrence and lands at invoice build). Computes
+// the discount against the cleaning base price. Returns null when no deep-clean
+// promo is active for the tenant.
+export async function computeCheckoutPromo(opts: {
+  companyId: number;
+  serviceType: string | null;
+  basePrice: number;
+}): Promise<{ kind: string; pct: number; amount: number; label: string } | null> {
+  if (opts.serviceType !== "deep_clean") return null;
+  const active = await loadActivePromos(opts.companyId);
+  const dc = active.find((p) => p.kind === DEEP_CLEAN && p.pct > 0);
+  if (!dc) return null;
+  const amount = promoAmount(dc.pct, opts.basePrice);
+  if (!(amount > 0)) return null;
+  return { kind: dc.kind, pct: dc.pct, amount, label: dc.label };
+}
+
+// Idempotent boot migration: create the auto_promos table and seed the two
+// initial offers for the requested companies (Phes Oak Lawn = co1, Schaumburg =
+// co4) at 15%. Re-running is a no-op (ON CONFLICT-free guarded inserts). Safe to
+// call on every cold start.
+export async function runAutoPromosMigration(seedCompanyIds: number[] = [1, 4]): Promise<void> {
+  try {
+    await db.execute(sql`
+      CREATE TABLE IF NOT EXISTS auto_promos (
+        id serial PRIMARY KEY,
+        company_id integer NOT NULL REFERENCES companies(id),
+        kind text NOT NULL,
+        discount_pct numeric(5,2) NOT NULL,
+        is_active boolean NOT NULL DEFAULT true,
+        label text,
+        created_at timestamp NOT NULL DEFAULT now()
+      )
+    `);
+    // One active row per (company, kind). Partial unique index keeps the seed
+    // idempotent and prevents accidental duplicate active promos of a kind.
+    await db.execute(sql`
+      CREATE UNIQUE INDEX IF NOT EXISTS auto_promos_company_kind_active_uidx
+        ON auto_promos (company_id, kind) WHERE is_active = true
+    `);
+    for (const cid of seedCompanyIds) {
+      // Only seed if the company exists and has no active row for the kind.
+      for (const kind of [SECOND_RECURRING, DEEP_CLEAN]) {
+        await db.execute(sql`
+          INSERT INTO auto_promos (company_id, kind, discount_pct, label)
+          SELECT ${cid}, ${kind}, 15.00, ${defaultPromoLabel(kind, 15)}
+           WHERE EXISTS (SELECT 1 FROM companies WHERE id = ${cid})
+             AND NOT EXISTS (
+               SELECT 1 FROM auto_promos
+                WHERE company_id = ${cid} AND kind = ${kind} AND is_active = true
+             )
+        `);
+      }
+    }
+    console.log(`[auto-promos] migration ok — seeded companies ${seedCompanyIds.join(", ")}`);
+  } catch (err) {
+    console.error("[auto-promos] migration error (non-fatal):", err);
+  }
+}

--- a/artifacts/api-server/src/lib/invoice-line-items.ts
+++ b/artifacts/api-server/src/lib/invoice-line-items.ts
@@ -16,14 +16,25 @@
 import { db } from "@workspace/db";
 import { jobsTable, jobAddOnsTable, addOnsTable, jobDiscountsTable } from "@workspace/db/schema";
 import { eq, and } from "drizzle-orm";
+import { ensureAutoPromosForJob } from "./auto-promos.js";
 
 export type InvoiceLineItem = { description: string; quantity: number; unit_price: number; total: number };
 
 export async function buildJobLineItems(
   companyId: number,
   jobId: number,
+  exec: any = db,
 ): Promise<{ lineItems: InvoiceLineItem[]; subtotal: number } | null> {
-  const [job] = await db
+  // [auto-promos 2026-06-21] Single chokepoint: ensure the job carries exactly
+  // the auto-promo it's entitled to (15% off 2nd recurring visit / any deep
+  // clean) as a job_discounts row BEFORE we read job_discounts below. This makes
+  // every invoice surface (completion, draft re-sync, office recalc) honor the
+  // advertised offers with no per-call-site wiring. Idempotent + self-healing.
+  // `exec` (pool by default) lets the verification harness run the whole flow in
+  // a rolled-back transaction.
+  await ensureAutoPromosForJob(companyId, jobId, exec);
+
+  const [job] = await exec
     .select({
       service_type: jobsTable.service_type,
       base_fee: jobsTable.base_fee,
@@ -50,7 +61,7 @@ export async function buildJobLineItems(
   let runningTotal = scopeAmount;
 
   if (!job.billed_amount) {
-    const addons = await db
+    const addons = await exec
       .select({
         name: addOnsTable.name,
         quantity: jobAddOnsTable.quantity,
@@ -72,12 +83,18 @@ export async function buildJobLineItems(
     }
   }
 
-  const jobDisc = await db.select().from(jobDiscountsTable)
+  const jobDisc = await exec.select().from(jobDiscountsTable)
     .where(and(eq(jobDiscountsTable.job_id, jobId), eq(jobDiscountsTable.company_id, companyId)));
   for (const d of jobDisc) {
     const amt = parseFloat(String(d.amount));
     runningTotal -= amt;
-    const label = `Discount${d.code ? ` ${d.code}` : (d.type === "percent" ? ` ${parseFloat(String(d.value))}%` : "")}${d.reason && d.reason !== d.code ? ` — ${d.reason}` : ""}`;
+    // Auto-promo rows (code AUTO_*) carry a human label in `reason` — show that
+    // alone so the invoice reads "Deep Clean Promo (15% off)", not the internal
+    // AUTO_ code. Other discounts keep the existing code/percent labeling.
+    const isAuto = typeof d.code === "string" && d.code.startsWith("AUTO_");
+    const label = isAuto && d.reason
+      ? String(d.reason)
+      : `Discount${d.code ? ` ${d.code}` : (d.type === "percent" ? ` ${parseFloat(String(d.value))}%` : "")}${d.reason && d.reason !== d.code ? ` — ${d.reason}` : ""}`;
     lineItems.push({ description: label, quantity: 1, unit_price: -amt, total: -amt });
   }
 

--- a/artifacts/api-server/src/routes/public.ts
+++ b/artifacts/api-server/src/routes/public.ts
@@ -472,6 +472,26 @@ export async function runCalculate(params: {
     }
   }
 
+  // [auto-promos 2026-06-21] Auto-applied promotions honored at checkout. Only
+  // the deep-clean promo is determinable from a single quote (the 2nd-recurring
+  // promo is contextual to a schedule occurrence and lands at invoice build).
+  // Computed against the cleaning base price and REPORTED in a dedicated field —
+  // we deliberately do NOT mutate final_total, so a booked job's stored base_fee
+  // stays PRE-promo and the discount is applied exactly once, at invoice time,
+  // by the single chokepoint (see lib/auto-promos.ts ensureAutoPromosForJob).
+  // The booking widget displays final_total_after_auto_promo so the advertised
+  // price is honored at checkout. This keeps "stored price = pre-promo" an
+  // invariant — there is no path where the promo can double-apply.
+  const { computeCheckoutPromo } = await import("../lib/auto-promos.js");
+  const autoPromo = await computeCheckoutPromo({
+    companyId: company_id,
+    serviceType: scopeNameToServiceType(scope.name),
+    basePrice: base_price,
+  });
+  const final_total_after_auto_promo = autoPromo
+    ? Math.max(0, Math.round((final_total - autoPromo.amount) * 100) / 100)
+    : Math.round(final_total * 100) / 100;
+
   return {
     scope_id,
     scope_name: scope.name,
@@ -492,6 +512,14 @@ export async function runCalculate(params: {
     discount_amount: Math.round(discount_amount * 100) / 100,
     discount_valid: discount_code ? discount_valid : undefined,
     final_total: Math.round(final_total * 100) / 100,
+    // [auto-promos] Auto-applied promotions (deep-clean at checkout). final_total
+    // stays PRE-promo (= the stored base); final_total_after_auto_promo is the
+    // advertised price the widget shows. Discount itemizes on the invoice.
+    auto_promos: autoPromo
+      ? [{ kind: autoPromo.kind, label: autoPromo.label, pct: autoPromo.pct, amount: autoPromo.amount }]
+      : [],
+    auto_promo_discount: autoPromo ? autoPromo.amount : 0,
+    final_total_after_auto_promo,
   };
 }
 

--- a/artifacts/api-server/src/tests/auto-promos.test.ts
+++ b/artifacts/api-server/src/tests/auto-promos.test.ts
@@ -1,0 +1,71 @@
+// [auto-promos 2026-06-21] Unit tests for the pure promo logic — math + the
+// non-stacking selection rule. Runs without a live DB (stub DATABASE_URL lets
+// the @workspace/db Pool import without connecting, since the pure functions
+// never issue a query).
+//
+//   pnpm --filter @workspace/api-server run test:promos
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  promoAmount,
+  selectAutoPromo,
+  promoCode,
+  defaultPromoLabel,
+  SECOND_RECURRING,
+  DEEP_CLEAN,
+  type ActivePromo,
+} from "../lib/auto-promos-core.js";
+
+const deep: ActivePromo = { kind: DEEP_CLEAN, pct: 15, label: "Deep Clean Promo (15% off)" };
+const recur: ActivePromo = { kind: SECOND_RECURRING, pct: 15, label: "Second Visit Promo (15% off)" };
+
+describe("promoAmount", () => {
+  it("computes 15% of a base, rounded to cents", () => {
+    assert.equal(promoAmount(15, 200), 30);
+    assert.equal(promoAmount(15, 199.99), 30); // 29.9985 → 30.00
+    assert.equal(promoAmount(15, 56.67), 8.5); // 8.5005 → 8.50
+  });
+  it("clamps junk / non-positive inputs to 0", () => {
+    assert.equal(promoAmount(0, 200), 0);
+    assert.equal(promoAmount(15, 0), 0);
+    assert.equal(promoAmount(-15, 200), 0);
+    assert.equal(promoAmount(15, -5), 0);
+    assert.equal(promoAmount(NaN, 200), 0);
+  });
+});
+
+describe("selectAutoPromo (non-stacking rule)", () => {
+  it("applies the deep-clean promo to a deep clean", () => {
+    const p = selectAutoPromo({ serviceType: "deep_clean", isSecondRecurringVisit: false, active: [deep, recur] });
+    assert.equal(p?.kind, DEEP_CLEAN);
+  });
+  it("applies the 2nd-recurring promo to the 2nd visit", () => {
+    const p = selectAutoPromo({ serviceType: "recurring", isSecondRecurringVisit: true, active: [deep, recur] });
+    assert.equal(p?.kind, SECOND_RECURRING);
+  });
+  it("does NOT stack — a 2nd-visit deep clean gets ONE promo (highest pct), not two", () => {
+    const bigDeep: ActivePromo = { kind: DEEP_CLEAN, pct: 20, label: "x" };
+    const p = selectAutoPromo({ serviceType: "deep_clean", isSecondRecurringVisit: true, active: [bigDeep, recur] });
+    assert.equal(p?.kind, DEEP_CLEAN); // 20% beats 15%
+    assert.equal(p?.pct, 20);
+  });
+  it("returns null when nothing applies", () => {
+    assert.equal(selectAutoPromo({ serviceType: "standard_clean", isSecondRecurringVisit: false, active: [deep, recur] }), null);
+    assert.equal(selectAutoPromo({ serviceType: "deep_clean", isSecondRecurringVisit: false, active: [] }), null);
+  });
+  it("ignores zero/negative-percent promos", () => {
+    const dead: ActivePromo = { kind: DEEP_CLEAN, pct: 0, label: "x" };
+    assert.equal(selectAutoPromo({ serviceType: "deep_clean", isSecondRecurringVisit: false, active: [dead] }), null);
+  });
+});
+
+describe("codes + labels", () => {
+  it("stamps a stable, idempotent code per kind", () => {
+    assert.equal(promoCode(DEEP_CLEAN), "AUTO_DEEP_CLEAN");
+    assert.equal(promoCode(SECOND_RECURRING), "AUTO_SECOND_RECURRING");
+  });
+  it("produces readable invoice labels", () => {
+    assert.equal(defaultPromoLabel(DEEP_CLEAN, 15), "Deep Clean Promo (15% off)");
+    assert.equal(defaultPromoLabel(SECOND_RECURRING, 15), "Second Visit Promo (15% off)");
+  });
+});

--- a/artifacts/qleno/src/pages/book.tsx
+++ b/artifacts/qleno/src/pages/book.tsx
@@ -67,6 +67,18 @@ interface CalcResult {
   discount_amount: number;
   discount_valid?: boolean;
   final_total: number;
+  // [auto-promos 2026-06-21] Auto-applied promotions (e.g. 15% off any deep
+  // clean). final_total stays PRE-promo; final_total_after_auto_promo is the
+  // advertised price. auto_promos lists each applied offer for itemized display.
+  auto_promos?: Array<{ kind: string; label: string; pct: number; amount: number }>;
+  auto_promo_discount?: number;
+  final_total_after_auto_promo?: number;
+}
+
+// Effective customer-facing per-visit total after any auto-applied promotion.
+// Falls back to final_total when the API hasn't supplied the promo fields.
+function effectiveTotal(c: CalcResult): number {
+  return c.final_total_after_auto_promo != null ? c.final_total_after_auto_promo : c.final_total;
 }
 
 // ── Stepper counter component ────────────────────────────────────────────────
@@ -1285,6 +1297,9 @@ export default function BookPage() {
       {calcResult.discount_amount > 0 && (
         <Row label="Discount code applied" value={`-$${calcResult.discount_amount.toFixed(2)}`} green />
       )}
+      {(calcResult.auto_promos ?? []).filter(p => p.amount > 0).map((p, i) => (
+        <Row key={`promo-${i}`} label={p.label} value={`-$${p.amount.toFixed(2)}`} green />
+      ))}
       {calcResult.minimum_applied && (
         <p style={{ fontSize: 11, color: "#F59E0B", margin: "2px 0 0" }}>Minimum applied</p>
       )}
@@ -1326,7 +1341,7 @@ export default function BookPage() {
           )}
           <div style={{ borderTop: "1px solid #E5E2DC", paddingTop: 8, marginBottom: 10, display: "flex", justifyContent: "space-between", alignItems: "baseline" }}>
             <span style={{ fontSize: 13, color: "#6B6860" }}>First Visit Total</span>
-            <span style={{ fontSize: 15, fontWeight: 800, color: "#1A1917" }}>${calcResult.final_total.toFixed(2)}</span>
+            <span style={{ fontSize: 15, fontWeight: 800, color: "#1A1917" }}>${effectiveTotal(calcResult).toFixed(2)}</span>
           </div>
         </div>
       )}
@@ -1342,7 +1357,7 @@ export default function BookPage() {
           {sqft > 0 && <p style={{ margin: 0, fontSize: 11, color: "#6B6860" }}>{sqft.toLocaleString()} sqft</p>}
         </div>
         <div style={{ display: "flex", alignItems: "center", gap: 8, flexShrink: 0 }}>
-          <span style={{ fontSize: 17, fontWeight: 800, color: "#1A1917" }}>${calcResult.final_total.toFixed(2)}</span>
+          <span style={{ fontSize: 17, fontWeight: 800, color: "#1A1917" }}>${effectiveTotal(calcResult).toFixed(2)}</span>
           <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#6B6860" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"
             style={{ transform: mobilePriceExpanded ? "rotate(180deg)" : "rotate(0deg)", transition: "transform 0.2s" }}>
             <polyline points="6 9 12 15 18 9" />
@@ -1413,7 +1428,7 @@ export default function BookPage() {
                 {calcResult.addon_breakdown.filter(a => a.amount !== 0).length > 0 && (
                   <div style={{ borderTop: "1px solid #E5E2DC", paddingTop: 12, marginTop: 10, display: "flex", justifyContent: "space-between", alignItems: "baseline" }}>
                     <span style={{ fontSize: 13, color: "#6B6860" }}>First Visit Total</span>
-                    <span style={{ fontSize: 18, fontWeight: 800, color: "#1A1917" }}>${calcResult.final_total.toFixed(2)}</span>
+                    <span style={{ fontSize: 18, fontWeight: 800, color: "#1A1917" }}>${effectiveTotal(calcResult).toFixed(2)}</span>
                   </div>
                 )}
                 <div style={{ marginTop: 10, padding: "10px 12px", background: `${brand}0D`, borderRadius: 8, border: `1px solid ${brand}25`, display: "flex", flexDirection: "column", gap: 6 }}>
@@ -1439,7 +1454,7 @@ export default function BookPage() {
               calcResult.addon_breakdown.filter(a => a.amount !== 0).length > 0 ? (
                 <div style={{ borderTop: "1px solid #E5E2DC", paddingTop: 12, marginTop: 8, display: "flex", justifyContent: "space-between", alignItems: "baseline" }}>
                   <span style={{ fontSize: 13, color: "#6B6860" }}>First Visit Total</span>
-                  <span style={{ fontSize: 24, fontWeight: 800, color: "#1A1917" }}>${calcResult.final_total.toFixed(2)}</span>
+                  <span style={{ fontSize: 24, fontWeight: 800, color: "#1A1917" }}>${effectiveTotal(calcResult).toFixed(2)}</span>
                 </div>
               ) : null
             )}
@@ -2848,7 +2863,7 @@ export default function BookPage() {
               {calcResult && selectedAddonIds.length > 0 && (
                 <div style={{ textAlign: "right", marginBottom: 12 }}>
                   <span style={{ fontSize: 14, fontWeight: 600, color: "#1A1917", fontFamily: "'Plus Jakarta Sans', sans-serif" }}>
-                    Subtotal: ${calcResult.final_total.toFixed(2)}
+                    Subtotal: ${effectiveTotal(calcResult).toFixed(2)}
                   </span>
                 </div>
               )}
@@ -3107,7 +3122,7 @@ export default function BookPage() {
                   {address && <Row label="Address" value={address} />}
                   {calcResult && calcResult.base_hours > 0 && <Row label="Estimated Time" value={`${(calcResult.total_hours ?? calcResult.base_hours).toFixed(1)} hrs`} />}
                   {/* FIX 4: "Total" relabeled to "First Visit Total" */}
-                  {calcResult && <Row label="First Visit Total" value={`$${(calcResult.final_total * conditionMultiplier).toFixed(2)}`} bold />}
+                  {calcResult && <Row label="First Visit Total" value={`$${(effectiveTotal(calcResult) * conditionMultiplier).toFixed(2)}`} bold />}
                 </div>
               </div>
 

--- a/lib/db/src/schema/auto_promos.ts
+++ b/lib/db/src/schema/auto_promos.ts
@@ -1,0 +1,42 @@
+import { pgTable, serial, integer, timestamp, text, numeric, boolean } from "drizzle-orm/pg-core";
+import { createInsertSchema } from "drizzle-zod";
+import { z } from "zod/v4";
+import { companiesTable } from "./companies";
+
+// [auto-promos 2026-06-21] Tenant-scoped, automatically-applied promotional
+// discounts. These are NOT manual coupon codes (those live in pricing_discounts)
+// — they fire on their own when the rule matches, so the advertised offer is
+// always honored without the office or customer entering anything.
+//
+// Two kinds ship initially (the `kind` column is the rule selector):
+//   second_recurring — 15% off the SECOND visit of a customer's recurring plan
+//                       (ordinal 2 within a recurring_schedule). Stamped onto
+//                       that visit as a job_discounts row at invoice build time.
+//   deep_clean       — 15% off ANY deep clean (jobs.service_type='deep_clean'),
+//                       year-round. Shown at checkout (runCalculate) and stamped
+//                       as a job_discounts row at invoice build time.
+//
+// Multi-tenant: every row is company-scoped. The realized discount always lands
+// in job_discounts (the existing per-job snapshot table the invoice builder
+// already itemizes), so promos are auditable + traceable per job and never
+// recomputed after the fact. `discount_pct` is the percent off (e.g. 15.00).
+export const autoPromoKinds = ["second_recurring", "deep_clean"] as const;
+export type AutoPromoKind = (typeof autoPromoKinds)[number];
+
+export const autoPromosTable = pgTable("auto_promos", {
+  id: serial("id").primaryKey(),
+  company_id: integer("company_id").references(() => companiesTable.id).notNull(),
+  // One of autoPromoKinds. Kept as text (not a pg enum) so adding a new promo
+  // rule later is an INSERT, never a fragile ALTER TYPE.
+  kind: text("kind").notNull(),
+  discount_pct: numeric("discount_pct", { precision: 5, scale: 2 }).notNull(),
+  is_active: boolean("is_active").notNull().default(true),
+  // Human label stamped onto the job_discounts.reason so it reads cleanly on the
+  // invoice (e.g. "Second Visit Promo (15% off)").
+  label: text("label"),
+  created_at: timestamp("created_at").notNull().defaultNow(),
+});
+
+export const insertAutoPromoSchema = createInsertSchema(autoPromosTable).omit({ id: true, created_at: true });
+export type InsertAutoPromo = z.infer<typeof insertAutoPromoSchema>;
+export type AutoPromo = typeof autoPromosTable.$inferSelect;

--- a/lib/db/src/schema/index.ts
+++ b/lib/db/src/schema/index.ts
@@ -21,6 +21,7 @@ export * from "./audit_log";
 export * from "./articles";
 export * from "./discounts";
 export * from "./job_discounts";
+export * from "./auto_promos";
 export * from "./availability";
 export * from "./contact_tickets";
 export * from "./employee_notes";


### PR DESCRIPTION
## What

Two advertised offers were **verbal-only** — they didn't exist in the system. This makes them real, automatically applied, multi-tenant, and honored at **checkout AND on the invoice**:

1. **15% off your second recurring clean** — the 2nd visit of a recurring plan.
2. **15% off any deep clean** — year-round.

Enabled (seeded) for **co1 (Oak Lawn)** and **co4 (Schaumburg)** at 15%.

## Design — single source of truth = `job_discounts`

The invoice builder already itemizes `job_discounts` as negative lines, so the realized discount always lands there (code prefixed `AUTO_`) and stays auditable/traceable per job.

- **New `auto_promos` table** (`company_id`, `kind`, `discount_pct`, `is_active`, `label`) + an idempotent boot migration that creates it and seeds co1/co4. Tenant-scoped; a new offer is an INSERT, never an `ALTER TYPE`.
- **`ensureAutoPromosForJob` is the ONE chokepoint**, called from `buildJobLineItems`. Every invoice surface (completion, dispatch draft re-sync, office recalc) honors the offers with zero per-call-site wiring. Idempotent + self-healing (clears prior `AUTO_` rows and re-derives), so an edit/re-run can never duplicate or go stale. Manual discounts are never touched.
- **Non-stacking**: a job gets at most one auto-promo (highest applicable %), so a 2nd-visit deep clean is 15% off, not 30%.
- **Invariant: stored `base_fee` is always PRE-promo.** The discount is applied exactly once, at invoice time — there is no code path where it can double-apply.
- **Checkout**: `runCalculate` reports the deep-clean promo (`auto_promo_discount`, `final_total_after_auto_promo`); `book.tsx` shows the promo line + the discounted total. The 2nd-recurring promo is contextual to a schedule occurrence, so it lands at invoice build (when the 2nd visit is completed/invoiced).

## Tests / verification

- **Unit** (`pnpm --filter @workspace/api-server run test:promos`, 9 cases): promo math + the non-stacking selection rule. Pure logic lives in `auto-promos-core.ts` (no DB import).
- **End-to-end against production data, in a rolled-back transaction (nothing mutated):**
  - Deep clean $300 → `Deep Clean Promo (15% off)` line of **-$45.00** → subtotal **$255.00**.
  - Recurring plan $150/visit: visit 1 = full **$150** (no promo); visit 2 → **-$22.50** → **$127.50**.
  - Idempotency: 3× ensure → still exactly one `AUTO_` row.
  - Checkout (real deep-clean pricing, 1800 sqft): base $520 → **-$78** → customer pays **$442**.

### Also confirmed: existing recurring rates are accurate (co1, 3br/2ba ≈ 1800 sqft)
- **Standard Clean** ($65/hr, one-time $247): weekly **−20%** ($197.60), biweekly **−10%** ($222.30), monthly **0%** ($247). ✅ matches mockup
- **Deep Clean** ($80/hr): one-time/monthly **$80/hr (0%)**, weekly **$56/hr (−30%)**, biweekly **$63/hr (−21.25%**, mockup says −21%). ✅ matches mockup

## Notes
- DB table is created at runtime via the idempotent boot migration (same pattern as the cutover migrations); CI build doesn't push DB.
- **Do not merge / deploy** — for Sal's review per request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)