### PR TITLE
Phase 5: GHL-style estimate engagement dashboard (timeline + pipeline + month summary)

### DIFF
--- a/artifacts/api-server/src/routes/estimates.ts
+++ b/artifacts/api-server/src/routes/estimates.ts
@@ -188,6 +188,147 @@ router.delete("/templates/:id", requireAuth, async (req, res) => {
   }
 });
 
+// ─── Engagement dashboard (Phase 5) ─────────────────────────────────────────
+// Read models over engagement_events + follow_up_enrollments + estimates. All
+// company-scoped. Registered before /:id (distinct 2-segment paths, no clash).
+
+// Per-estimate aggregate sub-select (opens / clicks / views / touches sent).
+const EV_AGG = sql`
+  SELECT
+    COUNT(*) FILTER (WHERE event_type = 'opened')                 AS opened,
+    COUNT(*) FILTER (WHERE event_type = 'clicked')                AS clicked,
+    COUNT(*) FILTER (WHERE event_type IN ('viewed'))              AS viewed,
+    COUNT(*) FILTER (WHERE event_type = 'sent')                   AS touches_sent,
+    MAX(occurred_at)                                              AS last_event_at
+  FROM engagement_events ee WHERE ee.estimate_id = e.id`;
+
+// GET /api/estimates/engagement/pipeline — all sent estimates + engagement.
+router.get("/engagement/pipeline", requireAuth, async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    const rows = await db.execute(sql`
+      SELECT e.id, e.estimate_number, e.status, e.total, e.sent_at, e.accepted_at, e.declined_at,
+             COALESCE(NULLIF(e.property_name, ''), NULLIF(e.contact_name, ''), 'Untitled') AS recipient,
+             ev.opened, ev.clicked, ev.viewed, ev.touches_sent, ev.last_event_at,
+             enr.current_step, enr.next_fire_at, enr.stopped_at, enr.completed_at
+      FROM estimates e
+      LEFT JOIN LATERAL (${EV_AGG}) ev ON true
+      LEFT JOIN LATERAL (
+        SELECT current_step, next_fire_at, stopped_at, completed_at
+        FROM follow_up_enrollments fe WHERE fe.estimate_id = e.id ORDER BY fe.id DESC LIMIT 1
+      ) enr ON true
+      WHERE e.company_id = ${companyId} AND e.status <> 'draft'
+      ORDER BY e.sent_at DESC NULLS LAST, e.id DESC
+      LIMIT 300
+    `);
+    return res.json({ data: (rows as any).rows });
+  } catch (err) {
+    console.error("Engagement pipeline error:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
+// GET /api/estimates/engagement/summary?month=YYYY-MM — month rollup.
+router.get("/engagement/summary", requireAuth, async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    const monthStr = str(req.query?.month, 7); // "YYYY-MM"
+    const now = new Date();
+    const base = monthStr && /^\d{4}-\d{2}$/.test(monthStr)
+      ? new Date(`${monthStr}-01T00:00:00Z`)
+      : new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+    const start = new Date(Date.UTC(base.getUTCFullYear(), base.getUTCMonth(), 1)).toISOString();
+    const end = new Date(Date.UTC(base.getUTCFullYear(), base.getUTCMonth() + 1, 1)).toISOString();
+
+    const agg = await db.execute(sql`
+      SELECT
+        COUNT(*) FILTER (WHERE e.sent_at >= ${start} AND e.sent_at < ${end})                                  AS sent,
+        COUNT(*) FILTER (WHERE e.sent_at >= ${start} AND e.sent_at < ${end} AND ev.opened > 0)                AS opened,
+        COUNT(*) FILTER (WHERE e.sent_at >= ${start} AND e.sent_at < ${end} AND ev.clicked > 0)               AS clicked,
+        COUNT(*) FILTER (WHERE e.accepted_at >= ${start} AND e.accepted_at < ${end})                          AS won,
+        COUNT(*) FILTER (WHERE e.declined_at >= ${start} AND e.declined_at < ${end})                          AS lost
+      FROM estimates e
+      LEFT JOIN LATERAL (
+        SELECT COUNT(*) FILTER (WHERE event_type IN ('opened','viewed')) AS opened,
+               COUNT(*) FILTER (WHERE event_type = 'clicked') AS clicked
+        FROM engagement_events ee WHERE ee.estimate_id = e.id
+      ) ev ON true
+      WHERE e.company_id = ${companyId}
+    `);
+    const won = await db.execute(sql`
+      SELECT COALESCE(AVG(t.cnt), 0)::numeric(6,1) AS avg_touches_to_win FROM (
+        SELECT (SELECT COUNT(*) FROM engagement_events ee WHERE ee.estimate_id = e.id AND ee.event_type = 'sent') AS cnt
+        FROM estimates e
+        WHERE e.company_id = ${companyId} AND e.accepted_at >= ${start} AND e.accepted_at < ${end}
+      ) t
+    `);
+    const row: any = (agg as any).rows[0] ?? {};
+    const sent = Number(row.sent || 0);
+    return res.json({
+      month: `${base.getUTCFullYear()}-${String(base.getUTCMonth() + 1).padStart(2, "0")}`,
+      sent,
+      opened: Number(row.opened || 0),
+      clicked: Number(row.clicked || 0),
+      won: Number(row.won || 0),
+      lost: Number(row.lost || 0),
+      opened_pct: sent ? Math.round((Number(row.opened || 0) / sent) * 100) : 0,
+      clicked_pct: sent ? Math.round((Number(row.clicked || 0) / sent) * 100) : 0,
+      avg_touches_to_win: Number((won as any).rows[0]?.avg_touches_to_win || 0),
+    });
+  } catch (err) {
+    console.error("Engagement summary error:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
+// GET /api/estimates/:id/engagement — per-estimate detail + touchpoint timeline.
+router.get("/:id/engagement", requireAuth, async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    const id = parseInt(String(req.params.id), 10);
+    if (!Number.isFinite(id)) return res.status(404).json({ error: "Not Found" });
+    const e = await db.execute(sql`
+      SELECT id, estimate_number, status, total, contact_name, property_name, service_address,
+             sent_at, viewed_at, accepted_at, declined_at
+      FROM estimates WHERE id = ${id} AND company_id = ${companyId} LIMIT 1
+    `);
+    const est = (e as any).rows[0];
+    if (!est) return res.status(404).json({ error: "Not Found" });
+
+    const counts = await db.execute(sql`
+      SELECT
+        COUNT(*) FILTER (WHERE event_type = 'opened')  AS opened,
+        COUNT(*) FILTER (WHERE event_type = 'clicked') AS clicked,
+        COUNT(*) FILTER (WHERE event_type = 'viewed')  AS viewed,
+        COUNT(*) FILTER (WHERE event_type = 'sent')    AS touches_sent
+      FROM engagement_events WHERE estimate_id = ${id} AND company_id = ${companyId}
+    `);
+    const timeline = await db.execute(sql`
+      SELECT event_type, channel, recipient, meta, occurred_at
+      FROM engagement_events WHERE estimate_id = ${id} AND company_id = ${companyId}
+      ORDER BY occurred_at ASC, id ASC
+    `);
+    // Latest enrollment → next scheduled touch + step progress.
+    const enr = await db.execute(sql`
+      SELECT fe.id, fe.current_step, fe.next_fire_at, fe.stopped_at, fe.stopped_reason, fe.completed_at,
+             (SELECT COUNT(*)::int FROM follow_up_steps s WHERE s.sequence_id = fe.sequence_id) AS total_steps,
+             (SELECT channel FROM follow_up_steps s WHERE s.sequence_id = fe.sequence_id AND s.step_number = fe.current_step LIMIT 1) AS next_channel
+      FROM follow_up_enrollments fe WHERE fe.estimate_id = ${id} AND fe.company_id = ${companyId}
+      ORDER BY fe.id DESC LIMIT 1
+    `);
+
+    return res.json({
+      estimate: est,
+      counts: (counts as any).rows[0] ?? { opened: 0, clicked: 0, viewed: 0, touches_sent: 0 },
+      timeline: (timeline as any).rows,
+      enrollment: (enr as any).rows[0] ?? null,
+    });
+  } catch (err) {
+    console.error("Estimate engagement error:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
 // ─── Public hosted estimate (no auth — tokenized) ───────────────────────────
 // [estimate-hosted-page 2026-06-10] The link the office texts/emails to the
 // property manager. GET marks first view (sent → viewed); accept/decline are

--- a/artifacts/api-server/src/tests/engagement-dashboard.test.ts
+++ b/artifacts/api-server/src/tests/engagement-dashboard.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Phase 5 — Engagement dashboard read API + routing.
+ *
+ * Stub-DB. The dashboard is read-only UI over SQL aggregates, so we guard the
+ * three read endpoints exist + are company-scoped, the summary computes the
+ * rates, and the frontend route is ordered before /estimates/:id so the
+ * dashboard isn't swallowed by the builder's :id route.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const read = (rel: string) => readFileSync(resolve(here, rel), "utf8");
+const estimatesRoute = read("../routes/estimates.ts");
+const app = read("../../../qleno/src/App.tsx");
+const page = read("../../../qleno/src/pages/estimate-engagement.tsx");
+
+describe("Phase 5 — read endpoints", () => {
+  it("pipeline, summary, and per-estimate engagement endpoints exist", () => {
+    assert.match(estimatesRoute, /router\.get\("\/engagement\/pipeline"/);
+    assert.match(estimatesRoute, /router\.get\("\/engagement\/summary"/);
+    assert.match(estimatesRoute, /router\.get\("\/:id\/engagement"/);
+  });
+  it("all three are company-scoped", () => {
+    const block = estimatesRoute.slice(estimatesRoute.indexOf("Engagement dashboard (Phase 5)"));
+    // each handler references req.auth!.companyId and filters by it
+    const scoped = (block.match(/company_id = \$\{companyId\}/g) || []).length;
+    assert.ok(scoped >= 3, `expected >=3 company_id filters in engagement block, got ${scoped}`);
+  });
+  it("summary computes opened%/clicked% + avg touches to win", () => {
+    assert.match(estimatesRoute, /opened_pct/);
+    assert.match(estimatesRoute, /clicked_pct/);
+    assert.match(estimatesRoute, /avg_touches_to_win/);
+  });
+  it("per-estimate returns a touchpoint timeline ordered by time", () => {
+    assert.match(estimatesRoute, /FROM engagement_events WHERE estimate_id = \$\{id\}[\s\S]*ORDER BY occurred_at ASC/);
+    assert.match(estimatesRoute, /next_fire_at/); // next-scheduled surfaced
+  });
+});
+
+describe("Phase 5 — frontend wiring", () => {
+  it("engagement route is registered BEFORE the /estimates/:id builder route", () => {
+    const iEng = app.indexOf('path="/estimates/engagement"');
+    const iId = app.indexOf('path="/estimates/:id"');
+    assert.ok(iEng > 0, "engagement route present");
+    assert.ok(iId > 0, "builder :id route present");
+    assert.ok(iEng < iId, "engagement must be matched before :id");
+  });
+  it("dashboard page renders summary, pipeline, and a timeline", () => {
+    assert.match(page, /engagement\/summary/);
+    assert.match(page, /engagement\/pipeline/);
+    assert.match(page, /\/engagement`/); // per-estimate fetch in Timeline
+    assert.match(page, /Avg touches/);
+  });
+  it("estimates list links to the engagement dashboard", () => {
+    const list = read("../../../qleno/src/pages/estimates.tsx");
+    assert.match(list, /navigate\("\/estimates\/engagement"\)/);
+  });
+});

--- a/artifacts/qleno/src/App.tsx
+++ b/artifacts/qleno/src/App.tsx
@@ -68,6 +68,7 @@ const QuotesPage          = lazy(() => import("@/pages/quotes"));
 const QuoteBuilderPage    = lazy(() => import("@/pages/quote-builder"));
 const EstimatesPage       = lazy(() => import("@/pages/estimates"));
 const EstimateBuilderPage = lazy(() => import("@/pages/estimate-builder"));
+const EstimateEngagementPage = lazy(() => import("@/pages/estimate-engagement"));
 const EstimatePublicPage  = lazy(() => import("@/pages/estimate-public"));
 const QuoteDetailPage     = lazy(() => import("@/pages/quote-detail"));
 const QuotingPage         = lazy(() => import("@/pages/quoting"));
@@ -311,6 +312,7 @@ function Router() {
         <Route path="/quotes" component={QuotesPage} />
 
         <Route path="/estimates/new" component={EstimateBuilderPage} />
+        <Route path="/estimates/engagement" component={EstimateEngagementPage} />
         <Route path="/estimates/:id" component={EstimateBuilderPage} />
         <Route path="/estimates" component={EstimatesPage} />
         {/* Public hosted estimate — no login, tokenized (like /pay/:token). */}

--- a/artifacts/qleno/src/pages/estimate-engagement.tsx
+++ b/artifacts/qleno/src/pages/estimate-engagement.tsx
@@ -1,0 +1,208 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useLocation } from "wouter";
+import { getAuthHeaders } from "@/lib/auth";
+import { DashboardLayout } from "@/components/layout/dashboard-layout";
+import {
+  ArrowLeft, Mail, MessageSquare, Eye, MousePointerClick, Send, CheckCircle,
+  XCircle, CornerUpLeft, Clock, ChevronDown, ChevronRight, Activity,
+} from "lucide-react";
+
+const FF = "'Plus Jakarta Sans', sans-serif";
+const API = import.meta.env.BASE_URL.replace(/\/$/, "");
+const INK = "#1A1917";
+const MUTE = "#6B7280";
+const BORDER = "#E5E2DC";
+const MINT = "#00C9A0";
+
+async function apiFetch(path: string) {
+  const r = await fetch(`${API}${path}`, { headers: getAuthHeaders() as Record<string, string> });
+  if (!r.ok) throw new Error(await r.text());
+  return r.json();
+}
+
+const money = (n: any) => `$${Number(n || 0).toLocaleString("en-US", { maximumFractionDigits: 0 })}`;
+const TOTAL_TOUCHES = 8;
+
+const STATUS_STYLE: Record<string, { bg: string; fg: string; label: string }> = {
+  sent:     { bg: "#EFF6FF", fg: "#1D4ED8", label: "Sent" },
+  viewed:   { bg: "#FEF3C7", fg: "#92400E", label: "Viewed" },
+  accepted: { bg: "#ECFDF5", fg: "#047857", label: "Won" },
+  declined: { bg: "#FEF2F2", fg: "#991B1B", label: "Lost" },
+  expired:  { bg: "#F3F4F6", fg: "#6B7280", label: "Expired" },
+  draft:    { bg: "#F3F4F6", fg: "#6B7280", label: "Draft" },
+};
+
+function StatusChip({ status }: { status: string }) {
+  const s = STATUS_STYLE[status] ?? STATUS_STYLE.draft;
+  return <span style={{ padding: "3px 9px", borderRadius: 999, background: s.bg, color: s.fg, fontSize: 12, fontWeight: 700 }}>{s.label}</span>;
+}
+
+// Timeline event icon + color + label per event type.
+const EVENT_META: Record<string, { icon: any; color: string; label: string }> = {
+  sent:     { icon: Send, color: "#1D4ED8", label: "Touch sent" },
+  opened:   { icon: Eye, color: "#92400E", label: "Email opened" },
+  clicked:  { icon: MousePointerClick, color: "#7C3AED", label: "Link clicked" },
+  viewed:   { icon: Eye, color: "#0891B2", label: "Estimate viewed" },
+  replied:  { icon: CornerUpLeft, color: "#0D9488", label: "Customer replied" },
+  accepted: { icon: CheckCircle, color: "#047857", label: "Accepted" },
+  declined: { icon: XCircle, color: "#991B1B", label: "Declined" },
+  failed:   { icon: XCircle, color: "#9CA3AF", label: "Send failed" },
+};
+
+function fmtTime(s: string | null) {
+  if (!s) return "";
+  const d = new Date(s);
+  return d.toLocaleString("en-US", { month: "short", day: "numeric", hour: "numeric", minute: "2-digit" });
+}
+function daysSince(s: string | null) {
+  if (!s) return null;
+  return Math.max(0, Math.floor((Date.now() - new Date(s).getTime()) / 86400000));
+}
+
+function StatCard({ label, value, sub }: { label: string; value: string; sub?: string }) {
+  return (
+    <div style={{ background: "#fff", border: `1px solid ${BORDER}`, borderRadius: 12, padding: "16px 18px", flex: 1, minWidth: 130 }}>
+      <div style={{ fontSize: 12, fontWeight: 700, color: MUTE, textTransform: "uppercase", letterSpacing: "0.04em", marginBottom: 6 }}>{label}</div>
+      <div style={{ fontSize: 26, fontWeight: 800, color: INK, lineHeight: 1 }}>{value}</div>
+      {sub && <div style={{ fontSize: 12, color: MUTE, marginTop: 4 }}>{sub}</div>}
+    </div>
+  );
+}
+
+function Timeline({ id }: { id: number }) {
+  const { data, isLoading } = useQuery({ queryKey: ["estimate-engagement", id], queryFn: () => apiFetch(`/api/estimates/${id}/engagement`) });
+  if (isLoading) return <div style={{ padding: 16, color: MUTE, fontSize: 13 }}>Loading timeline…</div>;
+  if (!data) return null;
+  const { counts, timeline, enrollment } = data;
+  const events: any[] = timeline || [];
+
+  const nextLine = (() => {
+    if (!enrollment) return "Not enrolled in a drip";
+    if (enrollment.stopped_at) return `Drip stopped (${enrollment.stopped_reason || "stopped"})`;
+    if (enrollment.completed_at) return "Drip complete — all touches sent";
+    if (enrollment.next_fire_at) return `Next: ${enrollment.next_channel === "sms" ? "SMS" : "email"} touch ${enrollment.current_step}/${enrollment.total_steps} · ${fmtTime(enrollment.next_fire_at)}`;
+    return "Drip pending activation";
+  })();
+
+  return (
+    <div style={{ padding: "4px 18px 18px 18px", background: "#FCFCFB", borderTop: `1px solid ${BORDER}` }}>
+      <div style={{ display: "flex", gap: 18, padding: "12px 0", flexWrap: "wrap" }}>
+        <MiniStat icon={Send} label="Touches" value={counts.touches_sent} />
+        <MiniStat icon={Eye} label="Opens" value={counts.opened} />
+        <MiniStat icon={MousePointerClick} label="Clicks" value={counts.clicked} />
+        <MiniStat icon={Activity} label="Views" value={counts.viewed} />
+      </div>
+      <div style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 13, color: INK, fontWeight: 600, padding: "6px 0 14px" }}>
+        <Clock size={14} style={{ color: MINT }} /> {nextLine}
+      </div>
+      {events.length === 0 ? (
+        <div style={{ fontSize: 13, color: MUTE, paddingBottom: 6 }}>No engagement events yet.</div>
+      ) : (
+        <div style={{ position: "relative", paddingLeft: 8 }}>
+          {events.map((ev, i) => {
+            const m = EVENT_META[ev.event_type] || { icon: Activity, color: MUTE, label: ev.event_type };
+            const Icon = m.icon;
+            const ch = ev.channel === "sms" ? MessageSquare : ev.channel === "email" ? Mail : null;
+            return (
+              <div key={i} style={{ display: "flex", gap: 10, paddingBottom: 14, position: "relative" }}>
+                {i < events.length - 1 && <div style={{ position: "absolute", left: 11, top: 22, bottom: 0, width: 2, background: BORDER }} />}
+                <div style={{ width: 24, height: 24, borderRadius: 999, background: "#fff", border: `2px solid ${m.color}`, display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0, zIndex: 1 }}>
+                  <Icon size={12} style={{ color: m.color }} />
+                </div>
+                <div style={{ flex: 1, paddingTop: 1 }}>
+                  <div style={{ fontSize: 13, fontWeight: 700, color: INK, display: "flex", alignItems: "center", gap: 6 }}>
+                    {m.label}
+                    {ch && <span style={{ color: MUTE }}>{(() => { const C = ch; return <C size={12} />; })()}</span>}
+                  </div>
+                  <div style={{ fontSize: 12, color: MUTE }}>{fmtTime(ev.occurred_at)}{ev.recipient ? ` · ${ev.recipient}` : ""}</div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MiniStat({ icon, label, value }: { icon: any; label: string; value: any }) {
+  const Icon = icon;
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 7 }}>
+      <Icon size={15} style={{ color: MUTE }} />
+      <span style={{ fontSize: 16, fontWeight: 800, color: INK }}>{Number(value || 0)}</span>
+      <span style={{ fontSize: 12, color: MUTE }}>{label}</span>
+    </div>
+  );
+}
+
+export default function EstimateEngagementPage() {
+  const [, navigate] = useLocation();
+  const [expanded, setExpanded] = useState<number | null>(null);
+
+  const { data: summary } = useQuery({ queryKey: ["engagement-summary"], queryFn: () => apiFetch("/api/estimates/engagement/summary") });
+  const { data: pipeline, isLoading } = useQuery({ queryKey: ["engagement-pipeline"], queryFn: () => apiFetch("/api/estimates/engagement/pipeline") });
+  const rows: any[] = pipeline?.data || [];
+
+  return (
+    <DashboardLayout>
+      <div style={{ fontFamily: FF, maxWidth: 1100, margin: "0 auto", padding: "8px 4px 80px" }}>
+        <button onClick={() => navigate("/estimates")} style={{ display: "inline-flex", alignItems: "center", gap: 5, background: "none", border: "none", color: MUTE, fontSize: 13, fontWeight: 600, cursor: "pointer", fontFamily: FF, padding: 0, marginBottom: 12 }}>
+          <ArrowLeft size={15} /> Estimates
+        </button>
+        <h1 style={{ fontSize: 23, fontWeight: 800, color: INK, margin: "0 0 18px" }}>Estimate Engagement</h1>
+
+        {/* Month summary */}
+        <div style={{ display: "flex", gap: 10, flexWrap: "wrap", marginBottom: 24 }}>
+          <StatCard label="Sent" value={String(summary?.sent ?? 0)} sub="this month" />
+          <StatCard label="Opened" value={`${summary?.opened_pct ?? 0}%`} sub={`${summary?.opened ?? 0} of ${summary?.sent ?? 0}`} />
+          <StatCard label="Clicked" value={`${summary?.clicked_pct ?? 0}%`} sub={`${summary?.clicked ?? 0} of ${summary?.sent ?? 0}`} />
+          <StatCard label="Won" value={String(summary?.won ?? 0)} sub={`${summary?.lost ?? 0} lost`} />
+          <StatCard label="Avg touches / win" value={String(summary?.avg_touches_to_win ?? 0)} sub="to close" />
+        </div>
+
+        {/* Pipeline */}
+        <h2 style={{ fontSize: 13, fontWeight: 800, color: INK, textTransform: "uppercase", letterSpacing: "0.05em", margin: "0 0 10px" }}>Pipeline</h2>
+        <div style={{ background: "#fff", border: `1px solid ${BORDER}`, borderRadius: 12, overflow: "hidden" }}>
+          <div style={{ display: "grid", gridTemplateColumns: "1.6fr 90px 70px 1fr 110px 90px", gap: 8, padding: "10px 14px", borderBottom: `1px solid ${BORDER}`, fontSize: 11, fontWeight: 700, color: MUTE, textTransform: "uppercase", letterSpacing: "0.04em" }}>
+            <span>Recipient</span><span>Status</span><span>Day</span><span>Engagement</span><span>Amount</span><span>Last</span>
+          </div>
+          {isLoading ? (
+            <div style={{ padding: 24, textAlign: "center", color: MUTE, fontSize: 13 }}>Loading…</div>
+          ) : rows.length === 0 ? (
+            <div style={{ padding: 24, textAlign: "center", color: MUTE, fontSize: 13 }}>No sent estimates yet. Engagement appears here once you send one.</div>
+          ) : rows.map((r) => {
+            const isOpen = expanded === r.id;
+            const day = daysSince(r.sent_at);
+            const won = r.status === "accepted"; const lost = r.status === "declined";
+            const active = !won && !lost && !r.stopped_at && !r.completed_at && r.current_step;
+            return (
+              <div key={r.id} style={{ borderBottom: `1px solid ${BORDER}` }}>
+                <div
+                  onClick={() => setExpanded(isOpen ? null : r.id)}
+                  style={{ display: "grid", gridTemplateColumns: "1.6fr 90px 70px 1fr 110px 90px", gap: 8, padding: "12px 14px", alignItems: "center", cursor: "pointer", fontSize: 13, color: INK }}
+                >
+                  <span style={{ display: "flex", alignItems: "center", gap: 6, fontWeight: 700, minWidth: 0 }}>
+                    {isOpen ? <ChevronDown size={14} style={{ color: MUTE, flexShrink: 0 }} /> : <ChevronRight size={14} style={{ color: MUTE, flexShrink: 0 }} />}
+                    <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{r.recipient}</span>
+                  </span>
+                  <span><StatusChip status={r.status} /></span>
+                  <span style={{ color: MUTE }}>{active && day != null ? `${Math.min(day, 16)}/16` : "—"}</span>
+                  <span style={{ display: "flex", gap: 12, color: MUTE, fontSize: 12 }}>
+                    <span title="opens"><Eye size={12} /> {Number(r.opened || 0)}</span>
+                    <span title="clicks"><MousePointerClick size={12} /> {Number(r.clicked || 0)}</span>
+                    <span title="touches sent"><Send size={12} /> {Number(r.touches_sent || 0)}</span>
+                  </span>
+                  <span style={{ fontWeight: 700 }}>{money(r.total)}</span>
+                  <span style={{ color: MUTE, fontSize: 12 }}>{r.last_event_at ? fmtTime(r.last_event_at).split(",")[0] : "—"}</span>
+                </div>
+                {isOpen && <Timeline id={r.id} />}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/artifacts/qleno/src/pages/estimates.tsx
+++ b/artifacts/qleno/src/pages/estimates.tsx
@@ -3,7 +3,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useLocation } from "wouter";
 import { getAuthHeaders } from "@/lib/auth";
 import { DashboardLayout } from "@/components/layout/dashboard-layout";
-import { Plus, FileText, Send, CheckCircle, Clock, Trash2, Pencil, LayoutTemplate, Search } from "lucide-react";
+import { Plus, FileText, Send, CheckCircle, Clock, Trash2, Pencil, LayoutTemplate, Search, Activity } from "lucide-react";
 import { toast } from "sonner";
 
 const FF = "'Plus Jakarta Sans', sans-serif";
@@ -107,10 +107,16 @@ export default function EstimatesPage() {
             <h1 style={{ fontSize: 24, fontWeight: 800, color: INK, margin: 0 }}>Estimates</h1>
             <p style={{ fontSize: 13, color: MUTE, margin: "4px 0 0" }}>Build, send, and track commercial &amp; common-area estimates.</p>
           </div>
-          <button onClick={() => navigate("/estimates/new")}
-            style={{ display: "inline-flex", alignItems: "center", gap: 6, background: INK, color: "#fff", border: "none", borderRadius: 10, padding: "10px 16px", fontSize: 14, fontWeight: 700, cursor: "pointer", fontFamily: FF }}>
-            <Plus size={16} /> New Estimate
-          </button>
+          <div style={{ display: "flex", gap: 8 }}>
+            <button onClick={() => navigate("/estimates/engagement")}
+              style={{ display: "inline-flex", alignItems: "center", gap: 6, background: "#fff", color: INK, border: `1px solid ${BORDER}`, borderRadius: 10, padding: "10px 16px", fontSize: 14, fontWeight: 700, cursor: "pointer", fontFamily: FF }}>
+              <Activity size={16} /> Engagement
+            </button>
+            <button onClick={() => navigate("/estimates/new")}
+              style={{ display: "inline-flex", alignItems: "center", gap: 6, background: INK, color: "#fff", border: "none", borderRadius: 10, padding: "10px 16px", fontSize: 14, fontWeight: 700, cursor: "pointer", fontFamily: FF }}>
+              <Plus size={16} /> New Estimate
+            </button>
+          </div>
         </div>
 
         {/* Stat strip */}


### PR DESCRIPTION
## Phase 5 — Engagement dashboard (native, minimalist)

A clean GHL-style engagement view over the Phase-4 data layer. No external services.

### Backend (read-only, company-scoped) — on the estimates router
- `GET /api/estimates/engagement/pipeline` — all sent estimates: opens / clicks / touches, day N/16, status (Won/Lost), amount, last activity.
- `GET /api/estimates/engagement/summary?month=YYYY-MM` — sent, opened %, clicked %, won/lost, avg touches-to-win.
- `GET /api/estimates/:id/engagement` — per-estimate counts + full **touchpoint timeline** (every event with channel + timestamp) + **next-scheduled** touch from the enrollment.

### Frontend — `estimate-engagement.tsx` (`/estimates/engagement`)
Registered **before** `/estimates/:id` so the builder's `:id` route doesn't swallow it.
- Month summary stat cards (Sent / Opened % / Clicked % / Won / Avg touches per win).
- Pipeline list; click a row → inline **touchpoint timeline** (icon per event type, channel, time, a "next scheduled" line, mini opens/clicks/touches).
- "Engagement" button added to the estimates list header.

### Tests (`engagement-dashboard.test.ts`, 7)
endpoints exist + company-scoped; summary computes the rates; per-estimate returns a time-ordered timeline + next-scheduled; frontend route ordered before `:id`; page renders summary/pipeline/timeline; list links to it.

### Verification
- Test **7/7** · `typecheck:libs` clean · frontend typecheck **zero new errors** (242=242) · backend estimates.ts back to its 9 pre-existing (**zero new**) · backend bundle builds.

Read-only · no sends · `COMMS_ENABLED` untouched · additive only · all data preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)