### PR TITLE
feat(recurring): per-site scheduling for multi-building commercial

### DIFF
--- a/artifacts/api-server/src/lib/recurring-jobs.ts
+++ b/artifacts/api-server/src/lib/recurring-jobs.ts
@@ -291,6 +291,15 @@ type ScheduleInput = {
   // (default) leaves base_fee as the per-visit price.
   monthly_charge_amount?: string | null;
   monthly_charge_mode?: string | null;
+  // [commercial-site-schedule] Per-site targeting for multi-building commercial.
+  // When set, stamped onto every generated job so each site carries its account
+  // link + address. NULL = ordinary single-location schedule (client address).
+  account_id?: number | null;
+  account_property_id?: number | null;
+  service_address_street?: string | null;
+  service_address_city?: string | null;
+  service_address_state?: string | null;
+  service_address_zip?: string | null;
   // [legacy-pricing-pin 2026-06-20] When the schedule's agreed price is manually
   // pinned (grandfathered / unreproducible by the current catalog — e.g. the
   // MaidCentral import has no sqft, so the sqft-tier engine can't recompute it),
@@ -422,7 +431,15 @@ export async function computeOccurrencesForSchedule(
       notes: schedule.notes ?? null,
       recurring_schedule_id: schedule.id,
       booking_location: (bookingLocation ?? null) as any,
-      address_zip: (clientZip ?? null) as any,
+      // [commercial-site-schedule] When the schedule targets a specific site,
+      // stamp its account link + address so each multi-building site's visits
+      // carry the right location. Otherwise leave the client-derived defaults.
+      account_id: (schedule.account_id ?? null) as any,
+      account_property_id: (schedule.account_property_id ?? null) as any,
+      address_street: (schedule.service_address_street ?? null) as any,
+      address_city: (schedule.service_address_city ?? null) as any,
+      address_state: (schedule.service_address_state ?? null) as any,
+      address_zip: (schedule.service_address_zip ?? clientZip ?? null) as any,
       // Sidecar — NOT a jobs column. Stripped in generateJobsFromSchedule
       // before the actual INSERT; passed through unchanged in dry-run.
       _parking_fee_applies: parkingApplies,

--- a/lib/db/src/schema/recurring_schedules.ts
+++ b/lib/db/src/schema/recurring_schedules.ts
@@ -45,6 +45,18 @@ export const recurringSchedulesTable = pgTable("recurring_schedules", {
   //                         of each calendar month, $0 on the rest.
   monthly_charge_amount: text("monthly_charge_amount"),
   monthly_charge_mode: text("monthly_charge_mode").notNull().default("manual"),
+  // [commercial-site-schedule 2026-06-24] Targets a specific commercial site.
+  // Multi-building accounts (KMA, Cucci, Daniel Walter PPM, Daveco) have one
+  // client/account with many service addresses, each on its own cadence — one
+  // schedule per site. When set, the engine stamps these onto every generated
+  // job so each site's visits carry the right account link + address. NULL on
+  // ordinary single-location schedules (the client's own address is used).
+  account_id: integer("account_id"),
+  account_property_id: integer("account_property_id"),
+  service_address_street: text("service_address_street"),
+  service_address_city: text("service_address_city"),
+  service_address_state: text("service_address_state"),
+  service_address_zip: text("service_address_zip"),
   notes: text("notes"),
   is_active: boolean("is_active").notNull().default(true),
   last_generated_date: date("last_generated_date"),


### PR DESCRIPTION
## Why
Multi-building commercial accounts (KMA, Cucci, Daniel Walter PPM, Daveco) have one client/account with many service addresses, each on its own cadence. The recurring engine was client-only, so these couldn't auto-generate — they only existed as the hand-made July jobs.

## What
Optional site-targeting columns on `recurring_schedules`: `account_id`, `account_property_id`, `service_address_{street,city,state,zip}`. When set, the generator stamps them onto every job so each site's recurring visits carry the right account link + address. NULL on ordinary schedules (client address used), so residential generation is unchanged and type-clean.

## Applied
Columns added to prod (additive). 3 single-site commercial accounts wired up immediately (Heritage, Jennifer Halper, Cucci 10410 Moody): schedules created, 55 Aug–Dec jobs generated, **0 duplicates** (anchored to August into empty space).

## Still needed to finish the rest (follow-up)
- **Account-based KMA + Cucci (10 sites)**: `recurring_schedules.customer_id` is NOT NULL but these have no client — needs that made nullable + engine handling for client-less account schedules.
- **Daniel Walter PPM + Daveco**: client-based but their July jobs lack distinct `address_street`, so per-site address + cadence/price must be specified to split the sites.

Generated with Claude Code