### PR TITLE
feat(estimates): flat-price mode — one price + a what's-included checklist

### DIFF
--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -380,6 +380,10 @@ async function runBookingSchemaGuard(): Promise<void> {
     // [multi-recipient-estimates 2026-06-25] Additional CC recipient emails on an
     // estimate (comma-separated). Additive + idempotent.
     { label: "estimates.cc_emails", stmt: `ALTER TABLE estimates ADD COLUMN IF NOT EXISTS cc_emails TEXT` },
+    // [estimate-flat-mode 2026-06-26] Flat-price estimates: one price for the
+    // whole job + scope-only line items. Additive + idempotent.
+    { label: "estimates.billing_mode", stmt: `ALTER TABLE estimates ADD COLUMN IF NOT EXISTS billing_mode TEXT NOT NULL DEFAULT 'itemized'` },
+    { label: "estimates.flat_price", stmt: `ALTER TABLE estimates ADD COLUMN IF NOT EXISTS flat_price NUMERIC(12,2) NOT NULL DEFAULT 0` },
     // [engagement-tracking-phase4 2026-06-25] Unified engagement timeline +
     // native click-redirect / open-pixel tokens. Additive + idempotent.
     { label: "CREATE engagement_events", stmt: `

--- a/artifacts/api-server/src/routes/estimates.ts
+++ b/artifacts/api-server/src/routes/estimates.ts
@@ -60,11 +60,21 @@ function normalizeItems(raw: unknown): NormalizedItem[] {
   });
 }
 
-function computeTotals(items: NormalizedItem[], discountRaw: unknown) {
-  const subtotal = Math.round(items.reduce((s, it) => s + it.amount, 0) * 100) / 100;
+// [estimate-flat-mode] In 'flat' mode the subtotal is the single flat price the
+// office typed — line items are scope only and carry no price. Otherwise the
+// subtotal is the sum of line-item amounts (itemized, the default).
+function computeTotals(items: NormalizedItem[], discountRaw: unknown, billingMode = "itemized", flatPriceRaw?: unknown) {
+  const subtotal = billingMode === "flat"
+    ? Math.round((Math.max(0, Number(flatPriceRaw ?? 0) || 0)) * 100) / 100
+    : Math.round(items.reduce((s, it) => s + it.amount, 0) * 100) / 100;
   const discount = Math.max(0, Number(discountRaw ?? 0) || 0);
   const total = Math.round(Math.max(0, subtotal - discount) * 100) / 100;
   return { subtotal, discount, total };
+}
+
+// Normalize the billing mode to one of the two known values.
+function billingModeOf(v: unknown): "itemized" | "flat" {
+  return String(v ?? "").trim() === "flat" ? "flat" : "itemized";
 }
 
 function str(v: unknown, max = 2000): string | null {
@@ -624,18 +634,20 @@ router.post("/", requireAuth, async (req, res) => {
       `);
       items = normalizeItems((ti as any).rows);
     }
-    const { subtotal, discount, total } = computeTotals(items, b.discount_amount);
+    const billingMode = billingModeOf(b.billing_mode);
+    const { subtotal, discount, total } = computeTotals(items, b.discount_amount, billingMode, b.flat_price);
+    const flatPrice = billingMode === "flat" ? subtotal : 0;
 
     const inserted = await db.execute(sql`
       INSERT INTO estimates
         (company_id, branch_id, account_id, account_property_id, client_id,
          contact_name, contact_email, cc_emails, contact_phone, property_name, service_address,
-         title, intro_note, terms, internal_notes, status,
+         title, intro_note, terms, internal_notes, status, billing_mode, flat_price,
          subtotal, discount_amount, total, valid_until, created_by, updated_at)
       VALUES
         (${companyId}, ${intOrNull(b.branch_id)}, ${intOrNull(b.account_id)}, ${intOrNull(b.account_property_id)}, ${intOrNull(b.client_id)},
          ${str(b.contact_name, 200)}, ${str(b.contact_email, 200)}, ${normalizeEmails(b.cc_emails, str(b.contact_email, 200))}, ${str(b.contact_phone, 40)}, ${str(b.property_name, 300)}, ${str(b.service_address, 400)},
-         ${str(b.title, 300)}, ${str(b.intro_note)}, ${str(b.terms)}, ${str(b.internal_notes)}, 'draft',
+         ${str(b.title, 300)}, ${str(b.intro_note)}, ${str(b.terms)}, ${str(b.internal_notes)}, 'draft', ${billingMode}, ${flatPrice},
          ${subtotal}, ${discount}, ${total}, ${b.valid_until ? new Date(b.valid_until) : null}, ${req.auth!.userId}, now())
       RETURNING id
     `);
@@ -659,11 +671,15 @@ router.patch("/:id", requireAuth, async (req, res) => {
 
     const b = req.body ?? {};
     const items = normalizeItems(b.items);
-    const { subtotal, discount, total } = computeTotals(items, b.discount_amount);
+    const billingMode = billingModeOf(b.billing_mode);
+    const { subtotal, discount, total } = computeTotals(items, b.discount_amount, billingMode, b.flat_price);
+    const flatPrice = billingMode === "flat" ? subtotal : 0;
 
     await db.execute(sql`
       UPDATE estimates SET
         account_id = ${intOrNull(b.account_id)},
+        billing_mode = ${billingMode},
+        flat_price = ${flatPrice},
         account_property_id = ${intOrNull(b.account_property_id)},
         client_id = ${intOrNull(b.client_id)},
         contact_name = ${str(b.contact_name, 200)},

--- a/artifacts/api-server/src/tests/estimate-flat-mode.test.ts
+++ b/artifacts/api-server/src/tests/estimate-flat-mode.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Estimate flat-price mode: one price for the whole job + a scope checklist
+ * (no per-line pricing), persisted via billing_mode/flat_price, rendered on the
+ * editor and the client-facing hosted page. Source-assertion guard.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const read = (rel: string) => readFileSync(resolve(here, rel), "utf8");
+
+describe("estimate flat-price mode", () => {
+  const route = read("../routes/estimates.ts");
+  const migration = read("../phes-data-migration.ts");
+  const schema = read("../../../../lib/db/src/schema/estimates.ts");
+  const builder = read("../../../qleno/src/pages/estimate-builder.tsx");
+  const pub = read("../../../qleno/src/pages/estimate-public.tsx");
+
+  it("schema + migration add billing_mode and flat_price (additive, idempotent)", () => {
+    assert.match(schema, /billing_mode: text\("billing_mode"\)/);
+    assert.match(schema, /flat_price: numeric\("flat_price"/);
+    assert.match(migration, /ADD COLUMN IF NOT EXISTS billing_mode TEXT NOT NULL DEFAULT 'itemized'/);
+    assert.match(migration, /ADD COLUMN IF NOT EXISTS flat_price NUMERIC\(12,2\) NOT NULL DEFAULT 0/);
+  });
+
+  it("totals use the flat price in flat mode, sum of lines otherwise", () => {
+    assert.match(route, /billingMode === "flat"\s*\?\s*Math\.round\(\(Math\.max\(0, Number\(flatPriceRaw/);
+    assert.match(route, /function billingModeOf/);
+  });
+
+  it("create + update persist billing_mode and flat_price", () => {
+    assert.match(route, /const billingMode = billingModeOf\(b\.billing_mode\)/);
+    assert.match(route, /const flatPrice = billingMode === "flat" \? subtotal : 0/);
+    assert.match(route, /billing_mode = \$\{billingMode\}/);   // PATCH
+    assert.match(route, /status, billing_mode, flat_price,/);  // INSERT column list
+  });
+
+  it("editor has the mode toggle, a single price field, and a scope list", () => {
+    assert.match(builder, /const \[billingMode, setBillingMode\]/);
+    assert.match(builder, /\["flat", "itemized"\] as const/);
+    assert.match(builder, /billing_mode: billingMode/);
+    assert.match(builder, /flat_price: billingMode === "flat" \? \(Number\(flatPrice\) \|\| 0\) : 0/);
+    assert.match(builder, /What's included/);
+  });
+
+  it("client page renders the flat scope list + single total when flat", () => {
+    assert.match(pub, /est\.billing_mode === "flat"/);
+    assert.match(pub, /What's included/);
+  });
+});

--- a/artifacts/qleno/src/pages/estimate-builder.tsx
+++ b/artifacts/qleno/src/pages/estimate-builder.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useRoute } from "wouter";
 import { getAuthHeaders } from "@/lib/auth";
 import { DashboardLayout } from "@/components/layout/dashboard-layout";
-import { Plus, Trash2, ArrowLeft, Save, Send, LayoutTemplate, GripVertical } from "lucide-react";
+import { Plus, Trash2, ArrowLeft, Save, Send, LayoutTemplate, GripVertical, Check } from "lucide-react";
 import { toast } from "sonner";
 import { CalendarPopover } from "@/components/calendar-popover";
 import { useAddressAutocomplete } from "@/hooks/use-address-autocomplete";
@@ -95,6 +95,10 @@ export default function EstimateBuilderPage() {
   const [discount, setDiscount] = useState("0");
   const [validUntil, setValidUntil] = useState("");
   const [items, setItems] = useState<Item[]>([blankItem()]);
+  // [estimate-flat-mode] 'itemized' (price each line) vs 'flat' (one price for
+  // the whole job + a scope checklist). Default itemized.
+  const [billingMode, setBillingMode] = useState<"itemized" | "flat">("itemized");
+  const [flatPrice, setFlatPrice] = useState("");
 
   // [estimate-templates-phase2] One-click template picker (new estimates only).
   const [templates, setTemplates] = useState<any[]>([]);
@@ -130,6 +134,8 @@ export default function EstimateBuilderPage() {
           setPropertyName(e.property_name || ""); setServiceAddress(e.service_address || "");
           setTitle(e.title || ""); setIntroNote(e.intro_note || ""); setTerms(e.terms || ""); setInternalNotes(e.internal_notes || "");
           setDiscount(String(e.discount_amount ?? "0"));
+          setBillingMode(e.billing_mode === "flat" ? "flat" : "itemized");
+          setFlatPrice(e.flat_price != null && Number(e.flat_price) > 0 ? String(e.flat_price) : "");
           setValidUntil(e.valid_until ? String(e.valid_until).slice(0, 10) : "");
           setItems((e.items || []).length ? e.items.map(mapRow) : [blankItem()]);
         } else {
@@ -156,7 +162,12 @@ export default function EstimateBuilderPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const subtotal = useMemo(() => items.reduce((s, it) => s + lineAmount(it), 0), [items]);
+  // [estimate-flat-mode] Flat mode = the one price the office typed; itemized =
+  // sum of the priced lines.
+  const subtotal = useMemo(
+    () => billingMode === "flat" ? (Number(flatPrice) || 0) : items.reduce((s, it) => s + lineAmount(it), 0),
+    [billingMode, flatPrice, items],
+  );
   const total = Math.max(0, subtotal - (Number(discount) || 0));
 
   const body = () => ({
@@ -165,11 +176,16 @@ export default function EstimateBuilderPage() {
     property_name: propertyName, service_address: serviceAddress,
     title, intro_note: introNote, terms, internal_notes: internalNotes,
     discount_amount: Number(discount) || 0,
+    billing_mode: billingMode,
+    flat_price: billingMode === "flat" ? (Number(flatPrice) || 0) : 0,
     valid_until: validUntil || null,
-    items: items.filter(it => it.name.trim() || Number(it.unit_rate) > 0).map(it => ({
-      name: it.name, pricing_type: it.pricing_type, frequency: it.frequency,
-      quantity: Number(it.quantity) || 0, unit_rate: Number(it.unit_rate) || 0,
-    })),
+    // Flat mode persists scope only (name + shared frequency, no price); itemized
+    // keeps the full priced line. Empty scope rows are dropped either way.
+    items: items.filter(it => it.name.trim() || (billingMode === "itemized" && Number(it.unit_rate) > 0)).map(it => (
+      billingMode === "flat"
+        ? { name: it.name, pricing_type: "flat", frequency: it.frequency, quantity: 1, unit_rate: 0 }
+        : { name: it.name, pricing_type: it.pricing_type, frequency: it.frequency, quantity: Number(it.quantity) || 0, unit_rate: Number(it.unit_rate) || 0 }
+    )),
   });
 
   // [multi-recipient-estimates] CC chip helpers. Accept comma/semicolon/space or
@@ -408,9 +424,19 @@ export default function EstimateBuilderPage() {
           <Field label="Intro note (shown to the client)"><textarea style={{ ...inp, minHeight: 64, resize: "vertical" }} value={introNote} onChange={e => setIntroNote(e.target.value)} placeholder="Thank you for the opportunity to quote your common-area cleaning…" /></Field>
         </Section>
 
-        <Section title="Line items" right={
-          <button onClick={() => setItems(its => [...its, blankItem()])} style={addBtn}><Plus size={15} /> Add line</button>
+        <Section title="Services & pricing" right={
+          <button onClick={() => setItems(its => [...its, blankItem()])} style={addBtn}><Plus size={15} /> {billingMode === "flat" ? "Add item" : "Add line"}</button>
         }>
+          {/* [estimate-flat-mode] Flat price (one number + scope list) vs itemized. */}
+          <div style={{ display: "inline-flex", border: `1px solid ${BORDER}`, borderRadius: 9, overflow: "hidden", marginBottom: 14 }}>
+            {(["flat", "itemized"] as const).map(m => (
+              <button key={m} onClick={() => setBillingMode(m)} style={{
+                fontFamily: FF, fontSize: 13, fontWeight: 700, padding: "7px 16px", border: "none", cursor: "pointer",
+                background: billingMode === m ? INK : "#fff", color: billingMode === m ? "#fff" : MUTE,
+              }}>{m === "flat" ? "Flat price" : "Itemized"}</button>
+            ))}
+          </div>
+
           {/* [estimate-bulk-frequency] Pick a cadence → applies to every line. */}
           <div style={{ display: "flex", alignItems: "flex-end", gap: 8, marginBottom: 12, padding: "10px 12px", border: `1px solid ${BORDER}`, borderRadius: 10, background: "#FCFCFB", flexWrap: "wrap" }}>
             <div style={{ flex: 1, minWidth: 180 }}>
@@ -419,35 +445,57 @@ export default function EstimateBuilderPage() {
             </div>
             <span style={{ fontSize: 12, color: MUTE, alignSelf: "center", whiteSpace: "nowrap" }}>{commonFreq ? `All lines: ${commonFreq}` : "Lines vary"}</span>
           </div>
-          {items.map((it, i) => {
-            const L = TYPE_LABELS[it.pricing_type];
-            return (
-              <div key={i} style={{ border: `1px solid ${BORDER}`, borderRadius: 12, padding: 14, marginBottom: 10, background: "#FCFCFB" }}>
-                <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 10 }}>
-                  <GripVertical size={15} style={{ color: "#C9C6BF", flexShrink: 0 }} />
-                  <input style={{ ...inp, fontWeight: 700 }} value={it.name} onChange={e => updateItem(i, { name: e.target.value })} placeholder="Lobby & common hallways" />
-                  <button title="Remove" onClick={() => setItems(its => its.length > 1 ? its.filter((_, idx) => idx !== i) : its)} style={{ ...iconBtn, flexShrink: 0 }}><Trash2 size={15} /></button>
-                </div>
-                <div style={{ display: "grid", gridTemplateColumns: "1.2fr 1fr", gap: 8, marginBottom: 8 }}>
-                  <Field label="Type">
-                    <select style={inp} value={it.pricing_type} onChange={e => updateItem(i, { pricing_type: e.target.value as PricingType })}>
-                      <option value="flat">Flat / recurring</option>
-                      <option value="hourly">Hourly</option>
-                      <option value="one_time">One-time</option>
-                    </select>
-                  </Field>
-                  <Field label="Frequency">
-                    <FrequencyPicker value={it.frequency} onChange={v => updateItem(i, { frequency: v })} />
-                  </Field>
-                </div>
-                <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: 8, alignItems: "end" }}>
-                  <Field label={L.qty}><input style={inp} type="number" min="0" step="0.25" value={it.quantity} onChange={e => updateItem(i, { quantity: e.target.value })} /></Field>
-                  <Field label={L.rate}><input style={inp} type="number" min="0" step="0.01" value={it.unit_rate} onChange={e => updateItem(i, { unit_rate: e.target.value })} placeholder="0.00" /></Field>
-                  <Field label="Amount"><div style={{ ...inp, background: "#F3F4F6", fontWeight: 700, color: INK }}>{money(lineAmount(it))}</div></Field>
+
+          {billingMode === "flat" ? (
+            <>
+              <div style={{ marginBottom: 14, padding: "12px 14px", border: `1px solid ${BORDER}`, borderRadius: 10, background: "#FCFCFB" }}>
+                <span style={{ display: "block", fontSize: 11, fontWeight: 700, color: MUTE, textTransform: "uppercase", letterSpacing: "0.04em", marginBottom: 5 }}>Service price</span>
+                <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                  <span style={{ color: MUTE, fontSize: 16 }}>$</span>
+                  <input style={{ ...inp, maxWidth: 200, fontWeight: 700, fontSize: 16 }} type="number" min="0" step="0.01" value={flatPrice} onChange={e => setFlatPrice(e.target.value)} placeholder="0.00" />
+                  <span style={{ fontSize: 12, color: MUTE }}>one price for the whole job — shown to the client as the total</span>
                 </div>
               </div>
-            );
-          })}
+              <span style={{ display: "block", fontSize: 11, fontWeight: 700, color: MUTE, textTransform: "uppercase", letterSpacing: "0.04em", marginBottom: 8 }}>What's included <span style={{ fontWeight: 400, textTransform: "none", letterSpacing: 0, color: "#9CA3AF" }}>— scope shown to the client, no per-line price</span></span>
+              {items.map((it, i) => (
+                <div key={i} style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8 }}>
+                  <span style={{ width: 20, height: 20, borderRadius: 6, background: MINT, color: "#fff", display: "inline-flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }}><Check size={13} /></span>
+                  <input style={inp} value={it.name} onChange={e => updateItem(i, { name: e.target.value })} placeholder="Workstations & desks — dust & sanitize" />
+                  <button title="Remove" onClick={() => setItems(its => its.length > 1 ? its.filter((_, idx) => idx !== i) : its)} style={{ ...iconBtn, flexShrink: 0 }}><Trash2 size={15} /></button>
+                </div>
+              ))}
+            </>
+          ) : (
+            items.map((it, i) => {
+              const L = TYPE_LABELS[it.pricing_type];
+              return (
+                <div key={i} style={{ border: `1px solid ${BORDER}`, borderRadius: 12, padding: 14, marginBottom: 10, background: "#FCFCFB" }}>
+                  <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 10 }}>
+                    <GripVertical size={15} style={{ color: "#C9C6BF", flexShrink: 0 }} />
+                    <input style={{ ...inp, fontWeight: 700 }} value={it.name} onChange={e => updateItem(i, { name: e.target.value })} placeholder="Lobby & common hallways" />
+                    <button title="Remove" onClick={() => setItems(its => its.length > 1 ? its.filter((_, idx) => idx !== i) : its)} style={{ ...iconBtn, flexShrink: 0 }}><Trash2 size={15} /></button>
+                  </div>
+                  <div style={{ display: "grid", gridTemplateColumns: "1.2fr 1fr", gap: 8, marginBottom: 8 }}>
+                    <Field label="Type">
+                      <select style={inp} value={it.pricing_type} onChange={e => updateItem(i, { pricing_type: e.target.value as PricingType })}>
+                        <option value="flat">Flat / recurring</option>
+                        <option value="hourly">Hourly</option>
+                        <option value="one_time">One-time</option>
+                      </select>
+                    </Field>
+                    <Field label="Frequency">
+                      <FrequencyPicker value={it.frequency} onChange={v => updateItem(i, { frequency: v })} />
+                    </Field>
+                  </div>
+                  <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: 8, alignItems: "end" }}>
+                    <Field label={L.qty}><input style={inp} type="number" min="0" step="0.25" value={it.quantity} onChange={e => updateItem(i, { quantity: e.target.value })} /></Field>
+                    <Field label={L.rate}><input style={inp} type="number" min="0" step="0.01" value={it.unit_rate} onChange={e => updateItem(i, { unit_rate: e.target.value })} placeholder="0.00" /></Field>
+                    <Field label="Amount"><div style={{ ...inp, background: "#F3F4F6", fontWeight: 700, color: INK }}>{money(lineAmount(it))}</div></Field>
+                  </div>
+                </div>
+              );
+            })
+          )}
         </Section>
 
         {/* Totals */}

--- a/artifacts/qleno/src/pages/estimate-public.tsx
+++ b/artifacts/qleno/src/pages/estimate-public.tsx
@@ -38,6 +38,8 @@ type PublicEstimate = {
   intro_note: string | null;
   terms: string | null;
   status: string;
+  // [estimate-flat-mode] 'flat' → render scope list + single price; else itemized.
+  billing_mode?: string | null;
   subtotal: string;
   discount_amount: string;
   total: string;
@@ -263,6 +265,39 @@ export default function EstimatePublicPage() {
 
             {(() => {
               const opts = (Array.isArray(est.options) ? est.options : []).filter(o => o.configured);
+              // [estimate-flat-mode] One price + a scope checklist (no per-line
+              // prices). The total is the single flat price the office set.
+              if (est.billing_mode === "flat") {
+                return (
+                  <>
+                    {est.items.length > 0 && (
+                      <div style={{ border: `1px solid ${BORDER}`, borderRadius: 12, padding: "14px 16px", marginBottom: 18 }}>
+                        <p style={{ fontSize: 11, fontWeight: 700, color: MUTE, textTransform: "uppercase", letterSpacing: "0.04em", margin: "0 0 10px" }}>What's included</p>
+                        {est.items.map((it, i) => (
+                          <div key={i} style={{ display: "flex", alignItems: "flex-start", gap: 10, padding: "6px 0" }}>
+                            <span style={{ width: 18, height: 18, borderRadius: 5, background: MINT, color: "#fff", display: "inline-flex", alignItems: "center", justifyContent: "center", flexShrink: 0, marginTop: 1, fontSize: 12, fontWeight: 800, lineHeight: 1 }}>✓</span>
+                            <span style={{ fontSize: 14, color: INK }}>
+                              {it.name || "Service"}
+                              {it.frequency && <span style={{ color: MUTE }}>{` · ${it.frequency}`}</span>}
+                            </span>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                    <div style={{ marginBottom: 18 }}>
+                      {Number(est.discount_amount) > 0 && (
+                        <div style={{ display: "flex", justifyContent: "space-between", fontSize: 13, color: "#047857", padding: "3px 0" }}>
+                          <span>Discount</span><span>−{money(est.discount_amount)}</span>
+                        </div>
+                      )}
+                      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", borderTop: `2px solid ${INK}`, marginTop: 8, paddingTop: 10 }}>
+                        <span style={{ fontSize: 15, fontWeight: 800, color: INK }}>Total</span>
+                        <span style={{ fontSize: 26, fontWeight: 800, color: MINT, letterSpacing: "-0.01em" }}>{money(est.total)}</span>
+                      </div>
+                    </div>
+                  </>
+                );
+              }
               // No snapshot → keep the original single line-items + total render.
               if (opts.length < 1) {
                 return (

--- a/lib/db/src/schema/estimates.ts
+++ b/lib/db/src/schema/estimates.ts
@@ -39,6 +39,12 @@ export const estimatesTable = pgTable("estimates", {
   terms: text("terms"),
   internal_notes: text("internal_notes"),
   status: text("status").notNull().default("draft"), // draft|sent|viewed|accepted|declined|expired
+  // [estimate-flat-mode 2026-06-26] How the estimate is priced/shown:
+  //   'itemized' (default) — line items each carry a price; total = sum.
+  //   'flat'     — one price for the whole job; line items are scope only
+  //                (name + frequency, no per-line price) and total = flat_price.
+  billing_mode: text("billing_mode").notNull().default("itemized"),
+  flat_price: numeric("flat_price", { precision: 12, scale: 2 }).notNull().default("0"),
   subtotal: numeric("subtotal", { precision: 12, scale: 2 }).notNull().default("0"),
   discount_amount: numeric("discount_amount", { precision: 12, scale: 2 }).notNull().default("0"),
   total: numeric("total", { precision: 12, scale: 2 }).notNull().default("0"),


### PR DESCRIPTION
Building an estimate no longer means setting type/frequency/hours/rate on six rows. A **Flat price · Itemized** toggle switches the whole estimate to one price for the job + a scope checklist (task names + shared frequency, no per-line pricing). Itemized stays the default and is unchanged.

- **Schema/migration:** `estimates.billing_mode` ('itemized' default) + `flat_price` — additive, idempotent.
- **API:** `computeTotals` branches on billing_mode (flat → subtotal = flat_price); create + update persist both.
- **Editor:** mode toggle, single price field, check-marked scope list; flat mode strips per-line price on save.
- **Client hosted page:** flat estimates show a 'What's included' checklist + single total instead of a priced table.
- **Email:** unaffected (sends total + hosted-page link, no itemization).

Option A of the approved 'Both (A now, B next)' plan — package picker (B) is the follow-up.

flat-mode guard 5/5 · frequency guard 4/4 · esbuild OK · frontend typecheck zero new errors · 0 net-new api-server errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)