### PR TITLE
feat(recurring): monthly-batch billing setting for commercial accounts

### DIFF
--- a/artifacts/api-server/src/lib/recurring-jobs.ts
+++ b/artifacts/api-server/src/lib/recurring-jobs.ts
@@ -285,6 +285,12 @@ type ScheduleInput = {
   scheduled_time?: string | null;
   duration_minutes: number | null;
   base_fee: string | null;
+  // [monthly-batch-billing] Commercial accounts billed once a month. When
+  // monthly_charge_mode='auto_first_visit', the engine drops monthly_charge_amount
+  // on the first visit of each calendar month and $0 on the rest. 'manual'
+  // (default) leaves base_fee as the per-visit price.
+  monthly_charge_amount?: string | null;
+  monthly_charge_mode?: string | null;
   // [legacy-pricing-pin 2026-06-20] When the schedule's agreed price is manually
   // pinned (grandfathered / unreproducible by the current catalog — e.g. the
   // MaidCentral import has no sqft, so the sqft-tier engine can't recompute it),
@@ -374,6 +380,25 @@ export async function computeOccurrencesForSchedule(
   const parkingEnabled = !!schedule.parking_fee_enabled;
   const parkingDays: number[] | null = schedule.parking_fee_days ?? null;
 
+  // [monthly-batch-billing] 'auto_first_visit' mode: drop the monthly lump on
+  // the first occurrence of each calendar month and $0 on the rest. 'manual'
+  // (default) leaves base_fee as the schedule's per-visit price. The first-of-
+  // month set is derived from ALL occurrences in the window (not just the
+  // not-yet-existing ones) so the lump lands on the true first visit. (Caveat:
+  // if a window starts mid-month after that month's first visit already exists,
+  // the existing visit already carries the decision — we don't re-stamp it.)
+  const autoMonthly =
+    schedule.monthly_charge_mode === "auto_first_visit" && schedule.monthly_charge_amount != null;
+  const firstOfMonth = new Set<string>();
+  if (autoMonthly) {
+    const seenMonths = new Set<string>();
+    for (const d of [...occurrences].sort((a, b) => a.getTime() - b.getTime())) {
+      const key = `${d.getFullYear()}-${d.getMonth()}`;
+      if (!seenMonths.has(key)) { seenMonths.add(key); firstOfMonth.add(toDateStr(d)); }
+    }
+  }
+  const monthlyLump = autoMonthly ? parseFloat(schedule.monthly_charge_amount!).toFixed(2) : "0.00";
+
   const rows = toInsert.map(d => {
     const dow = d.getDay(); // 0=Sun..6=Sat
     const parkingApplies = parkingEnabled && (parkingDays == null || parkingDays.includes(dow));
@@ -387,7 +412,9 @@ export async function computeOccurrencesForSchedule(
       occurrence_date: toDateStr(d),
       scheduled_time: (schedule.scheduled_time ?? null) as any,
       frequency: mapFrequency(schedule.frequency) as any,
-      base_fee: schedule.base_fee ? String(parseFloat(schedule.base_fee).toFixed(2)) : "0.00",
+      base_fee: autoMonthly
+        ? (firstOfMonth.has(toDateStr(d)) ? monthlyLump : "0.00")
+        : (schedule.base_fee ? String(parseFloat(schedule.base_fee).toFixed(2)) : "0.00"),
       // [legacy-pricing-pin 2026-06-20] Carry the schedule's pin onto the job so
       // a pinned agreed price stays sticky on future occurrences.
       manual_rate_override: !!schedule.manual_rate_override,

--- a/artifacts/api-server/src/routes/recurring.ts
+++ b/artifacts/api-server/src/routes/recurring.ts
@@ -173,6 +173,36 @@ router.put("/:id", requireAuth, requireRole("owner", "admin", "office"), async (
   }
 });
 
+// PATCH /api/recurring/:id/monthly-charge — configure monthly-batch billing for
+// commercial accounts that bill one lump per month (e.g. Bill Azzarello
+// $761.25/mo). Body: { amount?: number|null, mode: 'manual'|'auto_first_visit' }.
+//   'manual'           — generated visits are $0; office adds the lump by hand.
+//   'auto_first_visit' — engine drops `amount` on the first visit of each month.
+// This is the toggle behind Option A (manual, default) ↔ Option B (automatic).
+router.patch("/:id/monthly-charge", requireAuth, requireRole("owner", "admin", "office"), async (req, res) => {
+  try {
+    const id = parseInt(req.params.id);
+    const { amount, mode } = req.body as { amount?: number | string | null; mode?: string };
+    if (mode && mode !== "manual" && mode !== "auto_first_visit") {
+      return res.status(400).json({ error: "mode must be 'manual' or 'auto_first_visit'" });
+    }
+    const [row] = await db.update(recurringSchedulesTable)
+      // cast: @workspace/db dist types lag the source schema add of these two
+      // columns; runtime (tsx / Railway build) compiles the source fresh.
+      .set({
+        monthly_charge_amount: amount == null || amount === "" ? null : String(parseFloat(String(amount)).toFixed(2)),
+        ...(mode ? { monthly_charge_mode: mode } : {}),
+      } as any)
+      .where(and(eq(recurringSchedulesTable.id, id), eq(recurringSchedulesTable.company_id, req.auth!.companyId)))
+      .returning();
+    if (!row) return res.status(404).json({ error: "Not found" });
+    return res.json(row);
+  } catch (err) {
+    console.error("[recurring monthly-charge PATCH]", err);
+    return res.status(500).json({ error: "Server error" });
+  }
+});
+
 // GET /api/recurring/:id/occurrence-counts?exclude_job_id=N — counts of past
 // vs future jobs in the series, used by the edit-job-modal cascade picker
 // to show "Affects this + 63 future + 4 past" previews on each option.

--- a/lib/db/src/schema/recurring_schedules.ts
+++ b/lib/db/src/schema/recurring_schedules.ts
@@ -35,6 +35,16 @@ export const recurringSchedulesTable = pgTable("recurring_schedules", {
   service_type: text("service_type"),
   duration_minutes: integer("duration_minutes"),
   base_fee: text("base_fee"),
+  // [monthly-batch-billing 2026-06-24] Commercial accounts billed once a month
+  // (one visit carries the whole charge, the rest are $0 — e.g. Bill Azzarello
+  // $761.25/mo, 4009 Condo $416.76/mo). monthly_charge_amount holds that lump.
+  // monthly_charge_mode controls how the engine reproduces it:
+  //   'manual' (default)  — generate $0 visits; the office drops the lump on one
+  //                         visit by hand (the current MaidCentral/QuickBooks flow).
+  //   'auto_first_visit'  — engine puts monthly_charge_amount on the FIRST visit
+  //                         of each calendar month, $0 on the rest.
+  monthly_charge_amount: text("monthly_charge_amount"),
+  monthly_charge_mode: text("monthly_charge_mode").notNull().default("manual"),
   notes: text("notes"),
   is_active: boolean("is_active").notNull().default(true),
   last_generated_date: date("last_generated_date"),


### PR DESCRIPTION
## Why
Some commercial accounts bill **one lump per month** (one visit carries the whole charge, the rest are $0): Bill Azzarello $761.25/mo, 4009 Condo $416.76/mo, Wesl $350/mo, the two Bz condos $300/mo. A single per-visit `base_fee` can't represent that, so the recurring generator was producing wrong dollar amounts on these accounts.

## What
Two new columns on `recurring_schedules`:
- `monthly_charge_amount` — the monthly lump.
- `monthly_charge_mode` — `'manual'` (default) or `'auto_first_visit'`.

Engine (`computeOccurrencesForSchedule`): in **auto_first_visit** mode the generator drops `monthly_charge_amount` on the **first visit of each calendar month** and $0 on the rest. **manual** leaves `base_fee` as the per-visit price (office adds the lump by hand — current MaidCentral/QuickBooks flow).

This is the **Option A (manual) ↔ Option B (automatic)** toggle. New `PATCH /api/recurring/:id/monthly-charge` sets amount + mode per schedule.

## Data
Columns added to prod (additive). The 5 Phes commercial accounts seeded to **Option A**: $0 visits + stored monthly lump, mode=manual. 31 future Aug–Sep jobs zeroed to match.

## Notes
- recurring-jobs.ts typechecks clean. The route's Drizzle `.set()` is cast `as any` because the `@workspace/db` dist types lag the source column add (runtime compiles source fresh; same TS2769 pattern as the file's existing db calls).
- Caveat: auto_first_visit picks the first occurrence **in the generation window**; if a window starts mid-month after that month's first visit already exists, the existing visit keeps its decision (not re-stamped). Fine for the daily cron (windows roll in at month start).

Generated with Claude Code