### PR TITLE
chore(photos): remove temporary R2 credential diagnostic

### DIFF
--- a/artifacts/api-server/src/lib/r2.ts
+++ b/artifacts/api-server/src/lib/r2.ts
@@ -25,21 +25,6 @@ const clean = (s: string | undefined): string =>
 const ACCOUNT_ID = clean(process.env.R2_ACCOUNT_ID);
 const BUCKET = clean(process.env.R2_BUCKET) || "qleno-photos";
 
-// Safe diagnostic — lengths only, never the values. `stripped > 0` means that
-// variable had non-printable paste junk in it.
-export function r2CredFingerprint() {
-  const fp = (k: string) => {
-    const raw = process.env[k] || "";
-    return { raw_len: raw.length, clean_len: clean(raw).length };
-  };
-  return {
-    account: fp("R2_ACCOUNT_ID"),
-    access_key_id: fp("R2_ACCESS_KEY_ID"),
-    secret: fp("R2_SECRET_ACCESS_KEY"),
-    bucket: fp("R2_BUCKET"),
-  };
-}
-
 let _client: S3Client | null = null;
 
 /** True once all R2 env vars are present. Routes fall back to legacy base64

--- a/artifacts/api-server/src/routes/photos.ts
+++ b/artifacts/api-server/src/routes/photos.ts
@@ -4,7 +4,7 @@ import { requireAuth } from "../lib/auth.js";
 import { db } from "@workspace/db";
 import { jobPhotosTable } from "@workspace/db/schema";
 import { eq, like, sql } from "drizzle-orm";
-import { r2Configured, r2Upload, jobPhotoKey, r2CredFingerprint } from "../lib/r2.js";
+import { r2Configured, r2Upload, jobPhotoKey } from "../lib/r2.js";
 import crypto from "node:crypto";
 
 const router = Router();
@@ -51,7 +51,7 @@ router.post("/migrate-to-r2", requireAuth, async (req: Request, res: Response) =
       .select({ c: sql<number>`count(*)::int` })
       .from(jobPhotosTable)
       .where(like(jobPhotosTable.url, "data:%"));
-    res.json({ migrated, failed, remaining: Number(row?.c ?? 0), error_sample: firstError, cred_fp: firstError ? r2CredFingerprint() : undefined });
+    res.json({ migrated, failed, remaining: Number(row?.c ?? 0), error_sample: firstError });
   } catch (err) {
     console.error("[migrate-to-r2]:", err);
     res.status(500).json({ error: "migration_failed" });


### PR DESCRIPTION
Removes the cred_fp length-only diagnostic added during R2 credential debugging (now resolved). Generated with Claude Code