### PR TITLE
feat(clients): account health 3-check model (Happy / Active / Making money)

### DIFF
--- a/artifacts/api-server/src/routes/clients.ts
+++ b/artifacts/api-server/src/routes/clients.ts
@@ -2431,6 +2431,71 @@ router.get("/:id/profitability", requireAuth, requireRole("owner", "office"), as
     if (companyAvgBill > 0 && avgBill < companyAvgBill) health -= 5;
     health = Math.max(0, Math.min(100, health));
 
+    // [account-health 2026-06-25] Bug #9: replace the money-only score with a
+    // simple 3-check model — Happy / Active / Making money. The old score
+    // ignored quality entirely, so an unhappy-but-profitable client read
+    // "Healthy" (Maribel's complaint). Each check links to real records for the
+    // click-through detail. Quality window 90d, real (past) cancellations 60d.
+    const recleanRows = (await db.execute(sql`
+      SELECT qc.id, qc.complaint_date::text AS date, qc.description, qc.job_id
+      FROM quality_complaints qc JOIN jobs j ON j.id = qc.job_id
+      WHERE j.client_id = ${clientId} AND qc.company_id = ${companyId}
+        AND (qc.re_clean_required OR qc.valid)
+        AND qc.complaint_date >= CURRENT_DATE - INTERVAL '90 days'
+      ORDER BY qc.complaint_date DESC`)).rows as any[];
+    const ticketRows = (await db.execute(sql`
+      SELECT t.id, t.ticket_type::text AS ticket_type, t.notes, t.job_id, t.created_at::text AS date
+      FROM contact_tickets t
+      WHERE t.client_id = ${clientId} AND t.company_id = ${companyId}
+        AND t.ticket_type IN ('complaint_poor_cleaning','complaint_attitude','breakage','incident')
+        AND t.created_at >= CURRENT_DATE - INTERVAL '90 days'
+      ORDER BY t.created_at DESC`)).rows as any[];
+    const refundRows = (await db.execute(sql`
+      SELECT p.id, p.amount, p.refunded_at::text AS date, p.refund_reason, p.job_id
+      FROM payments p JOIN jobs j ON j.id = p.job_id
+      WHERE j.client_id = ${clientId} AND p.refunded_at IS NOT NULL
+        AND p.refunded_at >= CURRENT_DATE - INTERVAL '90 days'
+      ORDER BY p.refunded_at DESC`)).rows as any[];
+    const cancelRows = (await db.execute(sql`
+      SELECT id, scheduled_date::text AS date FROM jobs
+      WHERE client_id = ${clientId} AND company_id = ${companyId} AND status = 'cancelled'
+        AND scheduled_date BETWEEN CURRENT_DATE - INTERVAL '60 days' AND CURRENT_DATE
+      ORDER BY scheduled_date DESC`)).rows as any[];
+
+    const happyPass = (recleanRows.length + ticketRows.length + refundRows.length) === 0;
+    const realCancels = cancelRows.length;
+    const activePass = realCancels < 3;                       // 3+ real cancellations = churn risk
+    const moneyPass = netPct >= 15 && laborPct <= 40;         // matches the prior thresholds
+    const fails = [happyPass, activePass, moneyPass].filter(p => !p).length;
+    const healthStatus = fails === 0 ? "healthy" : fails === 1 ? "watch" : "at_risk";
+
+    const ticketLabel = (t: string) => ({ complaint_poor_cleaning: "Poor cleaning", complaint_attitude: "Attitude", breakage: "Breakage", incident: "Incident" } as Record<string,string>)[t] ?? t;
+    const happyParts: string[] = [];
+    if (recleanRows.length) happyParts.push(`${recleanRows.length} re-clean${recleanRows.length > 1 ? "s" : ""}`);
+    if (ticketRows.length) happyParts.push(`${ticketRows.length} complaint${ticketRows.length > 1 ? "s" : ""}`);
+    if (refundRows.length) happyParts.push(`${refundRows.length} refund${refundRows.length > 1 ? "s" : ""}`);
+    const healthChecks = {
+      happy: {
+        pass: happyPass,
+        summary: happyPass ? "No complaints or re-cleans" : happyParts.join(", "),
+        items: [
+          ...recleanRows.map(r => ({ kind: "reclean", label: r.description || "Re-clean", date: r.date, job_id: r.job_id, tag: "RE-CLEAN" })),
+          ...ticketRows.map(t => ({ kind: "complaint", label: t.notes || ticketLabel(t.ticket_type), date: String(t.date).split("T")[0], job_id: t.job_id, tag: ticketLabel(t.ticket_type).toUpperCase() })),
+          ...refundRows.map(r => ({ kind: "refund", label: `Refund $${Number(r.amount || 0).toFixed(0)}${r.refund_reason ? ` · ${r.refund_reason}` : ""}`, date: String(r.date).split("T")[0], job_id: r.job_id, tag: "REFUND" })),
+        ],
+      },
+      active: {
+        pass: activePass,
+        summary: activePass ? "Visits on track" : `Cancelled ${realCancels} visit${realCancels > 1 ? "s" : ""} recently`,
+        items: cancelRows.map(c => ({ kind: "cancel", label: "Cancelled visit", date: c.date, job_id: c.id, tag: "CANCELLED" })),
+      },
+      money: {
+        pass: moneyPass,
+        summary: moneyPass ? "Healthy margin" : (netPct < 15 ? `Low margin (${netPct.toFixed(0)}%)` : `Labor cost high (${laborPct.toFixed(0)}%)`),
+        details: { revenue, net_pct: netPct, labor_pct: laborPct, avg_bill: avgBill, company_avg_bill: companyAvgBill },
+      },
+    };
+
     // Top services by revenue
     const svcsRes = await db.execute(sql`
       SELECT service_type,
@@ -2501,6 +2566,8 @@ router.get("/:id/profitability", requireAuth, requireRole("owner", "office"), as
       net_pct: netPct,
       month_multiplier: monthMultiplier,
       health_score: health,
+      health_status: healthStatus,
+      health_checks: healthChecks,
       last_job_date: lastJobDate,
       days_since_last_job: daysSinceLastJob,
       company_avg_bill: companyAvgBill,

--- a/artifacts/qleno/src/pages/customer-profile.tsx
+++ b/artifacts/qleno/src/pages/customer-profile.tsx
@@ -2747,6 +2747,73 @@ function RevenueTrendTab({ clientId, jobs }: { clientId: number; jobs: any[] }) 
 
 
 // ─── Profitability Tab ───────────────────────────────────────────────────────
+// [account-health 2026-06-25] Bug #9: the simple 3-check health card — Happy /
+// Active / Making money → Healthy / Watch / At risk. Each failing check expands
+// to show the real records behind it (re-cleans, complaints, refunds,
+// cancellations, margin). Replaces the old money-only 0-100 gauge.
+function AccountHealthCard({ status, checks }: { status?: string; checks?: any }) {
+  const [open, setOpen] = useState<string | null>(null);
+  if (!checks) return null;
+  const st = status === "healthy" ? { label: "Healthy", color: "#06715C", bg: "#EAF9F4", dot: "#00C9A0" }
+    : status === "watch" ? { label: "Watch", color: "#9A7B12", bg: "#FBF1E0", dot: "#E0A93B" }
+    : { label: "At risk", color: "#B91C1C", bg: "#FDECEC", dot: "#E25555" };
+  const CHECKS = [
+    { key: "happy", title: "Happy", c: checks.happy },
+    { key: "active", title: "Active", c: checks.active },
+    { key: "money", title: "Making money", c: checks.money },
+  ];
+  const tagStyle = (kind: string) => kind === "complaint"
+    ? { background: "#FBF1E0", color: "#946200" }
+    : kind === "cancel" ? { background: "#F1EFEA", color: "#6B6860" }
+    : { background: "#FDECEC", color: "#B91C1C" };
+  return (
+    <div style={{ background: "#FFFFFF", border: "1px solid #E5E2DC", borderRadius: 10, padding: "16px" }}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 6 }}>
+        <div style={{ fontSize: 10, fontWeight: 700, color: "#9E9B94", textTransform: "uppercase" as const, letterSpacing: "0.08em" }}>Account Health</div>
+        <span style={{ display: "inline-flex", alignItems: "center", gap: 7, fontSize: 12, fontWeight: 800, padding: "5px 12px", borderRadius: 20, background: st.bg, color: st.color }}>
+          <span style={{ width: 8, height: 8, borderRadius: "50%", background: st.dot }} /> {st.label}
+        </span>
+      </div>
+      {CHECKS.map(({ key, title, c }) => {
+        if (!c) return null;
+        const hasDetail = (c.items && c.items.length > 0) || key === "money";
+        const isOpen = open === key;
+        return (
+          <div key={key} style={{ borderTop: "1px solid #F1EFEA" }}>
+            <div onClick={() => hasDetail && setOpen(isOpen ? null : key)} style={{ display: "flex", alignItems: "center", gap: 11, padding: "11px 0", cursor: hasDetail ? "pointer" : "default" }}>
+              <span style={{ width: 22, height: 22, borderRadius: "50%", background: c.pass ? "#00B894" : "#E25555", display: "inline-flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }}>
+                {c.pass ? <Check size={13} color="#fff" /> : <X size={13} color="#fff" />}
+              </span>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ fontSize: 13, fontWeight: 700, color: "#1A1917" }}>{title}</div>
+                <div style={{ fontSize: 11.5, color: c.pass ? "#9E9B94" : "#B91C1C" }}>{c.summary}</div>
+              </div>
+              {hasDetail && (isOpen ? <ChevronUp size={15} color="#C9C5BD" /> : <ChevronDown size={15} color="#C9C5BD" />)}
+            </div>
+            {isOpen && (
+              <div style={{ paddingBottom: 10 }}>
+                {key === "money" && c.details && (
+                  <div style={{ fontSize: 12.5, color: "#4B4A47", paddingLeft: 33, display: "flex", flexDirection: "column", gap: 6 }}>
+                    <div style={{ display: "flex", justifyContent: "space-between" }}><span style={{ color: "#9E9B94" }}>Revenue</span><b>${Math.round(c.details.revenue || 0).toLocaleString()}</b></div>
+                    <div style={{ display: "flex", justifyContent: "space-between" }}><span style={{ color: "#9E9B94" }}>Profit margin</span><b style={{ color: (c.details.net_pct ?? 0) >= 15 ? "#06715C" : "#B91C1C" }}>{Number(c.details.net_pct || 0).toFixed(0)}%</b></div>
+                    <div style={{ display: "flex", justifyContent: "space-between" }}><span style={{ color: "#9E9B94" }}>Avg bill</span><b>${Math.round(c.details.avg_bill || 0)}<span style={{ fontWeight: 400, color: "#9E9B94", fontSize: 11 }}> vs ${Math.round(c.details.company_avg_bill || 0)} avg</span></b></div>
+                  </div>
+                )}
+                {c.items && c.items.map((it: any, i: number) => (
+                  <div key={i} style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 10, paddingLeft: 33, paddingTop: 6, fontSize: 12.5 }}>
+                    <div style={{ minWidth: 0 }}><div style={{ color: "#1A1917" }}>{it.label}</div><div style={{ color: "#9E9B94", fontSize: 11 }}>{it.date}{it.job_id ? ` · job #${it.job_id}` : ""}</div></div>
+                    {it.tag && <span style={{ fontSize: 9.5, fontWeight: 800, padding: "2px 7px", borderRadius: 5, whiteSpace: "nowrap" as const, ...tagStyle(it.kind) }}>{it.tag}</span>}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
 function ProfitabilityTab({ clientId }: { clientId: number }) {
   const [period, setPeriod] = useState<"monthly" | "quarterly" | "annually">("monthly");
 
@@ -2771,6 +2838,7 @@ function ProfitabilityTab({ clientId }: { clientId: number }) {
     labor_pct: laborPct, supply_pct: supplyPct, overhead_pct_of_rev: overheadPctOfRev,
     net_pct: netPct, month_multiplier: mm,
     health_score: healthScore, top_services: topServices, trend_data: trendData,
+    health_status: healthStatus, health_checks: healthChecks,
   } = data;
 
   const fmtDollar = (v: number) => `$${Math.max(0, v).toLocaleString("en-US", { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`;
@@ -2885,28 +2953,34 @@ function ProfitabilityTab({ clientId }: { clientId: number }) {
           ))}
         </div>
 
-        {/* Account Health Gauge */}
-        <div style={{ background: "#FFFFFF", border: "1px solid #E5E2DC", borderRadius: 10, padding: "18px 16px", textAlign: "center" as const }}>
-          <div style={{ fontSize: 10, fontWeight: 700, color: "#9E9B94", textTransform: "uppercase" as const, letterSpacing: "0.08em", marginBottom: 12 }}>Account Health</div>
-          <svg width="110" height="110" style={{ display: "block", margin: "0 auto" }}>
-            <circle cx="55" cy="55" r={r} fill="none" stroke="#F0EEE9" strokeWidth="11" />
-            <circle
-              cx="55" cy="55" r={r} fill="none"
-              stroke={healthColor} strokeWidth="11"
-              strokeDasharray={`${circ}`}
-              strokeDashoffset={`${dashOffset}`}
-              strokeLinecap="round"
-              transform="rotate(-90 55 55)"
-              style={{ transition: "stroke-dashoffset 0.6s ease" }}
-            />
-            <text x="55" y="51" textAnchor="middle" fontSize="22" fontWeight="800" fill="#1A1917" fontFamily="'Plus Jakarta Sans', sans-serif">{healthScore}</text>
-            <text x="55" y="68" textAnchor="middle" fontSize="11" fill="#9E9B94" fontFamily="'Plus Jakarta Sans', sans-serif">/100</text>
-          </svg>
-          <div style={{ marginTop: 8, fontSize: 11, color: "#6B7280" }}>Score</div>
-          <div style={{ marginTop: 6, fontSize: 10, fontWeight: 700, color: healthColor, background: `${healthColor}20`, borderRadius: 20, padding: "3px 10px", display: "inline-block" }}>
-            {healthScore >= 75 ? "Healthy" : healthScore >= 50 ? "Watch" : "At Risk"}
+        {/* [account-health 2026-06-25] Bug #9: 3-check health card with
+            click-through detail. Falls back to the old gauge if the backend
+            hasn't redeployed the new fields yet. */}
+        {healthChecks
+          ? <AccountHealthCard status={healthStatus} checks={healthChecks} />
+          : (
+          <div style={{ background: "#FFFFFF", border: "1px solid #E5E2DC", borderRadius: 10, padding: "18px 16px", textAlign: "center" as const }}>
+            <div style={{ fontSize: 10, fontWeight: 700, color: "#9E9B94", textTransform: "uppercase" as const, letterSpacing: "0.08em", marginBottom: 12 }}>Account Health</div>
+            <svg width="110" height="110" style={{ display: "block", margin: "0 auto" }}>
+              <circle cx="55" cy="55" r={r} fill="none" stroke="#F0EEE9" strokeWidth="11" />
+              <circle
+                cx="55" cy="55" r={r} fill="none"
+                stroke={healthColor} strokeWidth="11"
+                strokeDasharray={`${circ}`}
+                strokeDashoffset={`${dashOffset}`}
+                strokeLinecap="round"
+                transform="rotate(-90 55 55)"
+                style={{ transition: "stroke-dashoffset 0.6s ease" }}
+              />
+              <text x="55" y="51" textAnchor="middle" fontSize="22" fontWeight="800" fill="#1A1917" fontFamily="'Plus Jakarta Sans', sans-serif">{healthScore}</text>
+              <text x="55" y="68" textAnchor="middle" fontSize="11" fill="#9E9B94" fontFamily="'Plus Jakarta Sans', sans-serif">/100</text>
+            </svg>
+            <div style={{ marginTop: 8, fontSize: 11, color: "#6B7280" }}>Score</div>
+            <div style={{ marginTop: 6, fontSize: 10, fontWeight: 700, color: healthColor, background: `${healthColor}20`, borderRadius: 20, padding: "3px 10px", display: "inline-block" }}>
+              {healthScore >= 75 ? "Healthy" : healthScore >= 50 ? "Watch" : "At Risk"}
+            </div>
           </div>
-        </div>
+          )}
       </div>
 
       {/* Top Services */}


### PR DESCRIPTION
Bug #9: replaces the money-only health gauge with 3 plain checks (Happy/Active/Making money) backed by real records (re-cleans, complaints, refunds, cancellations, margin), with click-through detail. Validated against all 306 real clients. Generated with Claude Code