### PR TITLE
fix(boot): bind port + answer health before migrations (end deploy-healthcheck failures)

### DIFF
--- a/artifacts/api-server/src/app.ts
+++ b/artifacts/api-server/src/app.ts
@@ -7,6 +7,7 @@ import rateLimit from "express-rate-limit";
 import router from "./routes";
 import stripeWebhookRouter from "./routes/stripe-webhook.js";
 import { resolveShortLink } from "./lib/short-link.js";
+import { isAppReady } from "./lib/readiness.js";
 
 const __appDir: string =
   typeof __dirname !== "undefined"
@@ -108,6 +109,25 @@ app.use("/api/clients/:id/communications/sms", messageLimiter);
 app.use("/api/clients/:id/communications/email", messageLimiter);
 app.use("/api/job-sms", messageLimiter);
 app.use("/api", generalLimiter);
+
+// ── Readiness gate (2026-06-24) ───────────────────────────────────────────────
+// The server binds the port and answers health immediately on boot; the
+// migration chain runs in the background AFTER listen (index.ts). Until it
+// finishes, hold every non-health /api route at 503 so no request reads or
+// writes partially-migrated schema (preserves the 2026-05-17 read/write
+// divergence fix). Health stays green so Railway's healthcheck passes the
+// instant the port is bound — ending the chronic migrations-before-listen
+// deploy-healthcheck failures. Static mounts (/api/uploads, /api/pdfs) are
+// matched earlier in the chain, so they're never gated.
+app.use((req: Request, res: Response, next: NextFunction) => {
+  if (isAppReady()) return next();
+  if (req.path === "/api/health" || req.path === "/api/healthz") return next();
+  res.set("Retry-After", "5");
+  return res.status(503).json({
+    status: "warming_up",
+    message: "Server is starting; migrations in progress. Retry shortly.",
+  });
+});
 app.use("/api", router);
 
 // ── Short-link redirect ───────────────────────────────────────────────────────

--- a/artifacts/api-server/src/index.ts
+++ b/artifacts/api-server/src/index.ts
@@ -15,6 +15,7 @@ import { runLmsCertificateBackfill } from "./lib/lms-certificate-backfill.js";
 import { ensureJobHistoryLiveBridgeSchema, syncJobHistoryLiveBridge } from "./lib/job-history-sync.js";
 import { bootstrapOnboardingPasswords } from "./lib/onboarding-password-backfill.js";
 import { runLeaveAccrualCron } from "./lib/leave-accrual-cron.js";
+import { setAppReady } from "./lib/readiness.js";
 
 const port = Number(process.env.PORT) || 3000;
 
@@ -214,7 +215,7 @@ function withBootTimeout<T>(
 // onboarding-password bootstrap, LMS recompute backfills) moved AFTER listen,
 // fire-and-forget. The schema DDL that those data ops depend on
 // (ensureJobHistoryLiveBridgeSchema) STAYS before listen.
-async function startup() {
+async function runStartupMigrations() {
   try {
     await withBootTimeout("seedIfNeeded", MIGRATION_TIMEOUT_MS, () => seedIfNeeded());
   } catch (err: any) {
@@ -340,8 +341,21 @@ async function startup() {
   } catch (err: any) {
     console.error("[startup] ensureJobHistoryLiveBridgeSchema — non-fatal:", err?.message ?? err);
   }
+}
 
-  app.listen(port, "0.0.0.0", () => {
+// [boot-resilience 2026-06-24] Bind the port FIRST, then run the migration
+// chain in the background AFTER the server is listening. Health (/api/health,
+// /api/healthz) answers the instant the port is bound, so Railway's healthcheck
+// passes immediately — ending the chronic deploy-healthcheck failures caused by
+// the migrations-before-listen ordering (the old code ran all 16 guarded
+// migrations before app.listen(); under a slow/locked DB the cumulative
+// withBootTimeout budget exceeded even a 600s healthcheck window). The
+// readiness gate in app.ts holds all OTHER /api routes at 503 until the chain
+// completes, so no request can hit partially-migrated schema (preserves the
+// 2026-05-17 read/write-divergence fix). withBootTimeout still bounds each step,
+// so the gate always opens within a bounded time even on a degraded DB.
+async function startup() {
+  app.listen(port, "0.0.0.0", async () => {
     console.log("Server running on port", process.env.PORT || 3000);
     // [DR runbook 2026-04-30] Static reminder visible on every cold
     // start. Surfaces backup-state in Railway logs without requiring
@@ -351,6 +365,13 @@ async function startup() {
     // backup state changes maybe twice a year.
     // Procedure + RPO/RTO targets: docs/disaster-recovery.md
     console.log("[backup-check] static reminder: Railway Hobby plan provides daily backups, 7-day retention. Verify quarterly via dashboard. Procedure: docs/disaster-recovery.md");
+
+    // Run the schema/data migration chain now that the port is bound. Until
+    // this resolves, the app.ts readiness gate returns 503 for every non-health
+    // /api route. withBootTimeout bounds each step, so the gate always opens.
+    await runStartupMigrations();
+    setAppReady(true);
+    console.log("[startup] migrations complete — API readiness gate opened");
 
     // [boot-resilience 2026-06-19] Heavy NON-schema data work that does not
     // gate request correctness runs here, AFTER the port is bound, so a slow

--- a/artifacts/api-server/src/lib/readiness.ts
+++ b/artifacts/api-server/src/lib/readiness.ts
@@ -1,0 +1,23 @@
+/**
+ * App readiness flag (2026-06-24).
+ *
+ * The server binds the port and answers health checks immediately on boot;
+ * the schema/data migration chain runs in the background AFTER listen (see
+ * index.ts). Until that chain completes, the readiness gate in app.ts holds
+ * every non-health /api route at HTTP 503 so a request can never read or write
+ * partially-migrated schema — preserving the migrations-must-precede-dependent
+ * -reads guarantee (the 2026-05-17 read/write-divergence fix) WITHOUT blocking
+ * the port (which was the chronic cause of Railway deploy-healthcheck failures).
+ *
+ * Single boolean, flipped once. No external deps so both app.ts (reader) and
+ * index.ts (writer) can import it without pulling in the server graph.
+ */
+let ready = false;
+
+export function isAppReady(): boolean {
+  return ready;
+}
+
+export function setAppReady(value = true): void {
+  ready = value;
+}

--- a/artifacts/api-server/src/tests/boot-readiness.test.ts
+++ b/artifacts/api-server/src/tests/boot-readiness.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Boot ordering + readiness gate (Sal 2026-06-24).
+ *
+ * Durable fix for the chronic Railway deploy-healthcheck failures: the server
+ * now binds the port and answers health FIRST, then runs the migration chain in
+ * the background. A readiness gate holds non-health /api routes at 503 until the
+ * chain completes, so no request hits partially-migrated schema (preserves the
+ * 2026-05-17 read/write-divergence fix).
+ *
+ * Pure test of the readiness flag + file-grep invariants on the boot source
+ * (matching the cutover-3a pattern — the route's wiring is the load-bearing
+ * part and can't be unit-exercised without booting the server).
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { isAppReady, setAppReady } from "../lib/readiness.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const indexSrc = readFileSync(path.join(__dirname, "../index.ts"), "utf8");
+const appSrc = readFileSync(path.join(__dirname, "../app.ts"), "utf8");
+
+describe("readiness flag", () => {
+  it("starts not-ready and flips once", () => {
+    // Module starts false (nothing has flipped it in this test process yet).
+    assert.equal(isAppReady(), false);
+    setAppReady(true);
+    assert.equal(isAppReady(), true);
+    setAppReady(false);
+    assert.equal(isAppReady(), false);
+  });
+});
+
+describe("index.ts — port binds BEFORE migrations", () => {
+  it("startup() calls app.listen()", () => {
+    assert.ok(/async function startup\(\)\s*{[\s\S]*app\.listen\(port/.test(indexSrc));
+  });
+  it("migrations are extracted into runStartupMigrations()", () => {
+    assert.ok(indexSrc.includes("async function runStartupMigrations()"));
+  });
+  it("runStartupMigrations() is awaited INSIDE the listen callback (after bind)", () => {
+    const afterListen = indexSrc.slice(indexSrc.indexOf("app.listen(port"));
+    assert.ok(afterListen.includes("await runStartupMigrations()"));
+    // and readiness flips right after the chain completes
+    assert.ok(/await runStartupMigrations\(\);\s*\n\s*setAppReady\(true\)/.test(afterListen));
+  });
+  it("does NOT await migrations before app.listen()", () => {
+    const beforeListen = indexSrc.slice(0, indexSrc.indexOf("app.listen(port"));
+    assert.ok(!beforeListen.includes("await runStartupMigrations()"));
+  });
+});
+
+describe("app.ts — readiness gate", () => {
+  it("gate checks isAppReady and 503s when not ready", () => {
+    assert.ok(appSrc.includes("isAppReady()"));
+    assert.ok(/status\(503\)/.test(appSrc));
+    assert.ok(appSrc.includes("warming_up"));
+  });
+  it("gate exempts health + healthz so Railway's probe stays green", () => {
+    assert.ok(appSrc.includes('req.path === "/api/health"'));
+    assert.ok(appSrc.includes('req.path === "/api/healthz"'));
+  });
+  it("gate is mounted before the main /api router", () => {
+    const gateIdx = appSrc.indexOf("warming_up");
+    const routerIdx = appSrc.indexOf('app.use("/api", router)');
+    assert.ok(gateIdx > -1 && routerIdx > -1 && gateIdx < routerIdx);
+  });
+});


### PR DESCRIPTION
## The chronic problem
Many deploys fail Railway's healthcheck and roll back (`feat(accounts)`, `fix(quotes)`, `feat(time-off)`, **#632**…). `index.ts` ran all **16** schema/data migrations sequentially **before** `app.listen()`. Each is `withBootTimeout`-guarded (3×45s + 13×15s ≈ 330s budget); under a slow/locked DB — compounded by lock contention from overlapping failed-deploy attempts — boot blew past even the 600s window. **The port never binds until migrations finish**, so `/api/health` is connection-refused the whole time → healthcheck fails → old version stays active.

## The durable fix — decouple health from the migration chain
- `startup()` calls **`app.listen()` FIRST** → `/api/health` + `/api/healthz` answer the instant the port binds → healthcheck passes immediately.
- The 16 migrations move into `runStartupMigrations()`, awaited **inside** the listen callback (after bind); `setAppReady(true)` then opens the gate.
- New **readiness gate** (`app.ts`) holds every **non-health** `/api` route at `503 {status:"warming_up"}` until migrations finish — so no request hits partially-migrated schema. **This preserves the 2026-05-17 read/write-divergence fix** that motivated migrations-before-listen, without blocking the port.
- `withBootTimeout` still bounds each step, so the gate always opens in bounded time even on a degraded DB. Also self-corrects the lock contention: healthcheck passes immediately → Railway stops spawning competing attempts → residual locks clear.

## Correctness / safety
- No schema changes. The readiness window is normally **seconds** (idempotent DDL no-ops once applied); the SPA's static assets aren't gated, only `/api` calls briefly 503 with `Retry-After`.
- Carries the **#632 leave fixes** (already on main) into a deployable image.

## Verification
- `boot-readiness.test.ts` — 8 cases: flag toggle, `app.listen` before migrations, gate exempts health, gate mounted before router.
- Full leave + boot suites green (**115 cases**). Server entry **esbuild-bundles clean** (the exact `build.ts` server step). `typecheck:libs` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)