### PR TITLE
fix(quotes): re-booking at a new frequency updates the schedule cadence

### DIFF
--- a/artifacts/api-server/src/routes/quotes.ts
+++ b/artifacts/api-server/src/routes/quotes.ts
@@ -524,14 +524,17 @@ router.post("/:id/convert", requireAuth, requireRole("owner", "admin", "office")
       let sched: any;
       let allInBase = 0;
       if (prior) {
-        // Reuse the existing schedule. Agreed base + visit length stay exactly
-        // as-is; the only money change is folding any new add-ons into the
-        // all-in base going forward.
+        // Reuse the existing schedule (don't spawn a duplicate). Agreed base +
+        // visit length stay as-is; new add-ons fold into the all-in base. But a
+        // re-book at a DIFFERENT cadence is a deliberate change, so update the
+        // frequency to the quoted one — previously the DB row kept its old
+        // cadence even though the office picked a new one on the quote.
         const agreedBase = prior.base_fee != null ? parseFloat(prior.base_fee) : (recurringFee ?? 0);
         allInBase = Math.round((agreedBase + newAddonSubtotal) * 100) / 100;
         await db.execute(sql`
           UPDATE recurring_schedules
              SET base_fee = ${String(allInBase)},
+                 frequency = ${jobFreq},
                  scheduled_time = COALESCE(${scheduled_time || null}, scheduled_time),
                  assigned_employee_id = COALESCE(${assigned_user_id ? parseInt(String(assigned_user_id)) : null}, assigned_employee_id)
            WHERE id = ${prior.id} AND company_id = ${companyId}


### PR DESCRIPTION
## Why
When you re-book a client who already has a recurring schedule for that service, the convert reuses the schedule (so you don't get duplicates) but **never updated its frequency**. So re-booking a weekly client as biweekly silently kept them weekly. Surfaced by the cadence test suite.

## Fix
Add `frequency` to the schedule-reuse UPDATE so a deliberate cadence change on the quote actually sticks. Base fee + visit length are still preserved. The in-memory schedule object already reflected the new cadence; only the persisted row lagged.

## Test plan
- [x] `typecheck:libs` passes
- [ ] CI green
- [ ] Post-deploy: re-book a weekly client as biweekly → schedule flips to biweekly

🤖 Generated with [Claude Code](https://claude.com/claude-code)