### PR TITLE
fix(push): re-bind device push subscription to the current user (lock-screen push for techs)

### DIFF
--- a/artifacts/api-server/src/lib/notify.ts
+++ b/artifacts/api-server/src/lib/notify.ts
@@ -87,11 +87,21 @@ async function sendUserWebPush(userId: number, a: NotifyArgs): Promise<void> {
     const { webPushConfigured, sendWebPush } = await import("./webpush.js");
     if (!webPushConfigured()) return;
     const subs = await db.execute(sql`SELECT endpoint, p256dh, auth FROM push_subscriptions WHERE user_id = ${userId}`);
-    if (!subs.rows.length) return;
+    if (!subs.rows.length) {
+      console.log(`[push] user ${userId} type=${a.type}: no subscriptions — nothing sent`);
+      return;
+    }
     const payload = { title: a.title, body: a.body ?? "", link: a.link ?? "/", tag: a.type, data: a.meta ?? {} };
     for (const s of subs.rows as any[]) {
       const r = await sendWebPush({ endpoint: s.endpoint, p256dh: s.p256dh, auth: s.auth }, payload);
-      if (r.dead) await db.execute(sql`DELETE FROM push_subscriptions WHERE endpoint = ${s.endpoint}`).catch(() => {});
+      if (r.dead) {
+        await db.execute(sql`DELETE FROM push_subscriptions WHERE endpoint = ${s.endpoint}`).catch(() => {});
+        console.warn(`[push] user ${userId} type=${a.type}: subscription gone (${r.status}) — pruned`);
+      } else if (!r.ok) {
+        // Non-410 failure (e.g. VAPID/payload rejected by the push service).
+        // Log it so delivery problems aren't silent; do NOT prune (sub is valid).
+        console.warn(`[push] user ${userId} type=${a.type}: send failed status=${r.status ?? "?"} reason=${(r as any).reason ?? ""}`);
+      }
     }
   } catch (e) {
     console.error("[notify] web push failed:", e);

--- a/artifacts/qleno/src/components/notification-bell.tsx
+++ b/artifacts/qleno/src/components/notification-bell.tsx
@@ -13,6 +13,7 @@ import { useState, useRef, useEffect } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useLocation } from "wouter";
 import { useAuthStore, getAuthHeaders } from "@/lib/auth";
+import { resyncPushSubscription } from "@/lib/web-push-client";
 import { Bell, MessageSquare, Briefcase, CalendarDays, AlertTriangle } from "lucide-react";
 
 const API = import.meta.env.BASE_URL.replace(/\/$/, "");
@@ -33,6 +34,16 @@ export function NotificationBell() {
     document.addEventListener("mousedown", handler);
     return () => document.removeEventListener("mousedown", handler);
   }, [open]);
+
+  // [push-rebind 2026-06-25] On every authenticated load, re-bind this device's
+  // existing push subscription to the CURRENT user. Without this, a device that
+  // was subscribed under a previous login (e.g. the owner test-installed the PWA,
+  // then a tech logged into the same install) keeps the subscription mapped to
+  // the old user — so the current user's lock-screen pushes go nowhere. Idempotent
+  // (re-POST → ON CONFLICT repoints user_id); never prompts or creates a new sub.
+  useEffect(() => {
+    if (token) void resyncPushSubscription();
+  }, [token]);
 
   const { data } = useQuery({
     // Same key as the office shell's mobile-bell badge → one shared cache entry.

--- a/artifacts/qleno/src/lib/web-push-client.ts
+++ b/artifacts/qleno/src/lib/web-push-client.ts
@@ -68,6 +68,27 @@ export async function enablePush(): Promise<"enabled" | "denied" | "unsupported"
   }
 }
 
+// Re-bind THIS device's existing push subscription to the CURRENT logged-in
+// user. The "on this device" toggle is derived from the browser HAVING a
+// PushSubscription, not from the server owning a row for the current user — so
+// on a reused/shared device (or after re-login) the subscription can stay
+// mapped to a previous user and that user's pushes go nowhere. This silently
+// re-POSTs the existing subscription so the server's ON CONFLICT (endpoint)
+// repoints it to whoever is logged in now. No permission prompt, no new
+// subscribe — only re-registers a sub that already exists. Safe on every load.
+export async function resyncPushSubscription(): Promise<void> {
+  if (!pushSupported() || Notification.permission !== "granted") return;
+  try {
+    const reg = await navigator.serviceWorker.ready;
+    const sub = await reg.pushManager.getSubscription();
+    if (!sub) return;
+    await fetch(`${API}/api/push/subscribe`, {
+      method: "POST", headers: { ...getAuthHeaders(), "Content-Type": "application/json" },
+      body: JSON.stringify(sub.toJSON()),
+    });
+  } catch (e) { console.warn("[push] resync failed", e); }
+}
+
 export async function disablePush(): Promise<void> {
   if (!pushSupported()) return;
   try {


### PR DESCRIPTION
## Root cause (single concrete reason)
The lock-screen push never arrived because **`push_subscriptions` has zero rows for user 493** — the iPhone's Apple push endpoint is still bound to **user 1 (the owner)** from Sal's earlier owner-test-install of the PWA on that same device.

The bug: the "Push on this device" toggle derives "on" from **`isSubscribedOnThisDevice()`** (does the *browser* have a PushSubscription) — **not** from whether the *server* has a subscription for the *current* user. So when Sal opened the same installed PWA as 493, the toggle already showed "on," `enablePush()` (the only thing that POSTs `/api/push/subscribe`, which repoints the endpoint to the current user via `ON CONFLICT`) **never ran for 493**, and the endpoint stayed mapped to user 1. `sendUserWebPush(493)` found no rows → nothing sent. (The in-app bell worked because that's a DB row, not a push.)

Verified: prefs correct (`new_jobs_push=true`), `sendWebPush` only prunes on 404/410 (not the cause), VAPID configured, SW push handler correct. The only break was the missing 493 binding.

## Fix
- **`resyncPushSubscription()`** (`web-push-client.ts`): on every authenticated load, if the browser already has a subscription + permission is granted, silently re-POST it → server `ON CONFLICT (endpoint)` repoints `user_id` to the **current** user. No prompt, no new subscribe. Called from **`NotificationBell`'s mount** (renders on every authed screen, office + tech) → reused device / re-login always rebinds to whoever's logged in. Self-healing.
- **`notify.ts` logging**: log "no subscriptions", pruned 404/410, and (new) **non-410 send failures** (VAPID/payload rejections) that were previously swallowed — so any remaining delivery issue is visible, without pruning a valid sub.

No schema/API changes; idempotent.

## After deploy — re-test on Test Auditor's phone
1. Open the installed Qleno PWA as 493 (just opening it triggers the rebind via the bell mount).
2. Assign/reassign a job to 493 → **lock-screen push should arrive**.
If it still doesn't, the new `[push] user 493 … send failed status=…` server log will show Apple's rejection reason (VAPID/payload), which I'd fix next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)