### PR TITLE
feat(estimates): Send now — fire Day-0 email immediately + on-screen confirmation

### DIFF
--- a/artifacts/api-server/src/routes/estimates.ts
+++ b/artifacts/api-server/src/routes/estimates.ts
@@ -3,7 +3,7 @@ import { db } from "@workspace/db";
 import { sql } from "drizzle-orm";
 import { randomUUID } from "crypto";
 import { requireAuth } from "../lib/auth.js";
-import { enrollForEstimateSent, stopEnrollmentsForEstimate } from "../services/followUpService.js";
+import { enrollForEstimateSent, stopEnrollmentsForEstimate, fireEstimateDay0 } from "../services/followUpService.js";
 import { recordEngagementEvent } from "../lib/engagement.js";
 
 // [commercial-estimate-tool 2026-06-09] Commercial / common-area estimates.
@@ -738,11 +738,14 @@ router.post("/:id/send", requireAuth, async (req, res) => {
       WHERE id = ${id} AND company_id = ${companyId}
     `);
     // [estimate-drip-phase3] Auto-enroll into the native estimate follow-up
-    // cadence. No-op unless the tenant has an ACTIVE estimate_followup sequence
-    // (seeded inactive), and sends still pass the comms gates. Non-blocking.
-    enrollForEstimateSent(companyId as number, id).catch((e) =>
-      console.warn("[estimates] enrollForEstimateSent failed:", e?.message ?? e));
-    return res.json({ id, public_token: token });
+    // cadence (no-op unless an ACTIVE estimate_followup sequence exists).
+    // [estimate-send-now] Then fire the Day-0 email IMMEDIATELY (gated path) so
+    // the prospect gets it now instead of waiting up to 30 min for the cron, and
+    // we can confirm delivery back to the office. Both awaited so the response
+    // carries the result.
+    await enrollForEstimateSent(companyId as number, id);
+    const day0 = await fireEstimateDay0(companyId as number, id);
+    return res.json({ id, public_token: token, emailed: day0.emailed, email_status: day0.status, email_recipient: day0.recipient ?? null });
   } catch (err) {
     console.error("Send estimate error:", err);
     return res.status(500).json({ error: "Internal Server Error" });

--- a/artifacts/api-server/src/services/followUpService.ts
+++ b/artifacts/api-server/src/services/followUpService.ts
@@ -556,7 +556,11 @@ export async function processDueEnrollments(): Promise<void> {
   }
 }
 
-async function processEnrollment(enr: any): Promise<void> {
+// Returns the outcome of the touch it just processed (used by the immediate
+// "Send now" path to report whether the email actually went out). The cron
+// callers ignore the return.
+type TouchResult = { channel: string; status: string; recipient: string | null };
+async function processEnrollment(enr: any): Promise<TouchResult | null> {
   // Fetch the current step (template_id links to a managed message_templates row)
   const stepRows = await db.execute(sql`
     SELECT id, step_number, delay_hours, channel, subject, message_template, template_id
@@ -569,7 +573,7 @@ async function processEnrollment(enr: any): Promise<void> {
     await db.execute(sql`
       UPDATE follow_up_enrollments SET completed_at = NOW() WHERE id = ${enr.id}
     `);
-    return;
+    return null;
   }
   const step = stepRows.rows[0] as any;
 
@@ -791,6 +795,39 @@ async function processEnrollment(enr: any): Promise<void> {
       UPDATE follow_up_enrollments SET completed_at = NOW() WHERE id = ${enr.id}
     `);
     console.log(`[follow-up] Enrollment ${enr.id} completed — all steps sent`);
+  }
+  return { channel: step.channel, status: sendStatus, recipient: step.channel === "sms" ? recipientPhone : recipientEmail };
+}
+
+// [estimate-send-now] Fire an estimate's Day-0 touch IMMEDIATELY (instead of
+// waiting up to 30 min for the cron), through the same gated processEnrollment
+// path (comms gates, opt-out, CC, engagement event, step-advance all apply).
+// Returns whether the email actually went out so the office gets instant
+// confirmation. Safe no-op if the estimate isn't enrolled / already advanced.
+export async function fireEstimateDay0(
+  companyId: number, estimateId: number,
+): Promise<{ emailed: boolean; status: string; channel?: string; recipient?: string | null; reason?: string }> {
+  try {
+    const rows = await db.execute(sql`
+      SELECT fe.id, fe.company_id, fe.sequence_id, fe.quote_id, fe.client_id, fe.lead_id,
+             fe.abandoned_booking_id, fe.estimate_id, fe.current_step,
+             fs.name AS sequence_name, fs.sequence_type
+      FROM follow_up_enrollments fe
+      JOIN follow_up_sequences fs ON fs.id = fe.sequence_id
+      WHERE fe.estimate_id = ${estimateId} AND fe.company_id = ${companyId}
+        AND fe.completed_at IS NULL AND fe.stopped_at IS NULL
+      ORDER BY fe.id DESC LIMIT 1
+    `);
+    const enr = (rows as any).rows[0];
+    if (!enr) return { emailed: false, status: "not_enrolled", reason: "not_enrolled" };
+    // Only fire if still on the first (Day-0) step — never re-send a later touch.
+    if (Number(enr.current_step) !== 1) return { emailed: false, status: "already_started", reason: "already_started" };
+    const r = await processEnrollment(enr);
+    if (!r) return { emailed: false, status: "no_step", reason: "no_step" };
+    return { emailed: r.status === "sent" && r.channel === "email", status: r.status, channel: r.channel, recipient: r.recipient, reason: r.status !== "sent" ? r.status : undefined };
+  } catch (err: any) {
+    console.error("[estimate-send-now] fireEstimateDay0 error:", err?.message ?? err);
+    return { emailed: false, status: "error", reason: err?.message ?? "error" };
   }
 }
 

--- a/artifacts/api-server/src/tests/estimate-send-now.test.ts
+++ b/artifacts/api-server/src/tests/estimate-send-now.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Estimate "Send now" + sent confirmation.
+ *
+ * Stub-DB. Pins: fireEstimateDay0 exists and only fires the Day-0 (step 1) touch
+ * through the gated processEnrollment path; the /send route awaits it and returns
+ * the emailed result; the builder shows the confirmation.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { fireEstimateDay0 } from "../services/followUpService.ts";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const read = (rel: string) => readFileSync(resolve(here, rel), "utf8");
+
+describe("estimate send-now", () => {
+  const engine = read("../services/followUpService.ts");
+  const route = read("../routes/estimates.ts");
+  const ui = read("../../../qleno/src/pages/estimate-builder.tsx");
+
+  it("fireEstimateDay0 is exported", () => {
+    assert.equal(typeof fireEstimateDay0, "function");
+  });
+  it("only fires the Day-0 step (never re-sends a later touch)", () => {
+    assert.match(engine, /Number\(enr\.current_step\) !== 1/);
+  });
+  it("goes through the gated processEnrollment path (comms/opt-out/CC/engagement reused)", () => {
+    assert.match(engine, /const r = await processEnrollment\(enr\)/);
+    assert.match(engine, /emailed: r\.status === "sent" && r\.channel === "email"/);
+  });
+  it("/send awaits enroll + fireEstimateDay0 and returns the result", () => {
+    assert.match(route, /await enrollForEstimateSent/);
+    assert.match(route, /await fireEstimateDay0/);
+    assert.match(route, /emailed: day0\.emailed/);
+  });
+  it("builder confirms the send (toast + badge)", () => {
+    assert.match(ui, /setEmailedTo\(/);
+    assert.match(ui, /Estimate emailed to/);
+  });
+});

--- a/artifacts/qleno/src/hooks/use-address-autocomplete.ts
+++ b/artifacts/qleno/src/hooks/use-address-autocomplete.ts
@@ -54,7 +54,7 @@ function loadGoogleMaps(): Promise<boolean> {
 // Attaches Google Places autocomplete to an input while `enabled` is true.
 // Calls `onPick` with parsed address parts when the user selects a suggestion.
 export function useAddressAutocomplete(
-  inputRef: React.RefObject<HTMLInputElement>,
+  inputRef: React.RefObject<HTMLInputElement | null>,
   enabled: boolean,
   onPick: (parts: AddressParts) => void,
 ) {

--- a/artifacts/qleno/src/pages/estimate-builder.tsx
+++ b/artifacts/qleno/src/pages/estimate-builder.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useRoute } from "wouter";
 import { getAuthHeaders } from "@/lib/auth";
 import { DashboardLayout } from "@/components/layout/dashboard-layout";
 import { Plus, Trash2, ArrowLeft, Save, Send, LayoutTemplate, GripVertical } from "lucide-react";
 import { toast } from "sonner";
 import { CalendarPopover } from "@/components/calendar-popover";
+import { useAddressAutocomplete } from "@/hooks/use-address-autocomplete";
 
 const FF = "'Plus Jakarta Sans', sans-serif";
 const API = import.meta.env.BASE_URL.replace(/\/$/, "");
@@ -93,6 +94,15 @@ export default function EstimateBuilderPage() {
   const [templates, setTemplates] = useState<any[]>([]);
   const [showPicker, setShowPicker] = useState(isNew);
   const [applyingTemplate, setApplyingTemplate] = useState(false);
+
+  // [estimate-address-autocomplete] Google Places on the Service Address field —
+  // pick a suggestion to fill the canonical "Street, City, State ZIP" (zip is
+  // also what branch routing needs).
+  const serviceAddressRef = useRef<HTMLInputElement>(null);
+  useAddressAutocomplete(serviceAddressRef, true, (p) => {
+    const composed = [p.street, p.city, [p.state, p.zip].filter(Boolean).join(" ")].filter(Boolean).join(", ");
+    setServiceAddress(composed || p.formatted);
+  });
 
   // Load existing estimate, or seed a new one from a template (?template=id).
   useEffect(() => {
@@ -365,7 +375,7 @@ export default function EstimateBuilderPage() {
               </div>
             )}
           </Field>
-          <Field label="Service address"><input style={inp} value={serviceAddress} onChange={e => setServiceAddress(e.target.value)} placeholder="Street, City, State ZIP" /></Field>
+          <Field label="Service address"><input ref={serviceAddressRef} style={inp} value={serviceAddress} onChange={e => setServiceAddress(e.target.value)} placeholder="Start typing an address…" /></Field>
         </Section>
 
         <Section title="Estimate details">

--- a/artifacts/qleno/src/pages/estimate-builder.tsx
+++ b/artifacts/qleno/src/pages/estimate-builder.tsx
@@ -71,6 +71,8 @@ export default function EstimateBuilderPage() {
   const [status, setStatus] = useState("draft");
   const [estimateNumber, setEstimateNumber] = useState<string>("");
   const [publicToken, setPublicToken] = useState<string | null>(null);
+  // [estimate-send-now] Set to the recipient when the Day-0 email actually went out.
+  const [emailedTo, setEmailedTo] = useState<string | null>(null);
 
   const [contactName, setContactName] = useState("");
   const [contactEmail, setContactEmail] = useState("");
@@ -248,13 +250,17 @@ export default function EstimateBuilderPage() {
       const r = await apiFetch(`/api/estimates/${savedId}/send`, { method: "POST" });
       setStatus("sent");
       setPublicToken(r.public_token || null);
-      if (r.public_token) {
-        try {
-          await navigator.clipboard.writeText(publicLink(r.public_token));
-          toast.success("Estimate link copied — paste it into a text or email.");
-        } catch {
-          toast.success("Estimate is live — copy the link below to share it.");
-        }
+      // [estimate-send-now] r.emailed = the Day-0 email actually went out just now.
+      setEmailedTo(r.emailed ? (r.email_recipient || contactEmail) : null);
+      if (r.public_token) { try { await navigator.clipboard.writeText(publicLink(r.public_token)); } catch { /* clipboard optional */ } }
+      if (r.emailed) {
+        toast.success(`Estimate emailed to ${r.email_recipient || contactEmail}${ccEmails.length ? ` (+${ccEmails.length} CC)` : ""} — link also copied.`);
+      } else if (r.email_status === "email_opt_out") {
+        toast.success("Link copied. Email skipped — that recipient opted out.");
+      } else if (!contactEmail.trim()) {
+        toast.success("Link copied. Add an email above to also send the estimate by email.");
+      } else {
+        toast.success("Link copied. The follow-up email will go out shortly.");
       }
     } catch {
       toast.error("Failed to mark sent");
@@ -275,6 +281,12 @@ export default function EstimateBuilderPage() {
           <ArrowLeft size={15} /> Estimates
         </button>
 
+        {emailedTo && (
+          <div style={{ display: "flex", alignItems: "center", gap: 8, background: "#ECFDF8", border: "1px solid #99E9D3", borderRadius: 10, padding: "10px 14px", marginBottom: 10 }}>
+            <span style={{ width: 18, height: 18, borderRadius: 999, background: "#047857", color: "#fff", display: "inline-flex", alignItems: "center", justifyContent: "center", fontSize: 12, flexShrink: 0 }}>✓</span>
+            <p style={{ fontSize: 13, fontWeight: 600, color: "#065F46", margin: 0 }}>Estimate emailed to {emailedTo}{ccEmails.length ? ` and ${ccEmails.length} more` : ""}. Track opens/clicks on the Engagement page.</p>
+          </div>
+        )}
         {publicToken && (
           <div style={{ display: "flex", alignItems: "center", gap: 10, background: "#ECFDF8", border: "1px solid #99E9D3", borderRadius: 10, padding: "10px 14px", marginBottom: 14, flexWrap: "wrap" }}>
             <div style={{ flex: 1, minWidth: 200 }}>


### PR DESCRIPTION
Clicking **Send** enrolled the estimate in the drip but didn't email until the next 30-min cron run, and the office had no confirmation the email went out.

- **followUpService:** `processEnrollment` returns the touch outcome; new **`fireEstimateDay0()`** fires the estimate's Day-0 (step 1) touch **immediately** through the same **gated** path — comms gates, opt-out, CC, and the engagement 'sent' event all apply; the step advances so the cron won't re-send. No-op if not enrolled / past step 1.
- **`POST /estimates/:id/send`:** awaits enroll + fireEstimateDay0, returns `{ emailed, email_status, email_recipient }`.
- **Builder:** green **'✓ Estimate emailed to <recipient> (+N CC)'** banner + toast on send; clear alternate message if no email/opt-out. Opens/clicks still track on the Engagement page.

**Net:** Send emails the prospect right away (not up to 30 min later), with instant on-screen confirmation.

Tests 5/5 · libs clean · frontend zero new errors · backend bundle builds. No real messages sent in testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)