### PR TITLE
fix(time-off): bell scroll drives the <main> container (block:center + rAF)

### DIFF
--- a/artifacts/qleno/src/pages/employees.tsx
+++ b/artifacts/qleno/src/pages/employees.tsx
@@ -431,9 +431,15 @@ function TimeOffRequestsSection() {
   // section into view + briefly highlight it so the bell never feels dead.
   useEffect(() => {
     const focus = () => {
-      sectionRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-      setFlash(true);
-      window.setTimeout(() => setFlash(false), 1600);
+      // The scroll container is <main> (overflow:auto), not window — so do NOT
+      // touch window.scrollY. scrollIntoView drives the real scroll parent.
+      // block:'center' lands the section reliably (block:'start' + sticky bar
+      // only nudged ~19px on prod). Double-rAF so layout is settled first.
+      requestAnimationFrame(() => requestAnimationFrame(() => {
+        sectionRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        setFlash(true);
+        window.setTimeout(() => setFlash(false), 1600);
+      }));
     };
     let t: number | undefined;
     try {


### PR DESCRIPTION
Follow-up to #615. The section now always renders (good), but clicking the bell **while already on /employees** still didn't scroll to it — it nudged ~19px and stayed at the top.

## Root cause (from Sal's live-DOM diagnostics)
The scroll container is `<main>` (`overflow-y:auto`); **`window` itself doesn't scroll**. The focus handler used `scrollIntoView({block:'start'})`, which — with the sticky top bar — mis-landed (~19px). `block:'center'` on the section element correctly drives the `<main>` scroll parent (confirmed manually by Sal).

## Fix
`focus()` now calls `sectionRef.scrollIntoView({ behavior:'smooth', block:'center' })` inside a **double `requestAnimationFrame`** (so layout is settled), and never touches `window.scrollY`. Highlight ring unchanged.

## Verify
Reproduced in a prod-like `<main overflow:auto>` container in-browser: `window` stayed at 0, `main.scrollTop` jumped **0 → 583 (its max)**, the section entered the viewport, ring applied. Frontend build green; `block:"center"` present in the bundle.

Ship on green (live-functionality fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)