### PR TITLE
fix(estimates): PDF previews current edits + shows the company logo

### DIFF
--- a/artifacts/api-server/src/lib/estimate-pdf.ts
+++ b/artifacts/api-server/src/lib/estimate-pdf.ts
@@ -21,6 +21,7 @@ export interface EstimatePdfItem {
 
 export interface EstimatePdfData {
   companyName: string;
+  logo?: Buffer | null;
   estimateNumber: string | null;
   status: string;
   title: string | null;
@@ -61,14 +62,25 @@ export function renderEstimatePdf(data: EstimatePdfData): Promise<Buffer> {
     const width = right - left;
     const isFlat = data.billingMode === "flat";
 
-    // Header band
+    // Header band — logo on a white chip (or the company name as a fallback) on
+    // the left; ESTIMATE / number / status on the right.
     doc.rect(0, 0, doc.page.width, 84).fill(NAVY);
-    doc.fillColor("#FFFFFF").fontSize(20).font("Helvetica-Bold").text(data.companyName, left, 26, { width: width - 160 });
-    doc.fontSize(10).font("Helvetica").fillColor("#9CA3AF").text("ESTIMATE", left, 54);
-    doc.fillColor("#FFFFFF").fontSize(13).font("Helvetica-Bold")
-      .text(data.estimateNumber || "", right - 160, 30, { width: 160, align: "right" });
-    doc.fontSize(9).font("Helvetica").fillColor("#9CA3AF")
-      .text(String(data.status || "").toUpperCase(), right - 160, 50, { width: 160, align: "right" });
+    let drewLogo = false;
+    if (data.logo) {
+      try {
+        doc.roundedRect(left, 22, 156, 40, 6).fill("#FFFFFF");
+        doc.image(data.logo, left + 10, 27, { fit: [136, 30] });
+        drewLogo = true;
+      } catch { drewLogo = false; }
+    }
+    if (!drewLogo) {
+      doc.fillColor("#FFFFFF").fontSize(20).font("Helvetica-Bold").text(data.companyName, left, 32, { width: width - 190 });
+    }
+    doc.fillColor("#9CA3AF").fontSize(9).font("Helvetica").text("ESTIMATE", right - 190, 24, { width: 190, align: "right" });
+    doc.fillColor("#FFFFFF").fontSize(14).font("Helvetica-Bold")
+      .text(data.estimateNumber || "", right - 190, 38, { width: 190, align: "right" });
+    doc.fillColor("#9CA3AF").fontSize(9).font("Helvetica")
+      .text(String(data.status || "").toUpperCase(), right - 190, 57, { width: 190, align: "right" });
 
     let y = 108;
 

--- a/artifacts/api-server/src/routes/estimates.ts
+++ b/artifacts/api-server/src/routes/estimates.ts
@@ -6,6 +6,22 @@ import { requireAuth } from "../lib/auth.js";
 import { enrollForEstimateSent, stopEnrollmentsForEstimate, fireEstimateDay0 } from "../services/followUpService.js";
 import { recordEngagementEvent } from "../lib/engagement.js";
 import { renderEstimatePdf } from "../lib/estimate-pdf.js";
+import { appBaseUrl } from "../lib/app-url.js";
+
+// Fetch a company logo for embedding in the PDF. pdfkit only supports PNG/JPEG,
+// so anything else (or a fetch failure) falls back to the company name text.
+async function fetchLogoBuffer(logoUrl: string | null | undefined): Promise<Buffer | null> {
+  if (!logoUrl) return null;
+  try {
+    const abs = /^https?:\/\//i.test(logoUrl) ? logoUrl : `${appBaseUrl()}${logoUrl}`;
+    const r = await fetch(abs);
+    if (!r.ok) return null;
+    if (!/image\/(png|jpe?g)/i.test(r.headers.get("content-type") || "")) return null;
+    return Buffer.from(await r.arrayBuffer());
+  } catch {
+    return null;
+  }
+}
 
 // [commercial-estimate-tool 2026-06-09] Commercial / common-area estimates.
 // Raw SQL (db.execute) on purpose: the estimate tables are brand-new and the
@@ -671,7 +687,7 @@ router.get("/:id/pdf", requireAuth, async (req, res) => {
     const companyId = req.auth!.companyId;
     const id = parseInt(req.params.id, 10);
     const e = await db.execute(sql`
-      SELECT e.*, c.name AS company_name
+      SELECT e.*, c.name AS company_name, c.logo_url AS company_logo
       FROM estimates e JOIN companies c ON c.id = e.company_id
       WHERE e.id = ${id} AND e.company_id = ${companyId} LIMIT 1
     `);
@@ -681,8 +697,9 @@ router.get("/:id/pdf", requireAuth, async (req, res) => {
       SELECT name, pricing_type, frequency, quantity, unit_rate, amount
       FROM estimate_line_items WHERE estimate_id = ${id} AND company_id = ${companyId} ORDER BY sort_order
     `);
+    const logo = await fetchLogoBuffer(est.company_logo);
     const pdf = await renderEstimatePdf({
-      companyName: est.company_name || "Estimate",
+      companyName: est.company_name || "Estimate", logo,
       estimateNumber: est.estimate_number, status: est.status,
       title: est.title, introNote: est.intro_note,
       contactName: est.contact_name, propertyName: est.property_name, serviceAddress: est.service_address,

--- a/artifacts/api-server/src/tests/estimate-pdf.test.ts
+++ b/artifacts/api-server/src/tests/estimate-pdf.test.ts
@@ -37,13 +37,27 @@ describe("estimate PDF", () => {
     assert.equal(buf.subarray(0, 5).toString("latin1"), "%PDF-");
   });
 
-  it("route streams the PDF inline; builder has the preview button", () => {
+  it("embeds a company logo when one is provided", async () => {
+    // 1x1 transparent PNG.
+    const png = Buffer.from("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==", "base64");
+    const buf = await renderEstimatePdf({
+      ...base, logo: png, billingMode: "flat", flatPriceUnit: "month", scopeNote: null,
+      items: [{ name: "Restrooms", pricing_type: "flat", frequency: "Semi-monthly", quantity: 1, unit_rate: 0, amount: 0 }],
+    });
+    assert.equal(buf.subarray(0, 5).toString("latin1"), "%PDF-");
+  });
+
+  it("route fetches the logo + streams inline; builder previews after saving", () => {
     const route = read("../routes/estimates.ts");
     const builder = read("../../../qleno/src/pages/estimate-builder.tsx");
     assert.match(route, /router\.get\("\/:id\/pdf"/);
     assert.match(route, /setHeader\("Content-Type", "application\/pdf"\)/);
-    assert.match(route, /renderEstimatePdf\(/);
-    assert.match(builder, /async function downloadPdf/);
+    assert.match(route, /c\.logo_url AS company_logo/);
+    assert.match(route, /const logo = await fetchLogoBuffer\(est\.company_logo\)/);
+    assert.match(route, /renderEstimatePdf\(\{\s*companyName: est\.company_name \|\| "Estimate", logo,/);
+    // PDF + Send must persist current edits first (no stale preview/send).
+    assert.match(builder, /async function downloadPdf\(\) \{[\s\S]*?const savedId = await save\(\);/);
+    assert.match(builder, /async function markSent\(\) \{[\s\S]*?const savedId = await save\(\);/);
     assert.match(builder, /PDF preview/);
   });
 });

--- a/artifacts/qleno/src/pages/estimate-builder.tsx
+++ b/artifacts/qleno/src/pages/estimate-builder.tsx
@@ -300,7 +300,9 @@ export default function EstimateBuilderPage() {
   // to a download if a popup is blocked.
   const [pdfBusy, setPdfBusy] = useState(false);
   async function downloadPdf() {
-    const savedId = id || (await save());
+    // Always persist current edits first — the PDF is rendered server-side from
+    // the saved row, so a stale save would preview the wrong content.
+    const savedId = await save();
     if (!savedId) return;
     setPdfBusy(true);
     try {
@@ -318,7 +320,8 @@ export default function EstimateBuilderPage() {
   }
 
   async function markSent() {
-    const savedId = id || (await save());
+    // Persist current edits before sending so the client gets what's on screen.
+    const savedId = await save();
     if (!savedId) return;
     try {
       const r = await apiFetch(`/api/estimates/${savedId}/send`, { method: "POST" });


### PR DESCRIPTION
Two issues from the PDF preview review:

- **Stale content** — 'PDF preview' (and 'Send — get link') only saved first when the estimate was *new*, so an existing estimate previewed/sent the last **saved** row; unsaved edits (switching to Flat price, changing the amount) were dropped. Both now always save current state first.
- **No logo** — the header printed the company name as text. It now embeds the tenant logo (`companies.logo_url`) on a white chip, fetched server-side (PNG/JPEG; falls back to the name on any failure).

estimate-pdf guard 4/4 (renders real %PDF with + without a logo) · esbuild OK · frontend typecheck zero new errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)