### PR TITLE
feat(help): add Help & Guides to the mobile More sheet (tech access)

### DIFF
--- a/artifacts/qleno/src/components/layout/dashboard-layout.tsx
+++ b/artifacts/qleno/src/components/layout/dashboard-layout.tsx
@@ -22,7 +22,7 @@ import {
   ChevronDown, Eye, LogOut, CircleHelp, KeyRound, Bell,
   CalendarX2, UserMinus, AlertTriangle, Plus, Receipt, Briefcase, UserPlus,
   GraduationCap,
-  Building2, CalendarClock,
+  Building2, CalendarClock, LifeBuoy,
 } from "lucide-react";
 import { useEmployeeView } from "@/contexts/employee-view-context";
 
@@ -105,6 +105,7 @@ const MORE_CARDS = [
   { title: 'Core KPIs',      href: '/reports/insights',  icon: TrendingUp  },
   // Other
   { title: 'Loyalty',        href: '/loyalty',            icon: Star        },
+  { title: 'Help & Guides',  href: '/help',               icon: LifeBuoy    },
   { title: 'Cleancyclopedia', href: '/cleancyclopedia',  icon: BookOpen    },
   { title: 'Training',       href: '/training',           icon: GraduationCap },
   { title: 'Company',        href: '/company',            icon: Settings    },


### PR DESCRIPTION
Follow-up to the now-merged Help & Guides center (#608). That PR wired the **desktop sidebar** link, the `/help` route, and the TechRouteGuard allowlist — but techs have **no sidebar on mobile**. The mobile bottom-nav "More" sheet is built from a separate hardcoded `MORE_CARDS` list in `dashboard-layout.tsx`, which #608 didn't touch, so on a phone there was no tappable way into the guides.

This adds a **Help & Guides** card to that sheet, right next to Cleancyclopedia / Training — closing the only gap in the tech-first (mobile) access path.

Net change: +1 import (`LifeBuoy`) and +1 `MORE_CARDS` entry.

## Test
- frontend build (CI)

Do not deploy without your go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)