### PR TITLE
fix(estimates): hosted estimate shows real branch/company contact, not hardcoded Schaumburg

### DIFF
--- a/artifacts/api-server/src/routes/estimates.ts
+++ b/artifacts/api-server/src/routes/estimates.ts
@@ -432,8 +432,12 @@ router.get("/public/:token", async (req, res) => {
     const token = String(req.params.token || "").trim();
     if (!token) return res.status(404).json({ error: "Not Found" });
     const rows = await db.execute(sql`
-      SELECT e.*, c.name AS company_name, c.logo_url AS company_logo, c.brand_color AS company_brand_color
-      FROM estimates e JOIN companies c ON c.id = e.company_id
+      SELECT e.*, c.name AS company_name, c.logo_url AS company_logo, c.brand_color AS company_brand_color,
+             c.phone AS company_phone, c.email AS company_email,
+             bz.name AS branch_name, bz.phone AS branch_phone
+      FROM estimates e
+      JOIN companies c ON c.id = e.company_id
+      LEFT JOIN branches bz ON bz.id = e.branch_id
       WHERE e.public_token = ${token} AND e.status <> 'draft'
       LIMIT 1
     `);
@@ -447,7 +451,8 @@ router.get("/public/:token", async (req, res) => {
         SELECT q.id, q.lead_name, q.address, q.service_type, q.total_price, q.base_price,
                q.addons, q.status, q.created_at, q.sent_at,
                q.frequency, q.frequency_options, q.selected_frequency,
-               c.name AS company_name, c.logo_url AS company_logo, c.brand_color AS company_brand_color
+               c.name AS company_name, c.logo_url AS company_logo, c.brand_color AS company_brand_color,
+               c.phone AS company_phone, c.email AS company_email
         FROM quotes q JOIN companies c ON c.id = q.company_id
         WHERE q.sign_token = ${token} LIMIT 1
       `);
@@ -489,6 +494,8 @@ router.get("/public/:token", async (req, res) => {
         company_name: qt.company_name,
         company_logo: qt.company_logo,
         company_brand_color: qt.company_brand_color,
+        company_phone: qt.company_phone,
+        company_email: qt.company_email,
         items,
         is_quote: true,
         // [multi-frequency] additive — the comparison tiers (empty array when the

--- a/artifacts/api-server/src/tests/estimate-public-contact.test.ts
+++ b/artifacts/api-server/src/tests/estimate-public-contact.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Hosted estimate contact: branch phone (when set) else company phone + company
+ * email — never the old hardcoded Schaumburg fallback. Source-assertion guard.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+const here = dirname(fileURLToPath(import.meta.url));
+const read = (rel: string) => readFileSync(resolve(here, rel), "utf8");
+
+describe("hosted estimate contact (branch-aware, not hardcoded)", () => {
+  const route = read("../routes/estimates.ts");
+  const pub = read("../../../qleno/src/pages/estimate-public.tsx");
+
+  it("public route returns company + branch contact", () => {
+    assert.match(route, /c\.phone AS company_phone, c\.email AS company_email/);
+    assert.match(route, /LEFT JOIN branches bz ON bz\.id = e\.branch_id/);
+    assert.match(route, /bz\.name AS branch_name, bz\.phone AS branch_phone/);
+  });
+  it("page uses branch→company contact and drops the Schaumburg hardcode", () => {
+    assert.match(pub, /est\.branch_phone \|\| est\.company_phone \|\| null/);
+    assert.match(pub, /est\.company_email \|\| null/);
+    assert.doesNotMatch(pub, /847.*538.*3729/);
+    assert.doesNotMatch(pub, /schaumburg@phes\.io/);
+  });
+});

--- a/artifacts/qleno/src/pages/estimate-public.tsx
+++ b/artifacts/qleno/src/pages/estimate-public.tsx
@@ -14,12 +14,9 @@ const MINT = "#00C9A0";
 const SUBLINE = "#9DA3B0";
 // Real Phes logo asset (public/). Used when the tenant has no logo_url of its own.
 const PHES_LOGO = `${API}/phes-logo.jpeg`;
-// Branch contact — fallback only. The public payload carries no per-tenant
-// phone/email yet, so these hardcoded Phes Schaumburg values render until that
-// field is exposed (tracked for a later backend pass).
-const FALLBACK_PHONE = "(847) 538-3729";
-const FALLBACK_PHONE_TEL = "+18475383729";
-const FALLBACK_EMAIL = "schaumburg@phes.io";
+// Contact comes from the estimate's branch (when set) or the company — never
+// hardcode a branch. tel: link is the digits with a US +1 prefix.
+const telOf = (phone: string) => `+1${phone.replace(/\D/g, "").replace(/^1/, "")}`;
 
 type Item = {
   name: string | null;
@@ -57,6 +54,10 @@ type PublicEstimate = {
   company_name: string;
   company_logo: string | null;
   company_brand_color: string | null;
+  company_phone?: string | null;
+  company_email?: string | null;
+  branch_name?: string | null;
+  branch_phone?: string | null;
   items: Item[];
   // Phes doc-type model: residential = QUOTE, commercial = ESTIMATE. The public
   // endpoint sets is_quote=true when the token resolved a quote (not an estimate)
@@ -411,13 +412,20 @@ export default function EstimatePublicPage() {
           </button>
         </div>
 
-        {/* Contact block */}
-        <div style={{ textAlign: "center", marginTop: 22, fontSize: 13, color: MUTE, lineHeight: 1.6 }}>
-          Questions? Call or text{" "}
-          <a href={`tel:${FALLBACK_PHONE_TEL}`} style={{ color: INK, fontWeight: 700, textDecoration: "none" }}>{FALLBACK_PHONE}</a>
-          {" · "}
-          <a href={`mailto:${FALLBACK_EMAIL}`} style={{ color: INK, fontWeight: 700, textDecoration: "none" }}>{FALLBACK_EMAIL}</a>
-        </div>
+        {/* Contact block — branch contact when set, else company; never hardcoded. */}
+        {(() => {
+          const phone = est.branch_phone || est.company_phone || null;
+          const email = est.company_email || null;
+          if (!phone && !email) return null;
+          return (
+            <div style={{ textAlign: "center", marginTop: 22, fontSize: 13, color: MUTE, lineHeight: 1.6 }}>
+              Questions? Call or text{" "}
+              {phone && <a href={`tel:${telOf(phone)}`} style={{ color: INK, fontWeight: 700, textDecoration: "none" }}>{phone}</a>}
+              {phone && email && " · "}
+              {email && <a href={`mailto:${email}`} style={{ color: INK, fontWeight: 700, textDecoration: "none" }}>{email}</a>}
+            </div>
+          );
+        })()}
 
         {/* Footer — Powered by Qleno (the only Qleno mention) */}
         <div style={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 7, marginTop: 18, paddingTop: 16, borderTop: `1px solid ${BORDER}` }}>


### PR DESCRIPTION
The hosted estimate footer hardcoded **(847) 538-3729 · schaumburg@phes.io** on every estimate regardless of branch — violating the never-hardcode-a-branch rule.

- Public route returns company phone/email + the estimate's branch name/phone (LEFT JOIN branches); same for the quote-fallback path.
- Page uses **branch phone when set, else company phone**, plus company email; renders nothing if neither exists. Schaumburg hardcode removed.

For Phes this now shows **(773) 706-6000 · info@phes.io** instead of Schaumburg.

contact guard 2/2 · frontend typecheck zero new errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)