### PR TITLE
feat(commercial): gate add-ons by client type

### DIFF
--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -185,6 +185,13 @@ async function runBookingSchemaGuard(): Promise<void> {
     // can no longer create a split-brain (two QB customers for one client).
     { label: "qb_customer_map dedupe", stmt: "DELETE FROM qb_customer_map a USING qb_customer_map b WHERE a.id > b.id AND a.company_id = b.company_id AND a.qleno_customer_id = b.qleno_customer_id" },
     { label: "qb_customer_map_company_customer_uq", stmt: "CREATE UNIQUE INDEX IF NOT EXISTS qb_customer_map_company_customer_uq ON qb_customer_map (company_id, qleno_customer_id)" },
+    // [commercial-cleanup 2026-06-23] Add-ons are residential by default; the
+    // create-job wizard filters by applies_to so commercial jobs no longer show
+    // Oven/Fridge/etc. Seed Phes's commercial-relevant ones (only while still at
+    // the default, so a later deliberate tenant change isn't clobbered).
+    { label: "pricing_addons.applies_to", stmt: "ALTER TABLE pricing_addons ADD COLUMN IF NOT EXISTS applies_to TEXT NOT NULL DEFAULT 'residential'" },
+    { label: "addons.parking+manual → both", stmt: "UPDATE pricing_addons SET applies_to='both' WHERE company_id=1 AND applies_to='residential' AND (name ILIKE 'Parking Fee' OR name ILIKE 'Manual Adjustment')" },
+    { label: "addons.commercial adjustment → commercial", stmt: "UPDATE pricing_addons SET applies_to='commercial' WHERE company_id=1 AND applies_to='residential' AND name ILIKE 'Commercial Adjustment'" },
     { label: "jobs.property_vacant",       stmt: "ALTER TABLE jobs ADD COLUMN IF NOT EXISTS property_vacant BOOLEAN DEFAULT false" },
     { label: "jobs.arrival_window",        stmt: "ALTER TABLE jobs ADD COLUMN IF NOT EXISTS arrival_window TEXT" },
     { label: "jobs.first_recurring_discounted", stmt: "ALTER TABLE jobs ADD COLUMN IF NOT EXISTS first_recurring_discounted BOOLEAN DEFAULT false" },

--- a/artifacts/qleno/src/components/job-wizard.tsx
+++ b/artifacts/qleno/src/components/job-wizard.tsx
@@ -689,16 +689,26 @@ export function JobWizard({ open, onClose, onCreated, preselectedClient, presetD
   }
 
   function renderAddOns() {
+    // [commercial-cleanup] Only show add-ons that apply to this client type.
+    // Commercial jobs are rate-card priced, so they should only see Parking Fee
+    // + the adjustments (applies_to commercial/both), never residential extras
+    // like Oven or Fridge. Rows missing the flag default to residential.
+    const visibleAddons = availableAddons.filter(a => {
+      const ap = (a.applies_to as string) || "residential";
+      return clientType === "commercial"
+        ? (ap === "commercial" || ap === "both")
+        : (ap === "residential" || ap === "both");
+    });
     return (
       <div>
         <p style={{ fontSize: 12, fontWeight: 700, color: "#6B7280", margin: "0 0 8px", textTransform: "uppercase", letterSpacing: "0.06em" }}>Add-ons</p>
         {addonsLoading ? (
           <p style={{ fontSize: 12, color: "#9E9B94", margin: 0 }}>Loading add-ons…</p>
-        ) : availableAddons.length === 0 ? (
+        ) : visibleAddons.length === 0 ? (
           <p style={{ fontSize: 12, color: "#9E9B94", margin: 0 }}>No add-ons configured.</p>
         ) : (
           <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-            {availableAddons.map(a => {
+            {visibleAddons.map(a => {
               const checked = selectedAddons.has(a.id);
               const isPct = a.price_type === "percent" || a.price_type === "percentage";
               const catalogPrice = Number(a.price_value ?? a.price ?? 0);

--- a/lib/db/src/schema/pricing.ts
+++ b/lib/db/src/schema/pricing.ts
@@ -59,6 +59,12 @@ export const pricingAddonsTable = pgTable("pricing_addons", {
   show_online: boolean("show_online").notNull().default(true),
   show_portal: boolean("show_portal").notNull().default(true),
   is_active: boolean("is_active").notNull().default(true),
+  // [commercial-cleanup] Which client type this add-on is offered for. The
+  // create-job wizard filters by this so commercial jobs stop showing
+  // residential add-ons (Oven, Fridge, etc). Values: residential | commercial
+  // | both. Defaults residential — commercial work is rate-card priced, so the
+  // only commercial add-ons are Parking Fee + the adjustments.
+  applies_to: text("applies_to").notNull().default("residential"),
   sort_order: integer("sort_order").notNull().default(0),
   created_at: timestamp("created_at").notNull().defaultNow(),
 });


### PR DESCRIPTION
## Why
The create-job wizard showed **every residential add-on** (Oven, Fridge, Kitchen Cabinets, Baseboards, Windows, Basement) on **commercial** jobs, where none of them apply, commercial is rate-card priced. Maribel flagged it; commercial should only offer **Parking Fee + the adjustments**.

## What (data-driven, multi-tenant)
- `pricing_addons.applies_to` (`residential | commercial | both`), default `residential`.
- Cold-start migration seeds Phes's commercial add-ons **only while still at the default** (won't clobber a later tenant change): Parking Fee + Manual Adjustment → `both`, Commercial Adjustment → `commercial`.
- Wizard `renderAddOns()` filters by the selected client type. The `/addons` endpoint already `SELECT *`s, so the flag flows through with no route change.

## Scope
First slice of the commercial cleanup. Service-type tidy (drop Retail Store / Medical Office / Post Event, group PPM) and the new cadences (15th, 3rd Wednesday, last Friday) follow as their own PRs.

## Test plan
- [x] `typecheck:libs` passes; job-wizard edit clean
- [ ] CI green
- [ ] Post-deploy: commercial job shows only Parking Fee + adjustments; residential still shows full set

🤖 Generated with [Claude Code](https://claude.com/claude-code)