### PR TITLE
feat(accounts): per-account pause-all-communications toggle (PPM/KMA)

### DIFF
--- a/artifacts/api-server/src/lib/account-comms.ts
+++ b/artifacts/api-server/src/lib/account-comms.ts
@@ -1,0 +1,32 @@
+// [account-comms-toggle 2026-06-25] Per-account "pause all communications".
+// Property-management accounts (PPM, KMA, …) with many properties can be silenced
+// via accounts.comms_enabled = false. Any customer record linked to the account
+// (clients.account_id) is then excluded from ALL automated SMS/email.
+//
+// Two enforcement shapes:
+//  - Bulk/cron queries: LEFT JOIN accounts and require (a.id IS NULL OR a.comms_enabled = true).
+//  - Per-job send paths: call isClientAccountCommsPaused(clientId) and skip when true.
+
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+// True when the client belongs to an account whose comms are paused.
+// Never throws — comms gating must never break the calling request.
+export async function isClientAccountCommsPaused(
+  clientId: number | null | undefined,
+): Promise<boolean> {
+  if (!clientId) return false;
+  try {
+    const r = await db.execute(sql`
+      SELECT 1
+        FROM clients c
+        JOIN accounts a ON a.id = c.account_id
+       WHERE c.id = ${clientId} AND a.comms_enabled = false
+       LIMIT 1
+    `);
+    return ((r as any).rows?.length ?? 0) > 0;
+  } catch (err) {
+    console.error("[account-comms] isClientAccountCommsPaused failed (non-fatal):", err);
+    return false;
+  }
+}

--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -373,6 +373,10 @@ async function runBookingSchemaGuard(): Promise<void> {
     // the builder can offer a one-click picker (common_areas|office|retail|
     // medical|null). Additive + idempotent.
     { label: "estimate_templates.category", stmt: `ALTER TABLE estimate_templates ADD COLUMN IF NOT EXISTS category TEXT` },
+    // [account-comms-toggle 2026-06-25] Per-account "pause all communications"
+    // master switch (default true). When false, no automated SMS/email reaches
+    // any customer record linked to the account. Additive + idempotent.
+    { label: "accounts.comms_enabled", stmt: `ALTER TABLE accounts ADD COLUMN IF NOT EXISTS comms_enabled boolean NOT NULL DEFAULT true` },
     // [engagement-tracking-phase4 2026-06-25] Unified engagement timeline +
     // native click-redirect / open-pixel tokens. Additive + idempotent.
     { label: "CREATE engagement_events", stmt: `

--- a/artifacts/api-server/src/routes/accounts.ts
+++ b/artifacts/api-server/src/routes/accounts.ts
@@ -161,6 +161,8 @@ router.patch("/:id", requireAuth, requireRole("owner", "admin"), async (req, res
     "account_name", "account_type", "invoice_frequency", "payment_method",
     "payment_terms_days", "notes", "is_active", "billing_contact_id",
     "auto_charge_on_completion", "stripe_customer_id", "square_customer_id",
+    // [account-comms-toggle] master "pause all communications" switch
+    "comms_enabled",
   ];
   const updates: Record<string, unknown> = { updated_at: new Date() };
   for (const key of allowed) {

--- a/artifacts/api-server/src/routes/jobs.ts
+++ b/artifacts/api-server/src/routes/jobs.ts
@@ -3660,8 +3660,11 @@ router.post("/:id/complete", requireAuth, async (req, res) => {
                   address: clientsTable.address, city: clientsTable.city, state: clientsTable.state,
                   first_name: clientsTable.first_name })
         .from(clientsTable).where(eq(clientsTable.id, clientId)).limit(1)
-        .then(([cl]) => {
+        .then(async ([cl]) => {
           if (!cl) return;
+          // [account-comms-toggle] Skip if this client's account paused comms.
+          const { isClientAccountCommsPaused } = await import("../lib/account-comms.js");
+          if (await isClientAccountCommsPaused(clientId)) return;
           const addr = [cl.address, cl.city, cl.state].filter(Boolean).join(", ");
           const mv = {
             first_name:       cl.first_name || "",

--- a/artifacts/api-server/src/routes/payments.ts
+++ b/artifacts/api-server/src/routes/payments.ts
@@ -49,6 +49,9 @@ router.post("/", requireAuth, requireRole("owner", "admin"), async (req, res) =>
       .from(clientsTable).where(eq(clientsTable.id, parseInt(client_id))).limit(1)
       .then(async ([cl]) => {
         if (!cl) return;
+        // [account-comms-toggle] Skip if this client's account paused comms.
+        const { isClientAccountCommsPaused } = await import("../lib/account-comms.js");
+        if (await isClientAccountCommsPaused(parseInt(client_id))) return;
         let invNum = invoice_id ? String(invoice_id) : "";
         if (invoice_id) {
           const [inv] = await db.select({ invoice_number: invoicesTable.invoice_number })

--- a/artifacts/api-server/src/routes/tech-clock.ts
+++ b/artifacts/api-server/src/routes/tech-clock.ts
@@ -341,6 +341,9 @@ async function sendOnMyWayForJob(
   // [comms-opt-out] A recorded SMS STOP overrides the per-client preference.
   const { isSmsOptedOut } = await import("../lib/opt-out.js");
   const smsOptedOut = await isSmsOptedOut(companyId, client?.phone ?? null);
+  // [account-comms-toggle] A paused account silences on-my-way for its clients.
+  const { isClientAccountCommsPaused } = await import("../lib/account-comms.js");
+  const accountPaused = await isClientAccountCommsPaused(job.client_id ?? null);
   return sendOnMyWaySms({
     toPhone: client?.phone ?? null,
     fromPhone: tenant?.twilio_from_number ?? null,
@@ -351,7 +354,7 @@ async function sendOnMyWayForJob(
     serviceAddress,
     promisedArrivalLabel: promisedLabel,
     tenantSmsEnabled: !!tenant?.sms_on_my_way_enabled,
-    clientOptedIn: client?.wants_on_my_way_notifications !== false && !smsOptedOut,
+    clientOptedIn: client?.wants_on_my_way_notifications !== false && !smsOptedOut && !accountPaused,
   });
 }
 

--- a/artifacts/api-server/src/services/notificationService.ts
+++ b/artifacts/api-server/src/services/notificationService.ts
@@ -285,9 +285,11 @@ export async function runReminderCron(daysAhead: number): Promise<void> {
               FROM jobs j
               JOIN clients c ON c.id = j.client_id
               JOIN companies co ON co.id = j.company_id
+              LEFT JOIN accounts a ON a.id = c.account_id
              WHERE j.scheduled_date = ${targetStr}
                AND j.status NOT IN ('cancelled', 'complete')
                AND co.comms_enabled = true
+               AND (a.id IS NULL OR a.comms_enabled = true)
                AND j.reminder_72h_sent = false
           `
         : drizzleSql`
@@ -298,9 +300,11 @@ export async function runReminderCron(daysAhead: number): Promise<void> {
               FROM jobs j
               JOIN clients c ON c.id = j.client_id
               JOIN companies co ON co.id = j.company_id
+              LEFT JOIN accounts a ON a.id = c.account_id
              WHERE j.scheduled_date = ${targetStr}
                AND j.status NOT IN ('cancelled', 'complete')
                AND co.comms_enabled = true
+               AND (a.id IS NULL OR a.comms_enabled = true)
                AND j.reminder_24h_sent = false
           `
     );
@@ -435,8 +439,10 @@ export async function runReviewRequestCron(): Promise<void> {
           FROM jobs j
           JOIN clients c ON c.id = j.client_id
           JOIN companies co ON co.id = j.company_id
+          LEFT JOIN accounts a ON a.id = c.account_id
          WHERE j.status = 'complete'
            AND DATE(j.created_at) = ${fromStr}
+           AND (a.id IS NULL OR a.comms_enabled = true)
            AND (c.survey_last_sent IS NULL OR c.survey_last_sent < NOW() - INTERVAL '30 days')
       `
     );

--- a/artifacts/api-server/src/tests/account-comms-toggle.test.ts
+++ b/artifacts/api-server/src/tests/account-comms-toggle.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Account-level "pause all communications" toggle.
+ *
+ * Stub-DB. Pins: the accounts.comms_enabled column + additive migration, the
+ * shared helper, and that every automated client-resolving send path honors a
+ * paused account (cron SQL guard, plus per-job helper checks).
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { accountsTable } from "@workspace/db/schema";
+import { isClientAccountCommsPaused } from "../lib/account-comms.ts";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const read = (rel: string) => readFileSync(resolve(here, rel), "utf8");
+
+describe("account comms — schema + migration", () => {
+  it("accounts.comms_enabled exists, defaults true", () => {
+    const col = (accountsTable as any).comms_enabled;
+    assert.ok(col, "accounts.comms_enabled should exist");
+    assert.equal(col.name, "comms_enabled");
+    assert.equal(col.default, true);
+  });
+  it("migration adds it idempotently", () => {
+    assert.match(read("../phes-data-migration.ts"),
+      /ALTER TABLE accounts ADD COLUMN IF NOT EXISTS comms_enabled boolean NOT NULL DEFAULT true/);
+  });
+  it("helper is exported", () => {
+    assert.equal(typeof isClientAccountCommsPaused, "function");
+  });
+});
+
+describe("account comms — enforced on every automated path", () => {
+  const notif = read("../services/notificationService.ts");
+  it("reminder cron (24h + 72h) excludes paused accounts", () => {
+    // both reminder queries join accounts and gate on comms_enabled
+    const matches = notif.match(/a\.id IS NULL OR a\.comms_enabled = true/g) || [];
+    assert.ok(matches.length >= 3, `expected >=3 account guards (24h, 72h, review), got ${matches.length}`);
+    assert.match(notif, /LEFT JOIN accounts a ON a\.id = c\.account_id/);
+  });
+  it("job completion checks the helper", () => {
+    assert.match(read("../routes/jobs.ts"), /isClientAccountCommsPaused/);
+  });
+  it("payment receipt checks the helper", () => {
+    assert.match(read("../routes/payments.ts"), /isClientAccountCommsPaused/);
+  });
+  it("on-my-way SMS checks the helper", () => {
+    assert.match(read("../routes/tech-clock.ts"), /isClientAccountCommsPaused/);
+  });
+  it("accounts PATCH route accepts comms_enabled", () => {
+    assert.match(read("../routes/accounts.ts"), /"comms_enabled"/);
+  });
+});

--- a/artifacts/qleno/src/pages/account-detail.tsx
+++ b/artifacts/qleno/src/pages/account-detail.tsx
@@ -179,6 +179,27 @@ export default function AccountDetailPage() {
 
   useEffect(() => { load(); }, [id]);
 
+  // [account-comms-toggle] Pause/resume ALL automated SMS+email for this account's
+  // customers (reminders, on-my-way, completion, receipts, review requests).
+  // Optimistic; reverts on failure. Manual invoice sends are unaffected.
+  async function toggleComms(next: boolean) {
+    if (!account) return;
+    const prev = account.comms_enabled;
+    setAccount({ ...account, comms_enabled: next });
+    try {
+      const r = await fetch(`${API}/api/accounts/${id}`, {
+        method: "PATCH",
+        headers: { ...getAuthHeaders(), "Content-Type": "application/json" } as Record<string, string>,
+        body: JSON.stringify({ comms_enabled: next }),
+      });
+      if (!r.ok) throw new Error();
+      toast({ title: next ? "Communications resumed for this account" : "Communications paused — no automated texts/emails to this account's customers" });
+    } catch {
+      setAccount({ ...account, comms_enabled: prev });
+      toast({ title: "Failed to update communications setting", variant: "destructive" });
+    }
+  }
+
   // [commercial-console slice 2] On desktop, auto-select the first building so the
   // detail pane is populated on arrival. On mobile we leave it on the list (the
   // detail is a drill-in there).
@@ -523,6 +544,23 @@ export default function AccountDetailPage() {
                     {account.auto_charge_on_completion ? "Enabled" : "Disabled"}
                   </span>
                 </div>
+              </div>
+            </div>
+
+            {/* Communications — pause all automated SMS/email for this account */}
+            <div className="bg-white border border-gray-100 rounded-xl p-4 space-y-3 sm:col-span-2">
+              <p className="text-xs font-semibold text-gray-400 uppercase tracking-wider">Communications</p>
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <p className="text-sm font-medium text-[#0A0E1A]">Automated customer messages</p>
+                  <p className="text-xs text-gray-500 mt-0.5 max-w-md">
+                    Reminders, on-my-way texts, completion &amp; receipt notices, review requests for every customer under this account.
+                    {account.comms_enabled === false
+                      ? " Currently PAUSED — nothing automated goes out. (Manual invoices still send.)"
+                      : " Turn off for property managers (PPM, KMA, …) who don't want the messaging."}
+                  </p>
+                </div>
+                <Switch checked={account.comms_enabled !== false} onCheckedChange={toggleComms} />
               </div>
             </div>
 

--- a/lib/db/src/schema/accounts.ts
+++ b/lib/db/src/schema/accounts.ts
@@ -29,6 +29,12 @@ export const accountsTable = pgTable("accounts", {
   square_customer_id: text("square_customer_id"),
   notes: text("notes"),
   is_active: boolean("is_active").notNull().default(true),
+  // [account-comms-toggle 2026-06-25] Master "pause all communications" switch
+  // for an account. When false, NO automated SMS/email goes to any customer
+  // record linked to this account (clients.account_id) — for property-management
+  // accounts (PPM, KMA, etc.) with many properties that don't want messaging.
+  // Default true = normal. Enforced in every client-resolving send path.
+  comms_enabled: boolean("comms_enabled").notNull().default(true),
   created_at: timestamp("created_at").notNull().defaultNow(),
   updated_at: timestamp("updated_at").notNull().defaultNow(),
 });


### PR DESCRIPTION
## Why
Property-management accounts (PPM, KMA, …) have many properties and don't want the automated customer messaging. There was **no** way to silence an account. This adds a master switch.

## What
- **Schema + migration:** `accounts.comms_enabled` (boolean, default true), additive/idempotent.
- **`lib/account-comms.ts`** — `isClientAccountCommsPaused(clientId)`: true when the client's account paused comms (never throws).
- **Enforced on every automated, client-resolving send path:**
  - 24h + 72h **reminder cron** and **review-request cron** → SQL `LEFT JOIN accounts … (a.id IS NULL OR a.comms_enabled = true)`
  - **job completion**, **payment receipt**, **on-my-way SMS** → helper check, skip when paused
  - **Manual invoice sends are intentionally NOT gated** — billing must still go out.
- **API:** accounts `PATCH` accepts `comms_enabled`.
- **UI:** a "Communications" card + toggle on the account **Overview** tab.

## Reality check (from prod)
Account contacts aren't on any send path today and only **1** client is account-linked, so practical exposure is small — but this makes the control explicit and future-proof: any client linked to a paused account is silenced.

## Tests
`account-comms-toggle.test.ts` (8): column/default/migration, helper, guard on each path + PATCH allow-list.

## Verification
test 8/8 · `typecheck:libs` clean · frontend typecheck **zero new errors** (242=242) · backend bundle builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)