### PR TITLE
feat(profile): Phase 2 — real clickable stat tiles + card polish (bars, reset countdown, waiting note)

### DIFF
--- a/artifacts/api-server/src/lib/leave-attendance-format.ts
+++ b/artifacts/api-server/src/lib/leave-attendance-format.ts
@@ -1,0 +1,58 @@
+/**
+ * Pure helpers for the attendance-summary endpoint (Phase 2). No DB — so the
+ * trickier bits (parsing unexcused hours out of the note marker, cleaning the
+ * note for display, picking the next disciplinary step) are unit-testable
+ * without the drizzle client. The DB query + assembly lives in routes/leave.ts.
+ */
+
+/** Discipline-type → human label (matches the dispatch/board conventions). */
+export const DISC_LABEL: Record<string, string> = {
+  tardy_warning: "Tardy warning",
+  absence_warning: "Written warning",
+  final_warning: "Final warning",
+  quality_probation: "Quality probation",
+  termination: "Termination review",
+  custom: "Discipline",
+};
+
+/** Unexcused hours live in the attendance_log note as "unexcused hours: X.XX"
+ *  (written by the ladder). Same regex the ladder reads back with. */
+export const UNEXCUSED_HOURS_RE = /unexcused hours:\s*([0-9.]+)/i;
+
+export function parseUnexcusedHours(notes: string | null): number {
+  const m = UNEXCUSED_HOURS_RE.exec(notes || "");
+  return m ? Number(m[1]) || 0 : 0;
+}
+
+/** Strip the "unexcused hours: X" marker (and wrapping parens) for display. */
+export function cleanUnexNote(notes: string | null): string {
+  return (
+    (notes || "")
+      .replace(/unexcused hours:\s*[0-9.]+/i, "")
+      .replace(/^\s*\(|\)\s*$/g, "")
+      .trim() || "Unexcused absence"
+  );
+}
+
+export type LadderStep = { threshold_hours?: number; window_days?: number; discipline_type?: string; label?: string };
+
+/** The lowest configured threshold the employee has NOT yet reached. Returns
+ *  null when no steps are configured or all are already crossed. */
+export function pickNextStep(
+  steps: ReadonlyArray<LadderStep>,
+  rollingHours: number,
+): { threshold: number; label: string } | null {
+  return steps
+    .map((s) => ({
+      threshold: Number(s?.threshold_hours),
+      label: s?.label || DISC_LABEL[String(s?.discipline_type)] || "Discipline",
+    }))
+    .filter((s) => s.threshold > 0)
+    .sort((a, b) => a.threshold - b.threshold)
+    .find((s) => s.threshold > rollingHours) || null;
+}
+
+/** Max rolling window across the configured steps, floored at `fallback`. */
+export function maxLadderWindow(steps: ReadonlyArray<LadderStep>, fallback: number): number {
+  return steps.reduce((m, s) => Math.max(m, Number(s?.window_days) || 0), fallback);
+}

--- a/artifacts/api-server/src/routes/leave.ts
+++ b/artifacts/api-server/src/routes/leave.ts
@@ -50,6 +50,8 @@ import {
   leaveBlackoutsTable,
   employeeAvailabilityTable,
   employeeLeaveUsageTable,
+  employeeAttendanceLogTable,
+  employeeDisciplineLogTable,
   companyLeavePolicyTable,
   usersTable,
 } from "@workspace/db/schema";
@@ -61,6 +63,14 @@ import {
   isPastWaitingPeriod,
   round2,
 } from "../lib/leave-balance.js";
+import { nextResetDate } from "../lib/leave-reset-format.js";
+import {
+  DISC_LABEL,
+  parseUnexcusedHours,
+  cleanUnexNote,
+  pickNextStep,
+  maxLadderWindow,
+} from "../lib/leave-attendance-format.js";
 import {
   checkRequestable,
   checkWaitingPeriod,
@@ -296,6 +306,8 @@ async function buildBalancesForUser(
     annual_cap_hours: number;
     waiting_period_days: number;
     past_waiting_period: boolean;
+    next_reset_date: string | null;
+    eligible_on: string | null;
   }>
 > {
   const buckets = await db
@@ -334,6 +346,19 @@ async function buildBalancesForUser(
     const past = hireDate
       ? isPastWaitingPeriod(hireDate, b.waiting_period_days, today)
       : false;
+    // Reset countdown + waiting-period note inputs (Phase 2 card polish).
+    // Flat-grant buckets reset on the work anniversary; office-recorded
+    // (Unexcused) never resets → null. eligible_on = hire + waiting period.
+    const nextReset =
+      b.accrual_mode === "flat_grant" && hireDate
+        ? nextResetDate(hireDate, today).toISOString().slice(0, 10)
+        : null;
+    let eligibleOn: string | null = null;
+    if (hireDate) {
+      const d = new Date(`${hireDate}T00:00:00Z`);
+      d.setUTCDate(d.getUTCDate() + (b.waiting_period_days || 0));
+      eligibleOn = d.toISOString().slice(0, 10);
+    }
     out.push({
       leave_type_id: b.id,
       display_name: b.display_name,
@@ -345,6 +370,8 @@ async function buildBalancesForUser(
       annual_cap_hours: Number(b.annual_cap_hours),
       waiting_period_days: b.waiting_period_days,
       past_waiting_period: past,
+      next_reset_date: nextReset,
+      eligible_on: eligibleOn,
     });
   }
   return out;
@@ -395,6 +422,147 @@ router.get("/usage", officeReadGate, async (req, res) => {
   const userId = Number(req.query.userId);
   if (!Number.isFinite(userId)) return bad(res, "userId required");
   const data = await buildUsageForUser(companyId, userId);
+  return res.json({ data });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Attendance summary (Phase 2) — real, clickable stat tiles + the Unexcused
+// disciplinary-ladder progress. Counts + per-day drill-down rows (date +
+// reason) over a rolling window, sourced from employee_attendance_log
+// (tardy/absent/ncns) + employee_leave_usage (pto/plawa note tags). Read-only.
+// ─────────────────────────────────────────────────────────────────────────────
+function ymdMinus(days: number): string {
+  return new Date(Date.now() - days * 86400000).toISOString().slice(0, 10);
+}
+
+async function buildAttendanceSummary(
+  companyId: number,
+  userId: number,
+  windowDays: number,
+) {
+  const to = new Date().toISOString().slice(0, 10);
+  const from = ymdMinus(windowDays);
+
+  const att = await db
+    .select({
+      log_date: employeeAttendanceLogTable.log_date,
+      type: employeeAttendanceLogTable.type,
+      notes: employeeAttendanceLogTable.notes,
+      is_protected: employeeAttendanceLogTable.protected,
+    })
+    .from(employeeAttendanceLogTable)
+    .where(
+      and(
+        eq(employeeAttendanceLogTable.company_id, companyId),
+        eq(employeeAttendanceLogTable.employee_id, userId),
+        gte(employeeAttendanceLogTable.log_date, from),
+      ),
+    )
+    .orderBy(desc(employeeAttendanceLogTable.log_date));
+
+  const usage = await buildUsageForUser(companyId, userId);
+  const usageInWindow = usage.filter(
+    (u) => String(u.date_used).slice(0, 10) >= from,
+  );
+
+  const dayRow = (date: any, reason: string, hours: number | null) => ({
+    date: String(date).slice(0, 10),
+    reason: (reason || "").trim(),
+    hours: hours != null ? round2(Number(hours)) : null,
+  });
+  const lateRows = att.filter((r) => r.type === "tardy").map((r) => dayRow(r.log_date, r.notes || "Late", null));
+  const absentRows = att.filter((r) => r.type === "absent" || r.type === "ncns").map((r) => dayRow(r.log_date, r.notes || "Absent", null));
+  const unexRows = att.filter((r) => r.type === "absent" && !r.is_protected).map((r) => dayRow(r.log_date, cleanUnexNote(r.notes), parseUnexcusedHours(r.notes)));
+  const ptoRows = usageInWindow.filter((u) => String(u.notes || "").includes("/pto")).map((u) => dayRow(u.date_used, String(u.notes || ""), Number(u.hours)));
+  const sickRows = usageInWindow.filter((u) => String(u.notes || "").includes("/plawa")).map((u) => dayRow(u.date_used, String(u.notes || ""), Number(u.hours)));
+  const timeOffRows = usageInWindow.map((u) => dayRow(u.date_used, String(u.notes || ""), Number(u.hours)));
+
+  const tile = (rows: Array<{ hours: number | null }>) => ({
+    count: rows.length,
+    hours: round2(rows.reduce((s, r) => s + (r.hours || 0), 0)),
+    days: rows,
+  });
+
+  // Unexcused disciplinary ladder (LMS-rule thresholds). The
+  // unexcused_hours_steps column may not exist yet in every tenant DB — read
+  // defensively so the tile degrades to a plain count until it's configured.
+  let steps: any[] = [];
+  try {
+    const r = await db.execute(
+      sql`SELECT unexcused_hours_steps FROM company_attendance_policy WHERE company_id = ${companyId} LIMIT 1`,
+    );
+    steps = ((r.rows[0] as any)?.unexcused_hours_steps as any[]) || [];
+  } catch {
+    steps = [];
+  }
+  const maxWindow = maxLadderWindow(steps, windowDays);
+  const ladderFrom = ymdMinus(maxWindow);
+  const rollingHours = round2(
+    att
+      .filter((r) => r.type === "absent" && !r.is_protected && String(r.log_date).slice(0, 10) >= ladderFrom)
+      .reduce((s, r) => s + parseUnexcusedHours(r.notes), 0),
+  );
+  const nextStep = pickNextStep(steps, rollingHours);
+
+  const disc = await db
+    .select({
+      discipline_type: employeeDisciplineLogTable.discipline_type,
+      custom_label: employeeDisciplineLogTable.custom_label,
+    })
+    .from(employeeDisciplineLogTable)
+    .where(
+      and(
+        eq(employeeDisciplineLogTable.company_id, companyId),
+        eq(employeeDisciplineLogTable.employee_id, userId),
+        eq(employeeDisciplineLogTable.dismissed, false),
+      ),
+    )
+    .orderBy(desc(employeeDisciplineLogTable.effective_date))
+    .limit(1);
+  const currentDiscipline = disc[0]
+    ? { label: disc[0].custom_label || DISC_LABEL[disc[0].discipline_type] || "Discipline" }
+    : null;
+
+  return {
+    window_days: windowDays,
+    from,
+    to,
+    tiles: {
+      late: tile(lateRows),
+      absent: tile(absentRows),
+      unexcused: tile(unexRows),
+      time_off: tile(timeOffRows),
+      sick: tile(sickRows),
+      pto: tile(ptoRows),
+    },
+    unexcused: {
+      rolling_hours: rollingHours,
+      window_days: maxWindow,
+      next_step: nextStep,
+      current_discipline: currentDiscipline,
+    },
+  };
+}
+
+function parseWindowDays(q: unknown): number {
+  const n = Number(q);
+  return [30, 90, 180, 365].includes(n) ? n : 180;
+}
+
+router.get("/attendance-summary/me", async (req, res) => {
+  const data = await buildAttendanceSummary(
+    req.auth!.companyId!,
+    req.auth!.userId!,
+    parseWindowDays(req.query.windowDays),
+  );
+  return res.json({ data });
+});
+
+router.get("/attendance-summary", officeReadGate, async (req, res) => {
+  const companyId = req.auth!.companyId!;
+  const userId = Number(req.query.userId);
+  if (!Number.isFinite(userId)) return bad(res, "userId required");
+  const data = await buildAttendanceSummary(companyId, userId, parseWindowDays(req.query.windowDays));
   return res.json({ data });
 });
 

--- a/artifacts/api-server/src/tests/leave-attendance-format.test.ts
+++ b/artifacts/api-server/src/tests/leave-attendance-format.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Attendance-summary pure helpers (Phase 2, Sal 2026-06-24).
+ * Hours-parse + note-cleanup + disciplinary next-step selection.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  parseUnexcusedHours,
+  cleanUnexNote,
+  pickNextStep,
+  maxLadderWindow,
+} from "../lib/leave-attendance-format.js";
+
+describe("parseUnexcusedHours", () => {
+  it("reads the ladder marker", () => {
+    assert.equal(parseUnexcusedHours("unexcused hours: 4.00 (left early)"), 4);
+    assert.equal(parseUnexcusedHours("unexcused hours: 8"), 8);
+  });
+  it("0 when no marker / null", () => {
+    assert.equal(parseUnexcusedHours("just a note"), 0);
+    assert.equal(parseUnexcusedHours(null), 0);
+  });
+});
+
+describe("cleanUnexNote", () => {
+  it("strips the marker + parens for display", () => {
+    assert.equal(cleanUnexNote("unexcused hours: 4.00 (no call)"), "no call");
+  });
+  it("falls back when only the marker is present", () => {
+    assert.equal(cleanUnexNote("unexcused hours: 4.00"), "Unexcused absence");
+    assert.equal(cleanUnexNote(null), "Unexcused absence");
+  });
+});
+
+describe("pickNextStep — LMS-rule disciplinary ladder", () => {
+  const steps = [
+    { threshold_hours: 16, window_days: 90, discipline_type: "final_warning" },
+    { threshold_hours: 8, window_days: 90, discipline_type: "absence_warning" },
+    { threshold_hours: 24, window_days: 90, discipline_type: "termination" },
+  ];
+  it("picks the lowest threshold not yet reached", () => {
+    assert.deepEqual(pickNextStep(steps, 0), { threshold: 8, label: "Written warning" });
+    assert.deepEqual(pickNextStep(steps, 8), { threshold: 16, label: "Final warning" });
+    assert.deepEqual(pickNextStep(steps, 20), { threshold: 24, label: "Termination review" });
+  });
+  it("null when all crossed or no steps configured", () => {
+    assert.equal(pickNextStep(steps, 30), null);
+    assert.equal(pickNextStep([], 0), null);
+  });
+  it("honors a custom label override", () => {
+    assert.deepEqual(
+      pickNextStep([{ threshold_hours: 8, discipline_type: "custom", label: "Coaching" }], 0),
+      { threshold: 8, label: "Coaching" },
+    );
+  });
+});
+
+describe("maxLadderWindow", () => {
+  it("max window across steps, floored at fallback", () => {
+    assert.equal(maxLadderWindow([{ window_days: 90 }, { window_days: 30 }], 180), 180);
+    assert.equal(maxLadderWindow([{ window_days: 365 }], 180), 365);
+    assert.equal(maxLadderWindow([], 180), 180);
+  });
+});

--- a/artifacts/qleno/src/pages/employee-profile.tsx
+++ b/artifacts/qleno/src/pages/employee-profile.tsx
@@ -86,13 +86,27 @@ function leaveBucketTag(slug: string): string {
   if (s.includes('unexcused')) return '/unexcused';
   return '/' + s;
 }
-function leaveBucketColors(slug: string): { bg: string; fg: string } {
+// Dispatch-board-consistent accent palette. White card + colored left bar /
+// dot / label / number in this accent. (Phase 3 will source these per-tenant.)
+function leaveBucketAccent(slug: string): string {
   const s = (slug || '').toLowerCase();
-  if (s.includes('plawa') || s.includes('sick')) return { bg: '#FEF3C7', fg: '#92400E' };
-  if (s.includes('pto')) return { bg: 'var(--brand-dim)', fg: 'var(--brand)' };
-  if (s.includes('unpaid')) return { bg: '#EEF2F7', fg: '#334155' };
-  if (s.includes('unexcused')) return { bg: '#FCE7E7', fg: '#991B1B' };
-  return { bg: '#F3F4F6', fg: '#374151' };
+  if (s.includes('plawa') || s.includes('sick')) return '#378ADD'; // blue
+  if (s.includes('pto')) return '#1D9E75';                          // green
+  if (s.includes('unpaid')) return '#BA7517';                       // amber
+  if (s.includes('unexcused')) return '#E24B4A';                    // red
+  return '#374151';
+}
+const LEAVE_LOW = '#BA7517';  // amber — running low
+const LEAVE_OUT = '#E24B4A';  // red — exhausted / step crossed
+// Days until a YYYY-MM-DD date (UTC), and a "Mon DD" label.
+function daysUntilYmd(ymd: string): number {
+  const t = new Date(`${ymd}T00:00:00Z`).getTime();
+  const today = new Date(new Date().toISOString().slice(0, 10) + 'T00:00:00Z').getTime();
+  return Math.round((t - today) / 86400000);
+}
+function shortDate(ymd: string): string {
+  const d = new Date(`${ymd}T00:00:00Z`);
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' });
 }
 
 const PAY_GROUPS: { label: string; types: string[] }[] = [
@@ -561,6 +575,16 @@ export default function EmployeeProfilePage() {
     enabled: activeTab === 'Attendance',
   });
   const leaveUsage: any[] = leaveUsageResp?.data || [];
+
+  // [Phase 2] Real attendance stats + per-day drill-downs. Default 180-day
+  // window (the API accepts windowDays 30/90/180/365 for a future selector).
+  const [statDrill, setStatDrill] = useState<null | { label: string; days: any[] }>(null);
+  const { data: attnSummaryResp } = useQuery({
+    queryKey: ['attendance-summary', userId],
+    queryFn: () => apiFetch(`/leave/attendance-summary?userId=${userId}&windowDays=180`),
+    enabled: activeTab === 'Attendance',
+  });
+  const attnSummary: any = attnSummaryResp?.data || null;
 
   const { data: ticketsData, refetch: refetchTickets } = useQuery({
     queryKey: ['contact-tickets', userId],
@@ -1166,27 +1190,84 @@ export default function EmployeeProfilePage() {
                   </div>
                 )}
                 {leaveBuckets.map((b: any) => {
-                  const c = leaveBucketColors(b.slug);
+                  const accent = leaveBucketAccent(b.slug);
                   const officeRecorded = b.accrual_mode === 'office_recorded';
                   const notVested = !officeRecorded && !b.past_waiting_period;
-                  const bigNum = officeRecorded ? Number(b.used || 0) : Number(b.available || 0);
+                  const granted = Number(b.granted || 0);
+                  const used = Number(b.used || 0);
+                  const avail = Number(b.available || 0);
+                  const unex = officeRecorded ? (attnSummary?.unexcused || null) : null;
+
+                  // Big number + usage bar geometry + smart color.
+                  let bigNum = avail.toFixed(1);
+                  let bigLabel = 'hours available';
+                  let barPct = 0;
+                  let barColor = accent;
+                  let barCaption = '';
+                  if (officeRecorded) {
+                    const rolling = Number(unex?.rolling_hours || 0);
+                    const nextThresh = Number(unex?.next_step?.threshold || 0);
+                    bigNum = rolling.toFixed(1);
+                    bigLabel = 'hours recorded';
+                    if (nextThresh > 0) {
+                      barPct = Math.min(100, (rolling / nextThresh) * 100);
+                      barColor = barPct >= 100 ? LEAVE_OUT : barPct >= 60 ? LEAVE_LOW : accent;
+                      barCaption = `${rolling.toFixed(1)} of ${nextThresh} h to next discipline step`;
+                    } else {
+                      barCaption = 'No disciplinary thresholds set';
+                    }
+                  } else {
+                    barPct = granted > 0 ? Math.min(100, (used / granted) * 100) : 0;
+                    barColor = avail <= 0 ? LEAVE_OUT : (granted > 0 && avail <= 0.2 * granted) ? LEAVE_LOW : accent;
+                    barCaption = `${used.toFixed(1)} used · ${avail.toFixed(1)} left · of ${granted.toFixed(1)} granted`;
+                  }
+                  const resetDays = !officeRecorded && b.next_reset_date ? daysUntilYmd(b.next_reset_date) : null;
+                  const eligDays = b.eligible_on ? daysUntilYmd(b.eligible_on) : null;
+
                   return (
-                    <div key={b.leave_type_id} style={{ background:c.bg, borderRadius:10, padding:'14px 16px' }}>
-                      <p style={{ fontSize:12,fontWeight:700,color:c.fg,margin:'0 0 2px 0',textTransform:'uppercase',letterSpacing:'0.04em' }}>{b.display_name}</p>
-                      <div style={{ display:'flex',alignItems:'baseline',gap:6 }}>
-                        <span style={{ fontSize:30,fontWeight:800,color:c.fg,lineHeight:1.1 }}>{notVested ? '—' : bigNum.toFixed(1)}</span>
-                        <span style={{ fontSize:12,color:c.fg,opacity:0.8 }}>{officeRecorded ? 'hours recorded' : 'hours available'}</span>
+                    <div key={b.leave_type_id} style={{ background:'#FFFFFF', border:'1px solid #E5E2DC', borderLeft:`4px solid ${accent}`, borderRadius:10, padding:'14px 16px' }}>
+                      <div style={{ display:'flex', justifyContent:'space-between', alignItems:'center', gap:8 }}>
+                        <div style={{ display:'flex', alignItems:'center', gap:7, minWidth:0 }}>
+                          <span style={{ width:9, height:9, borderRadius:'50%', background:accent, flexShrink:0 }} />
+                          <span style={{ fontSize:12, fontWeight:700, color:accent, textTransform:'uppercase', letterSpacing:'0.04em' }}>{b.display_name}</span>
+                        </div>
+                        {resetDays != null && resetDays >= 0 && !notVested && (
+                          <span style={{ fontSize:10.5, color:'#9E9B94', whiteSpace:'nowrap' }}>resets in {resetDays}d · {shortDate(b.next_reset_date)}</span>
+                        )}
                       </div>
-                      <p style={{ fontSize:11,color:c.fg,opacity:0.75,margin:'4px 0 0 0' }}>
-                        {notVested
-                          ? 'Eligible after waiting period'
-                          : officeRecorded
-                            ? `${Number(b.used||0).toFixed(1)} h recorded this period`
-                            : `${Number(b.granted||0).toFixed(1)} granted · ${Number(b.used||0).toFixed(1)} used`}
-                      </p>
+
+                      {notVested ? (
+                        <div style={{ marginTop:8 }}>
+                          <p style={{ fontSize:14, fontWeight:700, color:accent, margin:0 }}>
+                            {eligDays != null && eligDays > 0 ? `Unlocks in ${eligDays} day${eligDays === 1 ? '' : 's'}` : 'Eligible after waiting period'}
+                          </p>
+                          {b.eligible_on && eligDays != null && eligDays > 0 && (
+                            <p style={{ fontSize:11, color:'#9E9B94', margin:'2px 0 0 0' }}>{b.display_name} available {shortDate(b.eligible_on)}</p>
+                          )}
+                        </div>
+                      ) : (
+                        <>
+                          <div style={{ display:'flex', alignItems:'baseline', gap:6, marginTop:6 }}>
+                            <span style={{ fontSize:30, fontWeight:800, color:accent, lineHeight:1.1 }}>{bigNum}</span>
+                            <span style={{ fontSize:12, color:'#6B6860' }}>{bigLabel}</span>
+                            {officeRecorded && unex?.current_discipline && (
+                              <span style={{ marginLeft:'auto', fontSize:10.5, fontWeight:700, color:'#FFFFFF', background:LEAVE_OUT, borderRadius:99, padding:'2px 8px', whiteSpace:'nowrap' }}>{unex.current_discipline.label}</span>
+                            )}
+                          </div>
+                          {/* usage / progress bar */}
+                          <div style={{ height:6, borderRadius:99, background:'#EEEDEA', marginTop:8, overflow:'hidden' }}>
+                            <div style={{ height:'100%', width:`${barPct}%`, background:barColor, borderRadius:99, transition:'width 0.3s ease' }} />
+                          </div>
+                          <p style={{ fontSize:11, color:'#6B6860', margin:'5px 0 0 0' }}>{barCaption}</p>
+                          {!officeRecorded && (
+                            <p style={{ fontSize:11, color:'#9E9B94', margin:'2px 0 0 0' }}>{used.toFixed(1)} hrs taken this year</p>
+                          )}
+                        </>
+                      )}
+
                       <div style={{ display:'flex', gap:8, marginTop:10 }}>
-                        <button onClick={() => setHistoryBucket({ slug:b.slug, display_name:b.display_name })} style={{ flex:1,padding:'6px 0',border:`1px solid ${c.fg}`,borderRadius:6,fontSize:12,color:c.fg,background:'none',cursor:'pointer',fontFamily:'inherit' }}>View History</button>
-                        <button style={{ flex:1,padding:'6px 0',background:c.fg,border:'none',borderRadius:6,fontSize:12,color:'#FFFFFF',cursor:'pointer',fontFamily:'inherit' }}>Update</button>
+                        <button onClick={() => setHistoryBucket({ slug:b.slug, display_name:b.display_name })} style={{ flex:1,padding:'6px 0',border:`1px solid ${accent}`,borderRadius:6,fontSize:12,color:accent,background:'none',cursor:'pointer',fontFamily:'inherit' }}>View History</button>
+                        <button style={{ flex:1,padding:'6px 0',background:accent,border:'none',borderRadius:6,fontSize:12,color:'#FFFFFF',cursor:'pointer',fontFamily:'inherit' }}>Update</button>
                       </div>
                     </div>
                   );
@@ -1222,27 +1303,61 @@ export default function EmployeeProfilePage() {
                 })()}
 
                 <div style={{ background:'#FFFFFF', border:'1px solid #E5E2DC', borderRadius:10, padding:'14px 16px' }}>
-                  <div style={{ display:'flex', justifyContent:'space-between', alignItems:'center', marginBottom:12 }}>
-                    <p style={{ fontSize:13,fontWeight:700,color:'#1A1917',margin:0 }}>Stats — Last 180 Days</p>
+                  <div style={{ display:'flex', justifyContent:'space-between', alignItems:'center', marginBottom:8 }}>
+                    <p style={{ fontSize:13,fontWeight:700,color:'#1A1917',margin:0 }}>Attendance — Last 180 Days</p>
                   </div>
-                  {[
-                    {label:'Scheduled', value: user.total_jobs || 0},
-                    {label:'Worked', value: Math.round((user.total_jobs||0)*0.88)},
-                    {label:'Absent', value: 11, pct:'8%'},
-                    {label:'Time Off', value: 9, pct:'6%'},
-                    {label:'Excused', value: 0, pct:'0%'},
-                    {label:'Unexcused', value: 2, pct:'1%'},
-                    {label:'Paid Time Off', value: 3, pct:'2%'},
-                    {label:'Sick', value: 4, pct:'3%'},
-                    {label:'Late', value: 6, pct:'5%'},
-                    {label:'Score', value: scorePct != null ? `${scorePct.toFixed(0)}%` : '—'},
-                  ].map(row => (
-                    <div key={row.label} style={{ display:'flex', justifyContent:'space-between', alignItems:'center', padding:'5px 0', borderBottom:'1px solid #F3F4F6' }}>
-                      <span style={{ fontSize:12,color:'#6B7280' }}>{row.label}</span>
-                      <span style={{ fontSize:12,fontWeight:600,color:'#1A1917' }}>{row.value}{row.pct ? ` (${row.pct})` : ''}</span>
-                    </div>
-                  ))}
+                  {(() => {
+                    const t = attnSummary?.tiles;
+                    const rows: Array<{ label:string; value:any; days?:any[] }> = [
+                      { label:'Scheduled', value: user.total_jobs || 0 },
+                      { label:'Late', value: t?.late?.count ?? 0, days: t?.late?.days },
+                      { label:'Absent', value: t?.absent?.count ?? 0, days: t?.absent?.days },
+                      { label:'Unexcused', value: t?.unexcused?.count ?? 0, days: t?.unexcused?.days },
+                      { label:'Time Off', value: t?.time_off?.count ?? 0, days: t?.time_off?.days },
+                      { label:'Paid Time Off', value: t?.pto?.count ?? 0, days: t?.pto?.days },
+                      { label:'Sick', value: t?.sick?.count ?? 0, days: t?.sick?.days },
+                      { label:'Score', value: scorePct != null ? `${scorePct.toFixed(0)}%` : '—' },
+                    ];
+                    return rows.map(row => {
+                      const clickable = Array.isArray(row.days);
+                      const hasRows = clickable && (row.days as any[]).length > 0;
+                      return (
+                        <div key={row.label}
+                          onClick={hasRows ? () => setStatDrill({ label: row.label, days: row.days as any[] }) : undefined}
+                          style={{ display:'flex', justifyContent:'space-between', alignItems:'center', padding:'6px 0', borderBottom:'1px solid #F3F4F6', cursor: hasRows ? 'pointer' : 'default' }}>
+                          <span style={{ fontSize:12, color: hasRows ? 'var(--brand)' : '#6B7280' }}>{row.label}</span>
+                          <span style={{ fontSize:12, fontWeight:600, color:'#1A1917' }}>{row.value}{hasRows ? ' ›' : ''}</span>
+                        </div>
+                      );
+                    });
+                  })()}
+                  {!attnSummary && (
+                    <p style={{ fontSize:11, color:'#9E9B94', margin:'8px 0 0 0' }}>Loading…</p>
+                  )}
                 </div>
+
+                {/* [Phase 2] Stat-tile day-level drill-down (date + reason) */}
+                {statDrill && (
+                  <div onClick={() => setStatDrill(null)} style={{ position:'fixed',inset:0,background:'rgba(0,0,0,0.4)',display:'flex',alignItems:'center',justifyContent:'center',zIndex:1000 }}>
+                    <div onClick={e => e.stopPropagation()} style={{ background:'#FFFFFF',borderRadius:12,padding:24,width:560,maxWidth:'92vw',maxHeight:'80vh',overflowY:'auto',boxShadow:'0 20px 60px rgba(0,0,0,0.2)' }}>
+                      <div style={{ display:'flex',justifyContent:'space-between',alignItems:'center',marginBottom:16 }}>
+                        <h3 style={{ margin:0,fontSize:16,fontWeight:700,color:'#1A1917' }}>{statDrill.label} — last 180 days</h3>
+                        <button onClick={() => setStatDrill(null)} style={{ border:'none',background:'none',fontSize:22,lineHeight:1,cursor:'pointer',color:'#9E9B94' }}>×</button>
+                      </div>
+                      {statDrill.days.length === 0 ? (
+                        <p style={{ color:'#9E9B94',fontSize:13,margin:0 }}>No {statDrill.label.toLowerCase()} days recorded.</p>
+                      ) : statDrill.days.map((d: any, i: number) => (
+                        <div key={i} style={{ display:'flex',justifyContent:'space-between',gap:12,padding:'10px 0',borderTop: i ? '1px solid #E5E2DC' : 'none' }}>
+                          <div style={{ minWidth:0 }}>
+                            <div style={{ fontSize:13,fontWeight:600,color:'#1A1917' }}>{shortDate(String(d.date))} · {String(d.date)}</div>
+                            <div style={{ fontSize:12,color:'#6B6860' }}>{d.reason || '—'}</div>
+                          </div>
+                          {d.hours != null && <div style={{ fontSize:14,fontWeight:700,color:'#1A1917',whiteSpace:'nowrap' }}>{Number(d.hours).toFixed(2)} h</div>}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
               </div>
             </div>
           )}


### PR DESCRIPTION
**Phase 2 + card polish + add-ons** of the employee-profile redesign (order 1→2→4→3).

### Card polish (the Phase 1 bucket cards)
- **Recolor:** white cards, colored **left-accent bar + dot + label + big number** in the bucket accent (dispatch palette: PTO `#1D9E75`, PLAWA `#378ADD`, Unpaid `#BA7517`, Unexcused `#E24B4A`). Pastel fills gone.
- **Usage bar** per card: used vs granted in the bucket color → **amber when ≤20% left, red when exhausted**. Caption `X used · Y left · of Z granted`.
- **Unexcused** card tracks toward the next **LMS disciplinary step** (`company_attendance_policy.unexcused_hours_steps`), amber→red as it nears, and shows current status (e.g. "Final warning") from `employee_discipline_log`. Caption `X of N h to next discipline step`.
- **Reset countdown** per card (`resets in N days · Mon DD`, work-anniversary). **Waiting-period note** for new hires (`Unlocks in N days`) instead of a 0 card. **YTD** line (`X hrs taken this year`).

### Phase 2 — stat tiles
- New read-only **`GET /api/leave/attendance-summary(/me)?windowDays=`** — company-scoped, role-gated, default 180d (accepts 30/90/180/365 for a future selector). Returns per-tile counts + **per-day rows (date + reason)** for Late / Absent / Unexcused / Time-Off / Sick / PTO from `employee_attendance_log` + `employee_leave_usage`, plus the unexcused ladder data.
- Replaced the **fake hardcoded** stat tiles with real numbers; each populated tile is **clickable → day-list modal** (date + reason), same pattern as View History.
- Balances endpoint extended with `next_reset_date` + `eligible_on`.

### Scope notes
- Unexcused thresholds driven by the LMS-rule steps; `unexcused_hours_steps` is read **defensively** (absent in some tenant DBs today → tile degrades to a plain count until configured) — **no schema change**.
- **One-click request/approve from the card** is a WRITE action → left as a **fast-follow** per scope; the Update button stays a no-op placeholder.
- Read-only: no balance/usage/schema-destructive changes. The slug→color map remains the Phase-1 temporary that Phase 3 centralizes.

### Verification
Pure helpers split to `lib/leave-attendance-format.ts` (**8 tests**). `typecheck:libs` clean; server entry esbuild-bundles clean; **no new** `employee-profile.tsx` type errors; leave suite green (86). Will verify live on Norma (32) + a new-hire (Jose/Hilda) for the waiting-period note + click stat-tile drill-downs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)