### PR TITLE
feat(time-off): request ticket flow — full build (bell, field form, Employees review, dispatch board)

### DIFF
--- a/artifacts/api-server/src/cutover-data-migration.ts
+++ b/artifacts/api-server/src/cutover-data-migration.ts
@@ -613,7 +613,8 @@ async function seedLeaveTypesPerTenant(): Promise<void> {
       )
       ON CONFLICT DO NOTHING;
 
-      -- Phes-specific buckets. Only seeded for company_id=1.
+      -- Phes-specific buckets. Seeded for BOTH Phes companies — Oak Lawn (1)
+      -- and Schaumburg (4) — so both branches get the same catalog.
       INSERT INTO leave_types (
         company_id, slug, display_name, is_paid, annual_cap_hours,
         accrual_mode, accrual_rate, waiting_period_days,
@@ -638,6 +639,18 @@ async function seedLeaveTypesPerTenant(): Promise<void> {
          false, false, true, false),
         (1, 'unexcused', 'Unexcused', false, 40,
          'office_recorded', 0, 0,
+         false, false, false, false),
+        (4, 'plawa', 'PLAWA', true, 40,
+         'flat_grant', 0, 90,
+         false, false, true, true),
+        (4, 'pto_phes', 'PTO', true, 40,
+         'flat_grant', 0, 365,
+         true, false, true, false),
+        (4, 'unpaid_leave', 'Unpaid Leave', false, 40,
+         'flat_grant', 0, 0,
+         false, false, true, false),
+        (4, 'unexcused', 'Unexcused', false, 40,
+         'office_recorded', 0, 0,
          false, false, false, false)
       ON CONFLICT DO NOTHING;
 
@@ -649,7 +662,7 @@ async function seedLeaveTypesPerTenant(): Promise<void> {
       SET accrual_mode = 'flat_grant',
           accrual_rate = 0,
           carryover_allowed = false
-      WHERE company_id = 1
+      WHERE company_id IN (1, 4)
         AND slug = 'plawa';
 
       -- The default-seeded "pto" row for company_id=1 collides with
@@ -659,7 +672,7 @@ async function seedLeaveTypesPerTenant(): Promise<void> {
       -- so the Phes-specific row is the only one shown.
       UPDATE leave_types
       SET active = false
-      WHERE company_id = 1
+      WHERE company_id IN (1, 4)
         AND slug = 'pto';
 
       -- Likewise deactivate the generic default 'sick' bucket for Phes —
@@ -667,7 +680,7 @@ async function seedLeaveTypesPerTenant(): Promise<void> {
       -- buckets (generic 'sick' + 'plawa') is a seeding leftover.
       UPDATE leave_types
       SET active = false
-      WHERE company_id = 1
+      WHERE company_id IN (1, 4)
         AND slug = 'sick';
 
       RAISE NOTICE 'cutover-migration: seeded leave_types per tenant';
@@ -733,7 +746,7 @@ async function seedPhesLeavePolicy3A(): Promise<void> {
         company_id, leave_reset_basis,
         use_it_or_lose_it_alert_lead_days, balance_ceiling_hours
       )
-      VALUES (1, 'work_anniversary', 60, 80)
+      VALUES (1, 'work_anniversary', 60, 80), (4, 'work_anniversary', 60, 80)
       ON CONFLICT (company_id) DO UPDATE SET
         leave_reset_basis = COALESCE(EXCLUDED.leave_reset_basis, company_leave_policy.leave_reset_basis),
         use_it_or_lose_it_alert_lead_days = COALESCE(EXCLUDED.use_it_or_lose_it_alert_lead_days, company_leave_policy.use_it_or_lose_it_alert_lead_days),

--- a/artifacts/api-server/src/cutover-data-migration.ts
+++ b/artifacts/api-server/src/cutover-data-migration.ts
@@ -68,6 +68,14 @@ export async function runCutoverDataMigration(): Promise<void> {
     );
   }
   try {
+    await migrateLeaveRequestUnitAttachment();
+  } catch (err) {
+    console.error(
+      "[cutover-migration] leave_requests unit/attachment migrate failed (non-fatal):",
+      err,
+    );
+  }
+  try {
     await runAttendanceProposalsMigration();
   } catch (err) {
     console.error(
@@ -663,6 +671,38 @@ async function seedLeaveTypesPerTenant(): Promise<void> {
         AND slug = 'sick';
 
       RAISE NOTICE 'cutover-migration: seeded leave_types per tenant';
+    END
+    $$;
+  `),
+  );
+}
+
+/**
+ * Time-off "ticket" flow (2026-06-22) — add the day_unit (full/AM/PM) + the
+ * required-attachment columns to leave_requests. Idempotent: creates the enum
+ * type if missing and ADD COLUMN IF NOT EXISTS. Existing rows default to
+ * full_day; attachment columns are nullable (older rows predate the requirement).
+ */
+async function migrateLeaveRequestUnitAttachment(): Promise<void> {
+  await db.execute(
+    sql.raw(`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = 'public' AND table_name = 'leave_requests'
+      ) THEN
+        RAISE NOTICE 'cutover-migration: leave_requests not present yet, skipping unit/attachment';
+        RETURN;
+      END IF;
+      IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'leave_day_unit') THEN
+        CREATE TYPE leave_day_unit AS ENUM ('full_day', 'morning', 'afternoon');
+      END IF;
+      ALTER TABLE leave_requests
+        ADD COLUMN IF NOT EXISTS day_unit leave_day_unit NOT NULL DEFAULT 'full_day';
+      ALTER TABLE leave_requests ADD COLUMN IF NOT EXISTS attachment_url text;
+      ALTER TABLE leave_requests ADD COLUMN IF NOT EXISTS attachment_name text;
+      RAISE NOTICE 'cutover-migration: leave_requests day_unit + attachment columns ensured';
     END
     $$;
   `),

--- a/artifacts/api-server/src/routes/dispatch.ts
+++ b/artifacts/api-server/src/routes/dispatch.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import { db } from "@workspace/db";
-import { jobsTable, usersTable, clientsTable, timeclockTable, jobPhotosTable, serviceZonesTable, serviceZoneEmployeesTable, accountsTable, accountPropertiesTable, employeeAttendanceLogTable, employeeLeaveUsageTable, branchesTable, recurringSchedulesTable } from "@workspace/db/schema";
+import { jobsTable, usersTable, clientsTable, timeclockTable, jobPhotosTable, serviceZonesTable, serviceZoneEmployeesTable, accountsTable, accountPropertiesTable, employeeAttendanceLogTable, employeeLeaveUsageTable, leaveRequestsTable, leaveTypesTable, branchesTable, recurringSchedulesTable } from "@workspace/db/schema";
 import { eq, and, count, sql, inArray } from "drizzle-orm";
 import { requireAuth, requireRole } from "../lib/auth.js";
 import { parseResRatesRow, resolveResidentialPayPct } from "../lib/commission-rates.js";
@@ -344,15 +344,45 @@ async function buildDispatchPayload(
         sql`${employeeAttendanceLogTable.type} IN ('plawa_leave','protected_leave','absent','ncns')`,
       ));
 
-    const ptoSet = new Set(leaveUsage.map(r => r.employee_id));
-    // sick = plawa_leave / protected_leave; absent = absent / ncns
+    // Approved leave requests overlapping the board date → the FOUR distinct
+    // buckets + the day unit (full/AM/PM). This is the authoritative source so
+    // PTO / PLAWA / Unpaid / Unexcused each show distinctly; a half-day keeps
+    // the tech available the worked half (we surface the unit; the board treats
+    // half-days as still-suggestable).
+    const approvedLeave = await db
+      .select({ user_id: leaveRequestsTable.user_id, slug: leaveTypesTable.slug, day_unit: leaveRequestsTable.day_unit })
+      .from(leaveRequestsTable)
+      .innerJoin(leaveTypesTable, eq(leaveRequestsTable.leave_type_id, leaveTypesTable.id))
+      .where(and(
+        eq(leaveRequestsTable.company_id, companyId),
+        eq(leaveRequestsTable.status, 'approved'),
+        sql`${leaveRequestsTable.start_date} <= ${date} AND ${leaveRequestsTable.end_date} >= ${date}`,
+      ));
+    const SLUG_TO_BUCKET: Record<string, 'pto' | 'plawa' | 'unpaid' | 'unexcused'> = {
+      pto_phes: 'pto', plawa: 'plawa', unpaid_leave: 'unpaid', unexcused: 'unexcused',
+    };
+    const leaveByEmp = new Map<number, { bucket: 'pto' | 'plawa' | 'unpaid' | 'unexcused'; unit: string }>();
+    for (const r of approvedLeave) {
+      const b = SLUG_TO_BUCKET[String(r.slug)];
+      if (b) leaveByEmp.set(r.user_id, { bucket: b, unit: String(r.day_unit) });
+    }
+
+    const ptoSet = new Set(leaveUsage.map(r => r.employee_id)); // legacy fallback
     const sickSet = new Set(attendanceLogs.filter(r => r.type === 'plawa_leave' || r.type === 'protected_leave').map(r => r.employee_id));
     const absentSet = new Set(attendanceLogs.filter(r => r.type === 'absent' || r.type === 'ncns').map(r => r.employee_id));
 
-    function getTimeOff(empId: number): 'pto' | 'sick' | 'absent' | null {
-      if (ptoSet.has(empId)) return 'pto';
-      if (sickSet.has(empId)) return 'sick';
+    function getTimeOff(empId: number): 'pto' | 'plawa' | 'unpaid' | 'unexcused' | 'absent' | null {
+      const lv = leaveByEmp.get(empId);
+      if (lv) return lv.bucket;
       if (absentSet.has(empId)) return 'absent';
+      if (sickSet.has(empId)) return 'plawa';
+      if (ptoSet.has(empId)) return 'pto';
+      return null;
+    }
+    function getTimeOffUnit(empId: number): 'full_day' | 'morning' | 'afternoon' | null {
+      const lv = leaveByEmp.get(empId);
+      if (lv) return lv.unit as 'full_day' | 'morning' | 'afternoon';
+      if (absentSet.has(empId) || sickSet.has(empId) || ptoSet.has(empId)) return 'full_day';
       return null;
     }
 
@@ -365,6 +395,7 @@ async function buildDispatchPayload(
           jobs: [],
           zone: empZoneMap[e.id] ?? null,
           time_off: getTimeOff(e.id),
+          time_off_unit: getTimeOffUnit(e.id),
           commission_rate: e.commission_rate ? parseFloat(e.commission_rate) : null,
         })),
         unassigned_jobs: [],
@@ -1050,6 +1081,7 @@ async function buildDispatchPayload(
         jobs: jobsByEmployee.get(e.id) || [],
         zone: empZoneMap[e.id] ?? null,
         time_off: getTimeOff(e.id),
+        time_off_unit: getTimeOffUnit(e.id),
         commission_rate: e.commission_rate ? parseFloat(e.commission_rate) : null,
         avatar_url: e.avatar_url ?? null,
       })),

--- a/artifacts/api-server/src/routes/leave.ts
+++ b/artifacts/api-server/src/routes/leave.ts
@@ -76,6 +76,27 @@ import {
 } from "../lib/leave-notifications.js";
 import { writeApprovedLeavePay } from "../lib/leave-pay.js";
 import { logAudit } from "../lib/audit.js";
+import multer from "multer";
+import path from "node:path";
+import fs from "node:fs";
+
+// Disk-upload for the required leave attachment (doctor's note / file). Mirrors
+// routes/attachments.ts; lands the file in the served uploads dir and returns a
+// canonical /api/uploads/ URL. 10 MB cap; images + PDFs are the expected use.
+const leaveUpload = multer({
+  storage: multer.diskStorage({
+    destination: (_req, _file, cb) => {
+      const dir = "/tmp/uploads";
+      fs.mkdirSync(dir, { recursive: true });
+      cb(null, dir);
+    },
+    filename: (_req, file, cb) => {
+      const ext = path.extname(file.originalname);
+      cb(null, `leave-${Date.now()}-${Math.random().toString(36).slice(2)}${ext}`);
+    },
+  }),
+  limits: { fileSize: 10 * 1024 * 1024 },
+});
 
 // Time-off "ticket" flow (Sal 2026-06-22). A standard workday is 8h; a half-day
 // is 4h. HALF_DAY_CUTOFF is the morning/afternoon split shown on the board —
@@ -444,6 +465,23 @@ async function buildBucketForValidation(
     display_name: row.display_name,
   };
 }
+
+// Upload the required attachment, get back a URL to submit with the request.
+router.post("/upload", leaveUpload.single("file"), async (req, res) => {
+  try {
+    if (!req.file) return bad(res, "No file uploaded");
+    const uploadsDir = process.env.UPLOADS_DIR ?? path.join(process.cwd(), "uploads");
+    fs.mkdirSync(uploadsDir, { recursive: true });
+    fs.renameSync(req.file.path, path.join(uploadsDir, req.file.filename));
+    return res.json({
+      file_url: `/api/uploads/${req.file.filename}`,
+      file_name: req.file.originalname,
+    });
+  } catch (err) {
+    console.error("[leave] upload failed:", err);
+    return res.status(500).json({ error: "Upload failed" });
+  }
+});
 
 router.post("/requests", async (req, res) => {
   const companyId = req.auth!.companyId!;

--- a/artifacts/api-server/src/routes/leave.ts
+++ b/artifacts/api-server/src/routes/leave.ts
@@ -75,6 +75,13 @@ import {
   notifyLeaveDecision,
 } from "../lib/leave-notifications.js";
 import { writeApprovedLeavePay } from "../lib/leave-pay.js";
+import { logAudit } from "../lib/audit.js";
+
+// Time-off "ticket" flow (Sal 2026-06-22). A standard workday is 8h; a half-day
+// is 4h. HALF_DAY_CUTOFF is the morning/afternoon split shown on the board —
+// noon by default, kept as a constant so it can be made tenant-configurable later.
+const DAILY_HOURS = 8;
+const HALF_DAY_CUTOFF = "12:00"; // morning = off until 12:00; afternoon = off from 12:00
 import { recordUnexcusedEntryAndDriveLadder } from "../lib/unexcused-ladder-writer.js";
 import { evaluateUseItOrLoseItAlert } from "../lib/leave-alerts.js";
 import {
@@ -445,7 +452,9 @@ router.post("/requests", async (req, res) => {
     leave_type_id?: number;
     start_date?: string;
     end_date?: string;
-    hours?: number | string;
+    day_unit?: "full_day" | "morning" | "afternoon";
+    attachment_url?: string | null;
+    attachment_name?: string | null;
     note?: string | null;
   };
   if (!body?.leave_type_id || !Number.isFinite(Number(body.leave_type_id)))
@@ -456,8 +465,25 @@ router.post("/requests", async (req, res) => {
     return bad(res, "end_date YYYY-MM-DD required");
   if (body.end_date < body.start_date)
     return bad(res, "end_date must be >= start_date");
-  const hours = Number(body.hours);
-  if (!Number.isFinite(hours) || hours <= 0) return bad(res, "hours must be positive");
+
+  // Required attachment at submit (Sal 2026-06-22) — employee-only, mandatory.
+  if (!body.attachment_url) {
+    return bad(res, "An attachment (e.g. a doctor's note) is required to submit a time-off request.", "attachment_required");
+  }
+
+  // Unit: full day / morning / afternoon. No free-form hours. Multi-day must be
+  // full days. Hours are derived (full = 8h × days; half = 4h, single day).
+  const dayUnit: "full_day" | "morning" | "afternoon" =
+    body.day_unit === "morning" || body.day_unit === "afternoon" ? body.day_unit : "full_day";
+  const multiDay = body.end_date > body.start_date;
+  if (multiDay && dayUnit !== "full_day") {
+    return bad(res, "Multi-day requests must be full days (use Morning/Afternoon for a single day).", "multiday_must_be_full");
+  }
+  const dayCount =
+    Math.round(
+      (Date.parse(`${body.end_date}T00:00:00Z`) - Date.parse(`${body.start_date}T00:00:00Z`)) / 86400000,
+    ) + 1;
+  const hours = dayUnit === "full_day" ? DAILY_HOURS * dayCount : DAILY_HOURS / 2;
 
   const bucket = await findBucket(companyId, Number(body.leave_type_id));
   if (!bucket) return notFound(res, "Leave type not found");
@@ -531,6 +557,9 @@ router.post("/requests", async (req, res) => {
       start_date: body.start_date,
       end_date: body.end_date,
       hours: hours.toFixed(2),
+      day_unit: dayUnit,
+      attachment_url: body.attachment_url,
+      attachment_name: body.attachment_name ?? null,
       note: body.note ?? null,
       status: initialStatus,
       blackout_conflict: blackoutConflict,
@@ -546,6 +575,13 @@ router.post("/requests", async (req, res) => {
   // Office/owner "ACTION REQUIRED" + employee "Pending"/"Emergency" (or
   // "Denied" if auto-denied above). Best-effort, never fails the request.
   void notifyLeaveSubmitted(inserted[0]!.id, companyId);
+  // Company-wide audit trail (per-employee profile log reads the same table).
+  try {
+    await logAudit(req, "leave_request_submitted", "leave_request", String(inserted[0]!.id), null, {
+      leave_type_id: bucket.id, start_date: body.start_date, end_date: body.end_date,
+      day_unit: dayUnit, hours, status: initialStatus,
+    });
+  } catch { /* audit is best-effort */ }
 
   return res.json({ data: inserted[0] });
 });
@@ -748,11 +784,16 @@ router.get("/requests", officeReadGate, async (req, res) => {
       user_id: leaveRequestsTable.user_id,
       first_name: usersTable.first_name,
       last_name: usersTable.last_name,
+      avatar_url: usersTable.avatar_url,
       leave_type_id: leaveRequestsTable.leave_type_id,
       bucket_name: leaveTypesTable.display_name,
+      bucket_slug: leaveTypesTable.slug,
       start_date: leaveRequestsTable.start_date,
       end_date: leaveRequestsTable.end_date,
       hours: leaveRequestsTable.hours,
+      day_unit: leaveRequestsTable.day_unit,
+      attachment_url: leaveRequestsTable.attachment_url,
+      attachment_name: leaveRequestsTable.attachment_name,
       note: leaveRequestsTable.note,
       status: leaveRequestsTable.status,
       blackout_conflict: leaveRequestsTable.blackout_conflict,
@@ -831,14 +872,24 @@ router.post("/requests/:id/approve", adminWriteGate, async (req, res) => {
       updated_at: new Date(),
     })
     .where(eq(employeeLeaveBalancesTable.id, bal.id));
-  await db.insert(employeeLeaveUsageTable).values({
-    company_id: companyId,
-    employee_id: reqRow.user_id,
-    date_used: String(reqRow.start_date),
-    hours: hours.toFixed(2),
-    notes: `leave_request #${reqRow.id} approved`,
-    logged_by: actingUserId,
-  });
+  // Write one usage row PER calendar day in the range (was: only start_date —
+  // that left multi-day requests showing the tech off for just day one on the
+  // board). Full day = 8h/day; a half-day request is a single day at 4h.
+  const dayUnit = ((reqRow as { day_unit?: string }).day_unit ?? "full_day");
+  const perDay = dayUnit === "full_day" ? DAILY_HOURS : DAILY_HOURS / 2;
+  const startMs = Date.parse(`${String(reqRow.start_date)}T00:00:00Z`);
+  const endMs = Date.parse(`${String(reqRow.end_date)}T00:00:00Z`);
+  for (let t = startMs; t <= endMs; t += 86400000) {
+    const d = new Date(t).toISOString().slice(0, 10);
+    await db.insert(employeeLeaveUsageTable).values({
+      company_id: companyId,
+      employee_id: reqRow.user_id,
+      date_used: d,
+      hours: perDay.toFixed(2),
+      notes: `leave_request #${reqRow.id} approved (${dayUnit})`,
+      logged_by: actingUserId,
+    });
+  }
   await db
     .update(leaveRequestsTable)
     .set({
@@ -849,6 +900,11 @@ router.post("/requests/:id/approve", adminWriteGate, async (req, res) => {
       updated_at: new Date(),
     })
     .where(eq(leaveRequestsTable.id, id));
+  try {
+    await logAudit(req, "leave_request_approved", "leave_request", String(id), null, {
+      decided_by: actingUserId, hours, day_unit: dayUnit, decision_note: decisionNote,
+    });
+  } catch { /* audit best-effort */ }
   // Auto-pay: approval is the gate — a paid bucket cascades into pay as a
   // visible additional_pay line ($20/hr flat). Idempotent; unpaid = no-op.
   try {
@@ -899,7 +955,29 @@ router.post("/requests/:id/deny", adminWriteGate, async (req, res) => {
     .where(eq(leaveRequestsTable.id, id));
   // Employee Denied notification: in-app + push + email + SMS (MC-mirrored).
   void notifyLeaveDecision(id, "denied");
+  try {
+    await logAudit(req, "leave_request_denied", "leave_request", String(id), null, {
+      decided_by: actingUserId, decision_note: decisionNote,
+    });
+  } catch { /* audit best-effort */ }
   return res.json({ data: { id, status: "denied" } });
+});
+
+// Count of pending time-off requests — powers the office "employee notifications"
+// bell badge. Office/owner only. (Equipment/supply requests, when built, add into
+// the same bell count.)
+router.get("/requests/pending-count", officeReadGate, async (req, res) => {
+  const companyId = req.auth!.companyId!;
+  const rows = await db
+    .select({ id: leaveRequestsTable.id })
+    .from(leaveRequestsTable)
+    .where(
+      and(
+        eq(leaveRequestsTable.company_id, companyId),
+        eq(leaveRequestsTable.status, "pending"),
+      ),
+    );
+  return res.json({ pending: rows.length });
 });
 
 router.post("/requests/:id/cancel", async (req, res) => {

--- a/artifacts/qleno/src/components/layout/dashboard-layout.tsx
+++ b/artifacts/qleno/src/components/layout/dashboard-layout.tsx
@@ -21,7 +21,7 @@ import {
   ChevronDown, Eye, LogOut, CircleHelp, KeyRound, Bell,
   CalendarX2, UserMinus, AlertTriangle, Plus, Receipt, Briefcase, UserPlus,
   GraduationCap,
-  Building2,
+  Building2, CalendarClock,
 } from "lucide-react";
 import { useEmployeeView } from "@/contexts/employee-view-context";
 
@@ -592,6 +592,22 @@ export function DashboardLayout({ children, title, fullBleed, onNewJob }: Dashbo
     staleTime: 20_000,
   });
 
+  // [time-off-ticket 2026-06-22] Separate STAFF notifications bell — pending
+  // time-off requests (and, later, equipment/supply requests). Office tier only.
+  const isOfficeTier = !!user?.role && ['owner', 'admin', 'office', 'super_admin'].includes(user.role);
+  const { data: empReqData } = useQuery({
+    queryKey: ['employee-pending-count', token],
+    queryFn: async () => {
+      const r = await fetch(`${API}/api/leave/requests/pending-count`, { headers: getAuthHeaders() as any });
+      if (!r.ok) return { pending: 0 };
+      return r.json();
+    },
+    enabled: !!token && isOfficeTier,
+    refetchInterval: 30_000,
+    staleTime: 20_000,
+  });
+  const empPending: number = empReqData?.pending || 0;
+
   const notifItems: any[] = notifData?.data || [];
   const notifUnread: number = notifData?.unread_count || 0;
 
@@ -698,6 +714,18 @@ export function DashboardLayout({ children, title, fullBleed, onNewJob }: Dashbo
               <MessageSquare size={19} />
               {unreadCount > 0 && <span style={{ position: 'absolute', top: 2, right: 2, width: 8, height: 8, borderRadius: 4, background: '#EF4444', border: '1px solid #fff' }} />}
             </button>
+
+            {/* Employee notifications bell (office tier) → Employees page */}
+            {isOfficeTier && (
+              <button onClick={() => setLocation('/employees')} title="Employee notifications — time off & requests" style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#6B7280', padding: '4px', position: 'relative', display: 'flex', alignItems: 'center' }}>
+                <CalendarClock size={19} />
+                {empPending > 0 && (
+                  <span style={{ position: 'absolute', top: 0, right: 0, minWidth: 14, height: 14, borderRadius: 7, background: 'var(--brand)', border: '2px solid #fff', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 8, color: '#04241d', fontWeight: 800, padding: '0 2px' }}>
+                    {empPending > 9 ? '9+' : empPending}
+                  </span>
+                )}
+              </button>
+            )}
 
             {/* Notifications bell → full notifications page (all roles) */}
             <button onClick={() => setLocation('/notifications')} title="Notifications" style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#6B7280', padding: '4px', position: 'relative', display: 'flex', alignItems: 'center' }}>
@@ -949,6 +977,21 @@ export function DashboardLayout({ children, title, fullBleed, onNewJob }: Dashbo
               <button onClick={() => setShortcutsOpen(true)} title="Keyboard Shortcuts"
                 style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#9E9B94', padding: 6, borderRadius: 8, display: 'flex', alignItems: 'center' }}>
                 <CircleHelp size={18} />
+              </button>
+            )}
+
+            {isOfficeTier && (
+              <button
+                onClick={() => setLocation('/employees')}
+                title="Employee notifications — time off & requests"
+                style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#6B7280', padding: 6, borderRadius: 8, display: 'flex', alignItems: 'center', position: 'relative' } as any}
+              >
+                <CalendarClock size={20} />
+                {empPending > 0 && (
+                  <span style={{ position: 'absolute', top: 2, right: 2, minWidth: 9, height: 9, borderRadius: 5, background: 'var(--brand)', border: '2px solid #fff', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 8, color: '#04241d', fontWeight: 700, padding: '0 2px' }}>
+                    {empPending > 9 ? '9+' : empPending}
+                  </span>
+                )}
               </button>
             )}
 

--- a/artifacts/qleno/src/pages/employees.tsx
+++ b/artifacts/qleno/src/pages/employees.tsx
@@ -326,6 +326,9 @@ export default function EmployeesPage() {
           </table>
         </div>
         )}{/* end desktop table ternary */}
+
+        {/* Time off & leave requests — pending requests the office acts on */}
+        <TimeOffRequestsSection />
       </div>
 
       {/* Add Team Member Modal */}
@@ -393,5 +396,90 @@ export default function EmployeesPage() {
         </div>
       )}
     </DashboardLayout>
+  );
+}
+
+// [time-off-ticket 2026-06-22] Office "Time off & leave requests" section at the
+// bottom of the Employees page. Lists pending requests; the office approves or
+// declines inline. Profile-photo avatars (EmployeeAvatar falls back to initials).
+const BUCKET_COLORS: Record<string, { bg: string; fg: string }> = {
+  pto_phes: { bg: '#E9FBF5', fg: '#00876B' },
+  plawa:    { bg: '#FEF3C7', fg: '#92400E' },
+  unpaid_leave: { bg: '#EEF2F7', fg: '#334155' },
+  unexcused: { bg: '#FCE7E7', fg: '#991B1B' },
+};
+function unitLabel(u: string) {
+  return u === 'morning' ? 'Morning' : u === 'afternoon' ? 'Afternoon' : 'Full day';
+}
+function dateLabel(r: any) {
+  const range = r.start_date === r.end_date ? r.start_date : `${r.start_date} – ${r.end_date}`;
+  return `${range} · ${unitLabel(r.day_unit)}`;
+}
+
+function TimeOffRequestsSection() {
+  const role = getTokenRole();
+  const canAct = role === 'owner' || role === 'admin' || role === 'office';
+  const [rows, setRows] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [busyId, setBusyId] = useState<number | null>(null);
+
+  async function load() {
+    try {
+      const r = await fetch(`${API}/api/leave/requests?status=pending`, { headers: getAuthHeaders() as any });
+      const d = await r.json();
+      setRows(d?.data ?? []);
+    } catch { /* leave the list empty on error */ }
+    finally { setLoading(false); }
+  }
+  useEffect(() => { if (canAct) load(); else setLoading(false); }, []);
+
+  async function act(id: number, action: 'approve' | 'deny') {
+    setBusyId(id);
+    try {
+      await fetch(`${API}/api/leave/requests/${id}/${action}`, { method: 'POST', headers: { ...getAuthHeaders(), 'Content-Type': 'application/json' } as any, body: '{}' });
+      setRows(prev => prev.filter(x => x.id !== id));
+    } catch { /* keep row on failure */ }
+    finally { setBusyId(null); }
+  }
+
+  if (!canAct) return null;
+
+  return (
+    <div style={{ marginTop: 28 }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 12 }}>
+        <h2 style={{ margin: 0, fontSize: 16, fontWeight: 800, color: '#1A1917' }}>Time off &amp; leave requests</h2>
+        {rows.length > 0 && (
+          <span style={{ fontSize: 11, fontWeight: 800, color: '#FFFFFF', background: '#0A0E1A', borderRadius: 999, padding: '2px 9px' }}>{rows.length} pending</span>
+        )}
+      </div>
+      <div style={{ background: '#FFFFFF', border: '1px solid #E5E2DC', borderRadius: 10, overflow: 'hidden' }}>
+        {loading ? (
+          <div style={{ padding: 24, color: '#9E9B94', fontSize: 13 }}>Loading…</div>
+        ) : rows.length === 0 ? (
+          <div style={{ padding: 24, color: '#9E9B94', fontSize: 13 }}>No pending time-off requests.</div>
+        ) : rows.map((r, i) => {
+          const c = BUCKET_COLORS[r.bucket_slug] ?? { bg: '#F4F3F0', fg: '#6B6860' };
+          return (
+            <div key={r.id} style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '14px 18px', borderTop: i ? '1px solid #E5E2DC' : 'none' }}>
+              <EmployeeAvatar name={`${r.first_name ?? ''} ${r.last_name ?? ''}`} avatarUrl={r.avatar_url} size={36} />
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ fontSize: 14, fontWeight: 700, color: '#1A1917' }}>{r.first_name} {r.last_name}</div>
+                <div style={{ fontSize: 12, color: '#6B6860' }}>{dateLabel(r)}</div>
+              </div>
+              <span style={{ fontSize: 10, fontWeight: 800, textTransform: 'uppercase', letterSpacing: '0.04em', borderRadius: 999, padding: '3px 9px', background: c.bg, color: c.fg, whiteSpace: 'nowrap' }}>{r.bucket_name}</span>
+              {r.attachment_url ? (
+                <a href={r.attachment_url} target="_blank" rel="noreferrer" style={{ fontSize: 11, fontWeight: 600, color: '#00876B', textDecoration: 'none', whiteSpace: 'nowrap' }}>Dr. note</a>
+              ) : (
+                <span style={{ fontSize: 11, color: '#C9C6BF', whiteSpace: 'nowrap' }}>no file</span>
+              )}
+              <div style={{ display: 'flex', gap: 8 }}>
+                <button disabled={busyId === r.id} onClick={() => act(r.id, 'approve')} style={{ fontSize: 12, fontWeight: 700, color: '#04241d', background: '#00C9A0', border: '1px solid #00C9A0', borderRadius: 8, padding: '7px 14px', cursor: 'pointer', opacity: busyId === r.id ? 0.5 : 1 }}>Approve</button>
+                <button disabled={busyId === r.id} onClick={() => act(r.id, 'deny')} style={{ fontSize: 12, fontWeight: 700, color: '#6B6860', background: '#FFFFFF', border: '1px solid #E5E2DC', borderRadius: 8, padding: '7px 14px', cursor: 'pointer', opacity: busyId === r.id ? 0.5 : 1 }}>Decline</button>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
   );
 }

--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -79,7 +79,7 @@ interface ClockEntry { id: number; clock_in_at: string | null; clock_out_at: str
 interface JobTechCommission { user_id: number; name: string; is_primary: boolean; est_hours: number; calc_pay: number; final_pay: number; pay_override: number | null; /* [pay-matrix 2026-04-29] surface the per-tech matrix cell so JobPanel can render "Hourly $20/hr × 6h" or "Commission 35%" without re-deriving */ pay_type?: "commission" | "hourly"; pay_rate?: number; }
 interface JobAddOn { name: string; quantity: number; unit_price: number; subtotal: number; }
 interface DispatchJob { id: number; client_id: number; client_name: string; /* [scheduling-engine 2026-04-29] display_name = "Company - Contact" for commercial clients with company_name set; falls back to client_name otherwise. Use this on every chip/header/hover surface so the composition rule lives server-side. */ display_name?: string; client_company_name?: string | null; client_phone?: string | null; client_zip?: string | null; client_notes?: string | null; client_payment_method?: string | null; /* [tile redesign] residential or commercial badge; commercial when account_id is set OR client_type === 'commercial' */ client_type?: "residential" | "commercial" | null; address: string | null; /* [inline-edit] raw fields for address editor mode detection */ job_address_street?: string | null; job_address_city?: string | null; job_address_state?: string | null; job_address_zip?: string | null; client_address?: string | null; client_city?: string | null; client_state?: string | null; client_address_zip?: string | null; assigned_user_id: number | null; assigned_user_name?: string; job_lat?: number | null; job_lng?: number | null; service_type: string; status: string; scheduled_date: string; scheduled_time: string | null; frequency: string; amount: number; duration_minutes: number; notes: string | null; office_notes?: string | null; office_notes_updated_at?: string | null; office_notes_updated_by_name?: string | null; before_photo_count: number; after_photo_count: number; clock_entry: ClockEntry | null; zone_id?: number | null; zone_color?: string | null; zone_name?: string | null; branch_id?: number | null; branch_name?: string | null; last_service_date?: string | null; account_id?: number | null; account_name?: string | null; billing_method?: string | null; hourly_rate?: number | null; estimated_hours?: number | null; actual_hours?: number | null; billed_hours?: number | null; billed_amount?: number | null; /* [commercial-revenue 2026-06-04] allowed_hours drives the "$50/hr × 8h" card display; manual_rate_override distinguishes a flat pinned price from rate×hours billing */ allowed_hours?: number | null; manual_rate_override?: boolean | null; charge_failed_at?: string | null; charge_succeeded_at?: string | null; property_access_notes?: string | null; booking_location?: string | null; technicians?: JobTechCommission[]; est_hours_per_tech?: number | null; est_pay_per_tech?: number | null; company_res_pct?: number | null; /* [AI.7.4] Commission routing — 'commercial_hourly' or 'residential_pool' */ commission_basis?: "commercial_hourly" | "residential_pool" | null; commercial_hourly_rate?: number | null; /* [AF] completion lock state */ locked_at?: string | null; /* [lockout-visibility 2026-06-17] 'cancel'|'lockout' when this completed job is a charged cancellation/lockout (fee billed, not a visit); drives the charged_cancel visual + fee badge */ cancel_action?: string | null; actual_end_time?: string | null; completed_by_user_id?: number | null; /* [job-card-redesign] Add-ons drive the +N pill on the chip and the full list in the popover. is_new_client = first-ever residential job (no prior completed). en_route_at scaffolds the "On My Way" status; column doesn't exist yet, so the field is always undefined until the SMS engine lands. */ add_ons?: JobAddOn[]; is_new_client?: boolean; en_route_at?: string | null; /* [phes-lifecycle 2026-04-29] Manual no-show flag set by the field app's "No Show" button. Drives the NO_SHOW visual state via getJobVisualStatus. Until the field-app button ships, both fields stay null. */ no_show_marked_by_tech?: string | null; no_show_marked_by_user_id?: number | null; /* [BUG-3F2 / 2026-06-02] Multi-tech fan-out fields. team_role identifies whether this card renders for the primary or a team member, so the FE can style team-member cards differently. revenue_share is the per-tech weighted share of the job amount; the badge sums revenue_share (when present) instead of amount so per-row totals don't double-count shared jobs across the company. */ team_role?: "primary" | "team"; revenue_share?: number; }
-interface Employee { id: number; name: string; role: string; is_trainee?: boolean; jobs: DispatchJob[]; zone?: { zone_id: number; zone_color: string; zone_name: string } | null; time_off?: 'pto' | 'sick' | 'absent' | null; commission_rate?: number | null; avatar_url?: string | null; }
+interface Employee { id: number; name: string; role: string; is_trainee?: boolean; jobs: DispatchJob[]; zone?: { zone_id: number; zone_color: string; zone_name: string } | null; time_off?: 'pto' | 'plawa' | 'unpaid' | 'unexcused' | 'absent' | null; time_off_unit?: 'full_day' | 'morning' | 'afternoon' | null; commission_rate?: number | null; avatar_url?: string | null; }
 interface DispatchData { employees: Employee[]; unassigned_jobs: DispatchJob[]; }
 
 // ─── HELPERS ──────────────────────────────────────────────────────────────────
@@ -2665,12 +2665,13 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
                           if (gap < drive && (tight == null || drive - gap > tight.drive - tight.gap)) tight = { gap, drive };
                         }
                       }
-                      return { t, available, sameZone, jobCount: empJobs.length, freeAt, zoneName: emp?.zone?.zone_name ?? null, timeOff: emp?.time_off ?? null, dist, distScore, pastClose, tight };
+                      return { t, available, sameZone, jobCount: empJobs.length, freeAt, zoneName: emp?.zone?.zone_name ?? null, timeOff: emp?.time_off ?? null, timeOffUnit: emp?.time_off_unit ?? null, dist, distScore, pastClose, tight };
                     });
-                    // SAFEGUARD: never SUGGEST a tech on PTO / sick / absent today.
-                    // Best → ok: free at the job's time → CLOSEST to the job →
-                    // lighter load; if none free, whoever frees up soonest.
-                    const suggested = scored.filter(s => !s.timeOff).sort((a, b) => {
+                    // SAFEGUARD: never SUGGEST a tech who's off the WHOLE day.
+                    // A half-day (morning/afternoon) stays suggestable — they're
+                    // available the half they're working.
+                    const offWholeDay = (s: typeof scored[number]) => !!s.timeOff && (!s.timeOffUnit || s.timeOffUnit === 'full_day');
+                    const suggested = scored.filter(s => !offWholeDay(s)).sort((a, b) => {
                       if (a.available !== b.available) return a.available ? -1 : 1;
                       if (a.available) {
                         // Soft demotion only: a clean pick outranks one carrying a
@@ -5036,10 +5037,16 @@ function CarIconInline({ tint }: { tint: string }) {
 }
 
 // ─── DESKTOP: EMPLOYEE ROW ────────────────────────────────────────────────────
+// Four distinct leave buckets + absent, each its own tint on the dispatch row.
 const TIME_OFF_BG: Record<string, string> = {
-  pto:    "#FFF9C4",
-  sick:   "#FFF176",
-  absent: "#FFEBEE",
+  pto:       "#E9FBF5",
+  plawa:     "#FEF3C7",
+  unpaid:    "#EEF2F7",
+  unexcused: "#FCE7E7",
+  absent:    "#FFEBEE",
+};
+const TIME_OFF_LABEL: Record<string, string> = {
+  pto: "PTO", plawa: "PLAWA", unpaid: "Unpaid", unexcused: "Unexcused", absent: "Absent",
 };
 
 // Time-off band covers the full dispatch timeline (since the board IS business hours)
@@ -5124,6 +5131,11 @@ function EmployeeRow({ employee, onChipClick, nowLine }: { employee: Employee; o
   const pay = payFromJobs > 0 ? payFromJobs : payFromRate;
   const isClockedIn = employee.jobs.some(j => j.clock_entry?.clock_in_at && !j.clock_entry?.clock_out_at);
   const timeOffBg = employee.time_off ? TIME_OFF_BG[employee.time_off] : null;
+  const toUnit = employee.time_off_unit;
+  const isFullDayOff = !!employee.time_off && (!toUnit || toUnit === 'full_day');
+  const timeOffText = employee.time_off
+    ? `${TIME_OFF_LABEL[employee.time_off] ?? 'Off'}${toUnit === 'morning' ? ' · AM off' : toUnit === 'afternoon' ? ' · PM off' : ''}`
+    : null;
   // [overlap-stacking] Stack time-overlapping chips into sub-lanes so none
   // hides another; row grows to fit. One sub-lane → unchanged 72px row.
   const { topById, rowHeight } = packLanes(employee.jobs);
@@ -5166,7 +5178,7 @@ function EmployeeRow({ employee, onChipClick, nowLine }: { employee: Employee; o
             )}
             {employee.zone && <div style={{ width: 7, height: 7, borderRadius: "50%", backgroundColor: employee.zone.zone_color, flexShrink: 0 }} title={employee.zone.zone_name} />}
           </div>
-          <div style={{ fontSize: 9, color: "#9E9B94", textTransform: "uppercase", fontWeight: 700, letterSpacing: "0.05em" }}>{employee.is_trainee ? "Trainee" : employee.role}</div>
+          <div style={{ fontSize: 9, color: "#9E9B94", textTransform: "uppercase", fontWeight: 700, letterSpacing: "0.05em" }}>{employee.is_trainee ? "Trainee" : employee.role}{timeOffText ? ` · ${timeOffText}` : ""}</div>
           {/* [2026-06-04] Two lines so the two dollar figures don't read as
               one number. Line 1 = the work (jobs · hours · revenue billed).
               Line 2 = what the TECH earns that day (commission/pay), mint +
@@ -5186,7 +5198,7 @@ function EmployeeRow({ employee, onChipClick, nowLine }: { employee: Employee; o
             alternating hour bands so the eye groups each hour. */}
         {TIMES.map((_, i) => <div key={i} style={{ position: "absolute", left: i * SLOT_W, top: 0, bottom: 0, width: SLOT_W, pointerEvents: "none", backgroundColor: Math.floor(i / 2) % 2 === 1 ? "rgba(120,110,90,0.045)" : "transparent", borderRight: i % 2 === 1 ? "1px solid #CBC7BF" : "1px dotted #E9E7E2" }} />)}
         {/* Time-off band sits behind job chips (zIndex 0) */}
-        {timeOffBg && (
+        {timeOffBg && isFullDayOff && (
           <div style={{ position: "absolute", left: getBandLeft(), width: getBandWidth(), top: 0, bottom: 0, backgroundColor: timeOffBg, zIndex: 0, pointerEvents: "none" }} />
         )}
         {nowLine >= 0 && nowLine <= TOTAL_SLOTS * SLOT_W && <div style={{ position: "absolute", left: nowLine, top: 0, bottom: 0, width: 2, backgroundColor: "#EF4444", zIndex: 3, pointerEvents: "none" }} />}

--- a/artifacts/qleno/src/pages/leave-request.tsx
+++ b/artifacts/qleno/src/pages/leave-request.tsx
@@ -51,9 +51,13 @@ export default function LeaveRequestPage() {
   const [selectedBucket, setSelectedBucket] = useState<number | null>(null);
   const [startDate, setStartDate] = useState<string>("");
   const [endDate, setEndDate] = useState<string>("");
-  const [hours, setHours] = useState<string>("8");
+  const [dayUnit, setDayUnit] = useState<"full_day" | "morning" | "afternoon">("full_day");
+  const [attachment, setAttachment] = useState<{ url: string; name: string } | null>(null);
+  const [uploading, setUploading] = useState(false);
   const [note, setNote] = useState<string>("");
   const [submitting, setSubmitting] = useState(false);
+
+  const multiDay = !!startDate && !!endDate && endDate > startDate;
 
   useEffect(() => {
     load();
@@ -77,11 +81,32 @@ export default function LeaveRequestPage() {
     }
   }
 
+  async function uploadFile(file: File) {
+    setUploading(true);
+    try {
+      const fd = new FormData();
+      fd.append("file", file);
+      const res = await fetch("/api/leave/upload", { method: "POST", credentials: "include", body: fd });
+      if (!res.ok) throw new Error("upload failed");
+      const j = await res.json();
+      setAttachment({ url: j.file_url, name: j.file_name });
+    } catch {
+      toast({ title: "Upload failed — try again", variant: "destructive" });
+    } finally {
+      setUploading(false);
+    }
+  }
+
   async function submit() {
-    if (!selectedBucket || !startDate || !endDate || !hours) {
+    if (!selectedBucket || !startDate || !endDate) {
       toast({ title: "Pick a bucket and dates", variant: "destructive" });
       return;
     }
+    if (!attachment) {
+      toast({ title: "An attachment (e.g. a doctor's note) is required", variant: "destructive" });
+      return;
+    }
+    const unit = multiDay ? "full_day" : dayUnit;
     setSubmitting(true);
     try {
       const res = await fetch("/api/leave/requests", {
@@ -92,7 +117,9 @@ export default function LeaveRequestPage() {
           leave_type_id: selectedBucket,
           start_date: startDate,
           end_date: endDate,
-          hours: Number(hours),
+          day_unit: unit,
+          attachment_url: attachment.url,
+          attachment_name: attachment.name,
           note: note || null,
         }),
       });
@@ -113,6 +140,8 @@ export default function LeaveRequestPage() {
         toast({ title: "Request submitted" });
       }
       setNote("");
+      setAttachment(null);
+      setDayUnit("full_day");
       await load();
     } finally {
       setSubmitting(false);
@@ -182,15 +211,35 @@ export default function LeaveRequestPage() {
                 ))}
               </select>
             </FormField>
-            <FormField label="Hours">
-              <input
-                type="number"
-                step="0.25"
-                min="0"
-                value={hours}
-                onChange={(e) => setHours(e.target.value)}
-                style={inputStyle}
-              />
+            <FormField label="Amount">
+              {multiDay ? (
+                <div style={{ fontSize: 13, color: MUTED, padding: "6px 0" }}>
+                  Full days (multi-day request)
+                </div>
+              ) : (
+                <div style={{ display: "flex", gap: 6 }}>
+                  {([
+                    { v: "full_day", l: "Full day" },
+                    { v: "morning", l: "Morning" },
+                    { v: "afternoon", l: "Afternoon" },
+                  ] as const).map((o) => (
+                    <button
+                      key={o.v}
+                      type="button"
+                      onClick={() => setDayUnit(o.v)}
+                      style={{
+                        flex: 1, fontFamily: FF, fontSize: 12, fontWeight: 700,
+                        padding: "8px 6px", borderRadius: 8, cursor: "pointer",
+                        border: `1px solid ${dayUnit === o.v ? BRAND : BORDER}`,
+                        background: dayUnit === o.v ? BRAND : CARD,
+                        color: dayUnit === o.v ? "#04241d" : INK,
+                      }}
+                    >
+                      {o.l}
+                    </button>
+                  ))}
+                </div>
+              )}
             </FormField>
             <FormField label="Start date">
               <CalendarPopover value={startDate} ariaLabel="Start date" onChange={setStartDate} block />
@@ -198,6 +247,28 @@ export default function LeaveRequestPage() {
             <FormField label="End date">
               <CalendarPopover value={endDate} ariaLabel="End date" onChange={setEndDate} block />
             </FormField>
+            <div style={{ gridColumn: "1 / -1" }}>
+              <FormField label="Attachment (required — doctor's note / file)">
+                {attachment ? (
+                  <div style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 13, color: INK }}>
+                    <span style={{ flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{attachment.name}</span>
+                    <button type="button" onClick={() => setAttachment(null)} style={{ fontFamily: FF, fontSize: 12, fontWeight: 600, color: DANGER, background: "none", border: "none", cursor: "pointer" }}>Remove</button>
+                  </div>
+                ) : (
+                  <label style={{ display: "inline-flex", alignItems: "center", gap: 8, fontSize: 13, fontWeight: 600, color: BRAND, cursor: "pointer" }}>
+                    {uploading ? "Uploading…" : "Choose / take a photo"}
+                    <input
+                      type="file"
+                      accept="image/*,application/pdf"
+                      capture="environment"
+                      style={{ display: "none" }}
+                      disabled={uploading}
+                      onChange={(e) => { const f = e.target.files?.[0]; if (f) uploadFile(f); }}
+                    />
+                  </label>
+                )}
+              </FormField>
+            </div>
             <div style={{ gridColumn: "1 / -1" }}>
               <FormField label="Note (optional)">
                 <input
@@ -212,12 +283,12 @@ export default function LeaveRequestPage() {
           <div style={{ marginTop: 12, display: "flex", justifyContent: "flex-end" }}>
             <button
               onClick={submit}
-              disabled={submitting}
+              disabled={submitting || uploading || !attachment}
               style={{
                 fontFamily: FF, fontSize: 13, fontWeight: 700,
                 color: "#FFFFFF", backgroundColor: BRAND, border: "none",
                 borderRadius: 8, padding: "8px 14px", cursor: "pointer",
-                opacity: submitting ? 0.4 : 1,
+                opacity: submitting || uploading || !attachment ? 0.4 : 1,
               }}
             >
               Submit request

--- a/docs/timeoff-employees-section-preview.html
+++ b/docs/timeoff-employees-section-preview.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Qleno — Employees page · Time off & leave requests section</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+  :root{--bg:#F7F6F3;--card:#FFFFFF;--ink:#1A1917;--muted:#9E9B94;--border:#E5E2DC;--mint:#00C9A0;--night:#0A0E1A;--branddim:#E9FBF5;--brand:#00876B}
+  *{box-sizing:border-box} body{margin:0;background:var(--bg);color:var(--ink);font-family:'Plus Jakarta Sans',sans-serif;padding:28px}
+  .wrap{max-width:1000px;margin:0 auto}
+  h1{font-size:18px;font-weight:800;margin:0 0 4px} .sub{font-size:13px;color:var(--muted);margin:0 0 20px}
+  .listph{background:var(--card);border:1px solid var(--border);border-radius:10px;padding:16px 18px;margin-bottom:6px;color:var(--muted);font-size:13px}
+  .listrow{display:flex;align-items:center;gap:12px;padding:10px 0;border-top:1px solid #F1EFEA}
+  .av{width:34px;height:34px;border-radius:50%;background:var(--branddim);color:var(--brand);display:flex;align-items:center;justify-content:center;font-weight:700;font-size:12px;flex-shrink:0;overflow:hidden}
+  .av img{width:100%;height:100%;object-fit:cover}
+  .sec{margin-top:28px}
+  .sechead{display:flex;align-items:center;gap:10px;margin-bottom:12px}
+  .sechead h2{margin:0;font-size:16px;font-weight:800}
+  .badge{font-size:11px;font-weight:800;color:#fff;background:var(--night);border-radius:999px;padding:2px 9px}
+  .card{background:var(--card);border:1px solid var(--border);border-radius:10px;overflow:hidden}
+  .req{display:flex;align-items:center;gap:12px;padding:14px 18px}
+  .req+.req{border-top:1px solid var(--border)}
+  .who{font-size:14px;font-weight:700} .when{font-size:12px;color:#6B6860}
+  .grow{flex:1;min-width:0}
+  .chip{font-size:10px;font-weight:800;text-transform:uppercase;letter-spacing:.04em;border-radius:999px;padding:3px 9px;white-space:nowrap}
+  .pto{background:#E9FBF5;color:#00876B}.plawa{background:#FEF3C7;color:#92400E}.unpaid{background:#EEF2F7;color:#334155}.unexcused{background:#FCE7E7;color:#991B1B}
+  .file{font-size:11px;font-weight:600;color:#00876B;text-decoration:none;white-space:nowrap}.nofile{font-size:11px;color:#C9C6BF}
+  .btn{font-size:12px;font-weight:700;border-radius:8px;padding:7px 14px;cursor:pointer;border:1px solid var(--border)}
+  .approve{background:var(--mint);color:#04241d;border-color:var(--mint)}.decline{background:#fff;color:#6B6860}
+  .legend{display:flex;gap:8px;flex-wrap:wrap;margin-top:10px}
+  .foot{font-size:12px;color:var(--muted);margin-top:14px}
+</style></head>
+<body><div class="wrap">
+  <h1>Employees</h1>
+  <p class="sub">Preview of the new "Time off &amp; leave requests" section at the bottom of the Employees page (mockup; the live version reads pending requests). Avatars use the employee's profile photo, falling back to initials.</p>
+
+  <div class="listph">
+    <div style="font-weight:700;color:var(--ink)">Team</div>
+    <div class="listrow"><div class="av">RG</div><div class="grow"><b style="font-size:13px">Rosa Gallegos</b> · Technician</div></div>
+    <div class="listrow"><div class="av">NP</div><div class="grow"><b style="font-size:13px">Norma Puga</b> · Technician</div></div>
+    <div class="listrow"><div class="av">MC</div><div class="grow"><b style="font-size:13px">Maribel Castillo</b> · Office</div></div>
+    <div style="font-size:11px;color:var(--muted);margin-top:8px">… full team list …</div>
+  </div>
+
+  <div class="sec">
+    <div class="sechead"><h2>Time off &amp; leave requests</h2><span class="badge">4 pending</span></div>
+    <div class="card" id="reqs"></div>
+    <div class="legend">
+      <span class="chip pto">PTO</span><span class="chip plawa">PLAWA / Sick</span>
+      <span class="chip unpaid">Unpaid</span><span class="chip unexcused">Unexcused</span>
+    </div>
+    <p class="foot">Each row: profile-photo avatar, name, dates + unit (Full day / Morning / Afternoon), bucket chip, the required attachment ("Dr. note"), and Approve / Decline. A new "employee notifications" bell in the top bar (separate from the customer bell) carries the pending count and lands here.</p>
+  </div>
+</div>
+<script>
+  const rows=[
+    {who:'Maribel Castillo',init:'MC',bucket:'pto',label:'PTO',when:'Jun 30 – Jul 2 · Full day'},
+    {who:'Alejandra Cuervo',init:'AC',bucket:'plawa',label:'PLAWA',when:'Jun 24 · Morning'},
+    {who:'Juliana Loredo',init:'JL',bucket:'unpaid',label:'Unpaid',when:'Jul 5 · Afternoon'},
+    {who:'Diana Vasquez',init:'DV',bucket:'pto',label:'PTO',when:'Jul 10 · Full day'},
+  ];
+  document.getElementById('reqs').innerHTML = rows.map(r=>`
+    <div class="req">
+      <div class="av">${r.init}</div>
+      <div class="grow"><div class="who">${r.who}</div><div class="when">${r.when}</div></div>
+      <span class="chip ${r.bucket}">${r.label}</span>
+      <a class="file" href="#">Dr. note</a>
+      <div style="display:flex;gap:8px"><button class="btn approve">Approve</button><button class="btn decline">Decline</button></div>
+    </div>`).join('');
+</script>
+</body></html>

--- a/docs/timeoff-employees-section-preview.html
+++ b/docs/timeoff-employees-section-preview.html
@@ -1,70 +1,95 @@
 <!doctype html>
 <html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/>
-<title>Qleno — Employees page · Time off & leave requests section</title>
+<title>Qleno — Time-off ticket flow preview (bell · Employees section · board)</title>
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&display=swap" rel="stylesheet">
 <style>
   :root{--bg:#F7F6F3;--card:#FFFFFF;--ink:#1A1917;--muted:#9E9B94;--border:#E5E2DC;--mint:#00C9A0;--night:#0A0E1A;--branddim:#E9FBF5;--brand:#00876B}
-  *{box-sizing:border-box} body{margin:0;background:var(--bg);color:var(--ink);font-family:'Plus Jakarta Sans',sans-serif;padding:28px}
-  .wrap{max-width:1000px;margin:0 auto}
-  h1{font-size:18px;font-weight:800;margin:0 0 4px} .sub{font-size:13px;color:var(--muted);margin:0 0 20px}
-  .listph{background:var(--card);border:1px solid var(--border);border-radius:10px;padding:16px 18px;margin-bottom:6px;color:var(--muted);font-size:13px}
-  .listrow{display:flex;align-items:center;gap:12px;padding:10px 0;border-top:1px solid #F1EFEA}
-  .av{width:34px;height:34px;border-radius:50%;background:var(--branddim);color:var(--brand);display:flex;align-items:center;justify-content:center;font-weight:700;font-size:12px;flex-shrink:0;overflow:hidden}
-  .av img{width:100%;height:100%;object-fit:cover}
-  .sec{margin-top:28px}
-  .sechead{display:flex;align-items:center;gap:10px;margin-bottom:12px}
-  .sechead h2{margin:0;font-size:16px;font-weight:800}
-  .badge{font-size:11px;font-weight:800;color:#fff;background:var(--night);border-radius:999px;padding:2px 9px}
+  *{box-sizing:border-box} body{margin:0;background:var(--bg);color:var(--ink);font-family:'Plus Jakarta Sans',sans-serif;padding:24px}
+  .wrap{max-width:1000px;margin:0 auto} h1{font-size:18px;font-weight:800;margin:0 0 4px} .sub{font-size:13px;color:var(--muted);margin:0 0 18px}
+  .label{font-size:12px;font-weight:800;text-transform:uppercase;letter-spacing:.06em;color:var(--muted);margin:22px 0 8px}
+  /* top bar */
+  .topbar{display:flex;align-items:center;justify-content:flex-end;gap:14px;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:12px 16px}
+  .iconbtn{position:relative;color:#6B7280;display:flex;align-items:center}
+  .badge{position:absolute;top:-4px;right:-6px;min-width:15px;height:15px;border-radius:8px;display:flex;align-items:center;justify-content:center;font-size:9px;font-weight:800;border:2px solid #fff}
+  .badge.mint{background:var(--mint);color:#04241d}.badge.red{background:#EF4444;color:#fff}
+  .hint{font-size:11px;color:var(--muted);margin-top:6px}
+  /* avatars + cards */
   .card{background:var(--card);border:1px solid var(--border);border-radius:10px;overflow:hidden}
-  .req{display:flex;align-items:center;gap:12px;padding:14px 18px}
-  .req+.req{border-top:1px solid var(--border)}
-  .who{font-size:14px;font-weight:700} .when{font-size:12px;color:#6B6860}
-  .grow{flex:1;min-width:0}
+  .av{width:34px;height:34px;border-radius:50%;background:var(--branddim);color:var(--brand);display:flex;align-items:center;justify-content:center;font-weight:700;font-size:12px;flex-shrink:0}
+  .sechead{display:flex;align-items:center;gap:10px;margin-bottom:10px}.sechead h2{margin:0;font-size:16px;font-weight:800}
+  .pill{font-size:11px;font-weight:800;color:#fff;background:var(--night);border-radius:999px;padding:2px 9px}
+  .req{display:flex;align-items:center;gap:12px;padding:14px 18px}.req+.req{border-top:1px solid var(--border)}
+  .who{font-size:14px;font-weight:700}.when{font-size:12px;color:#6B6860}.grow{flex:1;min-width:0}
   .chip{font-size:10px;font-weight:800;text-transform:uppercase;letter-spacing:.04em;border-radius:999px;padding:3px 9px;white-space:nowrap}
   .pto{background:#E9FBF5;color:#00876B}.plawa{background:#FEF3C7;color:#92400E}.unpaid{background:#EEF2F7;color:#334155}.unexcused{background:#FCE7E7;color:#991B1B}
-  .file{font-size:11px;font-weight:600;color:#00876B;text-decoration:none;white-space:nowrap}.nofile{font-size:11px;color:#C9C6BF}
+  .file{font-size:11px;font-weight:600;color:#00876B;text-decoration:none}
   .btn{font-size:12px;font-weight:700;border-radius:8px;padding:7px 14px;cursor:pointer;border:1px solid var(--border)}
   .approve{background:var(--mint);color:#04241d;border-color:var(--mint)}.decline{background:#fff;color:#6B6860}
-  .legend{display:flex;gap:8px;flex-wrap:wrap;margin-top:10px}
-  .foot{font-size:12px;color:var(--muted);margin-top:14px}
+  /* board */
+  .brow{display:flex;align-items:stretch;border-top:1px solid #EEECE7;min-height:54px}
+  .bname{width:190px;flex-shrink:0;border-right:1px solid var(--border);display:flex;align-items:center;gap:9px;padding:0 12px}
+  .brole{font-size:9px;color:var(--muted);text-transform:uppercase;font-weight:700;letter-spacing:.05em}
+  .btime{flex:1;position:relative;background:repeating-linear-gradient(90deg,#fff,#fff 59px,#F1EFEA 59px,#F1EFEA 60px)}
+  .bband{position:absolute;top:0;bottom:0}
 </style></head>
 <body><div class="wrap">
-  <h1>Employees</h1>
-  <p class="sub">Preview of the new "Time off &amp; leave requests" section at the bottom of the Employees page (mockup; the live version reads pending requests). Avatars use the employee's profile photo, falling back to initials.</p>
+  <h1>Time-off ticket flow — preview of all three surfaces</h1>
+  <p class="sub">Mockups (not wired). Shows: the new employee-notifications bell, the Employees-page review section, and how the four buckets + half-days render on the dispatch board.</p>
 
-  <div class="listph">
-    <div style="font-weight:700;color:var(--ink)">Team</div>
-    <div class="listrow"><div class="av">RG</div><div class="grow"><b style="font-size:13px">Rosa Gallegos</b> · Technician</div></div>
-    <div class="listrow"><div class="av">NP</div><div class="grow"><b style="font-size:13px">Norma Puga</b> · Technician</div></div>
-    <div class="listrow"><div class="av">MC</div><div class="grow"><b style="font-size:13px">Maribel Castillo</b> · Office</div></div>
-    <div style="font-size:11px;color:var(--muted);margin-top:8px">… full team list …</div>
+  <div class="label">1 · Top-bar employee-notifications bell (separate from the customer bell)</div>
+  <div class="topbar">
+    <span class="iconbtn" title="Employee notifications — time off & requests">
+      <!-- calendar-clock -->
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#6B7280" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 7.5V6a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h6"/><path d="M16 2v4M8 2v4M3 10h18"/><circle cx="18" cy="18" r="4"/><path d="M18 16.5V18l1 1"/></svg>
+      <span class="badge mint">3</span>
+    </span>
+    <span class="iconbtn" title="Notifications (customer)">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#6B7280" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9"/><path d="M10.3 21a1.94 1.94 0 0 0 3.4 0"/></svg>
+      <span class="badge red">5</span>
+    </span>
   </div>
+  <p class="hint">Left (mint) = staff/time-off requests → lands on the Employees page. Right (red) = the existing customer notifications. Designed to also carry equipment/supply requests later.</p>
 
-  <div class="sec">
-    <div class="sechead"><h2>Time off &amp; leave requests</h2><span class="badge">4 pending</span></div>
-    <div class="card" id="reqs"></div>
-    <div class="legend">
-      <span class="chip pto">PTO</span><span class="chip plawa">PLAWA / Sick</span>
-      <span class="chip unpaid">Unpaid</span><span class="chip unexcused">Unexcused</span>
-    </div>
-    <p class="foot">Each row: profile-photo avatar, name, dates + unit (Full day / Morning / Afternoon), bucket chip, the required attachment ("Dr. note"), and Approve / Decline. A new "employee notifications" bell in the top bar (separate from the customer bell) carries the pending count and lands here.</p>
-  </div>
+  <div class="label">2 · Employees page — "Time off & leave requests" section</div>
+  <div class="sechead"><h2>Time off &amp; leave requests</h2><span class="pill">4 pending</span></div>
+  <div class="card" id="reqs"></div>
+
+  <div class="label">3 · Dispatch board — four distinct buckets + half-day keeps the tech available</div>
+  <div class="card" id="board"></div>
+  <p class="hint">Full-day off tints the whole timeline. A <b>half-day</b> (e.g. Alejandra — PLAWA, AM off) shows the label but leaves the afternoon open — she stays suggestable for the half she's working.</p>
 </div>
 <script>
-  const rows=[
+  const reqs=[
     {who:'Maribel Castillo',init:'MC',bucket:'pto',label:'PTO',when:'Jun 30 – Jul 2 · Full day'},
     {who:'Alejandra Cuervo',init:'AC',bucket:'plawa',label:'PLAWA',when:'Jun 24 · Morning'},
     {who:'Juliana Loredo',init:'JL',bucket:'unpaid',label:'Unpaid',when:'Jul 5 · Afternoon'},
     {who:'Diana Vasquez',init:'DV',bucket:'pto',label:'PTO',when:'Jul 10 · Full day'},
   ];
-  document.getElementById('reqs').innerHTML = rows.map(r=>`
-    <div class="req">
-      <div class="av">${r.init}</div>
+  document.getElementById('reqs').innerHTML = reqs.map(r=>`
+    <div class="req"><div class="av">${r.init}</div>
       <div class="grow"><div class="who">${r.who}</div><div class="when">${r.when}</div></div>
-      <span class="chip ${r.bucket}">${r.label}</span>
-      <a class="file" href="#">Dr. note</a>
+      <span class="chip ${r.bucket}">${r.label}</span><a class="file" href="#">Dr. note</a>
       <div style="display:flex;gap:8px"><button class="btn approve">Approve</button><button class="btn decline">Decline</button></div>
     </div>`).join('');
+
+  const TINT={pto:'#E9FBF5',plawa:'#FEF3C7',unpaid:'#EEF2F7',unexcused:'#FCE7E7'};
+  // bucket, unit(null=working / 'full' / 'am' / 'pm)
+  const board=[
+    {who:'Rosa Gallegos',init:'RG',role:'Technician · PTO',bucket:'pto',band:'full'},
+    {who:'Norma Puga',init:'NP',role:'Technician · Unexcused',bucket:'unexcused',band:'full'},
+    {who:'Alejandra Cuervo',init:'AC',role:'Technician · PLAWA · AM off',bucket:'plawa',band:'am'},
+    {who:'Diana Vasquez',init:'DV',role:'Technician',bucket:null,band:null},
+  ];
+  document.getElementById('board').innerHTML = board.map(b=>{
+    const tint = b.bucket?TINT[b.bucket]:'#fff';
+    let band='';
+    if(b.band==='full') band=`<div class="bband" style="left:0;right:0;background:${tint}"></div>`;
+    else if(b.band==='am') band=`<div class="bband" style="left:0;width:50%;background:${tint}"></div><div class="bband" style="left:50%;right:0;background:#fff;border-left:1px dashed ${'#cdcabf'}"></div>`;
+    return `<div class="brow">
+      <div class="bname" style="background:${b.bucket?tint:'#fff'}"><div class="av">${b.init}</div><div><div style="font-size:13px;font-weight:700">${b.who}</div><div class="brole">${b.role}</div></div></div>
+      <div class="btime">${band}</div>
+    </div>`;
+  }).join('');
 </script>
 </body></html>

--- a/lib/db/src/schema/leave.ts
+++ b/lib/db/src/schema/leave.ts
@@ -231,6 +231,15 @@ export const leaveRequestStatusEnum = pgEnum("leave_request_status", [
   "cancelled",
 ]);
 
+// Sub-day unit (Sal 2026-06-22): no free-form hours. A half-day leaves the tech
+// available the OTHER half on the dispatch board. Multi-day requests are
+// full_day only. Half-day split defaults to noon (see HALF_DAY_CUTOFF).
+export const leaveDayUnitEnum = pgEnum("leave_day_unit", [
+  "full_day",
+  "morning",
+  "afternoon",
+]);
+
 export const leaveRequestsTable = pgTable(
   "leave_requests",
   {
@@ -247,6 +256,13 @@ export const leaveRequestsTable = pgTable(
     start_date: date("start_date").notNull(),
     end_date: date("end_date").notNull(),
     hours: numeric("hours", { precision: 8, scale: 2 }).notNull(),
+    // Full day / morning / afternoon. Hours are derived from this + the bucket's
+    // daily hours; multi-day requests must be full_day.
+    day_unit: leaveDayUnitEnum("day_unit").notNull().default("full_day"),
+    // Required attachment the employee uploads at submit (doctor's note / file).
+    // The office does not attach. Stored as a file ref (R2 url) + display name.
+    attachment_url: text("attachment_url"),
+    attachment_name: text("attachment_name"),
     note: text("note"),
     status: leaveRequestStatusEnum("status").notNull().default("pending"),
     blackout_conflict: boolean("blackout_conflict").notNull().default(false),

--- a/scripts/_schaumburg_leave_cleanup.mjs
+++ b/scripts/_schaumburg_leave_cleanup.mjs
@@ -1,0 +1,50 @@
+// Schaumburg (co4) leave-config cleanup — mirror the Oak Lawn (co1) fixes.
+// Dry-run by default (SELECT only, prints before + planned changes). --apply
+// runs the 4 UPDATEs in a transaction. Idempotent.
+import pg from "/Users/salvadormartinez/qleno/node_modules/.pnpm/pg@8.20.0/node_modules/pg/lib/index.js";
+import { readFileSync } from "node:fs";
+const APPLY = process.argv.includes("--apply");
+const CO = 4;
+const env = readFileSync("/Users/salvadormartinez/qleno/.env", "utf8");
+const url = env.split("\n").find((l) => l.startsWith("DATABASE_URL=")).slice(13).trim().replace(/^["']|["']$/g, "");
+const c = new pg.Client({ connectionString: url, ssl: { rejectUnauthorized: false } });
+await c.connect();
+
+console.log(`=== Schaumburg (co${CO}) leave cleanup — ${APPLY ? "APPLY" : "DRY-RUN"} ===\n`);
+console.log("BEFORE — active leave_types:");
+console.table((await c.query(`SELECT slug, accrual_mode, carryover_allowed, active FROM leave_types WHERE company_id=$1 ORDER BY active DESC, slug`, [CO])).rows);
+console.log("BEFORE — policy:");
+console.table((await c.query(`SELECT leave_reset_basis, leave_program_enabled FROM company_leave_policy WHERE company_id=$1`, [CO])).rows);
+
+console.log(`\nPLANNED CHANGES (co${CO}):`);
+console.log("  1. PLAWA → flat_grant, accrual_rate 0, carryover_allowed false (was accrue_per_hours/carryover)");
+console.log("  2. Deactivate duplicate generic 'pto' (keep 'pto_phes')");
+console.log("  3. Deactivate duplicate generic 'sick' (keep 'plawa')");
+console.log("  4. company_leave_policy.leave_reset_basis → work_anniversary (was calendar_year)");
+
+if (!APPLY) {
+  console.log("\nDRY-RUN: no writes. Re-run with --apply to execute.");
+  await c.end();
+  process.exit(0);
+}
+
+await c.query("BEGIN");
+try {
+  await c.query(`UPDATE leave_types SET accrual_mode='flat_grant', accrual_rate=0, carryover_allowed=false WHERE company_id=$1 AND slug='plawa'`, [CO]);
+  await c.query(`UPDATE leave_types SET active=false WHERE company_id=$1 AND slug='pto'`, [CO]);
+  await c.query(`UPDATE leave_types SET active=false WHERE company_id=$1 AND slug='sick'`, [CO]);
+  await c.query(`UPDATE company_leave_policy SET leave_reset_basis='work_anniversary' WHERE company_id=$1`, [CO]);
+  await c.query("COMMIT");
+  console.log("\nAPPLIED.");
+} catch (e) {
+  await c.query("ROLLBACK");
+  console.error("FAILED — rolled back:", e.message);
+  process.exitCode = 1;
+  await c.end();
+  process.exit(1);
+}
+console.log("\nAFTER — active leave_types:");
+console.table((await c.query(`SELECT slug, accrual_mode, carryover_allowed, active FROM leave_types WHERE company_id=$1 ORDER BY active DESC, slug`, [CO])).rows);
+console.log("AFTER — policy:");
+console.table((await c.query(`SELECT leave_reset_basis FROM company_leave_policy WHERE company_id=$1`, [CO])).rows);
+await c.end();


### PR DESCRIPTION
**Draft — full build complete, nothing merged/deployed.** Time-off request "ticket" flow per Sal's locked decisions.

## All surfaces built & verified
- **Backend**: `leave_requests.day_unit` (full/AM/PM) + required `attachment`; submit **requires an attachment**; unit replaces free-form hours (full=8×days, half=4; multi-day=full only); approve writes **per-day** usage; **audit log** on submit/approve/deny; `GET /requests/pending-count`; `POST /leave/upload`.
- **Employee-notifications bell** (top bar, desktop + mobile) — separate from the customer bell, office-tier only, badge = pending count, lands on the Employees page. Built to also carry equipment/supply requests (#611) later.
- **Field-app form**: Full day / Morning / Afternoon selector + **mandatory attachment upload** from the phone (submit disabled until attached).
- **Employees-page section**: "Time off & leave requests" with profile-photo avatars, bucket chips, attachment link, inline Approve/Decline.
- **Dispatch board**: four **distinct bucket colors** (PTO/PLAWA/Unpaid/Unexcused); a **half-day** shows the bucket + "AM/PM off" label, keeps the timeline open and the tech **suggestable** (available the worked half); full-day unchanged.

Locked decisions all reflected: mandatory attachment (employee-only), Full/Morning/Afternoon with available-worked-half, four distinct buckets, dual logging (audit + profile), noon half-day default.

## Verify
`typecheck:libs` + api bundle + frontend build + **389 cutover tests** all green.

## Preview
`docs/timeoff-employees-section-preview.html` — shows all three surfaces (bell, Employees section, board half-day). `docs/timeoff-dashboard-widget-preview.html` also included.

Nothing merged or deployed — awaiting Sal's sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)