### PR TITLE
docs(employee-supply): employee equipment & supply requests spec (deferred)

### DIFF
--- a/artifacts/api-server/src/lib/commission-paytype.ts
+++ b/artifacts/api-server/src/lib/commission-paytype.ts
@@ -366,3 +366,147 @@ export function computePerTechCommissionRows(input: {
   }
   return out;
 }
+
+// ── Rich per-tech rows for the Payroll Detail SCREEN ───────────────────────
+/**
+ * A display row carrying the SAME pay math as computePerTechCommissionRows
+ * (both go through computeTechPay, so the screen and the paycheck never
+ * disagree) PLUS the per-line metadata the /payroll/detail UI renders:
+ * the pay type, an explain-the-math label, and the hours actually paid.
+ */
+export interface PerTechPayDetailRow {
+  user_id: number;
+  job_id: number;
+  /** Final pay for this tech on this job (after any deduction / override). */
+  amount: number;
+  payType: PayType;
+  /** "manual_override" when a final_pay dollar override won; else the routing. */
+  basis: "manual_override" | "commercial_pool" | "residential_pool";
+  isCommercial: boolean;
+  /** This tech's actual clocked hours on the job. */
+  clockedHours: number;
+  /** Hours the wage was paid on — hourly / hours-override lines only, else 0. */
+  paidHours: number;
+  /** True when a payroll_hours_overrides row drove paidHours. */
+  hoursOverridden: boolean;
+  /** Hour-weighted fee-split % (e.g. 0.16), else 0. */
+  effectivePct: number;
+  /** Dollars removed by a breakage/damage deduction (0 when none). */
+  deduction: number;
+  /** MC-style explain-the-math string for the UI's "Pay basis" column. */
+  payBasisLabel: string;
+  branch_id: number | null;
+  scheduled_date: string;
+}
+
+/**
+ * Compute rich per-tech pay rows for the Payroll Detail screen. Emits one row
+ * per tech who CLOCKED the job (helpers included) — un-clocked jobs produce no
+ * line, matching the screen's long-standing "only what was clocked shows"
+ * behavior. The dollar amounts are byte-identical to the period-lock paycheck
+ * engine because both route through computeTechPay with the same inputs.
+ *
+ * Honors, in priority order: (1) job_technicians.final_pay dollar override →
+ * "Manual $ override"; (2) payroll_hours_overrides → pay this line HOURLY on
+ * the override hours (the office's "pay this overage job hourly" lever);
+ * (3) the tech's pay type (fee_split / allowed_hours / hourly).
+ */
+export function computePerTechPayRowsDetailed(input: {
+  jobs: ReadonlyArray<CommissionInputJob>;
+  jobTechs: ReadonlyArray<JobTechRow>;
+  techHoursByKey: ReadonlyMap<string, number>;
+  serviceTypePctBySlug: ReadonlyMap<string, number>;
+  resRates: CompanyResRates;
+  commercial: { commercial_hourly_rate: number; commercial_comp_mode: "allowed_hours" | "actual_hours" };
+  /** "user_id:job_id" → final_pay dollar override. */
+  overrides?: ReadonlyMap<string, number>;
+  /** "user_id:job_id" → paid_hours override (pay this line hourly on these hrs). */
+  paidHoursOverride?: ReadonlyMap<string, number>;
+}): PerTechPayDetailRow[] {
+  const overrides = input.overrides ?? new Map();
+  const hoursOv = input.paidHoursOverride ?? new Map();
+  const techsByJob = new Map<number, JobTechRow[]>();
+  for (const t of input.jobTechs) {
+    const arr = techsByJob.get(t.job_id) ?? [];
+    arr.push(t);
+    techsByJob.set(t.job_id, arr);
+  }
+
+  const out: PerTechPayDetailRow[] = [];
+  for (const j of input.jobs) {
+    const isCommercial = isCommercialJob(j.account_id, j.service_type, j.client_type);
+    let techs = techsByJob.get(j.id) ?? [];
+    if (techs.length === 0 && j.assigned_user_id != null) {
+      techs = [{ job_id: j.id, user_id: j.assigned_user_id, is_primary: true,
+        pay_type: null, hourly_rate: null, commission_pct: null, pay_deduction_pct: null, pay_deduction_flat: null }];
+    }
+    const hoursOf = (uid: number) => round2(input.techHoursByKey.get(`${j.id}:${uid}`) ?? 0);
+    const totalTechHours = techs.reduce((s, t) => s + hoursOf(t.user_id), 0);
+    if (totalTechHours <= 0) continue; // display: only clocked lines
+
+    const servicePct = input.serviceTypePctBySlug.get((j.service_type ?? "").toLowerCase());
+    const scopePct = servicePct ?? resolveResidentialPayPct(j.service_type, input.resRates);
+    const defaults = defaultPayForJob({
+      isCommercial,
+      serviceType: j.service_type,
+      commercialHourlyRate: input.commercial.commercial_hourly_rate,
+      scopePct,
+    });
+    const ctx: JobPayContext = {
+      baseFee: Math.max(n(j.base_fee) ?? 0, n(j.billed_amount) ?? 0),
+      allowedHours: n(j.allowed_hours) ?? 0,
+      totalTechHours,
+    };
+
+    for (const t of techs) {
+      const key = `${t.user_id}:${j.id}`;
+      const clockedHours = hoursOf(t.user_id);
+      const base = { user_id: t.user_id, job_id: j.id, isCommercial,
+        clockedHours, branch_id: j.branch_id, scheduled_date: j.scheduled_date };
+
+      // (1) Manual dollar override always wins.
+      if (overrides.has(key)) {
+        out.push({ ...base, amount: round2(overrides.get(key) as number), payType: "hourly",
+          basis: "manual_override", paidHours: 0, hoursOverridden: false, effectivePct: 0,
+          deduction: 0, payBasisLabel: "Manual $ override" });
+        continue;
+      }
+
+      const resolved = resolveTechPayInput({
+        user_id: t.user_id, techHours: clockedHours,
+        overridePayType: asPayType(t.pay_type), overrideHourlyRate: n(t.hourly_rate),
+        overridePct: n(t.commission_pct), defaults,
+      });
+
+      // (2) Paid-hours override → pay this line HOURLY on the override hours.
+      if (hoursOv.has(key)) {
+        const oh = round2(hoursOv.get(key) as number);
+        const rate = resolved.hourlyRate > 0 ? resolved.hourlyRate : input.commercial.commercial_hourly_rate;
+        out.push({ ...base, amount: round2(oh * rate), payType: "hourly", basis: isCommercial ? "commercial_pool" : "residential_pool",
+          paidHours: oh, hoursOverridden: true, effectivePct: 0, deduction: 0,
+          payBasisLabel: `$${rate.toFixed(2)}/hr × ${oh}h (override)` });
+        continue;
+      }
+
+      // (3) Normal per-tech pay type.
+      resolved.deductionPct = n(t.pay_deduction_pct) ?? 0;
+      resolved.deductionFlat = n(t.pay_deduction_flat) ?? 0;
+      const row = computeTechPay(ctx, resolved);
+      let label: string;
+      let paidHours = 0;
+      if (resolved.payType === "hourly") {
+        paidHours = round2(clockedHours);
+        label = `$${resolved.hourlyRate.toFixed(2)}/hr × ${paidHours}h`;
+      } else if (resolved.payType === "allowed_hours") {
+        label = `$${resolved.hourlyRate.toFixed(2)}/hr × ${row.effectiveHours}h (allowed)`;
+      } else {
+        label = `${(row.effectivePct * 100).toFixed(2)}% of $${ctx.baseFee.toFixed(2)}`;
+      }
+      out.push({ ...base, amount: row.amount, payType: resolved.payType,
+        basis: isCommercial ? "commercial_pool" : "residential_pool",
+        paidHours, hoursOverridden: false, effectivePct: row.effectivePct,
+        deduction: row.deduction, payBasisLabel: label });
+    }
+  }
+  return out;
+}

--- a/artifacts/api-server/src/routes/payroll.ts
+++ b/artifacts/api-server/src/routes/payroll.ts
@@ -6,7 +6,10 @@ import { requireAuth, requireRole } from "../lib/auth.js";
 import { parseResRatesRow, resolveResidentialPayPct } from "../lib/commission-rates.js";
 import { computeCommissionRows } from "../lib/commission-compute.js";
 // [payroll-P0] per-tech-clocked attribution + 4-cell pay-type + hourly basis.
-import { computePayLines, type PayrollJob, type ClockEntry, type TechCell, type CompanyPayConfig, type HoursBasis } from "../lib/payroll-compute.js";
+import { type ClockEntry } from "../lib/payroll-compute.js";
+// [Option A 2026-06-22] Payroll Detail runs off the per-tech pay-type engine
+// (same computeTechPay the period-lock paychecks use) so screen == checks.
+import { computePerTechPayRowsDetailed, type JobTechRow } from "../lib/commission-paytype.js";
 import {
   resolveOvertimeRules,
   computeWeekOvertime,
@@ -753,11 +756,10 @@ router.get("/detail", requireAuth, async (req, res) => {
       for (const r of mRows.rows as any[]) mileageByUser.set(Number(r.user_id), parseFloat(String(r.total || 0)));
     } catch { /* mileage_legs absent — skip */ }
 
-    // ── [payroll-P0] per-tech-CLOCKED attribution via computePayLines ────────
+    // ── [payroll-P0] per-tech-CLOCKED attribution via the pay-type engine ────
     // A tech earns from every job they personally clocked (helpers included).
-    // Residential commission is a pool split among the job's clocked commission
-    // techs (weighted by minutes); clocked hourly techs are paid hourly and
-    // excluded from the pool. Pay type comes from the 4-cell matrix.
+    // Pay type is per-tech (job_technicians): fee_split / allowed_hours / hourly,
+    // computed by the SAME engine that cuts the paychecks (Option A).
     const jobById = new Map<number, typeof jobs[number]>(jobs.map(j => [j.id, j]));
     const inScopeJobIds = jobs.map(j => j.id);
     // [payroll-P0 hotfix] Use the codebase-proven inline int-array form
@@ -767,22 +769,25 @@ router.get("/detail", requireAuth, async (req, res) => {
     // integers (number-coerced, finite-filtered) — no injection surface.
     const intList = (a: number[]) => a.map(Number).filter(Number.isFinite).join(",");
 
-    // per-(tech, job) clocked hours, summed
+    // per-(tech, job) clocked hours, summed. source='punched' MATCHES the
+    // period-lock paycheck path (pay.ts) so the screen and the checks read the
+    // SAME hours — estimated/imported clocks never split pay (Option A parity).
     const clocks: ClockEntry[] = [];
     if (inScopeJobIds.length) {
       try {
         const cr = await db.execute(sql`
           SELECT user_id, job_id, ROUND(SUM(EXTRACT(EPOCH FROM (clock_out_at - clock_in_at)) / 3600.0)::numeric, 2) AS hrs
           FROM timeclock
-          WHERE company_id = ${companyId} AND job_id = ANY(ARRAY[${sql.raw(intList(inScopeJobIds))}]::int[]) AND clock_out_at IS NOT NULL
+          WHERE company_id = ${companyId} AND job_id = ANY(ARRAY[${sql.raw(intList(inScopeJobIds))}]::int[])
+            AND clock_out_at IS NOT NULL AND source = 'punched'
           GROUP BY user_id, job_id`);
         for (const r of cr.rows as any[]) clocks.push({ user_id: Number(r.user_id), job_id: Number(r.job_id), clocked_hours: parseFloat(String(r.hrs || 0)) });
       } catch (err) { console.error("[payroll/detail] clocks query failed:", err); }
     }
 
-    // 4-cell pay matrix per clocked tech (single source of truth for pay type)
+    // Clocked-tech identity + sandbox exclusion (pay type now comes from the
+    // per-tech engine below, NOT a per-user 4-cell matrix).
     const clockedUserIds = [...new Set(clocks.map(c => c.user_id))];
-    const cellByUser = new Map<number, TechCell>();
     const userMap = new Map<number, { first_name: string; last_name: string }>();
     // [sandbox-exclude 2026-06-20] Test/sandbox fixtures (is_sandbox=true) must
     // NEVER appear in payroll — the "Generic Cleaner" ghost computed $130 and
@@ -795,27 +800,13 @@ router.get("/detail", requireAuth, async (req, res) => {
     const sandboxUserIds = new Set<number>();
     if (clockedUserIds.length) {
       const urows = await db.execute(sql`
-        SELECT id, first_name, last_name, is_sandbox, residential_pay_type, residential_pay_rate, commercial_pay_type, commercial_pay_rate
+        SELECT id, first_name, last_name, is_sandbox
         FROM users WHERE company_id = ${companyId} AND id = ANY(ARRAY[${sql.raw(intList(clockedUserIds))}]::int[])`);
       for (const u of urows.rows as any[]) {
         if (u.is_sandbox === true) { sandboxUserIds.add(Number(u.id)); continue; }
         userMap.set(Number(u.id), { first_name: u.first_name ?? "", last_name: u.last_name ?? "" });
-        cellByUser.set(Number(u.id), {
-          residential_pay_type: u.residential_pay_type === "hourly" ? "hourly" : "commission",
-          residential_pay_rate: parseFloat(String(u.residential_pay_rate ?? resRates.res_tech_pay_pct)),
-          commercial_pay_type: u.commercial_pay_type === "commission" ? "commission" : "hourly",
-          commercial_pay_rate: parseFloat(String(u.commercial_pay_rate ?? commercialHourlyRate)),
-        });
       }
     }
-
-    // company hours-basis default for hourly techs (greater_of when unset/absent)
-    let hoursBasis: HoursBasis = "greater_of";
-    try {
-      const hb = await db.execute(sql`SELECT payroll_hours_basis FROM companies WHERE id = ${companyId} LIMIT 1`);
-      const v = (hb.rows[0] as any)?.payroll_hours_basis;
-      if (v === "actual_clocked" || v === "allowed_hours" || v === "greater_of") hoursBasis = v;
-    } catch { /* column absent pre-migration — keep greater_of default */ }
 
     // per-job HOURS overrides (office hand-adjusted paid hours; never dollars)
     const paidHoursOverride = new Map<string, number>();
@@ -837,19 +828,55 @@ router.get("/detail", requireAuth, async (req, res) => {
       } catch { /* job_technicians absent — no overrides */ }
     }
 
-    const payConfig: CompanyPayConfig = {
+    // Per-tech clocked hours map ("job:user" → hours), built from the clocks above.
+    const techHoursByKey = new Map<string, number>();
+    for (const ce of clocks) if (ce.clocked_hours > 0) techHoursByKey.set(`${ce.job_id}:${ce.user_id}`, ce.clocked_hours);
+
+    // Per-tech pay-type rows (job_technicians): pay_type / rate / % / deductions.
+    // This is what makes the screen honor "Norma fee-split, Jose hourly" on one job.
+    let jobTechsForPay: JobTechRow[] = [];
+    if (inScopeJobIds.length) {
+      try {
+        const tr = await db.execute(sql`
+          SELECT job_id, user_id, is_primary, pay_type, hourly_rate, commission_pct,
+                 pay_deduction_pct, pay_deduction_flat
+            FROM job_technicians
+           WHERE company_id = ${companyId} AND job_id = ANY(ARRAY[${sql.raw(intList(inScopeJobIds))}]::int[])`);
+        jobTechsForPay = (tr.rows as any[]).map(r => ({
+          job_id: Number(r.job_id), user_id: Number(r.user_id), is_primary: r.is_primary === true,
+          pay_type: r.pay_type ?? null, hourly_rate: r.hourly_rate ?? null, commission_pct: r.commission_pct ?? null,
+          pay_deduction_pct: r.pay_deduction_pct ?? null, pay_deduction_flat: r.pay_deduction_flat ?? null,
+        }));
+      } catch { /* pay-type columns absent — engine falls back to job defaults */ }
+    }
+
+    // Per-service fee-split % (service_types.commission_pct); NULL → company tier.
+    const serviceTypePctBySlug = new Map<string, number>();
+    try {
+      const svc = await db.execute(sql`SELECT slug, commission_pct FROM service_types WHERE company_id = ${companyId} AND commission_pct IS NOT NULL`);
+      for (const r of svc.rows as any[]) {
+        const pct = parseFloat(String(r.commission_pct));
+        if (Number.isFinite(pct)) serviceTypePctBySlug.set(String(r.slug).toLowerCase(), pct);
+      }
+    } catch { /* service_types.commission_pct absent — fall back to tiers */ }
+
+    // ── [Option A] ONE engine — same computeTechPay as the paycheck path ──────
+    const payLines = computePerTechPayRowsDetailed({
+      jobs: jobs.map(j => ({
+        id: j.id, assigned_user_id: (j as any).assigned_user_id ?? null,
+        account_id: (j as any).account_id ?? null, client_type: (j as any).client_type ?? null,
+        service_type: j.service_type, base_fee: j.base_fee, billed_amount: j.billed_amount,
+        allowed_hours: j.allowed_hours, actual_hours: j.actual_hours,
+        branch_id: (j as any).branch_id ?? null, scheduled_date: String(j.scheduled_date),
+      })),
+      jobTechs: jobTechsForPay,
+      techHoursByKey,
+      serviceTypePctBySlug,
       resRates,
-      commercial_hourly_rate: commercialHourlyRate,
-      commercial_comp_mode: commercialCompMode === "actual_hours" ? "actual_hours" : "allowed_hours",
-      hours_basis: hoursBasis,
-    };
-    const jobsForPay: PayrollJob[] = jobs.map(j => ({
-      id: j.id, account_id: (j as any).account_id ?? null, client_type: (j as any).client_type ?? null,
-      service_type: j.service_type, base_fee: j.base_fee, billed_amount: j.billed_amount,
-      allowed_hours: j.allowed_hours, actual_hours: j.actual_hours,
-      scheduled_date: String(j.scheduled_date), branch_id: (j as any).branch_id ?? null,
-    }));
-    const payLines = computePayLines({ jobs: jobsForPay, clocks, cellByUser, config: payConfig, paidHoursOverride, finalPayOverride });
+      commercial: { commercial_hourly_rate: commercialHourlyRate, commercial_comp_mode: commercialCompMode === "actual_hours" ? "actual_hours" : "allowed_hours" },
+      overrides: finalPayOverride,
+      paidHoursOverride,
+    });
 
     // group lines by tech (filterUserId applied here — techs see only their own)
     const linesByUser = new Map<number, typeof payLines>();
@@ -881,21 +908,21 @@ router.get("/detail", requireAuth, async (req, res) => {
           // tech's PAY for this job (hourly, commission-pool-share, or override).
           commission: l.amount,
           commission_overridden: l.basis === "manual_override",
-          commission_basis: l.pay_type === "hourly" ? "hourly" : l.basis,
+          commission_basis: l.payType === "hourly" ? "hourly" : l.basis,
           // explain-the-math label straight from the engine.
-          pay_basis: l.pay_basis_label,
-          pay_type: l.pay_type,
-          hours_overridden: l.hours_overridden,
+          pay_basis: l.payBasisLabel,
+          pay_type: l.payType,
+          hours_overridden: l.hoursOverridden,
           quality_score,
           branch_id: l.branch_id ?? null,
           branch_name: l.branch_id != null ? (branchNameMap.get(l.branch_id) ?? null) : null,
           hrs_scheduled: allowedHrs,
           // per-tech CLOCKED hours now (not the job's single actual_hours);
           // paid_hours when an hourly line floored/overrode above the clock.
-          hrs_worked: l.paid_hours > 0 ? l.paid_hours : l.clocked_hours,
-          hrs_actual: l.clocked_hours,
+          hrs_worked: l.paidHours > 0 ? l.paidHours : l.clockedHours,
+          hrs_actual: l.clockedHours,
           hrs_estimated: false,
-          effective_rate: l.clocked_hours > 0 ? Math.round((l.amount / l.clocked_hours) * 100) / 100 : null,
+          effective_rate: l.clockedHours > 0 ? Math.round((l.amount / l.clockedHours) * 100) / 100 : null,
         };
       });
 

--- a/docs/EMPLOYEE_TICKETS_SPEC.md
+++ b/docs/EMPLOYEE_TICKETS_SPEC.md
@@ -1,161 +1,78 @@
-# Employee Tickets — Spec & Build Estimate
+# Employee Equipment & Supply Requests — Spec & Build Estimate
 
-**Status:** Spec only. Nothing built or merged. For Sal's review + the decisions
-listed at the bottom.
+**Status:** Spec only. Nothing built or merged. **Lower priority** — the time-off
+request flow (separate spec / PR #613) ships first. Kept as a draft for later.
+
+> Re-scoped 2026-06-22: this was originally written as a generic "employee issue
+> ticket." Sal clarified it's specifically an **equipment & supply request**
+> feature (an employee's vacuum broke, they need parts, or new uniform shirts/
+> pants). The time-off "ticket" flow he also described is a *different* thing and
+> is specced separately (PR #613). This doc now covers equipment/supply only.
 
 ---
 
 ## Plain-English summary (for Sal)
 
-Today's "tickets" are about **customers** — the office logs a breakage, complaint,
-or compliment against a client/job, and nobody gets pinged. This feature adds a
-**separate** kind of ticket: an **employee** taps "Report an issue" in their phone
-app, types a short subject + description (optionally tagged to a job), and hits
-send. The moment they do, the **whole office team and you** get an alert. The
-office sees these in a simple inbox, works them, and marks each **Resolved** — with
-an optional note that goes back to the employee.
+A cleaner in the field needs something — their **vacuum broke and needs replacing**,
+they need **vacuum parts**, or **new uniform shirts/pants**. They tap "Request
+equipment/supplies" in the phone app, pick what they need, add a short note (and
+optionally a photo), and send. The **office team and you** get an alert. The office
+sees these in a simple inbox, orders/handles them, and marks each **Done** — with an
+optional note back to the employee.
 
-It's deliberately built to look and behave like the time-off request flow we just
-shipped (employee submits → office is alerted → office acts → status updates), so
-we're reusing proven parts rather than inventing new ones. **In-app (bell) alerts
-work immediately; the email/text versions turn on whenever you flip the company
-comms switch** — same as time off.
-
-Realistic build: **about 3–4 working days** for a solid first version (add ~1 day
-if employees can attach photos). A few small decisions from you are at the end.
+It reuses the same proven alert system as time off (notifies every owner/admin/
+office person at once), so it's a contained add.
 
 ---
 
 ## Goal & scope
 
-Let an employee raise an issue/ticket from the field app that fans out to the
-office team + owner, and give the office a place to triage and resolve it.
+Let an employee request equipment/supplies from the field app; alert the office
+team + owner; give the office an inbox to fulfill and close them.
 
-**In scope (v1):** employee "Report an issue" form (subject + description + optional
-job link); a dedicated employee-issue ticket type kept apart from customer tickets;
-office + owner alert on submit; office inbox with open → resolved status; optional
-resolved-note back to the employee; employee can see their own tickets + status.
+**Categories (Sal-confirmed):** replacement vacuum · vacuum parts · uniform shirt ·
+uniform pants · other. (Free-text note always; optional photo — Decision below.)
 
-**Out of scope (v1, future):** threaded back-and-forth chat on a ticket, SLA timers,
-assignment to a specific person, categories beyond a simple list, analytics. Noted
-at the end.
+## What we reuse (already live)
+- **Office+owner fan-out:** `notifyOfficeUsers(companyId, …)` — the same notifier
+  used by time off (in-app + push + email, gated by the comms switch).
+- **Employee "it's handled" message:** `notifyUser(…)`.
+- **The whole submit → alert → inbox → resolve pattern** mirrors the time-off flow.
+- **File storage** (R2) already exists if we include the optional photo.
 
-## What we reuse (already live in prod)
+Kept entirely separate from the customer `contact_tickets` and from time off.
 
-- **The office+owner fan-out:** `notifyOfficeUsers(companyId, …)` in
-  `lib/notify.ts` already alerts every owner/admin/office user at once (in-app +
-  push + email), gated by the comms switch. This is the exact piece that powers the
-  time-off "Action required" alert — we point it at tickets too.
-- **The employee alert:** `notifyUser(…)` (same file) sends the one-to-one in-app +
-  push + email — reused for the "your ticket was resolved" message.
-- **The end-to-end pattern:** the time-off request flow (`routes/leave.ts` +
-  `lib/leave-notifications.ts` + the `leave-review` office page + the field-app
-  "My Time Off" page) is a near-exact template for submit → notify → triage →
-  status.
-- **File storage** for photos already exists (Cloudflare R2; client attachments use
-  it today) — only relevant if we include the photo option.
+## Data model — new `employee_supply_requests` table
 
-We do **not** reuse the customer `contact_tickets` table — employee issues stay in
-their own table so HR/ops matters never mix into the customer-complaint records or
-reports.
+`id`, `company_id`, `raised_by_user_id`, `category` (vacuum / parts / uniform_shirt /
+uniform_pants / other), `note`, optional `photo` ref, `status` (open → fulfilled),
+`fulfilled_by_user_id`, `fulfilled_at`, `resolution_note`, timestamps. Multi-tenant
+by `company_id`.
 
-## Data model — new `employee_tickets` table
-
-| Field | Meaning |
-|---|---|
-| `id` | ticket id |
-| `company_id` | tenant (scopes everything, like all tables) |
-| `raised_by_user_id` | the employee who opened it |
-| `subject` | short title |
-| `body` | the description |
-| `category` | simple dropdown (see Decision 1) — e.g. equipment, pay, scheduling, safety, other |
-| `job_id` | optional link to a job |
-| `status` | `open` → `resolved` (optionally `acknowledged` in between — Decision 3) |
-| `resolved_by_user_id`, `resolved_at`, `resolution_note` | filled when the office resolves |
-| `created_at`, `updated_at` | timestamps |
-| *(optional)* `attachments` | photo file references, only if Decision 2 = yes |
-
-Multi-tenant scoped by `company_id` like everything else.
-
-## API endpoints (mirrors the leave-request routes)
-
-Employee (any authenticated tenant user, scoped to themselves):
-- `POST /api/employee-tickets` — create (subject, body, category, optional job_id).
-  On success → fan out the alert (below).
-- `GET /api/employee-tickets/mine` — the employee's own tickets + statuses.
-
-Office/owner (role-gated to owner/admin/office, like the leave review page):
-- `GET /api/employee-tickets` — inbox; filter by status (open/resolved).
-- `POST /api/employee-tickets/:id/resolve` — mark resolved + optional note → notify
-  the employee.
-- *(optional)* `POST /api/employee-tickets/:id/acknowledge` — if we keep an
-  in-between "seen it" state (Decision 3).
-
-## Notifications
-
-- **On submit →** `notifyOfficeUsers(companyId, { type: "employee_ticket", title:
-  "New issue from <employee>", body: <subject>, link: "/employee-tickets" })`.
-  Every owner/admin/office person (that's the office team **and** you) gets the
-  in-app bell alert immediately; the email/text versions ride the same call and
-  start sending once the company comms switch is on — exactly like time off.
-- **On resolve →** `notifyUser(…)` to the employee: "Your issue '<subject>' was
-  resolved" + the optional note (in-app/push now; email/text with comms on).
-- No new notification plumbing is written — both calls already exist and are proven.
+## API (mirrors the leave-request routes)
+- `POST /api/supply-requests` (employee) → create + fan-out alert to office + owner.
+- `GET /api/supply-requests/mine` (employee) → own requests + status.
+- `GET /api/supply-requests` (office) → inbox, filter by status.
+- `POST /api/supply-requests/:id/fulfill` (office) → mark done + optional note → notify employee.
 
 ## Frontend
+- Employee app: **"Request equipment/supplies"** button → form (category dropdown +
+  note + optional photo) and a "My requests" list with status.
+- Office app: an **inbox** (Open / Fulfilled tabs) with a Fulfill button + optional
+  note; a menu link for office/owner.
 
-**Employee app (field):**
-- A **"Report an issue"** button (e.g., on the home/My-Jobs or profile screen) →
-  opens a small form: subject, description, optional "related job" picker, and
-  (if Decision 2 = yes) an "add photo" button.
-- A **"My issues"** list showing each ticket's status and the resolution note when
-  closed — same shape as the "My time-off requests" list.
+## Build estimate
+**~3–4 working days** for v1 (+~1 day if photos are included). It's the same shape
+as the time-off flow, so most of the pattern is copy-and-adapt.
 
-**Office app:**
-- An **Employee Issues inbox** page (Open / Resolved tabs) listing tickets with who
-  raised it, when, the subject/body, the job link, and a **Resolve** button with an
-  optional note — modeled on the existing leave-review page.
-- A **menu/sidebar link** to it for office/owner. (Note: we should also add the
-  matching menu link for the time-off review page, which is built but currently
-  reachable only by its address.)
+## Decisions for Sal (when this comes up)
+1. **Photos** — let employees attach a photo of the broken item? (+~1 day.)
+2. **Uniform sizes** — capture shirt/pants size on the request, or handle in the
+   note? (A size field is a small add.)
+3. **Status steps** — just Open → Fulfilled, or add "Ordered" in between?
+4. **Audience** — alert all owner/admin/office (same as time off); confirm.
+5. **Both branches** (Oak Lawn + Schaumburg) or one?
 
-## Build estimate (realistic)
-
-| Piece | Effort |
-|---|---|
-| New table + migration (idempotent, multi-tenant) | ~0.5 day |
-| API endpoints (create, mine, inbox, resolve) | ~0.5–1 day |
-| Wire the two notifications (reuse) | ~0.25 day |
-| Employee form + "My issues" list (field app) | ~0.5–1 day |
-| Office inbox page + menu link | ~0.5–1 day |
-| Tests + QA + dry-run/deploy | ~0.5 day |
-| **v1 total** | **~3–4 working days** |
-| Photo attachments (if Decision 2 = yes) | **+~1 day** |
-
-This is a contained feature: one new table, ~5 endpoints, two small screens, and
-the notifier is already done — which is why the estimate is modest.
-
-## Decisions Sal needs to make
-
-1. **Categories.** What short list should the dropdown offer? Suggestion:
-   *Equipment/supplies · Pay/hours · Scheduling · Safety · Other.* (Or start with
-   just "Other" and no dropdown to keep it dead simple — your call.)
-2. **Photos.** Can employees attach a photo (e.g., a broken vacuum)? Storage
-   already exists; it adds ~1 day. Yes/no for v1.
-3. **In-between status.** Do you want an "Acknowledged/Seen" step between Open and
-   Resolved, or just **Open → Resolved**? (Simpler = just the two.)
-4. **Who is "the office team + Sal"?** The alert goes to every owner/admin/office
-   user. Confirm that's the right audience (it's the same group that gets the
-   time-off alerts). Want it to also notify a specific person every time
-   regardless of role?
-5. **Can the office open a ticket on an employee's behalf** (e.g., someone calls
-   it in)? Easy to allow; just confirm.
-6. **Does the employee see status changes?** Default yes — they see their own list
-   update and get the "resolved" message. Confirm that's wanted.
-7. **Schaumburg (co4) too, or Oak Lawn only?** This is generic/multi-tenant, so it
-   can apply to both branches — confirm scope.
-
-## Notes / future (not v1)
-Threaded comments on a ticket, assigning a ticket to a specific office person, SLA/
-overdue flags, and a small "open issues" count on the office dashboard are natural
-follow-ons but intentionally left out of the first version to keep it tight.
+## Notes
+Deliberately deferred behind the time-off flow. Threaded comments, vendor/PO links,
+and inventory tracking are possible later but out of scope for v1.

--- a/docs/EMPLOYEE_TICKETS_SPEC.md
+++ b/docs/EMPLOYEE_TICKETS_SPEC.md
@@ -1,0 +1,161 @@
+# Employee Tickets — Spec & Build Estimate
+
+**Status:** Spec only. Nothing built or merged. For Sal's review + the decisions
+listed at the bottom.
+
+---
+
+## Plain-English summary (for Sal)
+
+Today's "tickets" are about **customers** — the office logs a breakage, complaint,
+or compliment against a client/job, and nobody gets pinged. This feature adds a
+**separate** kind of ticket: an **employee** taps "Report an issue" in their phone
+app, types a short subject + description (optionally tagged to a job), and hits
+send. The moment they do, the **whole office team and you** get an alert. The
+office sees these in a simple inbox, works them, and marks each **Resolved** — with
+an optional note that goes back to the employee.
+
+It's deliberately built to look and behave like the time-off request flow we just
+shipped (employee submits → office is alerted → office acts → status updates), so
+we're reusing proven parts rather than inventing new ones. **In-app (bell) alerts
+work immediately; the email/text versions turn on whenever you flip the company
+comms switch** — same as time off.
+
+Realistic build: **about 3–4 working days** for a solid first version (add ~1 day
+if employees can attach photos). A few small decisions from you are at the end.
+
+---
+
+## Goal & scope
+
+Let an employee raise an issue/ticket from the field app that fans out to the
+office team + owner, and give the office a place to triage and resolve it.
+
+**In scope (v1):** employee "Report an issue" form (subject + description + optional
+job link); a dedicated employee-issue ticket type kept apart from customer tickets;
+office + owner alert on submit; office inbox with open → resolved status; optional
+resolved-note back to the employee; employee can see their own tickets + status.
+
+**Out of scope (v1, future):** threaded back-and-forth chat on a ticket, SLA timers,
+assignment to a specific person, categories beyond a simple list, analytics. Noted
+at the end.
+
+## What we reuse (already live in prod)
+
+- **The office+owner fan-out:** `notifyOfficeUsers(companyId, …)` in
+  `lib/notify.ts` already alerts every owner/admin/office user at once (in-app +
+  push + email), gated by the comms switch. This is the exact piece that powers the
+  time-off "Action required" alert — we point it at tickets too.
+- **The employee alert:** `notifyUser(…)` (same file) sends the one-to-one in-app +
+  push + email — reused for the "your ticket was resolved" message.
+- **The end-to-end pattern:** the time-off request flow (`routes/leave.ts` +
+  `lib/leave-notifications.ts` + the `leave-review` office page + the field-app
+  "My Time Off" page) is a near-exact template for submit → notify → triage →
+  status.
+- **File storage** for photos already exists (Cloudflare R2; client attachments use
+  it today) — only relevant if we include the photo option.
+
+We do **not** reuse the customer `contact_tickets` table — employee issues stay in
+their own table so HR/ops matters never mix into the customer-complaint records or
+reports.
+
+## Data model — new `employee_tickets` table
+
+| Field | Meaning |
+|---|---|
+| `id` | ticket id |
+| `company_id` | tenant (scopes everything, like all tables) |
+| `raised_by_user_id` | the employee who opened it |
+| `subject` | short title |
+| `body` | the description |
+| `category` | simple dropdown (see Decision 1) — e.g. equipment, pay, scheduling, safety, other |
+| `job_id` | optional link to a job |
+| `status` | `open` → `resolved` (optionally `acknowledged` in between — Decision 3) |
+| `resolved_by_user_id`, `resolved_at`, `resolution_note` | filled when the office resolves |
+| `created_at`, `updated_at` | timestamps |
+| *(optional)* `attachments` | photo file references, only if Decision 2 = yes |
+
+Multi-tenant scoped by `company_id` like everything else.
+
+## API endpoints (mirrors the leave-request routes)
+
+Employee (any authenticated tenant user, scoped to themselves):
+- `POST /api/employee-tickets` — create (subject, body, category, optional job_id).
+  On success → fan out the alert (below).
+- `GET /api/employee-tickets/mine` — the employee's own tickets + statuses.
+
+Office/owner (role-gated to owner/admin/office, like the leave review page):
+- `GET /api/employee-tickets` — inbox; filter by status (open/resolved).
+- `POST /api/employee-tickets/:id/resolve` — mark resolved + optional note → notify
+  the employee.
+- *(optional)* `POST /api/employee-tickets/:id/acknowledge` — if we keep an
+  in-between "seen it" state (Decision 3).
+
+## Notifications
+
+- **On submit →** `notifyOfficeUsers(companyId, { type: "employee_ticket", title:
+  "New issue from <employee>", body: <subject>, link: "/employee-tickets" })`.
+  Every owner/admin/office person (that's the office team **and** you) gets the
+  in-app bell alert immediately; the email/text versions ride the same call and
+  start sending once the company comms switch is on — exactly like time off.
+- **On resolve →** `notifyUser(…)` to the employee: "Your issue '<subject>' was
+  resolved" + the optional note (in-app/push now; email/text with comms on).
+- No new notification plumbing is written — both calls already exist and are proven.
+
+## Frontend
+
+**Employee app (field):**
+- A **"Report an issue"** button (e.g., on the home/My-Jobs or profile screen) →
+  opens a small form: subject, description, optional "related job" picker, and
+  (if Decision 2 = yes) an "add photo" button.
+- A **"My issues"** list showing each ticket's status and the resolution note when
+  closed — same shape as the "My time-off requests" list.
+
+**Office app:**
+- An **Employee Issues inbox** page (Open / Resolved tabs) listing tickets with who
+  raised it, when, the subject/body, the job link, and a **Resolve** button with an
+  optional note — modeled on the existing leave-review page.
+- A **menu/sidebar link** to it for office/owner. (Note: we should also add the
+  matching menu link for the time-off review page, which is built but currently
+  reachable only by its address.)
+
+## Build estimate (realistic)
+
+| Piece | Effort |
+|---|---|
+| New table + migration (idempotent, multi-tenant) | ~0.5 day |
+| API endpoints (create, mine, inbox, resolve) | ~0.5–1 day |
+| Wire the two notifications (reuse) | ~0.25 day |
+| Employee form + "My issues" list (field app) | ~0.5–1 day |
+| Office inbox page + menu link | ~0.5–1 day |
+| Tests + QA + dry-run/deploy | ~0.5 day |
+| **v1 total** | **~3–4 working days** |
+| Photo attachments (if Decision 2 = yes) | **+~1 day** |
+
+This is a contained feature: one new table, ~5 endpoints, two small screens, and
+the notifier is already done — which is why the estimate is modest.
+
+## Decisions Sal needs to make
+
+1. **Categories.** What short list should the dropdown offer? Suggestion:
+   *Equipment/supplies · Pay/hours · Scheduling · Safety · Other.* (Or start with
+   just "Other" and no dropdown to keep it dead simple — your call.)
+2. **Photos.** Can employees attach a photo (e.g., a broken vacuum)? Storage
+   already exists; it adds ~1 day. Yes/no for v1.
+3. **In-between status.** Do you want an "Acknowledged/Seen" step between Open and
+   Resolved, or just **Open → Resolved**? (Simpler = just the two.)
+4. **Who is "the office team + Sal"?** The alert goes to every owner/admin/office
+   user. Confirm that's the right audience (it's the same group that gets the
+   time-off alerts). Want it to also notify a specific person every time
+   regardless of role?
+5. **Can the office open a ticket on an employee's behalf** (e.g., someone calls
+   it in)? Easy to allow; just confirm.
+6. **Does the employee see status changes?** Default yes — they see their own list
+   update and get the "resolved" message. Confirm that's wanted.
+7. **Schaumburg (co4) too, or Oak Lawn only?** This is generic/multi-tenant, so it
+   can apply to both branches — confirm scope.
+
+## Notes / future (not v1)
+Threaded comments on a ticket, assigning a ticket to a specific office person, SLA/
+overdue flags, and a small "open issues" count on the office dashboard are natural
+follow-ons but intentionally left out of the first version to keep it tight.


### PR DESCRIPTION
**Spec only — no code, draft, lower priority.** Doc: `docs/EMPLOYEE_TICKETS_SPEC.md`.

Re-scoped from the original generic "employee issue ticket": this is specifically an **employee equipment & supply request** feature — a cleaner requests a replacement vacuum, vacuum parts, or new uniform shirts/pants. Routes to the office team + Sal via the existing `notifyOfficeUsers` notifier, with a simple office inbox (open → fulfilled) and an optional note back to the employee.

**This is NOT the time-off request flow** Sal described — that's specced separately in **#613** and ships first. This one is kept as a draft for later.

Categories: replacement vacuum · vacuum parts · uniform shirt · uniform pants · other. Est. ~3–4 days (+1 for photos). Decisions (photos, uniform sizes, status steps, audience, branches) listed in the doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)