### PR TITLE
fix(notifications): repair reminder cron (invalid enum status crashed every run)

### DIFF
--- a/artifacts/api-server/src/services/notificationService.ts
+++ b/artifacts/api-server/src/services/notificationService.ts
@@ -284,8 +284,10 @@ export async function runReminderCron(daysAhead: number): Promise<void> {
                    c.sms_opt_out_at, c.email_opt_out_at, c.email_unsub_token
               FROM jobs j
               JOIN clients c ON c.id = j.client_id
+              JOIN companies co ON co.id = j.company_id
              WHERE j.scheduled_date = ${targetStr}
-               AND j.status NOT IN ('cancelled', 'void', 'done', 'complete')
+               AND j.status NOT IN ('cancelled', 'complete')
+               AND co.comms_enabled = true
                AND j.reminder_72h_sent = false
           `
         : drizzleSql`
@@ -295,8 +297,10 @@ export async function runReminderCron(daysAhead: number): Promise<void> {
                    c.sms_opt_out_at, c.email_opt_out_at, c.email_unsub_token
               FROM jobs j
               JOIN clients c ON c.id = j.client_id
+              JOIN companies co ON co.id = j.company_id
              WHERE j.scheduled_date = ${targetStr}
-               AND j.status NOT IN ('cancelled', 'void', 'done', 'complete')
+               AND j.status NOT IN ('cancelled', 'complete')
+               AND co.comms_enabled = true
                AND j.reminder_24h_sent = false
           `
     );

--- a/artifacts/api-server/src/tests/reminder-cron-query.test.ts
+++ b/artifacts/api-server/src/tests/reminder-cron-query.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Reminder cron query guard.
+ *
+ * The 24h/72h reminder cron silently crashed on every run because its SQL
+ * filtered `status NOT IN ('cancelled','void','done','complete')` — but the
+ * job_status enum only has scheduled|in_progress|complete|cancelled, so Postgres
+ * threw "invalid input value for enum job_status: void" and NO reminder ever
+ * sent. These assertions pin the fix: only valid enum statuses, and a
+ * per-company comms gate so disabled tenants are never texted.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const src = readFileSync(
+  resolve(dirname(fileURLToPath(import.meta.url)), "../services/notificationService.ts"),
+  "utf8",
+);
+
+describe("reminder cron query", () => {
+  it("never references the non-existent statuses 'void' or 'done'", () => {
+    assert.doesNotMatch(src, /'void'/, "remove invalid enum status 'void'");
+    assert.doesNotMatch(src, /'done'/, "remove invalid enum status 'done'");
+  });
+  it("filters on valid enum statuses only", () => {
+    assert.match(src, /status NOT IN \('cancelled', 'complete'\)/);
+  });
+  it("gates on per-company comms_enabled (won't text disabled tenants)", () => {
+    assert.match(src, /JOIN companies co ON co\.id = j\.company_id/);
+    assert.match(src, /co\.comms_enabled = true/);
+  });
+});


### PR DESCRIPTION
## The bug
The 24h/72h appointment-reminder cron filtered jobs with `status NOT IN ('cancelled','void','done','complete')`. The `job_status` enum only has **scheduled / in_progress / complete / cancelled** — so Postgres threw `invalid input value for enum job_status: "void"` **every run**, the query aborted, and **no reminder ever sent**.

**Verified in prod:** `reminder_24h_sent=true` count = 0, `reminder_72h_sent=true` = 0 across the entire jobs table. Customers have never gotten appointment reminders.

## The fix
- Status filter now uses only valid enum values: `NOT IN ('cancelled','complete')`.
- Adds a **per-company comms gate** (`JOIN companies co … AND co.comms_enabled = true`). The cron previously checked only the global `COMMS_ENABLED` and had **no company scope**, so it would have texted every tenant's customers. Now it respects the same per-company switch as the rest of the app (so Demo/Evinco are excluded; Oak Lawn — now enabled — is included).

Each run still targets a single date (today+1 / today+3), so this resumes normal day-by-day reminders, **not** a backlog blast. Confirmed the corrected query runs against prod and returns tomorrow's eligible jobs (8).

## Test
`reminder-cron-query.test.ts` — pins valid statuses + the company gate (3/3 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)