### PR TITLE
fix(quickbooks): callback redirect drops stale /qleno prefix (404 on connect)

### DIFF
--- a/artifacts/api-server/src/routes/integrations/quickbooks.ts
+++ b/artifacts/api-server/src/routes/integrations/quickbooks.ts
@@ -72,11 +72,11 @@ router.get("/connect", requireAuth, requireRole("owner", "admin"), async (req, r
 
 // ── GET /api/integrations/quickbooks/callback ─────────────────────────────
 router.get("/callback", async (req, res) => {
-  // Derive the frontend base from the request (Railway-safe) instead of the
-  // legacy REPLIT_DEV_DOMAIN — an empty REPLIT_DEV_DOMAIN used to produce a
-  // relative redirect to `/company?...` that resolved under `/api/integrations/
-  // quickbooks/`, giving a broken success URL.
-  const baseFrontend = `${getPublicBase(req)}/qleno`;
+  // Derive the frontend base from the request (Railway-safe). The frontend is
+  // served at the domain root (e.g. app.qleno.com), so redirect straight to
+  // /company. The legacy `/qleno` base-path prefix is a Replit artifact — on
+  // Railway it made every successful connect land on a 404 at /qleno/company.
+  const baseFrontend = getPublicBase(req);
 
   try {
     const { code, state, realmId } = req.query as Record<string, string>;


### PR DESCRIPTION
## What
After a successful QuickBooks connect, the OAuth callback redirected to `${host}/qleno/company` instead of `${host}/company`, so every successful connect landed on a **404** (the `/qleno` base-path prefix is a Replit deployment artifact; on Railway the frontend is at the domain root).

Verified live today: Schaumburg (co4) connected successfully (`qb_connected=true`, realm id + encrypted tokens saved), but the post-connect redirect 404'd. This fixes the redirect.

## Why it matters
This hits **every tenant** on every successful QuickBooks connect. One-line base fix.

## Multi-tenant safety
`getPublicBase(req)` derives the host per request, so each tenant lands on its own domain's `/company`. The shared `app.qleno.com` callback already routes to the right tenant via the company id in the OAuth `state`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)