### PR TITLE
feat(estimates): flat-price clarity — price unit + scope paragraph

### DIFF
--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -388,6 +388,10 @@ async function runBookingSchemaGuard(): Promise<void> {
     // Additive + idempotent.
     { label: "estimate_templates.billing_mode", stmt: `ALTER TABLE estimate_templates ADD COLUMN IF NOT EXISTS billing_mode TEXT NOT NULL DEFAULT 'itemized'` },
     { label: "estimate_templates.flat_price", stmt: `ALTER TABLE estimate_templates ADD COLUMN IF NOT EXISTS flat_price NUMERIC(12,2) NOT NULL DEFAULT 0` },
+    // [estimate-flat-clarity 2026-06-26] Price unit ("$150 / visit") + optional
+    // free-text scope paragraph. Additive + idempotent.
+    { label: "estimates.flat_price_unit", stmt: `ALTER TABLE estimates ADD COLUMN IF NOT EXISTS flat_price_unit TEXT NOT NULL DEFAULT 'visit'` },
+    { label: "estimates.scope_note", stmt: `ALTER TABLE estimates ADD COLUMN IF NOT EXISTS scope_note TEXT` },
     // [engagement-tracking-phase4 2026-06-25] Unified engagement timeline +
     // native click-redirect / open-pixel tokens. Additive + idempotent.
     { label: "CREATE engagement_events", stmt: `

--- a/artifacts/api-server/src/routes/estimates.ts
+++ b/artifacts/api-server/src/routes/estimates.ts
@@ -77,6 +77,13 @@ function billingModeOf(v: unknown): "itemized" | "flat" {
   return String(v ?? "").trim() === "flat" ? "flat" : "itemized";
 }
 
+// What the flat price is charged per — drives the "$150 / visit" label.
+const PRICE_UNITS = new Set(["visit", "week", "month", "quarter", "year", "service", "total"]);
+function priceUnitOf(v: unknown): string {
+  const s = String(v ?? "").trim();
+  return PRICE_UNITS.has(s) ? s : "visit";
+}
+
 function str(v: unknown, max = 2000): string | null {
   if (v === undefined || v === null) return null;
   const s = v.toString().trim();
@@ -681,12 +688,12 @@ router.post("/", requireAuth, async (req, res) => {
       INSERT INTO estimates
         (company_id, branch_id, account_id, account_property_id, client_id,
          contact_name, contact_email, cc_emails, contact_phone, property_name, service_address,
-         title, intro_note, terms, internal_notes, status, billing_mode, flat_price,
+         title, intro_note, terms, internal_notes, status, billing_mode, flat_price, flat_price_unit, scope_note,
          subtotal, discount_amount, total, valid_until, created_by, updated_at)
       VALUES
         (${companyId}, ${intOrNull(b.branch_id)}, ${intOrNull(b.account_id)}, ${intOrNull(b.account_property_id)}, ${intOrNull(b.client_id)},
          ${str(b.contact_name, 200)}, ${str(b.contact_email, 200)}, ${normalizeEmails(b.cc_emails, str(b.contact_email, 200))}, ${str(b.contact_phone, 40)}, ${str(b.property_name, 300)}, ${str(b.service_address, 400)},
-         ${str(b.title, 300)}, ${str(b.intro_note)}, ${str(b.terms)}, ${str(b.internal_notes)}, 'draft', ${billingMode}, ${flatPrice},
+         ${str(b.title, 300)}, ${str(b.intro_note)}, ${str(b.terms)}, ${str(b.internal_notes)}, 'draft', ${billingMode}, ${flatPrice}, ${priceUnitOf(b.flat_price_unit)}, ${str(b.scope_note)},
          ${subtotal}, ${discount}, ${total}, ${b.valid_until ? new Date(b.valid_until) : null}, ${req.auth!.userId}, now())
       RETURNING id
     `);
@@ -719,6 +726,8 @@ router.patch("/:id", requireAuth, async (req, res) => {
         account_id = ${intOrNull(b.account_id)},
         billing_mode = ${billingMode},
         flat_price = ${flatPrice},
+        flat_price_unit = ${priceUnitOf(b.flat_price_unit)},
+        scope_note = ${str(b.scope_note)},
         account_property_id = ${intOrNull(b.account_property_id)},
         client_id = ${intOrNull(b.client_id)},
         contact_name = ${str(b.contact_name, 200)},

--- a/artifacts/api-server/src/tests/estimate-flat-clarity.test.ts
+++ b/artifacts/api-server/src/tests/estimate-flat-clarity.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Flat-price clarity: a price unit ("$150 / visit") and an optional free-text
+ * scope paragraph, end to end (schema, route, editor, client page).
+ * Source-assertion guard.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const read = (rel: string) => readFileSync(resolve(here, rel), "utf8");
+
+describe("estimate flat-price clarity", () => {
+  const route = read("../routes/estimates.ts");
+  const migration = read("../phes-data-migration.ts");
+  const schema = read("../../../../lib/db/src/schema/estimates.ts");
+  const builder = read("../../../qleno/src/pages/estimate-builder.tsx");
+  const pub = read("../../../qleno/src/pages/estimate-public.tsx");
+
+  it("schema + migration add flat_price_unit + scope_note", () => {
+    assert.match(schema, /flat_price_unit: text\("flat_price_unit"\)\.notNull\(\)\.default\("visit"\)/);
+    assert.match(schema, /scope_note: text\("scope_note"\)/);
+    assert.match(migration, /ADD COLUMN IF NOT EXISTS flat_price_unit TEXT NOT NULL DEFAULT 'visit'/);
+    assert.match(migration, /ADD COLUMN IF NOT EXISTS scope_note TEXT/);
+  });
+
+  it("route validates the unit and persists both on create + update", () => {
+    assert.match(route, /const PRICE_UNITS = new Set\(\["visit", "week", "month", "quarter", "year", "service", "total"\]\)/);
+    assert.match(route, /function priceUnitOf/);
+    assert.match(route, /flat_price, flat_price_unit, scope_note,/);    // INSERT columns
+    assert.match(route, /flat_price_unit = \$\{priceUnitOf\(b\.flat_price_unit\)\}/); // PATCH
+  });
+
+  it("editor has the unit selector + the scope paragraph, and sends both", () => {
+    assert.match(builder, /const PRICE_UNITS = \[/);
+    assert.match(builder, /const unitSuffix = \(u: string\) => \(u && u !== "total" \? ` \/ \$\{u\}` : ""\)/);
+    assert.match(builder, /const \[scopeNote, setScopeNote\]/);
+    assert.match(builder, /Scope description/);
+    assert.match(builder, /flat_price_unit: flatPriceUnit/);
+    assert.match(builder, /scope_note: billingMode === "flat" \? \(scopeNote\.trim\(\) \|\| null\) : null/);
+  });
+
+  it("client page shows the scope paragraph + the unit on the total", () => {
+    assert.match(pub, /est\.scope_note &&/);
+    assert.match(pub, /est\.flat_price_unit && est\.flat_price_unit !== "total" \? ` \/ \$\{est\.flat_price_unit\}` : ""/);
+  });
+});

--- a/artifacts/qleno/src/pages/estimate-builder.tsx
+++ b/artifacts/qleno/src/pages/estimate-builder.tsx
@@ -28,6 +28,19 @@ async function apiFetch(path: string, opts: { method?: string; body?: any } = {}
 
 const money = (n: number) => `$${n.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
 
+// [estimate-flat-clarity] What the flat price is charged per + the label suffix
+// ("$150 / visit"). "total" = a one-time price, so no suffix.
+const PRICE_UNITS = [
+  { v: "visit", label: "per visit" },
+  { v: "week", label: "per week" },
+  { v: "month", label: "per month" },
+  { v: "quarter", label: "per quarter" },
+  { v: "year", label: "per year" },
+  { v: "service", label: "per service" },
+  { v: "total", label: "one-time (total)" },
+];
+const unitSuffix = (u: string) => (u && u !== "total" ? ` / ${u}` : "");
+
 type PricingType = "flat" | "hourly" | "one_time";
 interface Item {
   name: string;
@@ -99,6 +112,10 @@ export default function EstimateBuilderPage() {
   // the whole job + a scope checklist). Default itemized.
   const [billingMode, setBillingMode] = useState<"itemized" | "flat">("itemized");
   const [flatPrice, setFlatPrice] = useState("");
+  // [estimate-flat-clarity] What the flat price is per + an optional free-text
+  // scope paragraph (alternative to itemizing the checklist).
+  const [flatPriceUnit, setFlatPriceUnit] = useState("visit");
+  const [scopeNote, setScopeNote] = useState("");
 
   // [estimate-templates-phase2] One-click template picker (new estimates only).
   const [templates, setTemplates] = useState<any[]>([]);
@@ -136,6 +153,8 @@ export default function EstimateBuilderPage() {
           setDiscount(String(e.discount_amount ?? "0"));
           setBillingMode(e.billing_mode === "flat" ? "flat" : "itemized");
           setFlatPrice(e.flat_price != null && Number(e.flat_price) > 0 ? String(e.flat_price) : "");
+          setFlatPriceUnit(e.flat_price_unit || "visit");
+          setScopeNote(e.scope_note || "");
           setValidUntil(e.valid_until ? String(e.valid_until).slice(0, 10) : "");
           setItems((e.items || []).length ? e.items.map(mapRow) : [blankItem()]);
         } else {
@@ -182,6 +201,8 @@ export default function EstimateBuilderPage() {
     discount_amount: Number(discount) || 0,
     billing_mode: billingMode,
     flat_price: billingMode === "flat" ? (Number(flatPrice) || 0) : 0,
+    flat_price_unit: flatPriceUnit,
+    scope_note: billingMode === "flat" ? (scopeNote.trim() || null) : null,
     valid_until: validUntil || null,
     // Flat mode persists scope only (name + shared frequency, no price); itemized
     // keeps the full priced line. Empty scope rows are dropped either way.
@@ -468,13 +489,26 @@ export default function EstimateBuilderPage() {
             <>
               <div style={{ marginBottom: 14, padding: "12px 14px", border: `1px solid ${BORDER}`, borderRadius: 10, background: "#FCFCFB" }}>
                 <span style={{ display: "block", fontSize: 11, fontWeight: 700, color: MUTE, textTransform: "uppercase", letterSpacing: "0.04em", marginBottom: 5 }}>Service price</span>
-                <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                <div style={{ display: "flex", alignItems: "center", gap: 6, flexWrap: "wrap" }}>
                   <span style={{ color: MUTE, fontSize: 16 }}>$</span>
-                  <input style={{ ...inp, maxWidth: 200, fontWeight: 700, fontSize: 16 }} type="number" min="0" step="0.01" value={flatPrice} onChange={e => setFlatPrice(e.target.value)} placeholder="0.00" />
-                  <span style={{ fontSize: 12, color: MUTE }}>one price for the whole job — shown to the client as the total</span>
+                  <input style={{ ...inp, maxWidth: 150, fontWeight: 700, fontSize: 16 }} type="number" min="0" step="0.01" value={flatPrice} onChange={e => setFlatPrice(e.target.value)} placeholder="0.00" />
+                  <select style={{ ...inp, maxWidth: 170 }} value={flatPriceUnit} onChange={e => setFlatPriceUnit(e.target.value)} aria-label="Price unit">
+                    {PRICE_UNITS.map(u => <option key={u.v} value={u.v}>{u.label}</option>)}
+                  </select>
                 </div>
+                <span style={{ display: "block", fontSize: 12, color: MUTE, marginTop: 6 }}>
+                  {flatPriceUnit === "total"
+                    ? `Client sees ${money(Number(flatPrice) || 0)} as a one-time total.`
+                    : `Client sees ${money(Number(flatPrice) || 0)}${unitSuffix(flatPriceUnit)} — the price for each ${flatPriceUnit}.`}
+                </span>
               </div>
-              <span style={{ display: "block", fontSize: 11, fontWeight: 700, color: MUTE, textTransform: "uppercase", letterSpacing: "0.04em", marginBottom: 8 }}>What's included <span style={{ fontWeight: 400, textTransform: "none", letterSpacing: 0, color: "#9CA3AF" }}>— scope shown to the client, no per-line price</span></span>
+
+              {/* [estimate-flat-clarity] Optional scope paragraph — describe the
+                  work in prose instead of (or alongside) the checklist below. */}
+              <span style={{ display: "block", fontSize: 11, fontWeight: 700, color: MUTE, textTransform: "uppercase", letterSpacing: "0.04em", marginBottom: 8 }}>Scope description <span style={{ fontWeight: 400, textTransform: "none", letterSpacing: 0, color: "#9CA3AF" }}>— optional, shown to the client above the checklist</span></span>
+              <textarea style={{ ...inp, minHeight: 70, resize: "vertical", marginBottom: 14 }} value={scopeNote} onChange={e => setScopeNote(e.target.value)} placeholder="e.g. Full janitorial service for the suite — all offices, the break room, both restrooms, and common hallways, cleaned each visit. Supplies included." />
+
+              <span style={{ display: "block", fontSize: 11, fontWeight: 700, color: MUTE, textTransform: "uppercase", letterSpacing: "0.04em", marginBottom: 8 }}>What's included <span style={{ fontWeight: 400, textTransform: "none", letterSpacing: 0, color: "#9CA3AF" }}>— optional checklist, no per-line price</span></span>
               {items.map((it, i) => (
                 <div key={i} style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8 }}>
                   <span style={{ width: 20, height: 20, borderRadius: 6, background: MINT, color: "#fff", display: "inline-flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }}><Check size={13} /></span>
@@ -528,7 +562,7 @@ export default function EstimateBuilderPage() {
           </div>
           <div style={{ borderTop: `1px solid ${BORDER}`, marginTop: 8, paddingTop: 12, display: "flex", justifyContent: "space-between", alignItems: "center" }}>
             <span style={{ fontSize: 16, fontWeight: 800, color: INK }}>Total</span>
-            <span style={{ fontSize: 22, fontWeight: 800, color: INK }}>{money(total)}</span>
+            <span style={{ fontSize: 22, fontWeight: 800, color: INK }}>{money(total)}{billingMode === "flat" && <span style={{ fontSize: 14, fontWeight: 600, color: MUTE }}>{unitSuffix(flatPriceUnit)}</span>}</span>
           </div>
         </div>
 

--- a/artifacts/qleno/src/pages/estimate-public.tsx
+++ b/artifacts/qleno/src/pages/estimate-public.tsx
@@ -40,6 +40,9 @@ type PublicEstimate = {
   status: string;
   // [estimate-flat-mode] 'flat' → render scope list + single price; else itemized.
   billing_mode?: string | null;
+  // [estimate-flat-clarity] price unit ("/ visit") + optional scope paragraph.
+  flat_price_unit?: string | null;
+  scope_note?: string | null;
   subtotal: string;
   discount_amount: string;
   total: string;
@@ -268,8 +271,12 @@ export default function EstimatePublicPage() {
               // [estimate-flat-mode] One price + a scope checklist (no per-line
               // prices). The total is the single flat price the office set.
               if (est.billing_mode === "flat") {
+                const unitSuffix = est.flat_price_unit && est.flat_price_unit !== "total" ? ` / ${est.flat_price_unit}` : "";
                 return (
                   <>
+                    {est.scope_note && (
+                      <p style={{ fontSize: 14, color: "#374151", margin: "0 0 16px", lineHeight: 1.6, whiteSpace: "pre-wrap" }}>{est.scope_note}</p>
+                    )}
                     {est.items.length > 0 && (
                       <div style={{ border: `1px solid ${BORDER}`, borderRadius: 12, padding: "14px 16px", marginBottom: 18 }}>
                         <p style={{ fontSize: 11, fontWeight: 700, color: MUTE, textTransform: "uppercase", letterSpacing: "0.04em", margin: "0 0 10px" }}>What's included</p>
@@ -290,9 +297,9 @@ export default function EstimatePublicPage() {
                           <span>Discount</span><span>−{money(est.discount_amount)}</span>
                         </div>
                       )}
-                      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", borderTop: `2px solid ${INK}`, marginTop: 8, paddingTop: 10 }}>
+                      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", borderTop: `2px solid ${INK}`, marginTop: 8, paddingTop: 10 }}>
                         <span style={{ fontSize: 15, fontWeight: 800, color: INK }}>Total</span>
-                        <span style={{ fontSize: 26, fontWeight: 800, color: MINT, letterSpacing: "-0.01em" }}>{money(est.total)}</span>
+                        <span style={{ fontSize: 26, fontWeight: 800, color: MINT, letterSpacing: "-0.01em" }}>{money(est.total)}<span style={{ fontSize: 15, fontWeight: 700, color: MUTE }}>{unitSuffix}</span></span>
                       </div>
                     </div>
                   </>

--- a/lib/db/src/schema/estimates.ts
+++ b/lib/db/src/schema/estimates.ts
@@ -45,6 +45,11 @@ export const estimatesTable = pgTable("estimates", {
   //                (name + frequency, no per-line price) and total = flat_price.
   billing_mode: text("billing_mode").notNull().default("itemized"),
   flat_price: numeric("flat_price", { precision: 12, scale: 2 }).notNull().default("0"),
+  // [estimate-flat-clarity 2026-06-26] What the flat price is per (visit / week /
+  // month / …) so the client sees "$150 / visit", and an optional free-text scope
+  // paragraph for when the office would rather describe the work than itemize it.
+  flat_price_unit: text("flat_price_unit").notNull().default("visit"),
+  scope_note: text("scope_note"),
   subtotal: numeric("subtotal", { precision: 12, scale: 2 }).notNull().default("0"),
   discount_amount: numeric("discount_amount", { precision: 12, scale: 2 }).notNull().default("0"),
   total: numeric("total", { precision: 12, scale: 2 }).notNull().default("0"),


### PR DESCRIPTION
Two flat-price gaps from review:

- **"$150 per what?"** — price-unit selector (per visit / week / month / quarter / year / service, or one-time total). Builder total shows **"$150 / visit"** + a plain helper; the client hosted page shows the same unit. New column `estimates.flat_price_unit` (default 'visit').
- **"in case I don't want to itemize"** — optional free-text **Scope description** paragraph above the checklist, rendered to the client above the What's-included list. New column `estimates.scope_note`. Checklist is now explicitly optional.

Additive/idempotent migration; create + update persist + validate both.

flat-clarity 4/4 · flat-mode 5/5 · packages 6/6 · esbuild OK · frontend typecheck zero new errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)