### PR TITLE
fix(my-jobs): make the no-jobs empty state actionable for techs

### DIFF
--- a/artifacts/qleno/src/pages/my-jobs.tsx
+++ b/artifacts/qleno/src/pages/my-jobs.tsx
@@ -1580,9 +1580,26 @@ export default function MyJobsPage() {
           {isLoading ? (
             <div style={{ textAlign: "center", padding: 40, color: "#9E9B94", fontSize: 14 }}>Loading your jobs…</div>
           ) : jobs.length === 0 ? (
-            <div style={{ textAlign: "center", padding: 40 }}>
+            // [empty-state 2026-06-21] The date nav + Pay button already live
+            // in the sticky header above this block, so a no-jobs day is NOT a
+            // dead end. Give the tech direct affordances here too — step to the
+            // next day and jump to their pay — so they never feel stranded on
+            // an empty screen (Sal's screenshot report).
+            <div style={{ textAlign: "center", padding: "40px 16px" }}>
               <p style={{ fontSize: 16, fontWeight: 600, color: "#1A1917", margin: "0 0 6px" }}>{isToday ? "No jobs today" : `No jobs on ${selectedLabel}`}</p>
-              <p style={{ fontSize: 13, color: "#9E9B94", margin: 0 }}>Check back or contact your manager</p>
+              <p style={{ fontSize: 13, color: "#9E9B94", margin: "0 0 18px", lineHeight: 1.5 }}>
+                {isToday ? "Use the arrows up top to browse upcoming days, or check your pay below." : "Try another day with the arrows above, or contact your manager."}
+              </p>
+              <div style={{ display: "flex", flexDirection: "column", gap: 8, maxWidth: 280, margin: "0 auto" }}>
+                <button type="button" onClick={() => shiftDay(1)}
+                  style={{ display: "inline-flex", alignItems: "center", justifyContent: "center", gap: 6, width: "100%", padding: "12px", borderRadius: 10, border: "1px solid #E5E2DC", background: "#FFFFFF", color: "#1A1917", fontSize: 14, fontWeight: 700, cursor: "pointer", fontFamily: "inherit", minHeight: 44 }}>
+                  Check the next day ›
+                </button>
+                <button type="button" onClick={() => setShowPay(true)}
+                  style={{ display: "inline-flex", alignItems: "center", justifyContent: "center", gap: 6, width: "100%", padding: "12px", borderRadius: 10, border: "none", background: "var(--brand, #00C9A0)", color: "#fff", fontSize: 14, fontWeight: 700, cursor: "pointer", fontFamily: "inherit", minHeight: 44 }}>
+                  <DollarSign size={15} aria-hidden="true" /> View my pay
+                </button>
+              </div>
             </div>
           ) : (
             <>


### PR DESCRIPTION
## Root cause / finding

Sal's screenshot showed the field-tech **My Jobs** mobile view stuck on a centered "No jobs today / Check back or contact your manager" message with no apparent way to browse to other days or reach Pay.

Investigating the current code (`artifacts/qleno/src/pages/my-jobs.tsx`), the bug as literally described — *nav removed/hidden in the empty case* — **does not reproduce**. `MyJobsPage` has a single unconditional `return`; the sticky header (with the **Pay** button) and the day-navigation row (‹ / date-picker / ›, "Back to today") are rendered **above** the content area, and the empty-state message sits *inside* that content area. The day nav has been structurally present since 2026-06-09 (`ede6055f`). The screenshot most likely predates that deploy.

What was genuinely weak: from the empty state itself there was **no explicit affordance** — the tech had to know to scroll up and use the header arrows or Pay button. On a near-empty screen that reads as a dead end.

## Change

Enrich only the `jobs.length === 0` block:
- "**Check the next day ›**" button → steps the selected date forward (`shiftDay(1)`).
- "**View my pay**" button → opens the earnings panel (`setShowPay(true)`).
- Clearer copy pointing at the day arrows up top.

The empty message already rendered within the normal layout under the header + day nav; this only adds in-place actions. **The has-jobs view is unchanged.**

## Verification (mobile, 375×812)

- No-jobs-today renders header (Pay), full day nav, and the two new buttons within the layout — message does not replace the screen.
- "Check the next day" advanced **Sun Jun 21 → Mon Jun 22** (date nav reachable from the empty state).
- "View my pay" reveals the pay panel.
- `pnpm run typecheck:libs` and `pnpm --filter @workspace/qleno run build` both pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)