### PR TITLE
fix(booking): confirmation-email logos, larger logo, public Maps key, dedupe terms link

### DIFF
--- a/artifacts/api-server/src/lib/booking-confirmation.ts
+++ b/artifacts/api-server/src/lib/booking-confirmation.ts
@@ -4,6 +4,7 @@ import { db } from "@workspace/db";
 import { sql } from "drizzle-orm";
 import { renderConfirmationEmail, extractPolicyCopy, fmtTime12h } from "./confirmation-email.js";
 import { shortenUrl } from "./short-link.js";
+import { appBaseUrl } from "./app-url.js";
 import { BOOKING_SMS } from "./sms-copy.js";
 
 // [booking-confirmation GAP1] Customer booking confirmation: a no-login,
@@ -142,7 +143,7 @@ export async function sendJobScheduledConfirmation(req: Request, jobId: number):
     // ONLY — no last name/contact. Per-tenant contact from the record, branch
     // fallback otherwise. The renderer reuses the merged template body's policy
     // copy verbatim (extractPolicyCopy) and reskins everything else.
-    const origin = originFromReq(req);
+    const origin = appBaseUrl();
     const FALLBACK_PHONE = "(847) 538-3729", FALLBACK_PHONE_TEL = "+18475383729", FALLBACK_EMAIL = "schaumburg@phes.io";
     const cPhone = j.company_phone || FALLBACK_PHONE;
     const cPhoneTel = j.company_phone ? String(j.company_phone).replace(/[^\d+]/g, "") : FALLBACK_PHONE_TEL;

--- a/artifacts/api-server/src/lib/confirmation-email.ts
+++ b/artifacts/api-server/src/lib/confirmation-email.ts
@@ -90,7 +90,7 @@ export function renderConfirmationEmail(o: ConfEmailOpts): string {
     <!-- Navy masthead -->
     <tr><td bgcolor="${NAVY}" style="background:${NAVY};padding:20px 28px;">
       <table role="presentation" cellpadding="0" cellspacing="0"><tr>
-        <td valign="middle" style="padding-right:13px;"><img src="${escAttr(o.logoUrl)}" width="40" alt="${escAttr(o.companyName)}" style="height:40px;width:auto;border-radius:8px;background:#ffffff;display:block;border:0;" /></td>
+        <td valign="middle" style="padding-right:13px;"><img src="${escAttr(o.logoUrl)}" width="60" alt="${escAttr(o.companyName)}" style="height:60px;width:auto;border-radius:8px;background:#ffffff;display:block;border:0;" /></td>
         <td valign="middle">
           <div style="font-family:${FONT};font-size:18px;font-weight:700;color:#ffffff;line-height:1.2;">${o.companyName}</div>
           <div style="font-family:${FONT};font-size:12px;color:${SUBLINE};line-height:1.4;">Residential &amp; Commercial Cleaning</div>

--- a/artifacts/api-server/src/routes/public.ts
+++ b/artifacts/api-server/src/routes/public.ts
@@ -56,6 +56,14 @@ function rateLimit(req: any, res: any, next: any) {
   return next();
 }
 
+// ── GET /api/public/config/google-maps-key ───────────────────────────────────
+// Public (no requireAuth) so the booking widget can load Maps Places at runtime.
+// The build-time VITE_GOOGLE_MAPS_API_KEY is empty in the Railway build, so the
+// browser key is served from the server-side GOOGLE_MAPS_API_KEY env instead.
+router.get("/config/google-maps-key", rateLimit, (_req, res) => {
+  return res.json({ key: process.env.GOOGLE_MAPS_API_KEY ?? "" });
+});
+
 // ── GET /api/public/company/:slug ────────────────────────────────────────────
 router.get("/company/:slug", rateLimit, async (req, res) => {
   try {

--- a/artifacts/qleno/src/pages/book.tsx
+++ b/artifacts/qleno/src/pages/book.tsx
@@ -521,8 +521,10 @@ export default function BookPage() {
   }, [slug]);
 
   // ── Load Google Maps Places ───────────────────────────────────────────────
+  // Fetch the browser key at runtime from the public config endpoint first
+  // (VITE_GOOGLE_MAPS_API_KEY is empty in the Railway build), then fall back to
+  // the build-time var if the runtime fetch yields nothing.
   useEffect(() => {
-    const key = (import.meta as any).env?.VITE_GOOGLE_MAPS_API_KEY ?? "";
     if ((window as any).google?.maps?.places) { setMapsReady(true); return; }
     const scriptId = "gmap-places-script";
     if (document.getElementById(scriptId)) {
@@ -530,14 +532,24 @@ export default function BookPage() {
       if (existing) { existing.addEventListener("load", () => setMapsReady(true)); }
       return;
     }
-    if (!key) return;
-    const s = document.createElement("script");
-    s.id = scriptId;
-    s.src = `https://maps.googleapis.com/maps/api/js?key=${key}&libraries=places`;
-    s.async = true;
-    s.defer = true;
-    s.onload = () => setMapsReady(true);
-    document.head.appendChild(s);
+    let cancelled = false;
+    (async () => {
+      let key = "";
+      try {
+        const res = await pubFetch("/api/public/config/google-maps-key");
+        key = String(res?.key ?? "");
+      } catch { /* fall through to build-time key */ }
+      if (!key) key = (import.meta as any).env?.VITE_GOOGLE_MAPS_API_KEY ?? "";
+      if (cancelled || !key) return;
+      if (document.getElementById(scriptId)) { setMapsReady(true); return; }
+      const s = document.createElement("script");
+      s.id = scriptId;
+      s.src = `https://maps.googleapis.com/maps/api/js?key=${key}&libraries=places`;
+      s.async = true; s.defer = true;
+      s.onload = () => setMapsReady(true);
+      document.head.appendChild(s);
+    })();
+    return () => { cancelled = true; };
   }, []);
 
   // ── Wire autocomplete after Maps is ready AND input is in the DOM ──────────
@@ -1676,8 +1688,6 @@ export default function BookPage() {
                   <input type="checkbox" checked={smsConsent} onChange={e => setSmsConsent(e.target.checked)} style={{ marginTop: 3, accentColor: brand, width: 16, height: 16, flexShrink: 0, minHeight: "unset" }} />
                   <span className="bw-consent" style={{ fontSize: 13, color: "#6B6860", width: "100%" }}>
                     By checking this box, you agree to receive transactional SMS messages from Phes regarding your appointment. Message frequency varies. Message and data rates may apply. Reply STOP to opt out. You must be 18 or older to opt in. View our{" "}
-                    <a href="https://phes.io/terms" target="_blank" rel="noopener noreferrer" style={{ color: brand, textDecoration: "underline" }}>Terms of Service</a>
-                    {" "}and{" "}
                     <a href="https://phes.io/privacy-policy" target="_blank" rel="noopener noreferrer" style={{ color: brand, textDecoration: "underline" }}>Privacy Policy</a>.
                   </span>
                 </label>


### PR DESCRIPTION
Four fixes to the public booking widget + confirmation email.

## 1 — Confirmation email logos were broken
The email built asset URLs from `originFromReq(req)`, which resolves to the wrong host behind Railway's proxy, so `/phes-logo.jpeg` and `/images/logo-mark.png` 404'd. Now uses `appBaseUrl()` (canonical `https://app.qleno.com`).
- `artifacts/api-server/src/lib/booking-confirmation.ts`

## 2 — Larger email logo
Header `<img>` bumped 40px → 60px.
- `artifacts/api-server/src/lib/confirmation-email.ts`

## 3 — Dead address autocomplete on the public widget
The build-time `VITE_GOOGLE_MAPS_API_KEY` is empty in the Railway build, and the existing key endpoint is auth-gated. Added a **public** `GET /api/public/config/google-maps-key` (serves the server-side `GOOGLE_MAPS_API_KEY`) and updated the Maps loader in `book.tsx` to fetch the key at runtime, falling back to the build-time var.
- `artifacts/api-server/src/routes/public.ts`
- `artifacts/qleno/src/pages/book.tsx`

> Deploy note: confirm `GOOGLE_MAPS_API_KEY` in Railway is a **browser** key with Maps JavaScript API + Places enabled and `app.qleno.com` in its allowed HTTP referrers.

## 4 — Redundant terms link removed
The SMS-consent line linked both "Terms of Service" and (via the agreement checkbox) "terms and conditions" to the same `https://phes.io/terms`. Removed the "Terms of Service" link from the SMS-consent line; Privacy Policy stays, and the separate agreement checkbox keeps the single terms reference.

**TCPA note:** terms are still surfaced (the agreement checkbox links them right below), and the SMS-consent line retains the full disclosure (frequency, rates, STOP, 18+, Privacy Policy). No required consent language was removed.
- `artifacts/qleno/src/pages/book.tsx`

## Verification
- Both affected packages typecheck with no new errors from these changes (pre-existing unrelated errors remain).
- Post-deploy: load https://app.qleno.com/book/phes-cleaning — address suggestions appear, one terms link, and a test booking's confirmation email shows both logos at the larger size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)