### PR TITLE
feat(estimates): Semi-monthly option + structured Custom cadence builder

### DIFF
--- a/artifacts/api-server/src/tests/estimate-bulk-frequency.test.ts
+++ b/artifacts/api-server/src/tests/estimate-bulk-frequency.test.ts
@@ -21,8 +21,15 @@ describe("estimate frequency dropdown", () => {
     assert.match(ui, /value="__custom__">Custom…/);
     assert.doesNotMatch(ui, /list="freq-options"/); // old filtered-datalist approach gone
   });
-  it("Custom… reveals a free-text field for any cadence", () => {
-    assert.match(ui, /e\.g\. 2x\/month, every 3 weeks/);
+  it("includes a Semi-monthly option", () => {
+    assert.match(ui, /"Semi-monthly"/);
+  });
+  it("Custom… is a structured builder: a count + a cadence selector", () => {
+    assert.match(ui, /const CADENCE_UNITS = \[/);
+    assert.match(ui, /label: "per month"/);
+    assert.match(ui, /const composeFreq = \(n: string, unit: string\) => `\$\{Math\.max\(1, Number\(n\) \|\| 1\)\}x\/\$\{unit\}`/);
+    assert.match(ui, /CADENCE_UNITS\.map\(u => <option key=\{u\.v\} value=\{u\.v\}>\{u\.label\}<\/option>\)/);
+    assert.doesNotMatch(ui, /e\.g\. 2x\/month, every 3 weeks/); // old free-text custom gone
   });
   it("estimate-level control sets every line at once", () => {
     assert.match(ui, /Service frequency — sets every line/);

--- a/artifacts/qleno/src/pages/estimate-builder.tsx
+++ b/artifacts/qleno/src/pages/estimate-builder.tsx
@@ -41,7 +41,21 @@ const TYPE_LABELS: Record<PricingType, { type: string; qty: string; rate: string
   hourly: { type: "Hourly", qty: "Hours", rate: "$/hr" },
   one_time: { type: "One-time", qty: "Qty", rate: "Price" },
 };
-const FREQUENCY_OPTIONS = ["Daily", "5x/week", "3x/week", "2x/week", "Weekly", "Bi-weekly", "Monthly", "One-time"];
+const FREQUENCY_OPTIONS = ["Daily", "5x/week", "3x/week", "2x/week", "Weekly", "Bi-weekly", "Semi-monthly", "Monthly", "Quarterly", "One-time"];
+
+// [frequency-custom] Custom cadence = a count + a unit (e.g. 2 × per month).
+// Stored as "Nx/<unit>" — same shape as the standard "2x/week" options.
+const CADENCE_UNITS = [
+  { v: "day", label: "per day" },
+  { v: "week", label: "per week" },
+  { v: "month", label: "per month" },
+  { v: "year", label: "per year" },
+];
+const parseCustomFreq = (v: string): { n: string; unit: string } | null => {
+  const m = /^(\d+)x\/(day|week|month|year)$/.exec((v || "").trim());
+  return m ? { n: m[1], unit: m[2] } : null;
+};
+const composeFreq = (n: string, unit: string) => `${Math.max(1, Number(n) || 1)}x/${unit}`;
 
 // [estimate-templates-phase2] One-click vertical picker. Seeded templates carry
 // a category; this maps it to a clean label + one-line scope hint for the cards.
@@ -572,22 +586,34 @@ const Row = ({ label, value }: { label: string; value: string }) => (
 // [frequency-dropdown] A real dropdown of all cadence options + "Custom…".
 // A free-text input with a datalist only shows suggestions matching what's
 // already typed, so a filled field looked like it had a single option — this
-// always shows the full list, with Custom… revealing a free-text field.
+// always shows the full list. Custom… reveals a structured builder: a count
+// (Frequency) + a cadence selector (per day/week/month/year), e.g. 2 × per month.
 function FrequencyPicker({ value, onChange }: { value: string; onChange: (v: string) => void }) {
   const isStd = FREQUENCY_OPTIONS.includes(value);
+  const parsed = parseCustomFreq(value);
   const [custom, setCustom] = useState(value !== "" && !isStd);
+  const [n, setN] = useState(parsed?.n ?? "2");
+  const [unit, setUnit] = useState(parsed?.unit ?? "month");
   useEffect(() => { if (FREQUENCY_OPTIONS.includes(value)) setCustom(false); }, [value]);
+  // Keep the builder in sync when an existing custom value loads in.
+  useEffect(() => { const p = parseCustomFreq(value); if (p) { setN(p.n); setUnit(p.unit); } }, [value]);
+
   if (custom) {
     return (
-      <div style={{ display: "flex", gap: 6 }}>
-        <input style={inp} autoFocus value={value} onChange={e => onChange(e.target.value)} placeholder="e.g. 2x/month, every 3 weeks" />
+      <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
+        <input style={{ ...inp, width: 70 }} type="number" min="1" step="1" value={n} autoFocus aria-label="Times"
+          onChange={e => { setN(e.target.value); onChange(composeFreq(e.target.value, unit)); }} />
+        <select style={inp} value={unit} aria-label="Cadence"
+          onChange={e => { setUnit(e.target.value); onChange(composeFreq(n, e.target.value)); }}>
+          {CADENCE_UNITS.map(u => <option key={u.v} value={u.v}>{u.label}</option>)}
+        </select>
         <button type="button" onClick={() => { setCustom(false); onChange(""); }} style={{ ...addBtn, flexShrink: 0 }} title="Back to the list">List</button>
       </div>
     );
   }
   return (
     <select style={inp} value={isStd ? value : ""} onChange={e => {
-      if (e.target.value === "__custom__") { setCustom(true); onChange(""); }
+      if (e.target.value === "__custom__") { setCustom(true); onChange(composeFreq(n, unit)); }
       else onChange(e.target.value);
     }}>
       <option value="">Select…</option>


### PR DESCRIPTION
Two frequency changes:

- **Semi-monthly** added to the standard dropdown (plus Quarterly). Distinct from Bi-weekly — twice a month (24/yr) vs every 2 weeks (26/yr).
- **Custom…** is now structured instead of free text: a count field + a cadence selector (`per day / week / month / year`), e.g. `2 × per month`. Stored as `Nx/<unit>` (same shape as the existing `2x/week` options) and parsed back into the two controls on reload.

frequency guard 5/5 · flat-mode guard 5/5 · frontend typecheck zero new errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)