### PR TITLE
feat(leave): Phase 3 — tenant-dynamic bucket display (delete the 4 hardcoded maps)

### DIFF
--- a/artifacts/api-server/src/cutover-data-migration.ts
+++ b/artifacts/api-server/src/cutover-data-migration.ts
@@ -62,6 +62,7 @@ export async function runCutoverDataMigration(): Promise<void> {
   try {
     await seedPhesLeavePolicy3A();
     await seedPhesOccurrenceLadders();
+    await seedPhesBucketDisplay();
   } catch (err) {
     console.error(
       "[cutover-migration] Phes 3A leave policy seed failed (non-fatal):",
@@ -819,6 +820,52 @@ async function seedPhesOccurrenceLadders(): Promise<void> {
         WHERE company_id IN (1,4)
           AND (tardy_occurrence_steps IS NULL OR tardy_occurrence_steps = '[]'::jsonb);
       RAISE NOTICE 'cutover-migration: ensured PHES occurrence disciplinary ladders (3/4/5 → written/final/termination)';
+    END
+    $$;
+  `),
+  );
+}
+
+/**
+ * Phase 3 — tenant-dynamic bucket display. Adds leave_types.display_config and
+ * seeds PHES (co1 + co4) with the EXACT colors/labels pulled from the four
+ * legacy hardcoded maps, so the dispatch board / review / profile render
+ * byte-identical. Seeds only where display_config IS NULL (never clobbers).
+ */
+async function seedPhesBucketDisplay(): Promise<void> {
+  const J = (o: Record<string, string>) => JSON.stringify(o);
+  const SEED: Record<string, Record<string, string>> = {
+    pto_phes:     { tint: "#E9FBF5", accent: "#1D9E75", on_tint: "#00876B", board_label: "PTO",       chip_label: "PTO" },
+    plawa:        { tint: "#FEF3C7", accent: "#378ADD", on_tint: "#92400E", board_label: "PLAWA",     chip_label: "Sick" },
+    unpaid_leave: { tint: "#EEF2F7", accent: "#BA7517", on_tint: "#334155", board_label: "Unpaid",    chip_label: "Unpaid" },
+    unexcused:    { tint: "#FCE7E7", accent: "#E24B4A", on_tint: "#991B1B", board_label: "Unexcused", chip_label: "Unexcused" },
+  };
+  const updates = Object.entries(SEED)
+    .map(
+      ([slug, cfg]) =>
+        `UPDATE leave_types SET display_config = '${J(cfg)}'::jsonb
+           WHERE company_id IN (1,4) AND slug = '${slug}' AND display_config IS NULL;`,
+    )
+    .join("\n");
+  await db.execute(
+    sql.raw(`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = 'public' AND table_name = 'leave_types'
+      ) THEN
+        RAISE NOTICE 'cutover-migration: leave_types not present yet, skipping bucket display';
+        RETURN;
+      END IF;
+      IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema='public' AND table_name='leave_types' AND column_name='display_config'
+      ) THEN
+        ALTER TABLE leave_types ADD COLUMN display_config jsonb;
+      END IF;
+      ${updates}
+      RAISE NOTICE 'cutover-migration: ensured PHES bucket display_config (byte-identical legacy colors)';
     END
     $$;
   `),

--- a/artifacts/api-server/src/lib/leave-bucket-display.ts
+++ b/artifacts/api-server/src/lib/leave-bucket-display.ts
@@ -1,0 +1,87 @@
+/**
+ * Tenant-dynamic leave-bucket display (Phase 3, Sal 2026-06-24).
+ *
+ * ONE source of truth for how a leave bucket renders across every surface —
+ * the dispatch board (row tint + label), the employees review chip (tint + a
+ * darker on-tint text), the profile cards (dark accent), and the history chips
+ * (accent + a short chip label). Each surface used to hardcode its own map;
+ * now the API resolves a bucket's display from leave_types.display_config and
+ * the frontend renders from data. A tenant with a different set of buckets (or
+ * no display_config at all) renders correctly with NO code change — the
+ * resolver derives sane, stable defaults from the slug.
+ *
+ * display_config JSON shape (all optional): { tint, accent, on_tint,
+ * board_label, chip_label }. `label` is always the leave_type display_name.
+ *
+ * The PHES backfill (seeded by the cutover migration) reproduces the four
+ * legacy hardcoded maps BYTE-IDENTICALLY — see PHES_BUCKET_DISPLAY below.
+ */
+export interface BucketDisplay {
+  slug: string;
+  label: string;        // canonical label = display_name
+  tint: string;         // pale row/chip background (board + review)
+  accent: string;       // bold accent (profile cards, dots, chip border/text)
+  on_tint: string;      // text color ON the tint (review chip)
+  board_label: string;  // dispatch-board chip text
+  chip_label: string;   // history-chip / profile short label
+}
+
+/** PHES exact values, pulled verbatim from the four legacy maps. Used to seed
+ *  leave_types.display_config and as the regression contract. */
+export const PHES_BUCKET_DISPLAY: Record<string, Omit<BucketDisplay, "slug" | "label">> = {
+  pto_phes:     { tint: "#E9FBF5", accent: "#1D9E75", on_tint: "#00876B", board_label: "PTO",       chip_label: "PTO" },
+  plawa:        { tint: "#FEF3C7", accent: "#378ADD", on_tint: "#92400E", board_label: "PLAWA",     chip_label: "Sick" },
+  unpaid_leave: { tint: "#EEF2F7", accent: "#BA7517", on_tint: "#334155", board_label: "Unpaid",    chip_label: "Unpaid" },
+  unexcused:    { tint: "#FCE7E7", accent: "#E24B4A", on_tint: "#991B1B", board_label: "Unexcused", chip_label: "Unexcused" },
+};
+
+/** Board-only pseudo-bucket: an attendance "absent" mark is NOT a tenant leave
+ *  type, so it has no leave_types row. The dispatch board renders it from this
+ *  constant (legacy TIME_OFF_BG.absent / TIME_OFF_LABEL.absent). */
+export const ABSENT_DISPLAY = { tint: "#FFEBEE", board_label: "Absent", accent: "#C62828" };
+
+// Stable default palette for tenants that haven't configured display_config —
+// keyed by a coarse classification of the slug so common buckets look sensible,
+// with a hashed fallback so even unknown buckets get a distinct, consistent hue.
+const DEFAULT_BY_KIND: Array<{ test: RegExp; d: Omit<BucketDisplay, "slug" | "label"> }> = [
+  { test: /plawa|sick/, d: { tint: "#FEF3C7", accent: "#378ADD", on_tint: "#92400E", board_label: "", chip_label: "" } },
+  { test: /pto|vacation/, d: { tint: "#E9FBF5", accent: "#1D9E75", on_tint: "#00876B", board_label: "", chip_label: "" } },
+  { test: /unpaid/, d: { tint: "#EEF2F7", accent: "#BA7517", on_tint: "#334155", board_label: "", chip_label: "" } },
+  { test: /unexcused|absence/, d: { tint: "#FCE7E7", accent: "#E24B4A", on_tint: "#991B1B", board_label: "", chip_label: "" } },
+];
+const FALLBACK_PALETTE = [
+  { tint: "#EEF2F7", accent: "#334155", on_tint: "#334155" },
+  { tint: "#F3ECFB", accent: "#6D28D9", on_tint: "#6D28D9" },
+  { tint: "#E7F3FB", accent: "#0E7490", on_tint: "#0E7490" },
+  { tint: "#FBEFE7", accent: "#B45309", on_tint: "#B45309" },
+];
+function hashIndex(s: string, mod: number): number {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) >>> 0;
+  return h % mod;
+}
+
+/** Resolve a bucket's full display from its leave_types row. display_config
+ *  wins field-by-field; missing fields fall back to a slug-derived default so
+ *  partial configs and brand-new tenant buckets both render correctly. */
+export function resolveBucketDisplay(row: {
+  slug: string;
+  display_name: string;
+  display_config?: Record<string, string> | null;
+}): BucketDisplay {
+  const cfg = row.display_config || {};
+  const s = (row.slug || "").toLowerCase();
+  const kind = DEFAULT_BY_KIND.find((k) => k.test.test(s))?.d;
+  const fb = kind ?? FALLBACK_PALETTE[hashIndex(s, FALLBACK_PALETTE.length)];
+  const tint = cfg.tint || fb.tint;
+  const accent = cfg.accent || fb.accent;
+  return {
+    slug: row.slug,
+    label: row.display_name,
+    tint,
+    accent,
+    on_tint: cfg.on_tint || (fb as any).on_tint || accent,
+    board_label: cfg.board_label || row.display_name,
+    chip_label: cfg.chip_label || row.display_name,
+  };
+}

--- a/artifacts/api-server/src/routes/dispatch.ts
+++ b/artifacts/api-server/src/routes/dispatch.ts
@@ -6,6 +6,7 @@ import { requireAuth, requireRole } from "../lib/auth.js";
 import { parseResRatesRow, resolveResidentialPayPct } from "../lib/commission-rates.js";
 import { jobRevenueExpr } from "../lib/job-revenue-sql.js";
 import { DAYS_AHEAD } from "../lib/recurring-jobs.js";
+import { resolveBucketDisplay, ABSENT_DISPLAY } from "../lib/leave-bucket-display.js";
 
 const router = Router();
 
@@ -358,25 +359,33 @@ async function buildDispatchPayload(
         eq(leaveRequestsTable.status, 'approved'),
         sql`${leaveRequestsTable.start_date} <= ${date} AND ${leaveRequestsTable.end_date} >= ${date}`,
       ));
-    const SLUG_TO_BUCKET: Record<string, 'pto' | 'plawa' | 'unpaid' | 'unexcused'> = {
-      pto_phes: 'pto', plawa: 'plawa', unpaid_leave: 'unpaid', unexcused: 'unexcused',
-    };
-    const leaveByEmp = new Map<number, { bucket: 'pto' | 'plawa' | 'unpaid' | 'unexcused'; unit: string }>();
+    // [Phase 3] Tenant-dynamic bucket display: resolve each bucket's row tint +
+    // label from the tenant's own leave_types.display_config (no hardcoded
+    // SLUG_TO_BUCKET / TIME_OFF_BG). time_off is now the SLUG; the board renders
+    // the returned time_off_color / time_off_label directly.
+    const tenantBuckets = await db
+      .select({ slug: leaveTypesTable.slug, display_name: leaveTypesTable.display_name, display_config: leaveTypesTable.display_config })
+      .from(leaveTypesTable)
+      .where(eq(leaveTypesTable.company_id, companyId));
+    const bucketDisplayBySlug = new Map(
+      tenantBuckets.map((b) => [String(b.slug), resolveBucketDisplay(b as any)]),
+    );
+    const leaveByEmp = new Map<number, { slug: string; unit: string }>();
     for (const r of approvedLeave) {
-      const b = SLUG_TO_BUCKET[String(r.slug)];
-      if (b) leaveByEmp.set(r.user_id, { bucket: b, unit: String(r.day_unit) });
+      leaveByEmp.set(r.user_id, { slug: String(r.slug), unit: String(r.day_unit) });
     }
 
     const ptoSet = new Set(leaveUsage.map(r => r.employee_id)); // legacy fallback
     const sickSet = new Set(attendanceLogs.filter(r => r.type === 'plawa_leave' || r.type === 'protected_leave').map(r => r.employee_id));
     const absentSet = new Set(attendanceLogs.filter(r => r.type === 'absent' || r.type === 'ncns').map(r => r.employee_id));
 
-    function getTimeOff(empId: number): 'pto' | 'plawa' | 'unpaid' | 'unexcused' | 'absent' | null {
+    // Returns the bucket SLUG (or 'absent' pseudo-bucket) in effect for the day.
+    function getTimeOff(empId: number): string | null {
       const lv = leaveByEmp.get(empId);
-      if (lv) return lv.bucket;
+      if (lv) return lv.slug;
       if (absentSet.has(empId)) return 'absent';
       if (sickSet.has(empId)) return 'plawa';
-      if (ptoSet.has(empId)) return 'pto';
+      if (ptoSet.has(empId)) return 'pto_phes';
       return null;
     }
     function getTimeOffUnit(empId: number): 'full_day' | 'morning' | 'afternoon' | null {
@@ -384,6 +393,18 @@ async function buildDispatchPayload(
       if (lv) return lv.unit as 'full_day' | 'morning' | 'afternoon';
       if (absentSet.has(empId) || sickSet.has(empId) || ptoSet.has(empId)) return 'full_day';
       return null;
+    }
+    function getTimeOffColor(empId: number): string | null {
+      const slug = getTimeOff(empId);
+      if (!slug) return null;
+      if (slug === 'absent') return ABSENT_DISPLAY.tint;
+      return bucketDisplayBySlug.get(slug)?.tint ?? null;
+    }
+    function getTimeOffLabel(empId: number): string | null {
+      const slug = getTimeOff(empId);
+      if (!slug) return null;
+      if (slug === 'absent') return ABSENT_DISPLAY.board_label;
+      return bucketDisplayBySlug.get(slug)?.board_label ?? null;
     }
 
     if (jobs.length === 0) {
@@ -396,6 +417,8 @@ async function buildDispatchPayload(
           zone: empZoneMap[e.id] ?? null,
           time_off: getTimeOff(e.id),
           time_off_unit: getTimeOffUnit(e.id),
+          time_off_color: getTimeOffColor(e.id),
+          time_off_label: getTimeOffLabel(e.id),
           commission_rate: e.commission_rate ? parseFloat(e.commission_rate) : null,
         })),
         unassigned_jobs: [],
@@ -1082,6 +1105,8 @@ async function buildDispatchPayload(
         zone: empZoneMap[e.id] ?? null,
         time_off: getTimeOff(e.id),
         time_off_unit: getTimeOffUnit(e.id),
+        time_off_color: getTimeOffColor(e.id),
+        time_off_label: getTimeOffLabel(e.id),
         commission_rate: e.commission_rate ? parseFloat(e.commission_rate) : null,
         avatar_url: e.avatar_url ?? null,
       })),

--- a/artifacts/api-server/src/routes/leave.ts
+++ b/artifacts/api-server/src/routes/leave.ts
@@ -66,6 +66,7 @@ import {
 import { nextResetDate } from "../lib/leave-reset-format.js";
 import { benefitYearStartDate } from "../lib/leave-grant-reset.js";
 import { nextOccurrenceStep } from "../lib/unexcused-ladder.js";
+import { resolveBucketDisplay } from "../lib/leave-bucket-display.js";
 import {
   DISC_LABEL,
   parseUnexcusedHours,
@@ -310,6 +311,11 @@ async function buildBalancesForUser(
     past_waiting_period: boolean;
     next_reset_date: string | null;
     eligible_on: string | null;
+    accent: string;
+    tint: string;
+    on_tint: string;
+    board_label: string;
+    chip_label: string;
   }>
 > {
   const buckets = await db
@@ -361,6 +367,7 @@ async function buildBalancesForUser(
       d.setUTCDate(d.getUTCDate() + (b.waiting_period_days || 0));
       eligibleOn = d.toISOString().slice(0, 10);
     }
+    const disp = resolveBucketDisplay(b as any);
     out.push({
       leave_type_id: b.id,
       display_name: b.display_name,
@@ -374,6 +381,11 @@ async function buildBalancesForUser(
       past_waiting_period: past,
       next_reset_date: nextReset,
       eligible_on: eligibleOn,
+      accent: disp.accent,
+      tint: disp.tint,
+      on_tint: disp.on_tint,
+      board_label: disp.board_label,
+      chip_label: disp.chip_label,
     });
   }
   return out;
@@ -1096,6 +1108,7 @@ router.get("/requests", officeReadGate, async (req, res) => {
       leave_type_id: leaveRequestsTable.leave_type_id,
       bucket_name: leaveTypesTable.display_name,
       bucket_slug: leaveTypesTable.slug,
+      bucket_display_config: leaveTypesTable.display_config,
       start_date: leaveRequestsTable.start_date,
       end_date: leaveRequestsTable.end_date,
       hours: leaveRequestsTable.hours,
@@ -1118,7 +1131,12 @@ router.get("/requests", officeReadGate, async (req, res) => {
     )
     .where(where)
     .orderBy(desc(leaveRequestsTable.created_at));
-  return res.json({ data: rows });
+  // Resolve each row's chip tint + on-tint from the tenant's bucket display.
+  const data = rows.map((r) => {
+    const d = resolveBucketDisplay({ slug: String(r.bucket_slug ?? ""), display_name: String(r.bucket_name ?? ""), display_config: r.bucket_display_config as any });
+    return { ...r, bucket_tint: d.tint, bucket_on_tint: d.on_tint };
+  });
+  return res.json({ data });
 });
 
 router.get("/requests/mine", async (req, res) => {

--- a/artifacts/api-server/src/tests/leave-bucket-display.test.ts
+++ b/artifacts/api-server/src/tests/leave-bucket-display.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Phase 3 — tenant-dynamic bucket display resolver (Sal 2026-06-24).
+ *
+ * THE BOARD INVARIANT: resolveBucketDisplay must reproduce the four legacy
+ * hardcoded maps BYTE-IDENTICALLY for PHES, so the dispatch board / employees
+ * review / profile cards / history chips render with zero color/label drift.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  resolveBucketDisplay,
+  PHES_BUCKET_DISPLAY,
+  ABSENT_DISPLAY,
+} from "../lib/leave-bucket-display.js";
+
+// The exact legacy values, transcribed from the 4 maps being deleted:
+//   dispatch TIME_OFF_BG (tint) + TIME_OFF_LABEL (board_label)
+//   employees BUCKET_COLORS ({bg=tint, fg=on_tint})
+//   profile leaveBucketAccent (accent) + leaveBucketLabel (chip_label)
+const LEGACY = {
+  pto_phes:     { display_name: "PTO",          tint: "#E9FBF5", accent: "#1D9E75", on_tint: "#00876B", board_label: "PTO",       chip_label: "PTO" },
+  plawa:        { display_name: "PLAWA",         tint: "#FEF3C7", accent: "#378ADD", on_tint: "#92400E", board_label: "PLAWA",     chip_label: "Sick" },
+  unpaid_leave: { display_name: "Unpaid Leave",  tint: "#EEF2F7", accent: "#BA7517", on_tint: "#334155", board_label: "Unpaid",    chip_label: "Unpaid" },
+  unexcused:    { display_name: "Unexcused",     tint: "#FCE7E7", accent: "#E24B4A", on_tint: "#991B1B", board_label: "Unexcused", chip_label: "Unexcused" },
+} as const;
+
+describe("resolveBucketDisplay — PHES byte-identical (board invariant)", () => {
+  for (const [slug, exp] of Object.entries(LEGACY)) {
+    it(`${slug} resolves to the exact legacy colors + labels`, () => {
+      const d = resolveBucketDisplay({
+        slug,
+        display_name: exp.display_name,
+        display_config: PHES_BUCKET_DISPLAY[slug], // what the migration seeds
+      });
+      assert.equal(d.tint, exp.tint, "tint (board row + review bg)");
+      assert.equal(d.accent, exp.accent, "accent (profile/chip)");
+      assert.equal(d.on_tint, exp.on_tint, "on_tint (review fg)");
+      assert.equal(d.board_label, exp.board_label, "board label");
+      assert.equal(d.chip_label, exp.chip_label, "chip label");
+      assert.equal(d.label, exp.display_name, "canonical label = display_name");
+    });
+  }
+
+  it("PHES_BUCKET_DISPLAY seed matches the legacy hex exactly", () => {
+    for (const [slug, exp] of Object.entries(LEGACY)) {
+      const seed = PHES_BUCKET_DISPLAY[slug];
+      assert.equal(seed.tint, exp.tint);
+      assert.equal(seed.accent, exp.accent);
+      assert.equal(seed.on_tint, exp.on_tint);
+      assert.equal(seed.board_label, exp.board_label);
+      assert.equal(seed.chip_label, exp.chip_label);
+    }
+  });
+
+  it("absent pseudo-bucket keeps its legacy board tint + label", () => {
+    assert.equal(ABSENT_DISPLAY.tint, "#FFEBEE");
+    assert.equal(ABSENT_DISPLAY.board_label, "Absent");
+  });
+});
+
+describe("resolveBucketDisplay — tenant-dynamic defaults (no config)", () => {
+  it("a brand-new tenant bucket with NO display_config still resolves a full, stable display", () => {
+    const d = resolveBucketDisplay({ slug: "bereavement", display_name: "Bereavement" });
+    assert.ok(/^#[0-9A-Fa-f]{6}$/.test(d.tint), "derived tint is a hex");
+    assert.ok(/^#[0-9A-Fa-f]{6}$/.test(d.accent), "derived accent is a hex");
+    assert.equal(d.label, "Bereavement");
+    assert.equal(d.board_label, "Bereavement"); // falls back to display_name
+    assert.equal(d.chip_label, "Bereavement");
+    // deterministic — same slug → same colors every call
+    const d2 = resolveBucketDisplay({ slug: "bereavement", display_name: "Bereavement" });
+    assert.deepEqual(d, d2);
+  });
+  it("partial config wins field-by-field; missing fields fall back", () => {
+    const d = resolveBucketDisplay({ slug: "jury", display_name: "Jury Duty", display_config: { accent: "#123456" } });
+    assert.equal(d.accent, "#123456");           // from config
+    assert.ok(/^#[0-9A-Fa-f]{6}$/.test(d.tint));  // derived
+    assert.equal(d.board_label, "Jury Duty");     // display_name fallback
+  });
+  it("a tenant configuring a DIFFERENT label/color renders exactly that (no code change)", () => {
+    const d = resolveBucketDisplay({
+      slug: "pto_acme",
+      display_name: "Vacation",
+      display_config: { tint: "#FFF0F0", accent: "#CC0000", on_tint: "#880000", board_label: "VAC", chip_label: "Vac" },
+    });
+    assert.equal(d.tint, "#FFF0F0");
+    assert.equal(d.board_label, "VAC");
+    assert.equal(d.chip_label, "Vac");
+  });
+});

--- a/artifacts/qleno/src/pages/employee-profile.tsx
+++ b/artifacts/qleno/src/pages/employee-profile.tsx
@@ -89,14 +89,12 @@ function leaveBucketTag(slug: string): string {
 }
 // Dispatch-board-consistent accent palette. White card + colored left bar /
 // dot / label / number in this accent. (Phase 3 will source these per-tenant.)
-function leaveBucketAccent(slug: string): string {
-  const s = (slug || '').toLowerCase();
-  if (s.includes('plawa') || s.includes('sick')) return '#378ADD'; // blue
-  if (s.includes('pto')) return '#1D9E75';                          // green
-  if (s.includes('unpaid')) return '#BA7517';                       // amber
-  if (s.includes('unexcused')) return '#E24B4A';                    // red
-  return '#374151';
-}
+// [Phase 3] Bucket accent/label are tenant-dynamic — resolved server-side from
+// leave_types.display_config and delivered on each balance row (b.accent,
+// b.chip_label). The chips look these up via a slug→display map built from the
+// balances response (see bucketDisplayMap). Unknown slugs get a neutral accent.
+type BucketDisp = { accent: string; label: string };
+const NEUTRAL_ACCENT = '#374151';
 const LEAVE_LOW = '#BA7517';  // amber — running low
 const LEAVE_OUT = '#E24B4A';  // red — exhausted / step crossed
 // Days until a YYYY-MM-DD date (UTC), and a "Mon DD" label.
@@ -113,16 +111,19 @@ function shortDate(ymd: string): string {
 // [Phase 4] Render a leave/attendance note as clean chips: a colored bucket
 // chip + a status/kind chip + the human remainder. Presentation-only — parses
 // both [MC import] and app-approved formats; falls back to plain text.
-function NoteChips({ note }: { note: string | null | undefined }) {
+function NoteChips({ note, bucketMap }: { note: string | null | undefined; bucketMap?: Record<string, BucketDisp> }) {
   const p = parseLeaveNote(note);
   if (!p.bucketSlug && !p.kind && !p.clean) {
     return <span style={{ fontSize: 12, color: '#9E9B94' }}>—</span>;
   }
   const toneStyle = KIND_TONE_STYLE[p.kindTone];
+  const disp = p.bucketSlug ? bucketMap?.[p.bucketSlug] : undefined;
+  const chipAccent = disp?.accent || NEUTRAL_ACCENT;
+  const chipLabel = disp?.label || leaveBucketLabel(p.bucketSlug);
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap' }}>
       {p.bucketSlug && (
-        <span style={{ fontSize: 10.5, fontWeight: 700, color: leaveBucketAccent(p.bucketSlug), background: '#FFFFFF', border: `1px solid ${leaveBucketAccent(p.bucketSlug)}`, borderRadius: 99, padding: '1px 7px', whiteSpace: 'nowrap' }}>{leaveBucketLabel(p.bucketSlug)}</span>
+        <span style={{ fontSize: 10.5, fontWeight: 700, color: chipAccent, background: '#FFFFFF', border: `1px solid ${chipAccent}`, borderRadius: 99, padding: '1px 7px', whiteSpace: 'nowrap' }}>{chipLabel}</span>
       )}
       {p.kind && (
         <span style={{ fontSize: 10.5, fontWeight: 600, color: toneStyle.fg, background: toneStyle.bg, borderRadius: 99, padding: '1px 7px', whiteSpace: 'nowrap' }}>{p.kind}</span>
@@ -592,6 +593,11 @@ export default function EmployeeProfilePage() {
     enabled: activeTab === 'Attendance',
   });
   const leaveBuckets: any[] = leaveBalancesResp?.data || [];
+  // [Phase 3] slug → {accent, chip label} for the history chips, built from the
+  // tenant's balance rows (which now carry display from leave_types config).
+  const bucketDisplayMap: Record<string, BucketDisp> = Object.fromEntries(
+    leaveBuckets.map((b: any) => [b.slug, { accent: b.accent || NEUTRAL_ACCENT, label: b.chip_label || b.display_name }]),
+  );
   const { data: leaveUsageResp } = useQuery({
     queryKey: ['leave-usage', userId],
     queryFn: () => apiFetch(`/leave/usage?userId=${userId}`),
@@ -1236,7 +1242,7 @@ export default function EmployeeProfilePage() {
                   </div>
                 )}
                 {leaveBuckets.map((b: any) => {
-                  const accent = leaveBucketAccent(b.slug);
+                  const accent = b.accent || NEUTRAL_ACCENT;
                   const officeRecorded = b.accrual_mode === 'office_recorded';
                   const notVested = !officeRecorded && !b.past_waiting_period;
                   const granted = Number(b.granted || 0);
@@ -1372,7 +1378,7 @@ export default function EmployeeProfilePage() {
                           <div key={i} style={{ display:'flex',justifyContent:'space-between',gap:12,padding:'10px 0',borderTop: i ? '1px solid #E5E2DC' : 'none' }}>
                             <div style={{ minWidth:0 }}>
                               <div style={{ fontSize:13,fontWeight:600,color:'#1A1917',marginBottom:3 }}>{shortDate(String(u.date_used).slice(0,10))} · {String(u.date_used).slice(0,10)}</div>
-                              <NoteChips note={u.notes} />
+                              <NoteChips note={u.notes} bucketMap={bucketDisplayMap} />
                             </div>
                             <div style={{ fontSize:14,fontWeight:700,color:'#1A1917',whiteSpace:'nowrap' }}>{Number(u.hours).toFixed(2)} h</div>
                           </div>
@@ -1430,7 +1436,7 @@ export default function EmployeeProfilePage() {
                         <div key={i} style={{ display:'flex',justifyContent:'space-between',gap:12,padding:'10px 0',borderTop: i ? '1px solid #E5E2DC' : 'none' }}>
                           <div style={{ minWidth:0 }}>
                             <div style={{ fontSize:13,fontWeight:600,color:'#1A1917',marginBottom:3 }}>{shortDate(String(d.date))} · {String(d.date)}</div>
-                            <NoteChips note={d.reason} />
+                            <NoteChips note={d.reason} bucketMap={bucketDisplayMap} />
                           </div>
                           {d.hours != null && <div style={{ fontSize:14,fontWeight:700,color:'#1A1917',whiteSpace:'nowrap' }}>{Number(d.hours).toFixed(2)} h</div>}
                         </div>

--- a/artifacts/qleno/src/pages/employees.tsx
+++ b/artifacts/qleno/src/pages/employees.tsx
@@ -402,12 +402,8 @@ export default function EmployeesPage() {
 // [time-off-ticket 2026-06-22] Office "Time off & leave requests" section at the
 // bottom of the Employees page. Lists pending requests; the office approves or
 // declines inline. Profile-photo avatars (EmployeeAvatar falls back to initials).
-const BUCKET_COLORS: Record<string, { bg: string; fg: string }> = {
-  pto_phes: { bg: '#E9FBF5', fg: '#00876B' },
-  plawa:    { bg: '#FEF3C7', fg: '#92400E' },
-  unpaid_leave: { bg: '#EEF2F7', fg: '#334155' },
-  unexcused: { bg: '#FCE7E7', fg: '#991B1B' },
-};
+// [Phase 3] Bucket chip colors are tenant-dynamic: the /leave/requests API
+// returns bucket_tint + bucket_on_tint (resolved from leave_types.display_config).
 function unitLabel(u: string) {
   return u === 'morning' ? 'Morning' : u === 'afternoon' ? 'Afternoon' : 'Full day';
 }
@@ -485,7 +481,7 @@ function TimeOffRequestsSection() {
         ) : rows.length === 0 ? (
           <div style={{ padding: 24, color: '#9E9B94', fontSize: 13 }}>No pending time-off requests.</div>
         ) : rows.map((r, i) => {
-          const c = BUCKET_COLORS[r.bucket_slug] ?? { bg: '#F4F3F0', fg: '#6B6860' };
+          const c = { bg: r.bucket_tint || '#F4F3F0', fg: r.bucket_on_tint || '#6B6860' };
           return (
             <div key={r.id} style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '14px 18px', borderTop: i ? '1px solid #E5E2DC' : 'none' }}>
               <EmployeeAvatar name={`${r.first_name ?? ''} ${r.last_name ?? ''}`} avatarUrl={r.avatar_url} size={36} />

--- a/artifacts/qleno/src/pages/jobs.tsx
+++ b/artifacts/qleno/src/pages/jobs.tsx
@@ -79,7 +79,7 @@ interface ClockEntry { id: number; clock_in_at: string | null; clock_out_at: str
 interface JobTechCommission { user_id: number; name: string; is_primary: boolean; est_hours: number; calc_pay: number; final_pay: number; pay_override: number | null; /* [pay-matrix 2026-04-29] surface the per-tech matrix cell so JobPanel can render "Hourly $20/hr × 6h" or "Commission 35%" without re-deriving */ pay_type?: "commission" | "hourly"; pay_rate?: number; }
 interface JobAddOn { name: string; quantity: number; unit_price: number; subtotal: number; }
 interface DispatchJob { id: number; client_id: number; client_name: string; /* [scheduling-engine 2026-04-29] display_name = "Company - Contact" for commercial clients with company_name set; falls back to client_name otherwise. Use this on every chip/header/hover surface so the composition rule lives server-side. */ display_name?: string; client_company_name?: string | null; client_phone?: string | null; client_zip?: string | null; client_notes?: string | null; client_payment_method?: string | null; /* [tile redesign] residential or commercial badge; commercial when account_id is set OR client_type === 'commercial' */ client_type?: "residential" | "commercial" | null; address: string | null; /* [inline-edit] raw fields for address editor mode detection */ job_address_street?: string | null; job_address_city?: string | null; job_address_state?: string | null; job_address_zip?: string | null; client_address?: string | null; client_city?: string | null; client_state?: string | null; client_address_zip?: string | null; assigned_user_id: number | null; assigned_user_name?: string; job_lat?: number | null; job_lng?: number | null; service_type: string; status: string; scheduled_date: string; scheduled_time: string | null; frequency: string; amount: number; duration_minutes: number; notes: string | null; office_notes?: string | null; office_notes_updated_at?: string | null; office_notes_updated_by_name?: string | null; before_photo_count: number; after_photo_count: number; clock_entry: ClockEntry | null; zone_id?: number | null; zone_color?: string | null; zone_name?: string | null; branch_id?: number | null; branch_name?: string | null; last_service_date?: string | null; account_id?: number | null; account_name?: string | null; billing_method?: string | null; hourly_rate?: number | null; estimated_hours?: number | null; actual_hours?: number | null; billed_hours?: number | null; billed_amount?: number | null; /* [commercial-revenue 2026-06-04] allowed_hours drives the "$50/hr × 8h" card display; manual_rate_override distinguishes a flat pinned price from rate×hours billing */ allowed_hours?: number | null; manual_rate_override?: boolean | null; charge_failed_at?: string | null; charge_succeeded_at?: string | null; property_access_notes?: string | null; booking_location?: string | null; technicians?: JobTechCommission[]; est_hours_per_tech?: number | null; est_pay_per_tech?: number | null; company_res_pct?: number | null; /* [AI.7.4] Commission routing — 'commercial_hourly' or 'residential_pool' */ commission_basis?: "commercial_hourly" | "residential_pool" | null; commercial_hourly_rate?: number | null; /* [AF] completion lock state */ locked_at?: string | null; /* [lockout-visibility 2026-06-17] 'cancel'|'lockout' when this completed job is a charged cancellation/lockout (fee billed, not a visit); drives the charged_cancel visual + fee badge */ cancel_action?: string | null; actual_end_time?: string | null; completed_by_user_id?: number | null; /* [job-card-redesign] Add-ons drive the +N pill on the chip and the full list in the popover. is_new_client = first-ever residential job (no prior completed). en_route_at scaffolds the "On My Way" status; column doesn't exist yet, so the field is always undefined until the SMS engine lands. */ add_ons?: JobAddOn[]; is_new_client?: boolean; en_route_at?: string | null; /* [phes-lifecycle 2026-04-29] Manual no-show flag set by the field app's "No Show" button. Drives the NO_SHOW visual state via getJobVisualStatus. Until the field-app button ships, both fields stay null. */ no_show_marked_by_tech?: string | null; no_show_marked_by_user_id?: number | null; /* [BUG-3F2 / 2026-06-02] Multi-tech fan-out fields. team_role identifies whether this card renders for the primary or a team member, so the FE can style team-member cards differently. revenue_share is the per-tech weighted share of the job amount; the badge sums revenue_share (when present) instead of amount so per-row totals don't double-count shared jobs across the company. */ team_role?: "primary" | "team"; revenue_share?: number; }
-interface Employee { id: number; name: string; role: string; is_trainee?: boolean; jobs: DispatchJob[]; zone?: { zone_id: number; zone_color: string; zone_name: string } | null; time_off?: 'pto' | 'plawa' | 'unpaid' | 'unexcused' | 'absent' | null; time_off_unit?: 'full_day' | 'morning' | 'afternoon' | null; commission_rate?: number | null; avatar_url?: string | null; }
+interface Employee { id: number; name: string; role: string; is_trainee?: boolean; jobs: DispatchJob[]; zone?: { zone_id: number; zone_color: string; zone_name: string } | null; time_off?: string | null; time_off_unit?: 'full_day' | 'morning' | 'afternoon' | null; time_off_color?: string | null; time_off_label?: string | null; commission_rate?: number | null; avatar_url?: string | null; }
 interface DispatchData { employees: Employee[]; unassigned_jobs: DispatchJob[]; }
 
 // ─── HELPERS ──────────────────────────────────────────────────────────────────
@@ -2729,7 +2729,7 @@ function JobPanel({ job, employees, onClose, onUpdate, mobile }: {
                     };
                     const hasWarn = (id: number) => { const s = scoredById.get(id); return !!s && warnsFor(s).length > 0; };
                     const busyLabel = (id: number) => { const f = freeAtOf(id); return f != null ? `On a job · frees up ${fmtAmpm(f)}` : "On a job"; };
-                    const offLabel = (id: number) => { const o = timeOffOf(id); return o === "pto" ? "On PTO today" : o === "sick" ? "Out sick today" : o === "absent" ? "Absent today" : ""; };
+                    const offLabel = (id: number) => { const o = (timeOffOf(id) || '').toLowerCase(); return o.includes("pto") ? "On PTO today" : (o.includes("plawa") || o.includes("sick")) ? "Out sick today" : o === "absent" ? "Absent today" : o ? "Off today" : ""; };
                     const groupHeader = (text: string) => (
                       <div style={{ fontSize: 10, fontWeight: 700, color: "#9E9B94", textTransform: "uppercase", letterSpacing: "0.05em", padding: "8px 2px 6px", marginTop: 4 }}>
                         {text}
@@ -5037,17 +5037,9 @@ function CarIconInline({ tint }: { tint: string }) {
 }
 
 // ─── DESKTOP: EMPLOYEE ROW ────────────────────────────────────────────────────
-// Four distinct leave buckets + absent, each its own tint on the dispatch row.
-const TIME_OFF_BG: Record<string, string> = {
-  pto:       "#E9FBF5",
-  plawa:     "#FEF3C7",
-  unpaid:    "#EEF2F7",
-  unexcused: "#FCE7E7",
-  absent:    "#FFEBEE",
-};
-const TIME_OFF_LABEL: Record<string, string> = {
-  pto: "PTO", plawa: "PLAWA", unpaid: "Unpaid", unexcused: "Unexcused", absent: "Absent",
-};
+// [Phase 3] Bucket tint + label are now tenant-dynamic: the dispatch API
+// returns each off employee's time_off_color + time_off_label (resolved from
+// leave_types.display_config). No hardcoded bucket→color/label map here.
 
 // Time-off band covers the full dispatch timeline (since the board IS business hours)
 function getBandLeft()  { return 0; }
@@ -5130,11 +5122,11 @@ function EmployeeRow({ employee, onChipClick, nowLine }: { employee: Employee; o
   const payFromRate = employee.commission_rate != null ? revenue * (employee.commission_rate / 100) : null;
   const pay = payFromJobs > 0 ? payFromJobs : payFromRate;
   const isClockedIn = employee.jobs.some(j => j.clock_entry?.clock_in_at && !j.clock_entry?.clock_out_at);
-  const timeOffBg = employee.time_off ? TIME_OFF_BG[employee.time_off] : null;
+  const timeOffBg = employee.time_off_color || null;
   const toUnit = employee.time_off_unit;
   const isFullDayOff = !!employee.time_off && (!toUnit || toUnit === 'full_day');
   const timeOffText = employee.time_off
-    ? `${TIME_OFF_LABEL[employee.time_off] ?? 'Off'}${toUnit === 'morning' ? ' · AM off' : toUnit === 'afternoon' ? ' · PM off' : ''}`
+    ? `${employee.time_off_label ?? 'Off'}${toUnit === 'morning' ? ' · AM off' : toUnit === 'afternoon' ? ' · PM off' : ''}`
     : null;
   // [overlap-stacking] Stack time-overlapping chips into sub-lanes so none
   // hides another; row grows to fit. One sub-lane → unchanged 72px row.

--- a/lib/db/src/schema/leave.ts
+++ b/lib/db/src/schema/leave.ts
@@ -45,6 +45,7 @@ import {
   date,
   time,
   timestamp,
+  jsonb,
   pgEnum,
   index,
   uniqueIndex,
@@ -140,6 +141,13 @@ export const leaveTypesTable = pgTable(
       .notNull()
       .default(false),
     active: boolean("active").notNull().default(true),
+    // [Phase 3 — tenant-dynamic buckets] Per-tenant display metadata so every
+    // surface (dispatch board, employees review, profile cards, history chips)
+    // renders this bucket's colors + labels from data, not hardcoded maps.
+    // Shape: { tint, accent, on_tint, board_label, chip_label }. Null → the
+    // resolver derives sane defaults (so a new tenant's buckets render with no
+    // code change). display_name remains the canonical label.
+    display_config: jsonb("display_config").$type<Record<string, string>>(),
     created_at: timestamp("created_at", { withTimezone: true })
       .notNull()
       .defaultNow(),


### PR DESCRIPTION
Final phase of the employee-profile redesign. Buckets + colors/labels are now driven entirely by each tenant's `leave_types` — a tenant with a different bucket set renders with **no code change** — and **PHES renders byte-identical** (the #1 requirement).

### One source of truth
- New `leave_types.display_config` jsonb `{ tint, accent, on_tint, board_label, chip_label }` (label = `display_name`). Shared resolver `lib/leave-bucket-display.ts` resolves the full display field-by-field, with **stable slug-derived defaults** so partial configs + brand-new tenant buckets still render.

### APIs return display
- **dispatch:** per-employee `time_off_color` + `time_off_label` (`time_off` is now the slug). `absent` stays a documented board-only constant.
- **/leave/balances:** each bucket carries `accent/tint/on_tint/board_label/chip_label`.
- **/leave/requests:** each row carries `bucket_tint` + `bucket_on_tint`.

### Deleted all 4 hardcoded maps (now data-driven)
`dispatch SLUG_TO_BUCKET` · `jobs.tsx TIME_OFF_BG/TIME_OFF_LABEL` · `employees.tsx BUCKET_COLORS` · `employee-profile.tsx leaveBucketAccent`. (The slug-aware `offLabel` tooltip was updated to survive the slug change.)

### Zero-drift safety
- The surfaces genuinely use **different palettes** (board pale tint `#E9FBF5` vs profile accent `#1D9E75`; review fg `#00876B`; labels board "PLAWA" vs chip "Sick", board "Unpaid" vs "Unpaid Leave") — so the config carries each, and the migration seeds PHES (co1+co4) with the **exact hex/labels pulled verbatim** from the 4 legacy maps (idempotent, only where NULL).
- `leave-bucket-display.test.ts` (**9**) asserts byte-identical reproduction of every legacy value + tenant-dynamic defaults + a differently-configured tenant. Full leave suite green (**178**). `typecheck:libs` + server bundle clean; **no new** frontend type errors; no change to balances/history/discipline.

**Will verify live** the PHES dispatch board + profile cards + history chips look identical (no color/label drift) and that colors now come from the API. If the board looks even slightly off, I'll flag before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)