### PR TITLE
feat(estimates): multi-recipient (CC) — send an estimate to more than one email

### DIFF
--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -377,6 +377,9 @@ async function runBookingSchemaGuard(): Promise<void> {
     // master switch (default true). When false, no automated SMS/email reaches
     // any customer record linked to the account. Additive + idempotent.
     { label: "accounts.comms_enabled", stmt: `ALTER TABLE accounts ADD COLUMN IF NOT EXISTS comms_enabled boolean NOT NULL DEFAULT true` },
+    // [multi-recipient-estimates 2026-06-25] Additional CC recipient emails on an
+    // estimate (comma-separated). Additive + idempotent.
+    { label: "estimates.cc_emails", stmt: `ALTER TABLE estimates ADD COLUMN IF NOT EXISTS cc_emails TEXT` },
     // [engagement-tracking-phase4 2026-06-25] Unified engagement timeline +
     // native click-redirect / open-pixel tokens. Additive + idempotent.
     { label: "CREATE engagement_events", stmt: `

--- a/artifacts/api-server/src/routes/estimates.ts
+++ b/artifacts/api-server/src/routes/estimates.ts
@@ -79,6 +79,26 @@ function intOrNull(v: unknown): number | null {
   return Number.isFinite(n) ? n : null;
 }
 
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+// [multi-recipient-estimates] Parse a CC list (comma/semicolon/whitespace
+// separated, or an array) → a normalized, de-duped, lower-cased comma-joined
+// string of valid emails, excluding `exclude` (the primary). Returns null when
+// empty. Invalid tokens are dropped silently. Capped at 20 to bound the list.
+export function normalizeEmails(v: unknown, exclude?: string | null): string | null {
+  const raw = Array.isArray(v) ? v : String(v ?? "").split(/[,;\s]+/);
+  const ex = (exclude ?? "").trim().toLowerCase();
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const t of raw) {
+    const e = String(t ?? "").trim().toLowerCase();
+    if (!e || e === ex || seen.has(e) || !EMAIL_RE.test(e)) continue;
+    seen.add(e);
+    out.push(e);
+    if (out.length >= 20) break;
+  }
+  return out.length ? out.join(",") : null;
+}
+
 async function insertLineItems(estimateId: number, companyId: number, items: NormalizedItem[]) {
   for (const it of items) {
     await db.execute(sql`
@@ -609,12 +629,12 @@ router.post("/", requireAuth, async (req, res) => {
     const inserted = await db.execute(sql`
       INSERT INTO estimates
         (company_id, branch_id, account_id, account_property_id, client_id,
-         contact_name, contact_email, contact_phone, property_name, service_address,
+         contact_name, contact_email, cc_emails, contact_phone, property_name, service_address,
          title, intro_note, terms, internal_notes, status,
          subtotal, discount_amount, total, valid_until, created_by, updated_at)
       VALUES
         (${companyId}, ${intOrNull(b.branch_id)}, ${intOrNull(b.account_id)}, ${intOrNull(b.account_property_id)}, ${intOrNull(b.client_id)},
-         ${str(b.contact_name, 200)}, ${str(b.contact_email, 200)}, ${str(b.contact_phone, 40)}, ${str(b.property_name, 300)}, ${str(b.service_address, 400)},
+         ${str(b.contact_name, 200)}, ${str(b.contact_email, 200)}, ${normalizeEmails(b.cc_emails, str(b.contact_email, 200))}, ${str(b.contact_phone, 40)}, ${str(b.property_name, 300)}, ${str(b.service_address, 400)},
          ${str(b.title, 300)}, ${str(b.intro_note)}, ${str(b.terms)}, ${str(b.internal_notes)}, 'draft',
          ${subtotal}, ${discount}, ${total}, ${b.valid_until ? new Date(b.valid_until) : null}, ${req.auth!.userId}, now())
       RETURNING id
@@ -648,6 +668,7 @@ router.patch("/:id", requireAuth, async (req, res) => {
         client_id = ${intOrNull(b.client_id)},
         contact_name = ${str(b.contact_name, 200)},
         contact_email = ${str(b.contact_email, 200)},
+        cc_emails = ${normalizeEmails(b.cc_emails, str(b.contact_email, 200))},
         contact_phone = ${str(b.contact_phone, 40)},
         property_name = ${str(b.property_name, 300)},
         service_address = ${str(b.service_address, 400)},

--- a/artifacts/api-server/src/services/followUpService.ts
+++ b/artifacts/api-server/src/services/followUpService.ts
@@ -91,6 +91,8 @@ async function sendEmailRaw(
   brand?: EmailBrand,
   // [comms-opt-out] Optional List-Unsubscribe headers + footer link.
   unsub?: { headers: Record<string, string>; footerHtml: string },
+  // [multi-recipient-estimates] Optional CC recipients.
+  cc?: string[],
 ): Promise<string | null> {
   const key = process.env.RESEND_API_KEY;
   if (!key) throw new Error("Resend not configured");
@@ -113,9 +115,11 @@ ${inner}
 <p style="font-size:13px;color:#9E9B94;margin:20px 0 0;">${brandName} &mdash; ${brandPhone} &mdash; ${brandEmail}</p>
 ${unsub?.footerHtml ?? ""}
 </div></div>`;
+  const ccList = (cc ?? []).filter((e) => e && e.toLowerCase() !== to.toLowerCase());
   const res: any = await resend.emails.send({
     from: fromAddress,
     to: [to],
+    ...(ccList.length ? { cc: ccList } : {}),
     subject,
     html: bodyHtml,
     ...(unsub?.headers && Object.keys(unsub.headers).length ? { headers: unsub.headers } : {}),
@@ -130,12 +134,12 @@ ${unsub?.footerHtml ?? ""}
   return res?.data?.id ?? res?.id ?? null;
 }
 
-async function sendEmail(to: string, subject: string, body: string, fromAddress?: string, brand?: EmailBrand, unsub?: { headers: Record<string, string>; footerHtml: string }): Promise<void> {
+async function sendEmail(to: string, subject: string, body: string, fromAddress?: string, brand?: EmailBrand, unsub?: { headers: Record<string, string>; footerHtml: string }, cc?: string[]): Promise<void> {
   if (process.env.COMMS_ENABLED !== "true") {
     console.log("[COMMS BLOCKED] Follow-up email suppressed:", { to, subject });
     return;
   }
-  await sendEmailRaw(to, subject, body, fromAddress, brand, unsub);
+  await sendEmailRaw(to, subject, body, fromAddress, brand, unsub, cc);
 }
 
 // Build the merge vars for a quote-tied enrollment touch (the quote email + SMS).
@@ -574,6 +578,8 @@ async function processEnrollment(enr: any): Promise<void> {
   let recipientEmail: string | null = null;
   let recipientPhone: string | null = null;
   let zip: string | null = null;
+  // [multi-recipient-estimates] Extra CC emails (estimate enrollments only).
+  let ccEmails: string[] = [];
 
   if (enr.client_id) {
     const clientRows = await db.execute(sql`
@@ -621,12 +627,13 @@ async function processEnrollment(enr: any): Promise<void> {
     }
   } else if (enr.estimate_id) {
     const estRows = await db.execute(sql`
-      SELECT contact_name, contact_email, contact_phone, service_address FROM estimates WHERE id = ${enr.estimate_id} LIMIT 1
+      SELECT contact_name, contact_email, cc_emails, contact_phone, service_address FROM estimates WHERE id = ${enr.estimate_id} LIMIT 1
     `);
     if (estRows.rows.length) {
       const e = estRows.rows[0] as any;
       firstName = (e.contact_name || "").split(" ")[0] || "";
       recipientEmail = e.contact_email || null;
+      ccEmails = String(e.cc_emails || "").split(",").map((s: string) => s.trim()).filter(Boolean);
       recipientPhone = e.contact_phone || null;
       zip = (String(e.service_address || "").match(/\b(\d{5})\b/) || [])[1] || null;
     }
@@ -721,7 +728,8 @@ async function processEnrollment(enr: any): Promise<void> {
         console.log(`[follow-up] email suppressed (${sendError}) enrollment ${enr.id}`);
       } else {
         const unsub = await buildEmailUnsubData(enr.company_id, recipientEmail);
-        await sendEmail(recipientEmail, subject, body, await companyFromAddress(enr.company_id), emailBrand, unsub ?? undefined);
+        // [multi-recipient-estimates] CC every additional recipient on each email touch.
+        await sendEmail(recipientEmail, subject, body, await companyFromAddress(enr.company_id), emailBrand, unsub ?? undefined, ccEmails);
       }
     } else {
       sendStatus = "failed";

--- a/artifacts/api-server/src/tests/multi-recipient-estimates.test.ts
+++ b/artifacts/api-server/src/tests/multi-recipient-estimates.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Multi-recipient estimates.
+ *
+ * Stub-DB. Pins: cc_emails column + migration, the normalizeEmails parser
+ * (comma/semicolon/array, validate, dedupe, drop primary, cap), and that the
+ * drip CCs every email touch while SMS stays single-recipient.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { estimatesTable } from "@workspace/db/schema";
+import { normalizeEmails } from "../routes/estimates.ts";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const read = (rel: string) => readFileSync(resolve(here, rel), "utf8");
+
+describe("multi-recipient — schema + migration", () => {
+  it("estimates.cc_emails exists", () => {
+    const col = (estimatesTable as any).cc_emails;
+    assert.ok(col, "cc_emails should exist");
+    assert.equal(col.name, "cc_emails");
+  });
+  it("migration adds it idempotently", () => {
+    assert.match(read("../phes-data-migration.ts"), /ALTER TABLE estimates ADD COLUMN IF NOT EXISTS cc_emails TEXT/);
+  });
+});
+
+describe("normalizeEmails", () => {
+  it("parses comma / semicolon / whitespace", () => {
+    assert.equal(normalizeEmails("a@x.com, b@y.com; c@z.com"), "a@x.com,b@y.com,c@z.com");
+  });
+  it("accepts an array too", () => {
+    assert.equal(normalizeEmails(["A@X.com", "b@y.com"]), "a@x.com,b@y.com");
+  });
+  it("lowercases, dedupes, and drops invalid tokens", () => {
+    assert.equal(normalizeEmails("A@X.com, a@x.com, notanemail, b@y.com"), "a@x.com,b@y.com");
+  });
+  it("excludes the primary recipient", () => {
+    assert.equal(normalizeEmails("primary@x.com, cc@y.com", "primary@x.com"), "cc@y.com");
+  });
+  it("returns null when empty", () => {
+    assert.equal(normalizeEmails(""), null);
+    assert.equal(normalizeEmails("garbage only"), null);
+  });
+});
+
+describe("multi-recipient — drip + UI wiring", () => {
+  const engine = read("../services/followUpService.ts");
+  it("email sender accepts + applies a CC list", () => {
+    assert.match(engine, /cc\?: string\[\]/);
+    assert.match(engine, /\{ cc: ccList \}/);
+  });
+  it("estimate touch reads cc_emails and passes it to the email send", () => {
+    assert.match(engine, /SELECT contact_name, contact_email, cc_emails/);
+    assert.match(engine, /emailBrand, unsub \?\? undefined, ccEmails\)/);
+  });
+  it("SMS stays single-recipient (recipientPhone only)", () => {
+    assert.match(engine, /sendSmsVia\(sender, recipientPhone, body\)/);
+  });
+  it("builder persists cc_emails + renders the CC field", () => {
+    const ui = read("../../../qleno/src/pages/estimate-builder.tsx");
+    assert.match(ui, /cc_emails: ccEmails\.join\(","\)/);
+    assert.match(ui, /CC — also email these people/);
+  });
+});

--- a/artifacts/qleno/src/pages/estimate-builder.tsx
+++ b/artifacts/qleno/src/pages/estimate-builder.tsx
@@ -73,6 +73,11 @@ export default function EstimateBuilderPage() {
 
   const [contactName, setContactName] = useState("");
   const [contactEmail, setContactEmail] = useState("");
+  // [multi-recipient-estimates] Additional CC recipients (chips) + in-progress input.
+  const [ccEmails, setCcEmails] = useState<string[]>([]);
+  const [ccInput, setCcInput] = useState("");
+  // Account contacts offered as quick-add CC (only when the estimate is account-tied).
+  const [accountContacts, setAccountContacts] = useState<{ name: string; email: string }[]>([]);
   const [contactPhone, setContactPhone] = useState("");
   const [propertyName, setPropertyName] = useState("");
   const [serviceAddress, setServiceAddress] = useState("");
@@ -98,6 +103,14 @@ export default function EstimateBuilderPage() {
           setStatus(e.status); setEstimateNumber(e.estimate_number || "");
           setPublicToken(e.public_token || null);
           setContactName(e.contact_name || ""); setContactEmail(e.contact_email || ""); setContactPhone(e.contact_phone || "");
+          setCcEmails(String(e.cc_emails || "").split(",").map((s: string) => s.trim()).filter(Boolean));
+          // Account-tied estimate → offer its contacts (with email) as quick-add CC.
+          if (e.account_id) {
+            try {
+              const cs = await apiFetch(`/api/accounts/${e.account_id}/contacts`);
+              setAccountContacts((Array.isArray(cs) ? cs : []).filter((c: any) => c.email).map((c: any) => ({ name: c.name || c.email, email: c.email })));
+            } catch { /* contacts are optional */ }
+          }
           setPropertyName(e.property_name || ""); setServiceAddress(e.service_address || "");
           setTitle(e.title || ""); setIntroNote(e.intro_note || ""); setTerms(e.terms || ""); setInternalNotes(e.internal_notes || "");
           setDiscount(String(e.discount_amount ?? "0"));
@@ -132,6 +145,7 @@ export default function EstimateBuilderPage() {
 
   const body = () => ({
     contact_name: contactName, contact_email: contactEmail, contact_phone: contactPhone,
+    cc_emails: ccEmails.join(","),
     property_name: propertyName, service_address: serviceAddress,
     title, intro_note: introNote, terms, internal_notes: internalNotes,
     discount_amount: Number(discount) || 0,
@@ -141,6 +155,23 @@ export default function EstimateBuilderPage() {
       quantity: Number(it.quantity) || 0, unit_rate: Number(it.unit_rate) || 0,
     })),
   });
+
+  // [multi-recipient-estimates] CC chip helpers. Accept comma/semicolon/space or
+  // Enter; validate; dedupe; never re-add the primary.
+  const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  function addCc(raw: string) {
+    const parts = raw.split(/[,;\s]+/).map(s => s.trim().toLowerCase()).filter(Boolean);
+    if (!parts.length) return;
+    setCcEmails(prev => {
+      const next = [...prev];
+      for (const e of parts) {
+        if (EMAIL_RE.test(e) && e !== contactEmail.trim().toLowerCase() && !next.includes(e)) next.push(e);
+      }
+      return next;
+    });
+    setCcInput("");
+  }
+  const removeCc = (e: string) => setCcEmails(prev => prev.filter(x => x !== e));
 
   async function save(): Promise<number | null> {
     setSaving(true);
@@ -304,6 +335,36 @@ export default function EstimateBuilderPage() {
             <Field label="Email"><input style={inp} value={contactEmail} onChange={e => setContactEmail(e.target.value)} placeholder="name@email.com" /></Field>
             <Field label="Phone"><input style={inp} value={contactPhone} onChange={e => setContactPhone(e.target.value)} placeholder="(773) 555-0123" /></Field>
           </Grid>
+          {/* [multi-recipient-estimates] Additional recipients (CC). Every emailed
+              touch goes to the primary Email + all of these. */}
+          <Field label="CC — also email these people">
+            <div style={{ display: "flex", flexWrap: "wrap", gap: 6, alignItems: "center", border: `1px solid ${BORDER}`, borderRadius: 9, padding: "6px 8px", background: "#fff" }}>
+              {ccEmails.map(e => (
+                <span key={e} style={{ display: "inline-flex", alignItems: "center", gap: 5, background: "#ECFDF8", border: "1px solid #99E9D3", color: "#065F46", borderRadius: 999, padding: "3px 8px", fontSize: 12, fontWeight: 600 }}>
+                  {e}
+                  <button onClick={() => removeCc(e)} aria-label={`Remove ${e}`} style={{ border: "none", background: "none", color: "#047857", cursor: "pointer", fontSize: 13, lineHeight: 1, padding: 0 }}>×</button>
+                </span>
+              ))}
+              <input
+                style={{ flex: 1, minWidth: 160, border: "none", outline: "none", fontSize: 14, fontFamily: FF, background: "transparent", padding: "4px 2px" }}
+                value={ccInput}
+                onChange={e => setCcInput(e.target.value)}
+                onKeyDown={e => { if (e.key === "Enter" || e.key === "," || e.key === ";") { e.preventDefault(); addCc(ccInput); } }}
+                onBlur={() => addCc(ccInput)}
+                placeholder={ccEmails.length ? "Add another…" : "manager@email.com, owner@email.com"}
+              />
+            </div>
+            {accountContacts.length > 0 && (
+              <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginTop: 6 }}>
+                <span style={{ fontSize: 11, color: MUTE, alignSelf: "center" }}>From this account:</span>
+                {accountContacts.filter(c => !ccEmails.includes(c.email.toLowerCase()) && c.email.toLowerCase() !== contactEmail.trim().toLowerCase()).map(c => (
+                  <button key={c.email} onClick={() => addCc(c.email)} style={{ background: "#fff", border: `1px solid ${BORDER}`, borderRadius: 999, padding: "3px 9px", fontSize: 12, color: INK, cursor: "pointer", fontFamily: FF }}>
+                    + {c.name}
+                  </button>
+                ))}
+              </div>
+            )}
+          </Field>
           <Field label="Service address"><input style={inp} value={serviceAddress} onChange={e => setServiceAddress(e.target.value)} placeholder="Street, City, State ZIP" /></Field>
         </Section>
 

--- a/lib/db/src/schema/estimates.ts
+++ b/lib/db/src/schema/estimates.ts
@@ -24,7 +24,11 @@ export const estimatesTable = pgTable("estimates", {
   account_property_id: integer("account_property_id").references(() => accountPropertiesTable.id),
   client_id: integer("client_id").references(() => clientsTable.id),
   contact_name: text("contact_name"),
-  contact_email: text("contact_email"),
+  contact_email: text("contact_email"),       // primary recipient (To)
+  // [multi-recipient-estimates 2026-06-25] Additional recipient emails (CC),
+  // comma-separated + normalized. Every drip EMAIL touch goes To contact_email
+  // and CCs all of these. SMS still goes to the primary mobile only.
+  cc_emails: text("cc_emails"),
   contact_phone: text("contact_phone"),
   property_name: text("property_name"),
   service_address: text("service_address"),


### PR DESCRIPTION
Estimates could only email a single contact_email. Now multiple recipients — every drip email touch CCs all of them (SMS stays primary-only).

- Schema/migration: estimates.cc_emails (comma-separated), additive.
- Routes: create + PATCH accept cc_emails via normalizeEmails() (comma/semicolon/whitespace/array → validated, lowercased, de-duped, primary dropped, cap 20).
- Drip: estimate email touch reads cc_emails and CCs all recipients each step (Resend cc).
- Builder UI: 'CC — also email these people' chip field (+ account-contact quick-adds when account-tied).

How Sal uses it: set Email (primary) then add any number of CC addresses; on send the drip emails primary + all CCs.

Tests 11/11 · libs clean · frontend zero new errors · backend bundle builds.

Generated with Claude Code