### PR TITLE
fix(photos): strip non-printable chars from R2 creds + diagnostic

### DIFF
--- a/artifacts/api-server/src/lib/r2.ts
+++ b/artifacts/api-server/src/lib/r2.ts
@@ -14,11 +14,31 @@ import {
 } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 
-// [photos-r2 fix] .trim() every value — a stray space/newline pasted into a
+// [photos-r2 fix] Strip ALL non-printable-ASCII chars (newlines, tabs, control,
+// non-ASCII), not just trim the ends — a stray character anywhere in a pasted
 // Railway variable corrupts the S3 SigV4 auth header ("Invalid character in
-// header content [authorization]") and every upload fails.
-const ACCOUNT_ID = (process.env.R2_ACCOUNT_ID || "").trim();
-const BUCKET = (process.env.R2_BUCKET || "qleno-photos").trim();
+// header content [authorization]") and every upload fails. R2 keys are hex, so
+// this only ever removes paste artifacts, never legitimate characters.
+const clean = (s: string | undefined): string =>
+  (s || "").replace(/[^\x20-\x7E]/g, "").trim();
+
+const ACCOUNT_ID = clean(process.env.R2_ACCOUNT_ID);
+const BUCKET = clean(process.env.R2_BUCKET) || "qleno-photos";
+
+// Safe diagnostic — lengths only, never the values. `stripped > 0` means that
+// variable had non-printable paste junk in it.
+export function r2CredFingerprint() {
+  const fp = (k: string) => {
+    const raw = process.env[k] || "";
+    return { raw_len: raw.length, clean_len: clean(raw).length };
+  };
+  return {
+    account: fp("R2_ACCOUNT_ID"),
+    access_key_id: fp("R2_ACCESS_KEY_ID"),
+    secret: fp("R2_SECRET_ACCESS_KEY"),
+    bucket: fp("R2_BUCKET"),
+  };
+}
 
 let _client: S3Client | null = null;
 
@@ -38,8 +58,8 @@ function client(): S3Client {
       region: "auto",
       endpoint: `https://${ACCOUNT_ID}.r2.cloudflarestorage.com`,
       credentials: {
-        accessKeyId: (process.env.R2_ACCESS_KEY_ID || "").trim(),
-        secretAccessKey: (process.env.R2_SECRET_ACCESS_KEY || "").trim(),
+        accessKeyId: clean(process.env.R2_ACCESS_KEY_ID),
+        secretAccessKey: clean(process.env.R2_SECRET_ACCESS_KEY),
       },
       // [photos-r2 fix] AWS SDK v3 (≥3.729) adds default CRC32 integrity
       // checksums + a streaming trailer that R2 rejects ("not implemented" /

--- a/artifacts/api-server/src/routes/photos.ts
+++ b/artifacts/api-server/src/routes/photos.ts
@@ -4,7 +4,7 @@ import { requireAuth } from "../lib/auth.js";
 import { db } from "@workspace/db";
 import { jobPhotosTable } from "@workspace/db/schema";
 import { eq, like, sql } from "drizzle-orm";
-import { r2Configured, r2Upload, jobPhotoKey } from "../lib/r2.js";
+import { r2Configured, r2Upload, jobPhotoKey, r2CredFingerprint } from "../lib/r2.js";
 import crypto from "node:crypto";
 
 const router = Router();
@@ -51,7 +51,7 @@ router.post("/migrate-to-r2", requireAuth, async (req: Request, res: Response) =
       .select({ c: sql<number>`count(*)::int` })
       .from(jobPhotosTable)
       .where(like(jobPhotosTable.url, "data:%"));
-    res.json({ migrated, failed, remaining: Number(row?.c ?? 0), error_sample: firstError });
+    res.json({ migrated, failed, remaining: Number(row?.c ?? 0), error_sample: firstError, cred_fp: firstError ? r2CredFingerprint() : undefined });
   } catch (err) {
     console.error("[migrate-to-r2]:", err);
     res.status(500).json({ error: "migration_failed" });


### PR DESCRIPTION
trim didn't fix the auth-header error; strip all non-printable chars from R2 creds + add safe length-only credential fingerprint to diagnose. Generated with Claude Code