### PR TITLE
fix(quickbooks): make in-app Connect actually authenticate

### DIFF
--- a/artifacts/api-server/src/routes/integrations/quickbooks.ts
+++ b/artifacts/api-server/src/routes/integrations/quickbooks.ts
@@ -36,7 +36,11 @@ function getPublicBase(req: any): string {
 function getRedirectUri(req: any): string {
   // Prefer env-configured value for production
   if (process.env.QB_REDIRECT_URI) return process.env.QB_REDIRECT_URI;
-  return `${getPublicBase(req)}/qleno/api/integrations/quickbooks/callback`;
+  // The callback route is mounted at /api/integrations/quickbooks/callback
+  // (the main router mounts at /api). The earlier `/qleno` prefix pointed at a
+  // non-existent path, so the Intuit handshake's redirect_uri never matched a
+  // real route. QB_REDIRECT_URI still overrides this for prod.
+  return `${getPublicBase(req)}/api/integrations/quickbooks/callback`;
 }
 
 // ── GET /api/integrations/quickbooks/connect ───────────────────────────────
@@ -55,7 +59,11 @@ router.get("/connect", requireAuth, requireRole("owner", "admin"), async (req, r
     });
 
     const authUrl = `https://appcenter.intuit.com/connect/oauth2?${params.toString()}`;
-    return res.redirect(authUrl);
+    // Return the URL as JSON instead of a 302. The frontend calls this endpoint
+    // with the Bearer token attached (a fetch), then navigates the browser to
+    // authUrl. A direct 302 here can't be reached: a top-level navigation to
+    // /connect carries no Authorization header, so requireAuth would 401.
+    return res.json({ authUrl });
   } catch (err) {
     console.error("[QB] Connect error:", err);
     return res.status(500).json({ error: "Failed to initiate QB connection" });

--- a/artifacts/qleno/src/pages/company.tsx
+++ b/artifacts/qleno/src/pages/company.tsx
@@ -729,8 +729,25 @@ function IntegrationsTab() {
 
   useEffect(() => { loadStatus(); }, [loadStatus]);
 
-  const handleConnect = () => {
-    window.location.href = `${API}/api/integrations/quickbooks/connect`;
+  const handleConnect = async () => {
+    // Fetch the Intuit authorize URL WITH the Bearer token (the connect endpoint
+    // requires auth), then navigate the browser to it. A plain navigation to the
+    // connect endpoint can't carry the token and would 401.
+    try {
+      const res = await f("/connect");
+      if (!res.ok) {
+        toast({ title: "Could not start QuickBooks connection", variant: "destructive" });
+        return;
+      }
+      const data = await res.json();
+      if (data?.authUrl) {
+        window.location.href = data.authUrl;
+      } else {
+        toast({ title: "Could not start QuickBooks connection", variant: "destructive" });
+      }
+    } catch {
+      toast({ title: "Could not start QuickBooks connection", variant: "destructive" });
+    }
   };
 
   const handleDisconnect = async () => {


### PR DESCRIPTION
## Problem

Schaumburg (co4) — and in fact **every** company — could not connect QuickBooks from the UI. The "Connect QuickBooks" button (`company.tsx` `IntegrationsTab`) did a top-level browser navigation:

```js
window.location.href = `${API}/api/integrations/quickbooks/connect`;
```

The connect endpoint is guarded by `requireAuth` + `requireRole("owner","admin")`, and `requireAuth` reads **only** the `Authorization: Bearer` header (no cookie / query fallback). A browser navigation cannot attach that header, so the request 401'd with `{"error":"unauthorized","message":"No token provided"}` — identical to hitting the raw URL. There was no working in-app path to connect.

## Fix (Option A)

1. **`routes/integrations/quickbooks.ts` `/connect`** — returns the Intuit authorize URL as JSON (`{ authUrl }`) instead of a 302. Auth is unchanged (`requireAuth` + owner/admin).
2. **`company.tsx` `handleConnect`** — now `fetch`es `/connect` via the existing `f()` helper (which attaches `getAuthHeaders()`), then `window.location.href = data.authUrl`. Auth rides the fetch; navigation is only the external redirect to Intuit. Toasts on failure.
3. **`getRedirectUri()` default** — dropped the stale `/qleno` prefix that matched no route; now `${publicBase}/api/integrations/quickbooks/callback` (the real mount). `QB_REDIRECT_URI` env still overrides for prod.

The OAuth **callback** (token/realm write + `qb_connected=true`) was already correct and is untouched.

## Verification

- `pnpm run typecheck:libs` (CI `tsc-check`) — exit 0
- `pnpm --filter @workspace/api-server run build` — ✓
- `pnpm --filter @workspace/qleno run build` (BASE_PATH=/) — ✓
- Diff scoped to the two files; no new artifact-level type errors (906 → 906, all pre-existing and out of CI's graph).

## Config still required before a connect can succeed (Railway + Intuit)

This PR fixes the code path. For the handshake to complete in prod, the deployed env/Intuit app must be set (not part of this PR):

- `QB_CLIENT_ID` / `QB_CLIENT_SECRET` — Intuit app credentials, present in Railway.
- `QB_REDIRECT_URI=https://app.qleno.com/api/integrations/quickbooks/callback` — set in Railway (don't rely on the default).
- **Register that exact redirect URI** in the Intuit app's Redirect URIs list (Intuit rejects any mismatch).
- `NODE_ENV=production` — so the QBO API client targets `quickbooks.api.intuit.com` (production), matching co4's real QBO company rather than sandbox.

**Do not merge/deploy — holding for Sal.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)