### PR TITLE
fix(routing): make TechRouteGuard read role from the JWT

### DIFF
--- a/artifacts/qleno/src/App.tsx
+++ b/artifacts/qleno/src/App.tsx
@@ -6,7 +6,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { ErrorBoundary } from "@/components/error-boundary";
 import { BranchProvider } from "@/contexts/branch-context";
 import { EmployeeViewProvider } from "@/contexts/employee-view-context";
-import { useAuthStore } from "@/lib/auth";
+import { useAuthStore, getTokenRole } from "@/lib/auth";
 
 const Login               = lazy(() => import("@/pages/login"));
 const Dashboard           = lazy(() => import("@/pages/dashboard"));
@@ -177,7 +177,12 @@ function isTechAllowedPath(pathname: string): boolean {
 }
 
 function TechRouteGuard({ children }: { children: React.ReactNode }) {
-  const role = useAuthStore((s) => s.user?.role);
+  // The role lives in the JWT, not the auth store (which only holds `token`).
+  // Read it via getTokenRole() — the same source the login redirect and the
+  // rest of the app use. Subscribe to `token` so the guard re-evaluates when
+  // the user logs in / out / switches company.
+  const token = useAuthStore((s) => s.token);
+  const role = token ? getTokenRole() : null;
   const [location, navigate] = useLocation();
   const isTech = role === "technician" || role === "team_lead";
   const blocked = isTech && !isTechAllowedPath(location);


### PR DESCRIPTION
## Problem

`TechRouteGuard` (`artifacts/qleno/src/App.tsx`) read the role from `useAuthStore((s) => s.user?.role)`, but the auth store has **no `user` field** — it only holds `token`, and the role lives inside the JWT (read everywhere else via `getTokenRole()`). So `role` was always `undefined`, the guard never matched, and the redirect was inert: a **technician/team_lead who landed on an office-only URL was not bounced to `/my-jobs`** (the [tech-boundary 2026-06-17] protection the guard was meant to provide).

## Change

One file, `artifacts/qleno/src/App.tsx`:
- Read the role via **`getTokenRole()`** — the same JWT source the login redirect and the rest of the app use.
- Subscribe to `token` (`useAuthStore((s) => s.token)`) so the guard re-evaluates on login / logout / company switch.

Office / admin / owner / super_admin roles still pass through untouched, and the login-first root redirect (#603) is unaffected.

## Verification (browser, against this build)

| Scenario | Result |
|----------|--------|
| Technician at `/dispatch` (office route) | → redirected to **`/my-jobs`** ✅ |
| Office user at `/dispatch` | stays on **`/dispatch`** (passes through) ✅ |
| Unauthenticated at `/` | still redirects to **`/login`** (no regression) ✅ |

`pnpm --filter @workspace/qleno run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)