### PR TITLE
fix(time-off): bell scrolls to requests section via stable id (direct scroll)

### DIFF
--- a/artifacts/qleno/src/components/layout/dashboard-layout.tsx
+++ b/artifacts/qleno/src/components/layout/dashboard-layout.tsx
@@ -608,13 +608,20 @@ export function DashboardLayout({ children, title, fullBleed, onNewJob }: Dashbo
   });
   const empPending: number = empReqData?.pending || 0;
 
-  // [employee-bell fix 2026-06-23] Clicking the staff bell must always DO
-  // something. setLocation('/employees') was a no-op when already on the page,
-  // so the bell felt dead. Now: if already there, fire a focus event the
-  // Employees page listens for (scroll + highlight the requests section);
-  // otherwise set a one-shot flag and navigate (the page focuses on mount).
+  // [employee-bell fix 2026-06-23] Clicking the staff bell focuses the requests
+  // section. Gate on the section element's PRESENCE in the DOM, not on
+  // `location === '/employees'` — that string compare didn't hold on prod, so the
+  // handler fell to a no-op navigate and the scroll stayed at the top.
+  // Element present → already on the page: scroll directly. The real scroll parent
+  //   is <main> (overflow:auto), NOT window; Element.scrollIntoView bubbles to the
+  //   nearest scrollable ancestor, so this drives <main> even though window never
+  //   scrolls. Fire the event too — but only to flash the highlight.
+  // Element absent  → navigate in; the section reads a one-shot flag on mount and
+  //   scrolls itself once laid out.
   const goToEmployeeRequests = () => {
-    if (location === '/employees') {
+    const el = document.getElementById('timeoff-requests-section');
+    if (el) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'center' });
       window.dispatchEvent(new CustomEvent('qleno:focus-timeoff'));
     } else {
       try { sessionStorage.setItem('qlenoFocusTimeOff', '1'); } catch { /* private mode */ }

--- a/artifacts/qleno/src/pages/employees.tsx
+++ b/artifacts/qleno/src/pages/employees.tsx
@@ -426,29 +426,26 @@ function TimeOffRequestsSection() {
   const [flash, setFlash] = useState(false);
 
   // [employee-bell fix 2026-06-23] The top-bar staff bell focuses this section.
-  // Two entry paths: navigated here (one-shot sessionStorage flag, read on mount)
-  // or already here (a 'qleno:focus-timeoff' window event). Both scroll the
-  // section into view + briefly highlight it so the bell never feels dead.
+  // Two entry paths:
+  //   navigate-in → one-shot sessionStorage flag, read on mount; this effect
+  //     scrolls the section in (the scroll parent is <main>, overflow:auto, NOT
+  //     window — scrollIntoView bubbles to it correctly).
+  //   already-on-page → the bell scrolled the section directly via its id, then
+  //     fired 'qleno:focus-timeoff'; here we only flash the highlight.
   useEffect(() => {
-    const focus = () => {
-      // The scroll container is <main> (overflow:auto), not window — so do NOT
-      // touch window.scrollY. scrollIntoView drives the real scroll parent.
-      // block:'center' lands the section reliably (block:'start' + sticky bar
-      // only nudged ~19px on prod). Double-rAF so layout is settled first.
-      requestAnimationFrame(() => requestAnimationFrame(() => {
-        sectionRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
-        setFlash(true);
-        window.setTimeout(() => setFlash(false), 1600);
-      }));
-    };
+    const flash = () => { setFlash(true); window.setTimeout(() => setFlash(false), 1600); };
     let t: number | undefined;
     try {
       if (sessionStorage.getItem('qlenoFocusTimeOff')) {
         sessionStorage.removeItem('qlenoFocusTimeOff');
-        t = window.setTimeout(focus, 350);
+        // 350ms lets layout settle after the route change before we scroll.
+        t = window.setTimeout(() => {
+          sectionRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+          flash();
+        }, 350);
       }
     } catch { /* private mode */ }
-    const onEvt = () => focus();
+    const onEvt = () => flash();
     window.addEventListener('qleno:focus-timeoff', onEvt);
     return () => { window.removeEventListener('qleno:focus-timeoff', onEvt); if (t) window.clearTimeout(t); };
   }, []);
@@ -475,7 +472,7 @@ function TimeOffRequestsSection() {
   if (!canAct) return null;
 
   return (
-    <div ref={sectionRef} style={{ marginTop: 28, scrollMarginTop: 80, borderRadius: 12, transition: 'box-shadow 0.4s ease', boxShadow: flash ? '0 0 0 3px rgba(0,201,160,0.65)' : 'none' }}>
+    <div ref={sectionRef} id="timeoff-requests-section" style={{ marginTop: 28, scrollMarginTop: 80, borderRadius: 12, transition: 'box-shadow 0.4s ease', boxShadow: flash ? '0 0 0 3px rgba(0,201,160,0.65)' : 'none' }}>
       <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 12 }}>
         <h2 style={{ margin: 0, fontSize: 16, fontWeight: 800, color: '#1A1917' }}>Time off &amp; leave requests</h2>
         {rows.length > 0 && (


### PR DESCRIPTION
## Problem
The top-bar "Employee notifications" bell did nothing on real prod. The handler gated on `location === '/employees'`, which didn't hold there, so it fell through to a no-op `setLocation('/employees')` and the scroll stayed at the top. (PRs #615/#616 tried event + double-rAF; passed in a test harness but failed on the real page.)

## Fix (simplest, most direct)
- Requests section gets a stable id `timeoff-requests-section`.
- Bell handler gates on the **element's presence**, not a route-string compare:
  - present (already on page) → `el.scrollIntoView({behavior:'smooth', block:'center'})` directly — bubbles to the real scroll parent `<main>` (overflow:auto; window never scrolls), then fires the event for the highlight only.
  - absent → set one-shot flag + navigate; the section scrolls itself on mount.
- Custom event no longer drives the scroll — highlight flash only.

Frontend-only, no migration. Built clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)