### PR TITLE
feat(estimates): PDF preview — download exactly what the client receives

### DIFF
--- a/artifacts/api-server/src/lib/estimate-pdf.ts
+++ b/artifacts/api-server/src/lib/estimate-pdf.ts
@@ -1,0 +1,170 @@
+// [estimate-pdf] Renders an estimate as a branded PDF so the office can preview
+// exactly what the client receives (and download / re-send it). Built with
+// pdfkit — Railway has no Chromium, so HTML->PDF is intentionally avoided,
+// mirroring lib/pdf-gen.ts and lib/confirmation-pdf.ts. Returns a Buffer.
+import PDFDocument from "pdfkit";
+
+const NAVY = "#0A0E1A";
+const MINT = "#00C9A0";
+const INK = "#1A1917";
+const MUTE = "#6B6860";
+const BORDER = "#E5E2DC";
+
+export interface EstimatePdfItem {
+  name: string | null;
+  pricing_type: string;
+  frequency: string | null;
+  quantity: string | number;
+  unit_rate: string | number;
+  amount: string | number;
+}
+
+export interface EstimatePdfData {
+  companyName: string;
+  estimateNumber: string | null;
+  status: string;
+  title: string | null;
+  introNote: string | null;
+  contactName: string | null;
+  propertyName: string | null;
+  serviceAddress: string | null;
+  billingMode: string;
+  flatPriceUnit: string | null;
+  scopeNote: string | null;
+  items: EstimatePdfItem[];
+  subtotal: string | number;
+  discount: string | number;
+  total: string | number;
+  terms: string | null;
+  validUntil: string | null;
+}
+
+const money = (n: any) => `$${Number(n || 0).toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+const unitSuffix = (u: string | null) => (u && u !== "total" ? ` / ${u}` : "");
+const fmtDate = (d: string | null) => {
+  if (!d) return null;
+  const [y, m, day] = String(d).slice(0, 10).split("-").map(Number);
+  if (!y || !m || !day) return null;
+  return new Date(y, m - 1, day).toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric" });
+};
+
+export function renderEstimatePdf(data: EstimatePdfData): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const doc = new PDFDocument({ margin: 50, size: "LETTER" });
+    const chunks: Buffer[] = [];
+    doc.on("data", (c) => chunks.push(c as Buffer));
+    doc.on("end", () => resolve(Buffer.concat(chunks)));
+    doc.on("error", reject);
+
+    const left = 50;
+    const right = doc.page.width - 50;
+    const width = right - left;
+    const isFlat = data.billingMode === "flat";
+
+    // Header band
+    doc.rect(0, 0, doc.page.width, 84).fill(NAVY);
+    doc.fillColor("#FFFFFF").fontSize(20).font("Helvetica-Bold").text(data.companyName, left, 26, { width: width - 160 });
+    doc.fontSize(10).font("Helvetica").fillColor("#9CA3AF").text("ESTIMATE", left, 54);
+    doc.fillColor("#FFFFFF").fontSize(13).font("Helvetica-Bold")
+      .text(data.estimateNumber || "", right - 160, 30, { width: 160, align: "right" });
+    doc.fontSize(9).font("Helvetica").fillColor("#9CA3AF")
+      .text(String(data.status || "").toUpperCase(), right - 160, 50, { width: 160, align: "right" });
+
+    let y = 108;
+
+    // Prepared for
+    doc.fillColor(MUTE).fontSize(9).font("Helvetica-Bold").text("PREPARED FOR", left, y);
+    y += 14;
+    doc.fillColor(INK).fontSize(12).font("Helvetica-Bold").text(data.contactName || data.propertyName || "Client", left, y);
+    y += 16;
+    doc.fillColor(MUTE).fontSize(10).font("Helvetica");
+    if (data.propertyName && data.contactName) { doc.text(data.propertyName, left, y); y += 13; }
+    if (data.serviceAddress) { doc.text(data.serviceAddress, left, y, { width }); y += 13; }
+    const issued = fmtDate(new Date().toISOString());
+    const validUntil = fmtDate(data.validUntil);
+    doc.text(`Issued ${issued}${validUntil ? `    Valid until ${validUntil}` : ""}`, left, y);
+    y += 24;
+
+    // Title + intro
+    if (data.title) {
+      doc.fillColor(INK).fontSize(15).font("Helvetica-Bold").text(data.title, left, y, { width });
+      y = doc.y + 6;
+    }
+    if (data.introNote) {
+      doc.fillColor("#374151").fontSize(10).font("Helvetica").text(data.introNote, left, y, { width, lineGap: 2 });
+      y = doc.y + 14;
+    }
+
+    doc.moveTo(left, y).lineTo(right, y).strokeColor(BORDER).stroke();
+    y += 16;
+
+    if (isFlat) {
+      // Scope paragraph (optional)
+      if (data.scopeNote) {
+        doc.fillColor("#374151").fontSize(10).font("Helvetica").text(data.scopeNote, left, y, { width, lineGap: 2 });
+        y = doc.y + 14;
+      }
+      // What's included checklist (optional)
+      const named = data.items.filter((it) => (it.name || "").trim());
+      if (named.length) {
+        doc.fillColor(MUTE).fontSize(9).font("Helvetica-Bold").text("WHAT'S INCLUDED", left, y);
+        y += 16;
+        for (const it of named) {
+          doc.fillColor(MINT).fontSize(11).font("Helvetica-Bold").text("✓", left, y, { continued: false, width: 14 });
+          const label = it.frequency ? `${it.name}  ·  ${it.frequency}` : `${it.name}`;
+          doc.fillColor(INK).fontSize(10.5).font("Helvetica").text(label || "Service", left + 18, y, { width: width - 18 });
+          y = doc.y + 6;
+        }
+        y += 6;
+      }
+    } else {
+      // Itemized table
+      for (const it of data.items) {
+        const sub = [
+          it.frequency,
+          it.pricing_type === "hourly" ? `${Number(it.quantity).toFixed(1)} hrs × ${money(it.unit_rate)}/hr`
+            : Number(it.quantity) !== 1 ? `${Number(it.quantity)} × ${money(it.unit_rate)}` : null,
+        ].filter(Boolean).join("  ·  ");
+        const startY = y;
+        doc.fillColor(INK).fontSize(10.5).font("Helvetica-Bold").text(it.name || "Service", left, y, { width: width - 90 });
+        y = doc.y;
+        if (sub) { doc.fillColor(MUTE).fontSize(9).font("Helvetica").text(sub, left, y, { width: width - 90 }); y = doc.y; }
+        doc.fillColor(INK).fontSize(10.5).font("Helvetica-Bold").text(money(it.amount), right - 90, startY, { width: 90, align: "right" });
+        y += 8;
+        doc.moveTo(left, y).lineTo(right, y).strokeColor("#F0EEE9").stroke();
+        y += 8;
+      }
+    }
+
+    // Totals
+    y += 6;
+    const labelX = right - 220, valX = right - 110;
+    if (!isFlat) {
+      doc.fillColor(MUTE).fontSize(10).font("Helvetica").text("Subtotal", labelX, y, { width: 110 });
+      doc.fillColor(INK).text(money(data.subtotal), valX, y, { width: 110, align: "right" });
+      y += 16;
+    }
+    if (Number(data.discount) > 0) {
+      doc.fillColor("#047857").fontSize(10).font("Helvetica").text("Discount", labelX, y, { width: 110 });
+      doc.text(`-${money(data.discount)}`, valX, y, { width: 110, align: "right" });
+      y += 16;
+    }
+    doc.moveTo(labelX, y).lineTo(right, y).strokeColor(INK).lineWidth(1.2).stroke();
+    y += 8;
+    doc.fillColor(INK).fontSize(13).font("Helvetica-Bold").text("Total", labelX, y, { width: 110 });
+    doc.fillColor(NAVY).fontSize(16).font("Helvetica-Bold")
+      .text(`${money(data.total)}${isFlat ? unitSuffix(data.flatPriceUnit) : ""}`, valX - 60, y - 2, { width: 170, align: "right" });
+    y += 30;
+
+    // Terms
+    if (data.terms) {
+      doc.moveTo(left, y).lineTo(right, y).strokeColor(BORDER).lineWidth(1).stroke();
+      y += 14;
+      doc.fillColor(MUTE).fontSize(9).font("Helvetica-Bold").text("TERMS", left, y);
+      y += 14;
+      doc.fillColor("#374151").fontSize(9.5).font("Helvetica").text(data.terms, left, y, { width, lineGap: 2 });
+    }
+
+    doc.end();
+  });
+}

--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -388,6 +388,10 @@ async function runBookingSchemaGuard(): Promise<void> {
     // Additive + idempotent.
     { label: "estimate_templates.billing_mode", stmt: `ALTER TABLE estimate_templates ADD COLUMN IF NOT EXISTS billing_mode TEXT NOT NULL DEFAULT 'itemized'` },
     { label: "estimate_templates.flat_price", stmt: `ALTER TABLE estimate_templates ADD COLUMN IF NOT EXISTS flat_price NUMERIC(12,2) NOT NULL DEFAULT 0` },
+    // [estimate-flat-clarity 2026-06-26] Price unit ("$150 / visit") + optional
+    // free-text scope paragraph. Additive + idempotent.
+    { label: "estimates.flat_price_unit", stmt: `ALTER TABLE estimates ADD COLUMN IF NOT EXISTS flat_price_unit TEXT NOT NULL DEFAULT 'visit'` },
+    { label: "estimates.scope_note", stmt: `ALTER TABLE estimates ADD COLUMN IF NOT EXISTS scope_note TEXT` },
     // [engagement-tracking-phase4 2026-06-25] Unified engagement timeline +
     // native click-redirect / open-pixel tokens. Additive + idempotent.
     { label: "CREATE engagement_events", stmt: `

--- a/artifacts/api-server/src/routes/estimates.ts
+++ b/artifacts/api-server/src/routes/estimates.ts
@@ -5,6 +5,7 @@ import { randomUUID } from "crypto";
 import { requireAuth } from "../lib/auth.js";
 import { enrollForEstimateSent, stopEnrollmentsForEstimate, fireEstimateDay0 } from "../services/followUpService.js";
 import { recordEngagementEvent } from "../lib/engagement.js";
+import { renderEstimatePdf } from "../lib/estimate-pdf.js";
 
 // [commercial-estimate-tool 2026-06-09] Commercial / common-area estimates.
 // Raw SQL (db.execute) on purpose: the estimate tables are brand-new and the
@@ -660,6 +661,41 @@ router.get("/:id", requireAuth, async (req, res) => {
     return res.json({ ...est, items: (items as any).rows });
   } catch (err) {
     console.error("Get estimate error:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
+// ─── Estimate PDF (office preview of exactly what the client receives) ────────
+router.get("/:id/pdf", requireAuth, async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    const id = parseInt(req.params.id, 10);
+    const e = await db.execute(sql`
+      SELECT e.*, c.name AS company_name
+      FROM estimates e JOIN companies c ON c.id = e.company_id
+      WHERE e.id = ${id} AND e.company_id = ${companyId} LIMIT 1
+    `);
+    const est = (e as any).rows[0];
+    if (!est) return res.status(404).json({ error: "Not Found" });
+    const items = await db.execute(sql`
+      SELECT name, pricing_type, frequency, quantity, unit_rate, amount
+      FROM estimate_line_items WHERE estimate_id = ${id} AND company_id = ${companyId} ORDER BY sort_order
+    `);
+    const pdf = await renderEstimatePdf({
+      companyName: est.company_name || "Estimate",
+      estimateNumber: est.estimate_number, status: est.status,
+      title: est.title, introNote: est.intro_note,
+      contactName: est.contact_name, propertyName: est.property_name, serviceAddress: est.service_address,
+      billingMode: est.billing_mode || "itemized", flatPriceUnit: est.flat_price_unit, scopeNote: est.scope_note,
+      items: (items as any).rows,
+      subtotal: est.subtotal, discount: est.discount_amount, total: est.total,
+      terms: est.terms, validUntil: est.valid_until ? String(est.valid_until) : null,
+    });
+    res.setHeader("Content-Type", "application/pdf");
+    res.setHeader("Content-Disposition", `inline; filename="${est.estimate_number || `estimate-${id}`}.pdf"`);
+    return res.end(pdf);
+  } catch (err) {
+    console.error("Estimate PDF error:", err);
     return res.status(500).json({ error: "Internal Server Error" });
   }
 });

--- a/artifacts/api-server/src/routes/estimates.ts
+++ b/artifacts/api-server/src/routes/estimates.ts
@@ -77,6 +77,13 @@ function billingModeOf(v: unknown): "itemized" | "flat" {
   return String(v ?? "").trim() === "flat" ? "flat" : "itemized";
 }
 
+// What the flat price is charged per — drives the "$150 / visit" label.
+const PRICE_UNITS = new Set(["visit", "week", "month", "quarter", "year", "service", "total"]);
+function priceUnitOf(v: unknown): string {
+  const s = String(v ?? "").trim();
+  return PRICE_UNITS.has(s) ? s : "visit";
+}
+
 function str(v: unknown, max = 2000): string | null {
   if (v === undefined || v === null) return null;
   const s = v.toString().trim();
@@ -681,12 +688,12 @@ router.post("/", requireAuth, async (req, res) => {
       INSERT INTO estimates
         (company_id, branch_id, account_id, account_property_id, client_id,
          contact_name, contact_email, cc_emails, contact_phone, property_name, service_address,
-         title, intro_note, terms, internal_notes, status, billing_mode, flat_price,
+         title, intro_note, terms, internal_notes, status, billing_mode, flat_price, flat_price_unit, scope_note,
          subtotal, discount_amount, total, valid_until, created_by, updated_at)
       VALUES
         (${companyId}, ${intOrNull(b.branch_id)}, ${intOrNull(b.account_id)}, ${intOrNull(b.account_property_id)}, ${intOrNull(b.client_id)},
          ${str(b.contact_name, 200)}, ${str(b.contact_email, 200)}, ${normalizeEmails(b.cc_emails, str(b.contact_email, 200))}, ${str(b.contact_phone, 40)}, ${str(b.property_name, 300)}, ${str(b.service_address, 400)},
-         ${str(b.title, 300)}, ${str(b.intro_note)}, ${str(b.terms)}, ${str(b.internal_notes)}, 'draft', ${billingMode}, ${flatPrice},
+         ${str(b.title, 300)}, ${str(b.intro_note)}, ${str(b.terms)}, ${str(b.internal_notes)}, 'draft', ${billingMode}, ${flatPrice}, ${priceUnitOf(b.flat_price_unit)}, ${str(b.scope_note)},
          ${subtotal}, ${discount}, ${total}, ${b.valid_until ? new Date(b.valid_until) : null}, ${req.auth!.userId}, now())
       RETURNING id
     `);
@@ -719,6 +726,8 @@ router.patch("/:id", requireAuth, async (req, res) => {
         account_id = ${intOrNull(b.account_id)},
         billing_mode = ${billingMode},
         flat_price = ${flatPrice},
+        flat_price_unit = ${priceUnitOf(b.flat_price_unit)},
+        scope_note = ${str(b.scope_note)},
         account_property_id = ${intOrNull(b.account_property_id)},
         client_id = ${intOrNull(b.client_id)},
         contact_name = ${str(b.contact_name, 200)},

--- a/artifacts/api-server/src/tests/estimate-flat-clarity.test.ts
+++ b/artifacts/api-server/src/tests/estimate-flat-clarity.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Flat-price clarity: a price unit ("$150 / visit") and an optional free-text
+ * scope paragraph, end to end (schema, route, editor, client page).
+ * Source-assertion guard.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const read = (rel: string) => readFileSync(resolve(here, rel), "utf8");
+
+describe("estimate flat-price clarity", () => {
+  const route = read("../routes/estimates.ts");
+  const migration = read("../phes-data-migration.ts");
+  const schema = read("../../../../lib/db/src/schema/estimates.ts");
+  const builder = read("../../../qleno/src/pages/estimate-builder.tsx");
+  const pub = read("../../../qleno/src/pages/estimate-public.tsx");
+
+  it("schema + migration add flat_price_unit + scope_note", () => {
+    assert.match(schema, /flat_price_unit: text\("flat_price_unit"\)\.notNull\(\)\.default\("visit"\)/);
+    assert.match(schema, /scope_note: text\("scope_note"\)/);
+    assert.match(migration, /ADD COLUMN IF NOT EXISTS flat_price_unit TEXT NOT NULL DEFAULT 'visit'/);
+    assert.match(migration, /ADD COLUMN IF NOT EXISTS scope_note TEXT/);
+  });
+
+  it("route validates the unit and persists both on create + update", () => {
+    assert.match(route, /const PRICE_UNITS = new Set\(\["visit", "week", "month", "quarter", "year", "service", "total"\]\)/);
+    assert.match(route, /function priceUnitOf/);
+    assert.match(route, /flat_price, flat_price_unit, scope_note,/);    // INSERT columns
+    assert.match(route, /flat_price_unit = \$\{priceUnitOf\(b\.flat_price_unit\)\}/); // PATCH
+  });
+
+  it("editor has the unit selector + the scope paragraph, and sends both", () => {
+    assert.match(builder, /const PRICE_UNITS = \[/);
+    assert.match(builder, /const unitSuffix = \(u: string\) => \(u && u !== "total" \? ` \/ \$\{u\}` : ""\)/);
+    assert.match(builder, /const \[scopeNote, setScopeNote\]/);
+    assert.match(builder, /Scope description/);
+    assert.match(builder, /flat_price_unit: flatPriceUnit/);
+    assert.match(builder, /scope_note: billingMode === "flat" \? \(scopeNote\.trim\(\) \|\| null\) : null/);
+  });
+
+  it("client page shows the scope paragraph + the unit on the total", () => {
+    assert.match(pub, /est\.scope_note &&/);
+    assert.match(pub, /est\.flat_price_unit && est\.flat_price_unit !== "total" \? ` \/ \$\{est\.flat_price_unit\}` : ""/);
+  });
+});

--- a/artifacts/api-server/src/tests/estimate-pdf.test.ts
+++ b/artifacts/api-server/src/tests/estimate-pdf.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Estimate PDF: renderEstimatePdf produces a real PDF Buffer for both flat and
+ * itemized estimates; the route streams it; the builder has a PDF preview button.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { renderEstimatePdf } from "../lib/estimate-pdf.ts";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const read = (rel: string) => readFileSync(resolve(here, rel), "utf8");
+
+const base = {
+  companyName: "Phes", estimateNumber: "EST-1001", status: "draft",
+  title: "Office Cleaning", introNote: "Thanks for the opportunity.",
+  contactName: "Brenda Graham", propertyName: "616 S Maplewood", serviceAddress: "616 S Maplewood Ave, Chicago, IL 60612",
+  subtotal: 150, discount: 0, total: 150, terms: "Net-15.", validUntil: "2026-07-26",
+};
+
+describe("estimate PDF", () => {
+  it("renders a flat-price estimate to a valid PDF buffer", async () => {
+    const buf = await renderEstimatePdf({
+      ...base, billingMode: "flat", flatPriceUnit: "visit", scopeNote: "Full janitorial each visit.",
+      items: [{ name: "Restrooms", pricing_type: "flat", frequency: "Bi-weekly", quantity: 1, unit_rate: 0, amount: 0 }],
+    });
+    assert.ok(Buffer.isBuffer(buf) && buf.length > 800);
+    assert.equal(buf.subarray(0, 5).toString("latin1"), "%PDF-");
+  });
+
+  it("renders an itemized estimate to a valid PDF buffer", async () => {
+    const buf = await renderEstimatePdf({
+      ...base, billingMode: "itemized", flatPriceUnit: "visit", scopeNote: null,
+      items: [{ name: "Floors", pricing_type: "hourly", frequency: "Weekly", quantity: 1.5, unit_rate: 50, amount: 75 }],
+    });
+    assert.equal(buf.subarray(0, 5).toString("latin1"), "%PDF-");
+  });
+
+  it("route streams the PDF inline; builder has the preview button", () => {
+    const route = read("../routes/estimates.ts");
+    const builder = read("../../../qleno/src/pages/estimate-builder.tsx");
+    assert.match(route, /router\.get\("\/:id\/pdf"/);
+    assert.match(route, /setHeader\("Content-Type", "application\/pdf"\)/);
+    assert.match(route, /renderEstimatePdf\(/);
+    assert.match(builder, /async function downloadPdf/);
+    assert.match(builder, /PDF preview/);
+  });
+});

--- a/artifacts/qleno/src/pages/estimate-builder.tsx
+++ b/artifacts/qleno/src/pages/estimate-builder.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useRoute } from "wouter";
 import { getAuthHeaders } from "@/lib/auth";
 import { DashboardLayout } from "@/components/layout/dashboard-layout";
-import { Plus, Trash2, ArrowLeft, Save, Send, LayoutTemplate, GripVertical, Check } from "lucide-react";
+import { Plus, Trash2, ArrowLeft, Save, Send, LayoutTemplate, GripVertical, Check, FileText } from "lucide-react";
 import { toast } from "sonner";
 import { CalendarPopover } from "@/components/calendar-popover";
 import { useAddressAutocomplete } from "@/hooks/use-address-autocomplete";
@@ -295,6 +295,28 @@ export default function EstimateBuilderPage() {
     return `${window.location.origin}${API}/estimate/${token}`;
   }
 
+  // [estimate-pdf] Save (if needed) then fetch the branded PDF with auth and open
+  // it in a new tab — a preview of exactly what the client receives. Falls back
+  // to a download if a popup is blocked.
+  const [pdfBusy, setPdfBusy] = useState(false);
+  async function downloadPdf() {
+    const savedId = id || (await save());
+    if (!savedId) return;
+    setPdfBusy(true);
+    try {
+      const r = await fetch(`${API}/api/estimates/${savedId}/pdf`, { headers: { ...(getAuthHeaders() as Record<string, string>) } });
+      if (!r.ok) throw new Error(await r.text());
+      const url = URL.createObjectURL(await r.blob());
+      const w = window.open(url, "_blank");
+      if (!w) { const a = document.createElement("a"); a.href = url; a.download = `${estimateNumber || "estimate"}.pdf`; a.click(); }
+      setTimeout(() => URL.revokeObjectURL(url), 60000);
+    } catch {
+      toast.error("Couldn't generate the PDF");
+    } finally {
+      setPdfBusy(false);
+    }
+  }
+
   async function markSent() {
     const savedId = id || (await save());
     if (!savedId) return;
@@ -581,6 +603,7 @@ export default function EstimateBuilderPage() {
         <div style={{ display: "flex", gap: 10, width: "100%", maxWidth: 860 }}>
           <button onClick={saveAsTemplate} style={ghostBtn}><LayoutTemplate size={15} /> Save as template</button>
           <div style={{ flex: 1 }} />
+          <button onClick={downloadPdf} disabled={pdfBusy} style={ghostBtn}><FileText size={15} /> {pdfBusy ? "Preparing…" : "PDF preview"}</button>
           <button onClick={save} disabled={saving} style={ghostBtn}><Save size={15} /> {saving ? "Saving…" : "Save"}</button>
           <button onClick={markSent} style={primaryBtn}><Send size={15} /> {publicToken ? "Re-copy link" : "Send — get link"}</button>
         </div>

--- a/artifacts/qleno/src/pages/estimate-builder.tsx
+++ b/artifacts/qleno/src/pages/estimate-builder.tsx
@@ -28,6 +28,19 @@ async function apiFetch(path: string, opts: { method?: string; body?: any } = {}
 
 const money = (n: number) => `$${n.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
 
+// [estimate-flat-clarity] What the flat price is charged per + the label suffix
+// ("$150 / visit"). "total" = a one-time price, so no suffix.
+const PRICE_UNITS = [
+  { v: "visit", label: "per visit" },
+  { v: "week", label: "per week" },
+  { v: "month", label: "per month" },
+  { v: "quarter", label: "per quarter" },
+  { v: "year", label: "per year" },
+  { v: "service", label: "per service" },
+  { v: "total", label: "one-time (total)" },
+];
+const unitSuffix = (u: string) => (u && u !== "total" ? ` / ${u}` : "");
+
 type PricingType = "flat" | "hourly" | "one_time";
 interface Item {
   name: string;
@@ -99,6 +112,10 @@ export default function EstimateBuilderPage() {
   // the whole job + a scope checklist). Default itemized.
   const [billingMode, setBillingMode] = useState<"itemized" | "flat">("itemized");
   const [flatPrice, setFlatPrice] = useState("");
+  // [estimate-flat-clarity] What the flat price is per + an optional free-text
+  // scope paragraph (alternative to itemizing the checklist).
+  const [flatPriceUnit, setFlatPriceUnit] = useState("visit");
+  const [scopeNote, setScopeNote] = useState("");
 
   // [estimate-templates-phase2] One-click template picker (new estimates only).
   const [templates, setTemplates] = useState<any[]>([]);
@@ -136,6 +153,8 @@ export default function EstimateBuilderPage() {
           setDiscount(String(e.discount_amount ?? "0"));
           setBillingMode(e.billing_mode === "flat" ? "flat" : "itemized");
           setFlatPrice(e.flat_price != null && Number(e.flat_price) > 0 ? String(e.flat_price) : "");
+          setFlatPriceUnit(e.flat_price_unit || "visit");
+          setScopeNote(e.scope_note || "");
           setValidUntil(e.valid_until ? String(e.valid_until).slice(0, 10) : "");
           setItems((e.items || []).length ? e.items.map(mapRow) : [blankItem()]);
         } else {
@@ -182,6 +201,8 @@ export default function EstimateBuilderPage() {
     discount_amount: Number(discount) || 0,
     billing_mode: billingMode,
     flat_price: billingMode === "flat" ? (Number(flatPrice) || 0) : 0,
+    flat_price_unit: flatPriceUnit,
+    scope_note: billingMode === "flat" ? (scopeNote.trim() || null) : null,
     valid_until: validUntil || null,
     // Flat mode persists scope only (name + shared frequency, no price); itemized
     // keeps the full priced line. Empty scope rows are dropped either way.
@@ -468,13 +489,26 @@ export default function EstimateBuilderPage() {
             <>
               <div style={{ marginBottom: 14, padding: "12px 14px", border: `1px solid ${BORDER}`, borderRadius: 10, background: "#FCFCFB" }}>
                 <span style={{ display: "block", fontSize: 11, fontWeight: 700, color: MUTE, textTransform: "uppercase", letterSpacing: "0.04em", marginBottom: 5 }}>Service price</span>
-                <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                <div style={{ display: "flex", alignItems: "center", gap: 6, flexWrap: "wrap" }}>
                   <span style={{ color: MUTE, fontSize: 16 }}>$</span>
-                  <input style={{ ...inp, maxWidth: 200, fontWeight: 700, fontSize: 16 }} type="number" min="0" step="0.01" value={flatPrice} onChange={e => setFlatPrice(e.target.value)} placeholder="0.00" />
-                  <span style={{ fontSize: 12, color: MUTE }}>one price for the whole job — shown to the client as the total</span>
+                  <input style={{ ...inp, maxWidth: 150, fontWeight: 700, fontSize: 16 }} type="number" min="0" step="0.01" value={flatPrice} onChange={e => setFlatPrice(e.target.value)} placeholder="0.00" />
+                  <select style={{ ...inp, maxWidth: 170 }} value={flatPriceUnit} onChange={e => setFlatPriceUnit(e.target.value)} aria-label="Price unit">
+                    {PRICE_UNITS.map(u => <option key={u.v} value={u.v}>{u.label}</option>)}
+                  </select>
                 </div>
+                <span style={{ display: "block", fontSize: 12, color: MUTE, marginTop: 6 }}>
+                  {flatPriceUnit === "total"
+                    ? `Client sees ${money(Number(flatPrice) || 0)} as a one-time total.`
+                    : `Client sees ${money(Number(flatPrice) || 0)}${unitSuffix(flatPriceUnit)} — the price for each ${flatPriceUnit}.`}
+                </span>
               </div>
-              <span style={{ display: "block", fontSize: 11, fontWeight: 700, color: MUTE, textTransform: "uppercase", letterSpacing: "0.04em", marginBottom: 8 }}>What's included <span style={{ fontWeight: 400, textTransform: "none", letterSpacing: 0, color: "#9CA3AF" }}>— scope shown to the client, no per-line price</span></span>
+
+              {/* [estimate-flat-clarity] Optional scope paragraph — describe the
+                  work in prose instead of (or alongside) the checklist below. */}
+              <span style={{ display: "block", fontSize: 11, fontWeight: 700, color: MUTE, textTransform: "uppercase", letterSpacing: "0.04em", marginBottom: 8 }}>Scope description <span style={{ fontWeight: 400, textTransform: "none", letterSpacing: 0, color: "#9CA3AF" }}>— optional, shown to the client above the checklist</span></span>
+              <textarea style={{ ...inp, minHeight: 70, resize: "vertical", marginBottom: 14 }} value={scopeNote} onChange={e => setScopeNote(e.target.value)} placeholder="e.g. Full janitorial service for the suite — all offices, the break room, both restrooms, and common hallways, cleaned each visit. Supplies included." />
+
+              <span style={{ display: "block", fontSize: 11, fontWeight: 700, color: MUTE, textTransform: "uppercase", letterSpacing: "0.04em", marginBottom: 8 }}>What's included <span style={{ fontWeight: 400, textTransform: "none", letterSpacing: 0, color: "#9CA3AF" }}>— optional checklist, no per-line price</span></span>
               {items.map((it, i) => (
                 <div key={i} style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8 }}>
                   <span style={{ width: 20, height: 20, borderRadius: 6, background: MINT, color: "#fff", display: "inline-flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }}><Check size={13} /></span>
@@ -528,7 +562,7 @@ export default function EstimateBuilderPage() {
           </div>
           <div style={{ borderTop: `1px solid ${BORDER}`, marginTop: 8, paddingTop: 12, display: "flex", justifyContent: "space-between", alignItems: "center" }}>
             <span style={{ fontSize: 16, fontWeight: 800, color: INK }}>Total</span>
-            <span style={{ fontSize: 22, fontWeight: 800, color: INK }}>{money(total)}</span>
+            <span style={{ fontSize: 22, fontWeight: 800, color: INK }}>{money(total)}{billingMode === "flat" && <span style={{ fontSize: 14, fontWeight: 600, color: MUTE }}>{unitSuffix(flatPriceUnit)}</span>}</span>
           </div>
         </div>
 

--- a/artifacts/qleno/src/pages/estimate-public.tsx
+++ b/artifacts/qleno/src/pages/estimate-public.tsx
@@ -40,6 +40,9 @@ type PublicEstimate = {
   status: string;
   // [estimate-flat-mode] 'flat' → render scope list + single price; else itemized.
   billing_mode?: string | null;
+  // [estimate-flat-clarity] price unit ("/ visit") + optional scope paragraph.
+  flat_price_unit?: string | null;
+  scope_note?: string | null;
   subtotal: string;
   discount_amount: string;
   total: string;
@@ -268,8 +271,12 @@ export default function EstimatePublicPage() {
               // [estimate-flat-mode] One price + a scope checklist (no per-line
               // prices). The total is the single flat price the office set.
               if (est.billing_mode === "flat") {
+                const unitSuffix = est.flat_price_unit && est.flat_price_unit !== "total" ? ` / ${est.flat_price_unit}` : "";
                 return (
                   <>
+                    {est.scope_note && (
+                      <p style={{ fontSize: 14, color: "#374151", margin: "0 0 16px", lineHeight: 1.6, whiteSpace: "pre-wrap" }}>{est.scope_note}</p>
+                    )}
                     {est.items.length > 0 && (
                       <div style={{ border: `1px solid ${BORDER}`, borderRadius: 12, padding: "14px 16px", marginBottom: 18 }}>
                         <p style={{ fontSize: 11, fontWeight: 700, color: MUTE, textTransform: "uppercase", letterSpacing: "0.04em", margin: "0 0 10px" }}>What's included</p>
@@ -290,9 +297,9 @@ export default function EstimatePublicPage() {
                           <span>Discount</span><span>−{money(est.discount_amount)}</span>
                         </div>
                       )}
-                      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", borderTop: `2px solid ${INK}`, marginTop: 8, paddingTop: 10 }}>
+                      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", borderTop: `2px solid ${INK}`, marginTop: 8, paddingTop: 10 }}>
                         <span style={{ fontSize: 15, fontWeight: 800, color: INK }}>Total</span>
-                        <span style={{ fontSize: 26, fontWeight: 800, color: MINT, letterSpacing: "-0.01em" }}>{money(est.total)}</span>
+                        <span style={{ fontSize: 26, fontWeight: 800, color: MINT, letterSpacing: "-0.01em" }}>{money(est.total)}<span style={{ fontSize: 15, fontWeight: 700, color: MUTE }}>{unitSuffix}</span></span>
                       </div>
                     </div>
                   </>

--- a/lib/db/src/schema/estimates.ts
+++ b/lib/db/src/schema/estimates.ts
@@ -45,6 +45,11 @@ export const estimatesTable = pgTable("estimates", {
   //                (name + frequency, no per-line price) and total = flat_price.
   billing_mode: text("billing_mode").notNull().default("itemized"),
   flat_price: numeric("flat_price", { precision: 12, scale: 2 }).notNull().default("0"),
+  // [estimate-flat-clarity 2026-06-26] What the flat price is per (visit / week /
+  // month / …) so the client sees "$150 / visit", and an optional free-text scope
+  // paragraph for when the office would rather describe the work than itemize it.
+  flat_price_unit: text("flat_price_unit").notNull().default("visit"),
+  scope_note: text("scope_note"),
   subtotal: numeric("subtotal", { precision: 12, scale: 2 }).notNull().default("0"),
   discount_amount: numeric("discount_amount", { precision: 12, scale: 2 }).notNull().default("0"),
   total: numeric("total", { precision: 12, scale: 2 }).notNull().default("0"),


### PR DESCRIPTION
Adds a **PDF preview** button to the estimate builder — there was no way to preview/generate a PDF of what's being sent.

- **lib/estimate-pdf.ts:** pdfkit renderer (no Chromium on Railway, mirrors the existing PDF libs). Brand header, prepared-for, title + intro, then either the flat scope paragraph + 'what's included' checklist with the **$150 / visit** total, or the itemized table + subtotal/discount/total, plus terms.
- **GET /api/estimates/:id/pdf** (auth, company-scoped) streams it inline.
- **Builder:** 'PDF preview' saves first if needed, fetches with auth, opens the PDF in a new tab (falls back to download if popups are blocked).

estimate-pdf guard 3/3 (renders real %PDF buffers, flat + itemized) · esbuild bundles pdfkit OK · frontend typecheck zero new errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)