### PR TITLE
feat(discipline): occurrence-based disciplinary ladder + load PHES ladder (co1+co4)

### DIFF
--- a/artifacts/api-server/src/cutover-data-migration.ts
+++ b/artifacts/api-server/src/cutover-data-migration.ts
@@ -61,6 +61,7 @@ export async function runCutoverDataMigration(): Promise<void> {
   }
   try {
     await seedPhesLeavePolicy3A();
+    await seedPhesOccurrenceLadders();
   } catch (err) {
     console.error(
       "[cutover-migration] Phes 3A leave policy seed failed (non-fatal):",
@@ -752,6 +753,72 @@ async function seedPhesLeavePolicy3A(): Promise<void> {
         use_it_or_lose_it_alert_lead_days = COALESCE(EXCLUDED.use_it_or_lose_it_alert_lead_days, company_leave_policy.use_it_or_lose_it_alert_lead_days),
         balance_ceiling_hours = COALESCE(EXCLUDED.balance_ceiling_hours, company_leave_policy.balance_ceiling_hours);
       RAISE NOTICE 'cutover-migration: ensured Phes 3A leave policy (work-anniversary reset)';
+    END
+    $$;
+  `),
+  );
+}
+
+/**
+ * PHES occurrence-based disciplinary ladders (Sal 2026-06-24, confirmed against
+ * the LMS "Phes Policies" module). Adds the two occurrence-step columns and
+ * seeds the ladder for co1 + co4: 3rd occurrence → written warning, 4th → final
+ * warning, 5th → termination — independently for unexcused absences and tardies,
+ * counted per Benefit Year. Seeds only when the column is empty so later office
+ * edits are never clobbered. (Tardy step 3 uses tardy_warning, unexcused step 3
+ * uses absence_warning; both render the label "Written warning".)
+ */
+async function seedPhesOccurrenceLadders(): Promise<void> {
+  const UNEXCUSED = JSON.stringify([
+    { occurrence: 3, discipline_type: "absence_warning", label: "Written warning", notify: true },
+    { occurrence: 4, discipline_type: "final_warning", label: "Final warning", notify: true },
+    { occurrence: 5, discipline_type: "termination", label: "Termination", notify: true },
+  ]);
+  const TARDY = JSON.stringify([
+    { occurrence: 3, discipline_type: "tardy_warning", label: "Written warning", notify: true },
+    { occurrence: 4, discipline_type: "final_warning", label: "Final warning", notify: true },
+    { occurrence: 5, discipline_type: "termination", label: "Termination", notify: true },
+  ]);
+  await db.execute(
+    sql.raw(`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = 'public' AND table_name = 'company_attendance_policy'
+      ) THEN
+        RAISE NOTICE 'cutover-migration: company_attendance_policy not present yet, skipping occurrence ladder';
+        RETURN;
+      END IF;
+
+      IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema='public' AND table_name='company_attendance_policy' AND column_name='unexcused_occurrence_steps'
+      ) THEN
+        ALTER TABLE company_attendance_policy ADD COLUMN unexcused_occurrence_steps jsonb DEFAULT '[]'::jsonb;
+      END IF;
+      IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema='public' AND table_name='company_attendance_policy' AND column_name='tardy_occurrence_steps'
+      ) THEN
+        ALTER TABLE company_attendance_policy ADD COLUMN tardy_occurrence_steps jsonb DEFAULT '[]'::jsonb;
+      END IF;
+
+      -- Ensure a policy row exists for co1 + co4 (no unique-constraint assumption).
+      INSERT INTO company_attendance_policy (company_id)
+        SELECT v FROM (VALUES (1),(4)) AS t(v)
+        WHERE NOT EXISTS (SELECT 1 FROM company_attendance_policy p WHERE p.company_id = t.v);
+
+      -- Seed the PHES ladders only where not already configured (never clobber edits).
+      UPDATE company_attendance_policy
+        SET unexcused_occurrence_steps = '${UNEXCUSED}'::jsonb
+        WHERE company_id IN (1,4)
+          AND (unexcused_occurrence_steps IS NULL OR unexcused_occurrence_steps = '[]'::jsonb);
+      UPDATE company_attendance_policy
+        SET tardy_occurrence_steps = '${TARDY}'::jsonb
+        WHERE company_id IN (1,4)
+          AND (tardy_occurrence_steps IS NULL OR tardy_occurrence_steps = '[]'::jsonb);
+      RAISE NOTICE 'cutover-migration: ensured PHES occurrence disciplinary ladders (3/4/5 → written/final/termination)';
     END
     $$;
   `),

--- a/artifacts/api-server/src/lib/unexcused-ladder-writer.ts
+++ b/artifacts/api-server/src/lib/unexcused-ladder-writer.ts
@@ -25,14 +25,18 @@ import {
   companyAttendancePolicyTable,
   employeeAttendanceLogTable,
   employeeDisciplineLogTable,
+  usersTable,
 } from "@workspace/db/schema";
 import { and, eq, gte, lte } from "drizzle-orm";
 import {
   evaluateLadder,
+  evaluateOccurrenceLadder,
   type LadderEvaluation,
   type UnexcusedStep,
   type UnexcusedEntry,
+  type OccurrenceStep,
 } from "./unexcused-ladder.js";
+import { benefitYearStartDate } from "./leave-grant-reset.js";
 
 /**
  * `tx` accepts the global db handle OR a transaction handle. Drizzle's
@@ -125,15 +129,28 @@ export async function recordUnexcusedEntryAndDriveLadder(
     .returning({ id: employeeAttendanceLogTable.id });
   const attendance_log_id = insertedLog[0]!.id;
 
-  // Drive the ladder. Pull the policy ladder + entries for the
-  // window-extent we need (max window_days across steps).
+  // Drive the ladder. Pull the policy ladders (occurrence + legacy hours).
   const policyRow = await tx
     .select({
       unexcused_hours_steps: companyAttendancePolicyTable.unexcused_hours_steps,
+      unexcused_occurrence_steps: companyAttendancePolicyTable.unexcused_occurrence_steps,
+      tardy_occurrence_steps: companyAttendancePolicyTable.tardy_occurrence_steps,
     })
     .from(companyAttendancePolicyTable)
     .where(eq(companyAttendancePolicyTable.company_id, args.company_id))
     .limit(1);
+
+  // [PHES occurrence ladder] If occurrence steps are configured for this
+  // incident kind, drive discipline off the per-Benefit-Year OCCURRENCE COUNT
+  // and return. Otherwise fall through to the legacy cumulative-hours ladder
+  // (so any tenant still on hours keeps working, and the 3B hours tests pass).
+  const kind: "tardy" | "unexcused" = args.type === "tardy" ? "tardy" : "unexcused";
+  const occSteps = (((kind === "tardy"
+    ? policyRow[0]?.tardy_occurrence_steps
+    : policyRow[0]?.unexcused_occurrence_steps) as OccurrenceStep[] | null) ?? []) as OccurrenceStep[];
+  if (occSteps.length > 0) {
+    return await driveOccurrenceLadder(tx, args, attendance_log_id, kind, occSteps);
+  }
   const steps = ((policyRow[0]?.unexcused_hours_steps as UnexcusedStep[] | null) ??
     []) as UnexcusedStep[];
   if (steps.length === 0) {
@@ -229,6 +246,115 @@ export async function recordUnexcusedEntryAndDriveLadder(
   return {
     attendance_log_id,
     ladder_eval: evalResult,
+    discipline_log_id: insertedDiscipline[0]?.id ?? null,
+    notification_sent,
+  };
+}
+
+/**
+ * Occurrence-based disciplinary ladder (PHES, Sal 2026-06-24).
+ *
+ * Counts INCIDENTS of one kind (unexcused absence OR tardy) within the
+ * employee's current Benefit Year (work anniversary — the same boundary the
+ * leave engine uses) and fires the matching discipline step. Idempotent per
+ * (kind, benefit-year, occurrence) via a reason marker; a new benefit year
+ * resets the counter so the same step can fire again next year.
+ */
+async function driveOccurrenceLadder(
+  tx: DbOrTx,
+  args: UnexcusedLadderArgs,
+  attendance_log_id: number,
+  kind: "tardy" | "unexcused",
+  steps: OccurrenceStep[],
+): Promise<UnexcusedLadderResult> {
+  const attType = kind === "tardy" ? "tardy" : "absent";
+  const marker = kind === "tardy" ? "tardy-occ" : "unexcused-occ";
+  const nullResult: UnexcusedLadderResult = {
+    attendance_log_id,
+    ladder_eval: { triggered_step: null, cumulative_hours: 0, as_of: args.log_date },
+    discipline_log_id: null,
+    notification_sent: false,
+  };
+
+  // Benefit-year window (work anniversary), reused from the leave engine.
+  const u = await tx
+    .select({ hire_date: usersTable.hire_date })
+    .from(usersTable)
+    .where(eq(usersTable.id, args.employee_id))
+    .limit(1);
+  const hireDate = u[0]?.hire_date ? String(u[0].hire_date).slice(0, 10) : args.log_date;
+  const byStart = benefitYearStartDate(hireDate, args.log_date).toISOString().slice(0, 10);
+
+  // Count this kind's NON-protected occurrences in the current benefit year
+  // (includes the row just inserted).
+  const rows = await tx
+    .select({
+      is_protected: employeeAttendanceLogTable.protected,
+    })
+    .from(employeeAttendanceLogTable)
+    .where(
+      and(
+        eq(employeeAttendanceLogTable.company_id, args.company_id),
+        eq(employeeAttendanceLogTable.employee_id, args.employee_id),
+        eq(employeeAttendanceLogTable.type, attType),
+        gte(employeeAttendanceLogTable.log_date, byStart),
+        lte(employeeAttendanceLogTable.log_date, args.log_date),
+      ),
+    );
+  const occurrenceCount = (rows as Array<{ is_protected: boolean | null }>).filter(
+    (r) => !r.is_protected,
+  ).length;
+
+  // Already-fired steps for THIS kind + THIS benefit year (idempotent).
+  const disc = await tx
+    .select({ reason: employeeDisciplineLogTable.reason })
+    .from(employeeDisciplineLogTable)
+    .where(
+      and(
+        eq(employeeDisciplineLogTable.company_id, args.company_id),
+        eq(employeeDisciplineLogTable.employee_id, args.employee_id),
+      ),
+    );
+  const fired = new Set<number>();
+  const re = new RegExp(`\\b${marker}\\s+s=(\\d+)\\s+by=${byStart}\\b`, "i");
+  for (const d of disc as Array<{ reason: string | null }>) {
+    const m = re.exec(d.reason ?? "");
+    if (m) fired.add(Number(m[1]));
+  }
+
+  const evalResult = evaluateOccurrenceLadder(steps, occurrenceCount, fired);
+  if (!evalResult.triggered_step) return nullResult;
+
+  const step = evalResult.triggered_step;
+  const insertedDiscipline = await tx
+    .insert(employeeDisciplineLogTable)
+    .values({
+      company_id: args.company_id,
+      employee_id: args.employee_id,
+      discipline_type: step.discipline_type,
+      custom_label: step.label ?? null,
+      reason: `${marker} s=${step.occurrence} by=${byStart} count=${occurrenceCount}`,
+      effective_date: args.log_date,
+      issued_by: args.logged_by,
+      pending_review: true,
+    })
+    .returning({ id: employeeDisciplineLogTable.id });
+
+  let notification_sent = false;
+  if (step.notify) {
+    // Reuse the existing (COMMS-gated) office-alert pattern; surface the
+    // occurrence count via the shared shape (window_days unused here).
+    void notifyOfficeOfDisciplineSilent(
+      args.company_id,
+      args.employee_id,
+      { threshold_hours: step.occurrence, window_days: 0, discipline_type: step.discipline_type, label: step.label ?? `${marker} #${step.occurrence}`, notify: true },
+      occurrenceCount,
+    );
+    notification_sent = true;
+  }
+  return {
+    attendance_log_id,
+    ladder_eval: { triggered_step: null, cumulative_hours: 0, as_of: args.log_date },
     discipline_log_id: insertedDiscipline[0]?.id ?? null,
     notification_sent,
   };

--- a/artifacts/api-server/src/lib/unexcused-ladder.ts
+++ b/artifacts/api-server/src/lib/unexcused-ladder.ts
@@ -110,3 +110,62 @@ export function evaluateLadder(
 function round2(n: number): number {
   return Math.round(n * 100) / 100;
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Occurrence-based ladder (PHES, Sal 2026-06-24).
+//
+// The PHES handbook/LMS disciplinary ladder counts INCIDENTS per Benefit Year
+// (work anniversary), NOT cumulative hours. Two independent counters: unexcused
+// absences and tardies. This pure evaluator returns the HIGHEST step the
+// occurrence count crosses that hasn't already fired this benefit year — so a
+// jump (e.g. straight to the 5th occurrence) emits one row at the highest level,
+// never re-firing a lower step.
+// ─────────────────────────────────────────────────────────────────────────────
+export type OccurrenceStep = {
+  occurrence: number; // fires at the Nth occurrence (1-based)
+  discipline_type:
+    | "tardy_warning"
+    | "absence_warning"
+    | "final_warning"
+    | "termination"
+    | "custom";
+  label?: string;
+  notify: boolean;
+};
+
+export type OccurrenceEvaluation = {
+  triggered_step: OccurrenceStep | null;
+  occurrence_count: number;
+};
+
+export function evaluateOccurrenceLadder(
+  steps: ReadonlyArray<OccurrenceStep>,
+  occurrenceCount: number,
+  alreadyFiredOccurrences: ReadonlySet<number>,
+): OccurrenceEvaluation {
+  const sorted = [...steps]
+    .filter((s) => Number(s.occurrence) > 0)
+    .sort((a, b) => a.occurrence - b.occurrence);
+  let triggered: OccurrenceStep | null = null;
+  for (const step of sorted) {
+    if (alreadyFiredOccurrences.has(step.occurrence)) continue;
+    if (occurrenceCount >= step.occurrence) {
+      triggered = step; // keep walking → highest crossed, not-yet-fired step
+    }
+  }
+  return { triggered_step: triggered, occurrence_count: occurrenceCount };
+}
+
+/** The next step the employee has NOT yet reached (for the card progress bar).
+ *  Returns null when no steps configured or all crossed. */
+export function nextOccurrenceStep(
+  steps: ReadonlyArray<OccurrenceStep>,
+  occurrenceCount: number,
+): OccurrenceStep | null {
+  return (
+    [...steps]
+      .filter((s) => Number(s.occurrence) > 0)
+      .sort((a, b) => a.occurrence - b.occurrence)
+      .find((s) => s.occurrence > occurrenceCount) || null
+  );
+}

--- a/artifacts/api-server/src/routes/leave.ts
+++ b/artifacts/api-server/src/routes/leave.ts
@@ -64,6 +64,8 @@ import {
   round2,
 } from "../lib/leave-balance.js";
 import { nextResetDate } from "../lib/leave-reset-format.js";
+import { benefitYearStartDate } from "../lib/leave-grant-reset.js";
+import { nextOccurrenceStep } from "../lib/unexcused-ladder.js";
 import {
   DISC_LABEL,
   parseUnexcusedHours,
@@ -505,6 +507,45 @@ async function buildAttendanceSummary(
   );
   const nextStep = pickNextStep(steps, rollingHours);
 
+  // Occurrence-based disciplinary ladders (PHES). Count INCIDENTS per Benefit
+  // Year (work anniversary) — unexcused absences and tardies independently.
+  // Steps read defensively (columns added by the cutover migration).
+  let unexOccSteps: any[] = [];
+  let tardyOccSteps: any[] = [];
+  try {
+    const r = await db.execute(
+      sql`SELECT unexcused_occurrence_steps, tardy_occurrence_steps FROM company_attendance_policy WHERE company_id = ${companyId} LIMIT 1`,
+    );
+    unexOccSteps = ((r.rows[0] as any)?.unexcused_occurrence_steps as any[]) || [];
+    tardyOccSteps = ((r.rows[0] as any)?.tardy_occurrence_steps as any[]) || [];
+  } catch {
+    unexOccSteps = [];
+    tardyOccSteps = [];
+  }
+  const uRow = await db
+    .select({ hire_date: usersTable.hire_date })
+    .from(usersTable)
+    .where(and(eq(usersTable.company_id, companyId), eq(usersTable.id, userId)))
+    .limit(1);
+  const occHireDate = uRow[0]?.hire_date ? String(uRow[0].hire_date).slice(0, 10) : to;
+  const benefitYearStart = benefitYearStartDate(occHireDate, to).toISOString().slice(0, 10);
+  const byRows = await db
+    .select({ type: employeeAttendanceLogTable.type, is_protected: employeeAttendanceLogTable.protected })
+    .from(employeeAttendanceLogTable)
+    .where(
+      and(
+        eq(employeeAttendanceLogTable.company_id, companyId),
+        eq(employeeAttendanceLogTable.employee_id, userId),
+        gte(employeeAttendanceLogTable.log_date, benefitYearStart),
+      ),
+    );
+  const unexOccCount = byRows.filter((r) => r.type === "absent" && !r.is_protected).length;
+  const tardyOccCount = byRows.filter((r) => r.type === "tardy" && !r.is_protected).length;
+  const fmtOccStep = (s: any | null) =>
+    s ? { occurrence: Number(s.occurrence), label: s.label || DISC_LABEL[s.discipline_type] || "Discipline" } : null;
+  const unexNextOcc = fmtOccStep(nextOccurrenceStep(unexOccSteps, unexOccCount));
+  const tardyNextOcc = fmtOccStep(nextOccurrenceStep(tardyOccSteps, tardyOccCount));
+
   // Discipline log (office/owner only — never returned to an employee's own
   // /me view). Active = not dismissed. Newest first.
   let discipline: Array<{ label: string; type: string; reason: string | null; effective_date: string; pending_review: boolean }> = [];
@@ -551,10 +592,21 @@ async function buildAttendanceSummary(
       pto: tile(ptoRows),
     },
     unexcused: {
-      rolling_hours: rollingHours,
-      window_days: maxWindow,
-      next_step: nextStep,
+      // Occurrence-based (PHES) — the disciplinary ladder counts incidents per
+      // benefit year. Falls back to plain count when no steps are configured.
+      occurrences: unexOccCount,
+      benefit_year_start: benefitYearStart,
+      next_step: unexNextOcc,
       current_discipline: currentDiscipline,
+      // Legacy cumulative-hours record (kept for reference, not the ladder).
+      rolling_hours: rollingHours,
+      hours_window_days: maxWindow,
+      hours_next_step: nextStep,
+    },
+    tardy: {
+      occurrences: tardyOccCount,
+      benefit_year_start: benefitYearStart,
+      next_step: tardyNextOcc,
     },
     discipline,
   };

--- a/artifacts/api-server/src/tests/cutover-3d-occurrence-ladder.test.ts
+++ b/artifacts/api-server/src/tests/cutover-3d-occurrence-ladder.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Cutover 3D — occurrence-based disciplinary ladder (PHES, Sal 2026-06-24).
+ *
+ * Pure evaluator tests + a fake-tx integration confirming the ladder fires the
+ * written warning at the 3rd occurrence, is idempotent within a benefit year,
+ * and drives the tardy counter independently.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  evaluateOccurrenceLadder,
+  nextOccurrenceStep,
+  type OccurrenceStep,
+} from "../lib/unexcused-ladder.js";
+import { recordUnexcusedEntryAndDriveLadder } from "../lib/unexcused-ladder-writer.js";
+
+const PHES_UNEX: OccurrenceStep[] = [
+  { occurrence: 3, discipline_type: "absence_warning", label: "Written warning", notify: true },
+  { occurrence: 4, discipline_type: "final_warning", label: "Final warning", notify: true },
+  { occurrence: 5, discipline_type: "termination", label: "Termination", notify: true },
+];
+const PHES_TARDY: OccurrenceStep[] = [
+  { occurrence: 3, discipline_type: "tardy_warning", label: "Written warning", notify: true },
+  { occurrence: 4, discipline_type: "final_warning", label: "Final warning", notify: true },
+  { occurrence: 5, discipline_type: "termination", label: "Termination", notify: true },
+];
+
+describe("evaluateOccurrenceLadder", () => {
+  it("fires nothing below the first step", () => {
+    assert.equal(evaluateOccurrenceLadder(PHES_UNEX, 2, new Set()).triggered_step, null);
+  });
+  it("fires written warning at the 3rd occurrence", () => {
+    const e = evaluateOccurrenceLadder(PHES_UNEX, 3, new Set());
+    assert.equal(e.triggered_step?.discipline_type, "absence_warning");
+    assert.equal(e.triggered_step?.label, "Written warning");
+  });
+  it("fires the HIGHEST crossed step on a jump (→5 = termination, once)", () => {
+    const e = evaluateOccurrenceLadder(PHES_UNEX, 5, new Set());
+    assert.equal(e.triggered_step?.discipline_type, "termination");
+  });
+  it("does not re-fire an already-fired step", () => {
+    assert.equal(evaluateOccurrenceLadder(PHES_UNEX, 3, new Set([3])).triggered_step, null);
+    // but the next step still fires once count reaches it
+    assert.equal(evaluateOccurrenceLadder(PHES_UNEX, 4, new Set([3])).triggered_step?.discipline_type, "final_warning");
+  });
+});
+
+describe("nextOccurrenceStep — card progress", () => {
+  it("returns the next un-reached step", () => {
+    assert.equal(nextOccurrenceStep(PHES_UNEX, 0)?.occurrence, 3);
+    assert.equal(nextOccurrenceStep(PHES_UNEX, 3)?.occurrence, 4);
+    assert.equal(nextOccurrenceStep(PHES_UNEX, 4)?.occurrence, 5);
+  });
+  it("null once all steps crossed / none configured", () => {
+    assert.equal(nextOccurrenceStep(PHES_UNEX, 5), null);
+    assert.equal(nextOccurrenceStep([], 0), null);
+  });
+});
+
+// ── Fake tx integration ──────────────────────────────────────────────────────
+function makeFakeTx(opts: {
+  unexSteps?: OccurrenceStep[];
+  tardySteps?: OccurrenceStep[];
+  hire_date?: string;
+  attendance?: Array<{ is_protected?: boolean }>;
+  discipline?: Array<{ reason: string }>;
+}) {
+  const disciplineInserts: any[] = [];
+  const NAME = Symbol.for("drizzle:Name");
+  const tx: any = {
+    insert: (table: any) => ({
+      values: (v: any) => ({
+        returning: () => {
+          const name = String(table?.[NAME] ?? "");
+          if (name === "employee_discipline_log") {
+            disciplineInserts.push(v);
+            return Promise.resolve([{ id: 99 }]);
+          }
+          return Promise.resolve([{ id: 1 }]); // attendance_log
+        },
+      }),
+    }),
+    select: () => {
+      const chain: any = {
+        _table: "",
+        from(t: any) { chain._table = String(t?.[NAME] ?? ""); return chain; },
+        where() { return chain; },
+        limit() {
+          if (chain._table === "company_attendance_policy")
+            return Promise.resolve([{ unexcused_hours_steps: [], unexcused_occurrence_steps: opts.unexSteps ?? [], tardy_occurrence_steps: opts.tardySteps ?? [] }]);
+          if (chain._table === "users") return Promise.resolve([{ hire_date: opts.hire_date ?? "2023-01-01" }]);
+          return Promise.resolve([]);
+        },
+        then(resolve: any) {
+          if (chain._table === "employee_attendance_log") return resolve(opts.attendance ?? []);
+          if (chain._table === "employee_discipline_log") return resolve((opts.discipline ?? []).map((d) => ({ reason: d.reason })));
+          return resolve([]);
+        },
+      };
+      return chain;
+    },
+  };
+  return { tx, disciplineInserts };
+}
+
+describe("recordUnexcusedEntryAndDriveLadder — occurrence path", () => {
+  it("3rd unexcused absence → fires written warning (absence_warning) with occ marker", async () => {
+    const fake = makeFakeTx({ unexSteps: PHES_UNEX, attendance: [{}, {}, {}], discipline: [] });
+    const r = await recordUnexcusedEntryAndDriveLadder(fake.tx, {
+      company_id: 1, employee_id: 42, log_date: "2026-05-29", hours: 8, type: "absent", logged_by: 1,
+    });
+    assert.equal(fake.disciplineInserts.length, 1);
+    assert.equal(fake.disciplineInserts[0].discipline_type, "absence_warning");
+    assert.match(fake.disciplineInserts[0].reason, /unexcused-occ s=3 by=2026-01-01 count=3/);
+    assert.equal(r.discipline_log_id, 99);
+  });
+  it("2nd unexcused absence → no discipline", async () => {
+    const fake = makeFakeTx({ unexSteps: PHES_UNEX, attendance: [{}, {}], discipline: [] });
+    await recordUnexcusedEntryAndDriveLadder(fake.tx, {
+      company_id: 1, employee_id: 42, log_date: "2026-05-29", hours: 8, type: "absent", logged_by: 1,
+    });
+    assert.equal(fake.disciplineInserts.length, 0);
+  });
+  it("idempotent: step already fired this benefit year → no re-fire", async () => {
+    const fake = makeFakeTx({
+      unexSteps: PHES_UNEX,
+      attendance: [{}, {}, {}],
+      discipline: [{ reason: "unexcused-occ s=3 by=2026-01-01 count=3" }],
+    });
+    await recordUnexcusedEntryAndDriveLadder(fake.tx, {
+      company_id: 1, employee_id: 42, log_date: "2026-05-29", hours: 8, type: "absent", logged_by: 1,
+    });
+    assert.equal(fake.disciplineInserts.length, 0);
+  });
+  it("protected absences don't count toward the ladder", async () => {
+    const fake = makeFakeTx({ unexSteps: PHES_UNEX, attendance: [{}, {}, { is_protected: true }], discipline: [] });
+    await recordUnexcusedEntryAndDriveLadder(fake.tx, {
+      company_id: 1, employee_id: 42, log_date: "2026-05-29", hours: 8, type: "absent", logged_by: 1,
+    });
+    assert.equal(fake.disciplineInserts.length, 0); // only 2 count
+  });
+  it("tardy counter is independent (uses tardy_occurrence_steps, tardy_warning)", async () => {
+    const fake = makeFakeTx({ tardySteps: PHES_TARDY, attendance: [{}, {}, {}], discipline: [] });
+    await recordUnexcusedEntryAndDriveLadder(fake.tx, {
+      company_id: 1, employee_id: 42, log_date: "2026-05-29", hours: 0, type: "tardy", logged_by: 1,
+    });
+    assert.equal(fake.disciplineInserts.length, 1);
+    assert.equal(fake.disciplineInserts[0].discipline_type, "tardy_warning");
+    assert.match(fake.disciplineInserts[0].reason, /tardy-occ s=3/);
+  });
+});

--- a/artifacts/qleno/src/pages/employee-profile.tsx
+++ b/artifacts/qleno/src/pages/employee-profile.tsx
@@ -1251,16 +1251,19 @@ export default function EmployeeProfilePage() {
                   let barColor = accent;
                   let barCaption = '';
                   if (officeRecorded) {
-                    const rolling = Number(unex?.rolling_hours || 0);
-                    const nextThresh = Number(unex?.next_step?.threshold || 0);
-                    bigNum = rolling.toFixed(1);
-                    bigLabel = 'hours recorded';
-                    if (nextThresh > 0) {
-                      barPct = Math.min(100, (rolling / nextThresh) * 100);
-                      barColor = barPct >= 100 ? LEAVE_OUT : barPct >= 60 ? LEAVE_LOW : accent;
-                      barCaption = `${rolling.toFixed(1)} of ${nextThresh} h to next discipline step`;
+                    // Occurrence-based disciplinary ladder (PHES): count incidents
+                    // this benefit year toward the next step.
+                    const occ = Number(unex?.occurrences || 0);
+                    const nextOcc = Number(unex?.next_step?.occurrence || 0);
+                    const nextLabel = (unex?.next_step?.label || 'discipline').toLowerCase();
+                    bigNum = String(occ);
+                    bigLabel = occ === 1 ? 'occurrence this year' : 'occurrences this year';
+                    if (nextOcc > 0) {
+                      barPct = Math.min(100, (occ / nextOcc) * 100);
+                      barColor = occ >= nextOcc ? LEAVE_OUT : (nextOcc - occ <= 1 ? LEAVE_LOW : accent);
+                      barCaption = `${occ} of ${nextOcc} occurrences to ${nextLabel}`;
                     } else {
-                      barCaption = 'No disciplinary thresholds set';
+                      barCaption = unex?.current_discipline ? 'At the final disciplinary step' : 'No disciplinary ladder set';
                     }
                   } else {
                     barPct = granted > 0 ? Math.min(100, (used / granted) * 100) : 0;
@@ -1318,6 +1321,37 @@ export default function EmployeeProfilePage() {
                     </div>
                   );
                 })}
+
+                {/* [Occurrence ladder] Tardy/Late disciplinary indicator —
+                    office/owner only (tardies aren't a leave bucket). */}
+                {['owner','admin','office','super_admin'].includes(getTokenRole() || '')
+                  && attnSummary?.tardy && (() => {
+                  const t = attnSummary.tardy;
+                  const occ = Number(t.occurrences || 0);
+                  const nextOcc = Number(t.next_step?.occurrence || 0);
+                  const nextLabel = (t.next_step?.label || 'discipline').toLowerCase();
+                  const accent = '#BA7517'; // tardy = amber accent
+                  const barPct = nextOcc > 0 ? Math.min(100, (occ / nextOcc) * 100) : (occ > 0 ? 100 : 0);
+                  const barColor = nextOcc > 0 ? (occ >= nextOcc ? LEAVE_OUT : (nextOcc - occ <= 1 ? LEAVE_OUT : accent)) : LEAVE_OUT;
+                  const caption = nextOcc > 0 ? `${occ} of ${nextOcc} occurrences to ${nextLabel}` : (occ > 0 ? 'At the final disciplinary step' : 'No disciplinary ladder set');
+                  return (
+                    <div style={{ background:'#FFFFFF', border:'1px solid #E5E2DC', borderLeft:`4px solid ${accent}`, borderRadius:10, padding:'14px 16px' }}>
+                      <div style={{ display:'flex', alignItems:'center', gap:7 }}>
+                        <span style={{ width:9, height:9, borderRadius:'50%', background:accent, flexShrink:0 }} />
+                        <span style={{ fontSize:12, fontWeight:700, color:accent, textTransform:'uppercase', letterSpacing:'0.04em' }}>Tardies</span>
+                        <span style={{ marginLeft:'auto', fontSize:10.5, color:'#9E9B94' }}>office only</span>
+                      </div>
+                      <div style={{ display:'flex', alignItems:'baseline', gap:6, marginTop:6 }}>
+                        <span style={{ fontSize:30, fontWeight:800, color:accent, lineHeight:1.1 }}>{occ}</span>
+                        <span style={{ fontSize:12, color:'#6B6860' }}>{occ === 1 ? 'late this year' : 'lates this year'}</span>
+                      </div>
+                      <div style={{ height:6, borderRadius:99, background:'#EEEDEA', marginTop:8, overflow:'hidden' }}>
+                        <div style={{ height:'100%', width:`${barPct}%`, background:barColor, borderRadius:99, transition:'width 0.3s ease' }} />
+                      </div>
+                      <p style={{ fontSize:11, color:'#6B6860', margin:'5px 0 0 0' }}>{caption}</p>
+                    </div>
+                  );
+                })()}
 
                 {/* Per-bucket usage history modal (data-driven over all buckets) */}
                 {historyBucket && (() => {

--- a/lib/db/src/schema/hr_policies.ts
+++ b/lib/db/src/schema/hr_policies.ts
@@ -86,6 +86,17 @@ export const companyAttendancePolicyTable = pgTable("company_attendance_policy",
   // { threshold_hours, window_days, discipline_type, label, notify }.
   // Empty array = ladder disabled.
   unexcused_hours_steps: jsonb("unexcused_hours_steps").$type<any[]>().default([]),
+  // ── Occurrence-based disciplinary ladders (PHES, Sal 2026-06-24) ──
+  // The PHES handbook/LMS ladder is OCCURRENCE-based per Benefit Year (work
+  // anniversary), NOT cumulative hours: count INCIDENTS. Two independent
+  // counters — one for unexcused absences, one for tardies. Each step is
+  // { occurrence, discipline_type, label, notify }. When configured, the
+  // ladder writer drives discipline off these (per benefit year) instead of
+  // unexcused_hours_steps. Empty array = occurrence ladder disabled (falls
+  // back to the legacy hours ladder). PHES: 3rd → written, 4th → final,
+  // 5th → termination, for both counters.
+  unexcused_occurrence_steps: jsonb("unexcused_occurrence_steps").$type<any[]>().default([]),
+  tardy_occurrence_steps: jsonb("tardy_occurrence_steps").$type<any[]>().default([]),
 
   ncns_policy_enabled: boolean("ncns_policy_enabled").default(false),
   ncns_may_terminate_immediately: boolean("ncns_may_terminate_immediately").default(false),


### PR DESCRIPTION
Implements **Option A** (Sal's call): extend the disciplinary engine from cumulative-hours to **occurrence-based** — matching the PHES LMS handbook (occurrences per Benefit Year) — and load the PHES ladder. The legacy hours ladder stays as a fallback.

### Engine
- New config on `company_attendance_policy`: `unexcused_occurrence_steps` + `tardy_occurrence_steps` (jsonb). **Two independent counters** (unexcused absences, tardies). Each step `{ occurrence, discipline_type, label, notify }`.
- Pure `evaluateOccurrenceLadder` + `nextOccurrenceStep` — fire the **highest crossed, not-yet-fired** step (a jump to the 5th fires termination once, never re-firing lower steps).
- The ladder writer **prefers the occurrence ladder when configured** for the incident kind, counting incidents in the employee's **Benefit Year (work-anniversary window, reused from the leave engine)**; otherwise falls back to the legacy hours ladder. **Idempotent** per (kind, benefit-year, occurrence) via a reason marker; resets each benefit year. Protected events never count. Attendance-log recording is unchanged.

### Loaded ladder (co1 + co4, idempotent — never clobbers edits)
3rd → **written warning**, 4th → **final warning**, 5th → **termination**, independently for unexcused absences and tardies. (Tardy step 3 = `tardy_warning`, unexcused step 3 = `absence_warning`; both labelled "Written warning".)

### UI / API
- `attendance-summary` returns occurrence-based `unexcused {occurrences, next_step, current_discipline, benefit_year_start}` + new `tardy {occurrences, next_step}` (legacy rolling-hours kept for reference).
- Unexcused card shows **occurrence progress** ("2 of 3 occurrences to written warning"); new **office-only Tardies** indicator card; discipline flag shows current standing; smart bar colors.

### Safety / verification
- Either/or design → **3B byte-identical hours-path tests still pass**; no double-firing. No destructive changes (additive columns; seeds only when empty).
- `cutover-3d-occurrence-ladder.test.ts` (**11** — pure evaluator + fake-tx integration: fires at 3rd, idempotent, protected excluded, tardy independent). 3A+3B+3D green (**141**); `typecheck:libs` clean; server bundles clean; no new `employee-profile.tsx` type errors.

After this, only **Phase 3** (tenant-dynamic buckets) remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)