### PR TITLE
feat(quickbooks): cutover guardrails for migrating tenants onto QB

### DIFF
--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -175,6 +175,16 @@ async function runBookingSchemaGuard(): Promise<void> {
     { label: "companies.default_residential_pay_rate", stmt: "ALTER TABLE companies ADD COLUMN IF NOT EXISTS default_residential_pay_rate NUMERIC(8,4) DEFAULT 0.35" },
     { label: "companies.default_commercial_pay_type",  stmt: "ALTER TABLE companies ADD COLUMN IF NOT EXISTS default_commercial_pay_type  TEXT DEFAULT 'hourly'" },
     { label: "companies.default_commercial_pay_rate",  stmt: "ALTER TABLE companies ADD COLUMN IF NOT EXISTS default_commercial_pay_rate  NUMERIC(8,4) DEFAULT 20.0000" },
+    // [qb-cutover 2026-06-23] Guardrails for tenants migrating onto QuickBooks
+    // from a system that already feeds the same QB company (Oak Lawn ←
+    // MaidCentral, July 1). qb_sync_start_date: when set, Qleno pushes only
+    // invoices created on/after this date — never re-pushing prior history.
+    { label: "companies.qb_sync_start_date", stmt: "ALTER TABLE companies ADD COLUMN IF NOT EXISTS qb_sync_start_date TIMESTAMPTZ" },
+    // Dedupe any pre-existing duplicate customer maps (keep lowest id) BEFORE
+    // adding the unique index, then add it so the syncCustomer concurrency race
+    // can no longer create a split-brain (two QB customers for one client).
+    { label: "qb_customer_map dedupe", stmt: "DELETE FROM qb_customer_map a USING qb_customer_map b WHERE a.id > b.id AND a.company_id = b.company_id AND a.qleno_customer_id = b.qleno_customer_id" },
+    { label: "qb_customer_map_company_customer_uq", stmt: "CREATE UNIQUE INDEX IF NOT EXISTS qb_customer_map_company_customer_uq ON qb_customer_map (company_id, qleno_customer_id)" },
     { label: "jobs.property_vacant",       stmt: "ALTER TABLE jobs ADD COLUMN IF NOT EXISTS property_vacant BOOLEAN DEFAULT false" },
     { label: "jobs.arrival_window",        stmt: "ALTER TABLE jobs ADD COLUMN IF NOT EXISTS arrival_window TEXT" },
     { label: "jobs.first_recurring_discounted", stmt: "ALTER TABLE jobs ADD COLUMN IF NOT EXISTS first_recurring_discounted BOOLEAN DEFAULT false" },

--- a/artifacts/api-server/src/routes/integrations/quickbooks.ts
+++ b/artifacts/api-server/src/routes/integrations/quickbooks.ts
@@ -211,6 +211,7 @@ router.get("/status", requireAuth, async (req, res) => {
         qb_company_name: companiesTable.qb_company_name,
         qb_last_sync_at: companiesTable.qb_last_sync_at,
         invoice_sequence_start: companiesTable.invoice_sequence_start,
+        qb_sync_start_date: companiesTable.qb_sync_start_date,
       })
       .from(companiesTable)
       .where(eq(companiesTable.id, companyId))
@@ -241,11 +242,75 @@ router.get("/status", requireAuth, async (req, res) => {
       last_sync_at: company.qb_last_sync_at,
       realm_id: company.qb_realm_id,
       invoice_sequence_start: company.invoice_sequence_start,
+      sync_start_date: company.qb_sync_start_date,
       stats,
     });
   } catch (err) {
     console.error("[QB] Status error:", err);
     return res.status(500).json({ error: "Failed to get status" });
+  }
+});
+
+// ── PATCH /api/integrations/quickbooks/cutover ────────────────────────────
+// Configure the migration guardrails for a tenant moving onto QuickBooks from
+// another system that already feeds the same QB company (e.g. Oak Lawn ←
+// MaidCentral). `sync_start_date` makes Qleno push ONLY invoices created on/
+// after that date, so it never re-pushes history the prior system already
+// sent. `invoice_sequence_start` continues the prior system's invoice numbers
+// instead of restarting at 1. Both are owner/admin-only.
+router.patch("/cutover", requireAuth, requireRole("owner", "admin"), async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    const { sync_start_date, invoice_sequence_start } = req.body as {
+      sync_start_date?: string | null;
+      invoice_sequence_start?: number;
+    };
+
+    const updates: Record<string, any> = {};
+
+    if (sync_start_date !== undefined) {
+      if (sync_start_date === null || sync_start_date === "") {
+        updates.qb_sync_start_date = null;
+      } else {
+        const d = new Date(sync_start_date);
+        if (isNaN(d.getTime())) {
+          return res.status(400).json({ error: "Invalid sync_start_date" });
+        }
+        updates.qb_sync_start_date = d;
+      }
+    }
+
+    if (invoice_sequence_start !== undefined) {
+      const n = Number(invoice_sequence_start);
+      if (!Number.isInteger(n) || n < 1) {
+        return res.status(400).json({ error: "invoice_sequence_start must be a positive integer" });
+      }
+      updates.invoice_sequence_start = n;
+    }
+
+    if (Object.keys(updates).length === 0) {
+      return res.status(400).json({ error: "Nothing to update" });
+    }
+
+    await db.update(companiesTable).set(updates).where(eq(companiesTable.id, companyId));
+
+    const [company] = await db
+      .select({
+        qb_sync_start_date: companiesTable.qb_sync_start_date,
+        invoice_sequence_start: companiesTable.invoice_sequence_start,
+      })
+      .from(companiesTable)
+      .where(eq(companiesTable.id, companyId))
+      .limit(1);
+
+    return res.json({
+      ok: true,
+      sync_start_date: company?.qb_sync_start_date ?? null,
+      invoice_sequence_start: company?.invoice_sequence_start,
+    });
+  } catch (err) {
+    console.error("[QB] Cutover config error:", err);
+    return res.status(500).json({ error: "Failed to update cutover config" });
   }
 });
 

--- a/artifacts/api-server/src/routes/integrations/quickbooks.ts
+++ b/artifacts/api-server/src/routes/integrations/quickbooks.ts
@@ -72,11 +72,11 @@ router.get("/connect", requireAuth, requireRole("owner", "admin"), async (req, r
 
 // ── GET /api/integrations/quickbooks/callback ─────────────────────────────
 router.get("/callback", async (req, res) => {
-  // Derive the frontend base from the request (Railway-safe) instead of the
-  // legacy REPLIT_DEV_DOMAIN — an empty REPLIT_DEV_DOMAIN used to produce a
-  // relative redirect to `/company?...` that resolved under `/api/integrations/
-  // quickbooks/`, giving a broken success URL.
-  const baseFrontend = `${getPublicBase(req)}/qleno`;
+  // Derive the frontend base from the request (Railway-safe). The frontend is
+  // served at the domain root (e.g. app.qleno.com), so redirect straight to
+  // /company. The legacy `/qleno` base-path prefix is a Replit artifact — on
+  // Railway it made every successful connect land on a 404 at /qleno/company.
+  const baseFrontend = getPublicBase(req);
 
   try {
     const { code, state, realmId } = req.query as Record<string, string>;

--- a/artifacts/api-server/src/services/quickbooks-sync.ts
+++ b/artifacts/api-server/src/services/quickbooks-sync.ts
@@ -388,11 +388,26 @@ export async function syncCustomer(companyId: number, customerId: number): Promi
         qbCustomerId = createData.Customer?.Id;
       }
 
-      await db.insert(qbCustomerMapTable).values({
-        company_id: companyId,
-        qleno_customer_id: customerId,
-        qb_customer_id: qbCustomerId,
-      });
+      // [qb-cutover] Concurrency guard. Two near-simultaneous syncs for the
+      // same client can both miss the map lookup above and each reach here.
+      // The unique index (company_id, qleno_customer_id) lets the loser's
+      // insert no-op; we then re-read the winner's qb_customer_id so both the
+      // queue row and any invoice CustomerRef point at the single mapped QB
+      // customer instead of a split-brain.
+      const inserted = await db
+        .insert(qbCustomerMapTable)
+        .values({ company_id: companyId, qleno_customer_id: customerId, qb_customer_id: qbCustomerId })
+        .onConflictDoNothing({ target: [qbCustomerMapTable.company_id, qbCustomerMapTable.qleno_customer_id] })
+        .returning({ id: qbCustomerMapTable.id });
+
+      if (inserted.length === 0) {
+        const [winner] = await db
+          .select({ qb_customer_id: qbCustomerMapTable.qb_customer_id })
+          .from(qbCustomerMapTable)
+          .where(and(eq(qbCustomerMapTable.company_id, companyId), eq(qbCustomerMapTable.qleno_customer_id, customerId)))
+          .limit(1);
+        if (winner?.qb_customer_id) qbCustomerId = winner.qb_customer_id;
+      }
     }
 
     await upsertQueue(companyId, "customer", customerId, "synced", qbCustomerId);
@@ -424,6 +439,22 @@ export async function syncInvoice(companyId: number, invoiceId: number): Promise
       .where(and(eq(invoicesTable.id, invoiceId), eq(invoicesTable.company_id, companyId)))
       .limit(1);
     if (!invoice) return;
+
+    // [qb-cutover] Cutover guard. Tenants migrating from another system that
+    // already feeds the SAME QuickBooks company (e.g. Oak Lawn ← MaidCentral)
+    // set companies.qb_sync_start_date. Any invoice created before the cutover
+    // is never pushed — only invoices from the cutover forward — so we never
+    // re-push the history the prior system already sent. NULL = sync all
+    // (clean-slate tenants like Schaumburg are unaffected).
+    const [cutoverCo] = await db
+      .select({ cutover: companiesTable.qb_sync_start_date })
+      .from(companiesTable)
+      .where(eq(companiesTable.id, companyId))
+      .limit(1);
+    if (cutoverCo?.cutover && invoice.created_at && new Date(invoice.created_at) < new Date(cutoverCo.cutover)) {
+      await upsertQueue(companyId, "invoice", invoiceId, "skipped", undefined, "before qb_sync_start_date cutover");
+      return;
+    }
 
     const { token, realmId } = auth;
 

--- a/lib/db/src/schema/companies.ts
+++ b/lib/db/src/schema/companies.ts
@@ -99,6 +99,12 @@ export const companiesTable = pgTable("companies", {
   qb_connected: boolean("qb_connected").notNull().default(false),
   qb_last_sync_at: timestamp("qb_last_sync_at"),
   qb_company_name: text("qb_company_name"),
+  // [qb-cutover] Cutover guard for tenants migrating from another system that
+  // already pushes to the same QB company (e.g. Oak Lawn from MaidCentral).
+  // When set, invoices created BEFORE this timestamp are never synced to QB —
+  // only invoices from the cutover forward — so we don't re-push history the
+  // prior system already sent. NULL = sync everything (clean-slate tenants).
+  qb_sync_start_date: timestamp("qb_sync_start_date", { withTimezone: true }),
   overhead_rate_pct: numeric("overhead_rate_pct", { precision: 5, scale: 2 }).default("10.00"),
   recurring_engine_enabled: boolean("recurring_engine_enabled").notNull().default(true),
   // Cancellation policy — per-tenant defaults. Both expressed as a

--- a/lib/db/src/schema/quickbooks.ts
+++ b/lib/db/src/schema/quickbooks.ts
@@ -1,4 +1,4 @@
-import { pgTable, serial, integer, text, timestamp } from "drizzle-orm/pg-core";
+import { pgTable, serial, integer, text, timestamp, uniqueIndex } from "drizzle-orm/pg-core";
 import { companiesTable } from "./companies";
 import { clientsTable } from "./clients";
 
@@ -21,7 +21,13 @@ export const qbCustomerMapTable = pgTable("qb_customer_map", {
   qleno_customer_id: integer("qleno_customer_id").references(() => clientsTable.id).notNull(),
   qb_customer_id: text("qb_customer_id").notNull(),
   created_at: timestamp("created_at").notNull().defaultNow(),
-});
+}, (t) => ({
+  // [qb-cutover] One QB customer per (tenant, Qleno client). Backstops the
+  // concurrency race where two near-simultaneous syncs for the same client
+  // both miss the map lookup and each create a QB customer. The map insert in
+  // syncCustomer uses ON CONFLICT against this index so the loser no-ops.
+  companyCustomerUq: uniqueIndex("qb_customer_map_company_customer_uq").on(t.company_id, t.qleno_customer_id),
+}));
 
 export type QbSyncQueue = typeof qbSyncQueueTable.$inferSelect;
 export type QbCustomerMap = typeof qbCustomerMapTable.$inferSelect;


### PR DESCRIPTION
## Why
Oak Lawn (co1) moves onto QuickBooks **July 1**, but its QB company is already fed by **MaidCentral**. Connecting Qleno to that same QB without guards would (a) re-push history MaidCentral already sent and (b) double-create customers. These guardrails make a migrating tenant's cutover as clean as a clean-slate tenant's (Schaumburg unaffected). Validated on Schaumburg first: a live write test confirmed job → invoice → QuickBooks works end-to-end and surfaced the customer-race this PR closes.

## What
**1. Sync-start-date cutoff** — new `companies.qb_sync_start_date`. When set, `syncInvoice` skips invoices created before it, so Qleno pushes only invoices from the cutover forward, never re-pushing history. NULL = sync all.

**2. Concurrency guard** — unique index on `qb_customer_map(company_id, qleno_customer_id)` + `ON CONFLICT DO NOTHING` in `syncCustomer` with a winner re-read. Closes the simultaneous-sync race that double-created a QB customer (seen in the Schaumburg test).

**3. Invoice-number continuity** — `PATCH /api/integrations/quickbooks/cutover` (owner/admin) sets `qb_sync_start_date` + `invoice_sequence_start` to continue the prior system's numbers instead of restarting at 1. `GET /status` now returns `sync_start_date`.

## Migration
Idempotent cold-start: add column, dedupe existing `qb_customer_map` dupes, create unique index.

## Cutover runbook (Oak Lawn, July 1)
1. Turn off MaidCentral's QuickBooks sync (one writer per QB company).
2. PATCH cutover: `sync_start_date` = July 1, `invoice_sequence_start` = MC last # + 1.
3. Connect co1 via the normal OAuth flow.

## Test plan
- [x] `pnpm run typecheck:libs` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)