### PR TITLE
feat(estimates): native follow-up drip editor (replaces GoHighLevel tab)

### DIFF
--- a/artifacts/api-server/src/routes/estimates.ts
+++ b/artifacts/api-server/src/routes/estimates.ts
@@ -281,6 +281,74 @@ router.delete("/templates/:id", requireAuth, async (req, res) => {
   }
 });
 
+// ─── Native estimate follow-up drip editor (replaces the GoHighLevel bridge) ──
+// Read + edit the company's estimate_followup sequence and its steps in-app; the
+// existing engine (followUpService.processEnrollment) sends straight from these.
+// Registered before /:id so the literal path wins over the :id param.
+router.get("/follow-up", requireAuth, async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    const seqRows = await db.execute(sql`
+      SELECT id, name, is_active FROM follow_up_sequences
+      WHERE company_id = ${companyId} AND sequence_type = 'estimate_followup'
+      ORDER BY id LIMIT 1
+    `);
+    const seq = (seqRows as any).rows[0] ?? null;
+    if (!seq) return res.json({ sequence: null, steps: [] });
+    const steps = await db.execute(sql`
+      SELECT step_number, channel, delay_hours, subject, message_template
+      FROM follow_up_steps WHERE sequence_id = ${seq.id} ORDER BY step_number
+    `);
+    return res.json({ sequence: seq, steps: (steps as any).rows });
+  } catch (err) {
+    console.error("Get estimate follow-up error:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
+router.put("/follow-up", requireAuth, async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    const b = req.body ?? {};
+    const isActive = b.is_active === true;
+    // Normalize incoming steps; order in the array = send order.
+    const steps = (Array.isArray(b.steps) ? b.steps : []).map((s: any, i: number) => ({
+      step_number: i + 1,
+      channel: String(s?.channel) === "sms" ? "sms" : "email",
+      delay_hours: Math.max(0, Math.round(Number(s?.delay_hours ?? 0)) || 0),
+      subject: str(s?.subject, 300),
+      message_template: str(s?.message_template, 4000),
+    })).filter((s: any) => s.message_template);
+
+    // Find or create the company's estimate sequence.
+    const existing = await db.execute(sql`
+      SELECT id FROM follow_up_sequences WHERE company_id = ${companyId} AND sequence_type = 'estimate_followup' ORDER BY id LIMIT 1
+    `);
+    let seqId = (existing as any).rows[0]?.id as number | undefined;
+    if (!seqId) {
+      const ins = await db.execute(sql`
+        INSERT INTO follow_up_sequences (company_id, sequence_type, name, is_active)
+        VALUES (${companyId}, 'estimate_followup', 'Estimate Follow-Up', ${isActive}) RETURNING id
+      `);
+      seqId = (ins as any).rows[0].id;
+    } else {
+      await db.execute(sql`UPDATE follow_up_sequences SET is_active = ${isActive} WHERE id = ${seqId} AND company_id = ${companyId}`);
+    }
+    // Replace steps wholesale.
+    await db.execute(sql`DELETE FROM follow_up_steps WHERE sequence_id = ${seqId}`);
+    for (const s of steps) {
+      await db.execute(sql`
+        INSERT INTO follow_up_steps (sequence_id, step_number, delay_hours, channel, subject, message_template)
+        VALUES (${seqId}, ${s.step_number}, ${s.delay_hours}, ${s.channel}, ${s.subject}, ${s.message_template})
+      `);
+    }
+    return res.json({ ok: true, sequence_id: seqId, steps: steps.length, is_active: isActive });
+  } catch (err) {
+    console.error("Save estimate follow-up error:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
 // ─── Engagement dashboard (Phase 5) ─────────────────────────────────────────
 // Read models over engagement_events + follow_up_enrollments + estimates. All
 // company-scoped. Registered before /:id (distinct 2-segment paths, no clash).

--- a/artifacts/api-server/src/tests/estimate-followup-editor.test.ts
+++ b/artifacts/api-server/src/tests/estimate-followup-editor.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Native estimate follow-up drip editor: GET/PUT the company's estimate_followup
+ * sequence + steps; the GoHighLevel tab is replaced by an in-app editor.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+const here = dirname(fileURLToPath(import.meta.url));
+const read = (rel: string) => readFileSync(resolve(here, rel), "utf8");
+
+describe("native follow-up drip editor", () => {
+  const route = read("../routes/estimates.ts");
+  const editor = read("../../../qleno/src/pages/estimates-followup-editor.tsx");
+  const page = read("../../../qleno/src/pages/estimates.tsx");
+
+  it("GET + PUT operate on the estimate_followup sequence, before /:id", () => {
+    assert.match(route, /router\.get\("\/follow-up"/);
+    assert.match(route, /router\.put\("\/follow-up"/);
+    assert.match(route, /sequence_type = 'estimate_followup'/);
+    // /follow-up must be declared before the catch-all GET /:id
+    assert.ok(route.indexOf('router.get("/follow-up"') < route.indexOf('router.get("/:id"'));
+    assert.match(route, /INSERT INTO follow_up_steps \(sequence_id, step_number, delay_hours, channel, subject, message_template\)/);
+  });
+  it("editor is master-detail with cadence presets + a default sequence", () => {
+    assert.match(editor, /export function FollowUpEditor/);
+    assert.match(editor, /const PRESETS: Record<string, number> = \{ standard: 1, aggressive: 0\.5, gentle: 2 \}/);
+    assert.match(editor, /const DEFAULT_STEPS: Step\[\]/);
+    assert.match(editor, /\/api\/estimates\/follow-up/);
+    assert.match(editor, /after the previous touch/);
+  });
+  it("estimates page swaps GoHighLevel for the Follow-up tab", () => {
+    assert.match(page, /\["followup", "Follow-up"\]/);
+    assert.match(page, /<FollowUpEditor \/>/);
+    assert.doesNotMatch(page, /GoHighLevel follow-up bridge/);
+  });
+});

--- a/artifacts/qleno/src/pages/estimates-followup-editor.tsx
+++ b/artifacts/qleno/src/pages/estimates-followup-editor.tsx
@@ -1,0 +1,266 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { getAuthHeaders } from "@/lib/auth";
+import { Mail, MessageSquare, Plus, Trash2, ChevronUp, ChevronDown } from "lucide-react";
+import { toast } from "sonner";
+
+const FF = "'Plus Jakarta Sans', sans-serif";
+const API = import.meta.env.BASE_URL.replace(/\/$/, "");
+const INK = "#1A1917", MUTE = "#6B7280", BORDER = "#E5E2DC", MINT = "#00C9A0";
+const BLUE = "#185FA5", TEAL = "#0F6E56", TEAL_BG = "#E1F5EE";
+
+async function apiFetch(path: string, opts: { method?: string; body?: any } = {}) {
+  const { body, ...rest } = opts;
+  const r = await fetch(`${API}${path}`, {
+    headers: { ...(getAuthHeaders() as Record<string, string>), "Content-Type": "application/json" },
+    ...rest, ...(body !== undefined && { body: JSON.stringify(body) }),
+  });
+  if (!r.ok) throw new Error(await r.text());
+  return r.json();
+}
+
+type Step = { channel: "email" | "sms"; delay_hours: number; subject: string | null; message_template: string };
+
+const VARS = ["first_name", "company_name", "company_phone", "property", "monthly", "estimate_link", "estimate_number"];
+const SAMPLE: Record<string, string> = {
+  first_name: "Brenda", company_name: "Phes", company_phone: "(773) 706-6000", property: "616 S Maplewood",
+  monthly: "$300.00 / month", estimate_link: "app.qleno.com/estimate/…", estimate_number: "EST-1001",
+};
+const fillVars = (s: string) => (s || "").replace(/\{\{(\w+)\}\}/g, (_, k) => SAMPLE[k] ?? `{{${k}}}`);
+
+// Canonical gaps (hours from the previous touch) for the cadence presets.
+const BASE_DELAYS = [0, 2, 48, 48, 72, 72, 72, 72];
+const PRESETS: Record<string, number> = { standard: 1, aggressive: 0.5, gentle: 2 };
+const presetDelays = (factor: number) => BASE_DELAYS.map((h, i) => (i === 0 ? 0 : Math.max(1, Math.round(h * factor))));
+
+const DEFAULT_STEPS: Step[] = [
+  { channel: "email", delay_hours: 0, subject: "Your cleaning estimate for {{property}}",
+    message_template: "Hi {{first_name}},\n\nThank you for the opportunity to quote cleaning for {{property}}. Your estimate is ready: {{monthly}}.\n\nView the full details and approve it here:\n{{estimate_link}}\n\nHappy to walk through anything or adjust the scope — just reply or call {{company_phone}}.\n\n— {{company_name}}" },
+  { channel: "sms", delay_hours: 2, subject: null,
+    message_template: "Hi {{first_name}}, it's {{company_name}} — just emailed your cleaning estimate for {{property}} ({{monthly}}). Here's the link: {{estimate_link}}. Any questions, just reply." },
+  { channel: "email", delay_hours: 48, subject: "Did you get your estimate?",
+    message_template: "Hi {{first_name}},\n\nJust making sure the cleaning estimate for {{property}} reached you. Review and approve it here:\n{{estimate_link}}\n\nIf anything needs adjusting — frequency, scope, budget — tell me and I'll revise it the same day.\n\n— {{company_name}}" },
+  { channel: "sms", delay_hours: 48, subject: null,
+    message_template: "Hi {{first_name}}, {{company_name}} checking in on your estimate for {{property}} — still happy to answer any questions. Here it is again: {{estimate_link}}" },
+  { channel: "email", delay_hours: 72, subject: "Why {{company_name}}",
+    message_template: "Hi {{first_name}},\n\nA quick note on what you get with {{company_name}}: fully insured, background-checked crews, a consistent team that learns your building, and one point of contact for anything.\n\nYour estimate for {{property}} is still ready here:\n{{estimate_link}}\n\n— {{company_name}}" },
+  { channel: "sms", delay_hours: 72, subject: null,
+    message_template: "Hi {{first_name}}, ready to get {{property}} on the schedule? We can usually start within a week. Reply YES and we'll hold a spot. {{estimate_link}}" },
+  { channel: "email", delay_hours: 72, subject: "Holding a spot for {{property}}",
+    message_template: "Hi {{first_name}},\n\nWe have a few openings coming up and I'd love to hold one for {{property}}. Approve your estimate and we'll lock in your start date:\n{{estimate_link}}\n\n— {{company_name}}" },
+  { channel: "email", delay_hours: 72, subject: "Closing the loop on your estimate",
+    message_template: "Hi {{first_name}},\n\nI don't want to crowd your inbox, so this is my last note for now. If the timing isn't right, no problem — your estimate for {{property}} stays here whenever you're ready:\n{{estimate_link}}\n\nThanks for considering {{company_name}}." },
+];
+
+const lbl: React.CSSProperties = { display: "block", fontSize: 10, fontWeight: 700, color: "#9CA3AF", letterSpacing: "0.06em", marginBottom: 6 };
+const inp: React.CSSProperties = { width: "100%", padding: "8px 11px", border: `1px solid ${BORDER}`, borderRadius: 8, fontSize: 13, fontFamily: FF, background: "#fff", boxSizing: "border-box", color: INK };
+
+export function FollowUpEditor() {
+  const qc = useQueryClient();
+  const { data, isLoading } = useQuery({ queryKey: ["estimate-followup"], queryFn: () => apiFetch("/api/estimates/follow-up") });
+
+  const [steps, setSteps] = useState<Step[]>([]);
+  const [active, setActive] = useState(false);
+  const [sel, setSel] = useState(0);
+  const [loaded, setLoaded] = useState(false);
+  const msgRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (data && !loaded) {
+      const s: Step[] = (data.steps || []).map((r: any) => ({
+        channel: r.channel === "sms" ? "sms" : "email", delay_hours: Number(r.delay_hours) || 0,
+        subject: r.subject ?? null, message_template: r.message_template || "",
+      }));
+      setSteps(s); setActive(!!data.sequence?.is_active); setLoaded(true);
+    }
+  }, [data, loaded]);
+
+  // Cumulative day each touch lands on (delay = hours from the previous touch).
+  const days = useMemo(() => {
+    let h = 0; return steps.map((s, i) => { h += i === 0 ? 0 : s.delay_hours; return Math.floor(h / 24); });
+  }, [steps]);
+  const totalDays = days.length ? days[days.length - 1] : 0;
+
+  const activePreset = useMemo(() => {
+    for (const [name, f] of Object.entries(PRESETS)) {
+      const d = presetDelays(f);
+      if (steps.length === d.length && steps.every((s, i) => s.delay_hours === d[i])) return name;
+    }
+    return "custom";
+  }, [steps]);
+
+  const cur = steps[sel];
+  const patch = (p: Partial<Step>) => setSteps(ss => ss.map((s, i) => (i === sel ? { ...s, ...p } : s)));
+  const applyPreset = (name: string) => {
+    const f = PRESETS[name]; if (!f) return;
+    const d = presetDelays(f);
+    setSteps(ss => ss.map((s, i) => ({ ...s, delay_hours: i < d.length ? d[i] : s.delay_hours })));
+  };
+  const move = (dir: -1 | 1) => {
+    const j = sel + dir; if (j < 0 || j >= steps.length) return;
+    setSteps(ss => { const n = [...ss]; [n[sel], n[j]] = [n[j], n[sel]]; return n; });
+    setSel(j);
+  };
+  const addTouch = () => { setSteps(ss => [...ss, { channel: "email", delay_hours: 72, subject: "", message_template: "" }]); setSel(steps.length); };
+  const removeTouch = (i: number) => { setSteps(ss => ss.filter((_, idx) => idx !== i)); setSel(s => Math.max(0, s > i ? s - 1 : s)); };
+  const insertVar = (v: string) => {
+    const el = msgRef.current; const token = `{{${v}}}`;
+    if (!el) { patch({ message_template: (cur?.message_template || "") + token }); return; }
+    const start = el.selectionStart ?? el.value.length, end = el.selectionEnd ?? el.value.length;
+    const next = el.value.slice(0, start) + token + el.value.slice(end);
+    patch({ message_template: next });
+    requestAnimationFrame(() => { el.focus(); el.selectionStart = el.selectionEnd = start + token.length; });
+  };
+
+  const save = useMutation({
+    mutationFn: () => apiFetch("/api/estimates/follow-up", { method: "PUT", body: { is_active: active, steps } }),
+    onSuccess: () => { qc.invalidateQueries({ queryKey: ["estimate-followup"] }); toast.success("Follow-up sequence saved"); },
+    onError: () => toast.error("Couldn't save the sequence"),
+  });
+
+  if (isLoading) return <div style={{ padding: 40, textAlign: "center", color: MUTE, fontFamily: FF }}>Loading…</div>;
+
+  if (!steps.length) {
+    return (
+      <div style={{ background: "#fff", border: `1px solid ${BORDER}`, borderRadius: 12, padding: "40px 24px", textAlign: "center", fontFamily: FF }}>
+        <p style={{ fontSize: 16, fontWeight: 700, color: INK, margin: "0 0 6px" }}>No follow-up sequence yet</p>
+        <p style={{ fontSize: 13, color: MUTE, margin: "0 0 18px", lineHeight: 1.6, maxWidth: 460, marginInline: "auto" }}>
+          Load a proven 8-touch cadence (email + SMS over ~16 days) that sends automatically after you send an estimate and stops the moment the client accepts or declines. Edit anything afterward.
+        </p>
+        <button onClick={() => { setSteps(DEFAULT_STEPS.map(s => ({ ...s }))); setActive(true); setSel(0); }}
+          style={{ background: INK, color: "#fff", border: "none", borderRadius: 9, padding: "10px 18px", fontSize: 13, fontWeight: 700, cursor: "pointer", fontFamily: FF }}>
+          Load the recommended sequence
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ fontFamily: FF }}>
+      {/* Header: title + active toggle + cadence preset + save */}
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 12, flexWrap: "wrap", marginBottom: 6 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+          <span style={{ fontSize: 16, fontWeight: 800, color: INK }}>Estimate follow-up</span>
+          <button onClick={() => setActive(a => !a)} title="Toggle active" style={{ display: "inline-flex", alignItems: "center", gap: 6, background: "none", border: "none", cursor: "pointer", fontFamily: FF, fontSize: 12, color: MUTE }}>
+            {active ? "Active" : "Paused"}
+            <span style={{ width: 34, height: 19, borderRadius: 20, background: active ? MINT : "#D3D1C7", position: "relative", display: "inline-block", transition: "background .15s" }}>
+              <span style={{ position: "absolute", top: 2, left: active ? 17 : 2, width: 15, height: 15, borderRadius: "50%", background: "#fff", transition: "left .15s" }} />
+            </span>
+          </button>
+        </div>
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <span style={{ fontSize: 12, color: "#9CA3AF" }}>Cadence</span>
+          <select value={activePreset} onChange={e => e.target.value !== "custom" && applyPreset(e.target.value)} style={{ ...inp, width: "auto", fontWeight: 600 }}>
+            <option value="standard">Standard · 16 days</option>
+            <option value="aggressive">Aggressive · ~8 days</option>
+            <option value="gentle">Gentle · ~32 days</option>
+            <option value="custom" disabled>Custom</option>
+          </select>
+          <button onClick={() => save.mutate()} disabled={save.isPending} style={{ background: INK, color: "#fff", border: "none", borderRadius: 8, padding: "8px 16px", fontSize: 13, fontWeight: 700, cursor: "pointer", fontFamily: FF }}>
+            {save.isPending ? "Saving…" : "Save"}
+          </button>
+        </div>
+      </div>
+      <p style={{ fontSize: 12, color: MUTE, margin: "0 0 16px" }}>Sent automatically after an estimate goes out · stops on accept or decline · all in Qleno{!active && " · currently paused"}</p>
+
+      <div style={{ display: "flex", gap: 14, alignItems: "flex-start", flexWrap: "wrap" }}>
+        {/* Left: touch list */}
+        <div style={{ width: 210, flexShrink: 0, border: `1px solid ${BORDER}`, borderRadius: 12, overflow: "hidden", background: "#fff" }}>
+          <div style={{ padding: "8px 11px", borderBottom: `1px solid #EEECE7`, fontSize: 10, fontWeight: 700, letterSpacing: "0.05em", color: "#9CA3AF" }}>
+            {steps.length} TOUCHES · {totalDays} DAYS
+          </div>
+          {steps.map((s, i) => {
+            const Icon = s.channel === "sms" ? MessageSquare : Mail;
+            const isSel = i === sel;
+            return (
+              <button key={i} onClick={() => setSel(i)} style={{
+                display: "flex", alignItems: "center", gap: 9, width: "100%", textAlign: "left", padding: "9px 11px",
+                borderBottom: `1px solid #F4F2EE`, border: "none", cursor: "pointer", fontFamily: FF,
+                background: isSel ? "#F0FBF7" : "#fff", boxShadow: isSel ? `inset 3px 0 0 ${MINT}` : "none",
+              }}>
+                <Icon size={15} style={{ color: s.channel === "sms" ? TEAL : BLUE, flexShrink: 0 }} />
+                <span style={{ lineHeight: 1.2 }}>
+                  <span style={{ display: "block", fontSize: 12, fontWeight: 700, color: INK }}>Touch {i + 1}</span>
+                  <span style={{ display: "block", fontSize: 10, color: "#9CA3AF" }}>Day {days[i]} · {s.channel === "sms" ? "SMS" : "Email"}</span>
+                </span>
+              </button>
+            );
+          })}
+          <button onClick={addTouch} style={{ display: "flex", alignItems: "center", gap: 6, width: "100%", padding: "10px 11px", border: "none", background: "#fff", cursor: "pointer", fontFamily: FF, fontSize: 12, fontWeight: 700, color: INK }}>
+            <Plus size={14} /> Add touch
+          </button>
+        </div>
+
+        {/* Right: detail editor */}
+        {cur && (
+          <div style={{ flex: 1, minWidth: 280, border: `1px solid ${BORDER}`, borderRadius: 12, padding: 16, background: "#fff" }}>
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 15 }}>
+              <span style={{ fontSize: 14, fontWeight: 800, color: INK }}>Touch {sel + 1}</span>
+              <div style={{ display: "flex", gap: 4 }}>
+                <button onClick={() => move(-1)} disabled={sel === 0} title="Move up" style={miniBtn}><ChevronUp size={15} /></button>
+                <button onClick={() => move(1)} disabled={sel === steps.length - 1} title="Move down" style={miniBtn}><ChevronDown size={15} /></button>
+                <button onClick={() => removeTouch(sel)} title="Delete touch" style={{ ...miniBtn, color: "#B91C1C" }}><Trash2 size={15} /></button>
+              </div>
+            </div>
+
+            <span style={lbl}>CHANNEL</span>
+            <div style={{ display: "inline-flex", border: `1px solid ${BORDER}`, borderRadius: 8, overflow: "hidden", marginBottom: 15 }}>
+              {(["email", "sms"] as const).map(ch => (
+                <button key={ch} onClick={() => patch({ channel: ch })} style={{
+                  fontFamily: FF, fontSize: 12.5, fontWeight: 700, padding: "7px 16px", border: "none", cursor: "pointer",
+                  background: cur.channel === ch ? INK : "#fff", color: cur.channel === ch ? "#fff" : MUTE,
+                }}>{ch === "sms" ? "SMS" : "Email"}</button>
+              ))}
+            </div>
+
+            <span style={lbl}>TIMING</span>
+            <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 6, flexWrap: "wrap" }}>
+              {sel === 0 ? (
+                <span style={{ fontSize: 13, color: INK }}>Sends immediately when the estimate is sent</span>
+              ) : (
+                <>
+                  <span style={{ fontSize: 13, color: MUTE }}>Wait</span>
+                  <input type="number" min={1} value={cur.delay_hours % 24 === 0 ? cur.delay_hours / 24 : cur.delay_hours}
+                    onChange={e => { const n = Math.max(1, Number(e.target.value) || 1); patch({ delay_hours: cur.delay_hours % 24 === 0 ? n * 24 : n }); }}
+                    style={{ ...inp, width: 60, textAlign: "center" }} />
+                  <select value={cur.delay_hours % 24 === 0 ? "days" : "hours"}
+                    onChange={e => { const v = cur.delay_hours % 24 === 0 ? cur.delay_hours / 24 : cur.delay_hours; patch({ delay_hours: e.target.value === "days" ? v * 24 : v }); }}
+                    style={{ ...inp, width: "auto" }}>
+                    <option value="hours">hours</option>
+                    <option value="days">days</option>
+                  </select>
+                  <span style={{ fontSize: 13, color: MUTE }}>after the previous touch</span>
+                </>
+              )}
+            </div>
+            <span style={{ fontSize: 11, color: TEAL, background: TEAL_BG, display: "inline-block", padding: "2px 9px", borderRadius: 20, marginBottom: 15 }}>Sends on Day {days[sel]}</span>
+
+            {cur.channel === "email" && (
+              <div style={{ marginBottom: 12 }}>
+                <span style={lbl}>SUBJECT</span>
+                <input style={inp} value={cur.subject || ""} onChange={e => patch({ subject: e.target.value })} placeholder="Your cleaning estimate for {{property}}" />
+              </div>
+            )}
+
+            <span style={lbl}>MESSAGE</span>
+            <textarea ref={msgRef} style={{ ...inp, minHeight: 120, resize: "vertical", lineHeight: 1.5 }} value={cur.message_template} onChange={e => patch({ message_template: e.target.value })} placeholder="Write the message…" />
+            <div style={{ display: "flex", flexWrap: "wrap", gap: 6, margin: "9px 0 14px" }}>
+              <span style={{ fontSize: 11, color: MUTE, alignSelf: "center", marginRight: 2 }}>Insert:</span>
+              {VARS.map(v => (
+                <button key={v} onClick={() => insertVar(v)} style={{ fontFamily: "monospace", fontSize: 11, background: "#F1EFE8", border: "none", padding: "3px 7px", borderRadius: 5, cursor: "pointer", color: "#444441" }}>{`{{${v}}}`}</button>
+              ))}
+            </div>
+
+            <div style={{ background: "#F8F7F4", borderRadius: 9, padding: "11px 13px" }}>
+              <span style={lbl}>PREVIEW</span>
+              {cur.channel === "email" && cur.subject && <div style={{ fontSize: 12.5, fontWeight: 700, color: INK, marginBottom: 4 }}>{fillVars(cur.subject)}</div>}
+              <div style={{ fontSize: 12.5, color: "#374151", lineHeight: 1.55, whiteSpace: "pre-wrap" }}>{fillVars(cur.message_template) || "—"}</div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+const miniBtn: React.CSSProperties = { width: 30, height: 30, display: "inline-flex", alignItems: "center", justifyContent: "center", background: "#fff", border: `1px solid ${BORDER}`, borderRadius: 7, color: MUTE, cursor: "pointer" };

--- a/artifacts/qleno/src/pages/estimates.tsx
+++ b/artifacts/qleno/src/pages/estimates.tsx
@@ -5,6 +5,7 @@ import { getAuthHeaders } from "@/lib/auth";
 import { DashboardLayout } from "@/components/layout/dashboard-layout";
 import { Plus, FileText, Send, CheckCircle, Clock, Trash2, Pencil, LayoutTemplate, Search, Activity } from "lucide-react";
 import { toast } from "sonner";
+import { FollowUpEditor } from "@/pages/estimates-followup-editor";
 
 const FF = "'Plus Jakarta Sans', sans-serif";
 const API = import.meta.env.BASE_URL.replace(/\/$/, "");
@@ -49,10 +50,7 @@ export default function EstimatesPage() {
   const [, navigate] = useLocation();
   const qc = useQueryClient();
   const [search, setSearch] = useState("");
-  const [tab, setTab] = useState<"estimates" | "templates" | "ghl">("estimates");
-  const [ghlSent, setGhlSent] = useState("");
-  const [ghlOutcome, setGhlOutcome] = useState("");
-  const [ghlLoaded, setGhlLoaded] = useState(false);
+  const [tab, setTab] = useState<"estimates" | "templates" | "followup">("estimates");
 
   const { data: statsData } = useQuery({ queryKey: ["estimate-stats"], queryFn: () => apiFetch("/api/estimates/stats") });
   const { data: listData, isLoading } = useQuery({
@@ -74,22 +72,6 @@ export default function EstimatesPage() {
     mutationFn: (id: number) => apiFetch(`/api/estimates/templates/${id}`, { method: "DELETE" }),
     onSuccess: () => { qc.invalidateQueries({ queryKey: ["estimate-templates"] }); toast.success("Template deleted"); },
     onError: () => toast.error("Failed to delete template"),
-  });
-
-  // GoHighLevel bridge settings live on the company row.
-  const { data: companyData } = useQuery({ queryKey: ["company-me"], queryFn: () => apiFetch("/api/companies/me") });
-  if (companyData && !ghlLoaded) {
-    setGhlSent(companyData.ghl_estimate_sent_webhook || "");
-    setGhlOutcome(companyData.ghl_estimate_outcome_webhook || "");
-    setGhlLoaded(true);
-  }
-  const saveGhl = useMutation({
-    mutationFn: () => apiFetch("/api/companies/me", {
-      method: "PATCH",
-      body: { ghl_estimate_sent_webhook: ghlSent.trim(), ghl_estimate_outcome_webhook: ghlOutcome.trim() },
-    }),
-    onSuccess: () => { qc.invalidateQueries({ queryKey: ["company-me"] }); toast.success("GoHighLevel settings saved"); },
-    onError: () => toast.error("Failed to save settings"),
   });
 
   const statCards = [
@@ -132,7 +114,7 @@ export default function EstimatesPage() {
 
         {/* Tabs */}
         <div style={{ display: "flex", gap: 6, borderBottom: `1px solid ${BORDER}`, marginBottom: 16 }}>
-          {([["estimates", "Estimates"], ["templates", "Templates"], ["ghl", "GoHighLevel"]] as const).map(([key, label]) => (
+          {([["estimates", "Estimates"], ["templates", "Templates"], ["followup", "Follow-up"]] as const).map(([key, label]) => (
             <button key={key} onClick={() => setTab(key)}
               style={{ background: "none", border: "none", borderBottom: tab === key ? `2px solid ${INK}` : "2px solid transparent", color: tab === key ? INK : MUTE, fontWeight: 700, fontSize: 14, padding: "8px 12px", cursor: "pointer", fontFamily: FF, marginBottom: -1 }}>
               {label}
@@ -187,41 +169,8 @@ export default function EstimatesPage() {
               )}
             </div>
           </>
-        ) : tab === "ghl" ? (
-          <div style={{ background: "#fff", border: `1px solid ${BORDER}`, borderRadius: 12, padding: "20px 22px", maxWidth: 640 }}>
-            <p style={{ fontSize: 15, fontWeight: 800, color: INK, margin: "0 0 4px" }}>GoHighLevel follow-up bridge</p>
-            <p style={{ fontSize: 13, color: MUTE, margin: "0 0 16px", lineHeight: 1.6 }}>
-              When you send an estimate, Qleno pushes the contact + estimate link to your GHL workflow so GHL runs the
-              SMS follow-up drip from your office line. When the customer accepts (or declines), Qleno fires the second
-              webhook so GHL stops the drip. Build the two workflows once in GHL (Inbound Webhook trigger), then paste
-              their webhook URLs here. Setup guide: <code style={{ fontSize: 12 }}>docs/GHL_ESTIMATE_BRIDGE.md</code>.
-            </p>
-            <label style={{ display: "block", marginBottom: 14 }}>
-              <span style={{ display: "block", fontSize: 11, fontWeight: 700, color: MUTE, textTransform: "uppercase", letterSpacing: "0.04em", marginBottom: 5 }}>
-                "Estimate sent" webhook URL — starts the drip
-              </span>
-              <input value={ghlSent} onChange={e => setGhlSent(e.target.value)} placeholder="https://services.leadconnectorhq.com/hooks/…"
-                style={{ width: "100%", padding: "9px 11px", border: `1px solid ${BORDER}`, borderRadius: 9, fontSize: 13, fontFamily: FF, boxSizing: "border-box" }} />
-            </label>
-            <label style={{ display: "block", marginBottom: 16 }}>
-              <span style={{ display: "block", fontSize: 11, fontWeight: 700, color: MUTE, textTransform: "uppercase", letterSpacing: "0.04em", marginBottom: 5 }}>
-                "Outcome" webhook URL — stops the drip on accept / decline
-              </span>
-              <input value={ghlOutcome} onChange={e => setGhlOutcome(e.target.value)} placeholder="https://services.leadconnectorhq.com/hooks/…"
-                style={{ width: "100%", padding: "9px 11px", border: `1px solid ${BORDER}`, borderRadius: 9, fontSize: 13, fontFamily: FF, boxSizing: "border-box" }} />
-            </label>
-            <button onClick={() => saveGhl.mutate()} disabled={saveGhl.isPending}
-              style={{ background: INK, color: "#fff", border: "none", borderRadius: 9, padding: "10px 18px", fontSize: 13, fontWeight: 700, cursor: "pointer", fontFamily: FF }}>
-              {saveGhl.isPending ? "Saving…" : "Save settings"}
-            </button>
-            <div style={{ background: "#F7F6F3", borderRadius: 10, padding: "12px 14px", marginTop: 18 }}>
-              <p style={{ fontSize: 11, fontWeight: 700, color: MUTE, textTransform: "uppercase", letterSpacing: "0.05em", margin: "0 0 6px" }}>Payload fields you can map in GHL</p>
-              <p style={{ fontSize: 12, color: "#4B5563", margin: 0, lineHeight: 1.7, fontFamily: "monospace" }}>
-                event · contact_name · contact_email · contact_phone · property_name · service_address · total ·
-                estimate_link · estimate_number · title · valid_until · accepted_name
-              </p>
-            </div>
-          </div>
+        ) : tab === "followup" ? (
+          <FollowUpEditor />
         ) : (
           <div style={{ background: "#fff", border: `1px solid ${BORDER}`, borderRadius: 12, overflow: "hidden" }}>
             {templates.length === 0 ? (


### PR DESCRIPTION
Own the estimate drip **in Qleno** instead of depending on GoHighLevel. The engine was already native (sends from `follow_up_steps` via Resend/Twilio) — this adds the editor.

- **API:** `GET`/`PUT /api/estimates/follow-up` read + replace the company's `estimate_followup` sequence/steps + active toggle. Declared before `/:id`. Creates the sequence on first save if missing.
- **UI:** the GoHighLevel tab is now **Follow-up** — a master-detail editor: touch list + per-touch editor (channel toggle, **Wait N days/hours after previous**, subject, message with `{{variable}}` insertion + live preview), reorder/add/delete, Active toggle, and a **cadence preset** (Standard 16d / Aggressive ~8d / Gentle ~32d) that rescales all timings. Ships a proven 8-touch default.

drip-editor guard 3/3 · esbuild OK · frontend typecheck zero new errors · GoHighLevel UI removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)