### PR TITLE
fix(ui): remove remaining nested <a> inside wouter <Link>

### DIFF
--- a/artifacts/qleno/src/components/layout/dashboard-layout.tsx
+++ b/artifacts/qleno/src/components/layout/dashboard-layout.tsx
@@ -412,15 +412,13 @@ function CompanySwitcher({ compact = false }: { compact?: boolean }) {
           {/* Cross-tenant owner roll-up — only reachable when the user has ≥2
               companies (this whole switcher only renders then), and the endpoint
               itself returns only companies the caller owns. */}
-          <Link href="/all-locations">
-            <a onClick={() => setOpen(false)} style={{
-              display: 'flex', alignItems: 'center', gap: 6, width: '100%', padding: '9px 14px',
-              borderTop: '1px solid #F0EDEA', background: 'transparent', textDecoration: 'none',
-              fontSize: 13, fontWeight: 600, color: 'var(--brand)', cursor: 'pointer',
-              fontFamily: "'Plus Jakarta Sans', sans-serif",
-            }}>
-              <Building2 size={13} /> All Locations
-            </a>
+          <Link href="/all-locations" onClick={() => setOpen(false)} style={{
+            display: 'flex', alignItems: 'center', gap: 6, width: '100%', padding: '9px 14px',
+            borderTop: '1px solid #F0EDEA', background: 'transparent', textDecoration: 'none',
+            fontSize: 13, fontWeight: 600, color: 'var(--brand)', cursor: 'pointer',
+            fontFamily: "'Plus Jakarta Sans', sans-serif",
+          }}>
+            <Building2 size={13} /> All Locations
           </Link>
         </div>
       )}

--- a/artifacts/qleno/src/pages/leads-partners.tsx
+++ b/artifacts/qleno/src/pages/leads-partners.tsx
@@ -160,11 +160,9 @@ export default function LeadsPartnersPage() {
   return (
     <DashboardLayout>
       <div style={{ maxWidth: 1100, margin: "0 auto", padding: "0 0 40px" }}>
-        <Link href="/leads">
-          <a style={{ display: "inline-flex", alignItems: "center", gap: 4, fontSize: 13, color: "#6B6860",
-            textDecoration: "none", marginBottom: 12 }}>
-            <ChevronLeft size={14} /> Back to Pipeline
-          </a>
+        <Link href="/leads" style={{ display: "inline-flex", alignItems: "center", gap: 4, fontSize: 13, color: "#6B6860",
+          textDecoration: "none", marginBottom: 12 }}>
+          <ChevronLeft size={14} /> Back to Pipeline
         </Link>
         <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 24 }}>
           <div>

--- a/artifacts/qleno/src/pages/leads-reports.tsx
+++ b/artifacts/qleno/src/pages/leads-reports.tsx
@@ -161,11 +161,9 @@ export default function LeadsReportsPage() {
   return (
     <DashboardLayout>
       <div style={{ maxWidth: 1180, margin: "0 auto", padding: "0 0 48px" }}>
-        <Link href="/leads">
-          <a style={{ display: "inline-flex", alignItems: "center", gap: 4, fontSize: 13, color: "#6B6860",
-            textDecoration: "none", marginBottom: 12 }}>
-            <ChevronLeft size={14} /> Back to Pipeline
-          </a>
+        <Link href="/leads" style={{ display: "inline-flex", alignItems: "center", gap: 4, fontSize: 13, color: "#6B6860",
+          textDecoration: "none", marginBottom: 12 }}>
+          <ChevronLeft size={14} /> Back to Pipeline
         </Link>
 
         <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 20, flexWrap: "wrap", gap: 12 }}>

--- a/artifacts/qleno/src/pages/leads-templates.tsx
+++ b/artifacts/qleno/src/pages/leads-templates.tsx
@@ -168,11 +168,9 @@ export default function LeadsTemplatesPage() {
   return (
     <DashboardLayout>
       <div style={{ maxWidth: 1100, margin: "0 auto", padding: "0 0 40px" }}>
-        <Link href="/leads">
-          <a style={{ display: "inline-flex", alignItems: "center", gap: 4, fontSize: 13, color: "#6B6860",
-            textDecoration: "none", marginBottom: 12 }}>
-            <ChevronLeft size={14} /> Back to Pipeline
-          </a>
+        <Link href="/leads" style={{ display: "inline-flex", alignItems: "center", gap: 4, fontSize: 13, color: "#6B6860",
+          textDecoration: "none", marginBottom: 12 }}>
+          <ChevronLeft size={14} /> Back to Pipeline
         </Link>
         <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 24 }}>
           <div>


### PR DESCRIPTION
## Problem

Same class of bug as #605. wouter v3's `<Link>` renders its **own** `<a>`, so any `<Link href><a>…</a></Link>` produces an `<a>` nested inside an `<a>` — invalid HTML that React flags as a hydration warning. After fixing the my-jobs Training link in #605, a full repo scan found the remaining occurrences.

## Change

Moved each inner `<a>`'s props onto `<Link>` and dropped the inner `<a>`. **Markup-only — every link keeps the same destination and styling.**

Files touched (4):
- `artifacts/qleno/src/components/layout/dashboard-layout.tsx` — "All Locations" (its `onClick={() => setOpen(false)}` preserved on `<Link>`)
- `artifacts/qleno/src/pages/leads-partners.tsx` — "Back to Pipeline"
- `artifacts/qleno/src/pages/leads-reports.tsx` — "Back to Pipeline"
- `artifacts/qleno/src/pages/leads-templates.tsx` — "Back to Pipeline"

## Scope / completeness

A scripted scan of every `<Link>…</Link>` block across `artifacts/qleno/src` (brace-aware, multi-line, ignores `=>` arrows) confirms these 4 were the only remaining genuine nested-anchor cases. `my-jobs.tsx` already shipped in #605.

## Verification (browser, against this build)

- Leads "Back to Pipeline" renders as a **single `<a href="/leads">`** with **0 nested anchors**.
- **No hydration warning** in the console.
- Clicking still navigates to **`/leads`**; styling preserved.
- `pnpm --filter @workspace/qleno run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)