### PR TITLE
feat(recurring): nth-weekday cadence — 3rd Wednesday / last Friday

### DIFF
--- a/artifacts/api-server/src/lib/recurring-cadences.ts
+++ b/artifacts/api-server/src/lib/recurring-cadences.ts
@@ -90,12 +90,29 @@ export function resolveDayOfMonth(year: number, month: number, day: number): num
   return day;
 }
 
+// [commercial-cadence] Nth weekday of a month — "3rd Wednesday", "last Friday".
+// nth: 1..4 = first..fourth; 5 (or anything >=5) = LAST occurrence in the
+// month. weekday: 0=Sun..6=Sat. Used by the monthly_weekday cadence.
+export function nthWeekdayOfMonth(year: number, month: number, nth: number, weekday: number): Date {
+  if (nth >= 5) {
+    const last = new Date(year, month + 1, 0);
+    const back = (last.getDay() - weekday + 7) % 7;
+    return new Date(year, month, last.getDate() - back);
+  }
+  const first = new Date(year, month, 1);
+  const offset = (weekday - first.getDay() + 7) % 7;
+  return new Date(year, month, 1 + offset + (nth - 1) * 7);
+}
+
 export interface CadenceInput {
   frequency: string;
   day_of_week: string | null;
   days_of_week?: number[] | null;
   days_of_month?: number[] | null;
   custom_frequency_weeks?: number | null;
+  // [commercial-cadence] 1..4 = first..fourth, 5 = last. Pairs with
+  // day_of_week for the monthly_weekday cadence ("3rd Wednesday" etc).
+  week_of_month?: number | null;
   // string from a Drizzle typed select; Date from a raw pg `date` column.
   start_date: string | Date;
   end_date?: string | Date | null;
@@ -172,6 +189,19 @@ export function generateCadenceDates(
       if (snapped >= start && snapped >= fromDate && snapped <= effectiveEnd) {
         dates.push(snapped);
       }
+      cursor = addMonths(cursor, 1);
+    }
+    return dates;
+  }
+
+  // ── Nth-weekday path: "3rd Wednesday", "last Friday" ────────────────────
+  // [commercial-cadence] week_of_month (1..4, or 5=last) + day_of_week.
+  if (freq === "monthly_weekday") {
+    const nth = schedule.week_of_month ?? 1;
+    let cursor = new Date(fromDate.getFullYear(), fromDate.getMonth(), 1);
+    while (cursor <= effectiveEnd) {
+      const d = nthWeekdayOfMonth(cursor.getFullYear(), cursor.getMonth(), nth, targetDow);
+      if (d >= start && d >= fromDate && d <= effectiveEnd) dates.push(d);
       cursor = addMonths(cursor, 1);
     }
     return dates;

--- a/artifacts/api-server/src/lib/recurring-jobs.ts
+++ b/artifacts/api-server/src/lib/recurring-jobs.ts
@@ -247,6 +247,7 @@ export function generateOccurrences(
     days_of_week?: number[] | null;
     days_of_month?: number[] | null;
     custom_frequency_weeks?: number | null;
+    week_of_month?: number | null;
     start_date: string | Date;
     end_date?: string | Date | null;
   },
@@ -271,6 +272,8 @@ type ScheduleInput = {
   // 0 = "last day of month" — engine resolves per-month.
   days_of_month?: number[] | null;
   custom_frequency_weeks?: number | null;
+  // [commercial-cadence] 1..4 = first..fourth, 5 = last (monthly_weekday).
+  week_of_month?: number | null;
   // string from a Drizzle typed select; Date from a raw pg `date` column.
   start_date: string | Date;
   end_date?: string | Date | null;

--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -190,6 +190,9 @@ async function runBookingSchemaGuard(): Promise<void> {
     // Oven/Fridge/etc. Seed Phes's commercial-relevant ones (only while still at
     // the default, so a later deliberate tenant change isn't clobbered).
     { label: "pricing_addons.applies_to", stmt: "ALTER TABLE pricing_addons ADD COLUMN IF NOT EXISTS applies_to TEXT NOT NULL DEFAULT 'residential'" },
+    // [commercial-cadence 2026-06-23] Nth-weekday recurring ("3rd Wednesday",
+    // "last Friday"): frequency='monthly_weekday' + week_of_month (1..4, 5=last).
+    { label: "recurring_schedules.week_of_month", stmt: "ALTER TABLE recurring_schedules ADD COLUMN IF NOT EXISTS week_of_month INTEGER" },
     { label: "addons.parking+manual → both", stmt: "UPDATE pricing_addons SET applies_to='both' WHERE company_id=1 AND applies_to='residential' AND (name ILIKE 'Parking Fee' OR name ILIKE 'Manual Adjustment')" },
     { label: "addons.commercial adjustment → commercial", stmt: "UPDATE pricing_addons SET applies_to='commercial' WHERE company_id=1 AND applies_to='residential' AND name ILIKE 'Commercial Adjustment'" },
     { label: "jobs.property_vacant",       stmt: "ALTER TABLE jobs ADD COLUMN IF NOT EXISTS property_vacant BOOLEAN DEFAULT false" },

--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -192,6 +192,7 @@ async function runBookingSchemaGuard(): Promise<void> {
     { label: "pricing_addons.applies_to", stmt: "ALTER TABLE pricing_addons ADD COLUMN IF NOT EXISTS applies_to TEXT NOT NULL DEFAULT 'residential'" },
     // [commercial-cadence 2026-06-23] Nth-weekday recurring ("3rd Wednesday",
     // "last Friday"): frequency='monthly_weekday' + week_of_month (1..4, 5=last).
+    { label: "recurring_frequency += monthly_weekday", stmt: "ALTER TYPE recurring_frequency ADD VALUE IF NOT EXISTS 'monthly_weekday'" },
     { label: "recurring_schedules.week_of_month", stmt: "ALTER TABLE recurring_schedules ADD COLUMN IF NOT EXISTS week_of_month INTEGER" },
     { label: "addons.parking+manual → both", stmt: "UPDATE pricing_addons SET applies_to='both' WHERE company_id=1 AND applies_to='residential' AND (name ILIKE 'Parking Fee' OR name ILIKE 'Manual Adjustment')" },
     { label: "addons.commercial adjustment → commercial", stmt: "UPDATE pricing_addons SET applies_to='commercial' WHERE company_id=1 AND applies_to='residential' AND name ILIKE 'Commercial Adjustment'" },

--- a/lib/db/src/schema/recurring_schedules.ts
+++ b/lib/db/src/schema/recurring_schedules.ts
@@ -44,6 +44,9 @@ export const recurringSchedulesTable = pgTable("recurring_schedules", {
   // Used when jobs.frequency='every_3_weeks' (no matching enum value on
   // recurring_schedules.frequency, which only has weekly/biweekly/monthly/custom).
   custom_frequency_weeks: integer("custom_frequency_weeks"),
+  // [commercial-cadence] For frequency='monthly_weekday' ("3rd Wednesday",
+  // "last Friday"): 1..4 = first..fourth, 5 = last. Pairs with day_of_week.
+  week_of_month: integer("week_of_month"),
   // [AH] Cascade target for commercial hourly rate. When the user picks
   // "this and all future" on a commercial recurring job, this column gets
   // the rate so the engine can re-derive base_fee for spawned jobs.

--- a/lib/db/src/schema/recurring_schedules.ts
+++ b/lib/db/src/schema/recurring_schedules.ts
@@ -14,6 +14,9 @@ export const recurringFrequencyEnum = pgEnum("recurring_frequency", [
   // (typically [1, 15] or [15, 30]). Engine snaps forward to next
   // business day when an anchor falls on a weekend.
   "semi_monthly",
+  // [commercial-cadence] Nth weekday of month — "3rd Wednesday", "last
+  // Friday". Pairs week_of_month (1..4, 5=last) with day_of_week.
+  "monthly_weekday",
 ]);
 
 export const recurringDayEnum = pgEnum("recurring_day", [


### PR DESCRIPTION
## Why
Chunk 2, slice 1. The recurring engine handled the 15th (day-of-month) but **not month-position weekdays** — and you need "3rd Wednesday / last Friday" for commercial.

## What
New frequency `monthly_weekday` + `week_of_month` (1..4 = first..fourth, **5 = last**) paired with `day_of_week`.
- Pure `nthWeekdayOfMonth()` helper + a `monthly_weekday` branch in `generateCadenceDates`.
- `recurring_schedules.week_of_month` column (cold-start migration).
- Threaded through `ScheduleInput` / `generateOccurrences`; loaders use `.select()` so it flows automatically.

## Verified
- **Unit test 6/6**: 3rd Wed, last Fri, 1st Mon, 2nd Thu all correct; weekly + the-15th regressions still green. (Pure function, no DB.)
- `typecheck:libs` clean.

## Next
The picker UI to actually *choose* this cadence (chunk 1 remainder) wires it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)