### PR TITLE
feat(tech-app): notification bell/inbox on field app + fix broken Notification settings link

### DIFF
--- a/artifacts/qleno/src/App.tsx
+++ b/artifacts/qleno/src/App.tsx
@@ -151,6 +151,7 @@ const TECH_ALLOWED_PREFIXES = [
   "/training",
   "/leave",
   "/notifications",
+  "/settings/notifications",  // tech notification prefs (avatar menu → Notification settings)
   "/pay/",        // token-based payment link
   "/sign/",       // token-based document sign
   "/sign-doc/",   // token-based document sign

--- a/artifacts/qleno/src/components/layout/dashboard-layout.tsx
+++ b/artifacts/qleno/src/components/layout/dashboard-layout.tsx
@@ -5,6 +5,7 @@ import { useAuthStore } from "@/lib/auth";
 import { useLocation, Link } from "wouter";
 import { useGetMe } from "@workspace/api-client-react";
 import { getAuthHeaders } from "@/lib/auth";
+import { NotificationBell } from "@/components/notification-bell";
 import { useTenantBrand } from "@/lib/tenant-brand";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { VoiceAssistant } from "@/components/voice-assistant";
@@ -516,10 +517,8 @@ export function DashboardLayout({ children, title, fullBleed, onNewJob }: Dashbo
   const [moreOpen, setMoreOpen] = useState(false);
   const [userDropOpen, setUserDropOpen] = useState(false);
   const [changePwOpen, setChangePwOpen] = useState(false);
-  const [notifOpen, setNotifOpen] = useState(false);
   const [quickCreateOpen, setQuickCreateOpen] = useState(false);
   const userDropRef = useRef<HTMLDivElement>(null);
-  const notifRef = useRef<HTMLDivElement>(null);
   const quickCreateRef = useRef<HTMLDivElement>(null);
   const queryClient = useQueryClient();
 
@@ -532,14 +531,6 @@ export function DashboardLayout({ children, title, fullBleed, onNewJob }: Dashbo
     return () => document.removeEventListener('mousedown', handler);
   }, [userDropOpen]);
 
-  useEffect(() => {
-    if (!notifOpen) return;
-    const handler = (e: MouseEvent) => {
-      if (notifRef.current && !notifRef.current.contains(e.target as Node)) setNotifOpen(false);
-    };
-    document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
-  }, [notifOpen]);
 
   useEffect(() => {
     if (!quickCreateOpen) return;
@@ -629,24 +620,9 @@ export function DashboardLayout({ children, title, fullBleed, onNewJob }: Dashbo
     }
   };
 
-  const notifItems: any[] = notifData?.data || [];
   const notifUnread: number = notifData?.unread_count || 0;
 
-  const markNotifRead = async (id: string, link?: string) => {
-    try {
-      await fetch(`${API}/api/notifications/inbox/${id}/read`, { method: 'PATCH', headers: getAuthHeaders() as any });
-      queryClient.invalidateQueries({ queryKey: ['notifications-inbox'] });
-    } catch (_) {}
-    if (link) setLocation(link);
-    setNotifOpen(false);
-  };
 
-  const markAllNotifRead = async () => {
-    try {
-      await fetch(`${API}/api/notifications/inbox/read-all`, { method: 'PATCH', headers: getAuthHeaders() as any });
-      queryClient.invalidateQueries({ queryKey: ['notifications-inbox'] });
-    } catch (_) {}
-  };
 
   useTenantBrand();
   const unreadCount = useUnreadCount(user?.id);
@@ -1017,82 +993,7 @@ export function DashboardLayout({ children, title, fullBleed, onNewJob }: Dashbo
             )}
 
             {user && (
-              <div ref={notifRef} style={{ position: 'relative' }}>
-                <button
-                  onClick={() => setNotifOpen(p => !p)}
-                  title="Notifications"
-                  style={{ background: notifOpen ? 'var(--brand-dim)' : 'none', border: 'none', cursor: 'pointer', color: notifOpen ? 'var(--brand)' : '#6B7280', padding: 6, borderRadius: 8, display: 'flex', alignItems: 'center', position: 'relative' } as any}
-                >
-                  <Bell size={20} />
-                  {notifUnread > 0 && (
-                    <span style={{ position: 'absolute', top: 2, right: 2, minWidth: 9, height: 9, borderRadius: 5, background: '#EF4444', border: '2px solid #fff', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 8, color: '#fff', fontWeight: 700, padding: '0 2px' }}>
-                      {notifUnread > 9 ? '9+' : notifUnread}
-                    </span>
-                  )}
-                </button>
-
-                {notifOpen && (
-                  <div style={{
-                    position: 'absolute', top: '100%', right: 0, marginTop: 6,
-                    background: '#fff', borderRadius: 12, border: '1px solid #E5E2DC',
-                    boxShadow: '0 8px 32px rgba(0,0,0,0.12)', width: 380, zIndex: 200,
-                    display: 'flex', flexDirection: 'column', overflow: 'hidden',
-                  }}>
-                    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '14px 16px 10px', borderBottom: '1px solid #F0EDEA' }}>
-                      <span style={{ fontSize: 14, fontWeight: 700, color: '#1A1917', fontFamily: "'Plus Jakarta Sans', sans-serif" }}>
-                        Notifications {notifUnread > 0 && <span style={{ fontSize: 11, color: '#EF4444', marginLeft: 4 }}>({notifUnread} unread)</span>}
-                      </span>
-                      <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-                        {notifUnread > 0 && (
-                          <button onClick={markAllNotifRead} style={{ fontSize: 11, color: 'var(--brand)', background: 'none', border: 'none', cursor: 'pointer', fontFamily: "'Plus Jakarta Sans', sans-serif", fontWeight: 600 }}>
-                            Mark all read
-                          </button>
-                        )}
-                        <button onClick={() => { setNotifOpen(false); setLocation('/notifications'); }} style={{ fontSize: 11, color: '#9E9B94', background: 'none', border: 'none', cursor: 'pointer', fontFamily: "'Plus Jakarta Sans', sans-serif" }}>
-                          View all
-                        </button>
-                      </div>
-                    </div>
-                    <div style={{ maxHeight: 420, overflowY: 'auto' }}>
-                      {notifItems.length === 0 ? (
-                        <div style={{ padding: '32px 16px', textAlign: 'center', color: '#9E9B94', fontSize: 13, fontFamily: "'Plus Jakarta Sans', sans-serif" }}>
-                          No notifications yet
-                        </div>
-                      ) : notifItems.map((n: any) => {
-                        const icon = n.type === 'new_message' ? <MessageSquare size={14} style={{ color: '#00C9A0' }} />
-                          : n.type === 'job_assigned' ? <Briefcase size={14} style={{ color: '#2563EB' }} />
-                          : n.type === 'job_changed' ? <CalendarDays size={14} style={{ color: '#F59E0B' }} />
-                          : n.type === 'new_booking' ? <Bell size={14} style={{ color: '#2563EB' }} />
-                          : n.type === 'late_clockin' ? <AlertTriangle size={14} style={{ color: '#F59E0B' }} />
-                          : <Bell size={14} style={{ color: '#6B7280' }} />;
-                        return (
-                          <button
-                            key={n.id}
-                            onClick={() => markNotifRead(n.id, n.link)}
-                            style={{
-                              display: 'flex', alignItems: 'flex-start', gap: 10, padding: '11px 16px',
-                              background: n.read ? '#fff' : '#F0F4FF',
-                              border: 'none', borderBottom: '1px solid #F7F6F3', cursor: 'pointer', width: '100%', textAlign: 'left',
-                            }}
-                          >
-                            <span style={{ marginTop: 2, flexShrink: 0, width: 28, height: 28, borderRadius: 7, background: n.read ? '#F3F4F6' : 'var(--brand-dim)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                              {icon}
-                            </span>
-                            <span style={{ flex: 1, minWidth: 0 }}>
-                              <span style={{ display: 'block', fontSize: 12, fontWeight: n.read ? 500 : 700, color: '#1A1917', fontFamily: "'Plus Jakarta Sans', sans-serif", lineHeight: 1.3 }}>{n.title}</span>
-                              {n.body && <span style={{ display: 'block', fontSize: 11, color: '#6B7280', marginTop: 2, lineHeight: 1.4, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{n.body}</span>}
-                              <span style={{ display: 'block', fontSize: 10, color: '#C0BDB8', marginTop: 3 }}>
-                                {new Date(n.created_at).toLocaleDateString('en-US', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })}
-                              </span>
-                            </span>
-                            {!n.read && <span style={{ width: 7, height: 7, borderRadius: '50%', background: '#2563EB', flexShrink: 0, marginTop: 4 }} />}
-                          </button>
-                        );
-                      })}
-                    </div>
-                  </div>
-                )}
-              </div>
+              <NotificationBell />
             )}
 
             {user && (

--- a/artifacts/qleno/src/components/notification-bell.tsx
+++ b/artifacts/qleno/src/components/notification-bell.tsx
@@ -1,0 +1,146 @@
+/**
+ * Shared notification bell + inbox dropdown (Sal 2026-06-25).
+ *
+ * Extracted from dashboard-layout.tsx so the office shell AND the tech field
+ * app (my-jobs) render the SAME bell and can't drift. Self-contained: own
+ * state, its own /api/notifications/inbox query (same query key as the office
+ * mobile-bell badge → shared React Query cache, no extra network), mark-read,
+ * and the popover. The inbox endpoint is per-user (inboxScope = self for a
+ * technician), so a tech sees exactly their own job-assigned / job-changed /
+ * leave alerts. Read + mark-read only — no writes beyond marking read.
+ */
+import { useState, useRef, useEffect } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useLocation } from "wouter";
+import { useAuthStore, getAuthHeaders } from "@/lib/auth";
+import { Bell, MessageSquare, Briefcase, CalendarDays, AlertTriangle } from "lucide-react";
+
+const API = import.meta.env.BASE_URL.replace(/\/$/, "");
+const FF = "'Plus Jakarta Sans', sans-serif";
+
+export function NotificationBell() {
+  const token = useAuthStore((s) => s.token);
+  const [, setLocation] = useLocation();
+  const queryClient = useQueryClient();
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
+
+  const { data } = useQuery({
+    // Same key as the office shell's mobile-bell badge → one shared cache entry.
+    queryKey: ["notifications-inbox", token],
+    queryFn: async () => {
+      const r = await fetch(`${API}/api/notifications/inbox?limit=20`, { headers: getAuthHeaders() as any });
+      if (!r.ok) return { data: [], unread_count: 0 };
+      return r.json();
+    },
+    enabled: !!token,
+    refetchInterval: 30_000,
+    staleTime: 20_000,
+  });
+
+  const items: any[] = data?.data || [];
+  const unread: number = data?.unread_count || 0;
+
+  const markRead = async (id: string, link?: string) => {
+    try {
+      await fetch(`${API}/api/notifications/inbox/${id}/read`, { method: "PATCH", headers: getAuthHeaders() as any });
+      queryClient.invalidateQueries({ queryKey: ["notifications-inbox"] });
+    } catch (_) { /* leave unread on failure */ }
+    if (link) setLocation(link);
+    setOpen(false);
+  };
+  const markAllRead = async () => {
+    try {
+      await fetch(`${API}/api/notifications/inbox/read-all`, { method: "PATCH", headers: getAuthHeaders() as any });
+      queryClient.invalidateQueries({ queryKey: ["notifications-inbox"] });
+    } catch (_) { /* no-op */ }
+  };
+
+  const iconFor = (type: string) =>
+    type === "new_message" ? <MessageSquare size={14} style={{ color: "#00C9A0" }} />
+    : type === "job_assigned" ? <Briefcase size={14} style={{ color: "#2563EB" }} />
+    : type === "job_changed" ? <CalendarDays size={14} style={{ color: "#F59E0B" }} />
+    : type === "new_booking" ? <Bell size={14} style={{ color: "#2563EB" }} />
+    : type === "late_clockin" ? <AlertTriangle size={14} style={{ color: "#F59E0B" }} />
+    : <Bell size={14} style={{ color: "#6B7280" }} />;
+
+  return (
+    <div ref={ref} style={{ position: "relative" }}>
+      <button
+        onClick={() => setOpen((p) => !p)}
+        title="Notifications"
+        style={{ background: open ? "var(--brand-dim)" : "none", border: "none", cursor: "pointer", color: open ? "var(--brand)" : "#6B7280", padding: 6, borderRadius: 8, display: "flex", alignItems: "center", position: "relative" } as any}
+      >
+        <Bell size={20} />
+        {unread > 0 && (
+          <span style={{ position: "absolute", top: 2, right: 2, minWidth: 9, height: 9, borderRadius: 5, background: "#EF4444", border: "2px solid #fff", display: "flex", alignItems: "center", justifyContent: "center", fontSize: 8, color: "#fff", fontWeight: 700, padding: "0 2px" }}>
+            {unread > 9 ? "9+" : unread}
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <div style={{
+          position: "absolute", top: "100%", right: 0, marginTop: 6,
+          background: "#fff", borderRadius: 12, border: "1px solid #E5E2DC",
+          boxShadow: "0 8px 32px rgba(0,0,0,0.12)", width: 380, maxWidth: "92vw", zIndex: 200,
+          display: "flex", flexDirection: "column", overflow: "hidden",
+        }}>
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", padding: "14px 16px 10px", borderBottom: "1px solid #F0EDEA" }}>
+            <span style={{ fontSize: 14, fontWeight: 700, color: "#1A1917", fontFamily: FF }}>
+              Notifications {unread > 0 && <span style={{ fontSize: 11, color: "#EF4444", marginLeft: 4 }}>({unread} unread)</span>}
+            </span>
+            <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+              {unread > 0 && (
+                <button onClick={markAllRead} style={{ fontSize: 11, color: "var(--brand)", background: "none", border: "none", cursor: "pointer", fontFamily: FF, fontWeight: 600 }}>
+                  Mark all read
+                </button>
+              )}
+              <button onClick={() => { setOpen(false); setLocation("/notifications"); }} style={{ fontSize: 11, color: "#9E9B94", background: "none", border: "none", cursor: "pointer", fontFamily: FF }}>
+                View all
+              </button>
+            </div>
+          </div>
+          <div style={{ maxHeight: 420, overflowY: "auto" }}>
+            {items.length === 0 ? (
+              <div style={{ padding: "32px 16px", textAlign: "center", color: "#9E9B94", fontSize: 13, fontFamily: FF }}>
+                No notifications yet
+              </div>
+            ) : items.map((n: any) => (
+              <button
+                key={n.id}
+                onClick={() => markRead(n.id, n.link)}
+                style={{
+                  display: "flex", alignItems: "flex-start", gap: 10, padding: "11px 16px",
+                  background: n.read ? "#fff" : "#F0F4FF",
+                  border: "none", borderBottom: "1px solid #F7F6F3", cursor: "pointer", width: "100%", textAlign: "left",
+                }}
+              >
+                <span style={{ marginTop: 2, flexShrink: 0, width: 28, height: 28, borderRadius: 7, background: n.read ? "#F3F4F6" : "var(--brand-dim)", display: "flex", alignItems: "center", justifyContent: "center" }}>
+                  {iconFor(n.type)}
+                </span>
+                <span style={{ flex: 1, minWidth: 0 }}>
+                  <span style={{ display: "block", fontSize: 12, fontWeight: n.read ? 500 : 700, color: "#1A1917", fontFamily: FF, lineHeight: 1.3 }}>{n.title}</span>
+                  {n.body && <span style={{ display: "block", fontSize: 11, color: "#6B7280", marginTop: 2, lineHeight: 1.4, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{n.body}</span>}
+                  <span style={{ display: "block", fontSize: 10, color: "#C0BDB8", marginTop: 3 }}>
+                    {new Date(n.created_at).toLocaleDateString("en-US", { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" })}
+                  </span>
+                </span>
+                {!n.read && <span style={{ width: 7, height: 7, borderRadius: "50%", background: "#2563EB", flexShrink: 0, marginTop: 4 }} />}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/artifacts/qleno/src/pages/my-jobs.tsx
+++ b/artifacts/qleno/src/pages/my-jobs.tsx
@@ -7,6 +7,7 @@ import { useToast } from "@/hooks/use-toast";
 import { Check, Eye, Navigation, Phone, GraduationCap, DollarSign, Users, MapPin, Sun, Cloud, CloudSun, CloudRain, CloudSnow, CloudDrizzle, CloudLightning, Plane, Bell, KeyRound, LogOut, Camera } from "lucide-react";
 import { Link, useLocation } from "wouter";
 import { ChangePasswordModal } from "@/components/change-password-modal";
+import { NotificationBell } from "@/components/notification-bell";
 import { useEmployeeView } from "@/contexts/employee-view-context";
 import { getJobVisualStatus, STATUS_VISUALS, ensureJobStatusStyles } from "@/lib/job-status";
 import { formatAddress, mapsDirectionsUrl } from "@/lib/format-address";
@@ -1425,6 +1426,9 @@ export default function MyJobsPage() {
             <Link href="/training" style={{ display: 'inline-flex', alignItems: 'center', gap: 4, padding: '6px 10px', background: '#FFFFFF', color: '#1A1917', border: '1px solid #E5E2DC', borderRadius: 8, fontSize: 12, fontWeight: 700, cursor: 'pointer', fontFamily: 'inherit', textDecoration: 'none' }}>
               <GraduationCap size={13}/> Training
             </Link>
+            {/* [tech notifications 2026-06-25] Shared bell + inbox — same
+                component as the office shell, fed by the per-user inbox. */}
+            <NotificationBell />
             {/* Account menu — tap the avatar */}
             <div ref={acctRef} style={{ position: "relative" }}>
               <button onClick={() => setAcctOpen(o => !o)} aria-label="Account menu"


### PR DESCRIPTION
Fixes the two gaps from the live test on Test Auditor (#493): the tech field app had **no way to see in-app notifications**, and the avatar-menu **"Notification settings" link did nothing.**

### 1. Notification bell/inbox on the tech app
- Extracted the office desktop bell into a shared **`<NotificationBell/>`** (`components/notification-bell.tsx`) — self-contained: own state, its own `/api/notifications/inbox` query (**same query key** as the office mobile-bell badge → shared React Query cache, no extra network), `mark-read` + `mark-all-read`, and the popover.
- **Mounted in BOTH** the office shell and the tech **my-jobs** header → they can't drift.
- Inbox endpoint is **per-user** (`inboxScope = self`), so a tech sees exactly their own `job_assigned`/`job_changed`/leave alerts. Read + mark-read only.

### 2. Fixed the broken "Notification settings" link
Root cause: the tech route-allowlist (`isTechAllowedPath` in `App.tsx`) had `/notifications` but **not** `/settings/notifications` — so a technician tapping it was bounced back to `/my-jobs` (no-op). Added `/settings/notifications` to `TECH_ALLOWED_PREFIXES` (narrow prefix; the rest of `/settings` stays office-only). The page itself already works for techs (`GET /api/notifications/settings` under `requireAuth`).

### Safety
- Frontend-only; **no API/schema changes** (all endpoints already existed).
- `dashboard-layout` net −101 lines (extracted, not duplicated); kept `notifData`/`notifUnread` for the office mobile-bell badge (shares the cache).
- `tsc` clean on all changed files (the 5 dashboard-layout errors are pre-existing, identical on baseline).

**Verify after deploy on Test Auditor's phone:** the bell should show the existing unread **"New job assigned" (job 9663)**, and "Notification settings" should open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)