### PR TITLE
fix(app): land unauthenticated visitors on login, not the marketing page

### DIFF
--- a/artifacts/api-server/src/app.ts
+++ b/artifacts/api-server/src/app.ts
@@ -122,13 +122,16 @@ app.get("/s/:code", async (req: Request, res: Response) => {
   return res.redirect(302, target);
 });
 
-// ── Landing Page ────────────────────────────────────────────────────────────
+// ── Marketing Landing Page ───────────────────────────────────────────────────
+// The marketing landing lives at /landing — NOT at the app root. Root "/" is
+// intentionally left to fall through to the SPA below so that an unauthenticated
+// visitor opening the app (field techs especially) lands on the login screen,
+// not the marketing page. The SPA's "/" route redirects unauthenticated users
+// to /login and renders the dashboard for authenticated ones.
+// Marketing visitors reach the page at /landing; its CTAs link to absolute
+// app.qleno.com/login and /register URLs, so they are unaffected by this move.
 const landingDir = path.resolve(__appDir, "../../../landing");
 if (fs.existsSync(landingDir)) {
-  app.get("/", (_req: Request, res: Response) => {
-    res.setHeader("Cache-Control", "no-cache, no-store, must-revalidate");
-    res.sendFile(path.join(landingDir, "index.html"));
-  });
   app.use("/landing", express.static(landingDir, { maxAge: "10m" }));
   // Serve privacy.html at /privacy
   app.get("/privacy", (_req: Request, res: Response) => {

--- a/artifacts/qleno/src/App.tsx
+++ b/artifacts/qleno/src/App.tsx
@@ -190,12 +190,24 @@ function TechRouteGuard({ children }: { children: React.ReactNode }) {
   return <>{children}</>;
 }
 
+// [login-first-entry] Root "/" entry point. The marketing landing no longer
+// sits at the app root (see api-server app.ts) — "/" is now the app's front
+// door. An unauthenticated visitor (a field tech opening the app especially)
+// is sent straight to the login screen instead of any marketing page.
+// Authenticated users render the dashboard; the TechRouteGuard above then
+// bounces technicians/team_leads to /my-jobs.
+function RootIndex() {
+  const token = useAuthStore((s) => s.token);
+  if (!token) return <Redirect to="/login" />;
+  return <Dashboard />;
+}
+
 function Router() {
   return (
     <Suspense fallback={<PageLoader />}>
       <TechRouteGuard>
       <Switch>
-        <Route path="/" component={Dashboard} />
+        <Route path="/" component={RootIndex} />
         <Route path="/login" component={Login} />
         <Route path="/accept-invite" component={AcceptInvitePage} />
         <Route path="/dashboard" component={Dashboard} />

--- a/landing/index.html
+++ b/landing/index.html
@@ -553,7 +553,7 @@
 
   <!-- Nav -->
   <nav>
-    <a href="/" class="nav-brand">
+    <a href="/landing" class="nav-brand">
       <svg width="36" height="36" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
         <circle cx="256" cy="256" r="240" fill="#3DDC97"/>
         <g fill="#FFFFFF">


### PR DESCRIPTION
## Problem

Opening the app (e.g. a field tech on mobile) showed the **marketing landing page** instead of login. The Express server served `landing/index.html` at the app root `/` (`artifacts/api-server/src/app.ts`); only already-logged-in users were bounced onward by the landing's inline script. Unauthenticated visitors had to find their own way to log in.

## Change

Make the app's front door the **login screen**, while keeping the marketing page intact as a route:

- **`artifacts/api-server/src/app.ts`** — remove the `app.get("/")` handler that served the marketing landing at root. Root `/` now falls through to the SPA. The marketing page stays reachable at **`/landing`** and **`/privacy`** (unchanged). Its CTAs already use absolute `app.qleno.com/login` + `/register` URLs, so they're unaffected.
- **`artifacts/qleno/src/App.tsx`** — new `RootIndex` component for the `/` route: unauthenticated → `<Redirect to="/login" />`; authenticated → renders the dashboard (the existing `TechRouteGuard` still routes technicians/team_leads to `/my-jobs`).
- **`landing/index.html`** — point the landing's own logo link from `/` to `/landing` so marketing visitors stay on marketing instead of bouncing to the app.

## Verification

- `pnpm --filter @workspace/api-server run build` ✅
- `pnpm --filter @workspace/qleno run build` ✅
- Ran the SPA locally and confirmed:
  - **No token at `/`** → redirects to `/login`, login form renders.
  - **Token at `/`** → stays at `/` and renders the app (no regression for logged-in users).

🤖 Generated with [Claude Code](https://claude.com/claude-code)