### PR TITLE
docs(time-off): request-ticket-flow spec + dashboard widget preview (mockup only)

### DIFF
--- a/docs/TIME_OFF_REQUEST_TICKET_FLOW_SPEC.md
+++ b/docs/TIME_OFF_REQUEST_TICKET_FLOW_SPEC.md
@@ -1,0 +1,107 @@
+# Time-Off Request "Ticket" Flow — Spec & Build Plan
+
+**Status:** Spec only. Nothing wired up or merged. Awaiting Sal's preview pick +
+go. This is the flow Sal actually meant by "ticket" — it **supersedes** the
+generic employee-issue spec (PR #611), pending his confirmation to close that one.
+
+Preview mockup for the dashboard widget: `docs/timeoff-dashboard-widget-preview.html`.
+
+---
+
+## Plain-English summary (for Sal)
+
+An employee requests time off (a bucket + hours) from their phone. That instantly
+becomes a **request the office sees on the dashboard** and gets an alert about. The
+office opens it, sees what the employee wrote (and any **doctor's note** attached),
+and **approves or declines**. On approval the employee is notified, they're **marked
+off on the dispatch schedule** for those exact dates/hours, the pay + balance update,
+and the whole thing is **logged** in the company audit trail and on the employee's
+own profile.
+
+Most of this already works (submit, approve/decline, notify, pay, balance, and the
+board can already show a tech as off). The remaining build is: the **dashboard
+widget**, **attachments**, **full date-range + four distinct bucket colors on the
+board**, and the **audit/profile logging**.
+
+---
+
+## The 6 steps — built vs. gap (from the code)
+
+| # | Step | Status |
+|---|------|--------|
+| 1 | Employee picks bucket + hours, submits | ✅ built (`/leave`, `POST /api/leave/requests`) |
+| 2a | Alert to office team + owner on submit | ✅ built (in-app/push now; email/text on comms switch) |
+| 2b | Request shows as a ticket on the dashboard | ❌ **build** — dashboard widget (see preview) |
+| 3a | Office opens it, populated with the request | ✅ built (the `leave-review` page) — needs a menu link |
+| 3b | Attachments (doctor's notes) | ❌ **build** — see attachments section |
+| 4 | Office approves / declines | ✅ built |
+| 5a | Employee notified on decision | ✅ built |
+| 5b | Marked off on the dispatch schedule | ⚠️ **partial** — board already renders time-off; needs full date-range + 4 distinct buckets |
+| 6 | Logged in audit log + employee profile | ⚠️ **partial** — profile shows leave usage; **global audit log not written** |
+
+## Attachments — the explanation Sal asked for
+
+"Who attaches" means **where in the flow a file (like a doctor's note) gets added:**
+
+- **(a) Employee at submit** — on their phone, they snap a photo / pick a file when
+  they send the request. Best for doctor's notes the employee already has.
+- **(b) Office on the review screen** — the office adds the file later (e.g. the
+  employee emails/texts it in and the office files it against the request).
+- **(c) Both** — employee can attach at submit; office can add or replace on review.
+
+**Recommendation: (c) both.** It costs little extra over doing one, and it covers
+every real case — the employee attaches their note up front, and the office can
+still add one when the employee hands it over later. → **Sal to confirm (c), or
+pick a/b.**
+
+## Locked decisions (folded into this spec)
+
+- **#2 — Partial days = hours. CONFIRMED.** Employees can request either full days
+  or a specific number of hours (e.g. 4h), drawn from the chosen bucket. **Multi-day
+  requests block every day in the range** on the schedule (not just day one — that's
+  a current limitation being fixed). The request form offers "full day(s)" or "set
+  hours."
+- **#3 — All FOUR buckets distinct on the board. LOCKED.** The four active buckets
+  are **PTO**, **PLAWA (sick)**, **Unpaid Leave**, and **Unexcused**. Each shows on
+  the dispatch board with its **own label + color** (PTO mint / PLAWA amber / Unpaid
+  slate / Unexcused red — see preview), never a single generic "off." Note: Unexcused
+  is **office-recorded** (not employee-requested), but still renders distinctly.
+- **#5 — Logging in BOTH places. CONFIRMED.** Every submit / approve / decline writes
+  to the **company-wide audit log** AND to a **time-off section on the employee's
+  profile** (who/what/when/decided-by).
+
+## Build plan for the gaps
+
+1. **Dashboard widget (2b).** A "Time Off Requests" widget listing pending requests
+   (name, bucket chip, dates/hours, "Dr. note" indicator, Approve/Decline), reading
+   the existing `GET /api/leave/requests?status=pending`. Placement per Sal's preview
+   pick (right rail vs. inline card). Add the matching menu link to the full review
+   page. ~1 day (either placement).
+2. **Attachments (3b).** New `leave_request_attachments` (file refs), reusing the
+   existing upload/storage plumbing; attach on submit (employee) and/or on review
+   (office) per the decision; show + open on the review screen + the dashboard
+   widget's "Dr. note" indicator. ~1–1.5 days.
+3. **Schedule placement (5b).** On approval, mark the tech off for **every date in
+   the range** (today only the start date is written), and tag the **bucket type** so
+   the board distinguishes all four. The dispatch board already renders time-off, so
+   this is mostly extending what approval writes + the board's color map. ~1–1.5 days
+   (incl. partial-hours display: a 4h request shows the tech as partially off that
+   day — exact half-day vs. all-day display per Sal, see open items).
+4. **Audit + profile logging (6).** Write an audit-log entry on submit/approve/
+   decline and surface a richer time-off activity list on the employee profile.
+   ~0.5–1 day.
+
+## Combined effort
+
+**~4–6 working days** for the full set (widget + attachments + schedule + logging),
+on top of the already-shipped request/approve/notify/pay/balance engine.
+
+## Open items before/while building
+
+- **Attachments decision** — confirm "both" (recommended) vs. employee-only / office-only.
+- **Dashboard placement** — pick Option A (right rail) or B (inline card) from the preview.
+- **Partial-hours on the board** — a 4-hour request: show the tech **off all day**
+  with an "AM/PM/4h" tag, or show them **partially available**? (Simpler = off-all-day
+  with the hours noted.)
+- **#611 fate** — confirm the generic employee-issue ticket spec is superseded /
+  should be closed, or kept as a separate future feature.

--- a/docs/TIME_OFF_REQUEST_TICKET_FLOW_SPEC.md
+++ b/docs/TIME_OFF_REQUEST_TICKET_FLOW_SPEC.md
@@ -1,8 +1,9 @@
 # Time-Off Request "Ticket" Flow — Spec & Build Plan
 
-**Status:** Spec only. Nothing wired up or merged. Awaiting Sal's preview pick +
-go. This is the flow Sal actually meant by "ticket" — it **supersedes** the
-generic employee-issue spec (PR #611), pending his confirmation to close that one.
+**Status:** Spec only. Nothing wired up or merged. Decisions locked except the
+dashboard-placement pick (Sal is choosing from the preview); build starts on his
+go. PR #611 is **kept** as a separate, lower-priority feature (employee equipment &
+supply requests) — not the same thing as this time-off flow.
 
 Preview mockup for the dashboard widget: `docs/timeoff-dashboard-widget-preview.html`.
 
@@ -33,7 +34,7 @@ board**, and the **audit/profile logging**.
 | 2a | Alert to office team + owner on submit | ✅ built (in-app/push now; email/text on comms switch) |
 | 2b | Request shows as a ticket on the dashboard | ❌ **build** — dashboard widget (see preview) |
 | 3a | Office opens it, populated with the request | ✅ built (the `leave-review` page) — needs a menu link |
-| 3b | Attachments (doctor's notes) | ❌ **build** — see attachments section |
+| 3b | Attachments (doctor's notes) — **required at submit** | ❌ **build** — mandatory employee upload; see attachments section |
 | 4 | Office approves / declines | ✅ built |
 | 5a | Employee notified on decision | ✅ built |
 | 5b | Marked off on the dispatch schedule | ⚠️ **partial** — board already renders time-off; needs full date-range + 4 distinct buckets |
@@ -49,18 +50,26 @@ board**, and the **audit/profile logging**.
   employee emails/texts it in and the office files it against the request).
 - **(c) Both** — employee can attach at submit; office can add or replace on review.
 
-**Recommendation: (c) both.** It costs little extra over doing one, and it covers
-every real case — the employee attaches their note up front, and the office can
-still add one when the employee hands it over later. → **Sal to confirm (c), or
-pick a/b.**
+**DECIDED (Sal): option (a), and MANDATORY.** The employee **must attach a file
+when they submit** — it's a **required field**; the request can't be sent without
+it (they photograph the doctor's note / file from their phone). The **office does
+NOT attach** — there is no office-side upload on the review screen. So every
+request that reaches the office already has its attachment.
+
+*(One-line flag: "required on every request" is spec'd as Sal stated. A doctor's
+note makes obvious sense for PLAWA/sick; if PTO/Unpaid shouldn't force a file, it's
+a one-line change to require it for sick only — flagging, not re-deciding.)*
 
 ## Locked decisions (folded into this spec)
 
-- **#2 — Partial days = hours. CONFIRMED.** Employees can request either full days
-  or a specific number of hours (e.g. 4h), drawn from the chosen bucket. **Multi-day
-  requests block every day in the range** on the schedule (not just day one — that's
-  a current limitation being fixed). The request form offers "full day(s)" or "set
-  hours."
+- **#2 — Full day / Morning / Afternoon (NO free-form hours). UPDATED per Sal.**
+  The request form's unit is **Full day**, **Morning**, or **Afternoon** — there is
+  **no arbitrary-hours entry**. A half-day draws half the bucket's daily hours.
+  **Critically, a half-day leaves the tech AVAILABLE for the half they're working:**
+  morning off → the board shows them **available in the afternoon** (and vice
+  versa) — they are NOT blocked for the whole day. **Multi-day requests block every
+  full day in the range.** So a request carries a per-day unit of
+  full / AM / PM, and the board reflects the worked half.
 - **#3 — All FOUR buckets distinct on the board. LOCKED.** The four active buckets
   are **PTO**, **PLAWA (sick)**, **Unpaid Leave**, and **Unexcused**. Each shows on
   the dispatch board with its **own label + color** (PTO mint / PLAWA amber / Unpaid
@@ -78,15 +87,17 @@ pick a/b.**
    pick (right rail vs. inline card). Add the matching menu link to the full review
    page. ~1 day (either placement).
 2. **Attachments (3b).** New `leave_request_attachments` (file refs), reusing the
-   existing upload/storage plumbing; attach on submit (employee) and/or on review
-   (office) per the decision; show + open on the review screen + the dashboard
-   widget's "Dr. note" indicator. ~1–1.5 days.
-3. **Schedule placement (5b).** On approval, mark the tech off for **every date in
-   the range** (today only the start date is written), and tag the **bucket type** so
-   the board distinguishes all four. The dispatch board already renders time-off, so
-   this is mostly extending what approval writes + the board's color map. ~1–1.5 days
-   (incl. partial-hours display: a 4h request shows the tech as partially off that
-   day — exact half-day vs. all-day display per Sal, see open items).
+   existing upload/storage plumbing. **Required at submit on the employee's phone —
+   the submit button is disabled until a file is attached.** No office-side upload.
+   Show + open the file on the review screen + the dashboard widget's attachment
+   indicator. ~1–1.5 days.
+3. **Schedule placement (5b).** On approval, mark the tech off for **every full day
+   in the range**, tagged by **bucket type** so the board distinguishes all four.
+   For a **half-day** (Morning/Afternoon), the board shows the tech off for that half
+   and **available for the other half** — so the request carries a per-day
+   full/AM/PM unit and the board renders the worked half as still-schedulable. The
+   dispatch board already renders time-off, so this extends what approval writes +
+   the board's color map + an AM/PM split. ~1.5 days.
 4. **Audit + profile logging (6).** Write an audit-log entry on submit/approve/
    decline and surface a richer time-off activity list on the employee profile.
    ~0.5–1 day.
@@ -98,10 +109,13 @@ on top of the already-shipped request/approve/notify/pay/balance engine.
 
 ## Open items before/while building
 
-- **Attachments decision** — confirm "both" (recommended) vs. employee-only / office-only.
-- **Dashboard placement** — pick Option A (right rail) or B (inline card) from the preview.
-- **Partial-hours on the board** — a 4-hour request: show the tech **off all day**
-  with an "AM/PM/4h" tag, or show them **partially available**? (Simpler = off-all-day
-  with the hours noted.)
-- **#611 fate** — confirm the generic employee-issue ticket spec is superseded /
-  should be closed, or kept as a separate future feature.
+- **Dashboard placement (ONLY open blocker)** — pick Option A (right rail) or B
+  (inline card) from the preview. Build starts once Sal picks.
+- ~~Attachments~~ — DECIDED: mandatory employee upload at submit.
+- ~~Partial-day model~~ — DECIDED: Full day / Morning / Afternoon, available the
+  worked half.
+- ~~Logging~~ — DECIDED: company audit log + employee profile.
+- **#611 — KEPT & reframed** (not closed): it's now the separate **employee
+  equipment & supply request** feature (replacement vacuum, parts, uniform shirts/
+  pants, other → routes to office + Sal, same inbox pattern). Lower priority; this
+  time-off flow ships first.

--- a/docs/timeoff-dashboard-widget-preview.html
+++ b/docs/timeoff-dashboard-widget-preview.html
@@ -11,7 +11,6 @@
   :root{
     --bg:#F7F6F3; --card:#FFFFFF; --ink:#1A1917; --muted:#9E9B94;
     --border:#E5E2DC; --mint:#00C9A0; --night:#0A0E1A;
-    /* bucket colors — 4 distinct */
     --pto-bg:#E9FBF5; --pto-fg:#00876B;
     --plawa-bg:#FEF3C7; --plawa-fg:#92400E;
     --unpaid-bg:#EEF2F7; --unpaid-fg:#334155;
@@ -25,8 +24,6 @@
   .note{display:inline-block;margin-top:10px;font-size:12px;color:var(--unexcused-fg);background:var(--unexcused-bg);border-radius:6px;padding:4px 10px;font-weight:600}
   .opt{max-width:1180px;margin:0 auto 34px}
   .optlabel{font-size:13px;font-weight:800;text-transform:uppercase;letter-spacing:.06em;color:var(--muted);margin:0 0 10px}
-  /* faux dashboard scaffolding */
-  .phcard{background:var(--card);border:1px solid var(--border);border-radius:14px}
   .ph{background:var(--card);border:1px solid var(--border);border-radius:14px;padding:18px;color:var(--muted)}
   .ph .ttl{font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--muted)}
   .ph .big{height:14px;width:60%;background:#EFEDE8;border-radius:6px;margin-top:12px}
@@ -36,10 +33,8 @@
   .kpi .n{font-size:22px;font-weight:800}
   .kpi .l{font-size:11px;color:var(--muted);font-weight:600;text-transform:uppercase;letter-spacing:.05em;margin-top:2px}
   .chart{height:150px}
-  /* layouts */
-  .rail-wrap{display:grid;grid-template-columns:1fr 340px;gap:16px;align-items:start}
+  .rail-wrap{display:grid;grid-template-columns:1fr 360px;gap:16px;align-items:start}
   .stack{display:flex;flex-direction:column;gap:14px}
-  /* the widget */
   .widget{background:var(--card);border:1px solid var(--border);border-radius:14px;overflow:hidden}
   .whead{display:flex;align-items:center;justify-content:space-between;padding:16px 18px 12px}
   .whead h2{font-size:15px;font-weight:800;margin:0}
@@ -53,29 +48,36 @@
   .chip.plawa{background:var(--plawa-bg);color:var(--plawa-fg)}
   .chip.unpaid{background:var(--unpaid-bg);color:var(--unpaid-fg)}
   .chip.unexcused{background:var(--unexcused-bg);color:var(--unexcused-fg)}
-  .docnote{display:inline-flex;align-items:center;gap:5px;font-size:11px;font-weight:600;color:var(--pto-fg);background:var(--pto-bg);border-radius:6px;padding:2px 8px}
+  .docnote{display:inline-flex;align-items:center;gap:5px;font-size:11px;font-weight:600;color:var(--pto-fg);background:var(--pto-bg);border-radius:6px;padding:2px 8px;align-self:flex-start}
   .docnote svg{width:11px;height:11px}
-  .actions{display:flex;gap:8px;margin-top:2px}
+  /* half-day board strip */
+  .halfday{display:flex;align-items:center;gap:8px;margin-top:2px;font-size:11px}
+  .halfday .lbl{color:var(--muted);font-weight:600}
+  .daycell{display:flex;border:1px solid var(--border);border-radius:8px;overflow:hidden;width:200px}
+  .daycell .half{flex:1;padding:6px 8px;font-weight:700;text-align:center;font-size:11px}
+  .half.off-plawa{background:var(--plawa-bg);color:var(--plawa-fg)}
+  .half.off-unpaid{background:var(--unpaid-bg);color:var(--unpaid-fg)}
+  .half.avail{background:#fff;color:var(--mint);}
+  .half.avail.b{border-left:1px solid var(--border)}
+  .actions{display:flex;gap:8px;margin-top:4px}
   .btn{font-family:inherit;font-size:12px;font-weight:700;border-radius:8px;padding:7px 14px;cursor:pointer;border:1px solid var(--border)}
   .btn.approve{background:var(--mint);color:#04241d;border-color:var(--mint)}
   .btn.decline{background:#fff;color:#6B6860}
   .legend{display:flex;flex-wrap:wrap;gap:8px;padding:12px 18px;border-top:1px solid var(--border)}
-  .legend .chip{cursor:default}
   .footer{max-width:1180px;margin:0 auto;font-size:12px;color:var(--muted)}
 </style>
 </head>
 <body>
   <div class="pagehead">
     <h1>Time Off Requests — dashboard widget placement preview</h1>
-    <p>Mockup only (not wired up). Same widget shown two ways so you can pick. All four leave types show distinctly. Brand styling matches the live dashboard.</p>
+    <p>Mockup only (not wired up). Units are Full day / Morning / Afternoon — a half-day leaves the tech available the other half. Every request has a required attachment. All four leave types show distinctly.</p>
     <span class="note">Pick one: Option A (right-hand rail) or Option B (inline card).</span>
   </div>
 
-  <!-- ============ OPTION A — RIGHT-HAND RAIL ============ -->
+  <!-- OPTION A — RIGHT RAIL -->
   <div class="opt">
     <p class="optlabel">Option A — dedicated right-hand rail</p>
     <div class="rail-wrap">
-      <!-- main dashboard column (placeholder) -->
       <div class="stack">
         <div class="kpis">
           <div class="kpi"><div class="n">18</div><div class="l">Today</div></div>
@@ -87,12 +89,11 @@
         <div class="ph chart"><div class="ttl">Revenue — last 14 days</div><div class="big"></div><div class="sm"></div></div>
         <div class="ph"><div class="ttl">Needs attention</div><div class="big"></div><div class="sm"></div></div>
       </div>
-      <!-- right rail with the widget -->
       <div id="widgetA"></div>
     </div>
   </div>
 
-  <!-- ============ OPTION B — INLINE CARD ============ -->
+  <!-- OPTION B — INLINE CARD -->
   <div class="opt">
     <p class="optlabel">Option B — full-width card in the dashboard flow</p>
     <div class="stack">
@@ -108,42 +109,41 @@
     </div>
   </div>
 
-  <div class="footer">Sample data. Bucket colors: PTO (mint), PLAWA/Sick (amber), Unpaid (slate), Unexcused (red). "Dr. note" = an attached file is on the request.</div>
+  <div class="footer">Sample data. Bucket colors: PTO (mint), PLAWA/Sick (amber), Unpaid (slate), Unexcused (red). Half-day rows show how the board keeps the tech available for the half they're working.</div>
 
 <script>
-  const PAPERCLIP = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.44 11.05l-9.19 9.19a5 5 0 0 1-7.07-7.07l9.19-9.19a3 3 0 0 1 4.24 4.24l-9.2 9.19a1 1 0 0 1-1.41-1.41l8.49-8.49"/></svg>';
+  const CLIP = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.44 11.05l-9.19 9.19a5 5 0 0 1-7.07-7.07l9.19-9.19a3 3 0 0 1 4.24 4.24l-9.2 9.19a1 1 0 0 1-1.41-1.41l8.49-8.49"/></svg>';
+  // half: null | 'am-off' | 'pm-off'
   const reqs = [
-    { who:'Maribel Castillo', bucket:'pto',   label:'PTO',     when:'Jun 30 – Jul 2 · 24 hrs', doc:false },
-    { who:'Alejandra Cuervo', bucket:'plawa', label:'PLAWA',   when:'Jun 24 · 8 hrs',          doc:true  },
-    { who:'Juliana Loredo',   bucket:'unpaid',label:'Unpaid',  when:'Jul 5 · 4 hrs (partial day)', doc:false },
-    { who:'Diana Vasquez',    bucket:'pto',   label:'PTO',     when:'Jul 10 · 8 hrs',          doc:true  },
+    { who:'Maribel Castillo', bucket:'pto',   label:'PTO',    when:'Jun 30 – Jul 2 · Full days', att:'Attachment', half:null },
+    { who:'Alejandra Cuervo', bucket:'plawa', label:'PLAWA',  when:'Jun 24 · Morning off',       att:'Dr. note',   half:'am-off' },
+    { who:'Juliana Loredo',   bucket:'unpaid',label:'Unpaid', when:'Jul 5 · Afternoon off',      att:'Attachment', half:'pm-off' },
+    { who:'Diana Vasquez',    bucket:'pto',   label:'PTO',    when:'Jul 10 · Full day',          att:'Attachment', half:null },
   ];
+  function halfStrip(r){
+    if(!r.half) return '';
+    const offCls = r.bucket==='unpaid' ? 'off-unpaid' : 'off-plawa';
+    const am = r.half==='am-off' ? `<div class="half ${offCls}">AM · Off</div><div class="half avail b">PM · Available</div>`
+                                 : `<div class="half avail">AM · Available</div><div class="half ${offCls} b">PM · Off</div>`;
+    return `<div class="halfday"><span class="lbl">On the board:</span><div class="daycell">${am}</div></div>`;
+  }
   function reqRow(r){
     return `<div class="req">
-      <div class="top">
-        <span class="who">${r.who}</span>
-        <span class="chip ${r.bucket}">${r.label}</span>
-      </div>
+      <div class="top"><span class="who">${r.who}</span><span class="chip ${r.bucket}">${r.label}</span></div>
       <div class="when">${r.when}</div>
-      ${r.doc ? `<span class="docnote">${PAPERCLIP} Dr. note</span>` : ''}
-      <div class="actions">
-        <button class="btn approve">Approve</button>
-        <button class="btn decline">Decline</button>
-      </div>
+      <span class="docnote">${CLIP} ${r.att}</span>
+      ${halfStrip(r)}
+      <div class="actions"><button class="btn approve">Approve</button><button class="btn decline">Decline</button></div>
     </div>`;
   }
   const legend = `<div class="legend">
-      <span class="chip pto">PTO</span>
-      <span class="chip plawa">PLAWA / Sick</span>
-      <span class="chip unpaid">Unpaid</span>
-      <span class="chip unexcused">Unexcused</span>
+      <span class="chip pto">PTO</span><span class="chip plawa">PLAWA / Sick</span>
+      <span class="chip unpaid">Unpaid</span><span class="chip unexcused">Unexcused</span>
     </div>`;
   function widget(){
     return `<div class="widget">
       <div class="whead"><h2>Time Off Requests</h2><span class="pill">4 pending</span></div>
-      ${reqs.map(reqRow).join('')}
-      ${legend}
-    </div>`;
+      ${reqs.map(reqRow).join('')}${legend}</div>`;
   }
   document.getElementById('widgetA').innerHTML = widget();
   document.getElementById('widgetB').innerHTML = widget();

--- a/docs/timeoff-dashboard-widget-preview.html
+++ b/docs/timeoff-dashboard-widget-preview.html
@@ -1,0 +1,152 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Qleno — Time Off Requests widget · placement preview</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+  :root{
+    --bg:#F7F6F3; --card:#FFFFFF; --ink:#1A1917; --muted:#9E9B94;
+    --border:#E5E2DC; --mint:#00C9A0; --night:#0A0E1A;
+    /* bucket colors — 4 distinct */
+    --pto-bg:#E9FBF5; --pto-fg:#00876B;
+    --plawa-bg:#FEF3C7; --plawa-fg:#92400E;
+    --unpaid-bg:#EEF2F7; --unpaid-fg:#334155;
+    --unexcused-bg:#FCE7E7; --unexcused-fg:#991B1B;
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);font-family:'Plus Jakarta Sans',sans-serif;padding:28px}
+  .pagehead{max-width:1180px;margin:0 auto 22px}
+  .pagehead h1{font-size:20px;font-weight:800;margin:0 0 4px}
+  .pagehead p{font-size:13px;color:var(--muted);margin:0}
+  .note{display:inline-block;margin-top:10px;font-size:12px;color:var(--unexcused-fg);background:var(--unexcused-bg);border-radius:6px;padding:4px 10px;font-weight:600}
+  .opt{max-width:1180px;margin:0 auto 34px}
+  .optlabel{font-size:13px;font-weight:800;text-transform:uppercase;letter-spacing:.06em;color:var(--muted);margin:0 0 10px}
+  /* faux dashboard scaffolding */
+  .phcard{background:var(--card);border:1px solid var(--border);border-radius:14px}
+  .ph{background:var(--card);border:1px solid var(--border);border-radius:14px;padding:18px;color:var(--muted)}
+  .ph .ttl{font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--muted)}
+  .ph .big{height:14px;width:60%;background:#EFEDE8;border-radius:6px;margin-top:12px}
+  .ph .sm{height:10px;width:40%;background:#F1EFEA;border-radius:6px;margin-top:8px}
+  .kpis{display:grid;grid-template-columns:repeat(5,1fr);gap:12px;margin-bottom:14px}
+  .kpi{background:var(--card);border:1px solid var(--border);border-radius:14px;padding:16px 14px}
+  .kpi .n{font-size:22px;font-weight:800}
+  .kpi .l{font-size:11px;color:var(--muted);font-weight:600;text-transform:uppercase;letter-spacing:.05em;margin-top:2px}
+  .chart{height:150px}
+  /* layouts */
+  .rail-wrap{display:grid;grid-template-columns:1fr 340px;gap:16px;align-items:start}
+  .stack{display:flex;flex-direction:column;gap:14px}
+  /* the widget */
+  .widget{background:var(--card);border:1px solid var(--border);border-radius:14px;overflow:hidden}
+  .whead{display:flex;align-items:center;justify-content:space-between;padding:16px 18px 12px}
+  .whead h2{font-size:15px;font-weight:800;margin:0}
+  .pill{font-size:11px;font-weight:800;color:#fff;background:var(--night);border-radius:999px;padding:3px 9px}
+  .req{border-top:1px solid var(--border);padding:14px 18px;display:flex;flex-direction:column;gap:8px}
+  .req .top{display:flex;align-items:center;justify-content:space-between;gap:8px}
+  .req .who{font-size:14px;font-weight:700}
+  .req .when{font-size:12px;color:var(--muted)}
+  .chip{font-size:10px;font-weight:800;text-transform:uppercase;letter-spacing:.04em;border-radius:999px;padding:3px 9px;white-space:nowrap}
+  .chip.pto{background:var(--pto-bg);color:var(--pto-fg)}
+  .chip.plawa{background:var(--plawa-bg);color:var(--plawa-fg)}
+  .chip.unpaid{background:var(--unpaid-bg);color:var(--unpaid-fg)}
+  .chip.unexcused{background:var(--unexcused-bg);color:var(--unexcused-fg)}
+  .docnote{display:inline-flex;align-items:center;gap:5px;font-size:11px;font-weight:600;color:var(--pto-fg);background:var(--pto-bg);border-radius:6px;padding:2px 8px}
+  .docnote svg{width:11px;height:11px}
+  .actions{display:flex;gap:8px;margin-top:2px}
+  .btn{font-family:inherit;font-size:12px;font-weight:700;border-radius:8px;padding:7px 14px;cursor:pointer;border:1px solid var(--border)}
+  .btn.approve{background:var(--mint);color:#04241d;border-color:var(--mint)}
+  .btn.decline{background:#fff;color:#6B6860}
+  .legend{display:flex;flex-wrap:wrap;gap:8px;padding:12px 18px;border-top:1px solid var(--border)}
+  .legend .chip{cursor:default}
+  .footer{max-width:1180px;margin:0 auto;font-size:12px;color:var(--muted)}
+</style>
+</head>
+<body>
+  <div class="pagehead">
+    <h1>Time Off Requests — dashboard widget placement preview</h1>
+    <p>Mockup only (not wired up). Same widget shown two ways so you can pick. All four leave types show distinctly. Brand styling matches the live dashboard.</p>
+    <span class="note">Pick one: Option A (right-hand rail) or Option B (inline card).</span>
+  </div>
+
+  <!-- ============ OPTION A — RIGHT-HAND RAIL ============ -->
+  <div class="opt">
+    <p class="optlabel">Option A — dedicated right-hand rail</p>
+    <div class="rail-wrap">
+      <!-- main dashboard column (placeholder) -->
+      <div class="stack">
+        <div class="kpis">
+          <div class="kpi"><div class="n">18</div><div class="l">Today</div></div>
+          <div class="kpi"><div class="n">3</div><div class="l">Unassigned</div></div>
+          <div class="kpi"><div class="n">2</div><div class="l">Late</div></div>
+          <div class="kpi"><div class="n">11</div><div class="l">Done</div></div>
+          <div class="kpi"><div class="n">$4.2k</div><div class="l">Revenue</div></div>
+        </div>
+        <div class="ph chart"><div class="ttl">Revenue — last 14 days</div><div class="big"></div><div class="sm"></div></div>
+        <div class="ph"><div class="ttl">Needs attention</div><div class="big"></div><div class="sm"></div></div>
+      </div>
+      <!-- right rail with the widget -->
+      <div id="widgetA"></div>
+    </div>
+  </div>
+
+  <!-- ============ OPTION B — INLINE CARD ============ -->
+  <div class="opt">
+    <p class="optlabel">Option B — full-width card in the dashboard flow</p>
+    <div class="stack">
+      <div class="kpis">
+        <div class="kpi"><div class="n">18</div><div class="l">Today</div></div>
+        <div class="kpi"><div class="n">3</div><div class="l">Unassigned</div></div>
+        <div class="kpi"><div class="n">2</div><div class="l">Late</div></div>
+        <div class="kpi"><div class="n">11</div><div class="l">Done</div></div>
+        <div class="kpi"><div class="n">$4.2k</div><div class="l">Revenue</div></div>
+      </div>
+      <div id="widgetB"></div>
+      <div class="ph chart"><div class="ttl">Revenue — last 14 days</div><div class="big"></div><div class="sm"></div></div>
+    </div>
+  </div>
+
+  <div class="footer">Sample data. Bucket colors: PTO (mint), PLAWA/Sick (amber), Unpaid (slate), Unexcused (red). "Dr. note" = an attached file is on the request.</div>
+
+<script>
+  const PAPERCLIP = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.44 11.05l-9.19 9.19a5 5 0 0 1-7.07-7.07l9.19-9.19a3 3 0 0 1 4.24 4.24l-9.2 9.19a1 1 0 0 1-1.41-1.41l8.49-8.49"/></svg>';
+  const reqs = [
+    { who:'Maribel Castillo', bucket:'pto',   label:'PTO',     when:'Jun 30 – Jul 2 · 24 hrs', doc:false },
+    { who:'Alejandra Cuervo', bucket:'plawa', label:'PLAWA',   when:'Jun 24 · 8 hrs',          doc:true  },
+    { who:'Juliana Loredo',   bucket:'unpaid',label:'Unpaid',  when:'Jul 5 · 4 hrs (partial day)', doc:false },
+    { who:'Diana Vasquez',    bucket:'pto',   label:'PTO',     when:'Jul 10 · 8 hrs',          doc:true  },
+  ];
+  function reqRow(r){
+    return `<div class="req">
+      <div class="top">
+        <span class="who">${r.who}</span>
+        <span class="chip ${r.bucket}">${r.label}</span>
+      </div>
+      <div class="when">${r.when}</div>
+      ${r.doc ? `<span class="docnote">${PAPERCLIP} Dr. note</span>` : ''}
+      <div class="actions">
+        <button class="btn approve">Approve</button>
+        <button class="btn decline">Decline</button>
+      </div>
+    </div>`;
+  }
+  const legend = `<div class="legend">
+      <span class="chip pto">PTO</span>
+      <span class="chip plawa">PLAWA / Sick</span>
+      <span class="chip unpaid">Unpaid</span>
+      <span class="chip unexcused">Unexcused</span>
+    </div>`;
+  function widget(){
+    return `<div class="widget">
+      <div class="whead"><h2>Time Off Requests</h2><span class="pill">4 pending</span></div>
+      ${reqs.map(reqRow).join('')}
+      ${legend}
+    </div>`;
+  }
+  document.getElementById('widgetA').innerHTML = widget();
+  document.getElementById('widgetB').innerHTML = widget();
+</script>
+</body>
+</html>


### PR DESCRIPTION
**Spec + visual mockup only — no feature code, draft for review.**

Docs:
- `docs/TIME_OFF_REQUEST_TICKET_FLOW_SPEC.md` — maps Sal's time-off "ticket" flow to the code (built vs gap) + build plan + estimate.
- `docs/timeoff-dashboard-widget-preview.html` — standalone HTML preview of the pending-requests dashboard widget in **both** placements (right rail vs inline card). Open in a browser to view.

Locked decisions: partial-hours requests + multi-day blocks every day (#2); all four buckets (PTO/PLAWA/Unpaid/Unexcused) distinct on the board (#3); log to company audit log + employee profile (#5). Attachments: recommend "both" (employee at submit + office on review), pending Sal's pick.

Gaps to build (≈4–6 days): dashboard widget + menu link, attachments, full date-range + 4 distinct bucket colors on the board, audit/profile logging. The submit/approve/decline/notify/pay/balance engine is already shipped.

Supersedes the generic employee-issue spec (#611), pending Sal's confirm to close it. Nothing wired up — awaiting the preview pick + go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)