### PR TITLE
Phase 2: vertical estimate templates + one-click builder picker

### DIFF
--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -369,6 +369,10 @@ async function runBookingSchemaGuard(): Promise<void> {
         created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
       )
     ` },
+    // [estimate-templates-phase2 2026-06-25] Optional vertical on templates so
+    // the builder can offer a one-click picker (common_areas|office|retail|
+    // medical|null). Additive + idempotent.
+    { label: "estimate_templates.category", stmt: `ALTER TABLE estimate_templates ADD COLUMN IF NOT EXISTS category TEXT` },
     // ── follow_up_sequences table ────────────────────────────────────────────
     { label: "CREATE follow_up_sequences", stmt: `
       CREATE TABLE IF NOT EXISTS follow_up_sequences (
@@ -5058,6 +5062,120 @@ export async function runPhesDataMigration(): Promise<void> {
 
   // Seed MC discounts + remove placeholder discount add-ons
   await runDiscountMigration();
+
+  // [estimate-templates-phase2 2026-06-25] Seed the 4 commercial estimate
+  // templates (Common Areas / Office / Retail / Medical) for the one-click
+  // builder picker. Idempotent per (company_id, category).
+  await runEstimateTemplateSeed();
+}
+
+// ── Estimate Template Seed (PHES) ───────────────────────────────────────────
+// Seeds 4 vertical commercial estimate templates as reusable starting points
+// for the estimate builder's one-click picker. Pricing reflects PHES commercial
+// rates (Common Areas $45/hr, Office $50/hr, Retail $48/hr, Medical $60/hr).
+// Idempotent: each vertical is inserted only if no template with that category
+// already exists for the company, so re-runs and operator edits are preserved.
+type SeedTemplateItem = {
+  name: string; pricing_type: "flat" | "hourly" | "one_time";
+  frequency: string; quantity: number; unit_rate: number;
+};
+type SeedTemplate = {
+  category: string; name: string; title: string; intro_note: string;
+  terms: string; items: SeedTemplateItem[];
+};
+export const ESTIMATE_TEMPLATE_SEED: ReadonlyArray<SeedTemplate> = [
+  {
+    category: "common_areas",
+    name: "Common Areas — Condo / HOA",
+    title: "Common Area Cleaning — Recurring Service",
+    intro_note: "Thank you for the opportunity to quote recurring cleaning for your building's common areas. The scope below covers the shared spaces your residents use every day — lobby, hallways, elevators, and restrooms — kept consistently clean on the schedule that fits your property.",
+    terms: "Pricing reflects recurring service at the frequency shown. First service billed on completion; net-15 thereafter. Estimate valid 30 days. Supplies included.",
+    items: [
+      { name: "Lobby & entrance", pricing_type: "hourly", frequency: "2x/week", quantity: 1.0, unit_rate: 45 },
+      { name: "Common hallways & stairwells", pricing_type: "hourly", frequency: "2x/week", quantity: 1.0, unit_rate: 45 },
+      { name: "Elevators — cab, tracks & glass", pricing_type: "hourly", frequency: "2x/week", quantity: 0.5, unit_rate: 45 },
+      { name: "Common restrooms — clean & restock", pricing_type: "hourly", frequency: "2x/week", quantity: 0.75, unit_rate: 45 },
+      { name: "Entry glass & interior windows", pricing_type: "flat", frequency: "Weekly", quantity: 1, unit_rate: 40 },
+      { name: "Trash removal & liner replacement", pricing_type: "flat", frequency: "2x/week", quantity: 1, unit_rate: 35 },
+    ],
+  },
+  {
+    category: "office",
+    name: "Office Cleaning",
+    title: "Office Cleaning — Recurring Janitorial",
+    intro_note: "Thank you for considering Phes for your office cleaning. The scope below keeps your workspace healthy and presentable — workstations, kitchen, restrooms, and floors — on a recurring schedule that works around your team.",
+    terms: "Pricing reflects recurring service at the frequency shown. First service billed on completion; net-15 thereafter. Estimate valid 30 days. Supplies included.",
+    items: [
+      { name: "Workstations & desks — dust & sanitize", pricing_type: "hourly", frequency: "3x/week", quantity: 1.0, unit_rate: 50 },
+      { name: "Kitchen / break room", pricing_type: "hourly", frequency: "3x/week", quantity: 0.75, unit_rate: 50 },
+      { name: "Restrooms — clean & restock", pricing_type: "hourly", frequency: "3x/week", quantity: 1.0, unit_rate: 50 },
+      { name: "Floors — vacuum & mop", pricing_type: "hourly", frequency: "3x/week", quantity: 1.0, unit_rate: 50 },
+      { name: "Trash & recycling removal", pricing_type: "flat", frequency: "3x/week", quantity: 1, unit_rate: 30 },
+    ],
+  },
+  {
+    category: "retail",
+    name: "Retail Store",
+    title: "Retail Store Cleaning — Nightly Service",
+    intro_note: "Thank you for the opportunity to quote nightly cleaning for your store. The scope below keeps your sales floor, fitting rooms, and entrance spotless and customer-ready every morning when you open.",
+    terms: "Pricing reflects nightly service. First service billed on completion; net-15 thereafter. Estimate valid 30 days. Supplies included.",
+    items: [
+      { name: "Sales floor — vacuum, mop & dust", pricing_type: "hourly", frequency: "Daily", quantity: 1.0, unit_rate: 48 },
+      { name: "Fitting rooms & mirrors", pricing_type: "hourly", frequency: "Daily", quantity: 0.5, unit_rate: 48 },
+      { name: "Entrance glass & display windows", pricing_type: "flat", frequency: "Daily", quantity: 1, unit_rate: 25 },
+      { name: "Restrooms — clean & restock", pricing_type: "hourly", frequency: "Daily", quantity: 0.5, unit_rate: 48 },
+      { name: "Trash removal & liner replacement", pricing_type: "flat", frequency: "Daily", quantity: 1, unit_rate: 25 },
+    ],
+  },
+  {
+    category: "medical",
+    name: "Medical Facility",
+    title: "Medical Facility Cleaning — Disinfection Service",
+    intro_note: "Thank you for considering Phes for your facility. The scope below follows CDC/OSHA cleaning and disinfection protocols for medical settings — exam rooms, high-touch surfaces, and regulated-waste handling — to keep your patients and staff safe.",
+    terms: "Service follows CDC/OSHA disinfection protocols with EPA List-N products. First service billed on completion; net-15 thereafter. Estimate valid 30 days. Supplies & PPE included.",
+    items: [
+      { name: "Exam rooms — clean & EPA disinfect", pricing_type: "hourly", frequency: "Daily", quantity: 1.5, unit_rate: 60 },
+      { name: "High-touch disinfection (CDC/OSHA protocol)", pricing_type: "hourly", frequency: "Daily", quantity: 0.75, unit_rate: 60 },
+      { name: "Waiting room & reception", pricing_type: "hourly", frequency: "Daily", quantity: 0.5, unit_rate: 60 },
+      { name: "Restrooms — clean & restock", pricing_type: "hourly", frequency: "Daily", quantity: 0.5, unit_rate: 60 },
+      { name: "Floors — disinfect mop", pricing_type: "hourly", frequency: "Daily", quantity: 1.0, unit_rate: 60 },
+      { name: "Biohazard / regulated-waste handling", pricing_type: "flat", frequency: "Daily", quantity: 1, unit_rate: 40 },
+    ],
+  },
+];
+
+async function runEstimateTemplateSeed(): Promise<void> {
+  const PHES = 1;
+  try {
+    for (const tpl of ESTIMATE_TEMPLATE_SEED) {
+      const existing = await db.execute(sql`
+        SELECT 1 FROM estimate_templates
+        WHERE company_id = ${PHES} AND category = ${tpl.category} LIMIT 1
+      `);
+      if ((existing as any).rows.length) continue; // already seeded — preserve operator edits
+
+      const inserted = await db.execute(sql`
+        INSERT INTO estimate_templates (company_id, name, category, title, intro_note, terms, created_by)
+        VALUES (${PHES}, ${tpl.name}, ${tpl.category}, ${tpl.title}, ${tpl.intro_note}, ${tpl.terms}, NULL)
+        RETURNING id
+      `);
+      const templateId = (inserted as any).rows[0].id;
+      let sort = 0;
+      for (const it of tpl.items) {
+        const amount = Math.round(it.quantity * it.unit_rate * 100) / 100;
+        await db.execute(sql`
+          INSERT INTO estimate_template_items
+            (template_id, company_id, sort_order, name, description, pricing_type, frequency, quantity, unit_rate, amount)
+          VALUES
+            (${templateId}, ${PHES}, ${sort}, ${it.name}, NULL, ${it.pricing_type}, ${it.frequency}, ${it.quantity}, ${it.unit_rate}, ${amount})
+        `);
+        sort++;
+      }
+    }
+    console.log("[estimate-template-seed] Commercial templates ensured for PHES.");
+  } catch (err) {
+    console.error("[estimate-template-seed] Seed error (non-fatal):", err);
+  }
 }
 
 // ── MaidCentral Discount Migration (2026-04-16) ─────────────────────────────

--- a/artifacts/api-server/src/routes/estimates.ts
+++ b/artifacts/api-server/src/routes/estimates.ts
@@ -152,8 +152,8 @@ router.post("/templates", requireAuth, async (req, res) => {
     if (!name) return res.status(400).json({ error: "Bad Request", message: "Template name is required" });
     const items = normalizeItems(req.body?.items);
     const inserted = await db.execute(sql`
-      INSERT INTO estimate_templates (company_id, name, title, intro_note, terms, created_by)
-      VALUES (${companyId}, ${name}, ${str(req.body?.title, 300)}, ${str(req.body?.intro_note)}, ${str(req.body?.terms)}, ${req.auth!.userId})
+      INSERT INTO estimate_templates (company_id, name, category, title, intro_note, terms, created_by)
+      VALUES (${companyId}, ${name}, ${str(req.body?.category, 40)}, ${str(req.body?.title, 300)}, ${str(req.body?.intro_note)}, ${str(req.body?.terms)}, ${req.auth!.userId})
       RETURNING id
     `);
     const templateId = (inserted as any).rows[0].id;

--- a/artifacts/api-server/src/tests/estimate-templates.test.ts
+++ b/artifacts/api-server/src/tests/estimate-templates.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Phase 2 — Estimate templates.
+ *
+ * Stub-DB (no connection): validates the schema gained the `category` column,
+ * the boot migration emits it additively, and the 4 seeded commercial templates
+ * are well-formed (categories, item shape, computable amounts). The seed runs
+ * against the live DB at boot/deploy; this guards the data the picker depends on.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { estimateTemplatesTable } from "@workspace/db/schema";
+import { ESTIMATE_TEMPLATE_SEED } from "../phes-data-migration.ts";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const migration = readFileSync(resolve(here, "../phes-data-migration.ts"), "utf8");
+
+describe("Phase 2 — estimate_templates.category", () => {
+  it("category column exists on the Drizzle schema", () => {
+    const col = (estimateTemplatesTable as any).category;
+    assert.ok(col, "estimate_templates.category should exist");
+    assert.equal(col.name, "category");
+  });
+  it("boot migration adds category idempotently", () => {
+    assert.match(
+      migration,
+      /ALTER TABLE estimate_templates ADD COLUMN IF NOT EXISTS category TEXT/,
+      "migration must ADD COLUMN IF NOT EXISTS estimate_templates.category",
+    );
+  });
+});
+
+describe("Phase 2 — seeded commercial templates", () => {
+  it("seeds exactly the 4 verticals", () => {
+    const cats = ESTIMATE_TEMPLATE_SEED.map((t) => t.category).sort();
+    assert.deepEqual(cats, ["common_areas", "medical", "office", "retail"]);
+  });
+
+  it("every template is well-formed and every line item is sane", () => {
+    const VALID_PRICING = new Set(["flat", "hourly", "one_time"]);
+    for (const t of ESTIMATE_TEMPLATE_SEED) {
+      assert.ok(t.name && t.title && t.intro_note && t.terms, `${t.category} has copy`);
+      assert.ok(t.items.length >= 4, `${t.category} has >= 4 line items`);
+      for (const it of t.items) {
+        assert.ok(it.name, `${t.category} item has a name`);
+        assert.ok(VALID_PRICING.has(it.pricing_type), `${t.category} item pricing_type valid`);
+        assert.ok(it.quantity > 0, `${t.category} item quantity > 0`);
+        assert.ok(it.unit_rate > 0, `${t.category} item unit_rate > 0`);
+      }
+    }
+  });
+
+  it("Common Areas uses the seeded $45/hr scope on hourly lines", () => {
+    const ca = ESTIMATE_TEMPLATE_SEED.find((t) => t.category === "common_areas")!;
+    const hourly = ca.items.filter((i) => i.pricing_type === "hourly");
+    assert.ok(hourly.length > 0, "Common Areas has hourly lines");
+    for (const i of hourly) assert.equal(i.unit_rate, 45, "common-area hourly rate is $45/hr");
+  });
+
+  it("migration source references each seeded category (seed wired in)", () => {
+    for (const cat of ["common_areas", "office", "retail", "medical"]) {
+      assert.match(migration, new RegExp(`category: "${cat}"`), `seed includes ${cat}`);
+    }
+    assert.match(migration, /runEstimateTemplateSeed\(\)/, "seed function is invoked");
+  });
+});

--- a/artifacts/qleno/src/pages/estimate-builder.tsx
+++ b/artifacts/qleno/src/pages/estimate-builder.tsx
@@ -42,6 +42,15 @@ const TYPE_LABELS: Record<PricingType, { type: string; qty: string; rate: string
 };
 const FREQUENCY_OPTIONS = ["Daily", "5x/week", "3x/week", "2x/week", "Weekly", "Bi-weekly", "Monthly", "One-time"];
 
+// [estimate-templates-phase2] One-click vertical picker. Seeded templates carry
+// a category; this maps it to a clean label + one-line scope hint for the cards.
+const CATEGORY_META: Record<string, { label: string; hint: string }> = {
+  common_areas: { label: "Common Areas", hint: "Lobby, halls, elevators, restrooms" },
+  office: { label: "Office", hint: "Desks, kitchen, restrooms, floors" },
+  retail: { label: "Retail Store", hint: "Sales floor, fitting rooms, nightly" },
+  medical: { label: "Medical Facility", hint: "Exam rooms, disinfection, biohaz" },
+};
+
 const blankItem = (): Item => ({ name: "", pricing_type: "flat", frequency: "Monthly", quantity: "1", unit_rate: "" });
 
 function lineAmount(it: Item): number {
@@ -75,6 +84,11 @@ export default function EstimateBuilderPage() {
   const [validUntil, setValidUntil] = useState("");
   const [items, setItems] = useState<Item[]>([blankItem()]);
 
+  // [estimate-templates-phase2] One-click template picker (new estimates only).
+  const [templates, setTemplates] = useState<any[]>([]);
+  const [showPicker, setShowPicker] = useState(isNew);
+  const [applyingTemplate, setApplyingTemplate] = useState(false);
+
   // Load existing estimate, or seed a new one from a template (?template=id).
   useEffect(() => {
     (async () => {
@@ -95,6 +109,13 @@ export default function EstimateBuilderPage() {
             const t = await apiFetch(`/api/estimates/templates/${templateId}`);
             setTitle(t.title || ""); setIntroNote(t.intro_note || ""); setTerms(t.terms || "");
             setItems((t.items || []).length ? t.items.map(mapRow) : [blankItem()]);
+            setShowPicker(false);
+          } else {
+            // Load the template list for the one-click picker. Non-fatal.
+            try {
+              const r = await apiFetch(`/api/estimates/templates`);
+              setTemplates(Array.isArray(r?.data) ? r.data : []);
+            } catch { /* picker just won't show */ }
           }
         }
       } catch {
@@ -153,6 +174,25 @@ export default function EstimateBuilderPage() {
       toast.success("Saved as template");
     } catch {
       toast.error("Failed to save template");
+    }
+  }
+
+  // Apply a template's body + line items into the current (new) estimate.
+  // Everything stays editable afterward; this just pre-fills.
+  async function applyTemplate(t: any) {
+    setApplyingTemplate(true);
+    try {
+      const full = await apiFetch(`/api/estimates/templates/${t.id}`);
+      if (full.title) setTitle(full.title);
+      if (full.intro_note) setIntroNote(full.intro_note);
+      if (full.terms) setTerms(full.terms);
+      setItems((full.items || []).length ? full.items.map(mapRow) : [blankItem()]);
+      setShowPicker(false);
+      toast.success(`Started from "${t.name}" — edit anything below`);
+    } catch {
+      toast.error("Couldn't load that template");
+    } finally {
+      setApplyingTemplate(false);
     }
   }
 
@@ -217,6 +257,45 @@ export default function EstimateBuilderPage() {
           <h1 style={{ fontSize: 23, fontWeight: 800, color: INK, margin: 0 }}>{isNew && !id ? "New Estimate" : (estimateNumber || "Estimate")}</h1>
           <span style={{ fontSize: 12, fontWeight: 700, color: MUTE, textTransform: "uppercase", letterSpacing: "0.05em" }}>{status}</span>
         </div>
+
+        {/* [estimate-templates-phase2] One-click vertical picker — new estimates only. */}
+        {isNew && !id && showPicker && templates.length > 0 && (
+          <div style={{ border: `1px solid ${BORDER}`, borderRadius: 14, padding: 18, marginBottom: 22, background: "#FCFCFB" }}>
+            <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 14 }}>
+              <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                <LayoutTemplate size={16} style={{ color: MINT }} />
+                <h2 style={{ fontSize: 13, fontWeight: 800, color: INK, textTransform: "uppercase", letterSpacing: "0.05em", margin: 0 }}>Start from a template</h2>
+              </div>
+              <button onClick={() => setShowPicker(false)} style={{ background: "none", border: "none", color: MUTE, fontSize: 13, fontWeight: 700, cursor: "pointer", fontFamily: FF, padding: 0 }}>
+                Start blank
+              </button>
+            </div>
+            <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(180px, 1fr))", gap: 10 }}>
+              {[...templates]
+                .sort((a, b) => (CATEGORY_META[b.category] ? 1 : 0) - (CATEGORY_META[a.category] ? 1 : 0))
+                .map((t) => {
+                  const meta = CATEGORY_META[t.category];
+                  return (
+                    <button
+                      key={t.id}
+                      onClick={() => !applyingTemplate && applyTemplate(t)}
+                      disabled={applyingTemplate}
+                      style={{
+                        textAlign: "left", background: "#fff", border: `1px solid ${BORDER}`, borderRadius: 12,
+                        padding: "13px 14px", cursor: applyingTemplate ? "default" : "pointer", fontFamily: FF,
+                        display: "flex", flexDirection: "column", gap: 4, transition: "border-color 0.12s",
+                      }}
+                      onMouseEnter={(e) => (e.currentTarget.style.borderColor = MINT)}
+                      onMouseLeave={(e) => (e.currentTarget.style.borderColor = BORDER)}
+                    >
+                      <span style={{ fontSize: 14, fontWeight: 800, color: INK }}>{meta?.label || t.name}</span>
+                      <span style={{ fontSize: 12, color: MUTE, lineHeight: 1.35 }}>{meta?.hint || `${t.item_count ?? 0} line items`}</span>
+                    </button>
+                  );
+                })}
+            </div>
+          </div>
+        )}
 
         <Section title="Who it's for">
           <Grid>

--- a/lib/db/src/schema/estimates.ts
+++ b/lib/db/src/schema/estimates.ts
@@ -75,6 +75,10 @@ export const estimateTemplatesTable = pgTable("estimate_templates", {
   id: serial("id").primaryKey(),
   company_id: integer("company_id").references(() => companiesTable.id).notNull(),
   name: text("name").notNull(),
+  // [estimate-templates-phase2 2026-06-25] Optional vertical so the builder can
+  // offer a one-click picker (common_areas | office | retail | medical | null).
+  // null = a user-saved template with no fixed vertical.
+  category: text("category"),
   title: text("title"),
   intro_note: text("intro_note"),
   terms: text("terms"),


### PR DESCRIPTION
## Phase 2 — Estimate templates (native, no GHL)

Adds a **vertical/category** to estimate templates, seeds **4 commercial starting-point templates** from the pricing catalog, and surfaces them via a clean **one-click picker** in the estimate builder.

### Schema + migration (additive/idempotent)
- `estimate_templates.category` (text, nullable) — `ADD COLUMN IF NOT EXISTS`. Drizzle model updated.

### Seeded templates (idempotent per `company_id`+`category`; operator edits preserved)
| Vertical | Rate | Scope |
|---|---|---|
| **Common Areas** (Condo/HOA) | $45/hr | lobby, halls, elevators, restrooms, glass, trash |
| **Office** | $50/hr | desks, kitchen, restrooms, floors, trash |
| **Retail Store** (nightly) | $48/hr | sales floor, fitting rooms, glass, restrooms, trash |
| **Medical Facility** | $60/hr | exam rooms, CDC/OSHA disinfection, restrooms, biohaz, floors |

Each is a named bundle of `estimate_template_items` with title + intro + terms copy at sensible PHES pricing.

### Builder UX
One-click vertical picker on **new** estimates: pick a vertical → pre-fills title/intro/terms + line items, **fully editable**; "Start blank" dismisses it. `POST /api/estimates/templates` now persists `category`. Existing `?template=id` deep-link still works.

### Tests (`estimate-templates.test.ts`, 6)
category on schema + migration; seed covers exactly the 4 verticals; every line item sane (valid pricing_type, qty/rate > 0); Common Areas hourly = $45; seed wired into `runPhesDataMigration`.

### Verification
- Test **6/6** pass
- `typecheck:libs` **clean**
- Frontend typecheck **zero new errors** (worktree 242 = main 242; the one estimate-builder error is pre-existing)
- Backend esbuild bundle **builds clean**

Additive/idempotent only · no existing estimate/quote/cadence/lead data touched · `COMMS_ENABLED` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)