### PR TITLE
fix(leave): restore usage rows + void pay on cancel; bucket-tag approved usage

### DIFF
--- a/artifacts/api-server/src/lib/leave-bucket.ts
+++ b/artifacts/api-server/src/lib/leave-bucket.ts
@@ -1,0 +1,18 @@
+/**
+ * Map a leave_type slug to the canonical bucket tag written into
+ * employee_leave_usage note text ("usage/<bucket>").
+ *
+ * The per-bucket "View History" modal on the employee profile filters usage
+ * rows on a "/pto" vs "/plawa" substring (the same convention the [MC import]
+ * rows already use). Tagging app-approved usage rows by bucket keeps PTO and
+ * Sick history complete for leave approved going forward; unpaid/unexcused get
+ * their own self-describing tags and stay out of the PTO/Sick views (correct).
+ */
+export function slugToBucket(slug?: string | null): string {
+  const s = String(slug ?? "").toLowerCase();
+  if (s === "plawa" || s.includes("plawa") || s.includes("sick")) return "plawa";
+  if (s.includes("pto")) return "pto";
+  if (s.includes("unpaid")) return "unpaid";
+  if (s.includes("unexcused")) return "unexcused";
+  return s || "other";
+}

--- a/artifacts/api-server/src/lib/leave-pay.ts
+++ b/artifacts/api-server/src/lib/leave-pay.ts
@@ -71,3 +71,32 @@ export async function writeApprovedLeavePay(
 
   return { paid: true, type: payType, hours, amount };
 }
+
+/**
+ * Reverse the auto-pay for a leave request when its approval is cancelled.
+ * Marks any non-voided `additional_pay` row carrying this request's
+ * `leave_req#<id>` marker as 'voided' (payroll excludes 'voided'), so the
+ * employee is not paid for cancelled leave.
+ *
+ * Idempotent + symmetric with writeApprovedLeavePay:
+ *  - re-cancel: only non-voided rows are touched, so it's a no-op the 2nd time
+ *  - re-approve after cancel: the voided row no longer satisfies
+ *    writeApprovedLeavePay's NOT EXISTS (status <> 'voided') guard, so a fresh
+ *    pending row is inserted — never a double-pay, never a stranded one.
+ * Unpaid buckets never created a pay row, so the UPDATE matches nothing.
+ */
+export async function voidApprovedLeavePay(
+  companyId: number,
+  requestId: number,
+  voidedByUserId?: number | null,
+): Promise<void> {
+  const marker = `leave_req#${requestId}`;
+  await db.execute(sql`
+    UPDATE additional_pay
+       SET status = 'voided',
+           voided_at = NOW(),
+           voided_by = ${voidedByUserId ?? null}
+     WHERE company_id = ${companyId}
+       AND notes LIKE ${"%" + marker + "%"}
+       AND COALESCE(status,'pending') <> 'voided'`);
+}

--- a/artifacts/api-server/src/routes/leave.ts
+++ b/artifacts/api-server/src/routes/leave.ts
@@ -53,7 +53,7 @@ import {
   companyLeavePolicyTable,
   usersTable,
 } from "@workspace/db/schema";
-import { and, asc, desc, eq, gte, inArray, isNotNull, lte, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gte, inArray, isNotNull, like, lte, sql } from "drizzle-orm";
 import { requireAuth, requireRole } from "../lib/auth.js";
 import { notifyUserAsync } from "../lib/push.js";
 import {
@@ -74,7 +74,8 @@ import {
   notifyLeaveSubmitted,
   notifyLeaveDecision,
 } from "../lib/leave-notifications.js";
-import { writeApprovedLeavePay } from "../lib/leave-pay.js";
+import { writeApprovedLeavePay, voidApprovedLeavePay } from "../lib/leave-pay.js";
+import { slugToBucket } from "../lib/leave-bucket.js";
 import { logAudit } from "../lib/audit.js";
 import multer from "multer";
 import path from "node:path";
@@ -917,6 +918,17 @@ router.post("/requests/:id/approve", adminWriteGate, async (req, res) => {
   const perDay = dayUnit === "full_day" ? DAILY_HOURS : DAILY_HOURS / 2;
   const startMs = Date.parse(`${String(reqRow.start_date)}T00:00:00Z`);
   const endMs = Date.parse(`${String(reqRow.end_date)}T00:00:00Z`);
+  // Bucket tag (Sal 2026-06-24): the per-bucket View History modal filters
+  // usage rows on a "/pto" vs "/plawa" note tag (matching the [MC import]
+  // rows). App-approved rows previously carried no tag and so never showed
+  // in history — tag each one by its leave_type bucket so PTO/Sick history
+  // stays complete for leave approved going forward.
+  const ltRow = await db
+    .select({ slug: leaveTypesTable.slug })
+    .from(leaveTypesTable)
+    .where(eq(leaveTypesTable.id, reqRow.leave_type_id))
+    .limit(1);
+  const bucket = slugToBucket(ltRow[0]?.slug);
   for (let t = startMs; t <= endMs; t += 86400000) {
     const d = new Date(t).toISOString().slice(0, 10);
     await db.insert(employeeLeaveUsageTable).values({
@@ -924,7 +936,9 @@ router.post("/requests/:id/approve", adminWriteGate, async (req, res) => {
       employee_id: reqRow.user_id,
       date_used: d,
       hours: perDay.toFixed(2),
-      notes: `leave_request #${reqRow.id} approved (${dayUnit})`,
+      // Stable prefix "leave_request #<id> approved" is the key the cancel
+      // path matches on to remove every day of this request.
+      notes: `leave_request #${reqRow.id} approved (${dayUnit}) usage/${bucket}`,
       logged_by: actingUserId,
     });
   }
@@ -1058,19 +1072,26 @@ router.post("/requests/:id/cancel", async (req, res) => {
         updated_at: new Date(),
       })
       .where(eq(employeeLeaveBalancesTable.id, bal.id));
+    // Remove EVERY usage day for this request. The prior code matched only
+    // start_date AND an exact note string without the "(dayUnit) usage/<bucket>"
+    // suffix, so it deleted 0 rows on a multi-day or tagged request, leaving
+    // the days showing as "taken" even though the balance was restored. Key on
+    // the stable "leave_request #<id> approved" prefix instead — covers all
+    // days and both the old and new note formats.
     await db
       .delete(employeeLeaveUsageTable)
       .where(
         and(
           eq(employeeLeaveUsageTable.company_id, companyId),
           eq(employeeLeaveUsageTable.employee_id, reqRow.user_id),
-          eq(employeeLeaveUsageTable.date_used, String(reqRow.start_date)),
-          eq(
+          like(
             employeeLeaveUsageTable.notes,
-            `leave_request #${reqRow.id} approved`,
+            `leave_request #${reqRow.id} approved%`,
           ),
         ),
       );
+    // Reverse the auto-pay so the employee isn't paid for cancelled leave.
+    await voidApprovedLeavePay(companyId, reqRow.id, actingUserId);
   }
   await db
     .update(leaveRequestsTable)

--- a/artifacts/api-server/src/tests/leave-cancel-restore.test.ts
+++ b/artifacts/api-server/src/tests/leave-cancel-restore.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Leave cancel/restore + bucket-tag correctness (Sal 2026-06-24).
+ *
+ * Three bugs fixed:
+ *  1. Cancel of an approved request now deletes EVERY usage day (keyed on the
+ *     stable "leave_request #<id> approved" note prefix), not just start_date
+ *     with a note string that no longer matched.
+ *  2. Cancel reverses the auto-pay (voidApprovedLeavePay) so cancelled leave
+ *     isn't paid.
+ *  3. App-approved usage rows are bucket-tagged ("usage/<bucket>") so the
+ *     per-bucket View History modal shows them.
+ *
+ * Pure tests on slugToBucket + a note/LIKE-pattern consistency check, plus
+ * file-grep invariants on the route source (matching the cutover-3a pattern).
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { slugToBucket } from "../lib/leave-bucket.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const leaveRoute = readFileSync(
+  path.join(__dirname, "../routes/leave.ts"),
+  "utf8",
+);
+const leavePay = readFileSync(
+  path.join(__dirname, "../lib/leave-pay.ts"),
+  "utf8",
+);
+
+/** Minimal SQL-LIKE matcher for the prefix patterns we use ("...approved%"). */
+function likeMatch(value: string, pattern: string): boolean {
+  // Escape regex specials, then translate LIKE wildcards: % -> .*, _ -> .
+  const re = new RegExp(
+    "^" +
+      pattern
+        .replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+        .replace(/%/g, ".*")
+        .replace(/_/g, ".") +
+      "$",
+  );
+  return re.test(value);
+}
+
+describe("slugToBucket — maps Phes slugs to View-History tags", () => {
+  it("PTO bucket → 'pto' (contains '/pto' once tagged)", () => {
+    assert.equal(slugToBucket("pto_phes"), "pto");
+    assert.ok(`usage/${slugToBucket("pto_phes")}`.includes("/pto"));
+  });
+  it("PLAWA/sick bucket → 'plawa'", () => {
+    assert.equal(slugToBucket("plawa"), "plawa");
+    assert.ok(`usage/${slugToBucket("plawa")}`.includes("/plawa"));
+  });
+  it("unpaid + unexcused get their own tags, NOT pto/plawa", () => {
+    assert.equal(slugToBucket("unpaid_leave"), "unpaid");
+    assert.equal(slugToBucket("unexcused"), "unexcused");
+    assert.ok(!`usage/${slugToBucket("unpaid_leave")}`.includes("/pto"));
+    assert.ok(!`usage/${slugToBucket("unpaid_leave")}`.includes("/plawa"));
+  });
+  it("never collides: pto tag isn't matched by the /plawa filter and vice-versa", () => {
+    assert.ok(!`usage/${slugToBucket("pto_phes")}`.includes("/plawa"));
+    assert.ok(!`usage/${slugToBucket("plawa")}`.includes("/pto"));
+  });
+  it("null/unknown slug degrades safely", () => {
+    assert.equal(slugToBucket(null), "other");
+    assert.equal(slugToBucket(undefined), "other");
+  });
+});
+
+describe("approval note ↔ cancel delete-pattern consistency", () => {
+  // The cancel path deletes WHERE notes LIKE `leave_request #<id> approved%`.
+  // Every note format the approve path can write MUST match that pattern, for
+  // every day of the request, across all buckets.
+  const id = 5;
+  const cancelPattern = `leave_request #${id} approved%`;
+  for (const unit of ["full_day", "morning", "afternoon"]) {
+    for (const slug of ["pto_phes", "plawa", "unpaid_leave"]) {
+      it(`matches ${unit}/${slug}`, () => {
+        const note = `leave_request #${id} approved (${unit}) usage/${slugToBucket(slug)}`;
+        assert.ok(likeMatch(note, cancelPattern), `"${note}" should match LIKE "${cancelPattern}"`);
+      });
+    }
+  }
+  it("does NOT match a different request id (#50 vs #5)", () => {
+    const other = `leave_request #50 approved (full_day) usage/pto`;
+    assert.ok(!likeMatch(other, cancelPattern));
+  });
+  it("does NOT match an [MC import] row", () => {
+    const mc = `[MC import #1] usage/plawa — She felt sick - MC`;
+    assert.ok(!likeMatch(mc, cancelPattern));
+  });
+});
+
+describe("route source invariants", () => {
+  it("approval tags usage notes with the bucket (usage/${bucket})", () => {
+    assert.ok(/approved \(\$\{dayUnit\}\) usage\/\$\{bucket\}/.test(leaveRoute));
+    assert.ok(leaveRoute.includes("slugToBucket("));
+  });
+  it("cancel deletes usage by stable prefix via like(), not by start_date", () => {
+    assert.ok(/like\(\s*employeeLeaveUsageTable\.notes/.test(leaveRoute));
+    assert.ok(leaveRoute.includes("approved%`"));
+    // the old start_date-only match must be gone from the cancel path
+    assert.ok(!leaveRoute.includes("date_used, String(reqRow.start_date)"));
+  });
+  it("cancel reverses auto-pay", () => {
+    assert.ok(leaveRoute.includes("voidApprovedLeavePay(companyId, reqRow.id, actingUserId)"));
+  });
+  it("voidApprovedLeavePay is idempotent (only non-voided rows, sets voided)", () => {
+    assert.ok(/SET\s+status\s*=\s*'voided'/.test(leavePay));
+    assert.ok(/COALESCE\(status,'pending'\)\s*<>\s*'voided'/.test(leavePay));
+    assert.ok(leavePay.includes("leave_req#"));
+  });
+});


### PR DESCRIPTION
Three correctness bugs in the leave **approve → cancel** path (investigation findings, bug-fixes only — redesign is separate).

### 1. Cancel didn't remove usage-history rows
Approval wrote the usage note as `leave_request #N approved (full_day)`, but cancel deleted rows matching the exact string `leave_request #N approved` (no suffix) **and** only `start_date`. Net: it deleted **0 rows** on any multi-day or tagged request — the days kept showing as "taken" even though the balance was correctly restored (split-brain). **Fix:** delete by the stable `leave_request #N approved%` prefix across **every** day.

### 2. Cancel didn't reverse the auto-pay
Approval writes a `$20/hr` `additional_pay` line; cancel left it, so cancelled leave stayed paid. **Fix:** `voidApprovedLeavePay()` marks the matching `leave_req#<id>` row `voided` (payroll already excludes `voided`). Idempotent + symmetric with the insert's `NOT EXISTS(status<>'voided')` guard → re-cancel is a no-op, re-approve re-inserts a fresh row, never double-pays.

### 3. App-approved usage wasn't bucket-tagged
The per-bucket View History modal filters notes for `/pto` vs `/plawa`; app-approved rows had no tag so they'd never appear. **Fix:** approval appends `usage/<bucket>` (`slugToBucket` extracted to `lib/leave-bucket.ts`).

### Safety
- **No schema changes.** **No existing data altered** — the 120 `[MC import]` rows and all current balances are untouched (the delete prefix `leave_request #N approved%` can't match `[MC import …]`).
- The cancel delete-prefix matches **both** the old and new note formats (backward-compatible).

### Tests
New `leave-cancel-restore.test.ts` — 20 cases: `slugToBucket` mapping (incl. no pto/plawa collision), approval-note ↔ cancel-LIKE consistency across unit×bucket, and route-source invariants. All pass; existing leave suites (87 cases) still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)