### PR TITLE
Phase 4: native engagement tracking (events timeline + click/open tokens)

### DIFF
--- a/artifacts/api-server/src/lib/engagement.ts
+++ b/artifacts/api-server/src/lib/engagement.ts
@@ -1,0 +1,85 @@
+// [engagement-tracking-phase4 2026-06-25] Native engagement layer.
+// One append-only timeline (engagement_events) that every source fans into, plus
+// our own click-redirect / open-pixel tokens (tracked_links) so opens & clicks
+// are recorded natively — not just via Resend. No external analytics.
+
+import { randomBytes } from "crypto";
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+import { appBaseUrl } from "./app-url.js";
+
+export type EngagementEventType =
+  | "sent" | "delivered" | "opened" | "clicked" | "replied"
+  | "viewed" | "accepted" | "declined" | "bounced" | "failed";
+
+export interface RecordEventArgs {
+  companyId: number;
+  eventType: EngagementEventType;
+  estimateId?: number | null;
+  enrollmentId?: number | null;
+  channel?: string | null;
+  recipient?: string | null;
+  meta?: Record<string, unknown> | null;
+}
+
+// Append one engagement event. Never throws — engagement is observability, it
+// must never break the calling request (a send, a page view, a webhook).
+export async function recordEngagementEvent(a: RecordEventArgs): Promise<void> {
+  try {
+    await db.execute(sql`
+      INSERT INTO engagement_events
+        (company_id, estimate_id, enrollment_id, event_type, channel, recipient, meta)
+      VALUES
+        (${a.companyId}, ${a.estimateId ?? null}, ${a.enrollmentId ?? null},
+         ${a.eventType}, ${a.channel ?? null}, ${a.recipient ?? null},
+         ${a.meta ? JSON.stringify(a.meta) : null}::jsonb)
+    `);
+  } catch (err) {
+    console.error("[engagement] recordEngagementEvent failed (non-fatal):", err);
+  }
+}
+
+function genToken(len = 18): string {
+  const alphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+  const bytes = randomBytes(len);
+  let out = "";
+  for (let i = 0; i < len; i++) out += alphabet[bytes[i] % alphabet.length];
+  return out;
+}
+
+// Mint a click-redirect link. Returns a public URL (/api/track/c/<token>) that,
+// when hit, records a 'clicked' event tied to the estimate + enrollment then
+// 302s to target_url. Falls back to target_url on any DB failure.
+export async function createTrackedLink(args: {
+  companyId: number; targetUrl: string; estimateId?: number | null; enrollmentId?: number | null;
+}): Promise<string> {
+  try {
+    const token = genToken();
+    await db.execute(sql`
+      INSERT INTO tracked_links (token, company_id, estimate_id, enrollment_id, kind, target_url)
+      VALUES (${token}, ${args.companyId}, ${args.estimateId ?? null}, ${args.enrollmentId ?? null}, 'click', ${args.targetUrl})
+    `);
+    return `${appBaseUrl()}/api/track/c/${token}`;
+  } catch (err) {
+    console.error("[engagement] createTrackedLink failed (non-fatal):", err);
+    return args.targetUrl;
+  }
+}
+
+// Mint an open-pixel URL (/api/track/o/<token>.png). Returns "" on failure so
+// callers can simply skip the pixel.
+export async function createOpenPixel(args: {
+  companyId: number; estimateId?: number | null; enrollmentId?: number | null;
+}): Promise<string> {
+  try {
+    const token = genToken();
+    await db.execute(sql`
+      INSERT INTO tracked_links (token, company_id, estimate_id, enrollment_id, kind, target_url)
+      VALUES (${token}, ${args.companyId}, ${args.estimateId ?? null}, ${args.enrollmentId ?? null}, 'open', NULL)
+    `);
+    return `${appBaseUrl()}/api/track/o/${token}.png`;
+  } catch (err) {
+    console.error("[engagement] createOpenPixel failed (non-fatal):", err);
+    return "";
+  }
+}

--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -373,6 +373,38 @@ async function runBookingSchemaGuard(): Promise<void> {
     // the builder can offer a one-click picker (common_areas|office|retail|
     // medical|null). Additive + idempotent.
     { label: "estimate_templates.category", stmt: `ALTER TABLE estimate_templates ADD COLUMN IF NOT EXISTS category TEXT` },
+    // [engagement-tracking-phase4 2026-06-25] Unified engagement timeline +
+    // native click-redirect / open-pixel tokens. Additive + idempotent.
+    { label: "CREATE engagement_events", stmt: `
+      CREATE TABLE IF NOT EXISTS engagement_events (
+        id            SERIAL PRIMARY KEY,
+        company_id    INTEGER NOT NULL,
+        estimate_id   INTEGER,
+        enrollment_id INTEGER,
+        event_type    TEXT NOT NULL,
+        channel       TEXT,
+        recipient     TEXT,
+        meta          JSONB,
+        occurred_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      )
+    ` },
+    { label: "idx_engagement_events_estimate",
+      stmt: `CREATE INDEX IF NOT EXISTS idx_engagement_events_estimate ON engagement_events(company_id, estimate_id, occurred_at)` },
+    { label: "idx_engagement_events_company_time",
+      stmt: `CREATE INDEX IF NOT EXISTS idx_engagement_events_company_time ON engagement_events(company_id, occurred_at)` },
+    { label: "CREATE tracked_links", stmt: `
+      CREATE TABLE IF NOT EXISTS tracked_links (
+        id            SERIAL PRIMARY KEY,
+        token         TEXT NOT NULL UNIQUE,
+        company_id    INTEGER NOT NULL,
+        estimate_id   INTEGER,
+        enrollment_id INTEGER,
+        kind          TEXT NOT NULL DEFAULT 'click',
+        target_url    TEXT,
+        created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      )
+    ` },
     // ── follow_up_sequences table ────────────────────────────────────────────
     { label: "CREATE follow_up_sequences", stmt: `
       CREATE TABLE IF NOT EXISTS follow_up_sequences (

--- a/artifacts/api-server/src/routes/estimates.ts
+++ b/artifacts/api-server/src/routes/estimates.ts
@@ -4,6 +4,7 @@ import { sql } from "drizzle-orm";
 import { randomUUID } from "crypto";
 import { requireAuth } from "../lib/auth.js";
 import { enrollForEstimateSent, stopEnrollmentsForEstimate } from "../services/followUpService.js";
+import { recordEngagementEvent } from "../lib/engagement.js";
 
 // [commercial-estimate-tool 2026-06-09] Commercial / common-area estimates.
 // Raw SQL (db.execute) on purpose: the estimate tables are brand-new and the
@@ -274,6 +275,9 @@ router.get("/public/:token", async (req, res) => {
       est.status = "viewed";
       est.viewed_at = est.viewed_at || new Date().toISOString();
     }
+    // [engagement-phase4] Record the hosted-page view (web channel).
+    recordEngagementEvent({ companyId: est.company_id, estimateId: est.id, eventType: "viewed", channel: "web",
+      meta: { ua: req.get("user-agent") || null } }).catch(() => {});
 
     const items = await db.execute(sql`
       SELECT name, description, pricing_type, frequency, quantity, unit_rate, amount
@@ -301,7 +305,7 @@ router.post("/public/:token/accept", async (req, res) => {
     // there). Recorded in the lead audit note below for proof of consent.
     const smsConsent = req.body?.sms_consent === true;
     const rows = await db.execute(sql`
-      SELECT id, status, valid_until FROM estimates WHERE public_token = ${token} AND status <> 'draft' LIMIT 1
+      SELECT id, company_id, status, valid_until FROM estimates WHERE public_token = ${token} AND status <> 'draft' LIMIT 1
     `);
     const est = (rows as any).rows[0];
     if (!est) {
@@ -360,6 +364,7 @@ router.post("/public/:token/accept", async (req, res) => {
     `);
     // [estimate-drip-phase3] Accepted → stop the follow-up drip. Non-blocking.
     stopEnrollmentsForEstimate(Number(est.id), "accepted").catch(() => {});
+    recordEngagementEvent({ companyId: Number(est.company_id), estimateId: Number(est.id), eventType: "accepted", channel: "web", meta: { name } }).catch(() => {});
     return res.json({ ok: true, status: "accepted" });
   } catch (err) {
     console.error("Accept estimate error:", err);
@@ -371,7 +376,7 @@ router.post("/public/:token/decline", async (req, res) => {
   try {
     const token = String(req.params.token || "").trim();
     const rows = await db.execute(sql`
-      SELECT id, status FROM estimates WHERE public_token = ${token} AND status <> 'draft' LIMIT 1
+      SELECT id, company_id, status FROM estimates WHERE public_token = ${token} AND status <> 'draft' LIMIT 1
     `);
     const est = (rows as any).rows[0];
     if (!est) return res.status(404).json({ error: "Not Found" });
@@ -380,6 +385,7 @@ router.post("/public/:token/decline", async (req, res) => {
       await db.execute(sql`UPDATE estimates SET status = 'declined', declined_at = now(), updated_at = now() WHERE id = ${est.id}`);
       // [estimate-drip-phase3] Declined → stop the follow-up drip. Non-blocking.
       stopEnrollmentsForEstimate(Number(est.id), "declined").catch(() => {});
+      recordEngagementEvent({ companyId: Number(est.company_id), estimateId: Number(est.id), eventType: "declined", channel: "web" }).catch(() => {});
     }
     return res.json({ ok: true, status: "declined" });
   } catch (err) {

--- a/artifacts/api-server/src/routes/index.ts
+++ b/artifacts/api-server/src/routes/index.ts
@@ -29,6 +29,7 @@ import notificationsRouter from "./notifications.js";
 import jobSmsRouter from "./job-sms.js";
 import quotesRouter from "./quotes.js";
 import estimatesRouter from "./estimates.js";
+import trackRouter from "./track.js";
 import paymentsRouter from "./payments.js";
 import attachmentsRouter from "./attachments.js";
 import { quoteAttachmentsRouter, jobAttachmentsRouter } from "./quote-attachments.js";
@@ -138,6 +139,7 @@ router.use("/reports", reportsRouter);
 router.use("/notifications", notificationsRouter);
 router.use("/quotes", quotesRouter);
 router.use("/estimates", estimatesRouter);
+router.use("/track", trackRouter);
 router.use("/payments", paymentsRouter);
 router.use("/attachments", attachmentsRouter);
 // [translate-job-notes 2026-05-27] Office-only translation endpoint —

--- a/artifacts/api-server/src/routes/track.ts
+++ b/artifacts/api-server/src/routes/track.ts
@@ -1,0 +1,84 @@
+// [engagement-tracking-phase4 2026-06-25] Native click-redirect + open-pixel
+// endpoints (PUBLIC, no auth — the token IS the capability). Each hit records an
+// engagement_event tied to the estimate + enrollment, then:
+//   GET /api/track/c/:token        → 302 to the stored target_url (click)
+//   GET /api/track/o/:token(.png)  → 1x1 transparent GIF (open)
+// Unknown/again tokens still behave gracefully (redirect home / return pixel) so
+// a stale link never errors a customer.
+
+import { Router } from "express";
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+import { recordEngagementEvent } from "../lib/engagement.js";
+import { appBaseUrl } from "../lib/app-url.js";
+
+const router = Router();
+
+// 1x1 transparent GIF.
+const PIXEL = Buffer.from("R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7", "base64");
+
+function sendPixel(res: any) {
+  res.set({
+    "Content-Type": "image/gif",
+    "Content-Length": String(PIXEL.length),
+    "Cache-Control": "no-store, no-cache, must-revalidate, private",
+    "Pragma": "no-cache",
+    "Expires": "0",
+  });
+  return res.status(200).send(PIXEL);
+}
+
+// ── Click redirect ──────────────────────────────────────────────────────────
+router.get("/c/:token", async (req, res) => {
+  const token = String(req.params.token || "").trim();
+  let target = `${appBaseUrl()}/`;
+  try {
+    const rows = await db.execute(sql`
+      SELECT company_id, estimate_id, enrollment_id, target_url
+      FROM tracked_links WHERE token = ${token} AND kind = 'click' LIMIT 1
+    `);
+    const link = (rows as any).rows[0];
+    if (link) {
+      if (link.target_url) target = link.target_url;
+      await recordEngagementEvent({
+        companyId: link.company_id,
+        estimateId: link.estimate_id,
+        enrollmentId: link.enrollment_id,
+        eventType: "clicked",
+        channel: "email",
+        meta: { token, target_url: link.target_url, ua: req.get("user-agent") || null },
+      });
+    }
+  } catch (err) {
+    console.error("[track] click error (non-fatal):", err);
+  }
+  return res.redirect(302, target);
+});
+
+// ── Open pixel ──────────────────────────────────────────────────────────────
+// Accepts /o/:token and /o/:token.png (the .png is stripped).
+router.get("/o/:token", async (req, res) => {
+  const token = String(req.params.token || "").trim().replace(/\.png$/i, "");
+  try {
+    const rows = await db.execute(sql`
+      SELECT company_id, estimate_id, enrollment_id
+      FROM tracked_links WHERE token = ${token} AND kind = 'open' LIMIT 1
+    `);
+    const link = (rows as any).rows[0];
+    if (link) {
+      await recordEngagementEvent({
+        companyId: link.company_id,
+        estimateId: link.estimate_id,
+        enrollmentId: link.enrollment_id,
+        eventType: "opened",
+        channel: "email",
+        meta: { token, ua: req.get("user-agent") || null },
+      });
+    }
+  } catch (err) {
+    console.error("[track] open error (non-fatal):", err);
+  }
+  return sendPixel(res);
+});
+
+export default router;

--- a/artifacts/api-server/src/services/followUpService.ts
+++ b/artifacts/api-server/src/services/followUpService.ts
@@ -186,7 +186,7 @@ async function buildQuoteMergeVars(companyId: number, quoteId: number): Promise<
 // estimate's public token (→ the hosted /estimate/ page), total, property +
 // contact and the tenant brand. Merge fields used by the estimate sequence copy:
 // {{first_name}} {{company_name}} {{company_phone}} {{property}} {{monthly}} {{estimate_link}}.
-async function buildEstimateMergeVars(companyId: number, estimateId: number): Promise<Record<string, string>> {
+async function buildEstimateMergeVars(companyId: number, estimateId: number, enrollmentId?: number): Promise<Record<string, string>> {
   const r = await db.execute(sql`
     SELECT e.id, e.total, e.property_name, e.service_address, e.public_token, e.contact_name,
            c.name AS company_name, c.phone AS company_phone, c.email AS company_email
@@ -196,7 +196,16 @@ async function buildEstimateMergeVars(companyId: number, estimateId: number): Pr
   const e: any = r.rows[0];
   if (!e) return {};
   const fullLink = e.public_token ? `${appBaseUrl()}/estimate/${e.public_token}` : `${appBaseUrl()}/estimate`;
-  const link = e.public_token ? ((await shortenUrl(fullLink, companyId)) || fullLink) : fullLink;
+  // [engagement-phase4] When sending a real touch (enrollmentId present), route
+  // the link through our own click-redirect so the click is recorded natively
+  // and attributed to this estimate + enrollment. Falls back to a short link.
+  let link: string;
+  if (enrollmentId) {
+    const { createTrackedLink } = await import("../lib/engagement.js");
+    link = await createTrackedLink({ companyId, targetUrl: fullLink, estimateId, enrollmentId });
+  } else {
+    link = e.public_token ? ((await shortenUrl(fullLink, companyId)) || fullLink) : fullLink;
+  }
   const total = e.total != null ? Number(e.total).toFixed(2) : "0.00";
   return {
     company_name:   e.company_name || "Phes",
@@ -456,7 +465,7 @@ export async function stopEstimateEnrollmentsByPhone(
   try {
     const digits = (phone || "").replace(/\D/g, "").slice(-10);
     if (digits.length !== 10) return;
-    await db.execute(sql`
+    const stopped = await db.execute(sql`
       UPDATE follow_up_enrollments fe
       SET stopped_at = NOW(), stopped_reason = ${reason}
       FROM estimates e
@@ -465,8 +474,18 @@ export async function stopEstimateEnrollmentsByPhone(
         AND right(regexp_replace(e.contact_phone, '\\D', '', 'g'), 10) = ${digits}
         AND fe.completed_at IS NULL
         AND fe.stopped_at IS NULL
+      RETURNING fe.id AS enrollment_id, fe.estimate_id
     `);
-    console.log(`[follow-up] Stopped estimate enrollments by phone ${digits} (company=${companyId}) — reason: ${reason}`);
+    // [engagement-phase4] Record an inbound reply against each stopped estimate.
+    const { recordEngagementEvent } = await import("../lib/engagement.js");
+    for (const r of (stopped as any).rows ?? []) {
+      await recordEngagementEvent({
+        companyId, estimateId: r.estimate_id, enrollmentId: r.enrollment_id,
+        eventType: "replied", channel: "sms", recipient: digits,
+        meta: { reason },
+      });
+    }
+    console.log(`[follow-up] Stopped ${((stopped as any).rows ?? []).length} estimate enrollment(s) by phone ${digits} (company=${companyId}) — reason: ${reason}`);
   } catch (err) {
     console.error("[follow-up] stopEstimateEnrollmentsByPhone error (non-fatal):", err);
   }
@@ -644,7 +663,7 @@ async function processEnrollment(enr: any): Promise<void> {
   if (enr.quote_id) Object.assign(mergeVars, await buildQuoteMergeVars(enr.company_id, enr.quote_id));
   // Estimate enrollments get the commercial-estimate merge set (contact, property,
   // monthly total, hosted view link).
-  if (enr.estimate_id) Object.assign(mergeVars, await buildEstimateMergeVars(enr.company_id, enr.estimate_id));
+  if (enr.estimate_id) Object.assign(mergeVars, await buildEstimateMergeVars(enr.company_id, enr.estimate_id, enr.id));
   // Abandoned-booking enrollments get {{resume_link}} (the company booking page)
   // + {{office_phone}} (the steps reference both).
   if (enr.abandoned_booking_id) {
@@ -654,9 +673,19 @@ async function processEnrollment(enr: any): Promise<void> {
     mergeVars.resume_link = slug ? `${base}/book/${slug}` : `${base}/book`;
     mergeVars.office_phone = mergeVars.company_phone;
   }
-  const body    = resolveMergeFields(rawBody, mergeVars);
+  let body      = resolveMergeFields(rawBody, mergeVars);
   const subject = rawSubject ? resolveMergeFields(rawSubject, mergeVars) : "";
   const emailBrand: EmailBrand = { companyName: mergeVars.company_name, phone: mergeVars.company_phone, email: mergeVars.company_email };
+
+  // [engagement-phase4] Estimate email touches carry a 1x1 open pixel so opens
+  // are recorded natively, attributed to this estimate + enrollment.
+  if (enr.estimate_id && step.channel === "email") {
+    try {
+      const { createOpenPixel } = await import("../lib/engagement.js");
+      const pixel = await createOpenPixel({ companyId: enr.company_id, estimateId: enr.estimate_id, enrollmentId: enr.id });
+      if (pixel) body += `\n<img src="${pixel}" width="1" height="1" alt="" style="display:none" />`;
+    } catch { /* pixel optional */ }
+  }
 
   let sendStatus = "sent";
   let sendError  = "";
@@ -715,6 +744,21 @@ async function processEnrollment(enr: any): Promise<void> {
        ${subject || null}, ${body}, ${sendStatus},
        ${enr.sequence_name}, ${step.step_number})
   `);
+
+  // [engagement-phase4] Fan the cadence send into the engagement timeline
+  // (estimate enrollments only). sent → 'sent'; otherwise → 'failed' with reason.
+  if (enr.estimate_id) {
+    const { recordEngagementEvent } = await import("../lib/engagement.js");
+    await recordEngagementEvent({
+      companyId: enr.company_id,
+      estimateId: enr.estimate_id,
+      enrollmentId: enr.id,
+      eventType: sendStatus === "sent" ? "sent" : "failed",
+      channel: step.channel,
+      recipient: step.channel === "sms" ? recipientPhone : recipientEmail,
+      meta: { step_number: step.step_number, status: sendStatus, ...(sendError ? { error: sendError } : {}) },
+    });
+  }
 
   // Advance or complete — next_fire_at clamped to 8am–9pm America/Chicago.
   const nextStepRows = await db.execute(sql`
@@ -794,7 +838,7 @@ export async function sendSingleEnrollmentTouch(
   const ci = await companyInfo(companyId);
   const mergeVars: Record<string, string> = { first_name: firstName, company_name: ci.name, company_phone: ci.phone, company_email: ci.email };
   if (enr.quote_id) Object.assign(mergeVars, await buildQuoteMergeVars(companyId, enr.quote_id));
-  if (enr.estimate_id) Object.assign(mergeVars, await buildEstimateMergeVars(companyId, enr.estimate_id));
+  if (enr.estimate_id) Object.assign(mergeVars, await buildEstimateMergeVars(companyId, enr.estimate_id, enr.id));
   const body = resolveMergeFields(rawBody, mergeVars);
   const subject = rawSubject ? resolveMergeFields(rawSubject, mergeVars) : "";
   const emailBrand: EmailBrand = { companyName: mergeVars.company_name, phone: mergeVars.company_phone, email: mergeVars.company_email };

--- a/artifacts/api-server/src/tests/engagement-tracking.test.ts
+++ b/artifacts/api-server/src/tests/engagement-tracking.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Phase 4 — Engagement tracking (data layer).
+ *
+ * Stub-DB. Guards the unified engagement_events timeline, the native
+ * click-redirect / open-pixel tokens, and that every source fans in:
+ * estimate views/accept/decline, cadence sends (+ tracked link + open pixel),
+ * and inbound-SMS replies.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { engagementEventsTable, trackedLinksTable } from "@workspace/db/schema";
+import { recordEngagementEvent, createTrackedLink, createOpenPixel } from "../lib/engagement.ts";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const read = (rel: string) => readFileSync(resolve(here, rel), "utf8");
+const migration = read("../phes-data-migration.ts");
+const engine = read("../services/followUpService.ts");
+const estimatesRoute = read("../routes/estimates.ts");
+const trackRoute = read("../routes/track.ts");
+const routesIndex = read("../routes/index.ts");
+
+function cols(table: any, names: string[], label: string) {
+  for (const n of names) {
+    assert.ok(table[n], `${label}.${n} should exist`);
+    assert.equal(table[n].name, n);
+  }
+}
+
+describe("Phase 4 — schema + migration", () => {
+  it("engagement_events columns on schema", () => {
+    cols(engagementEventsTable, ["id", "company_id", "estimate_id", "enrollment_id", "event_type", "channel", "recipient", "meta", "occurred_at"], "engagement_events");
+  });
+  it("tracked_links columns on schema", () => {
+    cols(trackedLinksTable, ["id", "token", "company_id", "estimate_id", "enrollment_id", "kind", "target_url"], "tracked_links");
+  });
+  it("migration creates both tables idempotently + indexes", () => {
+    assert.match(migration, /CREATE TABLE IF NOT EXISTS engagement_events/);
+    assert.match(migration, /CREATE TABLE IF NOT EXISTS tracked_links/);
+    assert.match(migration, /idx_engagement_events_estimate/);
+  });
+});
+
+describe("Phase 4 — engagement lib", () => {
+  it("exports the recorder + link/pixel minters", () => {
+    assert.equal(typeof recordEngagementEvent, "function");
+    assert.equal(typeof createTrackedLink, "function");
+    assert.equal(typeof createOpenPixel, "function");
+  });
+});
+
+describe("Phase 4 — native click-redirect + open-pixel route", () => {
+  it("is mounted at /track", () => {
+    assert.match(routesIndex, /router\.use\("\/track", trackRouter\)/);
+  });
+  it("click endpoint records 'clicked' then 302-redirects", () => {
+    assert.match(trackRoute, /\/c\/:token/);
+    assert.match(trackRoute, /eventType:\s*"clicked"/);
+    assert.match(trackRoute, /res\.redirect\(302/);
+  });
+  it("open endpoint records 'opened' then returns a pixel", () => {
+    assert.match(trackRoute, /\/o\/:token/);
+    assert.match(trackRoute, /eventType:\s*"opened"/);
+    assert.match(trackRoute, /image\/gif/);
+  });
+});
+
+describe("Phase 4 — fan-in wiring", () => {
+  it("estimate public page records viewed / accepted / declined", () => {
+    assert.match(estimatesRoute, /eventType:\s*"viewed"/);
+    assert.match(estimatesRoute, /eventType:\s*"accepted"/);
+    assert.match(estimatesRoute, /eventType:\s*"declined"/);
+  });
+  it("cadence estimate send records sent/failed + injects pixel + tracked link", () => {
+    assert.match(engine, /eventType:\s*sendStatus === "sent" \? "sent" : "failed"/);
+    assert.match(engine, /createOpenPixel/);
+    assert.match(engine, /createTrackedLink/);
+  });
+  it("inbound reply records 'replied' against stopped estimates", () => {
+    assert.match(engine, /eventType:\s*"replied"/);
+    assert.match(engine, /RETURNING fe\.id AS enrollment_id, fe\.estimate_id/);
+  });
+});

--- a/lib/db/src/schema/engagement.ts
+++ b/lib/db/src/schema/engagement.ts
@@ -1,0 +1,47 @@
+import { pgTable, serial, integer, text, jsonb, timestamp } from "drizzle-orm/pg-core";
+import { companiesTable } from "./companies";
+
+// [engagement-tracking-phase4 2026-06-25] Native engagement layer for the
+// estimate workflow — no external analytics. Two tables:
+//
+//  - engagement_events: the unified, append-only timeline that every source
+//    fans into (cadence sends, our own click-redirect + open-pixel, the public
+//    estimate page views/accept/decline, and inbound SMS replies). One row per
+//    event; the Phase-5 dashboard reads straight from here.
+//  - tracked_links: our own click-redirect + open-pixel tokens so clicks/opens
+//    are recorded natively (not just via Resend), each tied to estimate +
+//    enrollment for attribution.
+//
+// No FK constraints beyond company_id (mirrors the estimate/cadence tables);
+// scoping is enforced in code. Additive + idempotent.
+
+export const engagementEventsTable = pgTable("engagement_events", {
+  id: serial("id").primaryKey(),
+  company_id: integer("company_id").references(() => companiesTable.id).notNull(),
+  // What the event is about (any may be null for non-estimate sources).
+  estimate_id: integer("estimate_id"),
+  enrollment_id: integer("enrollment_id"),
+  // sent | delivered | opened | clicked | replied | viewed | accepted |
+  // declined | bounced | failed
+  event_type: text("event_type").notNull(),
+  channel: text("channel"), // email | sms | web
+  recipient: text("recipient"),
+  // Free-form details: clicked url, message id, step number, source table, etc.
+  meta: jsonb("meta"),
+  occurred_at: timestamp("occurred_at").notNull().defaultNow(),
+  created_at: timestamp("created_at").notNull().defaultNow(),
+});
+
+export const trackedLinksTable = pgTable("tracked_links", {
+  id: serial("id").primaryKey(),
+  token: text("token").notNull().unique(),
+  company_id: integer("company_id").references(() => companiesTable.id).notNull(),
+  estimate_id: integer("estimate_id"),
+  enrollment_id: integer("enrollment_id"),
+  kind: text("kind").notNull().default("click"), // click | open
+  target_url: text("target_url"), // null for open pixels
+  created_at: timestamp("created_at").notNull().defaultNow(),
+});
+
+export type EngagementEvent = typeof engagementEventsTable.$inferSelect;
+export type TrackedLink = typeof trackedLinksTable.$inferSelect;

--- a/lib/db/src/schema/index.ts
+++ b/lib/db/src/schema/index.ts
@@ -7,6 +7,8 @@ export * from "./referral_partners";
 // (previously raw-SQL-migration-only tables, now first-class Drizzle models).
 export * from "./leads";
 export * from "./follow_up";
+// [engagement-tracking-phase4 2026-06-25] Native engagement timeline + tracked links.
+export * from "./engagement";
 export * from "./marketing_spend";
 export * from "./kpi_targets";
 export * from "./lead_report_settings";


### PR DESCRIPTION
## Phase 4 — Engagement tracking (data layer, native)

The unified data layer for the estimate engagement dashboard — **our own** click/open tracking, no external analytics.

### What ships
- **`engagement_events`** — unified append-only timeline. One row per event: `sent | delivered | opened | clicked | replied | viewed | accepted | declined | failed`, tied to `estimate_id` + `enrollment_id`, with `channel` / `recipient` / `meta`. Indexed by `(company_id, estimate_id, occurred_at)`. This is what the Phase 5 dashboard reads.
- **`tracked_links`** — our own click-redirect + open-pixel tokens, each attributed to estimate + enrollment.
- **`lib/engagement.ts`** — `recordEngagementEvent` (never throws), `createTrackedLink`, `createOpenPixel`.
- **`routes/track.ts`** (PUBLIC, token = capability): `GET /api/track/c/:token` records `clicked` → 302 to target; `GET /api/track/o/:token.png` records `opened` → 1×1 gif.

### Fan-in from every source
- **Estimate hosted page** → `viewed` / `accepted` / `declined` (fires in prod now)
- **Cadence estimate sends** → `sent`/`failed`, with the view link routed through our click-redirect and an open pixel injected into the email
- **Inbound SMS reply** (stop-on-reply) → `replied` per stopped estimate

### Tests (`engagement-tracking.test.ts`, 10)
schema + migration (both tables + indexes); lib surface; track route (click→302, open→pixel, mounted at `/track`); fan-in wiring across all sources.

### Verification
- Test **10/10** · `typecheck:libs` clean · new files **zero** type errors (estimates.ts unchanged at its 9 pre-existing) · backend bundle builds.

No sends occur (drip still inert) · `COMMS_ENABLED` untouched · additive/idempotent only · all data preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)