### PR TITLE
feat(comms): STOP/unsubscribe compliance layer (SMS opt-out + email unsubscribe)

### DIFF
--- a/artifacts/api-server/package.json
+++ b/artifacts/api-server/package.json
@@ -12,7 +12,8 @@
     "test:parking": "DATABASE_URL=postgres://stub@stub/stub tsx --test src/tests/parking-waterfall.test.ts",
     "test:lms": "DATABASE_URL=postgres://stub@stub/stub tsx --test src/tests/lms-*.test.ts",
     "test:cutover": "DATABASE_URL=postgres://stub@stub/stub tsx --test src/tests/cutover-*.test.ts",
-    "test:promos": "DATABASE_URL=postgres://stub@stub/stub tsx --test src/tests/auto-promos.test.ts"
+    "test:promos": "DATABASE_URL=postgres://stub@stub/stub tsx --test src/tests/auto-promos.test.ts",
+    "test:optout": "DATABASE_URL=postgres://stub@stub/stub tsx --test src/tests/opt-out.test.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.71.0",

--- a/artifacts/api-server/src/index.ts
+++ b/artifacts/api-server/src/index.ts
@@ -234,6 +234,16 @@ async function startup() {
   } catch (err: any) {
     console.error("[startup] runAutoPromosMigration — non-fatal:", err?.message ?? err);
   }
+  // [comms-opt-out 2026-06-21] clients.sms_opt_out_at / email_opt_out_at /
+  // email_unsub_token columns + token backfill + unique index.
+  try {
+    await withBootTimeout("runCommsOptOutMigration", SCHEMA_TIMEOUT_MS, async () => {
+      const { runCommsOptOutMigration } = await import("./lib/opt-out.js");
+      await runCommsOptOutMigration();
+    });
+  } catch (err: any) {
+    console.error("[startup] runCommsOptOutMigration — non-fatal:", err?.message ?? err);
+  }
   // [booking-confirmation GAP1] token column + job_scheduled SMS template (all tenants)
   try {
     await withBootTimeout("ensureBookingConfirmationSetup", SCHEMA_TIMEOUT_MS, async () => {

--- a/artifacts/api-server/src/lib/opt-out-core.ts
+++ b/artifacts/api-server/src/lib/opt-out-core.ts
@@ -1,0 +1,56 @@
+// [comms-opt-out 2026-06-21] PURE helpers for the opt-out layer — no
+// `@workspace/db` import, so unit tests load them without triggering Drizzle
+// init (same pattern as auto-promos-core.ts). The DB-backed helpers live in
+// opt-out.ts and re-export everything here.
+
+// Last-10-digits of a phone, the match key used across the SMS store + opt-out.
+export function phoneDigits(raw: string | null | undefined): string {
+  return String(raw ?? "").replace(/\D/g, "").slice(-10);
+}
+
+// SMS STOP / START keyword sets (mirror Twilio's carrier-level keywords).
+const STOP_WORDS = new Set(["STOP", "STOPALL", "UNSUBSCRIBE", "CANCEL", "END", "QUIT"]);
+const START_WORDS = new Set(["START", "UNSTOP", "YES", "UNCANCEL", "RESUME"]);
+
+export function isStopKeyword(body: string): boolean {
+  return STOP_WORDS.has(String(body ?? "").trim().toUpperCase());
+}
+export function isStartKeyword(body: string): boolean {
+  return START_WORDS.has(String(body ?? "").trim().toUpperCase());
+}
+
+// Public base URL for the unsubscribe link. Configurable; defaults to prod.
+export function appBaseUrl(): string {
+  return (
+    process.env.APP_BASE_URL ||
+    process.env.PUBLIC_APP_URL ||
+    "https://workspaceapi-server-production-b9d4.up.railway.app"
+  ).replace(/\/+$/, "");
+}
+
+export type EmailUnsubData = {
+  token: string;
+  unsubUrl: string;
+  headers: Record<string, string>;
+  footerHtml: string;
+};
+
+// Build the List-Unsubscribe headers + footer link for a known token (no DB).
+export function buildUnsubDataFromToken(token: string): EmailUnsubData {
+  const unsubUrl = `${appBaseUrl()}/api/comms/unsubscribe?token=${encodeURIComponent(token)}`;
+  return {
+    token,
+    unsubUrl,
+    headers: {
+      // RFC 2369 + RFC 8058 one-click. Gmail/Outlook render the native
+      // "Unsubscribe" affordance and POST to this URL on click.
+      "List-Unsubscribe": `<${unsubUrl}>`,
+      "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+    },
+    footerHtml:
+      `<div style="margin-top:16px;font-size:11px;color:#9E9B94;text-align:center;line-height:1.5">` +
+      `Don't want these emails? ` +
+      `<a href="${unsubUrl}" style="color:#9E9B94;text-decoration:underline">Unsubscribe</a>.` +
+      `</div>`,
+  };
+}

--- a/artifacts/api-server/src/lib/opt-out.ts
+++ b/artifacts/api-server/src/lib/opt-out.ts
@@ -1,0 +1,186 @@
+// [comms-opt-out 2026-06-21] Compliance layer for SMS STOP + email unsubscribe.
+//
+// Before this, SMS STOP was only handled at Twilio's carrier level (Qleno
+// recorded nothing, so reminder/review crons still fired at opted-out people)
+// and email had no unsubscribe at all (the mockup linked a dead
+// phes.io/unsubscribe). Both are legal exposure (TCPA / CAN-SPAM) before comms
+// go live. This module is the single source of truth for:
+//   * reading opt-out state on every send path (isSmsOptedOut / isEmailOptedOut)
+//   * setting it from the Twilio inbound webhook (setSmsOptOutByPhone) and the
+//     tokenized email unsubscribe route (setEmailOptOutByToken)
+//   * building the List-Unsubscribe headers + footer link for outbound email
+//
+// Multi-tenant: every lookup is company-scoped (token lookup resolves its own
+// company). Reads FAIL OPEN (send) on a DB/transient error or a pre-migration
+// schema so a hiccup can't silently black-hole all comms — but a recorded
+// opt-out is always honored.
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+import { randomUUID } from "crypto";
+import {
+  phoneDigits,
+  isStopKeyword,
+  isStartKeyword,
+  appBaseUrl,
+  buildUnsubDataFromToken,
+  type EmailUnsubData,
+} from "./opt-out-core.js";
+
+// Re-export the pure surface so existing importers of this module are unchanged.
+export { phoneDigits, isStopKeyword, isStartKeyword, appBaseUrl, buildUnsubDataFromToken };
+export type { EmailUnsubData };
+
+// True when a client in this company with this phone has opted out of SMS.
+export async function isSmsOptedOut(companyId: number, phone: string | null | undefined): Promise<boolean> {
+  const d = phoneDigits(phone);
+  if (!d || d.length < 10) return false;
+  try {
+    const r = await db.execute(sql`
+      SELECT 1 FROM clients
+       WHERE company_id = ${companyId}
+         AND sms_opt_out_at IS NOT NULL
+         AND right(regexp_replace(COALESCE(phone,''), '\\D', '', 'g'), 10) = ${d}
+       LIMIT 1
+    `);
+    return r.rows.length > 0;
+  } catch (e) {
+    console.warn("[opt-out] isSmsOptedOut read failed (failing open):", (e as any)?.message ?? e);
+    return false;
+  }
+}
+
+// True when a client in this company with this email has opted out of email.
+export async function isEmailOptedOut(companyId: number, email: string | null | undefined): Promise<boolean> {
+  const e = String(email ?? "").trim().toLowerCase();
+  if (!e) return false;
+  try {
+    const r = await db.execute(sql`
+      SELECT 1 FROM clients
+       WHERE company_id = ${companyId}
+         AND email_opt_out_at IS NOT NULL
+         AND lower(email) = ${e}
+       LIMIT 1
+    `);
+    return r.rows.length > 0;
+  } catch (err) {
+    console.warn("[opt-out] isEmailOptedOut read failed (failing open):", (err as any)?.message ?? err);
+    return false;
+  }
+}
+
+// Set / clear the SMS opt-out flag for every client in a company matching a
+// phone (last-10). Returns the number of client rows updated. Used by the Twilio
+// inbound webhook.
+export async function setSmsOptOutByPhone(companyId: number, phone: string, optedOut: boolean): Promise<number> {
+  const d = phoneDigits(phone);
+  if (!d || d.length < 10) return 0;
+  try {
+    const r = await db.execute(sql`
+      UPDATE clients
+         SET sms_opt_out_at = ${optedOut ? sql`now()` : sql`NULL`}
+       WHERE company_id = ${companyId}
+         AND right(regexp_replace(COALESCE(phone,''), '\\D', '', 'g'), 10) = ${d}
+    `);
+    return (r as any).rowCount ?? 0;
+  } catch (e) {
+    console.error("[opt-out] setSmsOptOutByPhone failed:", (e as any)?.message ?? e);
+    return 0;
+  }
+}
+
+// Set the email opt-out flag from an unsubscribe token. Returns the affected
+// client (id/email/company_id) or null when the token doesn't match. Idempotent.
+export async function setEmailOptOutByToken(
+  token: string,
+): Promise<{ id: number; email: string | null; company_id: number } | null> {
+  const t = String(token ?? "").trim();
+  if (!t) return null;
+  try {
+    const r = await db.execute(sql`
+      UPDATE clients SET email_opt_out_at = now()
+       WHERE email_unsub_token = ${t}
+       RETURNING id, email, company_id
+    `);
+    return (r.rows[0] as any) ?? null;
+  } catch (e) {
+    console.error("[opt-out] setEmailOptOutByToken failed:", (e as any)?.message ?? e);
+    return null;
+  }
+}
+
+// Re-subscribe via token (the confirmation page offers it for accidental clicks).
+export async function clearEmailOptOutByToken(
+  token: string,
+): Promise<{ id: number; email: string | null; company_id: number } | null> {
+  const t = String(token ?? "").trim();
+  if (!t) return null;
+  try {
+    const r = await db.execute(sql`
+      UPDATE clients SET email_opt_out_at = NULL
+       WHERE email_unsub_token = ${t}
+       RETURNING id, email, company_id
+    `);
+    return (r.rows[0] as any) ?? null;
+  } catch (e) {
+    console.error("[opt-out] clearEmailOptOutByToken failed:", (e as any)?.message ?? e);
+    return null;
+  }
+}
+
+// Resolve (or lazily mint) the unsubscribe token for a recipient email in a
+// company, and build the List-Unsubscribe headers + a footer link. Returns null
+// when no matching client row exists (e.g. a lead-only recipient or a fresh
+// schema) — callers then send without the header rather than failing.
+export async function buildEmailUnsubData(
+  companyId: number,
+  email: string | null | undefined,
+): Promise<EmailUnsubData | null> {
+  const e = String(email ?? "").trim().toLowerCase();
+  if (!e) return null;
+  try {
+    const r = await db.execute(sql`
+      SELECT id, email_unsub_token FROM clients
+       WHERE company_id = ${companyId} AND lower(email) = ${e}
+       LIMIT 1
+    `);
+    const row = r.rows[0] as any;
+    if (!row) return null;
+    let token: string = row.email_unsub_token;
+    if (!token) {
+      token = randomUUID();
+      await db.execute(sql`UPDATE clients SET email_unsub_token = ${token} WHERE id = ${row.id}`);
+    }
+    return buildUnsubDataFromToken(token);
+  } catch (err) {
+    console.warn("[opt-out] buildEmailUnsubData failed:", (err as any)?.message ?? err);
+    return null;
+  }
+}
+
+// Idempotent boot migration: add the opt-out columns, backfill a token for every
+// existing client, and add a unique index on the token. Safe to run on every
+// cold start.
+export async function runCommsOptOutMigration(): Promise<void> {
+  try {
+    await db.execute(sql`ALTER TABLE clients ADD COLUMN IF NOT EXISTS sms_opt_out_at timestamp`);
+    await db.execute(sql`ALTER TABLE clients ADD COLUMN IF NOT EXISTS email_opt_out_at timestamp`);
+    await db.execute(sql`ALTER TABLE clients ADD COLUMN IF NOT EXISTS email_unsub_token text`);
+    // Backfill tokens for existing rows (gen_random_uuid from pgcrypto; falls
+    // back silently if the extension isn't present on some installs).
+    try {
+      await db.execute(sql`
+        UPDATE clients SET email_unsub_token = gen_random_uuid()::text
+         WHERE email_unsub_token IS NULL
+      `);
+    } catch (e) {
+      console.warn("[opt-out] token backfill via gen_random_uuid skipped:", (e as any)?.message ?? e);
+    }
+    await db.execute(sql`
+      CREATE UNIQUE INDEX IF NOT EXISTS clients_email_unsub_token_uidx
+        ON clients (email_unsub_token) WHERE email_unsub_token IS NOT NULL
+    `);
+    console.log("[opt-out] migration ok");
+  } catch (err) {
+    console.error("[opt-out] migration error (non-fatal):", err);
+  }
+}

--- a/artifacts/api-server/src/routes/comms-inbound.ts
+++ b/artifacts/api-server/src/routes/comms-inbound.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { handleInboundReply } from "../lib/lead-sync.js";
 import { resolveTenantByNumber, recordInboundSms } from "../lib/sms-store.js";
+import { isStopKeyword, isStartKeyword, setSmsOptOutByPhone, setEmailOptOutByToken, clearEmailOptOutByToken } from "../lib/opt-out.js";
 
 const router = Router();
 
@@ -52,11 +53,78 @@ router.post("/inbound", async (req, res) => {
         await stopEnrollmentsForClient(match.client_id, optOut ? "opted_out" : "replied");
       } catch (e) { console.warn("[comms/inbound] client cadence stop failed:", e); }
     }
+
+    // [comms-opt-out 2026-06-21] Record the SMS opt-out flag on the client(s)
+    // (matched by phone, last-10) so EVERY send path honors it — not just the
+    // follow-up cadence. STOP/UNSUBSCRIBE/CANCEL/QUIT sets it; START/UNSTOP
+    // clears it (a customer can resubscribe by text, as carriers require).
+    try {
+      if (isStopKeyword(body)) {
+        const n = await setSmsOptOutByPhone(companyId, from, true);
+        console.log(`[comms/inbound] SMS opt-OUT recorded for ${n} client(s) (company=${companyId})`);
+      } else if (isStartKeyword(body)) {
+        const n = await setSmsOptOutByPhone(companyId, from, false);
+        console.log(`[comms/inbound] SMS opt-IN (resubscribe) for ${n} client(s) (company=${companyId})`);
+      }
+    } catch (e) { console.warn("[comms/inbound] opt-out flag update failed:", e); }
+
     return res.type("text/xml").send("<Response/>");
   } catch (err) {
     console.error("[comms/inbound]", err);
     return res.type("text/xml").send("<Response/>");
   }
+});
+
+// ── Email unsubscribe (tokenized) ────────────────────────────────────────────
+// Replaces the dead phes.io/unsubscribe mockup link. Every outbound customer
+// email carries a List-Unsubscribe header + footer link pointing here.
+//
+//   POST /api/comms/unsubscribe?token=...  — RFC 8058 one-click (mail clients
+//        POST here automatically when the user taps the native Unsubscribe). No
+//        body needed; always 200.
+//   GET  /api/comms/unsubscribe?token=...  — the visible footer link. Sets the
+//        opt-out and renders a confirmation page with a one-tap resubscribe (so
+//        an accidental / prefetched click is reversible).
+//   GET  ...&action=resubscribe            — re-opt-in.
+function unsubPage(title: string, message: string, resubscribeUrl?: string): string {
+  return `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1"><title>${title}</title>
+<style>body{margin:0;background:#F7F6F3;font-family:'Plus Jakarta Sans',-apple-system,Segoe UI,Roboto,Arial,sans-serif;color:#1A1917}
+.card{max-width:440px;margin:64px auto;background:#fff;border:1px solid #E5E2DC;border-radius:12px;padding:32px;text-align:center}
+h1{font-size:20px;margin:0 0 12px}p{font-size:14px;color:#6B6860;line-height:1.6;margin:0 0 20px}
+a.btn{display:inline-block;background:#00C9A0;color:#0A0E1A;text-decoration:none;font-weight:700;font-size:14px;padding:12px 22px;border-radius:8px}</style>
+</head><body><div class="card"><h1>${title}</h1><p>${message}</p>
+${resubscribeUrl ? `<a class="btn" href="${resubscribeUrl}">Resubscribe</a>` : ""}
+</div></body></html>`;
+}
+
+router.post("/unsubscribe", async (req, res) => {
+  const token = String(req.query.token ?? req.body?.token ?? "");
+  await setEmailOptOutByToken(token); // idempotent; 200 regardless (one-click never errors back)
+  return res.status(200).send("ok");
+});
+
+router.get("/unsubscribe", async (req, res) => {
+  const token = String(req.query.token ?? "");
+  const action = String(req.query.action ?? "");
+  if (!token) {
+    return res.status(400).type("html").send(unsubPage("Invalid link", "This unsubscribe link is missing its token."));
+  }
+  if (action === "resubscribe") {
+    const c = await clearEmailOptOutByToken(token);
+    return res.type("html").send(
+      c ? unsubPage("You're resubscribed", "You'll receive Phes emails again. You can unsubscribe any time.")
+        : unsubPage("Link not recognized", "We couldn't find this subscription. No action was taken."),
+    );
+  }
+  const c = await setEmailOptOutByToken(token);
+  if (!c) {
+    return res.status(404).type("html").send(unsubPage("Link not recognized", "We couldn't find this subscription. No action was taken."));
+  }
+  const resubUrl = `/api/comms/unsubscribe?token=${encodeURIComponent(token)}&action=resubscribe`;
+  return res.type("html").send(
+    unsubPage("You've been unsubscribed", "You won't receive marketing or reminder emails from Phes anymore. Changed your mind?", resubUrl),
+  );
 });
 
 export default router;

--- a/artifacts/api-server/src/routes/communications.ts
+++ b/artifacts/api-server/src/routes/communications.ts
@@ -91,6 +91,12 @@ router.post("/sms", requireAuth, async (req, res) => {
       return res.status(422).json({ error: "Client has no phone number on file" });
     }
 
+    // [comms-opt-out] Block messaging a client who texted STOP.
+    const { isSmsOptedOut } = await import("../lib/opt-out.js");
+    if (await isSmsOptedOut(companyId, client.phone)) {
+      return res.status(422).json({ error: "sms_opt_out", message: "This client has opted out of SMS (texted STOP). They must text START to resubscribe." });
+    }
+
     const companies = await db
       .select({ twilio_from_number: companiesTable.twilio_from_number })
       .from(companiesTable)

--- a/artifacts/api-server/src/routes/invoices.ts
+++ b/artifacts/api-server/src/routes/invoices.ts
@@ -566,12 +566,16 @@ router.post("/:id/remind", requireAuth, requireRole("owner", "admin", "office"),
     const invNum = invoice.invoice_number || generateInvoiceNumber(invoiceId);
 
     if (clientEmail && process.env.RESEND_API_KEY) {
+      const { isEmailOptedOut, buildEmailUnsubData } = await import("../lib/opt-out.js");
       if (process.env.COMMS_ENABLED !== "true") {
         console.log("[COMMS BLOCKED] Invoice reminder email suppressed:", { to: clientEmail, invoiceId });
+      } else if (await isEmailOptedOut(req.auth!.companyId!, clientEmail)) {
+        console.log("[comms-opt-out] Invoice reminder email suppressed (opt-out):", { to: clientEmail, invoiceId });
       } else {
       const { Resend } = await import("resend");
       const resend = new Resend(process.env.RESEND_API_KEY);
       const payLink = `${appBaseUrl()}/pay/${invoiceId}`;
+      const unsub = await buildEmailUnsubData(req.auth!.companyId!, clientEmail);
       await resend.emails.send({
         from: "notifications@phes.io",
         to: clientEmail,
@@ -579,7 +583,8 @@ router.post("/:id/remind", requireAuth, requireRole("owner", "admin", "office"),
         html: `<p>Hi ${client?.first_name || "there"},</p>
                <p>This is a friendly reminder that invoice <strong>${invNum}</strong> for <strong>$${parseFloat(invoice.total || "0").toFixed(2)}</strong> is due.</p>
                <p><a href="${payLink}">Pay Now</a></p>
-               <p>Thank you,<br>Phes</p>`,
+               <p>Thank you,<br>Phes</p>${unsub?.footerHtml ?? ""}`,
+        ...(unsub?.headers ? { headers: unsub.headers } : {}),
       });
       }
     }

--- a/artifacts/api-server/src/routes/job-sms.ts
+++ b/artifacts/api-server/src/routes/job-sms.ts
@@ -4,6 +4,7 @@ import { jobsTable, clientsTable, usersTable, companiesTable, jobStatusLogsTable
 import { eq, and, desc } from "drizzle-orm";
 import { requireAuth } from "../lib/auth.js";
 import { sendNotification } from "../services/notificationService.js";
+import { isSmsOptedOut } from "../lib/opt-out.js";
 
 const router = Router();
 
@@ -109,6 +110,11 @@ router.post("/:id/sms-status", requireAuth, async (req, res) => {
 
     if (!company.twilio_from_number) {
       return res.json({ success: true, sms_sent: false, reason: "No Twilio phone number configured", log_id: log.id });
+    }
+
+    // [comms-opt-out] Honor SMS STOP — never text a client who opted out.
+    if (await isSmsOptedOut(companyId, client.phone)) {
+      return res.json({ success: true, sms_sent: false, reason: "Client opted out of SMS", log_id: log.id });
     }
 
     const clientName = `${client.first_name}`;

--- a/artifacts/api-server/src/routes/satisfaction.ts
+++ b/artifacts/api-server/src/routes/satisfaction.ts
@@ -78,12 +78,16 @@ router.post("/send", requireAuth, async (req, res) => {
       .select({ phone: clientsTable.phone, first_name: clientsTable.first_name })
       .from(clientsTable).where(eq(clientsTable.id, parseInt(customer_id))).limit(1);
 
+    // [comms-opt-out] Never survey a client who texted STOP.
+    const { isSmsOptedOut } = await import("../lib/opt-out.js");
+    const smsOptedOut = client?.phone ? await isSmsOptedOut(companyId, client.phone) : false;
     const gate =
       !company?.survey_enabled ? "survey_disabled"
       : !company?.twilio_enabled ? "twilio_disabled"
       : !(company.twilio_account_sid && company.twilio_auth_token && company.twilio_from_number) ? "twilio_unconfigured"
       : process.env.COMMS_ENABLED !== "true" ? "comms_disabled"
       : !client?.phone ? "no_phone"
+      : smsOptedOut ? "sms_opt_out"
       : null;
 
     if (gate) {

--- a/artifacts/api-server/src/routes/sms-inbound.ts
+++ b/artifacts/api-server/src/routes/sms-inbound.ts
@@ -245,8 +245,12 @@ router.post("/", async (req, res) => {
     const reviewBody = `Hi ${matchedClient.first_name}, thank you so much for your feedback! We'd love it if you took a moment to share your experience on Google — it means the world to our team: ${reviewLink}. Thank you — Phes`;
 
     if (rating === 4) {
-      // Send review SMS immediately
-      if (reviewLink && company.twilio_from_number && matchedClient.phone) {
+      // Send review SMS immediately — but honor a recorded SMS opt-out.
+      const { isSmsOptedOut } = await import("../lib/opt-out.js");
+      const optedOut = await isSmsOptedOut(company.id, matchedClient.phone);
+      if (optedOut) {
+        await logNotification(company.id, matchedClient.id, job.id, "review_request_skipped", "Client opted out of SMS. Review SMS not sent.");
+      } else if (reviewLink && company.twilio_from_number && matchedClient.phone) {
         await sendTwilioSms(normalizePhone(matchedClient.phone), company.twilio_from_number, reviewBody);
         await logMessage(company.id, matchedClient.id, job.id, "outbound", reviewBody, normalizePhone(matchedClient.phone), company.twilio_from_number);
       } else if (!reviewLink) {

--- a/artifacts/api-server/src/routes/tech-clock.ts
+++ b/artifacts/api-server/src/routes/tech-clock.ts
@@ -338,6 +338,9 @@ async function sendOnMyWayForJob(
         minute: "2-digit",
       })
     : "shortly";
+  // [comms-opt-out] A recorded SMS STOP overrides the per-client preference.
+  const { isSmsOptedOut } = await import("../lib/opt-out.js");
+  const smsOptedOut = await isSmsOptedOut(companyId, client?.phone ?? null);
   return sendOnMyWaySms({
     toPhone: client?.phone ?? null,
     fromPhone: tenant?.twilio_from_number ?? null,
@@ -348,7 +351,7 @@ async function sendOnMyWayForJob(
     serviceAddress,
     promisedArrivalLabel: promisedLabel,
     tenantSmsEnabled: !!tenant?.sms_on_my_way_enabled,
-    clientOptedIn: client?.wants_on_my_way_notifications !== false,
+    clientOptedIn: client?.wants_on_my_way_notifications !== false && !smsOptedOut,
   });
 }
 

--- a/artifacts/api-server/src/services/followUpService.ts
+++ b/artifacts/api-server/src/services/followUpService.ts
@@ -89,6 +89,8 @@ async function sendEmailRaw(
   to: string, subject: string, body: string,
   fromAddress = "Phes Cleaning <noreply@phes.io>",
   brand?: EmailBrand,
+  // [comms-opt-out] Optional List-Unsubscribe headers + footer link.
+  unsub?: { headers: Record<string, string>; footerHtml: string },
 ): Promise<string | null> {
   const key = process.env.RESEND_API_KEY;
   if (!key) throw new Error("Resend not configured");
@@ -109,12 +111,14 @@ async function sendEmailRaw(
 </div>
 ${inner}
 <p style="font-size:13px;color:#9E9B94;margin:20px 0 0;">${brandName} &mdash; ${brandPhone} &mdash; ${brandEmail}</p>
+${unsub?.footerHtml ?? ""}
 </div></div>`;
   const res: any = await resend.emails.send({
     from: fromAddress,
     to: [to],
     subject,
     html: bodyHtml,
+    ...(unsub?.headers && Object.keys(unsub.headers).length ? { headers: unsub.headers } : {}),
   });
   // The Resend SDK returns { data, error } and does NOT throw on API errors
   // (unverified domain, invalid key, etc.). Surface it so callers don't record
@@ -126,12 +130,12 @@ ${inner}
   return res?.data?.id ?? res?.id ?? null;
 }
 
-async function sendEmail(to: string, subject: string, body: string, fromAddress?: string, brand?: EmailBrand): Promise<void> {
+async function sendEmail(to: string, subject: string, body: string, fromAddress?: string, brand?: EmailBrand, unsub?: { headers: Record<string, string>; footerHtml: string }): Promise<void> {
   if (process.env.COMMS_ENABLED !== "true") {
     console.log("[COMMS BLOCKED] Follow-up email suppressed:", { to, subject });
     return;
   }
-  await sendEmailRaw(to, subject, body, fromAddress, brand);
+  await sendEmailRaw(to, subject, body, fromAddress, brand, unsub);
 }
 
 // Build the merge vars for a quote-tied enrollment touch (the quote email + SMS).
@@ -531,9 +535,15 @@ async function processEnrollment(enr: any): Promise<void> {
   // Email rides Resend (not Twilio), so it only needs the master/company/branch
   // gates — not from_number/creds. SMS needs the full sender.reason check.
   const masterGate = process.env.COMMS_ENABLED === "true" && sender.company_comms_enabled && sender.enabled && sender.branch_comms_enabled;
+  // [comms-opt-out] Per-recipient opt-out gate (in addition to the comms gates).
+  const { isSmsOptedOut, isEmailOptedOut, buildEmailUnsubData } = await import("../lib/opt-out.js");
   try {
     if (step.channel === "sms" && recipientPhone) {
-      if (sender.reason) {
+      if (await isSmsOptedOut(enr.company_id, recipientPhone)) {
+        sendStatus = "blocked";
+        sendError  = "sms_opt_out";
+        console.log(`[follow-up] SMS suppressed (sms_opt_out) enrollment ${enr.id}`);
+      } else if (sender.reason) {
         sendStatus = "blocked";
         sendError  = sender.reason;
         console.log(`[follow-up] SMS suppressed (${sender.reason}) enrollment ${enr.id}`);
@@ -541,12 +551,17 @@ async function processEnrollment(enr: any): Promise<void> {
         await sendSmsVia(sender, recipientPhone, body);
       }
     } else if (step.channel === "email" && recipientEmail) {
-      if (!masterGate) {
+      if (await isEmailOptedOut(enr.company_id, recipientEmail)) {
+        sendStatus = "blocked";
+        sendError  = "email_opt_out";
+        console.log(`[follow-up] email suppressed (email_opt_out) enrollment ${enr.id}`);
+      } else if (!masterGate) {
         sendStatus = "blocked";
         sendError  = sender.reason || "branch_comms_disabled";
         console.log(`[follow-up] email suppressed (${sendError}) enrollment ${enr.id}`);
       } else {
-        await sendEmail(recipientEmail, subject, body, await companyFromAddress(enr.company_id), emailBrand);
+        const unsub = await buildEmailUnsubData(enr.company_id, recipientEmail);
+        await sendEmail(recipientEmail, subject, body, await companyFromAddress(enr.company_id), emailBrand, unsub ?? undefined);
       }
     } else {
       sendStatus = "failed";

--- a/artifacts/api-server/src/services/notificationService.ts
+++ b/artifacts/api-server/src/services/notificationService.ts
@@ -4,6 +4,7 @@ import { eq, and, sql } from "drizzle-orm";
 import { getBranchByZip } from "../lib/branchRouter";
 import { buildReminderEmail } from "../lib/emailTemplates";
 import { resolveSender, sendSmsVia } from "../lib/comms-sender.js";
+import { isSmsOptedOut, isEmailOptedOut, buildEmailUnsubData, buildUnsubDataFromToken } from "../lib/opt-out.js";
 import { Resend } from "resend";
 
 // ── Email brand constants ────────────────────────────────────────────────────
@@ -138,6 +139,12 @@ export async function sendNotification(
         await logNotification(companyId, recipientEmail, channel, templateKey, "skipped", "RESEND_API_KEY not configured", fullVars);
         return;
       }
+      // [comms-opt-out] Honor email opt-out. Transactional sends (reset/invite,
+      // to users not clients) bypass — they must always reach the recipient.
+      if (!transactional && await isEmailOptedOut(companyId, recipientEmail)) {
+        await logNotification(companyId, recipientEmail, channel, templateKey, "suppressed", "email_opt_out", fullVars);
+        return;
+      }
 
       const bodyHtml = tpl.body_html || tpl.body || "";
       const subject  = applyMerge(tpl.subject || "", fullVars);
@@ -154,9 +161,22 @@ export async function sendNotification(
       }
       // Opt-in dedicated renderer (confirmation email) replaces the shared chrome
       // for this send only; all other emails keep wrapEmailHtml unchanged.
-      const wrapped  = renderEmail
+      let wrapped  = renderEmail
         ? applyMerge(renderEmail(rawHtml, fullVars), fullVars)
         : applyMerge(wrapEmailHtml(rawHtml), fullVars);
+
+      // [comms-opt-out] Tokenized unsubscribe: append the footer link + set the
+      // List-Unsubscribe (+ one-click) headers for transactional-marketing
+      // sends. Skipped for true transactional sends (reset/invite) which aren't
+      // bulk mail and shouldn't carry an unsubscribe.
+      const emailHeaders: Record<string, string> = {};
+      if (!transactional) {
+        const unsub = await buildEmailUnsubData(companyId, recipientEmail);
+        if (unsub) {
+          Object.assign(emailHeaders, unsub.headers);
+          if (!wrapped.includes(unsub.unsubUrl)) wrapped = wrapped.replace(/<\/body>/i, `${unsub.footerHtml}</body>`);
+        }
+      }
 
       if (!transactional && process.env.COMMS_ENABLED !== "true") {
         console.log("[COMMS BLOCKED] Email suppressed:", { to: recipientEmail, subject });
@@ -170,6 +190,7 @@ export async function sendNotification(
         to:       recipientEmail,
         subject,
         html:     wrapped,
+        ...(Object.keys(emailHeaders).length ? { headers: emailHeaders } : {}),
       });
       // The Resend SDK returns { error } instead of throwing — surface it so a
       // rejected send isn't logged as success.
@@ -179,6 +200,11 @@ export async function sendNotification(
     } else if (channel === "sms") {
       if (!recipientPhone) {
         await logNotification(companyId, "no-phone", channel, templateKey, "skipped", "No recipient phone", fullVars);
+        return;
+      }
+      // [comms-opt-out] Honor SMS STOP. Transactional bypasses (to users).
+      if (!transactional && await isSmsOptedOut(companyId, recipientPhone)) {
+        await logNotification(companyId, recipientPhone, channel, templateKey, "suppressed", "sms_opt_out", fullVars);
         return;
       }
 
@@ -254,7 +280,8 @@ export async function runReminderCron(daysAhead: number): Promise<void> {
         ? drizzleSql`
             SELECT j.id, j.scheduled_date, j.service_type, j.arrival_window,
                    j.address_street, j.address_city, j.address_state, j.address_zip,
-                   c.first_name, c.last_name, c.email, c.phone, c.zip
+                   c.first_name, c.last_name, c.email, c.phone, c.zip,
+                   c.sms_opt_out_at, c.email_opt_out_at, c.email_unsub_token
               FROM jobs j
               JOIN clients c ON c.id = j.client_id
              WHERE j.scheduled_date = ${targetStr}
@@ -264,7 +291,8 @@ export async function runReminderCron(daysAhead: number): Promise<void> {
         : drizzleSql`
             SELECT j.id, j.scheduled_date, j.service_type, j.arrival_window,
                    j.address_street, j.address_city, j.address_state, j.address_zip,
-                   c.first_name, c.last_name, c.email, c.phone, c.zip
+                   c.first_name, c.last_name, c.email, c.phone, c.zip,
+                   c.sms_opt_out_at, c.email_opt_out_at, c.email_unsub_token
               FROM jobs j
               JOIN clients c ON c.id = j.client_id
              WHERE j.scheduled_date = ${targetStr}
@@ -297,8 +325,8 @@ export async function runReminderCron(daysAhead: number): Promise<void> {
       let emailSent = false;
       let smsSent = false;
 
-      // Email reminder
-      if (resendKey) {
+      // Email reminder — skip if the client opted out of email.
+      if (resendKey && job.email && !job.email_opt_out_at) {
         try {
           const { subject, html } = buildReminderEmail({
             firstName: job.first_name || "",
@@ -310,22 +338,33 @@ export async function runReminderCron(daysAhead: number): Promise<void> {
             branchConfig,
             hoursAhead: hoursAhead as 72 | 24,
           });
+          // [comms-opt-out] List-Unsubscribe header + footer link.
+          let emailHtml = html;
+          const headers: Record<string, string> = {};
+          if (job.email_unsub_token) {
+            const u = buildUnsubDataFromToken(job.email_unsub_token);
+            Object.assign(headers, u.headers);
+            emailHtml = emailHtml.includes("</body>") ? emailHtml.replace(/<\/body>/i, `${u.footerHtml}</body>`) : emailHtml + u.footerHtml;
+          }
           const resend = new Resend(resendKey);
           await resend.emails.send({
             from: `Phes <${branchConfig.officeEmail}>`,
             replyTo: branchConfig.officeEmail,
             to: [job.email],
             subject,
-            html,
+            html: emailHtml,
+            ...(Object.keys(headers).length ? { headers } : {}),
           });
           emailSent = true;
         } catch (emailErr) {
           console.error(`[reminder-${label}] Email failed for job ${job.id}:`, emailErr);
         }
+      } else if (job.email_opt_out_at) {
+        console.log(`[reminder-${label}] email suppressed (opt-out) job=${job.id}`);
       }
 
-      // SMS reminder
-      if (accountSid && authToken && job.phone) {
+      // SMS reminder — skip if the client opted out of SMS.
+      if (accountSid && authToken && job.phone && !job.sms_opt_out_at) {
         try {
           const smsBody = hoursAhead === 72
             ? `Hi ${job.first_name || "there"}, this is Phes confirming your cleaning appointment on ${scheduledDate} with a ${arrivalWindowLabel} arrival window at ${serviceAddress}. Questions? Call us at ${branchConfig.clientPhone}. Reply STOP to unsubscribe.`
@@ -346,6 +385,8 @@ export async function runReminderCron(daysAhead: number): Promise<void> {
         } catch (smsErr) {
           console.error(`[reminder-${label}] SMS error for job ${job.id}:`, smsErr);
         }
+      } else if (job.sms_opt_out_at) {
+        console.log(`[reminder-${label}] SMS suppressed (opt-out) job=${job.id}`);
       }
 
       // Mark sent if at least one channel succeeded

--- a/artifacts/api-server/src/tests/opt-out.test.ts
+++ b/artifacts/api-server/src/tests/opt-out.test.ts
@@ -1,0 +1,60 @@
+// [comms-opt-out 2026-06-21] Unit tests for the pure opt-out helpers — keyword
+// detection, phone normalization, and the List-Unsubscribe header/footer
+// builder. Runs without a live DB.
+//
+//   pnpm --filter @workspace/api-server run test:optout
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  phoneDigits,
+  isStopKeyword,
+  isStartKeyword,
+  buildUnsubDataFromToken,
+  appBaseUrl,
+} from "../lib/opt-out-core.js";
+
+describe("phoneDigits", () => {
+  it("normalizes to last 10 digits", () => {
+    assert.equal(phoneDigits("(773) 818-8400"), "7738188400");
+    assert.equal(phoneDigits("+1 773-818-8400"), "7738188400");
+    assert.equal(phoneDigits("7738188400"), "7738188400");
+    assert.equal(phoneDigits(null), "");
+  });
+});
+
+describe("STOP / START keyword detection", () => {
+  it("recognizes all carrier STOP keywords (case/space-insensitive)", () => {
+    for (const w of ["STOP", "stop", " Stop ", "UNSUBSCRIBE", "cancel", "QUIT", "end", "stopall"]) {
+      assert.equal(isStopKeyword(w), true, `expected STOP for "${w}"`);
+    }
+  });
+  it("recognizes START keywords", () => {
+    for (const w of ["START", "unstop", "YES", "resume"]) {
+      assert.equal(isStartKeyword(w), true, `expected START for "${w}"`);
+    }
+  });
+  it("does not treat normal replies as STOP/START", () => {
+    for (const w of ["thanks!", "see you then", "5", "stop by anytime"]) {
+      assert.equal(isStopKeyword(w), false);
+      assert.equal(isStartKeyword(w), false);
+    }
+  });
+});
+
+describe("List-Unsubscribe header + footer", () => {
+  it("builds RFC 8058 one-click headers pointing at the tokenized route", () => {
+    const u = buildUnsubDataFromToken("tok-123");
+    assert.equal(u.unsubUrl, `${appBaseUrl()}/api/comms/unsubscribe?token=tok-123`);
+    assert.equal(u.headers["List-Unsubscribe"], `<${u.unsubUrl}>`);
+    assert.equal(u.headers["List-Unsubscribe-Post"], "List-Unsubscribe=One-Click");
+  });
+  it("footer contains a working unsubscribe link (not the dead phes.io/unsubscribe)", () => {
+    const u = buildUnsubDataFromToken("tok-xyz");
+    assert.match(u.footerHtml, /\/api\/comms\/unsubscribe\?token=tok-xyz/);
+    assert.doesNotMatch(u.footerHtml, /phes\.io\/unsubscribe/);
+  });
+  it("url-encodes the token", () => {
+    const u = buildUnsubDataFromToken("a b/c");
+    assert.match(u.unsubUrl, /token=a%20b%2Fc/);
+  });
+});

--- a/lib/db/src/schema/clients.ts
+++ b/lib/db/src/schema/clients.ts
@@ -119,6 +119,19 @@ export const clientsTable = pgTable("clients", {
   // with a 0% no-fault clause).
   cancel_fee_pct: numeric("cancel_fee_pct", { precision: 5, scale: 2 }),
   lockout_fee_pct: numeric("lockout_fee_pct", { precision: 5, scale: 2 }),
+  // [comms-opt-out 2026-06-21] Compliance: per-client opt-out timestamps. NULL =
+  // opted in (the default). sms_opt_out_at is set by the Twilio inbound webhook
+  // on STOP/UNSUBSCRIBE/CANCEL/QUIT (cleared on START/UNSTOP); email_opt_out_at
+  // is set by the tokenized unsubscribe route / one-click List-Unsubscribe.
+  // EVERY automated send path checks the matching column before sending — SMS
+  // paths check sms_opt_out_at, email paths check email_opt_out_at. Storing the
+  // timestamp (not just a bool) keeps an audit of WHEN they opted out.
+  sms_opt_out_at: timestamp("sms_opt_out_at"),
+  email_opt_out_at: timestamp("email_opt_out_at"),
+  // Per-client, unguessable token for the email unsubscribe link + the
+  // List-Unsubscribe header. Backfilled for existing clients on cold start and
+  // generated for new clients; unique so a token resolves to exactly one client.
+  email_unsub_token: text("email_unsub_token"),
   created_at: timestamp("created_at").notNull().defaultNow(),
 });
 


### PR DESCRIPTION
## What

Before this, **SMS STOP was only handled at Twilio's carrier level** — Qleno recorded nothing, so reminder/review crons still fired at opted-out people — and **email had no unsubscribe at all** (the mockup linked a dead `phes.io/unsubscribe`). Both are TCPA / CAN-SPAM exposure that must exist before comms go live.

## Changes

- **Schema**: `clients.sms_opt_out_at`, `clients.email_opt_out_at`, `clients.email_unsub_token` + an idempotent boot migration (adds the columns, backfills a token per client, unique index).
- **Twilio inbound webhook** (`/api/comms/inbound`) now records the opt-out: `STOP/UNSUBSCRIBE/CANCEL/QUIT` → set `sms_opt_out_at`; `START/UNSTOP/YES/RESUME` → clear it (carriers require text-based resubscribe).
- **Real tokenized email unsubscribe route** at `/api/comms/unsubscribe` — `GET` (visible footer link, with a confirmation + one-tap resubscribe page) and one-click `POST` (RFC 8058). Replaces the dead mockup link.
- **`List-Unsubscribe` + `List-Unsubscribe-Post` headers + a working footer link** on every outbound customer email.
- **Opt-out honored on EVERY automated send path** (SMS paths check `sms_opt_out_at`, email paths check `email_opt_out_at`):
  - 72h/24h reminder cron (email + SMS)
  - on-my-way / arrived / paused / resumed / completed (`job-sms`, `tech-clock`)
  - review-request cron + inbound review SMS
  - quote follow-up + post-job retention + abandoned-booking drips (follow-up cadence)
  - invoice/payment notices (`invoice_sent`, `payment_received`, dunning reminder)
  - satisfaction survey SMS
  - manual office→client SMS
  - Transactional sends (password reset / user invite, to *users*) bypass — they must always arrive. Booking confirmations are transactional/customer-initiated (CAN-SPAM exempt) and still carry the List-Unsubscribe header via `sendNotification`.

Reads **fail open** on a transient / pre-migration error so a hiccup can't black-hole all comms, but a *recorded* opt-out is always honored.

## Tests / verification

- **Unit** (`pnpm --filter @workspace/api-server run test:optout`, 7 cases): STOP/START keyword detection, phone normalization, List-Unsubscribe header/footer builder. Pure logic in `opt-out-core.ts` (no DB import).
- **End-to-end against production, in a rolled-back transaction (nothing mutated):**
  - STOP → `sms_opt_out_at` set → reminder-cron guard + every event-path `isSmsOptedOut()` guard suppress.
  - START → resubscribed (`isSmsOptedOut` false again).
  - Email token → `email_opt_out_at` set → email guards suppress; unknown token is a no-op.
  - `List-Unsubscribe` + one-click headers present; footer links the real route, not `phes.io/unsubscribe`.

## Notes
- Columns are added at runtime via the idempotent boot migration (CI build doesn't push DB).
- Unsubscribe base URL is `APP_BASE_URL` / `PUBLIC_APP_URL`, defaulting to the prod app URL.
- **Do not merge / deploy** — for Sal's review per request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)