### PR TITLE
feat(estimates): Settings → Packages authoring screen (Option B)

### DIFF
--- a/artifacts/api-server/src/tests/estimate-bulk-frequency.test.ts
+++ b/artifacts/api-server/src/tests/estimate-bulk-frequency.test.ts
@@ -1,6 +1,7 @@
 /**
- * Estimate frequency UX: a real dropdown (all options always visible) + Custom,
- * an estimate-level "set every line" control, and per-line override.
+ * Estimate frequency UX: a shared FrequencyPicker component (real dropdown of all
+ * options + a structured Custom builder), wired into the estimate builder's
+ * "set every line" control and per-line override.
  * Frontend-only; source-assertion guard.
  */
 import { describe, it } from "node:test";
@@ -9,27 +10,32 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
 
-const ui = readFileSync(
-  resolve(dirname(fileURLToPath(import.meta.url)), "../../../qleno/src/pages/estimate-builder.tsx"),
-  "utf8",
-);
+const here = dirname(fileURLToPath(import.meta.url));
+const read = (rel: string) => readFileSync(resolve(here, rel), "utf8");
 
 describe("estimate frequency dropdown", () => {
-  it("is a real <select> listing every option + Custom… (not a filtered datalist)", () => {
-    assert.match(ui, /function FrequencyPicker/);
-    assert.match(ui, /FREQUENCY_OPTIONS\.map\(f => <option key=\{f\} value=\{f\}>\{f\}<\/option>\)/);
-    assert.match(ui, /value="__custom__">Custom…/);
-    assert.doesNotMatch(ui, /list="freq-options"/); // old filtered-datalist approach gone
+  const picker = read("../../../qleno/src/components/frequency-picker.tsx");
+  const ui = read("../../../qleno/src/pages/estimate-builder.tsx");
+
+  it("is a shared real <select> listing every option + Custom… (not a filtered datalist)", () => {
+    assert.match(picker, /export function FrequencyPicker/);
+    assert.match(picker, /FREQUENCY_OPTIONS\.map\(f => <option key=\{f\} value=\{f\}>\{f\}<\/option>\)/);
+    assert.match(picker, /value="__custom__">Custom…/);
+    assert.doesNotMatch(picker, /list="freq-options"/); // old filtered-datalist approach gone
   });
   it("includes a Semi-monthly option", () => {
-    assert.match(ui, /"Semi-monthly"/);
+    assert.match(picker, /"Semi-monthly"/);
   });
   it("Custom… is a structured builder: a count + a cadence selector", () => {
-    assert.match(ui, /const CADENCE_UNITS = \[/);
-    assert.match(ui, /label: "per month"/);
-    assert.match(ui, /const composeFreq = \(n: string, unit: string\) => `\$\{Math\.max\(1, Number\(n\) \|\| 1\)\}x\/\$\{unit\}`/);
-    assert.match(ui, /CADENCE_UNITS\.map\(u => <option key=\{u\.v\} value=\{u\.v\}>\{u\.label\}<\/option>\)/);
-    assert.doesNotMatch(ui, /e\.g\. 2x\/month, every 3 weeks/); // old free-text custom gone
+    assert.match(picker, /const CADENCE_UNITS = \[/);
+    assert.match(picker, /label: "per month"/);
+    assert.match(picker, /export const composeFreq = \(n: string, unit: string\) => `\$\{Math\.max\(1, Number\(n\) \|\| 1\)\}x\/\$\{unit\}`/);
+    assert.match(picker, /CADENCE_UNITS\.map\(u => <option key=\{u\.v\} value=\{u\.v\}>\{u\.label\}<\/option>\)/);
+    assert.doesNotMatch(picker, /e\.g\. 2x\/month, every 3 weeks/); // old free-text custom gone
+  });
+  it("builder imports the shared picker (single source of truth)", () => {
+    assert.match(ui, /import \{ FrequencyPicker \} from "@\/components\/frequency-picker"/);
+    assert.doesNotMatch(ui, /function FrequencyPicker/); // no local copy
   });
   it("estimate-level control sets every line at once", () => {
     assert.match(ui, /Service frequency — sets every line/);

--- a/artifacts/api-server/src/tests/estimate-packages.test.ts
+++ b/artifacts/api-server/src/tests/estimate-packages.test.ts
@@ -44,4 +44,16 @@ describe("estimate packages (flat-price templates)", () => {
     assert.match(builder, /setBillingMode\("flat"\)/);
     assert.match(builder, /t\.billing_mode === "flat"/); // picker card shows the price
   });
+
+  it("a Settings → Packages authoring page exists and is routed", () => {
+    const page = read("../../../qleno/src/pages/company/packages.tsx");
+    const app = read("../../../qleno/src/App.tsx");
+    assert.match(page, /export default function PackagesPage/);
+    assert.match(page, /billing_mode: "flat"/);            // always creates flat packages
+    assert.match(page, /method: "PATCH"/);                 // edit
+    assert.match(page, /method: "POST"/);                  // create
+    assert.match(page, /filter\(\(t: any\) => t\.billing_mode === "flat"\)/); // lists packages only
+    assert.match(page, /from "@\/components\/frequency-picker"/); // reuses the shared picker
+    assert.match(app, /component=\{PackagesPage\}/);
+  });
 });

--- a/artifacts/qleno/src/App.tsx
+++ b/artifacts/qleno/src/App.tsx
@@ -82,6 +82,7 @@ const ChurnBoardPage      = lazy(() => import("@/pages/intelligence/churn"));
 const RetentionBoardPage  = lazy(() => import("@/pages/intelligence/retention"));
 const SatisfactionReportPage = lazy(() => import("@/pages/reports/satisfaction"));
 const AddOnCatalogPage    = lazy(() => import("@/pages/company/addons"));
+const PackagesPage        = lazy(() => import("@/pages/company/packages"));
 const RatesPage           = lazy(() => import("@/pages/company/rates"));
 const ReferralReportPage  = lazy(() => import("@/pages/reports/referrals"));
 const IncentivesPage      = lazy(() => import("@/pages/reports/incentives"));
@@ -286,6 +287,7 @@ function Router() {
         <Route path="/company/quoting" component={QuotingPage} />
         <Route path="/company/zones" component={ZonesPage} />
         <Route path="/company/addons" component={AddOnCatalogPage} />
+        <Route path="/company/packages" component={PackagesPage} />
         <Route path="/company/rates" component={RatesPage} />
         <Route path="/survey/:token" component={SurveyPage} />
         {/* Public customer appointment view — no login, tokenized (booking confirmation link). */}

--- a/artifacts/qleno/src/components/frequency-picker.tsx
+++ b/artifacts/qleno/src/components/frequency-picker.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from "react";
+
+// Shared cadence picker — used by the estimate builder (per-line + "set every
+// line") and the Settings → Packages authoring screen so both surfaces offer the
+// exact same options + Custom behavior.
+const FF = "'Plus Jakarta Sans', sans-serif";
+const INK = "#1A1917";
+const MUTE = "#6B7280";
+const BORDER = "#E5E2DC";
+const inp: React.CSSProperties = {
+  width: "100%", padding: "9px 11px", border: `1px solid ${BORDER}`, borderRadius: 9,
+  fontSize: 14, fontFamily: FF, background: "#fff", boxSizing: "border-box", color: INK,
+};
+const listBtn: React.CSSProperties = {
+  display: "inline-flex", alignItems: "center", background: "#fff", border: `1px solid ${BORDER}`,
+  borderRadius: 9, padding: "7px 12px", fontSize: 13, fontWeight: 700, color: INK, cursor: "pointer", fontFamily: FF,
+};
+
+export const FREQUENCY_OPTIONS = ["Daily", "5x/week", "3x/week", "2x/week", "Weekly", "Bi-weekly", "Semi-monthly", "Monthly", "Quarterly", "One-time"];
+
+// [frequency-custom] Custom cadence = a count + a unit (e.g. 2 × per month).
+// Stored as "Nx/<unit>" — same shape as the standard "2x/week" options.
+const CADENCE_UNITS = [
+  { v: "day", label: "per day" },
+  { v: "week", label: "per week" },
+  { v: "month", label: "per month" },
+  { v: "year", label: "per year" },
+];
+export const parseCustomFreq = (v: string): { n: string; unit: string } | null => {
+  const m = /^(\d+)x\/(day|week|month|year)$/.exec((v || "").trim());
+  return m ? { n: m[1], unit: m[2] } : null;
+};
+export const composeFreq = (n: string, unit: string) => `${Math.max(1, Number(n) || 1)}x/${unit}`;
+
+// A real dropdown of all cadence options + "Custom…". A free-text input with a
+// datalist only shows suggestions matching what's already typed, so a filled
+// field looked like it had a single option — this always shows the full list.
+// Custom… reveals a structured builder: a count (Frequency) + a cadence selector
+// (per day/week/month/year), e.g. 2 × per month.
+export function FrequencyPicker({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+  const isStd = FREQUENCY_OPTIONS.includes(value);
+  const parsed = parseCustomFreq(value);
+  const [custom, setCustom] = useState(value !== "" && !isStd);
+  const [n, setN] = useState(parsed?.n ?? "2");
+  const [unit, setUnit] = useState(parsed?.unit ?? "month");
+  useEffect(() => { if (FREQUENCY_OPTIONS.includes(value)) setCustom(false); }, [value]);
+  // Keep the builder in sync when an existing custom value loads in.
+  useEffect(() => { const p = parseCustomFreq(value); if (p) { setN(p.n); setUnit(p.unit); } }, [value]);
+
+  if (custom) {
+    return (
+      <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
+        <input style={{ ...inp, width: 70 }} type="number" min="1" step="1" value={n} autoFocus aria-label="Times"
+          onChange={e => { setN(e.target.value); onChange(composeFreq(e.target.value, unit)); }} />
+        <select style={inp} value={unit} aria-label="Cadence"
+          onChange={e => { setUnit(e.target.value); onChange(composeFreq(n, e.target.value)); }}>
+          {CADENCE_UNITS.map(u => <option key={u.v} value={u.v}>{u.label}</option>)}
+        </select>
+        <button type="button" onClick={() => { setCustom(false); onChange(""); }} style={{ ...listBtn, flexShrink: 0 }} title="Back to the list">List</button>
+      </div>
+    );
+  }
+  return (
+    <select style={inp} value={isStd ? value : ""} onChange={e => {
+      if (e.target.value === "__custom__") { setCustom(true); onChange(composeFreq(n, unit)); }
+      else onChange(e.target.value);
+    }}>
+      <option value="">Select…</option>
+      {FREQUENCY_OPTIONS.map(f => <option key={f} value={f}>{f}</option>)}
+      <option value="__custom__">Custom…</option>
+    </select>
+  );
+}

--- a/artifacts/qleno/src/pages/company/packages.tsx
+++ b/artifacts/qleno/src/pages/company/packages.tsx
@@ -1,0 +1,167 @@
+import { useState } from "react";
+import { DashboardLayout } from "@/components/layout/dashboard-layout";
+import { getAuthHeaders } from "@/lib/auth";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { Plus, Pencil, Trash2, Loader2, X, Check } from "lucide-react";
+import { FrequencyPicker } from "@/components/frequency-picker";
+
+const API = import.meta.env.BASE_URL.replace(/\/$/, "");
+const FF = "'Plus Jakarta Sans', sans-serif";
+const INK = "#1A1917", MUTE = "#6B7280", BORDER = "#E5E2DC", MINT = "#00C9A0";
+
+async function apiFetch(path: string, opts: RequestInit = {}) {
+  const r = await fetch(`${API}${path}`, { ...opts, headers: { ...(getAuthHeaders() as Record<string, string>), "Content-Type": "application/json", ...opts.headers } });
+  if (!r.ok) throw new Error(await r.text());
+  return r.json();
+}
+
+const money = (n: any) => `$${Number(n || 0).toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+const inp: React.CSSProperties = { width: "100%", padding: "9px 11px", border: `1px solid ${BORDER}`, borderRadius: 8, fontSize: 14, fontFamily: FF, background: "#fff", boxSizing: "border-box", color: INK };
+const lbl: React.CSSProperties = { display: "block", fontSize: 11, fontWeight: 700, color: MUTE, textTransform: "uppercase", letterSpacing: "0.05em", marginBottom: 5 };
+
+type Form = { id: number | null; name: string; frequency: string; price: string; intro_note: string; scope: string[] };
+const EMPTY: Form = { id: null, name: "", frequency: "Monthly", price: "", intro_note: "", scope: [""] };
+
+export default function PackagesPage() {
+  const qc = useQueryClient();
+  const [modalOpen, setModalOpen] = useState(false);
+  const [form, setForm] = useState<Form>(EMPTY);
+
+  // Packages = flat-price templates. Other (itemized) templates are managed from
+  // the estimate via "Save as template", so this screen lists flat ones only.
+  const { data: packages = [], isLoading } = useQuery<any[]>({
+    queryKey: ["estimate-packages"],
+    queryFn: () => apiFetch("/api/estimates/templates").then(r => (r.data || []).filter((t: any) => t.billing_mode === "flat")),
+  });
+
+  const saveMut = useMutation({
+    mutationFn: (f: Form) => {
+      const body = {
+        name: f.name.trim(),
+        billing_mode: "flat",
+        flat_price: parseFloat(f.price) || 0,
+        intro_note: f.intro_note.trim() || null,
+        items: f.scope.filter(s => s.trim()).map(name => ({ name: name.trim(), pricing_type: "flat", frequency: f.frequency, quantity: 1, unit_rate: 0 })),
+      };
+      return f.id
+        ? apiFetch(`/api/estimates/templates/${f.id}`, { method: "PATCH", body: JSON.stringify(body) })
+        : apiFetch("/api/estimates/templates", { method: "POST", body: JSON.stringify(body) });
+    },
+    onSuccess: () => { qc.invalidateQueries({ queryKey: ["estimate-packages"] }); setModalOpen(false); setForm(EMPTY); },
+  });
+
+  const deleteMut = useMutation({
+    mutationFn: (id: number) => apiFetch(`/api/estimates/templates/${id}`, { method: "DELETE" }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["estimate-packages"] }),
+  });
+
+  function openAdd() { setForm(EMPTY); setModalOpen(true); }
+  async function openEdit(p: any) {
+    const full = await apiFetch(`/api/estimates/templates/${p.id}`);
+    const items = Array.isArray(full.items) ? full.items : [];
+    setForm({
+      id: p.id, name: full.name || "", price: full.flat_price != null ? String(full.flat_price) : "",
+      frequency: items[0]?.frequency || "Monthly", intro_note: full.intro_note || "",
+      scope: items.length ? items.map((i: any) => i.name || "") : [""],
+    });
+    setModalOpen(true);
+  }
+
+  const setScope = (i: number, v: string) => setForm(f => ({ ...f, scope: f.scope.map((s, idx) => idx === i ? v : s) }));
+  const addScope = () => setForm(f => ({ ...f, scope: [...f.scope, ""] }));
+  const removeScope = (i: number) => setForm(f => ({ ...f, scope: f.scope.length > 1 ? f.scope.filter((_, idx) => idx !== i) : f.scope }));
+
+  return (
+    <DashboardLayout>
+      <div style={{ display: "flex", flexDirection: "column", gap: 20, fontFamily: FF }}>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+          <div>
+            <h1 style={{ fontSize: 22, fontWeight: 700, color: INK, margin: "0 0 4px" }}>Service Packages</h1>
+            <p style={{ fontSize: 13, color: MUTE, margin: 0 }}>Flat-price packages (e.g. Basic, Standard, Premium). Pick one when building an estimate to drop in the price and scope.</p>
+          </div>
+          <button onClick={openAdd} style={{ display: "flex", alignItems: "center", gap: 7, padding: "9px 16px", backgroundColor: "var(--brand)", color: "#fff", border: "none", borderRadius: 8, fontSize: 13, fontWeight: 600, cursor: "pointer", fontFamily: FF }}>
+            <Plus size={14} /> New Package
+          </button>
+        </div>
+
+        {isLoading ? (
+          <div style={{ padding: 40, textAlign: "center", color: "#9E9B94" }}><Loader2 size={20} style={{ animation: "spin 1s linear infinite" }} /></div>
+        ) : packages.length === 0 ? (
+          <div style={{ background: "#fff", border: `1px solid ${BORDER}`, borderRadius: 10, padding: 40, textAlign: "center", color: "#9E9B94" }}>
+            No packages yet. Click "New Package" to create your first one — for example Basic, Standard, and Premium tiers.
+          </div>
+        ) : (
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(240px, 1fr))", gap: 14 }}>
+            {packages.map((p: any) => (
+              <div key={p.id} style={{ background: "#fff", border: `1px solid ${BORDER}`, borderRadius: 12, padding: 16, display: "flex", flexDirection: "column", gap: 8 }}>
+                <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 8 }}>
+                  <span style={{ fontSize: 15, fontWeight: 800, color: INK }}>{p.name}</span>
+                  <div style={{ display: "flex", gap: 6, flexShrink: 0 }}>
+                    <button onClick={() => openEdit(p)} title="Edit" style={{ background: "none", border: "none", cursor: "pointer", color: "#9E9B94", padding: 2 }}><Pencil size={14} /></button>
+                    <button onClick={() => { if (confirm(`Delete package "${p.name}"?`)) deleteMut.mutate(p.id); }} title="Delete" style={{ background: "none", border: "none", cursor: "pointer", color: "#EF4444", padding: 2 }}><Trash2 size={14} /></button>
+                  </div>
+                </div>
+                <span style={{ fontSize: 20, fontWeight: 800, color: INK }}>{money(p.flat_price)}</span>
+                <span style={{ fontSize: 12, color: MUTE }}>{`${p.item_count ?? 0} item${(p.item_count ?? 0) === 1 ? "" : "s"} included`}</span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {modalOpen && (
+        <div style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,0.4)", display: "flex", alignItems: "center", justifyContent: "center", zIndex: 1000, padding: 16 }}>
+          <div style={{ background: "#fff", borderRadius: 14, padding: 26, width: 480, maxHeight: "88vh", overflowY: "auto", boxShadow: "0 20px 60px rgba(0,0,0,0.2)" }}>
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 18 }}>
+              <h3 style={{ margin: 0, fontSize: 16, fontWeight: 800, color: INK }}>{form.id ? "Edit package" : "New package"}</h3>
+              <button onClick={() => setModalOpen(false)} style={{ background: "none", border: "none", cursor: "pointer", color: "#9E9B94" }}><X size={16} /></button>
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+              <div>
+                <label style={lbl}>Package name</label>
+                <input style={inp} value={form.name} onChange={e => setForm(f => ({ ...f, name: e.target.value }))} placeholder="e.g. Standard" />
+              </div>
+              <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
+                <div>
+                  <label style={lbl}>Frequency</label>
+                  <FrequencyPicker value={form.frequency} onChange={v => setForm(f => ({ ...f, frequency: v }))} />
+                </div>
+                <div>
+                  <label style={lbl}>Price</label>
+                  <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                    <span style={{ color: MUTE }}>$</span>
+                    <input style={inp} type="number" min="0" step="0.01" value={form.price} onChange={e => setForm(f => ({ ...f, price: e.target.value }))} placeholder="0.00" />
+                  </div>
+                </div>
+              </div>
+              <div>
+                <label style={lbl}>What's included</label>
+                {form.scope.map((s, i) => (
+                  <div key={i} style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8 }}>
+                    <span style={{ width: 18, height: 18, borderRadius: 5, background: MINT, color: "#fff", display: "inline-flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }}><Check size={12} /></span>
+                    <input style={inp} value={s} onChange={e => setScope(i, e.target.value)} placeholder="Restrooms — clean & restock" />
+                    <button onClick={() => removeScope(i)} title="Remove" style={{ background: "none", border: `1px solid ${BORDER}`, borderRadius: 8, width: 34, height: 34, cursor: "pointer", color: MUTE, flexShrink: 0 }}><Trash2 size={14} /></button>
+                  </div>
+                ))}
+                <button onClick={addScope} style={{ display: "inline-flex", alignItems: "center", gap: 5, background: "#fff", border: `1px dashed ${BORDER}`, borderRadius: 8, padding: "7px 12px", fontSize: 13, fontWeight: 700, color: INK, cursor: "pointer", fontFamily: FF }}><Plus size={14} /> Add item</button>
+              </div>
+              <div>
+                <label style={lbl}>Intro note (optional)</label>
+                <textarea style={{ ...inp, minHeight: 56, resize: "vertical" }} value={form.intro_note} onChange={e => setForm(f => ({ ...f, intro_note: e.target.value }))} placeholder="Shown to the client at the top of the estimate." />
+              </div>
+            </div>
+            <div style={{ display: "flex", gap: 10, justifyContent: "flex-end", marginTop: 20 }}>
+              <button onClick={() => setModalOpen(false)} style={{ padding: "8px 16px", border: `1px solid ${BORDER}`, borderRadius: 8, fontSize: 13, background: "#fff", cursor: "pointer", fontFamily: FF }}>Cancel</button>
+              <button onClick={() => saveMut.mutate(form)} disabled={!form.name.trim() || saveMut.isPending}
+                style={{ padding: "8px 20px", background: "var(--brand)", color: "#fff", border: "none", borderRadius: 8, fontSize: 13, fontWeight: 600, cursor: form.name.trim() ? "pointer" : "default", opacity: form.name.trim() ? 1 : 0.6, fontFamily: FF }}>
+                {saveMut.isPending ? "Saving…" : form.id ? "Save changes" : "Create package"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <style>{`@keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }`}</style>
+    </DashboardLayout>
+  );
+}

--- a/artifacts/qleno/src/pages/estimate-builder.tsx
+++ b/artifacts/qleno/src/pages/estimate-builder.tsx
@@ -6,6 +6,7 @@ import { Plus, Trash2, ArrowLeft, Save, Send, LayoutTemplate, GripVertical, Chec
 import { toast } from "sonner";
 import { CalendarPopover } from "@/components/calendar-popover";
 import { useAddressAutocomplete } from "@/hooks/use-address-autocomplete";
+import { FrequencyPicker } from "@/components/frequency-picker";
 
 const FF = "'Plus Jakarta Sans', sans-serif";
 const API = import.meta.env.BASE_URL.replace(/\/$/, "");
@@ -41,21 +42,6 @@ const TYPE_LABELS: Record<PricingType, { type: string; qty: string; rate: string
   hourly: { type: "Hourly", qty: "Hours", rate: "$/hr" },
   one_time: { type: "One-time", qty: "Qty", rate: "Price" },
 };
-const FREQUENCY_OPTIONS = ["Daily", "5x/week", "3x/week", "2x/week", "Weekly", "Bi-weekly", "Semi-monthly", "Monthly", "Quarterly", "One-time"];
-
-// [frequency-custom] Custom cadence = a count + a unit (e.g. 2 × per month).
-// Stored as "Nx/<unit>" — same shape as the standard "2x/week" options.
-const CADENCE_UNITS = [
-  { v: "day", label: "per day" },
-  { v: "week", label: "per week" },
-  { v: "month", label: "per month" },
-  { v: "year", label: "per year" },
-];
-const parseCustomFreq = (v: string): { n: string; unit: string } | null => {
-  const m = /^(\d+)x\/(day|week|month|year)$/.exec((v || "").trim());
-  return m ? { n: m[1], unit: m[2] } : null;
-};
-const composeFreq = (n: string, unit: string) => `${Math.max(1, Number(n) || 1)}x/${unit}`;
 
 // [estimate-templates-phase2] One-click vertical picker. Seeded templates carry
 // a category; this maps it to a clean label + one-line scope hint for the cards.
@@ -373,9 +359,12 @@ export default function EstimateBuilderPage() {
                 <LayoutTemplate size={16} style={{ color: MINT }} />
                 <h2 style={{ fontSize: 13, fontWeight: 800, color: INK, textTransform: "uppercase", letterSpacing: "0.05em", margin: 0 }}>Start from a template</h2>
               </div>
-              <button onClick={() => setShowPicker(false)} style={{ background: "none", border: "none", color: MUTE, fontSize: 13, fontWeight: 700, cursor: "pointer", fontFamily: FF, padding: 0 }}>
-                Start blank
-              </button>
+              <div style={{ display: "flex", alignItems: "center", gap: 16 }}>
+                <a href={`${API}/company/packages`} style={{ color: MINT, fontSize: 13, fontWeight: 700, textDecoration: "none" }}>Manage packages</a>
+                <button onClick={() => setShowPicker(false)} style={{ background: "none", border: "none", color: MUTE, fontSize: 13, fontWeight: 700, cursor: "pointer", fontFamily: FF, padding: 0 }}>
+                  Start blank
+                </button>
+              </div>
             </div>
             <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(180px, 1fr))", gap: 10 }}>
               {[...templates]
@@ -598,45 +587,6 @@ const Row = ({ label, value }: { label: string; value: string }) => (
   <div style={{ display: "flex", justifyContent: "space-between", fontSize: 14, color: INK }}><span style={{ color: MUTE }}>{label}</span><span style={{ fontWeight: 600 }}>{value}</span></div>
 );
 
-// [frequency-dropdown] A real dropdown of all cadence options + "Custom…".
-// A free-text input with a datalist only shows suggestions matching what's
-// already typed, so a filled field looked like it had a single option — this
-// always shows the full list. Custom… reveals a structured builder: a count
-// (Frequency) + a cadence selector (per day/week/month/year), e.g. 2 × per month.
-function FrequencyPicker({ value, onChange }: { value: string; onChange: (v: string) => void }) {
-  const isStd = FREQUENCY_OPTIONS.includes(value);
-  const parsed = parseCustomFreq(value);
-  const [custom, setCustom] = useState(value !== "" && !isStd);
-  const [n, setN] = useState(parsed?.n ?? "2");
-  const [unit, setUnit] = useState(parsed?.unit ?? "month");
-  useEffect(() => { if (FREQUENCY_OPTIONS.includes(value)) setCustom(false); }, [value]);
-  // Keep the builder in sync when an existing custom value loads in.
-  useEffect(() => { const p = parseCustomFreq(value); if (p) { setN(p.n); setUnit(p.unit); } }, [value]);
-
-  if (custom) {
-    return (
-      <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
-        <input style={{ ...inp, width: 70 }} type="number" min="1" step="1" value={n} autoFocus aria-label="Times"
-          onChange={e => { setN(e.target.value); onChange(composeFreq(e.target.value, unit)); }} />
-        <select style={inp} value={unit} aria-label="Cadence"
-          onChange={e => { setUnit(e.target.value); onChange(composeFreq(n, e.target.value)); }}>
-          {CADENCE_UNITS.map(u => <option key={u.v} value={u.v}>{u.label}</option>)}
-        </select>
-        <button type="button" onClick={() => { setCustom(false); onChange(""); }} style={{ ...addBtn, flexShrink: 0 }} title="Back to the list">List</button>
-      </div>
-    );
-  }
-  return (
-    <select style={inp} value={isStd ? value : ""} onChange={e => {
-      if (e.target.value === "__custom__") { setCustom(true); onChange(composeFreq(n, unit)); }
-      else onChange(e.target.value);
-    }}>
-      <option value="">Select…</option>
-      {FREQUENCY_OPTIONS.map(f => <option key={f} value={f}>{f}</option>)}
-      <option value="__custom__">Custom…</option>
-    </select>
-  );
-}
 
 const inp: React.CSSProperties = {
   width: "100%", padding: "9px 11px", border: `1px solid ${BORDER}`, borderRadius: 9,


### PR DESCRIPTION
Define flat-price packages once, then one-click them into an estimate — completes Option B.

- **New page `/company/packages`:** list packages (flat templates), create/edit via modal — name, frequency, price, 'what's included' scope list, optional intro note. Uses POST + PATCH `/api/estimates/templates` with `billing_mode='flat'`.
- **Shared picker:** extracted the cadence control into `components/frequency-picker.tsx` (FrequencyPicker + Custom builder) so the builder and packages screen share one source of truth.
- **Link:** the estimate template picker gains a 'Manage packages' link.

Picking a package drops into the flat-price estimate view (prior PR) with price + scope prefilled.

estimate-packages 6/6 · frequency 6/6 · frontend typecheck zero new errors. (Local vite build hits a worktree-only missing rollup native binary — CI build-frontend validates the real bundle.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)