### PR TITLE
fix(photos): R2 PutObject checksum fix + migrate error detail

### DIFF
--- a/artifacts/api-server/src/lib/r2.ts
+++ b/artifacts/api-server/src/lib/r2.ts
@@ -38,6 +38,12 @@ function client(): S3Client {
         accessKeyId: process.env.R2_ACCESS_KEY_ID || "",
         secretAccessKey: process.env.R2_SECRET_ACCESS_KEY || "",
       },
+      // [photos-r2 fix] AWS SDK v3 (≥3.729) adds default CRC32 integrity
+      // checksums + a streaming trailer that R2 rejects ("not implemented" /
+      // signature mismatch on PutObject). Force checksums to WHEN_REQUIRED so
+      // they're omitted for normal puts. This is the standard R2 + aws-sdk fix.
+      requestChecksumCalculation: "WHEN_REQUIRED",
+      responseChecksumValidation: "WHEN_REQUIRED",
     });
   }
   return _client;

--- a/artifacts/api-server/src/routes/photos.ts
+++ b/artifacts/api-server/src/routes/photos.ts
@@ -29,6 +29,7 @@ router.post("/migrate-to-r2", requireAuth, async (req: Request, res: Response) =
   try {
     const rows = await db.select().from(jobPhotosTable).where(like(jobPhotosTable.url, "data:%")).limit(limit);
     let migrated = 0, failed = 0;
+    let firstError: string | null = null;
     for (const p of rows) {
       try {
         const m = String(p.url).match(/^data:([^;]+);base64,([\s\S]*)$/);
@@ -42,6 +43,7 @@ router.post("/migrate-to-r2", requireAuth, async (req: Request, res: Response) =
         migrated++;
       } catch (e) {
         console.error("[migrate-to-r2] photo", p.id, e);
+        if (!firstError) firstError = e instanceof Error ? e.message : String(e);
         failed++;
       }
     }
@@ -49,7 +51,7 @@ router.post("/migrate-to-r2", requireAuth, async (req: Request, res: Response) =
       .select({ c: sql<number>`count(*)::int` })
       .from(jobPhotosTable)
       .where(like(jobPhotosTable.url, "data:%"));
-    res.json({ migrated, failed, remaining: Number(row?.c ?? 0) });
+    res.json({ migrated, failed, remaining: Number(row?.c ?? 0), error_sample: firstError });
   } catch (err) {
     console.error("[migrate-to-r2]:", err);
     res.status(500).json({ error: "migration_failed" });


### PR DESCRIPTION
Migrate smoke test returned failed:1. AWS SDK v3 default CRC32 checksums break R2 PutObject; force WHEN_REQUIRED. Also surface error_sample in the migrate response. Generated with Claude Code