### PR TITLE
fix(quote-builder): Maribel's report — multi-cleaner, optional combo, adjustments apply

### DIFF
--- a/artifacts/api-server/src/routes/pricing.ts
+++ b/artifacts/api-server/src/routes/pricing.ts
@@ -526,6 +526,10 @@ router.post("/calculate", requireAuth, async (req, res) => {
   try {
     const companyId = req.auth!.companyId;
     const { scope_id, sqft, hours, frequency, addon_ids, discount_code, manual_adjustment, addon_quantities,
+            // [combo-optional] Bundle ids the office toggled OFF on the quote.
+            // Matching bundles are still RETURNED (so the UI can show + re-enable
+            // them) but not subtracted from the total.
+            disabled_bundle_ids,
             // [PR #63] Per-client hourly rate override. When the caller
             // (edit-job modal) passes a positive number, it wins over the
             // scope's tenant-wide hourly_rate. Frequency multipliers still
@@ -642,7 +646,11 @@ router.post("/calculate", requireAuth, async (req, res) => {
 
     // ── Bundle discounts (must match public/calculate logic exactly) ──────────
     let bundle_discount = 0;
-    const bundle_breakdown: Array<{ name: string; discount: number }> = [];
+    const bundle_breakdown: Array<{ id: number; name: string; discount: number; applied: boolean }> = [];
+    const disabledBundleSet = new Set(
+      (Array.isArray(disabled_bundle_ids) ? disabled_bundle_ids : [])
+        .map((x: any) => parseInt(String(x))).filter((n: number) => !isNaN(n)),
+    );
     if (Array.isArray(addon_ids) && addon_ids.length > 0) {
       const validIdsForBundles = addon_ids.map((id: any) => parseInt(String(id))).filter(n => !isNaN(n));
       if (validIdsForBundles.length > 0) {
@@ -677,16 +685,19 @@ router.post("/calculate", requireAuth, async (req, res) => {
           } else if (bundle.discount_type === "percentage") {
             disc = (dv / 100) * base_price;
           }
-          return { name: String(bundle.name), required, disc };
-        }).filter(Boolean) as Array<{ name: string; required: number[]; disc: number }>;
+          return { id: Number(bundle.id), name: String(bundle.name), required, disc };
+        }).filter(Boolean) as Array<{ id: number; name: string; required: number[]; disc: number }>;
         // Most specific first; equal specificity → larger discount wins.
         candidates.sort((a, b) => (b.required.length - a.required.length) || (b.disc - a.disc));
         const consumedAddons = new Set<number>();
         for (const c of candidates) {
           if (c.required.some(rid => consumedAddons.has(rid))) continue; // overlaps a higher-priority bundle
           c.required.forEach(rid => consumedAddons.add(rid));
-          bundle_discount += c.disc;
-          bundle_breakdown.push({ name: c.name, discount: Math.round(c.disc * 100) / 100 });
+          // [combo-optional] A bundle the office toggled off is still surfaced
+          // (so the UI can show + re-enable it) but its discount is NOT applied.
+          const applied = !disabledBundleSet.has(c.id);
+          if (applied) bundle_discount += c.disc;
+          bundle_breakdown.push({ id: c.id, name: c.name, discount: Math.round(c.disc * 100) / 100, applied });
         }
       }
     }

--- a/artifacts/api-server/src/routes/quotes.ts
+++ b/artifacts/api-server/src/routes/quotes.ts
@@ -370,7 +370,7 @@ router.post("/:id/convert", requireAuth, requireRole("owner", "admin", "office")
   try {
     const id = parseInt(req.params.id);
     const companyId = req.auth!.companyId;
-    const { scheduled_date, scheduled_time, assigned_user_id } = req.body || {};
+    const { scheduled_date, scheduled_time, assigned_user_id, team_user_ids } = req.body || {};
 
     // Mark quote as booked
     const [q] = await db.update(quotesTable)
@@ -711,20 +711,38 @@ router.post("/:id/convert", requireAuth, requireRole("owner", "admin", "office")
     // invariant, every code path that assigns a tech MUST write both. Promote
     // the chosen tech to primary (is_primary=true) so the dispatch grid and the
     // per-tech fan-out recognize the assignment.
-    const assignedTechId = assigned_user_id ? parseInt(String(assigned_user_id)) : NaN;
-    if (jobId && !isNaN(assignedTechId)) {
-      await db.execute(sql`
-        INSERT INTO job_technicians (job_id, user_id, company_id, is_primary)
-        VALUES (${jobId}, ${assignedTechId}, ${companyId}, true)
-        ON CONFLICT (job_id, user_id) DO UPDATE SET is_primary = EXCLUDED.is_primary
-      `);
-      // [notifications A.2] Alert the assigned tech of the new booking (in-app).
-      import("../lib/notify.js").then(({ notifyUser }) => notifyUser({
-        companyId, userId: assignedTechId, type: "job_assigned",
-        title: "New job assigned",
-        body: `${String(serviceType).replace(/_/g, " ")} on ${jobDate}`,
-        link: "/my-jobs", meta: { job_id: jobId },
-      })).catch(() => {});
+    // Multi-tech assignment. team_user_ids carries the full crew chosen on the
+    // Review step; assigned_user_id is the primary (already mirrored onto
+    // jobs.assigned_user_id by the INSERT above). Write a job_technicians row
+    // per cleaner, flagging ONLY the primary, so the dispatch grid and the
+    // per-tech fan-out recognize every assigned tech and the labor splits.
+    const primaryTechId = assigned_user_id ? parseInt(String(assigned_user_id)) : NaN;
+    const teamIds: number[] = (Array.isArray(team_user_ids) ? team_user_ids : [])
+      .map((t: any) => parseInt(String(t)))
+      .filter((n: number) => !isNaN(n));
+    // Primary first, then the remaining crew (deduped). Falls back to the lone
+    // primary when no team array is sent (older clients / single assignment).
+    const orderedTechIds = [
+      ...(!isNaN(primaryTechId) ? [primaryTechId] : []),
+      ...teamIds.filter(t => t !== primaryTechId),
+    ];
+    if (jobId && orderedTechIds.length) {
+      for (let i = 0; i < orderedTechIds.length; i++) {
+        const techId = orderedTechIds[i];
+        const isPrimary = !isNaN(primaryTechId) ? techId === primaryTechId : i === 0;
+        await db.execute(sql`
+          INSERT INTO job_technicians (job_id, user_id, company_id, is_primary)
+          VALUES (${jobId}, ${techId}, ${companyId}, ${isPrimary})
+          ON CONFLICT (job_id, user_id) DO UPDATE SET is_primary = EXCLUDED.is_primary
+        `);
+        // [notifications A.2] Alert each assigned tech of the new booking (in-app).
+        import("../lib/notify.js").then(({ notifyUser }) => notifyUser({
+          companyId, userId: techId, type: "job_assigned",
+          title: "New job assigned",
+          body: `${String(serviceType).replace(/_/g, " ")} on ${jobDate}`,
+          link: "/my-jobs", meta: { job_id: jobId },
+        })).catch(() => {});
+      }
     }
 
     logAudit(req, "CONVERTED", "quote", id, null, { status: "booked", total_price: q.total_price, job_id: jobId });

--- a/artifacts/qleno/src/pages/quote-builder.tsx
+++ b/artifacts/qleno/src/pages/quote-builder.tsx
@@ -165,7 +165,7 @@ interface CalcResult {
   hourly_rate: number; base_price: number; minimum_applied: boolean;
   minimum_bill: number; addons_total: number;
   addon_breakdown: Array<{ id: number; name: string; amount: number; price_type?: string }>;
-  bundle_discount: number; bundle_breakdown: Array<{ name: string; discount: number }>;
+  bundle_discount: number; bundle_breakdown: Array<{ id: number; name: string; discount: number; applied: boolean }>;
   subtotal: number; discount_amount: number; discount_valid?: boolean; final_total: number;
 }
 
@@ -181,6 +181,9 @@ interface SelectedScopeState {
   adjPlusReason: string;
   adjMinus: number;
   adjMinusReason: string;
+  // [combo-optional] Bundle ids the office toggled OFF for this scope. Passed
+  // to the pricing engine so their discount isn't applied to the total.
+  disabledBundleIds: number[];
   frequencies: PricingFrequency[];
   addons: PricingAddon[];
   calc: CalcResult | null;
@@ -643,6 +646,9 @@ export default function QuoteBuilderPage() {
           if (currentSqft > 0) body.sqft = currentSqft;
         }
         if (discountCodeRef.current) body.discount_code = discountCodeRef.current;
+        // [combo-optional] Tell the engine which bundles the office toggled off
+        // so their discount isn't applied (they're still returned for the UI).
+        if (state.disabledBundleIds && state.disabledBundleIds.length > 0) body.disabled_bundle_ids = state.disabledBundleIds;
         const result = await apiFetch("/api/pricing/calculate", { method: "POST", body });
         setSelectedScopes(prev => prev.map(s => s.scope_id === scopeId ? { ...s, calc: result, calcLoading: false } : s));
       } catch {
@@ -689,6 +695,7 @@ export default function QuoteBuilderPage() {
         adjPlusReason: "",
         adjMinus: 0,
         adjMinusReason: "",
+        disabledBundleIds: [],
         frequencies: freqs as PricingFrequency[],
         addons: addons as PricingAddon[],
         calc: null,
@@ -702,6 +709,7 @@ export default function QuoteBuilderPage() {
         scope_id: scope.id, frequency: initialState?.frequency ?? "", hours: initialState?.hours ?? 0,
         hoursOverrideSet: false, addon_ids: initialState?.addon_ids ?? [],
         addonQtys: {}, addonRecurring: {}, adjPlus: 0, adjPlusReason: "", adjMinus: 0, adjMinusReason: "",
+        disabledBundleIds: [],
         frequencies: [], addons: [],
         calc: null, calcLoading: false, expanded: true,
       }]);
@@ -751,6 +759,17 @@ export default function QuoteBuilderPage() {
     setSelectedScopes(prev => prev.map(s => s.scope_id === scopeId ? { ...s, [field]: val } : s));
   }
 
+  // [combo-optional] Toggle a bundle (e.g. "Appliance Combo") on/off for a
+  // scope, then recalc so the total reflects whether its discount applies.
+  function toggleBundle(scopeId: number, bundleId: number) {
+    setSelectedScopes(prev => prev.map(s => {
+      if (s.scope_id !== scopeId) return s;
+      const off = s.disabledBundleIds.includes(bundleId);
+      return { ...s, disabledBundleIds: off ? s.disabledBundleIds.filter(id => id !== bundleId) : [...s.disabledBundleIds, bundleId] };
+    }));
+    recalcScopeById(scopeId, 0);
+  }
+
   function updateScopeAddon(scopeId: number, addonId: number, checked: boolean) {
     setSelectedScopes(prev => prev.map(s => {
       if (s.scope_id !== scopeId) return s;
@@ -782,7 +801,9 @@ export default function QuoteBuilderPage() {
         scope_name: scopes.find(sc => sc.id === s.scope_id)?.name ?? "",
         frequency: s.frequency,
         addon_ids: s.addon_ids,
-        total: s.calc?.final_total ?? null,
+        // Include this scope's manual price adjustments so the saved total
+        // matches the preview (the engine's final_total excludes them).
+        total: s.calc?.final_total != null ? s.calc.final_total + (s.adjPlus || 0) - (s.adjMinus || 0) : null,
       }));
     return {
       client_id: selectedClientId || null,
@@ -801,7 +822,7 @@ export default function QuoteBuilderPage() {
       base_price: quickBookPrice != null ? String(quickBookPrice) : (cr ? String(cr.base_price) : null),
       addons_total: cr ? String(cr.addons_total) : "0",
       discount_amount: cr ? String(cr.discount_amount) : "0",
-      total_price: quickBookPrice != null ? String(quickBookPrice) : (cr ? String(cr.final_total) : null),
+      total_price: quickBookPrice != null ? String(quickBookPrice) : (cr ? String(cr.final_total + (primaryScopeState?.adjPlus || 0) - (primaryScopeState?.adjMinus || 0)) : null),
       // [addon-hours 2026-06-04] Persist TOTAL hours (base + add-on time-adds)
       // so Hourly/Time-Add add-ons (Oven, Cabinets, Basement, etc.) flow into
       // the booked job's allowed hours. Was base_hours, which silently dropped
@@ -2661,9 +2682,24 @@ export default function QuoteBuilderPage() {
                           items summed to MORE than the Total and it looked like broken
                           addition (Maribel's "the issue is the addition" — a hidden $35).
                           Render each matched bundle so Base + add-ons − bundle = Total. */}
+                      {/* [combo-optional] Each matched bundle is a toggle. Applied
+                          bundles subtract; toggling off keeps the line (greyed,
+                          struck) with an "Add" affordance so the office controls
+                          whether the combo discount applies. */}
                       {(s.calc.bundle_breakdown ?? []).map((b, i) => (
-                        <div key={`bundle-${i}`} style={{ display: "flex", justifyContent: "space-between", fontSize: 13, color: "#16A34A" }}>
-                          <span>{b.name || "Bundle discount"}</span><span>-${b.discount.toFixed(2)}</span>
+                        <div key={`bundle-${b.id ?? i}`} style={{ display: "flex", justifyContent: "space-between", alignItems: "center", fontSize: 13, color: b.applied ? "#16A34A" : "#9E9B94" }}>
+                          <span style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
+                            <button
+                              type="button"
+                              onClick={() => toggleBundle(s.scope_id, b.id)}
+                              title={b.applied ? "Remove this combo discount" : "Apply this combo discount"}
+                              style={{ display: "inline-flex", alignItems: "center", justifyContent: "center", width: 16, height: 16, borderRadius: 4, border: "1px solid #E5E2DC", background: b.applied ? "#16A34A" : "#FFF", color: b.applied ? "#FFF" : "#9E9B94", fontSize: 11, lineHeight: 1, cursor: "pointer", padding: 0, fontFamily: FF }}
+                            >
+                              {b.applied ? "×" : "+"}
+                            </button>
+                            <span style={{ textDecoration: b.applied ? "none" : "line-through" }}>{b.name || "Bundle discount"}</span>
+                          </span>
+                          <span style={{ textDecoration: b.applied ? "none" : "line-through" }}>-${b.discount.toFixed(2)}</span>
                         </div>
                       ))}
                       {s.calc.discount_amount > 0 && (

--- a/artifacts/qleno/src/pages/quote-builder.tsx
+++ b/artifacts/qleno/src/pages/quote-builder.tsx
@@ -305,7 +305,12 @@ export default function QuoteBuilderPage() {
 
   // ── Tech suggestions ─────────────────────────────────────────────────────
   const [suggestedTechs, setSuggestedTechs] = useState<SuggestedTech[]>([]);
-  const [selectedTechId, setSelectedTechId] = useState<number | null>(null);
+  // Multi-tech assignment: the office can assign more than one cleaner to a
+  // job at quote time. First selected = primary (mirrored onto
+  // jobs.assigned_user_id); the rest become job_technicians rows on convert.
+  const [selectedTechIds, setSelectedTechIds] = useState<number[]>([]);
+  const toggleTech = (id: number) =>
+    setSelectedTechIds(prev => (prev.includes(id) ? prev.filter(x => x !== id) : [...prev, id]));
   const [techAvailability, setTechAvailability] = useState<Record<number, number>>({});
   const [techAvailLoading, setTechAvailLoading] = useState(false);
 
@@ -892,7 +897,11 @@ export default function QuoteBuilderPage() {
           body: {
             scheduled_date: selectedDate || undefined,
             scheduled_time: selectedTime || undefined,
-            assigned_user_id: selectedTechId || undefined,
+            // Primary = first selected (mirrored onto jobs.assigned_user_id);
+            // team_user_ids carries the full crew so the convert writes a
+            // job_technicians row per cleaner.
+            assigned_user_id: selectedTechIds[0] || undefined,
+            team_user_ids: selectedTechIds,
           },
         });
         toast.success("Quote converted to job.");
@@ -1069,7 +1078,7 @@ export default function QuoteBuilderPage() {
       await toggleScope(matchedScope, { frequency: service.frequency ?? undefined });
       setFinalScopeId(matchedScope.id);
     }
-    if (preferredTech) setSelectedTechId(preferredTech.id);
+    if (preferredTech) setSelectedTechIds([preferredTech.id]);
     setQuickBookPrice(service.last_price);
     setQuickBookBanner({ scope: service.scope, date: service.last_date });
     setActiveSection(4);
@@ -1728,9 +1737,9 @@ export default function QuoteBuilderPage() {
                   <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
                     <span style={{ fontSize: 11, color: "#9E9B94", fontFamily: FF }}>Zone techs:</span>
                     {suggestedTechs.map(tech => {
-                      const isSel = selectedTechId === tech.id;
+                      const isSel = selectedTechIds.includes(tech.id);
                       return (
-                        <button key={tech.id} onClick={() => setSelectedTechId(isSel ? null : tech.id)}
+                        <button key={tech.id} onClick={() => toggleTech(tech.id)}
                           style={{ display: "inline-flex", alignItems: "center", gap: 5, padding: "3px 10px", borderRadius: 14, fontSize: 12, fontWeight: isSel ? 600 : 400, border: isSel ? "1.5px solid var(--brand)" : "1px solid #E5E2DC", background: isSel ? "#EAF9F4" : "#FFF", color: "#1A1917", cursor: "pointer", fontFamily: FF }}>
                           <span style={{ width: 18, height: 18, borderRadius: "50%", background: isSel ? "var(--brand)" : "#E5E2DC", display: "flex", alignItems: "center", justifyContent: "center", color: isSel ? "#FFF" : "#6B6860", fontSize: 9, fontWeight: 700 }}>{tech.name.charAt(0)}</span>
                           {tech.name}
@@ -1774,12 +1783,12 @@ export default function QuoteBuilderPage() {
                   <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
                     <span style={{ fontSize: 11, color: "#9E9B94", fontFamily: FF }}>Preferred:</span>
                     <button
-                      onClick={() => setSelectedTechId(selectedTechId === preferredTech.id ? null : preferredTech.id)}
-                      style={{ display: "inline-flex", alignItems: "center", gap: 5, padding: "3px 10px", borderRadius: 14, fontSize: 12, fontWeight: selectedTechId === preferredTech.id ? 600 : 400, border: selectedTechId === preferredTech.id ? "1.5px solid var(--brand)" : "1px solid #E5E2DC", background: selectedTechId === preferredTech.id ? "#EAF9F4" : "#FFF", color: "#1A1917", cursor: "pointer", fontFamily: FF }}
+                      onClick={() => toggleTech(preferredTech.id)}
+                      style={{ display: "inline-flex", alignItems: "center", gap: 5, padding: "3px 10px", borderRadius: 14, fontSize: 12, fontWeight: selectedTechIds.includes(preferredTech.id) ? 600 : 400, border: selectedTechIds.includes(preferredTech.id) ? "1.5px solid var(--brand)" : "1px solid #E5E2DC", background: selectedTechIds.includes(preferredTech.id) ? "#EAF9F4" : "#FFF", color: "#1A1917", cursor: "pointer", fontFamily: FF }}
                     >
-                      <span style={{ width: 18, height: 18, borderRadius: "50%", background: selectedTechId === preferredTech.id ? "var(--brand)" : "#5B9BD5", display: "flex", alignItems: "center", justifyContent: "center", color: "#FFF", fontSize: 9, fontWeight: 700 }}>{preferredTech.full_name.charAt(0)}</span>
+                      <span style={{ width: 18, height: 18, borderRadius: "50%", background: selectedTechIds.includes(preferredTech.id) ? "var(--brand)" : "#5B9BD5", display: "flex", alignItems: "center", justifyContent: "center", color: "#FFF", fontSize: 9, fontWeight: 700 }}>{preferredTech.full_name.charAt(0)}</span>
                       {preferredTech.full_name}
-                      {selectedTechId === preferredTech.id && <Check style={{ width: 12, height: 12, color: "var(--brand)" }} />}
+                      {selectedTechIds.includes(preferredTech.id) && <Check style={{ width: 12, height: 12, color: "var(--brand)" }} />}
                     </button>
                   </div>
                 )}
@@ -2045,9 +2054,9 @@ export default function QuoteBuilderPage() {
                     {[...suggestedTechs].sort((a, b) => (techAvailability[a.id] ?? 0) - (techAvailability[b.id] ?? 0)).map(tech => {
                       const count = techAvailability[tech.id];
                       const avail = count !== undefined ? techAvailDot(count) : null;
-                      const isSel = selectedTechId === tech.id;
+                      const isSel = selectedTechIds.includes(tech.id);
                       return (
-                        <div key={tech.id} onClick={() => setSelectedTechId(isSel ? null : tech.id)} style={{ display: "flex", alignItems: "center", gap: 10, padding: "8px 10px", borderRadius: 6, cursor: "pointer", border: isSel ? "2px solid var(--brand)" : "1px solid #E5E2DC", background: isSel ? "rgba(0,201,160,0.05)" : "#FFF", opacity: avail?.muted ? 0.55 : 1 }}>
+                        <div key={tech.id} onClick={() => toggleTech(tech.id)} style={{ display: "flex", alignItems: "center", gap: 10, padding: "8px 10px", borderRadius: 6, cursor: "pointer", border: isSel ? "2px solid var(--brand)" : "1px solid #E5E2DC", background: isSel ? "rgba(0,201,160,0.05)" : "#FFF", opacity: avail?.muted ? 0.55 : 1 }}>
                           <div style={{ width: 28, height: 28, borderRadius: "50%", background: "var(--brand)", display: "flex", alignItems: "center", justifyContent: "center", color: "#FFF", fontSize: 11, fontWeight: 700 }}>{tech.name.charAt(0).toUpperCase()}</div>
                           <div style={{ flex: 1, fontSize: 13, fontWeight: isSel ? 700 : 500, color: "#1A1917" }}>{tech.name}</div>
                           {avail && (
@@ -2506,12 +2515,12 @@ export default function QuoteBuilderPage() {
                       {/* Preferred tech shortcut */}
                       {preferredTech && (
                         <button
-                          onClick={() => setSelectedTechId(selectedTechId === preferredTech.id ? null : preferredTech.id)}
-                          style={{ display: "inline-flex", alignItems: "center", gap: 4, padding: "4px 10px", borderRadius: 14, fontSize: 12, fontWeight: selectedTechId === preferredTech.id ? 600 : 400, border: selectedTechId === preferredTech.id ? "1.5px solid var(--brand)" : "1px solid #E5E2DC", background: selectedTechId === preferredTech.id ? "#EAF9F4" : "#FFF", color: "#1A1917", cursor: "pointer", fontFamily: FF }}
+                          onClick={() => toggleTech(preferredTech.id)}
+                          style={{ display: "inline-flex", alignItems: "center", gap: 4, padding: "4px 10px", borderRadius: 14, fontSize: 12, fontWeight: selectedTechIds.includes(preferredTech.id) ? 600 : 400, border: selectedTechIds.includes(preferredTech.id) ? "1.5px solid var(--brand)" : "1px solid #E5E2DC", background: selectedTechIds.includes(preferredTech.id) ? "#EAF9F4" : "#FFF", color: "#1A1917", cursor: "pointer", fontFamily: FF }}
                         >
-                          <span style={{ width: 18, height: 18, borderRadius: "50%", background: selectedTechId === preferredTech.id ? "var(--brand)" : "#5B9BD5", display: "flex", alignItems: "center", justifyContent: "center", color: "#FFF", fontSize: 9, fontWeight: 700 }}>{preferredTech.full_name.charAt(0)}</span>
+                          <span style={{ width: 18, height: 18, borderRadius: "50%", background: selectedTechIds.includes(preferredTech.id) ? "var(--brand)" : "#5B9BD5", display: "flex", alignItems: "center", justifyContent: "center", color: "#FFF", fontSize: 9, fontWeight: 700 }}>{preferredTech.full_name.charAt(0)}</span>
                           {preferredTech.full_name}
-                          {selectedTechId === preferredTech.id && <Check style={{ width: 12, height: 12, color: "var(--brand)" }} />}
+                          {selectedTechIds.includes(preferredTech.id) && <Check style={{ width: 12, height: 12, color: "var(--brand)" }} />}
                         </button>
                       )}
                       {/* Tech chips. Prefer the zone-matched techs; if the
@@ -2524,9 +2533,9 @@ export default function QuoteBuilderPage() {
                         return (
                           <>
                             {chips.map(tech => {
-                              const isSel = selectedTechId === tech.id;
+                              const isSel = selectedTechIds.includes(tech.id);
                               return (
-                                <button key={tech.id} onClick={() => setSelectedTechId(isSel ? null : tech.id)}
+                                <button key={tech.id} onClick={() => toggleTech(tech.id)}
                                   style={{ display: "inline-flex", alignItems: "center", gap: 4, padding: "4px 10px", borderRadius: 14, fontSize: 12, fontWeight: isSel ? 600 : 400, border: isSel ? "1.5px solid var(--brand)" : "1px solid #E5E2DC", background: isSel ? "#EAF9F4" : "#FFF", color: "#1A1917", cursor: "pointer", fontFamily: FF }}
                                 >
                                   <span style={{ width: 18, height: 18, borderRadius: "50%", background: isSel ? "var(--brand)" : "#E5E2DC", display: "flex", alignItems: "center", justifyContent: "center", color: isSel ? "#FFF" : "#6B6860", fontSize: 9, fontWeight: 700 }}>{tech.name.charAt(0)}</span>
@@ -2691,7 +2700,7 @@ export default function QuoteBuilderPage() {
                         // hours reflect add-on time (e.g. Oven +45 min) just like the
                         // Est. hours line above.
                         const estHrs = s.calc?.total_hours ?? s.hours ?? s.calc?.base_hours ?? 0;
-                        const techCount = selectedTechId ? 1 : 0;
+                        const techCount = selectedTechIds.length;
                         const cs = calculateCommissionSplit(total, estHrs, techCount, undefined, "residential", scope?.name);
                         const ratePct = Math.round((cs.commissionRate ?? 0.35) * 100);
                         return (
@@ -2732,7 +2741,7 @@ export default function QuoteBuilderPage() {
               // into the multi-scope grand total (was summing base_hours and dropping
               // Oven/Refrigerator/etc. minutes).
               const totalHours = selectedScopes.reduce((sum, s) => sum + (s.calc?.total_hours ?? s.hours ?? s.calc?.base_hours ?? 0), 0);
-              const techCount = selectedTechId ? 1 : 0;
+              const techCount = selectedTechIds.length;
               // [tiered-residential] Per-scope commission so a quote
               // with mixed Standard + Deep Clean shows the right total
               // (35% × standard + 32% × deep), not a flat 35%.


### PR DESCRIPTION
Fixes all three issues in Maribel's quote-builder screenshot. **Each reproduced on the live backend before calling it done.**

## #1 — Can't select more than one cleaner (circled)
Review-step picker was a single `selectedTechId`; now a `selectedTechIds[]` multi-select. First pick = primary (mirrored onto `jobs.assigned_user_id`); `/quotes/:id/convert` accepts `team_user_ids` and writes a `job_technicians` row per cleaner (only primary flagged).
**Reproduced:** converted a quote with crew [32,33,34] → job got 3 crew rows, primary=32, mirror=32. ✅

## #2 — 'Appliance Combo' −$20 should be optional (underlined)
`/pricing/calculate` accepts `disabled_bundle_ids`; matching bundles are still returned (now with `id` + `applied`) so the UI shows them, but a disabled bundle's discount isn't subtracted. Price preview renders each combo as a toggle (× / +).
**Reproduced:** Move In/Out + Oven + Refrigerator → combo on = $688 (applied:true); toggled off = $708 (applied:false), +$20.00. ✅

## #3 — Adjustments from the quoting tool don't work
The preview showed `final_total + adjPlus − adjMinus` but the SAVED `total_price` used the engine total without adjustments, so the booked job ignored them. Saved total now includes the scope's adjustments (no double-count — backend stores `total_price` as-sent and keeps `manual_adjustments` as a record).
**Verified:** frontend now sends the same adjusted total the preview shows; backend stores as-sent and passes it to the job fee. (typecheck + build green)

## Commits
- `d79b863` multi-cleaner (frontend + convert)
- `eb19ee4` optional combo + adjustments apply

## Test plan
- [x] `typecheck:libs` green
- [x] bug #1 + #2 reproduced on live API, data cleaned up
- [ ] CI green