### PR TITLE
fix(my-jobs): remove nested <a> in the Training header link

### DIFF
--- a/artifacts/qleno/src/pages/my-jobs.tsx
+++ b/artifacts/qleno/src/pages/my-jobs.tsx
@@ -1412,10 +1412,10 @@ export default function MyJobsPage() {
               style={{ display: 'flex', alignItems: 'center', gap: 4, padding: '6px 10px', background: showPay ? 'var(--brand)' : 'var(--brand-dim)', color: showPay ? '#fff' : 'var(--brand)', border: '1px solid rgba(0,201,160,0.2)', borderRadius: 8, fontSize: 12, fontWeight: 700, cursor: 'pointer', fontFamily: 'inherit' }}>
               <DollarSign size={13}/> Pay
             </button>
-            <Link href="/training">
-              <a style={{ display: 'inline-flex', alignItems: 'center', gap: 4, padding: '6px 10px', background: '#FFFFFF', color: '#1A1917', border: '1px solid #E5E2DC', borderRadius: 8, fontSize: 12, fontWeight: 700, cursor: 'pointer', fontFamily: 'inherit', textDecoration: 'none' }}>
-                <GraduationCap size={13}/> Training
-              </a>
+            {/* wouter v3 <Link> renders its own <a>; style goes on Link to
+                avoid a nested <a> inside <a> (invalid markup / hydration warning). */}
+            <Link href="/training" style={{ display: 'inline-flex', alignItems: 'center', gap: 4, padding: '6px 10px', background: '#FFFFFF', color: '#1A1917', border: '1px solid #E5E2DC', borderRadius: 8, fontSize: 12, fontWeight: 700, cursor: 'pointer', fontFamily: 'inherit', textDecoration: 'none' }}>
+              <GraduationCap size={13}/> Training
             </Link>
             {/* Account menu — tap the avatar */}
             <div ref={acctRef} style={{ position: "relative" }}>


### PR DESCRIPTION
## Problem

On the my-jobs header, the Training link rendered an **`<a>` nested inside another `<a>`** — invalid HTML that React flagged as a hydration warning in the console:

```
In HTML, <a> cannot be a descendant of <a>. This will cause a hydration error.
```

wouter v3's `<Link>` renders its **own** `<a>` element, so wrapping a child `<a>` inside it produces the nested anchor:

```jsx
<Link href="/training">
  <a style={{...}}>…Training</a>   {/* ← nested <a> inside Link's <a> */}
</Link>
```

## Change

One file, `artifacts/qleno/src/pages/my-jobs.tsx` — drop the inner `<a>` and move its `style` onto `<Link>` (the convention already used elsewhere, e.g. `dashboard-layout.tsx:810`, `time-clock.tsx`). Markup-only; **same destination (`/training`), same styling.**

## Verification (browser, against this build)

- The Training link renders as a **single `<a href="/training">`** with **0 nested anchors**.
- The nested-anchor **hydration warning is gone** from the console.
- Border styling preserved.
- Clicking the link still navigates to **`/training`**.

`pnpm --filter @workspace/qleno run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)