### PR TITLE
feat(layout): app-wide width/polish pass

### DIFF
--- a/artifacts/qleno/src/components/layout/dashboard-layout.tsx
+++ b/artifacts/qleno/src/components/layout/dashboard-layout.tsx
@@ -1192,7 +1192,7 @@ export function DashboardLayout({ children, title, fullBleed, onNewJob }: Dashbo
         ) : (
           <main style={{ flex: 1, overflowY: 'auto', scrollbarGutter: 'stable', backgroundColor: '#F7F6F3', display: 'flex', flexDirection: 'column' }}>
             <CommsPausedBanner />
-            <div style={{ padding: '28px 28px', maxWidth: 1400, margin: '0 auto', width: '100%' }}>{children}</div>
+            <div style={{ padding: '28px 28px', maxWidth: 1600, margin: '0 auto', width: '100%' }}>{children}</div>
           </main>
         )}
       </div>

--- a/artifacts/qleno/src/pages/accounts.tsx
+++ b/artifacts/qleno/src/pages/accounts.tsx
@@ -133,7 +133,7 @@ export default function AccountsPage() {
 
   return (
     <DashboardLayout>
-      <div className="p-6 max-w-6xl mx-auto space-y-5">
+      <div className="space-y-5">
         {/* Header */}
         <div className="flex items-center justify-between">
           <div>

--- a/artifacts/qleno/src/pages/agreement-templates.tsx
+++ b/artifacts/qleno/src/pages/agreement-templates.tsx
@@ -109,7 +109,7 @@ export default function AgreementTemplatesPage() {
 
   return (
     <DashboardLayout>
-      <div style={{ padding: "28px 32px", maxWidth: "1100px", margin: "0 auto" }}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '24px' }}>
         {/* Header */}
         <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", marginBottom: "24px" }}>
           <div>

--- a/artifacts/qleno/src/pages/cleancyclopedia.tsx
+++ b/artifacts/qleno/src/pages/cleancyclopedia.tsx
@@ -46,7 +46,7 @@ export default function CleancyclopediaPage() {
       <div style={{ display: 'flex', flexDirection: 'column', gap: '28px' }}>
         {/* Header */}
         <div>
-          <h1 style={{ fontFamily: "'Plus Jakarta Sans', sans-serif", fontWeight: 700, fontSize: '42px', color: '#1A1917', margin: 0, lineHeight: 1.1 }}>Cleancyclopedia</h1>
+          <h1 style={{ fontFamily: "'Plus Jakarta Sans', sans-serif", fontWeight: 700, fontSize: '24px', color: '#1A1917', margin: 0, lineHeight: 1.1 }}>Cleancyclopedia</h1>
           <p style={{ fontFamily: "'Plus Jakarta Sans', sans-serif", fontWeight: 300, fontSize: '13px', color: '#6B7280', marginTop: '6px' }}>Training library, SOPs, chemical guides, and client communication scripts.</p>
         </div>
 

--- a/artifacts/qleno/src/pages/clock-monitor.tsx
+++ b/artifacts/qleno/src/pages/clock-monitor.tsx
@@ -193,7 +193,7 @@ export default function ClockMonitorPage() {
 
   return (
     <DashboardLayout>
-      <div style={{ padding: "28px 32px", fontFamily: "'Plus Jakarta Sans', sans-serif" }}>
+      <div style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}>
         <div style={{ marginBottom: 28 }}>
           <h1 style={{ fontSize: 22, fontWeight: 700, color: "#1A1917", margin: "0 0 4px" }}>Clock Monitor</h1>
           <p style={{ fontSize: 13, color: "#6B7280", margin: 0 }}>Today's clock activity across all employees</p>

--- a/artifacts/qleno/src/pages/company.tsx
+++ b/artifacts/qleno/src/pages/company.tsx
@@ -75,7 +75,7 @@ export default function CompanyPage() {
     <DashboardLayout>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '28px' }}>
         <div>
-          <h1 style={{ fontFamily: "'Plus Jakarta Sans', sans-serif", fontWeight: 700, fontSize: '42px', color: '#1A1917', margin: 0, lineHeight: 1.1 }}>Company Settings</h1>
+          <h1 style={{ fontFamily: "'Plus Jakarta Sans', sans-serif", fontWeight: 700, fontSize: '24px', color: '#1A1917', margin: 0, lineHeight: 1.1 }}>Company Settings</h1>
           <p style={{ fontFamily: "'Plus Jakarta Sans', sans-serif", fontWeight: 300, fontSize: '13px', color: '#6B7280', marginTop: '6px' }}>Manage your company profile, branding, and integrations.</p>
           {branchName && (
             <div style={{ display: 'inline-flex', alignItems: 'center', gap: 8, marginTop: 10, backgroundColor: 'var(--brand-dim)', border: '1px solid rgba(91,155,213,0.3)', borderRadius: 8, padding: '6px 12px', fontSize: 12, color: 'var(--brand)', fontFamily: "'Plus Jakarta Sans', sans-serif", fontWeight: 600 }}>

--- a/artifacts/qleno/src/pages/discounts.tsx
+++ b/artifacts/qleno/src/pages/discounts.tsx
@@ -161,7 +161,7 @@ export default function DiscountsPage() {
         {/* Header */}
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
           <div>
-            <h1 style={{ fontFamily: "'Plus Jakarta Sans', sans-serif", fontWeight: 700, fontSize: '42px', color: '#1A1917', margin: 0, lineHeight: 1.1 }}>Discounts</h1>
+            <h1 style={{ fontFamily: "'Plus Jakarta Sans', sans-serif", fontWeight: 700, fontSize: '24px', color: '#1A1917', margin: 0, lineHeight: 1.1 }}>Discounts</h1>
             <p style={{ fontFamily: "'Plus Jakarta Sans', sans-serif", fontWeight: 300, fontSize: '13px', color: '#6B7280', marginTop: '6px' }}>Create and manage promo codes and discount rules.</p>
           </div>
           <button

--- a/artifacts/qleno/src/pages/jobs-list.tsx
+++ b/artifacts/qleno/src/pages/jobs-list.tsx
@@ -284,7 +284,7 @@ export default function JobsListPage() {
 
   return (
     <DashboardLayout title="Jobs">
-      <div style={{ padding: "28px 32px", fontFamily: FF, minHeight: "100%", background: BG }}>
+      <div style={{ padding: "0", fontFamily: FF, minHeight: "100%", background: BG }}>
 
         {/* Header */}
         <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 28 }}>

--- a/artifacts/qleno/src/pages/leads-reports.tsx
+++ b/artifacts/qleno/src/pages/leads-reports.tsx
@@ -160,7 +160,7 @@ export default function LeadsReportsPage() {
 
   return (
     <DashboardLayout>
-      <div style={{ maxWidth: 1180, margin: "0 auto", padding: "0 0 48px" }}>
+      <div style={{ padding: "0 0 48px" }}>
         <Link href="/leads" style={{ display: "inline-flex", alignItems: "center", gap: 4, fontSize: 13, color: "#6B6860",
           textDecoration: "none", marginBottom: 12 }}>
           <ChevronLeft size={14} /> Back to Pipeline

--- a/artifacts/qleno/src/pages/leads.tsx
+++ b/artifacts/qleno/src/pages/leads.tsx
@@ -916,7 +916,7 @@ export default function LeadsPage() {
 
   return (
     <DashboardLayout>
-      <div style={{ maxWidth: 1200, margin: "0 auto", padding: "0 0 40px" }}>
+      <div style={{ padding: "0 0 40px" }}>
 
         {/* Page header */}
         <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between",

--- a/artifacts/qleno/src/pages/leave-request.tsx
+++ b/artifacts/qleno/src/pages/leave-request.tsx
@@ -180,7 +180,7 @@ export default function LeaveRequestPage() {
 
   return (
     <DashboardLayout>
-      <div style={{ fontFamily: FF, color: INK, padding: "8px 0 32px", maxWidth: 760 }}>
+      <div style={{ fontFamily: FF, color: INK, padding: "8px 0 32px", maxWidth: 760, margin: "0 auto" }}>
         <h1 style={{ fontSize: 22, fontWeight: 800, margin: 0 }}>My Time Off</h1>
         <div style={{ fontSize: 12, color: MUTED, marginBottom: 16 }}>
           Submit a request and check your balances.

--- a/artifacts/qleno/src/pages/loyalty.tsx
+++ b/artifacts/qleno/src/pages/loyalty.tsx
@@ -81,7 +81,7 @@ export default function LoyaltyPage() {
       <div style={{ display: 'flex', flexDirection: 'column', gap: '32px' }}>
         {/* Header */}
         <div>
-          <h1 style={{ fontFamily: "'Plus Jakarta Sans', sans-serif", fontWeight: 700, fontSize: '42px', color: '#1A1917', margin: 0, lineHeight: 1.1 }}>Loyalty Program</h1>
+          <h1 style={{ fontFamily: "'Plus Jakarta Sans', sans-serif", fontWeight: 700, fontSize: '24px', color: '#1A1917', margin: 0, lineHeight: 1.1 }}>Loyalty Program</h1>
           <p style={{ fontFamily: "'Plus Jakarta Sans', sans-serif", fontWeight: 300, fontSize: '13px', color: '#6B7280', marginTop: '6px' }}>Configure your CleanRewards program style, earn rules, and rewards.</p>
         </div>
 

--- a/artifacts/qleno/src/pages/property-groups.tsx
+++ b/artifacts/qleno/src/pages/property-groups.tsx
@@ -73,7 +73,7 @@ export default function PropertyGroupsPage() {
 
   return (
     <DashboardLayout>
-      <div style={{ padding: "28px 32px", maxWidth: "1100px", margin: "0 auto" }}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '24px' }}>
         {/* Header */}
         <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", marginBottom: "24px" }}>
           <div>

--- a/artifacts/qleno/src/pages/quotes.tsx
+++ b/artifacts/qleno/src/pages/quotes.tsx
@@ -338,7 +338,7 @@ export default function QuotesPage() {
   // ── Desktop layout ─────────────────────────────────────────────────────────
   return (
     <DashboardLayout>
-      <div className="p-6 max-w-6xl mx-auto space-y-6">
+      <div className="space-y-6">
         <div className="flex items-center justify-between flex-wrap gap-3">
           <div>
             <h1 className="text-2xl font-bold text-[#1A1917]">Quotes</h1>

--- a/artifacts/qleno/src/pages/quoting.tsx
+++ b/artifacts/qleno/src/pages/quoting.tsx
@@ -190,7 +190,7 @@ export default function QuotingPage() {
 
   return (
     <DashboardLayout>
-    <div className="p-6 max-w-5xl mx-auto space-y-6">
+    <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold text-[#1A1917]">Quoting Settings</h1>
@@ -208,7 +208,7 @@ export default function QuotingPage() {
               Load PHES Defaults
             </Button>
           )}
-          <Button onClick={() => setIsCreating(true)} className="gap-2 bg-[#5B9BD5] hover:bg-[#4a8ac4] text-white">
+          <Button onClick={() => setIsCreating(true)} className="gap-2 bg-[#00C9A0] hover:bg-[#00b38f] text-white">
             <Plus className="w-4 h-4" />
             New Scope
           </Button>
@@ -261,7 +261,7 @@ export default function QuotingPage() {
           <div className="flex gap-2 pt-1">
             <Button
               size="sm"
-              className="bg-[#5B9BD5] hover:bg-[#4a8ac4] text-white"
+              className="bg-[#00C9A0] hover:bg-[#00b38f] text-white"
               onClick={() => createMutation.mutate(newScope)}
               disabled={!newScope.name || createMutation.isPending}
             >
@@ -432,7 +432,7 @@ function ScopeEditor({
             </div>
           </div>
           <div className="flex gap-2 pt-2">
-            <Button size="sm" className="bg-[#5B9BD5] hover:bg-[#4a8ac4] text-white" onClick={() => onPatchScope(basicFields)}>
+            <Button size="sm" className="bg-[#00C9A0] hover:bg-[#00b38f] text-white" onClick={() => onPatchScope(basicFields)}>
               Save Changes
             </Button>
             <AlertDialog>
@@ -549,7 +549,7 @@ function ScopeEditor({
             </Button>
             <Button
               size="sm"
-              className="bg-[#5B9BD5] hover:bg-[#4a8ac4] text-white"
+              className="bg-[#00C9A0] hover:bg-[#00b38f] text-white"
               onClick={() => onSaveSqft(sqftEdits)}
             >
               Save Table
@@ -615,7 +615,7 @@ function ScopeEditor({
                 </div>
               </div>
               <div className="flex gap-2">
-                <Button size="sm" className="bg-[#5B9BD5] hover:bg-[#4a8ac4] text-white" onClick={() => { onAddAddon(newAddon); setShowNewAddon(false); setNewAddon({ name: "", price_type: "flat", price_value: "50", time_minutes: 0, tech_pay: true }); }} disabled={!newAddon.name}>
+                <Button size="sm" className="bg-[#00C9A0] hover:bg-[#00b38f] text-white" onClick={() => { onAddAddon(newAddon); setShowNewAddon(false); setNewAddon({ name: "", price_type: "flat", price_value: "50", time_minutes: 0, tech_pay: true }); }} disabled={!newAddon.name}>
                   Add
                 </Button>
                 <Button size="sm" variant="ghost" onClick={() => setShowNewAddon(false)}>Cancel</Button>

--- a/artifacts/qleno/src/pages/time-clock.tsx
+++ b/artifacts/qleno/src/pages/time-clock.tsx
@@ -506,7 +506,7 @@ export default function TimeClockPage() {
 
   return (
     <DashboardLayout>
-      <div style={{ fontFamily: FF, maxWidth: 920, margin: "0 auto" }}>
+      <div style={{ fontFamily: FF }}>
         {/* Header */}
         <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 6, flexWrap: "wrap", gap: 10 }}>
           <div>

--- a/artifacts/qleno/src/pages/zones.tsx
+++ b/artifacts/qleno/src/pages/zones.tsx
@@ -798,7 +798,7 @@ export default function ZonesPage() {
 
   return (
     <DashboardLayout>
-      <div style={{ maxWidth: 1100 }}>
+      <div>
         {isMobile ? (
           <MobileZones zones={zones} employees={employees} loading={loading} onRefresh={load} />
         ) : (


### PR DESCRIPTION
From a 69-page multi-agent layout audit. Global cap 1400->1600 + remove skinny-column caps on 11 pages + title/brand/centering polish. Build passes. Mobile responsive-grid fixes queued as next pass. Generated with Claude Code