### PR TITLE
feat(tech): one-tap push nudge + fix(comms): paused company suppresses employee email

### DIFF
--- a/artifacts/api-server/src/lib/leave-notifications.ts
+++ b/artifacts/api-server/src/lib/leave-notifications.ts
@@ -84,10 +84,26 @@ function dateLabel(c: LeaveCtx): string {
   return c.start_date === c.end_date ? c.start_date : `${c.start_date} → ${c.end_date}`;
 }
 
-/** Employee-facing email — gated by COMMS_ENABLED (employee-facing comms). */
+/** Employee-facing email — gated by the GLOBAL COMMS_ENABLED master AND the
+ *  per-company comms flag (companies.comms_enabled), matching how SMS is gated
+ *  and what the in-app "comms paused" banner promises ("global off OR company
+ *  off"). [comms-pause fix 2026-06-25] Previously only the global master was
+ *  checked, so a PAUSED company (co1) still emailed employees despite the banner
+ *  saying no messages would go out. */
 async function sendEmployeeEmail(c: LeaveCtx, subject: string, bodyHtml: string): Promise<void> {
   try {
-    if (process.env.COMMS_ENABLED !== "true") return;
+    if (process.env.COMMS_ENABLED !== "true") {
+      console.log(`[leave-notify] employee email suppressed (comms_disabled) for request #${c.request_id}`);
+      return;
+    }
+    // Honor the per-company gate too. resolveSender reads companies.comms_enabled;
+    // we use ONLY that company flag here — its branch / twilio-from-number checks
+    // are SMS-specific and must not block email.
+    const sender = await resolveSender(c.company_id, null);
+    if (!sender.company_comms_enabled) {
+      console.log(`[leave-notify] employee email suppressed (company_comms_disabled) for request #${c.request_id}`);
+      return;
+    }
     const key = process.env.RESEND_API_KEY;
     if (!key || !c.employee_email) return;
     const from = `${c.company_name} <${c.email_from}>`;

--- a/artifacts/qleno/src/components/push-nudge.tsx
+++ b/artifacts/qleno/src/components/push-nudge.tsx
@@ -1,0 +1,95 @@
+/**
+ * One-time "Turn on job alerts?" push nudge for the tech field app (Sal
+ * 2026-06-25). Adoption was near-zero because enabling push meant digging into
+ * Notification settings; this surfaces a one-tap CTA on the My Jobs screen.
+ *
+ * Shows ONLY when: push is supported, the device is NOT already subscribed,
+ * permission isn't 'denied', and the tech hasn't dismissed it (per-user
+ * localStorage flag). One tap calls the existing enablePush() flow. iOS-aware:
+ * if the app isn't installed to the Home Screen, enablePush() returns
+ * "needs_install" and we show the Add-to-Home-Screen instruction inline.
+ */
+import { useState, useEffect } from "react";
+import { Bell, X } from "lucide-react";
+import { getTokenUserId } from "@/lib/auth";
+import { pushSupported, isIOS, isStandalone, permissionState, isSubscribedOnThisDevice, enablePush } from "@/lib/web-push-client";
+
+const FF = "'Plus Jakarta Sans', sans-serif";
+const dismissKey = () => `qleno_push_nudge_dismissed_${getTokenUserId() ?? "anon"}`;
+
+export function PushNudge() {
+  const [show, setShow] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [needsInstall, setNeedsInstall] = useState(false);
+  const [msg, setMsg] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      if (!pushSupported()) return;
+      if (permissionState() === "denied") return;        // can't re-prompt; don't nag
+      try { if (localStorage.getItem(dismissKey()) === "1") return; } catch { /* private mode → just show */ }
+      // Re-surface only when there's no active subscription on this device.
+      if (await isSubscribedOnThisDevice()) return;
+      setNeedsInstall(isIOS() && !isStandalone());
+      setShow(true);
+    })();
+  }, []);
+
+  const dismiss = () => {
+    try { localStorage.setItem(dismissKey(), "1"); } catch { /* private mode */ }
+    setShow(false);
+  };
+
+  const turnOn = async () => {
+    setBusy(true);
+    setMsg(null);
+    try {
+      const r = await enablePush();
+      if (r === "enabled") { setShow(false); }                       // subscribed → done, hide for good
+      else if (r === "needs_install") { setNeedsInstall(true); setMsg("On iPhone: tap Share → Add to Home Screen, open Qleno from there, then turn on alerts."); }
+      else if (r === "denied") { setMsg("Notifications are blocked. Allow them in your phone's Settings, then try again."); }
+      else if (r === "unsupported") { setMsg("This browser can't show push notifications."); }
+      else { setMsg("Couldn't turn on alerts — try again."); }
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (!show) return null;
+
+  return (
+    <div style={{
+      margin: "10px 16px 0", padding: "12px 14px", borderRadius: 12,
+      background: "var(--brand-dim)", border: "1px solid rgba(0,201,160,0.30)",
+      display: "flex", alignItems: "flex-start", gap: 10, fontFamily: FF,
+    }}>
+      <span style={{ flexShrink: 0, width: 30, height: 30, borderRadius: 8, background: "var(--brand)", display: "flex", alignItems: "center", justifyContent: "center" }}>
+        <Bell size={16} color="#04241d" />
+      </span>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontSize: 14, fontWeight: 800, color: "#1A1917" }}>Turn on job alerts?</div>
+        <div style={{ fontSize: 12, color: "#3E5C53", marginTop: 2, lineHeight: 1.4 }}>
+          {needsInstall
+            ? "Add Qleno to your Home Screen first, then get a notification the moment a job is assigned — even when the app is closed."
+            : "Get a notification the moment a job is assigned to you — even when the app is closed."}
+        </div>
+        {msg && <div style={{ fontSize: 11.5, color: "#92400E", marginTop: 6, lineHeight: 1.4 }}>{msg}</div>}
+        <div style={{ display: "flex", gap: 8, marginTop: 10 }}>
+          {!needsInstall && (
+            <button onClick={turnOn} disabled={busy}
+              style={{ fontFamily: FF, fontSize: 13, fontWeight: 700, color: "#04241d", background: "var(--brand)", border: "none", borderRadius: 8, padding: "8px 16px", cursor: "pointer", opacity: busy ? 0.5 : 1 }}>
+              {busy ? "Turning on…" : "Turn on alerts"}
+            </button>
+          )}
+          <button onClick={dismiss}
+            style={{ fontFamily: FF, fontSize: 13, fontWeight: 600, color: "#6B6860", background: "none", border: "none", cursor: "pointer", padding: "8px 4px" }}>
+            {needsInstall ? "Got it" : "Not now"}
+          </button>
+        </div>
+      </div>
+      <button onClick={dismiss} aria-label="Dismiss" style={{ flexShrink: 0, background: "none", border: "none", cursor: "pointer", color: "#9E9B94", padding: 2 }}>
+        <X size={16} />
+      </button>
+    </div>
+  );
+}

--- a/artifacts/qleno/src/lib/auth.ts
+++ b/artifacts/qleno/src/lib/auth.ts
@@ -129,6 +129,17 @@ export function getTokenRole(): string | null {
   }
 }
 
+export function getTokenUserId(): number | null {
+  const token = useAuthStore.getState().token;
+  if (!token) return null;
+  try {
+    const payload = JSON.parse(atob(token.split('.')[1]));
+    return typeof payload.userId === 'number' ? payload.userId : (payload.userId ? Number(payload.userId) : null);
+  } catch {
+    return null;
+  }
+}
+
 export function getTokenIsSuperAdmin(): boolean {
   const token = useAuthStore.getState().token;
   if (!token) return false;

--- a/artifacts/qleno/src/pages/my-jobs.tsx
+++ b/artifacts/qleno/src/pages/my-jobs.tsx
@@ -8,6 +8,7 @@ import { Check, Eye, Navigation, Phone, GraduationCap, DollarSign, Users, MapPin
 import { Link, useLocation } from "wouter";
 import { ChangePasswordModal } from "@/components/change-password-modal";
 import { NotificationBell } from "@/components/notification-bell";
+import { PushNudge } from "@/components/push-nudge";
 import { useEmployeeView } from "@/contexts/employee-view-context";
 import { getJobVisualStatus, STATUS_VISUALS, ensureJobStatusStyles } from "@/lib/job-status";
 import { formatAddress, mapsDirectionsUrl } from "@/lib/format-address";
@@ -1513,6 +1514,10 @@ export default function MyJobsPage() {
             ›
           </button>
         </div>
+
+        {/* [push-nudge 2026-06-25] One-time CTA to enable lock-screen job
+            alerts; self-hides when already subscribed / dismissed. */}
+        <PushNudge />
 
         {/* [day-banner 2026-06-11] Qleno-Night day summary: Efficiency + Quality
             for the selected day, with a job-completion progress bar. */}


### PR DESCRIPTION
Two approved follow-ups in one PR.

### 1. One-tap "Turn on job alerts" push nudge (tech app)
Adoption was near-zero because enabling push meant digging through Notification settings.
- New **`<PushNudge/>`** on the My Jobs screen — a one-time, dismissable "Turn on job alerts?" banner with a single button that calls the existing `enablePush()` (permission → subscribe → POST `/api/push/subscribe`).
- **Shows only when**: push supported, **not** already subscribed on this device, permission ≠ `denied`, and not previously dismissed (per-user `localStorage` key via new `getTokenUserId()`). Self-hides once enabled; re-surfaces only if there's no active subscription.
- **iOS-aware**: reuses `enablePush()`'s `needs_install` path — if not an installed PWA, shows the "Add to Home Screen first" instruction instead of a dead button.

### 2. Comms-pause email leak fix
`sendEmployeeEmail` was gated by the **global** `COMMS_ENABLED` only, so a **paused** company (co1, `comms_enabled=false`) still emailed employees despite the banner saying "no messages will be sent."
- Now also checks the **per-company** gate via `resolveSender().company_comms_enabled` (the same company flag SMS uses). Suppression fires when **(global off OR company off)** — **exactly** the banner's `useCommsPaused` condition, so the pause is now honest for employee email too.
- Only the company flag is consulted — branch / twilio-from-number checks stay SMS-specific and don't block email (no over-suppression). Added suppression logging for both gates.

### Verify
1. **Non-subscribed tech** → nudge shows; one tap enables push; doesn't show when already subscribed or after dismissal; iOS shows the install hint.
2. **co1 paused** → employee leave email is suppressed (log: `employee email suppressed (company_comms_disabled)`); flips to sending when `companies.comms_enabled` is true.

No schema/API changes. Frontend tsc clean on changed files; `typecheck:libs` clean; server bundles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)