### PR TITLE
feat(estimates): packages = flat-price templates (apply with price prefilled)

### DIFF
--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -384,6 +384,10 @@ async function runBookingSchemaGuard(): Promise<void> {
     // whole job + scope-only line items. Additive + idempotent.
     { label: "estimates.billing_mode", stmt: `ALTER TABLE estimates ADD COLUMN IF NOT EXISTS billing_mode TEXT NOT NULL DEFAULT 'itemized'` },
     { label: "estimates.flat_price", stmt: `ALTER TABLE estimates ADD COLUMN IF NOT EXISTS flat_price NUMERIC(12,2) NOT NULL DEFAULT 0` },
+    // [estimate-packages 2026-06-26] Flat-price packages = flat templates.
+    // Additive + idempotent.
+    { label: "estimate_templates.billing_mode", stmt: `ALTER TABLE estimate_templates ADD COLUMN IF NOT EXISTS billing_mode TEXT NOT NULL DEFAULT 'itemized'` },
+    { label: "estimate_templates.flat_price", stmt: `ALTER TABLE estimate_templates ADD COLUMN IF NOT EXISTS flat_price NUMERIC(12,2) NOT NULL DEFAULT 0` },
     // [engagement-tracking-phase4 2026-06-25] Unified engagement timeline +
     // native click-redirect / open-pixel tokens. Additive + idempotent.
     { label: "CREATE engagement_events", stmt: `

--- a/artifacts/api-server/src/routes/estimates.ts
+++ b/artifacts/api-server/src/routes/estimates.ts
@@ -183,9 +183,11 @@ router.post("/templates", requireAuth, async (req, res) => {
     const name = str(req.body?.name, 200);
     if (!name) return res.status(400).json({ error: "Bad Request", message: "Template name is required" });
     const items = normalizeItems(req.body?.items);
+    const billingMode = billingModeOf(req.body?.billing_mode);
+    const flatPrice = billingMode === "flat" ? Math.max(0, Number(req.body?.flat_price ?? 0) || 0) : 0;
     const inserted = await db.execute(sql`
-      INSERT INTO estimate_templates (company_id, name, category, title, intro_note, terms, created_by)
-      VALUES (${companyId}, ${name}, ${str(req.body?.category, 40)}, ${str(req.body?.title, 300)}, ${str(req.body?.intro_note)}, ${str(req.body?.terms)}, ${req.auth!.userId})
+      INSERT INTO estimate_templates (company_id, name, category, title, intro_note, terms, billing_mode, flat_price, created_by)
+      VALUES (${companyId}, ${name}, ${str(req.body?.category, 40)}, ${str(req.body?.title, 300)}, ${str(req.body?.intro_note)}, ${str(req.body?.terms)}, ${billingMode}, ${flatPrice}, ${req.auth!.userId})
       RETURNING id
     `);
     const templateId = (inserted as any).rows[0].id;
@@ -201,6 +203,43 @@ router.post("/templates", requireAuth, async (req, res) => {
     return res.status(201).json({ id: templateId });
   } catch (err) {
     console.error("Create estimate template error:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
+// Update a template/package in place (replaces its items). Used by the
+// Settings → Packages authoring screen.
+router.patch("/templates/:id", requireAuth, async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    const id = parseInt(req.params.id, 10);
+    const exists = await db.execute(sql`SELECT id FROM estimate_templates WHERE id = ${id} AND company_id = ${companyId} LIMIT 1`);
+    if (!(exists as any).rows[0]) return res.status(404).json({ error: "Not Found" });
+    const name = str(req.body?.name, 200);
+    if (!name) return res.status(400).json({ error: "Bad Request", message: "Template name is required" });
+    const items = normalizeItems(req.body?.items);
+    const billingMode = billingModeOf(req.body?.billing_mode);
+    const flatPrice = billingMode === "flat" ? Math.max(0, Number(req.body?.flat_price ?? 0) || 0) : 0;
+    await db.execute(sql`
+      UPDATE estimate_templates SET
+        name = ${name}, category = ${str(req.body?.category, 40)}, title = ${str(req.body?.title, 300)},
+        intro_note = ${str(req.body?.intro_note)}, terms = ${str(req.body?.terms)},
+        billing_mode = ${billingMode}, flat_price = ${flatPrice}
+      WHERE id = ${id} AND company_id = ${companyId}
+    `);
+    await db.execute(sql`DELETE FROM estimate_template_items WHERE template_id = ${id} AND company_id = ${companyId}`);
+    for (const it of items) {
+      await db.execute(sql`
+        INSERT INTO estimate_template_items
+          (template_id, company_id, sort_order, name, description, pricing_type, frequency, quantity, unit_rate, amount)
+        VALUES
+          (${id}, ${companyId}, ${it.sort_order}, ${it.name}, ${it.description},
+           ${it.pricing_type}, ${it.frequency}, ${it.quantity}, ${it.unit_rate}, ${it.amount})
+      `);
+    }
+    return res.json({ id });
+  } catch (err) {
+    console.error("Update estimate template error:", err);
     return res.status(500).json({ error: "Internal Server Error" });
   }
 });
@@ -715,12 +754,13 @@ router.post("/:id/save-as-template", requireAuth, async (req, res) => {
     const id = parseInt(req.params.id, 10);
     const name = str(req.body?.name, 200);
     if (!name) return res.status(400).json({ error: "Bad Request", message: "Template name is required" });
-    const e = await db.execute(sql`SELECT title, intro_note, terms FROM estimates WHERE id = ${id} AND company_id = ${companyId} LIMIT 1`);
+    const e = await db.execute(sql`SELECT title, intro_note, terms, billing_mode, flat_price FROM estimates WHERE id = ${id} AND company_id = ${companyId} LIMIT 1`);
     const est = (e as any).rows[0];
     if (!est) return res.status(404).json({ error: "Not Found" });
+    // Carry the estimate's pricing mode → a flat estimate becomes a package.
     const inserted = await db.execute(sql`
-      INSERT INTO estimate_templates (company_id, name, title, intro_note, terms, created_by)
-      VALUES (${companyId}, ${name}, ${est.title}, ${est.intro_note}, ${est.terms}, ${req.auth!.userId})
+      INSERT INTO estimate_templates (company_id, name, title, intro_note, terms, billing_mode, flat_price, created_by)
+      VALUES (${companyId}, ${name}, ${est.title}, ${est.intro_note}, ${est.terms}, ${est.billing_mode ?? "itemized"}, ${est.flat_price ?? 0}, ${req.auth!.userId})
       RETURNING id
     `);
     const templateId = (inserted as any).rows[0].id;

--- a/artifacts/api-server/src/tests/estimate-packages.test.ts
+++ b/artifacts/api-server/src/tests/estimate-packages.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Estimate packages = flat-price templates. Templates gain billing_mode +
+ * flat_price; create / update / save-as-template persist them; applying a flat
+ * package drops the builder into flat-price view with the price prefilled.
+ * Source-assertion guard.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const read = (rel: string) => readFileSync(resolve(here, rel), "utf8");
+
+describe("estimate packages (flat-price templates)", () => {
+  const route = read("../routes/estimates.ts");
+  const migration = read("../phes-data-migration.ts");
+  const schema = read("../../../../lib/db/src/schema/estimates.ts");
+  const builder = read("../../../qleno/src/pages/estimate-builder.tsx");
+
+  it("templates table gains billing_mode + flat_price (schema + migration)", () => {
+    assert.match(schema, /estimateTemplatesTable[\s\S]*billing_mode: text\("billing_mode"\)/);
+    assert.match(migration, /ALTER TABLE estimate_templates ADD COLUMN IF NOT EXISTS billing_mode TEXT/);
+    assert.match(migration, /ALTER TABLE estimate_templates ADD COLUMN IF NOT EXISTS flat_price NUMERIC\(12,2\)/);
+  });
+
+  it("create template persists billing_mode + flat_price", () => {
+    assert.match(route, /INSERT INTO estimate_templates \(company_id, name, category, title, intro_note, terms, billing_mode, flat_price, created_by\)/);
+  });
+
+  it("a PATCH route edits a template/package in place", () => {
+    assert.match(route, /router\.patch\("\/templates\/:id"/);
+    assert.match(route, /UPDATE estimate_templates SET/);
+  });
+
+  it("save-as-template carries the estimate's pricing mode (flat → package)", () => {
+    assert.match(route, /SELECT title, intro_note, terms, billing_mode, flat_price FROM estimates/);
+    assert.match(route, /INSERT INTO estimate_templates \(company_id, name, title, intro_note, terms, billing_mode, flat_price, created_by\)/);
+  });
+
+  it("applying a flat package switches the builder to flat-price view", () => {
+    assert.match(builder, /full\.billing_mode === "flat"/);
+    assert.match(builder, /setBillingMode\("flat"\)/);
+    assert.match(builder, /t\.billing_mode === "flat"/); // picker card shows the price
+  });
+});

--- a/artifacts/qleno/src/pages/estimate-builder.tsx
+++ b/artifacts/qleno/src/pages/estimate-builder.tsx
@@ -157,6 +157,10 @@ export default function EstimateBuilderPage() {
           if (templateId) {
             const t = await apiFetch(`/api/estimates/templates/${templateId}`);
             setTitle(t.title || ""); setIntroNote(t.intro_note || ""); setTerms(t.terms || "");
+            if (t.billing_mode === "flat") {
+              setBillingMode("flat");
+              setFlatPrice(t.flat_price != null && Number(t.flat_price) > 0 ? String(t.flat_price) : "");
+            }
             setItems((t.items || []).length ? t.items.map(mapRow) : [blankItem()]);
             setShowPicker(false);
           } else {
@@ -263,6 +267,13 @@ export default function EstimateBuilderPage() {
       if (full.title) setTitle(full.title);
       if (full.intro_note) setIntroNote(full.intro_note);
       if (full.terms) setTerms(full.terms);
+      // [estimate-packages] A flat package drops straight into flat-price view.
+      if (full.billing_mode === "flat") {
+        setBillingMode("flat");
+        setFlatPrice(full.flat_price != null && Number(full.flat_price) > 0 ? String(full.flat_price) : "");
+      } else {
+        setBillingMode("itemized");
+      }
       setItems((full.items || []).length ? full.items.map(mapRow) : [blankItem()]);
       setShowPicker(false);
       toast.success(`Started from "${t.name}" — edit anything below`);
@@ -385,7 +396,11 @@ export default function EstimateBuilderPage() {
                       onMouseLeave={(e) => (e.currentTarget.style.borderColor = BORDER)}
                     >
                       <span style={{ fontSize: 14, fontWeight: 800, color: INK }}>{meta?.label || t.name}</span>
-                      <span style={{ fontSize: 12, color: MUTE, lineHeight: 1.35 }}>{meta?.hint || `${t.item_count ?? 0} line items`}</span>
+                      <span style={{ fontSize: 12, color: MUTE, lineHeight: 1.35 }}>
+                        {t.billing_mode === "flat"
+                          ? `${money(Number(t.flat_price) || 0)} · ${t.item_count ?? 0} item${(t.item_count ?? 0) === 1 ? "" : "s"} included`
+                          : (meta?.hint || `${t.item_count ?? 0} line items`)}
+                      </span>
                     </button>
                   );
                 })}

--- a/lib/db/src/schema/estimates.ts
+++ b/lib/db/src/schema/estimates.ts
@@ -92,6 +92,11 @@ export const estimateTemplatesTable = pgTable("estimate_templates", {
   title: text("title"),
   intro_note: text("intro_note"),
   terms: text("terms"),
+  // [estimate-packages 2026-06-26] A "package" is a flat-price template: one
+  // price + scope-only items. billing_mode mirrors estimates.billing_mode so
+  // applying a package drops straight into the flat-price view.
+  billing_mode: text("billing_mode").notNull().default("itemized"),
+  flat_price: numeric("flat_price", { precision: 12, scale: 2 }).notNull().default("0"),
   created_by: integer("created_by").references(() => usersTable.id),
   created_at: timestamp("created_at").notNull().defaultNow(),
 });


### PR DESCRIPTION
Groundwork for the package picker (Option B). A **package** = a flat-price template: one price + scope-only items.

- **Schema/migration:** `estimate_templates` gains `billing_mode` + `flat_price` (additive, idempotent).
- **API:** `POST /templates` + new `PATCH /templates/:id` persist the fields; `save-as-template` carries the estimate's pricing mode → saving a flat-price estimate creates a package.
- **Builder:** applying a flat package (picker or `?template=`) switches to flat-price view with price + scope prefilled; picker cards show the package price.

Next PR: `/settings/packages` authoring screen for Basic/Standard/Premium.

estimate guard suite 31/31 (packages 5/5 new) · esbuild OK · frontend typecheck zero new errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)