### PR TITLE
fix(attendance): add missing unexcused_hours_steps column (schema drift → 500 on record)

### DIFF
--- a/artifacts/api-server/src/cutover-data-migration.ts
+++ b/artifacts/api-server/src/cutover-data-migration.ts
@@ -804,6 +804,19 @@ async function seedPhesOccurrenceLadders(): Promise<void> {
       ) THEN
         ALTER TABLE company_attendance_policy ADD COLUMN tardy_occurrence_steps jsonb DEFAULT '[]'::jsonb;
       END IF;
+      -- [schema-drift fix 2026-06-25] The Drizzle schema (hr_policies.ts) defines
+      -- unexcused_hours_steps but the column was never added to the DB. The
+      -- attendance writer (recordUnexcusedEntryAndDriveLadder) SELECTs it on every
+      -- record, so without the column the office "Record unexcused/tardy" form AND
+      -- the attendance-overlay confirm path threw 500 after inserting the row.
+      -- co1/co4 use the occurrence ladder, so this stays '[]' (legacy hours ladder
+      -- dormant) — adding it just stops the SELECT from erroring.
+      IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema='public' AND table_name='company_attendance_policy' AND column_name='unexcused_hours_steps'
+      ) THEN
+        ALTER TABLE company_attendance_policy ADD COLUMN unexcused_hours_steps jsonb DEFAULT '[]'::jsonb;
+      END IF;
 
       -- Ensure a policy row exists for co1 + co4 (no unique-constraint assumption).
       INSERT INTO company_attendance_policy (company_id)


### PR DESCRIPTION
## Bug
Recording an unexcused absence / tardy returned **500** — the row inserted, then the policy SELECT threw. Root cause: **schema drift**. `hr_policies.ts:88` defines `company_attendance_policy.unexcused_hours_steps`, but the column was never added to the DB. `recordUnexcusedEntryAndDriveLadder` SELECTs it on every record → Postgres 42703 → endpoint 500.

This broke **both** the new office "Record" form (#662) **and** the pre-existing **attendance-overlay confirm** path — which is why `employee_attendance_log` was empty before the raw-SQL MC backfill (the backfill bypassed the writer).

Verified live: a test record on sandbox user 493 returned 500 but the row DID insert (and displayed cleanly), confirming the insert-then-SELECT-throws sequence. Test row deleted; `discipline_log` still empty.

## Fix
Add the column in the cold-start migration (`cutover-data-migration.ts`), idempotent `ADD COLUMN IF NOT EXISTS`, mirroring the adjacent occurrence-steps columns. co1/co4 use the occurrence ladder, so it stays `'[]'` (legacy hours ladder dormant) — purely stops the SELECT from erroring.

**Why CI didn't catch it:** build is esbuild (no queries); `typecheck:libs` checks against the Drizzle schema (which *has* the field); no integration test hits the live DB.

## After deploy
Re-test the record form on sandbox 493 → expect 200, entry shows with reason in the drill-down, then clean up. The dispatch-board attendance-overlay confirm also starts working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)