### PR TITLE
fix(booking): enlarge the booking-page header logo

### DIFF
--- a/artifacts/qleno/src/pages/book.tsx
+++ b/artifacts/qleno/src/pages/book.tsx
@@ -1563,7 +1563,7 @@ export default function BookPage() {
       {/* Top bar */}
       <div className="bw-topbar" style={{ background: "#fff", borderBottom: "1px solid #E5E2DC", padding: "12px 32px", display: "flex", alignItems: "center", gap: 16 }}>
         {logoSrc ? (
-          <img src={logoSrc} alt={company.name} style={{ width: 120, height: 48, objectFit: "contain", objectPosition: "left center", flexShrink: 0 }} />
+          <img src={logoSrc} alt={company.name} style={{ width: 200, height: 64, objectFit: "contain", objectPosition: "left center", flexShrink: 0 }} />
         ) : (
           <span style={{ fontWeight: 800, fontSize: 18, color: brand }}>{company.name}</span>
         )}


### PR DESCRIPTION
The top-left company logo on the public booking widget (phes.io/contact, app.qleno.com/book/:slug) rendered small. Bumped its box from 120x48 to 200x64 so the logo reads larger. `objectFit: contain` + left alignment preserved.

This is the *booking-page header* logo — distinct from the confirmation-email logo enlarged in #680.

- `artifacts/qleno/src/pages/book.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)