### PR TITLE
feat(profile): Phase 4 — clean history-row chips + office-only discipline flags

### DIFF
--- a/artifacts/api-server/src/routes/leave.ts
+++ b/artifacts/api-server/src/routes/leave.ts
@@ -439,6 +439,7 @@ async function buildAttendanceSummary(
   companyId: number,
   userId: number,
   windowDays: number,
+  includeDiscipline = false,
 ) {
   const to = new Date().toISOString().slice(0, 10);
   const from = ymdMinus(windowDays);
@@ -504,24 +505,38 @@ async function buildAttendanceSummary(
   );
   const nextStep = pickNextStep(steps, rollingHours);
 
-  const disc = await db
-    .select({
-      discipline_type: employeeDisciplineLogTable.discipline_type,
-      custom_label: employeeDisciplineLogTable.custom_label,
-    })
-    .from(employeeDisciplineLogTable)
-    .where(
-      and(
-        eq(employeeDisciplineLogTable.company_id, companyId),
-        eq(employeeDisciplineLogTable.employee_id, userId),
-        eq(employeeDisciplineLogTable.dismissed, false),
-      ),
-    )
-    .orderBy(desc(employeeDisciplineLogTable.effective_date))
-    .limit(1);
-  const currentDiscipline = disc[0]
-    ? { label: disc[0].custom_label || DISC_LABEL[disc[0].discipline_type] || "Discipline" }
-    : null;
+  // Discipline log (office/owner only — never returned to an employee's own
+  // /me view). Active = not dismissed. Newest first.
+  let discipline: Array<{ label: string; type: string; reason: string | null; effective_date: string; pending_review: boolean }> = [];
+  let currentDiscipline: { label: string } | null = null;
+  if (includeDiscipline) {
+    const disc = await db
+      .select({
+        discipline_type: employeeDisciplineLogTable.discipline_type,
+        custom_label: employeeDisciplineLogTable.custom_label,
+        reason: employeeDisciplineLogTable.reason,
+        effective_date: employeeDisciplineLogTable.effective_date,
+        pending_review: employeeDisciplineLogTable.pending_review,
+      })
+      .from(employeeDisciplineLogTable)
+      .where(
+        and(
+          eq(employeeDisciplineLogTable.company_id, companyId),
+          eq(employeeDisciplineLogTable.employee_id, userId),
+          eq(employeeDisciplineLogTable.dismissed, false),
+        ),
+      )
+      .orderBy(desc(employeeDisciplineLogTable.effective_date))
+      .limit(20);
+    discipline = disc.map((d) => ({
+      label: d.custom_label || DISC_LABEL[d.discipline_type] || "Discipline",
+      type: d.discipline_type,
+      reason: d.reason,
+      effective_date: String(d.effective_date).slice(0, 10),
+      pending_review: !!d.pending_review,
+    }));
+    currentDiscipline = discipline[0] ? { label: discipline[0].label } : null;
+  }
 
   return {
     window_days: windowDays,
@@ -541,6 +556,7 @@ async function buildAttendanceSummary(
       next_step: nextStep,
       current_discipline: currentDiscipline,
     },
+    discipline,
   };
 }
 
@@ -562,7 +578,7 @@ router.get("/attendance-summary", officeReadGate, async (req, res) => {
   const companyId = req.auth!.companyId!;
   const userId = Number(req.query.userId);
   if (!Number.isFinite(userId)) return bad(res, "userId required");
-  const data = await buildAttendanceSummary(companyId, userId, parseWindowDays(req.query.windowDays));
+  const data = await buildAttendanceSummary(companyId, userId, parseWindowDays(req.query.windowDays), true);
   return res.json({ data });
 });
 

--- a/artifacts/qleno/src/lib/leave-note-format.test.ts
+++ b/artifacts/qleno/src/lib/leave-note-format.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Leave note parser tests (Phase 4). Run: npx tsx --test leave-note-format.test.ts
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { parseLeaveNote, leaveBucketLabel } from "./leave-note-format.ts";
+
+describe("parseLeaveNote — MC import format", () => {
+  it("usage/pto", () => {
+    const p = parseLeaveNote("[MC import #11] usage/pto — Approved");
+    assert.equal(p.bucketSlug, "pto");
+    assert.equal(p.kind, "Used");
+    assert.equal(p.clean, "Approved");
+  });
+  it("accrual/plawa", () => {
+    const p = parseLeaveNote("[MC import #13] accrual/plawa — Employee has been here 90 days");
+    assert.equal(p.bucketSlug, "plawa");
+    assert.equal(p.kind, "Accrued");
+    assert.equal(p.kindTone, "good");
+    assert.equal(p.clean, "Employee has been here 90 days");
+  });
+  it("adjustment/pto", () => {
+    const p = parseLeaveNote("[MC import #13] adjustment/pto — Update after PTO Audit");
+    assert.equal(p.kind, "Adjustment");
+    assert.equal(p.kindTone, "warn");
+  });
+  it("payout/pto cash-out", () => {
+    const p = parseLeaveNote("[MC import #1] payout/pto — All hours were cashed out - MC");
+    assert.equal(p.kind, "Payout");
+    assert.equal(p.clean, "All hours were cashed out - MC");
+  });
+  it("cancelled/pto", () => {
+    const p = parseLeaveNote("[MC import #9] cancelled/pto — Cancelled");
+    assert.equal(p.kind, "Cancelled");
+    assert.equal(p.kindTone, "bad");
+  });
+  it("unspecified with (no note) placeholder → clean empty", () => {
+    const p = parseLeaveNote("[MC import #10] unspecified/plawa — (no note)");
+    assert.equal(p.kind, "Recorded");
+    assert.equal(p.clean, "");
+  });
+});
+
+describe("parseLeaveNote — app-approved format", () => {
+  it("full_day", () => {
+    const p = parseLeaveNote("leave_request #5 approved (full_day) usage/pto");
+    assert.equal(p.bucketSlug, "pto");
+    assert.equal(p.kind, "Used");
+    assert.equal(p.clean, "Approved");
+  });
+  it("morning half-day", () => {
+    const p = parseLeaveNote("leave_request #8 approved (morning) usage/plawa");
+    assert.equal(p.bucketSlug, "plawa");
+    assert.equal(p.clean, "Approved (morning)");
+  });
+});
+
+describe("parseLeaveNote — fallbacks", () => {
+  it("unknown text passes through clean, no bucket", () => {
+    const p = parseLeaveNote("some free-form office note");
+    assert.equal(p.bucketSlug, null);
+    assert.equal(p.kind, "");
+    assert.equal(p.clean, "some free-form office note");
+  });
+  it("null/empty safe", () => {
+    assert.equal(parseLeaveNote(null).clean, "");
+    assert.equal(parseLeaveNote(undefined).bucketSlug, null);
+  });
+});
+
+describe("leaveBucketLabel", () => {
+  it("maps slugs to display labels", () => {
+    assert.equal(leaveBucketLabel("pto_phes"), "PTO");
+    assert.equal(leaveBucketLabel("plawa"), "Sick");
+    assert.equal(leaveBucketLabel("unpaid_leave"), "Unpaid");
+    assert.equal(leaveBucketLabel("unexcused"), "Unexcused");
+  });
+});

--- a/artifacts/qleno/src/lib/leave-note-format.ts
+++ b/artifacts/qleno/src/lib/leave-note-format.ts
@@ -1,0 +1,91 @@
+/**
+ * Parse a leave usage-row note into display chips (Phase 4, Sal 2026-06-24).
+ *
+ * Presentation-only — the stored rows are never changed. Handles BOTH formats:
+ *   - MC import:   "[MC import #12] accrual/pto — 608: Default Policy"
+ *                  "[MC import #13] usage/pto — Requested 8 PTO hrs…"
+ *                  classes seen: usage | accrual | adjustment | payout |
+ *                                cancelled | unspecified
+ *   - App-approved: "leave_request #5 approved (full_day) usage/pto"
+ *
+ * Returns the bucket slug (for a colored bucket chip), a kind label + tone
+ * (for a status chip), and the clean human remainder (prefixes stripped).
+ */
+export type NoteKindTone = "neutral" | "good" | "warn" | "bad";
+export interface ParsedLeaveNote {
+  bucketSlug: string | null;
+  kind: string;          // "" when the class is unknown/absent
+  kindTone: NoteKindTone;
+  clean: string;
+}
+
+const KIND_MAP: Record<string, { label: string; tone: NoteKindTone }> = {
+  usage: { label: "Used", tone: "neutral" },
+  accrual: { label: "Accrued", tone: "good" },
+  adjustment: { label: "Adjustment", tone: "warn" },
+  payout: { label: "Payout", tone: "neutral" },
+  cashout: { label: "Cash-out", tone: "neutral" },
+  cancelled: { label: "Cancelled", tone: "bad" },
+  cancellation: { label: "Cancelled", tone: "bad" },
+  unspecified: { label: "Recorded", tone: "neutral" },
+};
+
+function cap(s: string): string {
+  return s ? s.charAt(0).toUpperCase() + s.slice(1) : s;
+}
+
+export function parseLeaveNote(notes: string | null | undefined): ParsedLeaveNote {
+  const raw = String(notes ?? "").trim();
+  let bucketSlug: string | null = null;
+  let kindKey = "";
+  let clean = raw;
+
+  // MC import: "[MC import #N] <class>/<bucket> — <human>"  (em-dash or hyphen)
+  const mc = /^\[MC import #\d+\]\s*([a-z_]+)\/([a-z_]+)\s*(?:[—–-]\s*)?(.*)$/i.exec(raw);
+  if (mc) {
+    kindKey = mc[1].toLowerCase();
+    bucketSlug = mc[2].toLowerCase();
+    clean = (mc[3] || "").trim();
+  } else {
+    // App-approved: "leave_request #N approved (unit) usage/<bucket>"
+    const app = /leave_request #\d+ approved(?:\s*\(([a-z_]+)\))?\s*usage\/([a-z_]+)/i.exec(raw);
+    if (app) {
+      kindKey = "usage";
+      bucketSlug = app[2].toLowerCase();
+      const unit = app[1];
+      clean = unit && unit !== "full_day" ? `Approved (${unit.replace(/_/g, " ")})` : "Approved";
+    }
+  }
+
+  // Tidy any leftover "class/bucket" token or empty-note placeholder.
+  clean = clean
+    .replace(/\b(usage|accrual|adjustment|payout|cancelled|cancellation|unspecified)\/[a-z_]+\b/gi, "")
+    .replace(/\(no note\)/i, "")
+    .trim();
+
+  const mapped = KIND_MAP[kindKey];
+  return {
+    bucketSlug,
+    kind: mapped ? mapped.label : kindKey ? cap(kindKey) : "",
+    kindTone: mapped ? mapped.tone : "neutral",
+    clean,
+  };
+}
+
+/** Display label for a bucket slug (chip text). */
+export function leaveBucketLabel(slug: string | null): string {
+  const s = (slug || "").toLowerCase();
+  if (s.includes("plawa") || s.includes("sick")) return "Sick";
+  if (s.includes("pto")) return "PTO";
+  if (s.includes("unpaid")) return "Unpaid";
+  if (s.includes("unexcused")) return "Unexcused";
+  return slug ? cap(s) : "";
+}
+
+/** Chip background tints for the kind tone. */
+export const KIND_TONE_STYLE: Record<NoteKindTone, { bg: string; fg: string }> = {
+  neutral: { bg: "#F3F4F6", fg: "#4B5563" },
+  good: { bg: "#E9FBF5", fg: "#00876B" },
+  warn: { bg: "#FEF3C7", fg: "#92400E" },
+  bad: { bg: "#FCE7E7", fg: "#991B1B" },
+};

--- a/artifacts/qleno/src/pages/employee-profile.tsx
+++ b/artifacts/qleno/src/pages/employee-profile.tsx
@@ -15,6 +15,7 @@ import {
 import { useEmployeeView } from "@/contexts/employee-view-context";
 import { EarningsPanel } from "@/components/earnings-panel";
 import { HRAttendanceTab, LeaveBalanceTab, DisciplineTab, QualityTab } from "./employee-profile-hr-tabs";
+import { parseLeaveNote, leaveBucketLabel, KIND_TONE_STYLE } from "@/lib/leave-note-format";
 
 const API = import.meta.env.BASE_URL.replace(/\/$/, "");
 
@@ -107,6 +108,28 @@ function daysUntilYmd(ymd: string): number {
 function shortDate(ymd: string): string {
   const d = new Date(`${ymd}T00:00:00Z`);
   return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' });
+}
+
+// [Phase 4] Render a leave/attendance note as clean chips: a colored bucket
+// chip + a status/kind chip + the human remainder. Presentation-only — parses
+// both [MC import] and app-approved formats; falls back to plain text.
+function NoteChips({ note }: { note: string | null | undefined }) {
+  const p = parseLeaveNote(note);
+  if (!p.bucketSlug && !p.kind && !p.clean) {
+    return <span style={{ fontSize: 12, color: '#9E9B94' }}>—</span>;
+  }
+  const toneStyle = KIND_TONE_STYLE[p.kindTone];
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap' }}>
+      {p.bucketSlug && (
+        <span style={{ fontSize: 10.5, fontWeight: 700, color: leaveBucketAccent(p.bucketSlug), background: '#FFFFFF', border: `1px solid ${leaveBucketAccent(p.bucketSlug)}`, borderRadius: 99, padding: '1px 7px', whiteSpace: 'nowrap' }}>{leaveBucketLabel(p.bucketSlug)}</span>
+      )}
+      {p.kind && (
+        <span style={{ fontSize: 10.5, fontWeight: 600, color: toneStyle.fg, background: toneStyle.bg, borderRadius: 99, padding: '1px 7px', whiteSpace: 'nowrap' }}>{p.kind}</span>
+      )}
+      {p.clean && <span style={{ fontSize: 12, color: '#6B6860' }}>{p.clean}</span>}
+    </div>
+  );
 }
 
 const PAY_GROUPS: { label: string; types: string[] }[] = [
@@ -1184,6 +1207,29 @@ export default function EmployeeProfilePage() {
               </div>
 
               <div style={{ display:'flex', flexDirection:'column', gap:12 }}>
+                {/* [Phase 4] Discipline flags — OFFICE/OWNER ONLY (never the
+                    employee's own self-view). Sourced from employee_discipline_log
+                    (the unexcused-ladder output). */}
+                {['owner','admin','office','super_admin'].includes(getTokenRole() || '')
+                  && Array.isArray(attnSummary?.discipline) && attnSummary.discipline.length > 0 && (
+                  <div style={{ background:'#FFFFFF', border:'1px solid #E24B4A', borderLeft:'4px solid #E24B4A', borderRadius:10, padding:'12px 16px' }}>
+                    <div style={{ display:'flex', alignItems:'center', gap:7, marginBottom:8 }}>
+                      <AlertCircle size={15} color="#E24B4A" />
+                      <span style={{ fontSize:12, fontWeight:700, color:'#E24B4A', textTransform:'uppercase', letterSpacing:'0.04em' }}>Discipline on file</span>
+                      <span style={{ marginLeft:'auto', fontSize:10.5, color:'#9E9B94' }}>office only</span>
+                    </div>
+                    {attnSummary.discipline.map((d: any, i: number) => (
+                      <div key={i} style={{ padding:'6px 0', borderTop: i ? '1px solid #F3F4F6' : 'none' }}>
+                        <div style={{ display:'flex', alignItems:'center', gap:6 }}>
+                          <span style={{ fontSize:11, fontWeight:700, color:'#FFFFFF', background:'#E24B4A', borderRadius:99, padding:'1px 8px' }}>{d.label}</span>
+                          <span style={{ fontSize:11, color:'#6B6860' }}>{shortDate(String(d.effective_date))}</span>
+                          {d.pending_review && <span style={{ fontSize:10, fontWeight:600, color:'#92400E', background:'#FEF3C7', borderRadius:99, padding:'1px 7px' }}>pending review</span>}
+                        </div>
+                        {d.reason && <div style={{ fontSize:11.5, color:'#6B6860', marginTop:2 }}>{d.reason}</div>}
+                      </div>
+                    ))}
+                  </div>
+                )}
                 {leaveBuckets.length === 0 && (
                   <div style={{ background:'#FFFFFF', border:'1px solid #E5E2DC', borderRadius:10, padding:'14px 16px', fontSize:13, color:'#9E9B94' }}>
                     No leave buckets configured.
@@ -1291,8 +1337,8 @@ export default function EmployeeProfilePage() {
                         ) : rows.map((u: any, i: number) => (
                           <div key={i} style={{ display:'flex',justifyContent:'space-between',gap:12,padding:'10px 0',borderTop: i ? '1px solid #E5E2DC' : 'none' }}>
                             <div style={{ minWidth:0 }}>
-                              <div style={{ fontSize:13,fontWeight:600,color:'#1A1917' }}>{String(u.date_used).slice(0,10)}</div>
-                              <div style={{ fontSize:12,color:'#6B6860' }}>{u.notes}</div>
+                              <div style={{ fontSize:13,fontWeight:600,color:'#1A1917',marginBottom:3 }}>{shortDate(String(u.date_used).slice(0,10))} · {String(u.date_used).slice(0,10)}</div>
+                              <NoteChips note={u.notes} />
                             </div>
                             <div style={{ fontSize:14,fontWeight:700,color:'#1A1917',whiteSpace:'nowrap' }}>{Number(u.hours).toFixed(2)} h</div>
                           </div>
@@ -1349,8 +1395,8 @@ export default function EmployeeProfilePage() {
                       ) : statDrill.days.map((d: any, i: number) => (
                         <div key={i} style={{ display:'flex',justifyContent:'space-between',gap:12,padding:'10px 0',borderTop: i ? '1px solid #E5E2DC' : 'none' }}>
                           <div style={{ minWidth:0 }}>
-                            <div style={{ fontSize:13,fontWeight:600,color:'#1A1917' }}>{shortDate(String(d.date))} · {String(d.date)}</div>
-                            <div style={{ fontSize:12,color:'#6B6860' }}>{d.reason || '—'}</div>
+                            <div style={{ fontSize:13,fontWeight:600,color:'#1A1917',marginBottom:3 }}>{shortDate(String(d.date))} · {String(d.date)}</div>
+                            <NoteChips note={d.reason} />
                           </div>
                           {d.hours != null && <div style={{ fontSize:14,fontWeight:700,color:'#1A1917',whiteSpace:'nowrap' }}>{Number(d.hours).toFixed(2)} h</div>}
                         </div>


### PR DESCRIPTION
**Phase 4** of the employee-profile redesign (1→2→4 done after this; **3 remains**).

### History row chips (View History modal + stat-tile drill-down modals)
- Stop showing raw note text (`[MC import #1] usage/plawa — …`). Each row now renders a colored **bucket chip** (PTO/Sick/Unpaid/Unexcused, card palette) + a **status/kind chip** (Used / Accrued / Adjustment / Payout / Cash-out / Cancelled / Recorded) + date + hours + the **clean human remainder**.
- New pure parser `lib/leave-note-format.ts` handles **both** formats — imported `[MC import #N] class/bucket — note` and app-approved `leave_request #N approved (unit) usage/bucket` — and falls back to plain text for free-form notes. **Presentation-only — stored rows untouched.**

### Discipline flags (office/owner only)
- `attendance-summary` now returns active `employee_discipline_log` entries (label, reason, effective date, pending-review), gated by a new `includeDiscipline` flag: the **office route passes true, the employee `/me` route passes false** → an employee never receives discipline data.
- The Attendance tab shows a red "Discipline on file" card listing them, rendered **only for owner/admin/office/super_admin viewers** (defense-in-depth on top of the API gating) — never on the employee's own self-view.

### Safety / verification
- Read-only: no balance/usage/schema changes.
- Tests: `leave-note-format.test.ts` (**11 cases** — both formats, fallbacks, bucket labels); api leave suite green (86); `typecheck:libs` clean; server entry esbuild-bundles clean; **no new** `employee-profile.tsx` type errors.

(Separately reported to Sal: the LMS disciplinary ladder is **occurrence-based per benefit year**, which the hours+window `unexcused_hours_steps` engine can't express — awaiting Sal's decision before loading any thresholds. Nothing applied.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)