### PR TITLE
fix(time-off): employee bell scrolls to + highlights the requests section (was a no-op on /employees)

### DIFF
--- a/artifacts/qleno/src/components/layout/dashboard-layout.tsx
+++ b/artifacts/qleno/src/components/layout/dashboard-layout.tsx
@@ -608,6 +608,20 @@ export function DashboardLayout({ children, title, fullBleed, onNewJob }: Dashbo
   });
   const empPending: number = empReqData?.pending || 0;
 
+  // [employee-bell fix 2026-06-23] Clicking the staff bell must always DO
+  // something. setLocation('/employees') was a no-op when already on the page,
+  // so the bell felt dead. Now: if already there, fire a focus event the
+  // Employees page listens for (scroll + highlight the requests section);
+  // otherwise set a one-shot flag and navigate (the page focuses on mount).
+  const goToEmployeeRequests = () => {
+    if (location === '/employees') {
+      window.dispatchEvent(new CustomEvent('qleno:focus-timeoff'));
+    } else {
+      try { sessionStorage.setItem('qlenoFocusTimeOff', '1'); } catch { /* private mode */ }
+      setLocation('/employees');
+    }
+  };
+
   const notifItems: any[] = notifData?.data || [];
   const notifUnread: number = notifData?.unread_count || 0;
 
@@ -717,7 +731,7 @@ export function DashboardLayout({ children, title, fullBleed, onNewJob }: Dashbo
 
             {/* Employee notifications bell (office tier) → Employees page */}
             {isOfficeTier && (
-              <button onClick={() => setLocation('/employees')} title="Employee notifications — time off & requests" style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#6B7280', padding: '4px', position: 'relative', display: 'flex', alignItems: 'center' }}>
+              <button onClick={goToEmployeeRequests} title="Employee notifications — time off & requests" style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#6B7280', padding: '4px', position: 'relative', display: 'flex', alignItems: 'center' }}>
                 <CalendarClock size={19} />
                 {empPending > 0 && (
                   <span style={{ position: 'absolute', top: 0, right: 0, minWidth: 14, height: 14, borderRadius: 7, background: 'var(--brand)', border: '2px solid #fff', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 8, color: '#04241d', fontWeight: 800, padding: '0 2px' }}>
@@ -982,7 +996,7 @@ export function DashboardLayout({ children, title, fullBleed, onNewJob }: Dashbo
 
             {isOfficeTier && (
               <button
-                onClick={() => setLocation('/employees')}
+                onClick={goToEmployeeRequests}
                 title="Employee notifications — time off & requests"
                 style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#6B7280', padding: 6, borderRadius: 8, display: 'flex', alignItems: 'center', position: 'relative' } as any}
               >

--- a/artifacts/qleno/src/pages/employees.tsx
+++ b/artifacts/qleno/src/pages/employees.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useLocation } from "wouter";
 import { DashboardLayout } from "@/components/layout/dashboard-layout";
@@ -422,6 +422,30 @@ function TimeOffRequestsSection() {
   const [rows, setRows] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
   const [busyId, setBusyId] = useState<number | null>(null);
+  const sectionRef = useRef<HTMLDivElement>(null);
+  const [flash, setFlash] = useState(false);
+
+  // [employee-bell fix 2026-06-23] The top-bar staff bell focuses this section.
+  // Two entry paths: navigated here (one-shot sessionStorage flag, read on mount)
+  // or already here (a 'qleno:focus-timeoff' window event). Both scroll the
+  // section into view + briefly highlight it so the bell never feels dead.
+  useEffect(() => {
+    const focus = () => {
+      sectionRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      setFlash(true);
+      window.setTimeout(() => setFlash(false), 1600);
+    };
+    let t: number | undefined;
+    try {
+      if (sessionStorage.getItem('qlenoFocusTimeOff')) {
+        sessionStorage.removeItem('qlenoFocusTimeOff');
+        t = window.setTimeout(focus, 350);
+      }
+    } catch { /* private mode */ }
+    const onEvt = () => focus();
+    window.addEventListener('qleno:focus-timeoff', onEvt);
+    return () => { window.removeEventListener('qleno:focus-timeoff', onEvt); if (t) window.clearTimeout(t); };
+  }, []);
 
   async function load() {
     try {
@@ -445,7 +469,7 @@ function TimeOffRequestsSection() {
   if (!canAct) return null;
 
   return (
-    <div style={{ marginTop: 28 }}>
+    <div ref={sectionRef} style={{ marginTop: 28, scrollMarginTop: 80, borderRadius: 12, transition: 'box-shadow 0.4s ease', boxShadow: flash ? '0 0 0 3px rgba(0,201,160,0.65)' : 'none' }}>
       <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 12 }}>
         <h2 style={{ margin: 0, fontSize: 16, fontWeight: 800, color: '#1A1917' }}>Time off &amp; leave requests</h2>
         {rows.length > 0 && (


### PR DESCRIPTION
**Fixes the just-shipped #614 bell bug:** clicking the top-bar "Employee notifications" bell did nothing.

## Root cause
The bell handler was `setLocation('/employees')` — a **no-op when you're already on `/employees`** (wouter doesn't re-navigate to the current path), and it never scrolled to the bottom "Time off & leave requests" section. So the click surfaced nothing. (The empty state already existed, so that wasn't the issue.)

## Fix
- Bell handler: if already on `/employees`, dispatch a `qleno:focus-timeoff` window event; otherwise set a one-shot `sessionStorage` flag and navigate.
- The section listens for the event (already-on-page) and reads the flag on mount (after navigation) → **scrolls itself into view** (`scroll-margin-top` clears the sticky top bar) and **briefly highlights** (mint ring). Both desktop + mobile bells.
- Empty state ("No pending time-off requests.") unchanged — the section always renders, so the bell never feels dead even with 0 pending.

## Verify
Frontend build green; fix present in the built bundle. Mechanism reproduced in a real browser (preview): focus event → `scrollIntoView` (scrollY 0→6134) + highlight ring applied; sessionStorage flag round-trips for the navigation path.

Deploying on green (live-functionality fix, same flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)