### PR TITLE
feat(recurring): start cron from per-company flag, retire env kill-switch

### DIFF
--- a/artifacts/api-server/src/index.ts
+++ b/artifacts/api-server/src/index.ts
@@ -379,18 +379,39 @@ async function startup() {
     // Fire-and-forget: each task self-logs and is independently guarded.
     void runPostListenDataTasks();
 
-    const recurringEngineEnabled = process.env.RECURRING_ENGINE_ENABLED !== "false";
-    // [2026-04-22 J3] Startup invocation of runRecurringJobGeneration() removed —
-    // Railway restart cascades caused 5x concurrent engine runs on the
-    // 2026-04-22 overnight cron, creating 270 duplicate rows. The engine now
-    // only fires via the 2 AM cron registered below. Seed + PHES data migration
-    // already completed above (await chain before listen).
-    if (recurringEngineEnabled) {
-    startRecurringJobCron();
-    console.log("[recurring-engine] Cron started");
-  } else {
-    console.log("[recurring-engine] Cron DISABLED via RECURRING_ENGINE_ENABLED=false env var");
-  }
+    // [2026-06-24] Cron control moved to the per-company
+    // companies.recurring_engine_enabled flag — enforced per-tenant inside
+    // generateRecurringJobs() and guarded by a per-company advisory lock, so a
+    // running cron only ever generates for enabled tenants (Oak Lawn yes,
+    // Schaumburg no). The legacy RECURRING_ENGINE_ENABLED env kill-switch is
+    // retired now the phase/dedup fixes are in + audited.
+    // RECURRING_ENGINE_ENABLED=off still forces a hard global stop (break-glass).
+    // [2026-04-22 J3] Startup invocation of runRecurringJobGeneration() stays
+    // removed — Railway restart cascades caused 5x concurrent runs / 270 dup
+    // rows. The engine only fires via the 2 AM cron registered below.
+    void (async () => {
+      if (process.env.RECURRING_ENGINE_ENABLED === "off") {
+        console.log("[recurring-engine] Cron HARD-STOPPED via RECURRING_ENGINE_ENABLED=off");
+        return;
+      }
+      try {
+        const { db } = await import("@workspace/db");
+        const { companiesTable } = await import("@workspace/db/schema");
+        const { eq } = await import("drizzle-orm");
+        const enabled = await db
+          .select({ id: companiesTable.id })
+          .from(companiesTable)
+          .where(eq(companiesTable.recurring_engine_enabled, true));
+        if (enabled.length > 0) {
+          startRecurringJobCron();
+          console.log(`[recurring-engine] Cron started — ${enabled.length} tenant(s) enabled (DB flag)`);
+        } else {
+          console.log("[recurring-engine] Cron not started — no tenant has recurring_engine_enabled=true");
+        }
+      } catch (err) {
+        console.error("[recurring-engine] cron-start flag check failed — not starting:", err);
+      }
+    })();
 
   // [AI] Per-tenant engine flag visibility. Future sessions verifying the
   // disabled state can grep this line. Runs after migrations complete so

--- a/artifacts/api-server/src/routes/health.ts
+++ b/artifacts/api-server/src/routes/health.ts
@@ -46,7 +46,9 @@ router.get("/health", async (_req, res) => {
     deployed_at: DEPLOYED_AT,
     db: dbStatus,
     dispatch_autonomous_mode: process.env.DISPATCH_AUTONOMOUS_MODE === "true",
-    recurring_engine_enabled: process.env.RECURRING_ENGINE_ENABLED !== "false",
+    // [2026-06-24] Cron now starts unless hard-stopped (env=off); which tenants
+    // actually generate is the per-company recurring_engine_enabled DB flag.
+    recurring_engine_enabled: process.env.RECURRING_ENGINE_ENABLED !== "off",
     // Global comms master gate. Non-secret boolean (not the value of any
     // credential) — reports whether email/SMS are allowed to leave the box.
     comms_enabled: process.env.COMMS_ENABLED === "true",


### PR DESCRIPTION
Moves the recurring cron's on/off from the RECURRING_ENGINE_ENABLED env var (set 'false' during the buggy period) onto the per-company companies.recurring_engine_enabled flag, which generateRecurringJobs() already enforces per-tenant behind an advisory lock. A running cron only generates for enabled tenants (Oak Lawn yes, Schaumburg no). Boot starts the cron if any tenant has the flag on; RECURRING_ENGINE_ENABLED=off stays a hard break-glass. Turns the engine on for Oak Lawn (flag already true) with a DB-toggleable kill, no env change needed. tsc clean. Generated with Claude Code