### PR TITLE
fix(deploy): raise Railway healthcheckTimeout 300→600s (unblock #625 deploy)

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -4,6 +4,6 @@
     "builder": "DOCKERFILE"
   },
   "deploy": {
-    "healthcheckTimeout": 300
+    "healthcheckTimeout": 600
   }
 }


### PR DESCRIPTION
**Problem:** #625 (View History buttons, frontend-only) keeps failing Railway's healthcheck at ~4:48–5:09 and gets rolled back to #624. The server code in #625 is byte-identical to #624 (which is running healthy), so the change itself can't be the cause.

**Root cause:** boot-chain creep. `index.ts` runs **16 sequential pre-listen migrations** before `app.listen()` (3×`MIGRATION_TIMEOUT_MS`=45s + 13×`SCHEMA_TIMEOUT_MS`=15s `withBootTimeout` guards). When the DB is slow/locked, most guards hit their timeout, so total boot approaches **330s** — over the `healthcheckTimeout: 300` window. The live instance booted an hour ago when the DB was faster and squeaked under; a fresh boot now exceeds it.

**Fix:** raise `healthcheckTimeout` to **600s**. Because `withBootTimeout` *always continues* after each guard, boot can never exceed 330s, so a 600s window guarantees the port binds and `/api/health` answers before Railway gives up. No change to the deliberate migrations-before-listen ordering.

Ships together with #625 (already on main), so this single deploy brings up both the timeout fix and the View History buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)