### PR TITLE
feat(customer-messages): office control panel — view, edit, pause, add, reschedule every customer message + per-customer audit trail

### DIFF
--- a/artifacts/api-server/src/index.ts
+++ b/artifacts/api-server/src/index.ts
@@ -5,7 +5,7 @@ import { runPhesDataMigration } from "./phes-data-migration";
 import { runCutoverDataMigration } from "./cutover-data-migration";
 import { verifyClockIntegrityConstraint } from "./lib/clock-integrity-self-check";
 import { runUserCompaniesMigration } from "./user-companies-migration.js";
-import { runReminderCron, runReviewRequestCron } from "./services/notificationService.js";
+import { runReminderCron, runReviewRequestCron, runScheduledJobMessages } from "./services/notificationService.js";
 import { runRateLockNightlyChecks } from "./utils/rateLock.js";
 import { processDueEnrollments } from "./services/followUpService.js";
 import { runSmokeTests } from "./lib/smoke-test.js";
@@ -72,23 +72,17 @@ function startNotificationCron() {
     const ctMonth = ctNow.getUTCMonth(); // 0-indexed; December = 11
     const ctDay   = ctNow.getUTCDate();
 
-    // 72h reminder (jobs ~3 days out): primary 9 AM CT + noon catch-up.
-    // [reminder-catchup 2026-06-26] A restart through the single 9 AM window
-    // used to drop the whole day silently. A second daily slot recovers it the
-    // same day; runReminderCron now matches a date RANGE and is flag-guarded
-    // per job, so the extra slot never double-sends.
-    for (const h of [9, 12]) {
-      if (ctH === h && fired[`reminder_3day-${h}`] !== ctDate) {
-        fired[`reminder_3day-${h}`] = ctDate;
-        runReminderCron(3).catch((e: Error) => console.error("[cron] reminder_3day error:", e));
-      }
-    }
-    // 24h reminder (jobs tomorrow): primary 4 PM CT + 6 PM catch-up.
-    for (const h of [16, 18]) {
-      if (ctH === h && fired[`reminder_1day-${h}`] !== ctDate) {
-        fired[`reminder_1day-${h}`] = ctDate;
-        runReminderCron(1).catch((e: Error) => console.error("[cron] reminder_1day error:", e));
-      }
+    // Every hour → scheduled customer-message engine. Replaces the old fixed
+    // 72h/24h reminder triggers: each tenant's offset messages (built-in
+    // reminders + any custom ones the office adds) carry their OWN send_hour, so
+    // the engine itself decides what's due this hour. It's idempotent via the
+    // job_message_sends ledger, so an hourly cadence + catch-up never
+    // double-sends. (runReminderCron is retained as a copy reference but no
+    // longer scheduled.)
+    const schedKey = `${ctDate}-${ctH}`;
+    if (fired["scheduled_messages"] !== schedKey) {
+      fired["scheduled_messages"] = schedKey;
+      runScheduledJobMessages().catch((e: Error) => console.error("[cron] scheduled_messages error:", e));
     }
     // Every hour → review_request
     const hrKey = `${ctDate}-${ctH}`;
@@ -271,6 +265,17 @@ async function runStartupMigrations() {
     });
   } catch (err: any) {
     console.error("[startup] runCommsOptOutMigration — non-fatal:", err?.message ?? err);
+  }
+  // [customer-messages 2026-06-26] customer_message_schedules + job_message_sends
+  // tables + ledger backfill from the legacy reminder_*_sent flags (so the new
+  // engine never re-sends an already-reminded job).
+  try {
+    await withBootTimeout("runCustomerMessagesMigration", SCHEMA_TIMEOUT_MS, async () => {
+      const { runCustomerMessagesMigration } = await import("./lib/customer-messages.js");
+      await runCustomerMessagesMigration();
+    });
+  } catch (err: any) {
+    console.error("[startup] runCustomerMessagesMigration — non-fatal:", err?.message ?? err);
   }
   // [booking-confirmation GAP1] token column + job_scheduled SMS template (all tenants)
   try {

--- a/artifacts/api-server/src/lib/comms.ts
+++ b/artifacts/api-server/src/lib/comms.ts
@@ -36,6 +36,11 @@ export async function sendOnMyWaySms(opts: {
   promisedArrivalLabel: string;
   tenantSmsEnabled: boolean;
   clientOptedIn: boolean;
+  // [customer-messages] When the office has an active on_my_way SMS template,
+  // the caller renders it (with {{tech_name}}/{{arrival_window}}/etc. already
+  // merged) and passes it here. Empty/undefined → the built-in default below,
+  // so a tenant with no template still gets a sensible message.
+  bodyOverride?: string;
 }): Promise<OnMyWaySmsResult> {
   if (process.env.COMMS_ENABLED !== "true") {
     console.log(
@@ -49,9 +54,12 @@ export async function sendOnMyWaySms(opts: {
 
   // Lead with the tenant's name; tech FIRST name only; concise, no ALL-CAPS.
   const sender = (opts.companyName || "").trim();
-  const body = `${sender ? sender + ": " : ""}your cleaner ${
-    opts.techName
-  } is on the way, arriving around ${opts.promisedArrivalLabel}.`;
+  const body =
+    opts.bodyOverride && opts.bodyOverride.trim()
+      ? opts.bodyOverride.trim()
+      : `${sender ? sender + ": " : ""}your cleaner ${
+          opts.techName
+        } is on the way, arriving around ${opts.promisedArrivalLabel}.`;
 
   const accountSid = process.env.TWILIO_ACCOUNT_SID;
   const authToken = process.env.TWILIO_AUTH_TOKEN;

--- a/artifacts/api-server/src/lib/customer-messages.ts
+++ b/artifacts/api-server/src/lib/customer-messages.ts
@@ -23,12 +23,35 @@ export interface CatalogChannelDefault {
   body: string;
 }
 
+// How a message's send time is determined:
+//  - on_booking    : fires immediately when the job is created (event)
+//  - before_appointment : offset_days before scheduled_date, at send_hour CT (cron)
+//  - on_my_way     : fires when the tech taps On My Way (event)
+//  - on_completion : fires when the job is marked complete (event)
+//  - after_review  : ~1 day after completion via the throttled review cron (event-ish)
+//  - after_appointment : offset_days AFTER scheduled_date, at send_hour CT (cron)
+// The offset cron engine only manages before_appointment / after_appointment;
+// the rest are event-driven and fire from their own call sites. Custom messages
+// the office adds are always before_/after_appointment so they have a clock.
+export type MsgAnchor =
+  | "on_booking"
+  | "before_appointment"
+  | "on_my_way"
+  | "on_completion"
+  | "after_review"
+  | "after_appointment";
+
+export const OFFSET_ANCHORS: MsgAnchor[] = ["before_appointment", "after_appointment"];
+
 export interface CustomerMessageDef {
   trigger: string;
   label: string; // office-facing name
   group: "before" | "during" | "after";
-  // Plain-English trigger + exact timing, shown read-only in the UI (the send
-  // SCHEDULE is code-controlled; only copy + on/off are editable).
+  anchor: MsgAnchor;
+  offsetDays?: number; // before_/after_appointment only
+  sendHour?: number;   // 0-23 CT, before_/after_appointment only
+  // Plain-English trigger + timing, shown in the UI. For offset messages the
+  // office can edit offsetDays + sendHour; event messages show timing read-only.
   timing: string;
   description: string;
   channels: CatalogChannelDefault[];
@@ -62,6 +85,7 @@ export const CUSTOMER_MESSAGE_CATALOG: CustomerMessageDef[] = [
     trigger: "job_scheduled",
     label: "Booking Confirmation",
     group: "before",
+    anchor: "on_booking",
     timing: "Immediately when an appointment is booked",
     description: "Confirms the appointment the moment it's created.",
     channels: [
@@ -82,6 +106,9 @@ export const CUSTOMER_MESSAGE_CATALOG: CustomerMessageDef[] = [
     trigger: "reminder_3day",
     label: "3-Day Reminder",
     group: "before",
+    anchor: "before_appointment",
+    offsetDays: 3,
+    sendHour: 9,
     timing: "9:00 AM CT, 3 days before the appointment",
     description: "Early heads-up so the customer can plan access.",
     channels: [
@@ -102,6 +129,9 @@ export const CUSTOMER_MESSAGE_CATALOG: CustomerMessageDef[] = [
     trigger: "reminder_1day",
     label: "Next-Day Reminder",
     group: "before",
+    anchor: "before_appointment",
+    offsetDays: 1,
+    sendHour: 16,
     timing: "4:00 PM CT, the day before the appointment",
     description: "Final reminder the afternoon before, with an access note.",
     channels: [
@@ -122,6 +152,7 @@ export const CUSTOMER_MESSAGE_CATALOG: CustomerMessageDef[] = [
     trigger: "on_my_way",
     label: '"On My Way" Text',
     group: "during",
+    anchor: "on_my_way",
     timing: "Real time, when the cleaner leaves for the home",
     description: "Live heads-up with an arrival ETA when the tech departs.",
     companyToggleColumn: "sms_on_my_way_enabled",
@@ -137,6 +168,7 @@ export const CUSTOMER_MESSAGE_CATALOG: CustomerMessageDef[] = [
     trigger: "job_completed",
     label: "Thank-You After Service",
     group: "after",
+    anchor: "on_completion",
     timing: "Immediately when the job is marked complete",
     description: "Thanks the customer once the visit is finished.",
     channels: [
@@ -157,6 +189,7 @@ export const CUSTOMER_MESSAGE_CATALOG: CustomerMessageDef[] = [
     trigger: "review_request",
     label: "Review Request",
     group: "after",
+    anchor: "after_review",
     timing: "About a day after the visit (max once per customer / 30 days)",
     description: "Asks for a rating or review after a completed visit.",
     channels: [
@@ -221,6 +254,99 @@ export async function ensureCustomerMessageTemplates(
     }
   }
   return seeded;
+}
+
+// ── Schedule engine schema + seeding ─────────────────────────────────────────
+// customer_message_schedules : per-tenant timing/on-off for every message (the
+//   built-ins above plus any the office adds). Copy lives in
+//   notification_templates keyed by (company_id, key, channel).
+// job_message_sends : a per-(job, message, channel) ledger. This is the HARD
+//   idempotency guard for the offset cron AND a row in the customer audit
+//   trail. A message can only fire once per job per channel — no double-sends,
+//   ever, regardless of restarts or catch-up runs.
+export async function runCustomerMessagesMigration(): Promise<void> {
+  await db.execute(sql`
+    CREATE TABLE IF NOT EXISTS customer_message_schedules (
+      id           SERIAL PRIMARY KEY,
+      company_id   INTEGER NOT NULL,
+      key          TEXT NOT NULL,
+      label        TEXT NOT NULL,
+      anchor       TEXT NOT NULL,
+      offset_days  INTEGER,
+      send_hour    INTEGER,
+      channels     TEXT[] NOT NULL DEFAULT '{}',
+      is_active    BOOLEAN NOT NULL DEFAULT TRUE,
+      is_builtin   BOOLEAN NOT NULL DEFAULT FALSE,
+      sort_order   INTEGER NOT NULL DEFAULT 0,
+      created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      UNIQUE (company_id, key)
+    )`);
+  await db.execute(sql`
+    CREATE TABLE IF NOT EXISTS job_message_sends (
+      id            SERIAL PRIMARY KEY,
+      company_id    INTEGER NOT NULL,
+      job_id        INTEGER NOT NULL,
+      client_id     INTEGER,
+      schedule_key  TEXT NOT NULL,
+      channel       TEXT NOT NULL,
+      status        TEXT NOT NULL DEFAULT 'sent',
+      recipient     TEXT,
+      sent_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      UNIQUE (job_id, schedule_key, channel)
+    )`);
+  await db.execute(sql`CREATE INDEX IF NOT EXISTS idx_jms_client ON job_message_sends (client_id)`);
+  await db.execute(sql`CREATE INDEX IF NOT EXISTS idx_jms_company ON job_message_sends (company_id)`);
+
+  // Backfill the ledger from the legacy reminder_*_sent boolean flags so the new
+  // engine treats already-reminded jobs as done and NEVER re-sends them. Both
+  // channels are marked (the legacy flag didn't record which channel succeeded);
+  // marking both is the safe choice — it prevents a duplicate, never forces one.
+  for (const [flag, key] of [["reminder_72h_sent", "reminder_3day"], ["reminder_24h_sent", "reminder_1day"]] as const) {
+    for (const channel of ["email", "sms"] as const) {
+      await db.execute(sql`
+        INSERT INTO job_message_sends (company_id, job_id, client_id, schedule_key, channel, status, sent_at)
+        SELECT j.company_id, j.id, j.client_id, ${key}, ${channel}, 'sent', NOW()
+          FROM jobs j
+         WHERE j.${sql.raw(flag)} = TRUE
+        ON CONFLICT (job_id, schedule_key, channel) DO NOTHING`);
+    }
+  }
+
+  // Seed the built-in schedule rows for EVERY tenant now, at boot — not lazily on
+  // first page view. Without this the offset cron would find zero schedules and
+  // silently stop sending reminders until someone opened the settings page.
+  const companies = await db.execute(sql`SELECT id FROM companies`);
+  for (const row of companies.rows as any[]) {
+    try {
+      await ensureCustomerMessageSchedules(Number(row.id));
+    } catch (err) {
+      console.error(`[customer-messages] seed schedules failed for company ${row.id}:`, err);
+    }
+  }
+}
+
+// Seed the built-in schedule rows + templates for a tenant. Idempotent — only
+// inserts what's missing, never clobbers office edits (timing or copy).
+export async function ensureCustomerMessageSchedules(companyId: number): Promise<void> {
+  await ensureCustomerMessageTemplates(companyId);
+  const existing = await db.execute(sql`SELECT key FROM customer_message_schedules WHERE company_id = ${companyId}`);
+  const have = new Set((existing.rows as any[]).map((r) => r.key));
+  let order = 0;
+  for (const def of CUSTOMER_MESSAGE_CATALOG) {
+    order += 10;
+    if (have.has(def.trigger)) continue;
+    // channels are fixed known tokens ('email'/'sms') — safe to embed as a
+    // Postgres array literal like '{email,sms}'.
+    const channelsLiteral = `{${def.channels.map((c) => c.channel).join(",")}}`;
+    await db.execute(sql`
+      INSERT INTO customer_message_schedules
+        (company_id, key, label, anchor, offset_days, send_hour, channels, is_active, is_builtin, sort_order)
+      VALUES (${companyId}, ${def.trigger}, ${def.label}, ${def.anchor},
+              ${def.offsetDays ?? null}, ${def.sendHour ?? null},
+              ${channelsLiteral}::text[],
+              true, true, ${order})
+      ON CONFLICT (company_id, key) DO NOTHING`);
+  }
 }
 
 export interface RenderedTemplate {

--- a/artifacts/api-server/src/lib/customer-messages.ts
+++ b/artifacts/api-server/src/lib/customer-messages.ts
@@ -1,0 +1,259 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// Customer Messages — single source of truth for every automated, customer-
+// facing message tied to a booking/job.
+//
+// WHY THIS EXISTS: historically the booking confirmation, completion, and review
+// messages read from `notification_templates` (office-editable), but the 72h/24h
+// reminders and the "on my way" text used HARDCODED copy in the cron / SMS
+// helpers. Editing those in the office UI did nothing. This module makes the
+// template table the ONE source: every send renders through `renderCustomer
+// Template()`, and the office UI lists exactly the catalog below with View /
+// Edit / Pause for each. Hardcoded strings remain ONLY as a last-ditch fallback
+// when a tenant has no active template row (so a missing row can never silence a
+// send mid-flight).
+// ─────────────────────────────────────────────────────────────────────────────
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+export type MsgChannel = "email" | "sms";
+
+export interface CatalogChannelDefault {
+  channel: MsgChannel;
+  subject?: string; // email only
+  body: string;
+}
+
+export interface CustomerMessageDef {
+  trigger: string;
+  label: string; // office-facing name
+  group: "before" | "during" | "after";
+  // Plain-English trigger + exact timing, shown read-only in the UI (the send
+  // SCHEDULE is code-controlled; only copy + on/off are editable).
+  timing: string;
+  description: string;
+  channels: CatalogChannelDefault[];
+  // Some sends are gated by a per-company on/off column rather than (or in
+  // addition to) the template is_active flag — surfaced so the UI can show the
+  // real switch. null = governed purely by the template's is_active.
+  companyToggleColumn?: string;
+}
+
+// Merge-tags available to every customer message. Keep this list in sync with
+// the help text shown in the editor.
+export const MERGE_TAGS = [
+  "first_name",
+  "client_name",
+  "company_name",
+  "company_phone",
+  "company_email",
+  "service_type",
+  "date",
+  "time",
+  "arrival_window",
+  "service_address",
+  "tech_name",
+  "appointment_link",
+  "review_link",
+] as const;
+
+// The canonical catalog. Order = the cadence order the customer experiences.
+export const CUSTOMER_MESSAGE_CATALOG: CustomerMessageDef[] = [
+  {
+    trigger: "job_scheduled",
+    label: "Booking Confirmation",
+    group: "before",
+    timing: "Immediately when an appointment is booked",
+    description: "Confirms the appointment the moment it's created.",
+    channels: [
+      {
+        channel: "email",
+        subject: "Your cleaning appointment is confirmed",
+        body:
+          "Hi {{first_name}},\n\nYour {{service_type}} is confirmed for {{date}} at {{time}}.\n\nService address: {{service_address}}\n\nView your appointment: {{appointment_link}}\n\nThank you for choosing {{company_name}}!",
+      },
+      {
+        channel: "sms",
+        body:
+          "{{company_name}}: your {{service_type}} is confirmed for {{date}} at {{time}}. Questions? Call {{company_phone}}. Reply STOP to unsubscribe.",
+      },
+    ],
+  },
+  {
+    trigger: "reminder_3day",
+    label: "3-Day Reminder",
+    group: "before",
+    timing: "9:00 AM CT, 3 days before the appointment",
+    description: "Early heads-up so the customer can plan access.",
+    channels: [
+      {
+        channel: "email",
+        subject: "Reminder: your cleaning is on {{date}}",
+        body:
+          "Hi {{first_name}},\n\nThis is a reminder that your {{service_type}} is scheduled for {{date}} with a {{arrival_window}} arrival window at {{service_address}}.\n\nQuestions? Call {{company_phone}}.\n\n{{company_name}}",
+      },
+      {
+        channel: "sms",
+        body:
+          "Hi {{first_name}}, this is {{company_name}} confirming your cleaning on {{date}} with a {{arrival_window}} arrival window at {{service_address}}. Questions? Call {{company_phone}}. Reply STOP to unsubscribe.",
+      },
+    ],
+  },
+  {
+    trigger: "reminder_1day",
+    label: "Next-Day Reminder",
+    group: "before",
+    timing: "4:00 PM CT, the day before the appointment",
+    description: "Final reminder the afternoon before, with an access note.",
+    channels: [
+      {
+        channel: "email",
+        subject: "Your cleaning is tomorrow",
+        body:
+          "Hi {{first_name}},\n\nYour {{company_name}} cleaning is tomorrow with a {{arrival_window}} arrival window at {{service_address}}. Please make sure our team can access your home.\n\nQuestions? Call {{company_phone}}.\n\n{{company_name}}",
+      },
+      {
+        channel: "sms",
+        body:
+          "Hi {{first_name}}, your {{company_name}} cleaning is tomorrow with a {{arrival_window}} arrival window at {{service_address}}. Please ensure access to your home is available. Questions? Call {{company_phone}}. Reply STOP to unsubscribe.",
+      },
+    ],
+  },
+  {
+    trigger: "on_my_way",
+    label: '"On My Way" Text',
+    group: "during",
+    timing: "Real time, when the cleaner leaves for the home",
+    description: "Live heads-up with an arrival ETA when the tech departs.",
+    companyToggleColumn: "sms_on_my_way_enabled",
+    channels: [
+      {
+        channel: "sms",
+        body:
+          "{{company_name}}: your cleaner {{tech_name}} is on the way, arriving around {{arrival_window}}.",
+      },
+    ],
+  },
+  {
+    trigger: "job_completed",
+    label: "Thank-You After Service",
+    group: "after",
+    timing: "Immediately when the job is marked complete",
+    description: "Thanks the customer once the visit is finished.",
+    channels: [
+      {
+        channel: "email",
+        subject: "Thank you from {{company_name}}",
+        body:
+          "Hi {{first_name}},\n\nThank you for letting {{company_name}} clean your home today. We hope everything looks great!\n\nQuestions? Call {{company_phone}}.\n\n{{company_name}}",
+      },
+      {
+        channel: "sms",
+        body:
+          "Thanks for choosing {{company_name}}, {{first_name}}! Your cleaning is complete. Questions? Call {{company_phone}}. Reply STOP to unsubscribe.",
+      },
+    ],
+  },
+  {
+    trigger: "review_request",
+    label: "Review Request",
+    group: "after",
+    timing: "About a day after the visit (max once per customer / 30 days)",
+    description: "Asks for a rating or review after a completed visit.",
+    channels: [
+      {
+        channel: "email",
+        subject: "How did we do, {{first_name}}?",
+        body:
+          "Hi {{first_name}},\n\nWe'd love your feedback on your recent cleaning with {{company_name}}. It only takes a minute: {{review_link}}\n\nThank you!\n\n{{company_name}}",
+      },
+      {
+        channel: "sms",
+        body:
+          "Hi {{first_name}}, thanks for choosing {{company_name}}! We'd love your feedback: {{review_link}} Reply STOP to unsubscribe.",
+      },
+    ],
+  },
+];
+
+// Quick lookup for the set of trigger keys that are customer messages.
+export const CUSTOMER_MESSAGE_TRIGGERS = new Set(
+  CUSTOMER_MESSAGE_CATALOG.map((m) => m.trigger),
+);
+
+// {{tag}} substitution. Missing tags render as empty string (never the literal
+// braces) so a stray tag can't leak into a customer message.
+export function applyMergeTags(
+  template: string,
+  vars: Record<string, string | null | undefined>,
+): string {
+  return (template || "").replace(/\{\{([^}]+)\}\}/g, (_, key) => {
+    const v = vars[String(key).trim()];
+    return v == null ? "" : String(v);
+  });
+}
+
+// Ensure every catalog (trigger, channel) row exists for a tenant. Idempotent:
+// only inserts rows that are missing, never overwrites office edits. Returns the
+// number of rows seeded. Safe to call on every load of the editor.
+export async function ensureCustomerMessageTemplates(
+  companyId: number,
+): Promise<number> {
+  const existing = await db.execute(sql`
+    SELECT trigger, channel FROM notification_templates WHERE company_id = ${companyId}`);
+  const have = new Set(
+    (existing.rows as any[]).map((r) => `${r.trigger}:${r.channel}`),
+  );
+  let seeded = 0;
+  for (const def of CUSTOMER_MESSAGE_CATALOG) {
+    for (const ch of def.channels) {
+      if (have.has(`${def.trigger}:${ch.channel}`)) continue;
+      const subject = ch.subject ?? null;
+      const body = ch.body;
+      // Populate body AND the channel-specific column so EVERY send path reads
+      // the same content regardless of which column it prefers.
+      const bodyHtml = ch.channel === "email" ? body : null;
+      const bodyText = ch.channel === "sms" ? body : null;
+      await db.execute(sql`
+        INSERT INTO notification_templates
+          (company_id, trigger, channel, subject, body, body_html, body_text, is_active, created_at)
+        VALUES (${companyId}, ${def.trigger}, ${ch.channel}, ${subject}, ${body}, ${bodyHtml}, ${bodyText}, true, NOW())`);
+      seeded++;
+    }
+  }
+  return seeded;
+}
+
+export interface RenderedTemplate {
+  subject: string | null;
+  body: string; // merged, ready to send (HTML for email, plain text for sms)
+  is_active: boolean;
+}
+
+// Fetch + merge the tenant's template for a (trigger, channel). Returns null
+// when there is NO row at all (caller falls back to its built-in default copy).
+// When a row exists but is paused, returns { is_active:false } so the caller can
+// honor the office's "off" choice. Reads body_html/body_text first (kept in sync
+// with body by the editor), falling back to body.
+export async function renderCustomerTemplate(
+  companyId: number,
+  trigger: string,
+  channel: MsgChannel,
+  vars: Record<string, string | null | undefined>,
+): Promise<RenderedTemplate | null> {
+  const rows = await db.execute(sql`
+    SELECT subject, body, body_html, body_text, is_active
+      FROM notification_templates
+     WHERE company_id = ${companyId} AND trigger = ${trigger} AND channel = ${channel}
+     LIMIT 1`);
+  const tpl = rows.rows[0] as any;
+  if (!tpl) return null;
+  const rawBody =
+    channel === "email"
+      ? tpl.body_html || tpl.body || ""
+      : tpl.body_text || tpl.body || "";
+  return {
+    subject: tpl.subject ? applyMergeTags(tpl.subject, vars) : null,
+    body: applyMergeTags(rawBody, vars),
+    is_active: !!tpl.is_active,
+  };
+}

--- a/artifacts/api-server/src/routes/batch-invoicing.ts
+++ b/artifacts/api-server/src/routes/batch-invoicing.ts
@@ -1,23 +1,38 @@
-// [invoicing-engine 2026-06-16] Batch invoicing — Sal's "first invoice of the
-// month" model (Scope 2). Mounted at /api/batch-invoicing. Owner/admin/office.
+// [invoicing-engine 2026-06-16; weekly-cadence 2026-06-26] Consolidated
+// invoicing — Sal's "one invoice per job, then merge them" model. Mounted at
+// /api/batch-invoicing. Owner/admin/office.
+//
+// WHY two steps (per-job draft → merge), not one weekly invoice:
+//   Each visit can differ — longer hours some days, a holiday with NO work other
+//   days. So every job keeps its OWN locked per-visit invoice (created on
+//   completion by ensure-invoice). The merge just sums whatever real visits
+//   landed in the billing window. Skipped/holiday days simply have no draft;
+//   long days carry their own higher total. Nothing is recomputed at merge time.
 //
 // How it works:
-//   - batch_invoice clients still get a per-visit DRAFT invoice on every
-//     completion (batch_status='pending'), created by the per-visit engine.
-//   - This page lists those pending drafts grouped by client for a month.
-//   - "Consolidate & Send" folds the month's pending visits into the FIRST
-//     invoice of the month (the parent): the parent carries the full month total
-//     as one line per visit; every OTHER pending invoice is zeroed and marked
-//     'superseded' with parent_invoice_id pointing at the parent. Only the parent
-//     is sent (net-0, due today) and pushed to QB. Superseded children never push.
-//   - Office may EXCLUDE individual visits before sending (e.g. already billed in
-//     QBO at month-start) via exclude_invoice_ids — excluded drafts are left
-//     untouched (their amount is simply not in the parent), the record is kept.
-//   - Idempotent: once a month is consolidated for a client (a superseded child
-//     exists), it cannot be re-consolidated.
+//   - A consolidated client (clients.billing_terms='batch_invoice') gets a
+//     per-visit DRAFT on each completion (batch_status='pending'), NOT sent, NOT
+//     charged, NOT pushed to QB — held for merging.
+//   - This route lists those pending drafts grouped by client for a billing
+//     WINDOW (cadence = 'weekly' Sun–Sat, or 'monthly'), keyed on the JOB's
+//     SERVICE DATE (jobs.scheduled_date) — NOT invoice created_at, so the lines
+//     and the window track when the work actually happened.
+//   - "Consolidate" folds the window's pending visits into the EARLIEST visit's
+//     invoice (the parent): the parent carries one line per visit (labeled with
+//     the service date), totals the window, is issued 'sent' due-on-receipt
+//     (due = today), and is pushed to QB. Every OTHER pending invoice is zeroed
+//     and marked 'superseded' with parent_invoice_id → the parent. Only the
+//     parent pushes to QB.
+//   - Office may EXCLUDE individual visits before merging (exclude_invoice_ids)
+//     — excluded drafts are left untouched (kept, just not in the parent).
+//   - Idempotent per (client, window): once a superseded child exists for a
+//     visit inside the window, that window can't be re-consolidated.
+//
+// per_visit clients (all residential + most commercial) never reach here: their
+// completion invoice is issued 'sent' immediately and is its own document.
 import { Router } from "express";
 import { db } from "@workspace/db";
-import { invoicesTable, clientsTable } from "@workspace/db/schema";
+import { invoicesTable, clientsTable, jobsTable } from "@workspace/db/schema";
 import { eq, and, gte, lte, sql, inArray } from "drizzle-orm";
 import { requireAuth, requireRole } from "../lib/auth.js";
 import { logAudit } from "../lib/audit.js";
@@ -25,176 +40,205 @@ import { queueSync } from "../services/quickbooks-sync.js";
 
 const router = Router();
 
-// Resolve [start, end] timestamps for a YYYY-MM month (defaults to current month).
-function monthWindow(monthParam?: string): { start: Date; end: Date; label: string } {
-  const now = new Date();
-  let year = now.getFullYear();
-  let month = now.getMonth(); // 0-based
-  if (monthParam && /^\d{4}-\d{2}$/.test(monthParam)) {
-    const [y, m] = monthParam.split("-").map(Number);
-    year = y; month = m - 1;
+type Cadence = "weekly" | "monthly";
+
+// Resolve the billing window [start, end] (inclusive YYYY-MM-DD strings) for a
+// cadence + an anchor date. weekly = Sunday..Saturday containing the anchor;
+// monthly = first..last day of the anchor's month. All math on UTC calendar
+// dates to match how jobs.scheduled_date (a DATE) is stored/compared — no TZ
+// drift. Anchor defaults to today.
+function resolveWindow(cadence: Cadence, anchorParam?: string): { start: string; end: string; label: string } {
+  // Parse anchor as a pure calendar date (UTC midnight) to avoid TZ shifts.
+  let anchor: Date;
+  if (anchorParam && /^\d{4}-\d{2}-\d{2}$/.test(anchorParam)) {
+    anchor = new Date(`${anchorParam}T00:00:00.000Z`);
+  } else if (anchorParam && /^\d{4}-\d{2}$/.test(anchorParam)) {
+    anchor = new Date(`${anchorParam}-01T00:00:00.000Z`);
+  } else {
+    const now = new Date();
+    anchor = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
   }
-  const start = new Date(year, month, 1, 0, 0, 0, 0);
-  const end = new Date(year, month + 1, 0, 23, 59, 59, 999); // last day of month
-  const label = `${year}-${String(month + 1).padStart(2, "0")}`;
-  return { start, end, label };
+  const iso = (d: Date) => d.toISOString().slice(0, 10);
+  if (cadence === "weekly") {
+    const dow = anchor.getUTCDay(); // 0=Sun..6=Sat
+    const start = new Date(anchor); start.setUTCDate(anchor.getUTCDate() - dow);
+    const end = new Date(start); end.setUTCDate(start.getUTCDate() + 6);
+    return { start: iso(start), end: iso(end), label: `Week of ${iso(start)}` };
+  }
+  // monthly
+  const y = anchor.getUTCFullYear(), m = anchor.getUTCMonth();
+  const start = new Date(Date.UTC(y, m, 1));
+  const end = new Date(Date.UTC(y, m + 1, 0));
+  return { start: iso(start), end: iso(end), label: `${y}-${String(m + 1).padStart(2, "0")}` };
 }
 
-// GET /api/batch-invoicing?month=YYYY-MM
-// Lists batch_invoice clients with pending per-visit drafts in the month,
-// grouped by client (visit count + month-to-date total).
+function parseCadence(v: any): Cadence {
+  return v === "weekly" ? "weekly" : "monthly";
+}
+
+// Friendly service-date label, e.g. "Mon Jun 22". Built from a YYYY-MM-DD string
+// as a UTC date so it never shifts a day under the server's local TZ.
+function svcDateLabel(ymd: string | null): string {
+  if (!ymd) return "";
+  const d = new Date(`${String(ymd).slice(0, 10)}T00:00:00.000Z`);
+  return d.toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric", timeZone: "UTC" });
+}
+
+// GET /api/batch-invoicing?cadence=weekly&date=YYYY-MM-DD
+// Lists consolidated (batch_invoice) clients with pending per-visit drafts whose
+// SERVICE DATE falls in the window, grouped by client (visit count + window
+// total + each visit's service date).
 router.get("/", requireAuth, requireRole("owner", "admin", "office"), async (req, res) => {
   try {
     const companyId = req.auth!.companyId as number;
-    const { start, end, label } = monthWindow(req.query.month as string | undefined);
+    const cadence = parseCadence(req.query.cadence);
+    const { start, end, label } = resolveWindow(cadence, (req.query.date || req.query.period) as string | undefined);
 
     const rows = await db
       .select({
         client_id: invoicesTable.client_id,
         client_name: sql<string>`concat(${clientsTable.first_name}, ' ', ${clientsTable.last_name})`,
+        company_name: clientsTable.company_name,
         client_email: clientsTable.email,
         invoice_id: invoicesTable.id,
         invoice_number: invoicesTable.invoice_number,
         total: invoicesTable.total,
         created_at: invoicesTable.created_at,
-        due_date: invoicesTable.due_date,
         line_items: invoicesTable.line_items,
         job_id: invoicesTable.job_id,
+        service_date: jobsTable.scheduled_date,
       })
       .from(invoicesTable)
+      .innerJoin(jobsTable, eq(invoicesTable.job_id, jobsTable.id))
       .leftJoin(clientsTable, eq(invoicesTable.client_id, clientsTable.id))
       .where(and(
         eq(invoicesTable.company_id, companyId),
         eq(invoicesTable.status, "draft"),
         eq(invoicesTable.batch_status, "pending"),
-        gte(invoicesTable.created_at, start),
-        lte(invoicesTable.created_at, end),
+        gte(jobsTable.scheduled_date, start),
+        lte(jobsTable.scheduled_date, end),
       ))
-      .orderBy(invoicesTable.client_id, invoicesTable.created_at);
+      .orderBy(invoicesTable.client_id, jobsTable.scheduled_date);
 
-    // Group by client.
     const byClient = new Map<number, any>();
     for (const r of rows) {
       const cid = r.client_id as number;
       if (!byClient.has(cid)) {
         byClient.set(cid, {
           client_id: cid,
-          client_name: r.client_name,
+          client_name: (r.company_name && r.company_name.trim()) || r.client_name,
           client_email: r.client_email,
           visit_count: 0,
-          month_to_date_total: 0,
-          first_invoice_id: r.invoice_id,         // earliest (ordered by created_at)
-          first_invoice_created_at: r.created_at,
+          window_total: 0,
           visits: [] as any[],
         });
       }
       const g = byClient.get(cid);
       g.visit_count += 1;
-      g.month_to_date_total = Math.round((g.month_to_date_total + parseFloat(r.total || "0")) * 100) / 100;
+      g.window_total = Math.round((g.window_total + parseFloat(r.total || "0")) * 100) / 100;
       g.visits.push({
         invoice_id: r.invoice_id,
         invoice_number: r.invoice_number,
         total: parseFloat(r.total || "0"),
-        created_at: r.created_at,
-        line_items: r.line_items,
+        service_date: r.service_date ? String(r.service_date).slice(0, 10) : null,
+        service_label: svcDateLabel(r.service_date ? String(r.service_date) : null),
         job_id: r.job_id,
       });
     }
 
-    return res.json({ month: label, clients: Array.from(byClient.values()) });
+    return res.json({ cadence, period_start: start, period_end: end, label, clients: Array.from(byClient.values()) });
   } catch (err) {
-    console.error("Batch invoicing list error:", err);
-    return res.status(500).json({ error: "Internal Server Error", message: "Failed to list batch invoices" });
+    console.error("Consolidated invoicing list error:", err);
+    return res.status(500).json({ error: "Internal Server Error", message: "Failed to list consolidated invoices" });
   }
 });
 
 // POST /api/batch-invoicing/:clientId/consolidate
-// Body: { month?: "YYYY-MM", exclude_invoice_ids?: number[] }
+// Body: { cadence?: 'weekly'|'monthly', date?: 'YYYY-MM-DD', exclude_invoice_ids?: number[] }
 router.post("/:clientId/consolidate", requireAuth, requireRole("owner", "admin", "office"), async (req, res) => {
   try {
     const companyId = req.auth!.companyId as number;
     const clientId = parseInt(String(req.params.clientId));
     if (isNaN(clientId)) return res.status(400).json({ error: "Bad Request", message: "Invalid client id" });
 
-    const { start, end, label } = monthWindow(req.body?.month);
+    const cadence = parseCadence(req.body?.cadence);
+    const { start, end, label } = resolveWindow(cadence, req.body?.date || req.body?.period);
     const excludeIds: number[] = Array.isArray(req.body?.exclude_invoice_ids)
       ? req.body.exclude_invoice_ids.map((n: any) => parseInt(n)).filter((n: number) => !isNaN(n))
       : [];
 
-    // Idempotency guard: if a child has already been superseded into a parent
-    // for this client in this month, the month is already consolidated.
+    // Pending per-visit drafts whose SERVICE DATE is in the window, earliest
+    // service date first. (created_at is irrelevant here — service date is the
+    // billing truth, so reschedules/backfills land in the right window.)
+    const pending = await db
+      .select({
+        id: invoicesTable.id,
+        invoice_number: invoicesTable.invoice_number,
+        total: invoicesTable.total,
+        line_items: invoicesTable.line_items,
+        job_id: invoicesTable.job_id,
+        service_date: jobsTable.scheduled_date,
+      })
+      .from(invoicesTable)
+      .innerJoin(jobsTable, eq(invoicesTable.job_id, jobsTable.id))
+      .where(and(
+        eq(invoicesTable.company_id, companyId),
+        eq(invoicesTable.client_id, clientId),
+        eq(invoicesTable.status, "draft"),
+        eq(invoicesTable.batch_status, "pending"),
+        gte(jobsTable.scheduled_date, start),
+        lte(jobsTable.scheduled_date, end),
+      ))
+      .orderBy(jobsTable.scheduled_date, invoicesTable.id);
+
+    if (pending.length === 0) {
+      return res.status(404).json({ error: "Not Found", message: `No pending visits to consolidate for ${label}` });
+    }
+
+    // Idempotency: if any visit in THIS window is already superseded, the window
+    // is already consolidated. (Keyed on service date via the job join.)
     const [alreadyDone] = await db
       .select({ id: invoicesTable.id })
       .from(invoicesTable)
+      .innerJoin(jobsTable, eq(invoicesTable.job_id, jobsTable.id))
       .where(and(
         eq(invoicesTable.company_id, companyId),
         eq(invoicesTable.client_id, clientId),
         eq(invoicesTable.status, "superseded"),
-        gte(invoicesTable.created_at, start),
-        lte(invoicesTable.created_at, end),
+        gte(jobsTable.scheduled_date, start),
+        lte(jobsTable.scheduled_date, end),
       ))
       .limit(1);
     if (alreadyDone) {
       return res.status(409).json({ error: "Conflict", message: `${label} is already consolidated for this client` });
     }
 
-    // Pending per-visit drafts for the month, earliest first.
-    const pending = await db
-      .select({
-        id: invoicesTable.id,
-        invoice_number: invoicesTable.invoice_number,
-        total: invoicesTable.total,
-        subtotal: invoicesTable.subtotal,
-        line_items: invoicesTable.line_items,
-        created_at: invoicesTable.created_at,
-        job_id: invoicesTable.job_id,
-        payment_source: invoicesTable.payment_source,
-      })
-      .from(invoicesTable)
-      .where(and(
-        eq(invoicesTable.company_id, companyId),
-        eq(invoicesTable.client_id, clientId),
-        eq(invoicesTable.status, "draft"),
-        eq(invoicesTable.batch_status, "pending"),
-        gte(invoicesTable.created_at, start),
-        lte(invoicesTable.created_at, end),
-      ))
-      .orderBy(invoicesTable.created_at, invoicesTable.id);
-
-    if (pending.length === 0) {
-      return res.status(404).json({ error: "Not Found", message: "No pending visits to consolidate for this month" });
-    }
-
-    // The FIRST invoice of the month becomes the parent. Everything else folds in.
+    // The EARLIEST-service-date visit becomes the parent. Everything else folds in.
     const parent = pending[0];
     const folded = pending.slice(1).filter((p) => !excludeIds.includes(p.id));
     const excluded = pending.filter((p) => excludeIds.includes(p.id));
-    // The parent itself can be excluded only if it's the sole invoice — guard:
     if (excludeIds.includes(parent.id)) {
-      return res.status(400).json({ error: "Bad Request", message: "Cannot exclude the first invoice of the month (it is the consolidation parent)" });
+      return res.status(400).json({ error: "Bad Request", message: "Cannot exclude the earliest visit of the window (it is the consolidation parent)" });
     }
 
-    // Build the parent's consolidated line items: one line per visit (parent +
-    // each folded child). Amounts come straight from each locked per-visit total
-    // — never recomputed.
-    const visitLine = (inv: any) => {
-      const d = inv.created_at ? new Date(inv.created_at).toLocaleDateString("en-US", { month: "short", day: "numeric" }) : "";
-      return {
-        description: `Visit ${d}${inv.invoice_number ? ` (#${inv.invoice_number})` : ""}`,
-        quantity: 1,
-        unit_price: parseFloat(inv.total || "0"),
-        total: parseFloat(inv.total || "0"),
-        source_invoice_id: inv.id,
-        job_id: inv.job_id,
-      };
-    };
+    // One line per visit, labeled with the SERVICE DATE. Amounts come straight
+    // from each locked per-visit total — never recomputed.
+    const visitLine = (inv: any) => ({
+      description: `Cleaning — ${svcDateLabel(inv.service_date ? String(inv.service_date) : null)}${inv.invoice_number ? ` (#${inv.invoice_number})` : ""}`,
+      quantity: 1,
+      unit_price: parseFloat(inv.total || "0"),
+      total: parseFloat(inv.total || "0"),
+      source_invoice_id: inv.id,
+      job_id: inv.job_id,
+      service_date: inv.service_date ? String(inv.service_date).slice(0, 10) : null,
+    });
 
     const parentLines = [visitLine(parent), ...folded.map(visitLine)];
     const parentTotal = Math.round(parentLines.reduce((s, l) => s + l.total, 0) * 100) / 100;
     const todayStr = new Date().toISOString().split("T")[0];
 
     await db.transaction(async (tx) => {
-      // Parent: full month total, one line per visit, sent + due today (net-0).
+      // Parent: window total, one line per visit, issued 'sent' due-on-receipt.
       await tx.update(invoicesTable)
         .set({
           line_items: parentLines,
@@ -224,14 +268,12 @@ router.post("/:clientId/consolidate", requireAuth, requireRole("owner", "admin",
             inArray(invoicesTable.id, folded.map((f) => f.id)),
           ));
       }
-      // Excluded drafts are intentionally left untouched (their amount is simply
-      // not in the parent; the office handles them separately, e.g. already
-      // billed in QBO). Record preserved per spec.
+      // Excluded drafts are intentionally left untouched.
     });
 
     logAudit(req, "UPDATE", "invoice", parent.id, null, {
-      action: "batch_consolidate", month: label, parent_invoice_id: parent.id,
-      folded_count: folded.length, excluded_count: excluded.length, total: parentTotal,
+      action: "consolidate", cadence, window: label, period_start: start, period_end: end,
+      parent_invoice_id: parent.id, folded_count: folded.length, excluded_count: excluded.length, total: parentTotal,
     });
 
     // Push ONLY the parent to QB (one consolidated document). Children never push.
@@ -242,7 +284,10 @@ router.post("/:clientId/consolidate", requireAuth, requireRole("owner", "admin",
 
     return res.json({
       ok: true,
-      month: label,
+      cadence,
+      window: label,
+      period_start: start,
+      period_end: end,
       parent_invoice_id: parent.id,
       parent_total: parentTotal,
       folded_invoice_ids: folded.map((f) => f.id),
@@ -250,7 +295,7 @@ router.post("/:clientId/consolidate", requireAuth, requireRole("owner", "admin",
       visit_count: parentLines.length,
     });
   } catch (err) {
-    console.error("Batch consolidate error:", err);
+    console.error("Consolidate error:", err);
     return res.status(500).json({ error: "Internal Server Error", message: "Failed to consolidate invoices" });
   }
 });

--- a/artifacts/api-server/src/routes/clients.ts
+++ b/artifacts/api-server/src/routes/clients.ts
@@ -595,6 +595,53 @@ router.get("/:id", requireAuth, async (req, res) => {
   }
 });
 
+// ─── CUSTOMER MESSAGE HISTORY ──────────────────────────────────────────────────
+// Every automated + manual message we've sent this customer, newest first —
+// unioned across notification_log (booking/reminder/completion/review sends),
+// sms_messages (two-way texting), and communication_log (logged emails/SMS).
+// Powers the "Messages" timeline on the customer profile. Office + up.
+router.get("/:id/messages", requireAuth, requireRole("owner", "admin", "office"), async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId!;
+    const clientId = parseInt(req.params.id);
+    const [client] = await db.select({ email: clientsTable.email, phone: clientsTable.phone })
+      .from(clientsTable)
+      .where(and(eq(clientsTable.id, clientId), eq(clientsTable.company_id, companyId))).limit(1);
+    if (!client) return res.status(404).json({ error: "Not Found" });
+    const email = client.email || "";
+    const phone = client.phone || "";
+
+    const result = await db.execute(sql`
+      SELECT * FROM (
+        SELECT sent_at AS at, channel::text AS channel, 'outbound'::text AS direction,
+               trigger::text AS type, recipient::text AS recipient, status::text AS status,
+               NULL::text AS subject, NULL::text AS body, 'automated'::text AS source
+          FROM notification_log
+         WHERE company_id = ${companyId}
+           AND (( ${email} <> '' AND recipient = ${email}) OR ( ${phone} <> '' AND recipient = ${phone}))
+        UNION ALL
+        SELECT created_at AS at, 'sms'::text AS channel, direction::text AS direction,
+               'sms'::text AS type, COALESCE(to_number, from_number)::text AS recipient,
+               status::text AS status, NULL::text AS subject, body::text AS body, 'two_way'::text AS source
+          FROM sms_messages
+         WHERE company_id = ${companyId} AND client_id = ${clientId}
+        UNION ALL
+        SELECT logged_at AS at, channel::text AS channel, direction::text AS direction,
+               COALESCE(source, 'message')::text AS type, recipient::text AS recipient,
+               delivery_status::text AS status, subject::text AS subject, body::text AS body, 'logged'::text AS source
+          FROM communication_log
+         WHERE company_id = ${companyId} AND customer_id = ${clientId}
+      ) t
+      ORDER BY at DESC NULLS LAST
+      LIMIT 200`);
+
+    return res.json({ data: result.rows });
+  } catch (err) {
+    console.error("Customer messages history error:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
 // ─── UPDATE CLIENT ─────────────────────────────────────────────────────────────
 router.put("/:id", requireAuth, async (req, res) => {
   try {

--- a/artifacts/api-server/src/routes/notifications.ts
+++ b/artifacts/api-server/src/routes/notifications.ts
@@ -7,7 +7,22 @@ import {
   CUSTOMER_MESSAGE_CATALOG,
   MERGE_TAGS,
   ensureCustomerMessageTemplates,
+  ensureCustomerMessageSchedules,
 } from "../lib/customer-messages.js";
+
+// Friendly "when does it send" string for an offset (cron-driven) message.
+function formatOffsetTiming(anchor: string, days: number | null, hour: number | null): string {
+  const h = hour == null ? 9 : hour;
+  const hr = `${((h + 11) % 12) + 1}:00 ${h < 12 ? "AM" : "PM"} CT`;
+  const d = days == null ? 0 : days;
+  const dl = `${d} day${d === 1 ? "" : "s"}`;
+  if (anchor === "before_appointment") return d === 0 ? `${hr}, the day of the appointment` : `${hr}, ${dl} before the appointment`;
+  return `${hr}, ${dl} after the appointment`;
+}
+function slugifyKey(label: string): string {
+  const base = "custom_" + (label || "message").toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "").slice(0, 36);
+  return base.replace(/_+$/g, "") || "custom_message";
+}
 
 const router = Router();
 
@@ -78,42 +93,135 @@ router.get("/templates", requireAuth, requireRole("owner", "admin"), async (req,
 });
 
 // ── Customer Messages control panel ─────────────────────────────────────────
-// Returns the canonical catalog of customer-facing messages merged with this
-// tenant's current copy + on/off state. This is what the office "Customer
-// Messages" screen renders: every booking/job message with View / Edit / Pause.
+// Schedule-driven: returns every customer message (built-in + custom) with its
+// timing, copy, and on/off state. Built-in metadata (group, description) comes
+// from the catalog; custom messages derive theirs from the schedule row.
 router.get("/customer-messages", requireAuth, requireRole("owner", "admin"), async (req, res) => {
   try {
     const companyId = req.auth!.companyId!;
-    // Idempotently make sure every catalog (trigger, channel) row exists so the
-    // editor never shows a blank for a message that can fire.
-    await ensureCustomerMessageTemplates(companyId);
-    const rows = await db.select().from(notificationTemplatesTable)
-      .where(eq(notificationTemplatesTable.company_id, companyId));
-    const byKey = new Map(rows.map((r: any) => [`${r.trigger}:${r.channel}`, r]));
+    await ensureCustomerMessageSchedules(companyId); // seeds schedules + templates idempotently
+    const [schedRes, tplRows] = await Promise.all([
+      db.execute(sql`SELECT key, label, anchor, offset_days, send_hour, channels, is_active, is_builtin, sort_order
+                       FROM customer_message_schedules WHERE company_id = ${companyId} ORDER BY sort_order, id`),
+      db.select().from(notificationTemplatesTable).where(eq(notificationTemplatesTable.company_id, companyId)),
+    ]);
+    const tplByKey = new Map((tplRows as any[]).map((r) => [`${r.trigger}:${r.channel}`, r]));
+    const catalogByKey = new Map(CUSTOMER_MESSAGE_CATALOG.map((d) => [d.trigger, d]));
 
-    const messages = CUSTOMER_MESSAGE_CATALOG.map((def) => ({
-      trigger: def.trigger,
-      label: def.label,
-      group: def.group,
-      timing: def.timing,
-      description: def.description,
-      channels: def.channels.map((ch) => {
-        const row: any = byKey.get(`${def.trigger}:${ch.channel}`);
-        const body = ch.channel === "email"
-          ? (row?.body_html || row?.body)
-          : (row?.body_text || row?.body);
-        return {
-          channel: ch.channel,
-          id: row?.id ?? null,
-          subject: row?.subject ?? ch.subject ?? null,
-          body: body ?? ch.body,
-          is_active: row?.is_active ?? true,
-        };
-      }),
-    }));
+    const messages = (schedRes.rows as any[]).map((s) => {
+      const def = catalogByKey.get(s.key);
+      const editableTiming = s.anchor === "before_appointment" || s.anchor === "after_appointment";
+      const channels: string[] = Array.isArray(s.channels) ? s.channels : [];
+      return {
+        key: s.key,
+        label: s.label,
+        group: def?.group ?? (s.anchor === "after_appointment" ? "after" : "before"),
+        description: def?.description ?? "",
+        anchor: s.anchor,
+        offset_days: s.offset_days,
+        send_hour: s.send_hour,
+        is_builtin: s.is_builtin,
+        editable_timing: editableTiming,
+        timing: editableTiming ? formatOffsetTiming(s.anchor, s.offset_days, s.send_hour) : (def?.timing ?? ""),
+        channels: channels.map((channel) => {
+          const row: any = tplByKey.get(`${s.key}:${channel}`);
+          const defCh = def?.channels.find((c) => c.channel === channel);
+          const body = channel === "email" ? (row?.body_html || row?.body) : (row?.body_text || row?.body);
+          return {
+            channel,
+            id: row?.id ?? null,
+            subject: row?.subject ?? defCh?.subject ?? null,
+            body: body ?? defCh?.body ?? "",
+            is_active: row?.is_active ?? true,
+          };
+        }),
+      };
+    });
     return res.json({ data: messages, merge_tags: MERGE_TAGS });
   } catch (err) {
     console.error("Customer messages fetch error:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
+// Edit the CADENCE (timing) of an offset message — days before/after + send hour.
+router.patch("/customer-messages/:key", requireAuth, requireRole("owner", "admin"), async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId!;
+    const key = req.params.key;
+    const { offset_days, send_hour } = req.body ?? {};
+    const [sched] = await db.execute(sql`SELECT anchor FROM customer_message_schedules WHERE company_id = ${companyId} AND key = ${key} LIMIT 1`).then((r: any) => r.rows);
+    if (!sched) return res.status(404).json({ error: "Message not found" });
+    if (sched.anchor !== "before_appointment" && sched.anchor !== "after_appointment") {
+      return res.status(400).json({ error: "This message's timing is event-driven and can't be rescheduled." });
+    }
+    const days = Math.max(0, Math.min(60, parseInt(String(offset_days))));
+    const hour = Math.max(0, Math.min(23, parseInt(String(send_hour))));
+    if (!Number.isFinite(days) || !Number.isFinite(hour)) return res.status(400).json({ error: "Invalid timing" });
+    await db.execute(sql`UPDATE customer_message_schedules SET offset_days = ${days}, send_hour = ${hour} WHERE company_id = ${companyId} AND key = ${key}`);
+    return res.json({ ok: true, offset_days: days, send_hour: hour });
+  } catch (err) {
+    console.error("Update cadence error:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
+// ADD a custom automated message to the cadence (before/after the appointment).
+router.post("/customer-messages", requireAuth, requireRole("owner", "admin"), async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId!;
+    const b = req.body ?? {};
+    const label = String(b.label || "").trim();
+    const anchor = b.anchor === "after_appointment" ? "after_appointment" : "before_appointment";
+    const days = Math.max(0, Math.min(60, parseInt(String(b.offset_days ?? 1)) || 0));
+    const hour = Math.max(0, Math.min(23, parseInt(String(b.send_hour ?? 9)) || 0));
+    const wantEmail = !!b.email_body;
+    const wantSms = !!b.sms_body;
+    if (!label) return res.status(400).json({ error: "Give the message a name." });
+    if (!wantEmail && !wantSms) return res.status(400).json({ error: "Add an email or text message body." });
+
+    // Unique key.
+    let key = slugifyKey(label);
+    const taken = new Set((await db.execute(sql`SELECT key FROM customer_message_schedules WHERE company_id = ${companyId}`)).rows.map((r: any) => r.key));
+    if (taken.has(key)) { let n = 2; while (taken.has(`${key}_${n}`)) n++; key = `${key}_${n}`; }
+
+    const channels = [wantEmail ? "email" : null, wantSms ? "sms" : null].filter(Boolean) as string[];
+    const channelsLiteral = `{${channels.join(",")}}`;
+    const maxOrder = (await db.execute(sql`SELECT COALESCE(MAX(sort_order), 0) AS m FROM customer_message_schedules WHERE company_id = ${companyId}`)).rows[0] as any;
+    await db.execute(sql`
+      INSERT INTO customer_message_schedules (company_id, key, label, anchor, offset_days, send_hour, channels, is_active, is_builtin, sort_order)
+      VALUES (${companyId}, ${key}, ${label}, ${anchor}, ${days}, ${hour}, ${channelsLiteral}::text[], true, false, ${Number(maxOrder.m) + 10})`);
+    if (wantEmail) {
+      const subj = String(b.email_subject || label);
+      const body = String(b.email_body);
+      await db.execute(sql`INSERT INTO notification_templates (company_id, trigger, channel, subject, body, body_html, is_active, created_at)
+                           VALUES (${companyId}, ${key}, 'email', ${subj}, ${body}, ${body}, true, NOW())`);
+    }
+    if (wantSms) {
+      const body = String(b.sms_body);
+      await db.execute(sql`INSERT INTO notification_templates (company_id, trigger, channel, subject, body, body_text, is_active, created_at)
+                           VALUES (${companyId}, ${key}, 'sms', NULL, ${body}, ${body}, true, NOW())`);
+    }
+    return res.json({ ok: true, key });
+  } catch (err) {
+    console.error("Add customer message error:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
+// DELETE a custom message (built-ins can't be deleted — only paused).
+router.delete("/customer-messages/:key", requireAuth, requireRole("owner", "admin"), async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId!;
+    const key = req.params.key;
+    const [sched] = await db.execute(sql`SELECT is_builtin FROM customer_message_schedules WHERE company_id = ${companyId} AND key = ${key} LIMIT 1`).then((r: any) => r.rows);
+    if (!sched) return res.status(404).json({ error: "Message not found" });
+    if (sched.is_builtin) return res.status(400).json({ error: "Built-in messages can be paused but not deleted." });
+    await db.execute(sql`DELETE FROM notification_templates WHERE company_id = ${companyId} AND trigger = ${key}`);
+    await db.execute(sql`DELETE FROM customer_message_schedules WHERE company_id = ${companyId} AND key = ${key}`);
+    return res.json({ ok: true });
+  } catch (err) {
+    console.error("Delete customer message error:", err);
     return res.status(500).json({ error: "Internal Server Error" });
   }
 });

--- a/artifacts/api-server/src/routes/notifications.ts
+++ b/artifacts/api-server/src/routes/notifications.ts
@@ -3,6 +3,11 @@ import { db } from "@workspace/db";
 import { notificationTemplatesTable, notificationLogTable } from "@workspace/db/schema";
 import { eq, and, desc, sql } from "drizzle-orm";
 import { requireAuth, requireRole } from "../lib/auth.js";
+import {
+  CUSTOMER_MESSAGE_CATALOG,
+  MERGE_TAGS,
+  ensureCustomerMessageTemplates,
+} from "../lib/customer-messages.js";
 
 const router = Router();
 
@@ -72,14 +77,72 @@ router.get("/templates", requireAuth, requireRole("owner", "admin"), async (req,
   }
 });
 
+// ── Customer Messages control panel ─────────────────────────────────────────
+// Returns the canonical catalog of customer-facing messages merged with this
+// tenant's current copy + on/off state. This is what the office "Customer
+// Messages" screen renders: every booking/job message with View / Edit / Pause.
+router.get("/customer-messages", requireAuth, requireRole("owner", "admin"), async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId!;
+    // Idempotently make sure every catalog (trigger, channel) row exists so the
+    // editor never shows a blank for a message that can fire.
+    await ensureCustomerMessageTemplates(companyId);
+    const rows = await db.select().from(notificationTemplatesTable)
+      .where(eq(notificationTemplatesTable.company_id, companyId));
+    const byKey = new Map(rows.map((r: any) => [`${r.trigger}:${r.channel}`, r]));
+
+    const messages = CUSTOMER_MESSAGE_CATALOG.map((def) => ({
+      trigger: def.trigger,
+      label: def.label,
+      group: def.group,
+      timing: def.timing,
+      description: def.description,
+      channels: def.channels.map((ch) => {
+        const row: any = byKey.get(`${def.trigger}:${ch.channel}`);
+        const body = ch.channel === "email"
+          ? (row?.body_html || row?.body)
+          : (row?.body_text || row?.body);
+        return {
+          channel: ch.channel,
+          id: row?.id ?? null,
+          subject: row?.subject ?? ch.subject ?? null,
+          body: body ?? ch.body,
+          is_active: row?.is_active ?? true,
+        };
+      }),
+    }));
+    return res.json({ data: messages, merge_tags: MERGE_TAGS });
+  } catch (err) {
+    console.error("Customer messages fetch error:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
 router.patch("/templates/:id", requireAuth, requireRole("owner", "admin"), async (req, res) => {
   try {
     const companyId = req.auth!.companyId!;
     const id = parseInt(req.params.id);
     const { is_active, subject, body } = req.body;
 
+    // Fetch the row first so we know its channel and can keep the editable
+    // `body` in sync with the channel-specific column the send path reads
+    // (body_html for email, body_text for sms). Without this sync, an edit to
+    // `body` is shadowed by a stale body_text/body_html and never goes out.
+    const [existing] = await db.select().from(notificationTemplatesTable)
+      .where(and(eq(notificationTemplatesTable.id, id), eq(notificationTemplatesTable.company_id, companyId)));
+    if (!existing) return res.status(404).json({ error: "Template not found" });
+
+    const patch: Record<string, any> = {};
+    if (is_active !== undefined) patch.is_active = is_active;
+    if (subject !== undefined) patch.subject = subject;
+    if (body !== undefined) {
+      patch.body = body;
+      if (existing.channel === "email") patch.body_html = body;
+      if (existing.channel === "sms") patch.body_text = body;
+    }
+
     const [updated] = await db.update(notificationTemplatesTable)
-      .set({ is_active, subject, body })
+      .set(patch)
       .where(and(eq(notificationTemplatesTable.id, id), eq(notificationTemplatesTable.company_id, companyId)))
       .returning();
 

--- a/artifacts/api-server/src/routes/tech-clock.ts
+++ b/artifacts/api-server/src/routes/tech-clock.ts
@@ -37,7 +37,7 @@ import { requireAuth } from "../lib/auth.js";
 import { validateClockGpsPayload } from "../lib/clock-integrity.js";
 import { haversineMeters, companyGeofenceMeters } from "../lib/distance.js";
 import { estimateEtaMinutes } from "../lib/eta.js";
-import { sendOnMyWaySms } from "../lib/comms.js";
+import { sendOnMyWaySms, type OnMyWaySmsResult } from "../lib/comms.js";
 import { geocodeAddress } from "../lib/geocode.js";
 import { ensureInvoiceForCompletedJob } from "../lib/ensure-invoice.js";
 
@@ -273,7 +273,7 @@ async function sendOnMyWayForJob(
   userId: number,
   job: { id: number; client_id: number | null; branch_id: number | null },
   promisedArrivalAt: Date | null,
-) {
+): Promise<OnMyWaySmsResult> {
   // Load tenant SMS flag, tenant from-number, client phone + opt-in,
   // tech first/last. Everything we need to compose the SMS.
   const [tenantRows, clientRows, techRows] = await Promise.all([
@@ -355,6 +355,21 @@ async function sendOnMyWayForJob(
   const { resolveSender } = await import("../lib/comms-sender.js");
   const sender = await resolveSender(companyId, job.branch_id ?? null);
   const fromPhone = tenant?.twilio_from_number ?? sender.from_number;
+  // [customer-messages] Pull the office-editable on_my_way SMS copy. A null
+  // template falls back to the built-in message inside sendOnMyWaySms; an
+  // explicitly paused (is_active=false) template honors the office's "off".
+  const { renderCustomerTemplate } = await import("../lib/customer-messages.js");
+  const omwTpl = await renderCustomerTemplate(companyId, "on_my_way", "sms", {
+    first_name: client?.first_name ?? "",
+    client_name: client?.first_name ?? "",
+    company_name: tenant?.name ?? "",
+    tech_name: tech?.first_name ?? "",
+    arrival_window: promisedLabel,
+    service_address: serviceAddress,
+  });
+  if (omwTpl && !omwTpl.is_active) {
+    return { status: "suppressed_tenant_disabled" };
+  }
   return sendOnMyWaySms({
     toPhone: client?.phone ?? null,
     fromPhone,
@@ -366,6 +381,7 @@ async function sendOnMyWayForJob(
     promisedArrivalLabel: promisedLabel,
     tenantSmsEnabled: !!tenant?.sms_on_my_way_enabled,
     clientOptedIn: client?.wants_on_my_way_notifications !== false && !smsOptedOut && !accountPaused,
+    bodyOverride: omwTpl?.body,
   });
 }
 

--- a/artifacts/api-server/src/services/notificationService.ts
+++ b/artifacts/api-server/src/services/notificationService.ts
@@ -5,6 +5,7 @@ import { getBranchByZip } from "../lib/branchRouter";
 import { buildReminderEmail } from "../lib/emailTemplates";
 import { resolveSender, sendSmsVia } from "../lib/comms-sender.js";
 import { isSmsOptedOut, isEmailOptedOut, buildEmailUnsubData, buildUnsubDataFromToken } from "../lib/opt-out.js";
+import { renderCustomerTemplate } from "../lib/customer-messages.js";
 import { Resend } from "resend";
 
 // ── Email brand constants ────────────────────────────────────────────────────
@@ -292,7 +293,8 @@ export async function runReminderCron(daysAhead: number): Promise<void> {
     const rows = await db.execute(
       hoursAhead === 72
         ? drizzleSql`
-            SELECT j.id, j.scheduled_date, j.service_type, j.arrival_window,
+            SELECT j.id, j.company_id, co.name AS company_name,
+                   j.scheduled_date, j.service_type, j.arrival_window,
                    j.address_street, j.address_city, j.address_state, j.address_zip,
                    c.first_name, c.last_name, c.email, c.phone, c.zip,
                    c.sms_opt_out_at, c.email_opt_out_at, c.email_unsub_token
@@ -308,7 +310,8 @@ export async function runReminderCron(daysAhead: number): Promise<void> {
                AND j.reminder_72h_sent = false
           `
         : drizzleSql`
-            SELECT j.id, j.scheduled_date, j.service_type, j.arrival_window,
+            SELECT j.id, j.company_id, co.name AS company_name,
+                   j.scheduled_date, j.service_type, j.arrival_window,
                    j.address_street, j.address_city, j.address_state, j.address_zip,
                    c.first_name, c.last_name, c.email, c.phone, c.zip,
                    c.sms_opt_out_at, c.email_opt_out_at, c.email_unsub_token
@@ -349,39 +352,74 @@ export async function runReminderCron(daysAhead: number): Promise<void> {
       let emailSent = false;
       let smsSent = false;
 
+      // [customer-messages] The reminder copy now comes from the office-editable
+      // notification_templates rows (reminder_3day / reminder_1day), so edits in
+      // the Customer Messages panel actually take effect. A null template (no
+      // row) falls back to the built-in copy so a missing row never silences a
+      // reminder; a PAUSED template (is_active=false) honors the office's "off".
+      const reminderTrigger = hoursAhead === 72 ? "reminder_3day" : "reminder_1day";
+      const mergeVars: Record<string, string> = {
+        first_name: job.first_name || "there",
+        client_name: [job.first_name, job.last_name].filter(Boolean).join(" ") || "there",
+        company_name: job.company_name || "Phes",
+        company_phone: branchConfig.clientPhone,
+        company_email: branchConfig.officeEmail,
+        service_type: serviceType,
+        date: scheduledDate,
+        arrival_window: arrivalWindowLabel,
+        service_address: serviceAddress,
+      };
+      const logMeta = { job_id: String(job.id) };
+
       // Email reminder — skip if the client opted out of email.
       if (resendKey && job.email && !job.email_opt_out_at) {
-        try {
-          const { subject, html } = buildReminderEmail({
-            firstName: job.first_name || "",
-            email: job.email,
-            serviceType,
-            scheduledDate,
-            arrivalWindow: arrivalWindowLabel,
-            serviceAddress,
-            branchConfig,
-            hoursAhead: hoursAhead as 72 | 24,
-          });
-          // [comms-opt-out] List-Unsubscribe header + footer link.
-          let emailHtml = html;
-          const headers: Record<string, string> = {};
-          if (job.email_unsub_token) {
-            const u = buildUnsubDataFromToken(job.email_unsub_token);
-            Object.assign(headers, u.headers);
-            emailHtml = emailHtml.includes("</body>") ? emailHtml.replace(/<\/body>/i, `${u.footerHtml}</body>`) : emailHtml + u.footerHtml;
+        const emailTpl = await renderCustomerTemplate(job.company_id, reminderTrigger, "email", mergeVars);
+        if (emailTpl && !emailTpl.is_active) {
+          console.log(`[reminder-${label}] email paused by template job=${job.id}`);
+          await logNotification(job.company_id, job.email, "email", reminderTrigger, "suppressed", "template_paused", logMeta);
+        } else {
+          try {
+            let subject: string;
+            let html: string;
+            if (emailTpl) {
+              subject = emailTpl.subject || `Reminder: your cleaning on ${scheduledDate}`;
+              const htmlBody = /<[a-z][\s\S]*>/i.test(emailTpl.body) ? emailTpl.body : emailTpl.body.replace(/\n/g, "<br>");
+              html = wrapEmailHtml(htmlBody);
+            } else {
+              ({ subject, html } = buildReminderEmail({
+                firstName: job.first_name || "",
+                email: job.email,
+                serviceType,
+                scheduledDate,
+                arrivalWindow: arrivalWindowLabel,
+                serviceAddress,
+                branchConfig,
+                hoursAhead: hoursAhead as 72 | 24,
+              }));
+            }
+            // [comms-opt-out] List-Unsubscribe header + footer link.
+            let emailHtml = html;
+            const headers: Record<string, string> = {};
+            if (job.email_unsub_token) {
+              const u = buildUnsubDataFromToken(job.email_unsub_token);
+              Object.assign(headers, u.headers);
+              emailHtml = emailHtml.includes("</body>") ? emailHtml.replace(/<\/body>/i, `${u.footerHtml}</body>`) : emailHtml + u.footerHtml;
+            }
+            const resend = new Resend(resendKey);
+            await resend.emails.send({
+              from: `Phes <${branchConfig.officeEmail}>`,
+              replyTo: branchConfig.officeEmail,
+              to: [job.email],
+              subject,
+              html: emailHtml,
+              ...(Object.keys(headers).length ? { headers } : {}),
+            });
+            emailSent = true;
+            await logNotification(job.company_id, job.email, "email", reminderTrigger, "sent", null, logMeta);
+          } catch (emailErr) {
+            console.error(`[reminder-${label}] Email failed for job ${job.id}:`, emailErr);
+            await logNotification(job.company_id, job.email, "email", reminderTrigger, "failed", String(emailErr), logMeta);
           }
-          const resend = new Resend(resendKey);
-          await resend.emails.send({
-            from: `Phes <${branchConfig.officeEmail}>`,
-            replyTo: branchConfig.officeEmail,
-            to: [job.email],
-            subject,
-            html: emailHtml,
-            ...(Object.keys(headers).length ? { headers } : {}),
-          });
-          emailSent = true;
-        } catch (emailErr) {
-          console.error(`[reminder-${label}] Email failed for job ${job.id}:`, emailErr);
         }
       } else if (job.email_opt_out_at) {
         console.log(`[reminder-${label}] email suppressed (opt-out) job=${job.id}`);
@@ -389,25 +427,40 @@ export async function runReminderCron(daysAhead: number): Promise<void> {
 
       // SMS reminder — skip if the client opted out of SMS.
       if (accountSid && authToken && job.phone && !job.sms_opt_out_at) {
-        try {
-          const smsBody = hoursAhead === 72
-            ? `Hi ${job.first_name || "there"}, this is Phes confirming your cleaning appointment on ${scheduledDate} with a ${arrivalWindowLabel} arrival window at ${serviceAddress}. Questions? Call us at ${branchConfig.clientPhone}. Reply STOP to unsubscribe.`
-            : `Hi ${job.first_name || "there"}, your Phes cleaning is tomorrow with a ${arrivalWindowLabel} arrival window at ${serviceAddress}. Please ensure access to your home is available. Questions? Call ${branchConfig.clientPhone}. Reply STOP to unsubscribe.`;
-          const smsRes = await fetch(
-            `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/Messages.json`,
-            {
-              method: "POST",
-              headers: {
-                Authorization: `Basic ${Buffer.from(`${accountSid}:${authToken}`).toString("base64")}`,
-                "Content-Type": "application/x-www-form-urlencoded",
-              },
-              body: new URLSearchParams({ To: job.phone, From: branchConfig.twilioFrom, Body: smsBody }).toString(),
+        const smsTpl = await renderCustomerTemplate(job.company_id, reminderTrigger, "sms", mergeVars);
+        if (smsTpl && !smsTpl.is_active) {
+          console.log(`[reminder-${label}] SMS paused by template job=${job.id}`);
+          await logNotification(job.company_id, job.phone, "sms", reminderTrigger, "suppressed", "template_paused", logMeta);
+        } else {
+          try {
+            const smsBody = smsTpl
+              ? smsTpl.body
+              : hoursAhead === 72
+              ? `Hi ${job.first_name || "there"}, this is Phes confirming your cleaning appointment on ${scheduledDate} with a ${arrivalWindowLabel} arrival window at ${serviceAddress}. Questions? Call us at ${branchConfig.clientPhone}. Reply STOP to unsubscribe.`
+              : `Hi ${job.first_name || "there"}, your Phes cleaning is tomorrow with a ${arrivalWindowLabel} arrival window at ${serviceAddress}. Please ensure access to your home is available. Questions? Call ${branchConfig.clientPhone}. Reply STOP to unsubscribe.`;
+            const smsRes = await fetch(
+              `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/Messages.json`,
+              {
+                method: "POST",
+                headers: {
+                  Authorization: `Basic ${Buffer.from(`${accountSid}:${authToken}`).toString("base64")}`,
+                  "Content-Type": "application/x-www-form-urlencoded",
+                },
+                body: new URLSearchParams({ To: job.phone, From: branchConfig.twilioFrom, Body: smsBody }).toString(),
+              }
+            );
+            if (smsRes.ok) {
+              smsSent = true;
+              await logNotification(job.company_id, job.phone, "sms", reminderTrigger, "sent", null, logMeta);
+            } else {
+              const errText = await smsRes.text();
+              console.error(`[reminder-${label}] Twilio failed for job ${job.id}:`, errText);
+              await logNotification(job.company_id, job.phone, "sms", reminderTrigger, "failed", errText.slice(0, 200), logMeta);
             }
-          );
-          if (smsRes.ok) smsSent = true;
-          else console.error(`[reminder-${label}] Twilio failed for job ${job.id}:`, await smsRes.text());
-        } catch (smsErr) {
-          console.error(`[reminder-${label}] SMS error for job ${job.id}:`, smsErr);
+          } catch (smsErr) {
+            console.error(`[reminder-${label}] SMS error for job ${job.id}:`, smsErr);
+            await logNotification(job.company_id, job.phone, "sms", reminderTrigger, "failed", String(smsErr), logMeta);
+          }
         }
       } else if (job.sms_opt_out_at) {
         console.log(`[reminder-${label}] SMS suppressed (opt-out) job=${job.id}`);

--- a/artifacts/api-server/src/services/notificationService.ts
+++ b/artifacts/api-server/src/services/notificationService.ts
@@ -486,6 +486,220 @@ export async function runReminderCron(daysAhead: number): Promise<void> {
   }
 }
 
+// ── Scheduled customer-message engine (configurable cadence) ──────────────────
+// Generalizes the old fixed 72h/24h reminders into a per-tenant, office-editable
+// set of offset-based messages (before/after the appointment), PLUS any custom
+// messages the office adds. Drives off customer_message_schedules (timing) +
+// notification_templates (copy) and is made idempotent by the job_message_sends
+// ledger — a message fires AT MOST once per (job, key, channel), so restarts,
+// catch-up runs, and overlapping ticks can never double-send. This REPLACES the
+// hardcoded runReminderCron calls in index.ts; runReminderCron is retained only
+// as the copy fallback's historical reference and is no longer scheduled.
+export async function runScheduledJobMessages(): Promise<void> {
+  if (process.env.COMMS_ENABLED !== "true") {
+    console.log("[COMMS BLOCKED] scheduled-messages cron suppressed — COMMS_ENABLED!=true");
+    return;
+  }
+  const { sql: drizzleSql } = await import("drizzle-orm");
+  const { renderCustomerTemplate } = await import("../lib/customer-messages.js");
+
+  // CT "now" (DST-aware), matching the offset math used elsewhere.
+  const now = new Date();
+  const jan = new Date(now.getFullYear(), 0, 1);
+  const jul = new Date(now.getFullYear(), 6, 1);
+  const stdOffset = Math.max(jan.getTimezoneOffset(), jul.getTimezoneOffset());
+  const isDST = now.getTimezoneOffset() < stdOffset;
+  const ctOffset = isDST ? -5 : -6;
+  const ctNow = new Date(now.getTime() + ctOffset * 3600000 + now.getTimezoneOffset() * 60000);
+  const ctHour = ctNow.getUTCHours();
+  const todayStr = ctNow.toISOString().slice(0, 10);
+
+  const resendKey = process.env.RESEND_API_KEY;
+  const accountSid = process.env.TWILIO_ACCOUNT_SID;
+  const authToken = process.env.TWILIO_AUTH_TOKEN;
+
+  let schedules: any[] = [];
+  try {
+    const r = await db.execute(drizzleSql`
+      SELECT s.company_id, s.key, s.label, s.anchor, s.offset_days, s.send_hour, s.channels
+        FROM customer_message_schedules s
+        JOIN companies co ON co.id = s.company_id
+       WHERE s.is_active = true
+         AND s.anchor IN ('before_appointment', 'after_appointment')
+         AND co.comms_enabled = true
+         AND s.offset_days IS NOT NULL`);
+    schedules = (r as any).rows ?? [];
+  } catch (err) {
+    console.error("[scheduled-messages] failed to load schedules:", err);
+    return;
+  }
+
+  for (const sched of schedules) {
+    try {
+      const offset = Number(sched.offset_days);
+      const sendHour = sched.send_hour == null ? 0 : Number(sched.send_hour);
+      const channels: string[] = Array.isArray(sched.channels) ? sched.channels : [];
+      if (!channels.length || !Number.isFinite(offset)) continue;
+      const isBefore = sched.anchor === "before_appointment";
+      // 1-day catch-up grace for offset >= 2 (a date-based message can fire a day
+      // late). offset 1 ("tomorrow"/"day after") gets NO grace — you can't sensibly
+      // say "tomorrow" once the day has arrived. This mirrors the deployed
+      // reminder behavior (72h fired [today+2,today+3], 24h fired exactly today+1)
+      // and stops a same-day job from collecting both the 3-day and 1-day copy.
+      const lowerOffset = offset >= 2 ? offset - 1 : offset;
+
+      // Candidate jobs in the catch-up window. before: [today+lowerOffset,
+      // today+offset], not yet started; after: [today-offset-1, today-offset],
+      // completed.
+      const rows = await db.execute(
+        isBefore
+          ? drizzleSql`
+              SELECT j.id, j.company_id, j.client_id, co.name AS company_name,
+                     j.scheduled_date::date AS sdate, j.service_type, j.arrival_window,
+                     j.address_street, j.address_city, j.address_state, j.address_zip,
+                     c.first_name, c.last_name, c.email, c.phone, c.zip,
+                     c.sms_opt_out_at, c.email_opt_out_at, c.email_unsub_token
+                FROM jobs j
+                JOIN clients c ON c.id = j.client_id
+                JOIN companies co ON co.id = j.company_id
+                LEFT JOIN accounts a ON a.id = c.account_id
+               WHERE j.company_id = ${sched.company_id}
+                 AND j.scheduled_date >= (${todayStr}::date + ${lowerOffset}::int)
+                 AND j.scheduled_date <= (${todayStr}::date + ${offset}::int)
+                 AND j.status NOT IN ('cancelled', 'complete')
+                 AND (a.id IS NULL OR a.comms_enabled = true)`
+          : drizzleSql`
+              SELECT j.id, j.company_id, j.client_id, co.name AS company_name,
+                     j.scheduled_date::date AS sdate, j.service_type, j.arrival_window,
+                     j.address_street, j.address_city, j.address_state, j.address_zip,
+                     c.first_name, c.last_name, c.email, c.phone, c.zip,
+                     c.sms_opt_out_at, c.email_opt_out_at, c.email_unsub_token
+                FROM jobs j
+                JOIN clients c ON c.id = j.client_id
+                JOIN companies co ON co.id = j.company_id
+                LEFT JOIN accounts a ON a.id = c.account_id
+               WHERE j.company_id = ${sched.company_id}
+                 AND j.scheduled_date <= (${todayStr}::date - ${offset}::int)
+                 AND j.scheduled_date >= (${todayStr}::date - ${offset}::int - 1)
+                 AND j.status = 'complete'
+                 AND (a.id IS NULL OR a.comms_enabled = true)`
+      );
+      const jobs: any[] = (rows as any).rows ?? [];
+
+      for (const job of jobs) {
+        // Hour gate ONLY on the exact target day — earlier (a missed prior day,
+        // now caught up) sends immediately so a skipped window self-recovers.
+        const sdate = String(job.sdate).slice(0, 10);
+        const targetStr = isBefore
+          ? new Date(Date.parse(`${todayStr}T00:00:00Z`) + offset * 86400000).toISOString().slice(0, 10)
+          : new Date(Date.parse(`${todayStr}T00:00:00Z`) - offset * 86400000).toISOString().slice(0, 10);
+        if (sdate === targetStr && ctHour < sendHour) continue;
+
+        const jobZip = job.address_zip || job.zip || "";
+        const branchConfig = getBranchByZip(jobZip);
+        const stateZip = [job.address_state, job.address_zip].filter(Boolean).join(" ");
+        const serviceAddress = [job.address_street, job.address_city, stateZip].filter(Boolean).join(", ") || "On file";
+        const arrivalWindowLabel = job.arrival_window === "morning" ? "9:00 AM – 12:00 PM"
+          : job.arrival_window === "afternoon" ? "12:00 PM – 2:00 PM" : "scheduled window";
+        const vars: Record<string, string> = {
+          first_name: job.first_name || "there",
+          client_name: [job.first_name, job.last_name].filter(Boolean).join(" ") || "there",
+          company_name: job.company_name || "Phes",
+          company_phone: branchConfig.clientPhone,
+          company_email: branchConfig.officeEmail,
+          service_type: labelServiceType(job.service_type),
+          date: formatDate(job.scheduled_date),
+          arrival_window: arrivalWindowLabel,
+          service_address: serviceAddress,
+        };
+
+        for (const channel of channels) {
+          if (channel !== "email" && channel !== "sms") continue;
+          // Ledger guard — the hard idempotency gate. One row = already fired.
+          const led = await db.execute(drizzleSql`
+            SELECT 1 FROM job_message_sends
+             WHERE job_id = ${job.id} AND schedule_key = ${sched.key} AND channel = ${channel} LIMIT 1`);
+          if (((led as any).rows ?? []).length) continue;
+
+          const tpl = await renderCustomerTemplate(job.company_id, sched.key, channel as "email" | "sms", vars);
+          if (tpl && !tpl.is_active) continue; // channel paused by office
+          if (!tpl) continue; // no copy row — skip (built-ins always have one)
+
+          if (channel === "email") {
+            if (!resendKey || !job.email || job.email_opt_out_at) continue;
+            try {
+              const htmlBody = /<[a-z][\s\S]*>/i.test(tpl.body) ? tpl.body : tpl.body.replace(/\n/g, "<br>");
+              let emailHtml = wrapEmailHtml(htmlBody);
+              const headers: Record<string, string> = {};
+              if (job.email_unsub_token) {
+                const u = buildUnsubDataFromToken(job.email_unsub_token);
+                Object.assign(headers, u.headers);
+                emailHtml = emailHtml.includes("</body>") ? emailHtml.replace(/<\/body>/i, `${u.footerHtml}</body>`) : emailHtml + u.footerHtml;
+              }
+              await new Resend(resendKey).emails.send({
+                from: `Phes <${branchConfig.officeEmail}>`,
+                replyTo: branchConfig.officeEmail,
+                to: [job.email],
+                subject: tpl.subject || sched.label,
+                html: emailHtml,
+                ...(Object.keys(headers).length ? { headers } : {}),
+              });
+              await recordJobMessageSend(job, sched.key, "email", "sent", job.email);
+              await logNotification(job.company_id, job.email, "email", sched.key, "sent", null, { job_id: String(job.id) });
+            } catch (e) {
+              console.error(`[scheduled-messages] email failed key=${sched.key} job=${job.id}:`, e);
+            }
+          } else {
+            if (!accountSid || !authToken || !job.phone || job.sms_opt_out_at) continue;
+            try {
+              const smsRes = await fetch(
+                `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/Messages.json`,
+                {
+                  method: "POST",
+                  headers: {
+                    Authorization: `Basic ${Buffer.from(`${accountSid}:${authToken}`).toString("base64")}`,
+                    "Content-Type": "application/x-www-form-urlencoded",
+                  },
+                  body: new URLSearchParams({ To: job.phone, From: branchConfig.twilioFrom, Body: tpl.body }).toString(),
+                }
+              );
+              if (smsRes.ok) {
+                await recordJobMessageSend(job, sched.key, "sms", "sent", job.phone);
+                await logNotification(job.company_id, job.phone, "sms", sched.key, "sent", null, { job_id: String(job.id) });
+              } else {
+                console.error(`[scheduled-messages] twilio failed key=${sched.key} job=${job.id}:`, (await smsRes.text()).slice(0, 200));
+              }
+            } catch (e) {
+              console.error(`[scheduled-messages] sms error key=${sched.key} job=${job.id}:`, e);
+            }
+          }
+        }
+      }
+    } catch (err) {
+      console.error(`[scheduled-messages] schedule ${sched.key} (co ${sched.company_id}) error:`, err);
+    }
+  }
+}
+
+// Ledger writer — the row that both prevents a re-send and feeds the customer
+// audit trail. ON CONFLICT keeps it idempotent under concurrent ticks.
+async function recordJobMessageSend(
+  job: { id: number; company_id: number; client_id: number | null },
+  scheduleKey: string,
+  channel: string,
+  status: string,
+  recipient: string,
+): Promise<void> {
+  try {
+    await db.execute(sql`
+      INSERT INTO job_message_sends (company_id, job_id, client_id, schedule_key, channel, status, recipient, sent_at)
+      VALUES (${job.company_id}, ${job.id}, ${job.client_id ?? null}, ${scheduleKey}, ${channel}, ${status}, ${recipient}, NOW())
+      ON CONFLICT (job_id, schedule_key, channel) DO NOTHING`);
+  } catch (err) {
+    console.error(`[scheduled-messages] ledger write failed job=${job.id} key=${scheduleKey}:`, err);
+  }
+}
+
 // ── Review request cron ──────────────────────────────────────────────────────
 export async function runReviewRequestCron(): Promise<void> {
   if (process.env.COMMS_ENABLED !== "true") {

--- a/artifacts/qleno/src/pages/company.tsx
+++ b/artifacts/qleno/src/pages/company.tsx
@@ -1560,6 +1560,13 @@ function NotificationsTab() {
   const [editSubject, setEditSubject] = useState("");
   const [showLog, setShowLog] = useState(false);
   const [saving, setSaving] = useState<number | null>(null);
+  const [timingKey, setTimingKey] = useState<string | null>(null);
+  const [timingDays, setTimingDays] = useState(1);
+  const [timingHour, setTimingHour] = useState(9);
+  const [showAdd, setShowAdd] = useState(false);
+  const blankAdd = { label: "", anchor: "before_appointment", offset_days: 1, send_hour: 9, email_subject: "", email_body: "", sms_body: "" };
+  const [addForm, setAddForm] = useState<any>(blankAdd);
+  const [addBusy, setAddBusy] = useState(false);
 
   async function load() {
     try {
@@ -1607,6 +1614,49 @@ function NotificationsTab() {
     finally { setSaving(null); }
   }
 
+  function startTiming(msg: any) {
+    setTimingKey(msg.key);
+    setTimingDays(msg.offset_days ?? 1);
+    setTimingHour(msg.send_hour ?? 9);
+  }
+  async function saveTiming(key: string) {
+    try {
+      await fetch(`${API}/api/notifications/customer-messages/${key}`, {
+        method: "PATCH",
+        headers: { ...getAuthHeaders(), "Content-Type": "application/json" },
+        body: JSON.stringify({ offset_days: timingDays, send_hour: timingHour }),
+      });
+      setTimingKey(null);
+      toast({ title: "Timing updated" });
+      load();
+    } catch { toast({ title: "Failed to update timing", variant: "destructive" }); }
+  }
+  async function addMessage() {
+    if (!addForm.label.trim()) { toast({ title: "Give the message a name", variant: "destructive" }); return; }
+    if (!addForm.email_body && !addForm.sms_body) { toast({ title: "Add an email or text body", variant: "destructive" }); return; }
+    setAddBusy(true);
+    try {
+      const r = await fetch(`${API}/api/notifications/customer-messages`, {
+        method: "POST",
+        headers: { ...getAuthHeaders(), "Content-Type": "application/json" },
+        body: JSON.stringify(addForm),
+      });
+      if (!r.ok) throw new Error();
+      setShowAdd(false); setAddForm(blankAdd);
+      toast({ title: "Message added" });
+      load();
+    } catch { toast({ title: "Failed to add message", variant: "destructive" }); }
+    finally { setAddBusy(false); }
+  }
+  async function deleteMessage(key: string, label: string) {
+    if (!confirm(`Delete "${label}"? This automated message will stop sending.`)) return;
+    try {
+      await fetch(`${API}/api/notifications/customer-messages/${key}`, { method: "DELETE", headers: getAuthHeaders() });
+      toast({ title: "Message deleted" });
+      load();
+    } catch { toast({ title: "Failed to delete", variant: "destructive" }); }
+  }
+
   function startEdit(ch: any) {
     setEditingId(ch.id);
     setEditBody(ch.body || "");
@@ -1627,13 +1677,72 @@ function NotificationsTab() {
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 20 }}>
         <div>
           <p style={{ fontSize: 16, fontWeight: 800, color: '#1A1917', margin: '0 0 4px' }}>Customer Messages</p>
-          <p style={{ fontSize: 12, color: '#9E9B94', margin: 0, maxWidth: 540, lineHeight: 1.5 }}>Every automated text and email customers receive, in the order they get them. Edit the wording, or pause any one. Timing is shown for each.</p>
+          <p style={{ fontSize: 12, color: '#9E9B94', margin: 0, maxWidth: 540, lineHeight: 1.5 }}>Every automated text and email customers receive, in the order they get them. Edit the wording or timing, pause any one, or add your own.</p>
         </div>
-        <button onClick={() => setShowLog(!showLog)}
-          style={{ fontSize: 12, fontWeight: 600, color: 'var(--brand, #5B9BD5)', background: '#EBF4FF', border: 'none', borderRadius: 6, padding: '6px 14px', cursor: 'pointer', fontFamily: FF, flexShrink: 0 }}>
-          {showLog ? "Hide Recent Sends" : "Recent Sends"} {logs.length > 0 && `(${logs.length})`}
-        </button>
+        <div style={{ display: 'flex', gap: 8, flexShrink: 0 }}>
+          <button onClick={() => { setAddForm(blankAdd); setShowAdd(true); }}
+            style={{ fontSize: 12, fontWeight: 700, color: '#fff', background: 'var(--brand, #5B9BD5)', border: 'none', borderRadius: 6, padding: '6px 14px', cursor: 'pointer', fontFamily: FF }}>
+            + Add a message
+          </button>
+          <button onClick={() => setShowLog(!showLog)}
+            style={{ fontSize: 12, fontWeight: 600, color: 'var(--brand, #5B9BD5)', background: '#EBF4FF', border: 'none', borderRadius: 6, padding: '6px 14px', cursor: 'pointer', fontFamily: FF }}>
+            {showLog ? "Hide Recent Sends" : "Recent Sends"} {logs.length > 0 && `(${logs.length})`}
+          </button>
+        </div>
       </div>
+
+      {showAdd && (
+        <div onClick={() => setShowAdd(false)} style={{ position: 'fixed', inset: 0, background: 'rgba(10,14,26,0.45)', display: 'flex', alignItems: 'flex-start', justifyContent: 'center', zIndex: 1000, padding: '40px 16px', overflowY: 'auto' }}>
+          <div onClick={e => e.stopPropagation()} style={{ background: '#fff', borderRadius: 14, padding: 24, width: '100%', maxWidth: 560, fontFamily: FF }}>
+            <p style={{ fontSize: 16, fontWeight: 800, color: '#1A1917', margin: '0 0 4px' }}>Add a message</p>
+            <p style={{ fontSize: 12, color: '#9E9B94', margin: '0 0 16px' }}>A new automated message that fires for every job, on your schedule.</p>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+              <div>
+                <p style={{ fontSize: 11, fontWeight: 700, color: '#9E9B94', margin: '0 0 5px', textTransform: 'uppercase', letterSpacing: '0.06em' }}>Name (internal)</p>
+                <input value={addForm.label} onChange={e => setAddForm({ ...addForm, label: e.target.value })} placeholder="e.g. Two-day follow-up"
+                  style={{ width: '100%', padding: '8px 12px', border: '1px solid #E5E2DC', borderRadius: 7, fontSize: 13, fontFamily: FF, boxSizing: 'border-box' }} />
+              </div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', fontSize: 13, color: '#374151' }}>
+                <span>Send</span>
+                <input type="number" min={0} max={60} value={addForm.offset_days} onChange={e => setAddForm({ ...addForm, offset_days: Math.max(0, Math.min(60, parseInt(e.target.value) || 0)) })}
+                  style={{ width: 56, padding: '6px 8px', border: '1px solid #E5E2DC', borderRadius: 6, fontFamily: FF, fontSize: 13 }} />
+                <span>day(s)</span>
+                <select value={addForm.anchor} onChange={e => setAddForm({ ...addForm, anchor: e.target.value })} style={{ padding: '6px 8px', border: '1px solid #E5E2DC', borderRadius: 6, fontFamily: FF, fontSize: 13 }}>
+                  <option value="before_appointment">before the appointment</option>
+                  <option value="after_appointment">after the appointment</option>
+                </select>
+                <span>at</span>
+                <select value={addForm.send_hour} onChange={e => setAddForm({ ...addForm, send_hour: parseInt(e.target.value) })} style={{ padding: '6px 8px', border: '1px solid #E5E2DC', borderRadius: 6, fontFamily: FF, fontSize: 13 }}>
+                  {Array.from({ length: 24 }, (_, h) => <option key={h} value={h}>{`${((h + 11) % 12) + 1}:00 ${h < 12 ? 'AM' : 'PM'}`}</option>)}
+                </select>
+                <span>CT</span>
+              </div>
+              <div>
+                <p style={{ fontSize: 11, fontWeight: 700, color: '#9E9B94', margin: '0 0 5px', textTransform: 'uppercase', letterSpacing: '0.06em' }}>Text message (leave blank to skip)</p>
+                <textarea value={addForm.sms_body} onChange={e => setAddForm({ ...addForm, sms_body: e.target.value })} placeholder="Hi {{first_name}}, ..."
+                  style={{ width: '100%', height: 64, padding: '9px 11px', border: '1px solid #E5E2DC', borderRadius: 7, fontSize: 12, fontFamily: FF, resize: 'vertical', boxSizing: 'border-box', lineHeight: 1.5 }} />
+              </div>
+              <div>
+                <p style={{ fontSize: 11, fontWeight: 700, color: '#9E9B94', margin: '0 0 5px', textTransform: 'uppercase', letterSpacing: '0.06em' }}>Email (leave blank to skip)</p>
+                <input value={addForm.email_subject} onChange={e => setAddForm({ ...addForm, email_subject: e.target.value })} placeholder="Email subject"
+                  style={{ width: '100%', padding: '8px 12px', border: '1px solid #E5E2DC', borderRadius: 7, fontSize: 13, fontFamily: FF, boxSizing: 'border-box', marginBottom: 6 }} />
+                <textarea value={addForm.email_body} onChange={e => setAddForm({ ...addForm, email_body: e.target.value })} placeholder="Hi {{first_name}}, ..."
+                  style={{ width: '100%', height: 96, padding: '9px 11px', border: '1px solid #E5E2DC', borderRadius: 7, fontSize: 12, fontFamily: FF, resize: 'vertical', boxSizing: 'border-box', lineHeight: 1.5 }} />
+              </div>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4 }}>
+                <span style={{ fontSize: 10, color: '#9E9B94', alignSelf: 'center', marginRight: 2 }}>Tags:</span>
+                {(mergeTags.length ? mergeTags : Object.keys(CM_SAMPLE)).map(v => (
+                  <span key={v} style={{ fontSize: 10, color: '#7C3AED', background: '#EDE9FE', borderRadius: 4, padding: '2px 7px' }}>{`{{${v}}}`}</span>
+                ))}
+              </div>
+              <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 4 }}>
+                <button onClick={() => setShowAdd(false)} style={{ padding: '8px 16px', border: '1px solid #E5E2DC', borderRadius: 7, background: '#fff', fontSize: 13, cursor: 'pointer', fontFamily: FF }}>Cancel</button>
+                <button onClick={addMessage} disabled={addBusy} style={{ padding: '8px 18px', border: 'none', borderRadius: 7, background: 'var(--brand, #5B9BD5)', color: '#fff', fontSize: 13, fontWeight: 700, cursor: 'pointer', fontFamily: FF }}>{addBusy ? 'Adding…' : 'Add message'}</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
 
       {showLog && (
         <div style={{ ...CARD, marginBottom: 20 }}>
@@ -1668,17 +1777,38 @@ function NotificationsTab() {
             {groupMsgs.map(msg => {
               const anyOn = msg.channels.some((c: any) => c.is_active);
               return (
-                <div key={msg.trigger} style={{ ...CARD, borderLeft: `3px solid ${anyOn ? 'var(--brand, #5B9BD5)' : '#E5E2DC'}` }}>
+                <div key={msg.key} style={{ ...CARD, borderLeft: `3px solid ${anyOn ? 'var(--brand, #5B9BD5)' : '#E5E2DC'}` }}>
                   <div style={{ marginBottom: 12 }}>
                     <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', marginBottom: 3 }}>
                       <span style={{ fontSize: 14, fontWeight: 800, color: '#1A1917' }}>{msg.label}</span>
                       {msg.channels.map((c: any) => (
                         <span key={c.channel} style={{ fontSize: 9, fontWeight: 700, letterSpacing: '0.06em', color: chTags[c.channel]?.color, background: chTags[c.channel]?.bg, padding: '2px 6px', borderRadius: 4 }}>{chTags[c.channel]?.label}</span>
                       ))}
+                      {!msg.is_builtin && <span style={{ fontSize: 9, fontWeight: 700, letterSpacing: '0.06em', color: '#7C3AED', background: '#EDE9FE', padding: '2px 6px', borderRadius: 4 }}>CUSTOM</span>}
+                      {!msg.is_builtin && (
+                        <button onClick={() => deleteMessage(msg.key, msg.label)} style={{ marginLeft: 'auto', fontSize: 11, color: '#DC2626', background: 'none', border: 'none', cursor: 'pointer', fontFamily: FF }}>Delete</button>
+                      )}
                     </div>
-                    <p style={{ fontSize: 11.5, color: '#6B7280', margin: 0, lineHeight: 1.5 }}>
-                      <span style={{ fontWeight: 600, color: '#374151' }}>When:</span> {msg.timing}
-                    </p>
+                    {timingKey === msg.key ? (
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', marginTop: 6, fontSize: 12, color: '#374151' }}>
+                        <span>Send</span>
+                        <input type="number" min={0} max={60} value={timingDays} onChange={e => setTimingDays(Math.max(0, Math.min(60, parseInt(e.target.value) || 0)))}
+                          style={{ width: 52, padding: '5px 8px', border: '1px solid #E5E2DC', borderRadius: 6, fontFamily: FF, fontSize: 12 }} />
+                        <span>day(s) {msg.anchor === 'after_appointment' ? 'after' : 'before'}, at</span>
+                        <select value={timingHour} onChange={e => setTimingHour(parseInt(e.target.value))}
+                          style={{ padding: '5px 8px', border: '1px solid #E5E2DC', borderRadius: 6, fontFamily: FF, fontSize: 12 }}>
+                          {Array.from({ length: 24 }, (_, h) => <option key={h} value={h}>{`${((h + 11) % 12) + 1}:00 ${h < 12 ? 'AM' : 'PM'}`}</option>)}
+                        </select>
+                        <span>CT</span>
+                        <button onClick={() => saveTiming(msg.key)} style={{ fontSize: 11, fontWeight: 700, color: '#fff', background: 'var(--brand, #5B9BD5)', border: 'none', borderRadius: 6, padding: '5px 12px', cursor: 'pointer', fontFamily: FF }}>Save</button>
+                        <button onClick={() => setTimingKey(null)} style={{ fontSize: 11, color: '#6B7280', background: 'none', border: 'none', cursor: 'pointer', fontFamily: FF }}>Cancel</button>
+                      </div>
+                    ) : (
+                      <p style={{ fontSize: 11.5, color: '#6B7280', margin: 0, lineHeight: 1.5 }}>
+                        <span style={{ fontWeight: 600, color: '#374151' }}>When:</span> {msg.timing}
+                        {msg.editable_timing && <button onClick={() => startTiming(msg)} style={{ marginLeft: 8, fontSize: 11, color: 'var(--brand, #5B9BD5)', background: 'none', border: 'none', cursor: 'pointer', fontFamily: FF, fontWeight: 600 }}>Edit timing</button>}
+                      </p>
+                    )}
                   </div>
 
                   <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>

--- a/artifacts/qleno/src/pages/company.tsx
+++ b/artifacts/qleno/src/pages/company.tsx
@@ -1531,25 +1531,44 @@ function SmsSmsSettingsCard() {
   );
 }
 
+// Sample values used to render a live preview of each message in the editor,
+// so the office sees what the customer actually gets (no {{tags}} on screen).
+const CM_SAMPLE: Record<string, string> = {
+  first_name: "Maria", client_name: "Maria Gomez", company_name: "Phes",
+  company_phone: "(708) 974-5517", company_email: "info@phes.io",
+  service_type: "Standard Cleaning", date: "Fri, Jun 26", time: "9:00 AM",
+  arrival_window: "9:00 AM – 12:00 PM", service_address: "123 Oak St, Oak Lawn, IL 60453",
+  tech_name: "Ana", appointment_link: "https://phes.io/appt/1234", review_link: "https://phes.io/review/1234",
+};
+function cmFill(s: string): string {
+  return (s || "").replace(/\{\{([^}]+)\}\}/g, (_, k) => CM_SAMPLE[String(k).trim()] ?? "");
+}
+const CM_GROUPS: { key: string; title: string; sub: string }[] = [
+  { key: "before", title: "Before the visit", sub: "Confirmation and reminders" },
+  { key: "during", title: "During the visit", sub: "Day-of, while the team is en route" },
+  { key: "after", title: "After the visit", sub: "Thank-you and review request" },
+];
+
 function NotificationsTab() {
   const { toast } = useToast();
-  const [templates, setTemplates] = useState<any[]>([]);
+  const [messages, setMessages] = useState<any[]>([]);
+  const [mergeTags, setMergeTags] = useState<string[]>([]);
   const [logs, setLogs] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
   const [editingId, setEditingId] = useState<number | null>(null);
   const [editBody, setEditBody] = useState("");
   const [editSubject, setEditSubject] = useState("");
   const [showLog, setShowLog] = useState(false);
-  const [testing, setTesting] = useState<number | null>(null);
   const [saving, setSaving] = useState<number | null>(null);
 
   async function load() {
     try {
-      const [t, l] = await Promise.all([
-        fetch(`${API}/api/notifications/templates`, { headers: getAuthHeaders() }).then(r => r.json()),
+      const [m, l] = await Promise.all([
+        fetch(`${API}/api/notifications/customer-messages`, { headers: getAuthHeaders() }).then(r => r.json()),
         fetch(`${API}/api/notifications/log`, { headers: getAuthHeaders() }).then(r => r.json()),
       ]);
-      setTemplates(t.data || []);
+      setMessages(m.data || []);
+      setMergeTags(m.merge_tags || []);
       setLogs(l.data || []);
     } catch {}
     finally { setLoading(false); }
@@ -1557,81 +1576,69 @@ function NotificationsTab() {
 
   useEffect(() => { load(); }, []);
 
-  async function toggle(id: number, is_active: boolean) {
-    const tmpl = templates.find(t => t.id === id);
-    if (!tmpl) return;
-    setTemplates(prev => prev.map(t => t.id === id ? { ...t, is_active } : t));
+  // Optimistically flip a channel's on/off, then persist. id = template row id.
+  async function toggle(id: number, ch: any, is_active: boolean) {
+    setMessages(prev => prev.map(m => ({ ...m, channels: m.channels.map((c: any) => c.id === id ? { ...c, is_active } : c) })));
     try {
       await fetch(`${API}/api/notifications/templates/${id}`, {
         method: "PATCH",
         headers: { ...getAuthHeaders(), "Content-Type": "application/json" },
-        body: JSON.stringify({ is_active, subject: tmpl.subject, body: tmpl.body }),
+        body: JSON.stringify({ is_active, subject: ch.subject, body: ch.body }),
       });
-      toast({ title: `Notification ${is_active ? "enabled" : "disabled"}` });
+      toast({ title: is_active ? "Message turned on" : "Message paused" });
     } catch {
       toast({ title: "Failed to update", variant: "destructive" });
       load();
     }
   }
 
-  async function save(id: number) {
+  async function save(id: number, ch: any) {
     setSaving(id);
     try {
-      const tmpl = templates.find(t => t.id === id)!;
       await fetch(`${API}/api/notifications/templates/${id}`, {
         method: "PATCH",
         headers: { ...getAuthHeaders(), "Content-Type": "application/json" },
-        body: JSON.stringify({ is_active: tmpl.is_active, subject: editSubject, body: editBody }),
+        body: JSON.stringify({ is_active: ch.is_active, subject: editSubject, body: editBody }),
       });
-      setTemplates(prev => prev.map(t => t.id === id ? { ...t, subject: editSubject, body: editBody } : t));
-      toast({ title: "Template saved" });
+      setMessages(prev => prev.map(m => ({ ...m, channels: m.channels.map((c: any) => c.id === id ? { ...c, subject: editSubject, body: editBody } : c) })));
+      toast({ title: "Message saved" });
       setEditingId(null);
     } catch { toast({ title: "Failed to save", variant: "destructive" }); }
     finally { setSaving(null); }
   }
 
-  async function testNotification(id: number) {
-    setTesting(id);
-    try {
-      const r = await fetch(`${API}/api/notifications/templates/${id}/test`, {
-        method: "POST", headers: getAuthHeaders(),
-      });
-      const d = await r.json();
-      toast({ title: "Test sent!", description: d.message });
-      load();
-    } catch { toast({ title: "Test failed", variant: "destructive" }); }
-    finally { setTesting(null); }
-  }
-
-  function startEdit(tmpl: any) {
-    setEditingId(tmpl.id);
-    setEditBody(tmpl.body);
-    setEditSubject(tmpl.subject || "");
+  function startEdit(ch: any) {
+    setEditingId(ch.id);
+    setEditBody(ch.body || "");
+    setEditSubject(ch.subject || "");
   }
 
   const FF = "'Plus Jakarta Sans', sans-serif";
   const CARD: React.CSSProperties = { background: '#fff', border: '1px solid #E5E2DC', borderRadius: 12, padding: '18px 20px', marginBottom: 12 };
+  const chTags: Record<string, { label: string; color: string; bg: string }> = {
+    email: { label: 'EMAIL', color: '#1D4ED8', bg: '#EFF6FF' },
+    sms: { label: 'TEXT', color: '#047857', bg: '#ECFDF5' },
+  };
 
   if (loading) return <div style={{ padding: '40px 0', textAlign: 'center', color: '#9E9B94', fontFamily: FF }}>Loading…</div>;
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 0, fontFamily: FF }}>
-      <SmsSmsSettingsCard />
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 20 }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 20 }}>
         <div>
-          <p style={{ fontSize: 14, fontWeight: 700, color: '#1A1917', margin: '0 0 4px' }}>Notification Triggers</p>
-          <p style={{ fontSize: 12, color: '#9E9B94', margin: 0 }}>Configure automatic messages sent to clients and staff</p>
+          <p style={{ fontSize: 16, fontWeight: 800, color: '#1A1917', margin: '0 0 4px' }}>Customer Messages</p>
+          <p style={{ fontSize: 12, color: '#9E9B94', margin: 0, maxWidth: 540, lineHeight: 1.5 }}>Every automated text and email customers receive, in the order they get them. Edit the wording, or pause any one. Timing is shown for each.</p>
         </div>
         <button onClick={() => setShowLog(!showLog)}
-          style={{ fontSize: 12, fontWeight: 600, color: 'var(--brand, #5B9BD5)', background: '#EBF4FF', border: 'none', borderRadius: 6, padding: '6px 14px', cursor: 'pointer', fontFamily: FF }}>
-          {showLog ? "Hide Log" : "View Log"} {logs.length > 0 && `(${logs.length})`}
+          style={{ fontSize: 12, fontWeight: 600, color: 'var(--brand, #5B9BD5)', background: '#EBF4FF', border: 'none', borderRadius: 6, padding: '6px 14px', cursor: 'pointer', fontFamily: FF, flexShrink: 0 }}>
+          {showLog ? "Hide Recent Sends" : "Recent Sends"} {logs.length > 0 && `(${logs.length})`}
         </button>
       </div>
 
       {showLog && (
         <div style={{ ...CARD, marginBottom: 20 }}>
-          <p style={{ fontSize: 13, fontWeight: 700, color: '#1A1917', margin: '0 0 12px' }}>Recent Notification Log</p>
-          {logs.length === 0 && <p style={{ fontSize: 12, color: '#9E9B94', margin: 0 }}>No notifications sent yet.</p>}
+          <p style={{ fontSize: 13, fontWeight: 700, color: '#1A1917', margin: '0 0 12px' }}>Recent Sends (all customers)</p>
+          {logs.length === 0 && <p style={{ fontSize: 12, color: '#9E9B94', margin: 0 }}>No messages sent yet.</p>}
           <div style={{ display: 'flex', flexDirection: 'column', gap: 6, maxHeight: 240, overflowY: 'auto' }}>
             {logs.map(l => (
               <div key={l.id} style={{ display: 'flex', justifyContent: 'space-between', padding: '7px 10px', background: '#F7F6F3', borderRadius: 6, alignItems: 'center' }}>
@@ -1640,8 +1647,8 @@ function NotificationsTab() {
                   <span style={{ fontSize: 11, color: '#9E9B94', marginLeft: 8 }}>{CHANNEL_LABELS[l.channel] || l.channel} → {l.recipient}</span>
                 </div>
                 <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-                  <span style={{ fontSize: 11, color: l.status === 'test_sent' ? '#7C3AED' : '#16A34A', fontWeight: 600 }}>{l.status}</span>
-                  <span style={{ fontSize: 10, color: '#9E9B94' }}>{new Date(l.sent_at).toLocaleString()}</span>
+                  <span style={{ fontSize: 11, color: l.status === 'sent' ? '#16A34A' : l.status === 'test_sent' ? '#7C3AED' : '#B45309', fontWeight: 600 }}>{l.status}</span>
+                  <span style={{ fontSize: 10, color: '#9E9B94' }}>{l.sent_at ? new Date(l.sent_at).toLocaleString() : ""}</span>
                 </div>
               </div>
             ))}
@@ -1649,84 +1656,106 @@ function NotificationsTab() {
         </div>
       )}
 
-      {templates.map(tmpl => (
-        <div key={tmpl.id} style={{ ...CARD, borderLeft: `3px solid ${tmpl.is_active ? 'var(--brand, #5B9BD5)' : '#E5E2DC'}` }}>
-          <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 12, marginBottom: editingId === tmpl.id ? 14 : 0 }}>
-            <div style={{ flex: 1 }}>
-              <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4 }}>
-                <span style={{ fontSize: 11, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.04em', color: '#6B7280' }}>{CHANNEL_LABELS[tmpl.channel] || tmpl.channel}</span>
-                <span style={{ fontSize: 13, fontWeight: 700, color: '#1A1917' }}>{TRIGGER_LABELS[tmpl.trigger] || tmpl.trigger}</span>
-                <span style={{ fontSize: 10, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', color: '#9E9B94', background: '#F3F4F6', padding: '2px 7px', borderRadius: 4 }}>{tmpl.channel}</span>
-              </div>
-              {editingId !== tmpl.id && (
-                <p style={{ fontSize: 12, color: '#6B7280', margin: 0, lineHeight: 1.5, overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical' }}>
-                  {tmpl.subject ? <><strong>{tmpl.subject}</strong> — </> : ""}{tmpl.body}
-                </p>
-              )}
+      {CM_GROUPS.map(group => {
+        const groupMsgs = messages.filter(m => m.group === group.key);
+        if (groupMsgs.length === 0) return null;
+        return (
+          <div key={group.key} style={{ marginBottom: 24 }}>
+            <div style={{ marginBottom: 10 }}>
+              <p style={{ fontSize: 11, fontWeight: 800, textTransform: 'uppercase', letterSpacing: '0.08em', color: 'var(--brand, #5B9BD5)', margin: '0 0 2px' }}>{group.title}</p>
+              <p style={{ fontSize: 11, color: '#9E9B94', margin: 0 }}>{group.sub}</p>
             </div>
-            <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 8, flexShrink: 0 }}>
-              <button
-                onClick={() => toggle(tmpl.id, !tmpl.is_active)}
-                style={{
-                  width: 44, height: 24, borderRadius: 12, border: 'none', cursor: 'pointer',
-                  background: tmpl.is_active ? 'var(--brand, #5B9BD5)' : '#E5E2DC', position: 'relative', transition: 'background 0.2s',
-                }}>
-                <div style={{
-                  width: 18, height: 18, borderRadius: 9, background: '#fff',
-                  position: 'absolute', top: 3, left: tmpl.is_active ? 23 : 3,
-                  transition: 'left 0.2s', boxShadow: '0 1px 3px rgba(0,0,0,0.15)',
-                }}/>
-              </button>
-              <div style={{ display: 'flex', gap: 5 }}>
-                <button onClick={() => editingId === tmpl.id ? setEditingId(null) : startEdit(tmpl)}
-                  style={{ fontSize: 11, color: 'var(--brand, #5B9BD5)', background: '#EBF4FF', border: 'none', borderRadius: 5, padding: '3px 8px', cursor: 'pointer', fontFamily: FF, fontWeight: 600 }}>
-                  {editingId === tmpl.id ? "Cancel" : "Edit"}
-                </button>
-                <button onClick={() => testNotification(tmpl.id)} disabled={testing === tmpl.id}
-                  style={{ fontSize: 11, color: '#6B7280', background: '#F3F4F6', border: 'none', borderRadius: 5, padding: '3px 8px', cursor: 'pointer', fontFamily: FF }}>
-                  {testing === tmpl.id ? "…" : "Test"}
-                </button>
-              </div>
-            </div>
-          </div>
+            {groupMsgs.map(msg => {
+              const anyOn = msg.channels.some((c: any) => c.is_active);
+              return (
+                <div key={msg.trigger} style={{ ...CARD, borderLeft: `3px solid ${anyOn ? 'var(--brand, #5B9BD5)' : '#E5E2DC'}` }}>
+                  <div style={{ marginBottom: 12 }}>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', marginBottom: 3 }}>
+                      <span style={{ fontSize: 14, fontWeight: 800, color: '#1A1917' }}>{msg.label}</span>
+                      {msg.channels.map((c: any) => (
+                        <span key={c.channel} style={{ fontSize: 9, fontWeight: 700, letterSpacing: '0.06em', color: chTags[c.channel]?.color, background: chTags[c.channel]?.bg, padding: '2px 6px', borderRadius: 4 }}>{chTags[c.channel]?.label}</span>
+                      ))}
+                    </div>
+                    <p style={{ fontSize: 11.5, color: '#6B7280', margin: 0, lineHeight: 1.5 }}>
+                      <span style={{ fontWeight: 600, color: '#374151' }}>When:</span> {msg.timing}
+                    </p>
+                  </div>
 
-          {editingId === tmpl.id && (
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-              {tmpl.channel === 'email' && (
-                <div>
-                  <p style={{ fontSize: 11, fontWeight: 700, color: '#9E9B94', margin: '0 0 5px', textTransform: 'uppercase', letterSpacing: '0.06em' }}>Subject Line</p>
-                  <input value={editSubject} onChange={e => setEditSubject(e.target.value)}
-                    style={{ width: '100%', padding: '8px 12px', border: '1px solid #E5E2DC', borderRadius: 7, fontSize: 13, fontFamily: FF, outline: 'none', boxSizing: 'border-box' }}/>
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+                    {msg.channels.map((ch: any) => (
+                      <div key={ch.channel} style={{ border: '1px solid #F0EEE9', borderRadius: 9, padding: '12px 14px', background: ch.is_active ? '#fff' : '#FAFAF8' }}>
+                        <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 12 }}>
+                          <div style={{ flex: 1, minWidth: 0 }}>
+                            <span style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.06em', color: chTags[ch.channel]?.color }}>{chTags[ch.channel]?.label}</span>
+                            {editingId !== ch.id && (
+                              <p style={{ fontSize: 12, color: ch.is_active ? '#374151' : '#9E9B94', margin: '4px 0 0', lineHeight: 1.5, whiteSpace: 'pre-wrap', overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 3, WebkitBoxOrient: 'vertical' }}>
+                                {ch.channel === 'email' && ch.subject ? <><strong>{cmFill(ch.subject)}</strong>{"\n"}</> : ""}{cmFill(ch.body)}
+                              </p>
+                            )}
+                          </div>
+                          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 8, flexShrink: 0 }}>
+                            <button onClick={() => toggle(ch.id, ch, !ch.is_active)} title={ch.is_active ? "On — tap to pause" : "Paused — tap to turn on"}
+                              style={{ width: 44, height: 24, borderRadius: 12, border: 'none', cursor: 'pointer', background: ch.is_active ? 'var(--brand, #5B9BD5)' : '#E5E2DC', position: 'relative', transition: 'background 0.2s' }}>
+                              <div style={{ width: 18, height: 18, borderRadius: 9, background: '#fff', position: 'absolute', top: 3, left: ch.is_active ? 23 : 3, transition: 'left 0.2s', boxShadow: '0 1px 3px rgba(0,0,0,0.15)' }}/>
+                            </button>
+                            <button onClick={() => editingId === ch.id ? setEditingId(null) : startEdit(ch)}
+                              style={{ fontSize: 11, color: 'var(--brand, #5B9BD5)', background: '#EBF4FF', border: 'none', borderRadius: 5, padding: '3px 10px', cursor: 'pointer', fontFamily: FF, fontWeight: 600 }}>
+                              {editingId === ch.id ? "Cancel" : "Edit"}
+                            </button>
+                          </div>
+                        </div>
+
+                        {editingId === ch.id && (
+                          <div style={{ display: 'flex', flexDirection: 'column', gap: 10, marginTop: 12 }}>
+                            {ch.channel === 'email' && (
+                              <div>
+                                <p style={{ fontSize: 11, fontWeight: 700, color: '#9E9B94', margin: '0 0 5px', textTransform: 'uppercase', letterSpacing: '0.06em' }}>Subject Line</p>
+                                <input value={editSubject} onChange={e => setEditSubject(e.target.value)}
+                                  style={{ width: '100%', padding: '8px 12px', border: '1px solid #E5E2DC', borderRadius: 7, fontSize: 13, fontFamily: FF, outline: 'none', boxSizing: 'border-box' }}/>
+                              </div>
+                            )}
+                            <div>
+                              <p style={{ fontSize: 11, fontWeight: 700, color: '#9E9B94', margin: '0 0 5px', textTransform: 'uppercase', letterSpacing: '0.06em' }}>{ch.channel === 'email' ? 'Email Body' : 'Text Message'}</p>
+                              <textarea value={editBody} onChange={e => setEditBody(e.target.value)}
+                                style={{ width: '100%', height: ch.channel === 'email' ? 150 : 90, padding: '10px 12px', border: '1px solid #E5E2DC', borderRadius: 7, fontSize: 12, fontFamily: FF, outline: 'none', resize: 'vertical', boxSizing: 'border-box', lineHeight: 1.5 }}/>
+                            </div>
+                            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4 }}>
+                              <span style={{ fontSize: 10, color: '#9E9B94', alignSelf: 'center', marginRight: 2 }}>Insert:</span>
+                              {(mergeTags.length ? mergeTags : Object.keys(CM_SAMPLE)).map(v => (
+                                <button key={v} onClick={() => setEditBody(b => b + `{{${v}}}`)}
+                                  style={{ fontSize: 10, color: '#7C3AED', background: '#EDE9FE', border: 'none', borderRadius: 4, padding: '2px 7px', cursor: 'pointer', fontFamily: FF }}>
+                                  {`{{${v}}}`}
+                                </button>
+                              ))}
+                            </div>
+                            <div style={{ background: '#F7F6F3', border: '1px solid #E5E2DC', borderRadius: 7, padding: '10px 12px' }}>
+                              <p style={{ fontSize: 10, fontWeight: 700, color: '#9E9B94', margin: '0 0 5px', textTransform: 'uppercase', letterSpacing: '0.06em' }}>Preview (sample customer)</p>
+                              {ch.channel === 'email' && editSubject && <p style={{ fontSize: 12, fontWeight: 700, color: '#1A1917', margin: '0 0 4px' }}>{cmFill(editSubject)}</p>}
+                              <p style={{ fontSize: 12, color: '#374151', margin: 0, lineHeight: 1.5, whiteSpace: 'pre-wrap' }}>{cmFill(editBody)}</p>
+                            </div>
+                            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
+                              <button onClick={() => setEditingId(null)}
+                                style={{ padding: '7px 14px', border: '1px solid #E5E2DC', borderRadius: 7, background: '#fff', fontSize: 12, cursor: 'pointer', fontFamily: FF }}>
+                                Cancel
+                              </button>
+                              <button onClick={() => save(ch.id, ch)} disabled={saving === ch.id}
+                                style={{ padding: '7px 16px', border: 'none', borderRadius: 7, background: 'var(--brand, #5B9BD5)', color: '#fff', fontSize: 12, fontWeight: 700, cursor: 'pointer', fontFamily: FF }}>
+                                {saving === ch.id ? "Saving…" : "Save"}
+                              </button>
+                            </div>
+                          </div>
+                        )}
+                      </div>
+                    ))}
+                  </div>
                 </div>
-              )}
-              <div>
-                <p style={{ fontSize: 11, fontWeight: 700, color: '#9E9B94', margin: '0 0 5px', textTransform: 'uppercase', letterSpacing: '0.06em' }}>Message Body</p>
-                <textarea value={editBody} onChange={e => setEditBody(e.target.value)}
-                  style={{ width: '100%', height: 120, padding: '10px 12px', border: '1px solid #E5E2DC', borderRadius: 7, fontSize: 12, fontFamily: FF, outline: 'none', resize: 'vertical', boxSizing: 'border-box', lineHeight: 1.5 }}/>
-              </div>
-              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4, marginBottom: 4 }}>
-                <span style={{ fontSize: 10, color: '#9E9B94', alignSelf: 'center', marginRight: 2 }}>Variables:</span>
-                {VARIABLES_HELP.map(v => (
-                  <button key={v} onClick={() => setEditBody(b => b + v)}
-                    style={{ fontSize: 10, color: '#7C3AED', background: '#EDE9FE', border: 'none', borderRadius: 4, padding: '2px 7px', cursor: 'pointer', fontFamily: FF }}>
-                    {v}
-                  </button>
-                ))}
-              </div>
-              <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
-                <button onClick={() => setEditingId(null)}
-                  style={{ padding: '7px 14px', border: '1px solid #E5E2DC', borderRadius: 7, background: '#fff', fontSize: 12, cursor: 'pointer', fontFamily: FF }}>
-                  Cancel
-                </button>
-                <button onClick={() => save(tmpl.id)} disabled={saving === tmpl.id}
-                  style={{ padding: '7px 16px', border: 'none', borderRadius: 7, background: 'var(--brand, #5B9BD5)', color: '#fff', fontSize: 12, fontWeight: 700, cursor: 'pointer', fontFamily: FF }}>
-                  {saving === tmpl.id ? "Saving…" : "Save Template"}
-                </button>
-              </div>
-            </div>
-          )}
-        </div>
-      ))}
+              );
+            })}
+          </div>
+        );
+      })}
+
+      <SmsSmsSettingsCard />
     </div>
   );
 }

--- a/artifacts/qleno/src/pages/customer-profile.tsx
+++ b/artifacts/qleno/src/pages/customer-profile.tsx
@@ -5484,10 +5484,60 @@ function ActivityTab({ clientId }: { clientId: number }) {
   );
 }
 
+// Per-customer message timeline — every automated + manual text/email we've
+// sent this customer, newest first (GET /api/clients/:id/messages).
+function CustomerMessagesTab({ clientId }: { clientId: number }) {
+  const [rows, setRows] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+  useEffect(() => {
+    let on = true;
+    fetch(`${API}/api/clients/${clientId}/messages`, { headers: getAuthHeaders() })
+      .then(r => r.json()).then(d => { if (on) setRows(d.data || []); })
+      .catch(() => {}).finally(() => { if (on) setLoading(false); });
+    return () => { on = false; };
+  }, [clientId]);
+
+  const TYPE_LABELS: Record<string, string> = {
+    job_scheduled: "Booking confirmation", reminder_3day: "3-day reminder", reminder_1day: "Next-day reminder",
+    on_my_way: "On-my-way text", job_completed: "Thank-you", review_request: "Review request", sms: "Text message",
+  };
+  const fmtType = (t: string) => TYPE_LABELS[t] || (t || "message").replace(/_/g, " ");
+  const statusColor = (s: string) =>
+    s === "sent" || s === "delivered" || s === "received" ? "#16A34A"
+    : s === "failed" || s === "undelivered" ? "#DC2626"
+    : (s || "").startsWith("suppress") || s === "skipped" ? "#B45309" : "#6B7280";
+
+  if (loading) return <div style={{ padding: 24, textAlign: "center", color: "#9E9B94", fontFamily: FF, fontSize: 13 }}>Loading…</div>;
+  if (rows.length === 0) return <div style={{ padding: 24, textAlign: "center", color: "#9E9B94", fontFamily: FF, fontSize: 13 }}>No messages sent to this customer yet.</div>;
+
+  return (
+    <div style={{ fontFamily: FF, display: "flex", flexDirection: "column", gap: 8 }}>
+      {rows.map((m, i) => (
+        <div key={i} style={{ display: "flex", gap: 12, padding: "10px 12px", background: "#F7F6F3", borderRadius: 8, alignItems: "flex-start" }}>
+          <span style={{ fontSize: 9, fontWeight: 700, letterSpacing: "0.06em", color: m.channel === "email" ? "#1D4ED8" : "#047857", background: m.channel === "email" ? "#EFF6FF" : "#ECFDF5", padding: "3px 7px", borderRadius: 4, marginTop: 1, flexShrink: 0 }}>{m.channel === "email" ? "EMAIL" : "TEXT"}</span>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", gap: 8, alignItems: "baseline" }}>
+              <span style={{ fontSize: 13, fontWeight: 700, color: "#1A1917" }}>{fmtType(m.type)}{m.direction === "inbound" && <span style={{ fontSize: 10, color: "#7C3AED", marginLeft: 6 }}>FROM CUSTOMER</span>}</span>
+              <span style={{ fontSize: 11, color: "#9E9B94", flexShrink: 0 }}>{m.at ? new Date(m.at).toLocaleString() : ""}</span>
+            </div>
+            {(m.subject || m.body) && (
+              <p style={{ fontSize: 12, color: "#6B6860", margin: "3px 0 2px", lineHeight: 1.5, whiteSpace: "pre-wrap", overflow: "hidden", display: "-webkit-box", WebkitLineClamp: 3, WebkitBoxOrient: "vertical" }}>
+                {m.subject ? <strong>{m.subject} — </strong> : ""}{m.body}
+              </p>
+            )}
+            <span style={{ fontSize: 11, fontWeight: 600, color: statusColor(m.status) }}>{m.status || ""}</span>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
 const PROFILE_TABS = [
   { id: "client",        label: "Client"        },
   { id: "property",      label: "Property"      },
   { id: "jobs",          label: "Jobs"          },
+  { id: "messages",      label: "Messages"      },
   { id: "admin",         label: "Admin"         },
   { id: "activity",      label: "Activity"      },
   { id: "profitability", label: "Profitability" },
@@ -6030,6 +6080,13 @@ export default function CustomerProfilePage() {
         </div>
       )}
 
+      {activeTab === "messages" && (
+        <div style={CS}>
+          <SectionHead title="Message History" action={<span style={{ fontSize: 11, color: "#9E9B94" }}>Texts &amp; emails sent to this customer</span>} />
+          <CustomerMessagesTab clientId={clientId} />
+        </div>
+      )}
+
       {/* ══════════════════════════════════════════════
           TAB 4: ADMIN — operational, not daily dispatch
           2-column grid top + full-width collapsibles below
@@ -6221,6 +6278,12 @@ export default function CustomerProfilePage() {
                 <CommLog2 clientId={clientId} />
               </CollapsibleSection>
             </>)}
+            {activeTab === "messages" && (
+              <div style={CS}>
+                <div style={CTitle}>Message History</div>
+                <CustomerMessagesTab clientId={clientId} />
+              </div>
+            )}
             {activeTab === "property" && (<>
               <div style={CS}>
                 <div style={CTitle}>Service Addresses</div>

--- a/artifacts/qleno/src/pages/invoices.tsx
+++ b/artifacts/qleno/src/pages/invoices.tsx
@@ -202,6 +202,150 @@ function NewInvoiceModal({ onClose, onDone }: { onClose: () => void; onDone: () 
   );
 }
 
+// [weekly-cadence 2026-06-26] On-demand consolidated invoicing. Lists
+// batch_invoice clients' pending per-visit drafts for a billing window (weekly
+// Sun–Sat or monthly), keyed on SERVICE DATE, and folds a client's window into
+// one invoice via POST /api/batch-invoicing/:clientId/consolidate. Office stays
+// in control — nothing generates automatically.
+function WeeklyInvoicingDrawer({ onClose, onDone }: { onClose: () => void; onDone: () => void }) {
+  const { toast } = useToast();
+  const qc = useQueryClient();
+  const [cadence, setCadence] = useState<"weekly" | "monthly">("weekly");
+  // Anchor any date inside the target window; default = today.
+  const [anchor, setAnchor] = useState(() => new Date().toISOString().slice(0, 10));
+  const [expanded, setExpanded] = useState<Set<number>>(new Set());
+  const [excluded, setExcluded] = useState<Set<number>>(new Set()); // invoice ids to leave out
+  const [busyClient, setBusyClient] = useState<number | null>(null);
+
+  const { data, isLoading, refetch } = useQuery({
+    queryKey: ["weekly-invoicing", cadence, anchor],
+    queryFn: () => apiFetch(`/api/batch-invoicing?cadence=${cadence}&date=${anchor}`),
+  });
+  const clients: any[] = data?.clients || [];
+
+  function shiftWindow(deltaDays: number) {
+    const d = new Date(`${anchor}T00:00:00.000Z`);
+    d.setUTCDate(d.getUTCDate() + deltaDays);
+    setAnchor(d.toISOString().slice(0, 10));
+  }
+  const fmtRange = (a?: string, b?: string) => {
+    if (!a || !b) return "";
+    const f = (s: string) => new Date(`${s}T00:00:00.000Z`).toLocaleDateString("en-US", { month: "short", day: "numeric", timeZone: "UTC" });
+    return `${f(a)} – ${f(b)}`;
+  };
+
+  async function consolidate(clientId: number) {
+    setBusyClient(clientId);
+    try {
+      const excludeForClient = (clients.find(c => c.client_id === clientId)?.visits || [])
+        .filter((v: any) => excluded.has(v.invoice_id)).map((v: any) => v.invoice_id);
+      const r = await apiFetch(`/api/batch-invoicing/${clientId}/consolidate`, {
+        method: "POST",
+        body: JSON.stringify({ cadence, date: anchor, exclude_invoice_ids: excludeForClient }),
+      });
+      toast({ title: "Weekly invoice created", description: `${r.visit_count} visit${r.visit_count !== 1 ? "s" : ""} · $${(r.parent_total || 0).toFixed(2)} · #${r.parent_invoice_id}` });
+      qc.invalidateQueries({ queryKey: ["invoices"] });
+      refetch();
+      onDone();
+    } catch (err: any) {
+      let msg = err?.message || "Failed";
+      try { msg = JSON.parse(msg).message || msg; } catch {}
+      toast({ title: "Could not consolidate", description: msg, variant: "destructive" });
+    } finally {
+      setBusyClient(null);
+    }
+  }
+
+  return (
+    <>
+      <div style={{ position: "fixed", inset: 0, backgroundColor: "rgba(0,0,0,0.45)", zIndex: 1000 }} onClick={onClose} />
+      <div style={{ position: "fixed", top: 0, right: 0, bottom: 0, width: "100%", maxWidth: 560, backgroundColor: "#FFFFFF", zIndex: 1001, display: "flex", flexDirection: "column", boxShadow: "-4px 0 24px rgba(0,0,0,0.12)", fontFamily: FF }}>
+        <div style={{ padding: "20px 24px", borderBottom: "1px solid #EEECE7", flexShrink: 0 }}>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start" }}>
+            <div>
+              <h2 style={{ margin: 0, fontSize: 18, fontWeight: 800, color: "#1A1917" }}>Weekly Invoicing</h2>
+              <p style={{ margin: "4px 0 0", fontSize: 13, color: "#6B7280" }}>Combine a client's visits into one invoice</p>
+            </div>
+            <button onClick={onClose} style={{ background: "none", border: "none", cursor: "pointer", color: "#9E9B94", padding: 4 }}><X size={20} /></button>
+          </div>
+          {/* cadence + window nav */}
+          <div style={{ display: "flex", alignItems: "center", gap: 8, marginTop: 14 }}>
+            <div style={{ display: "flex", border: "1px solid #E5E2DC", borderRadius: 8, overflow: "hidden" }}>
+              {(["weekly", "monthly"] as const).map(c => (
+                <button key={c} onClick={() => setCadence(c)}
+                  style={{ padding: "7px 14px", fontSize: 12, fontWeight: 700, border: "none", cursor: "pointer", fontFamily: FF, textTransform: "capitalize", backgroundColor: cadence === c ? "var(--brand)" : "#FFFFFF", color: cadence === c ? "#FFFFFF" : "#6B7280" }}>{c}</button>
+              ))}
+            </div>
+            <div style={{ flex: 1 }} />
+            <button onClick={() => shiftWindow(cadence === "weekly" ? -7 : -31)} style={{ background: "#F7F6F3", border: "1px solid #E5E2DC", borderRadius: 8, padding: "6px 10px", cursor: "pointer", fontFamily: FF }}>‹</button>
+            <span style={{ fontSize: 13, fontWeight: 700, color: "#1A1917", minWidth: 120, textAlign: "center" }}>{fmtRange(data?.period_start, data?.period_end)}</span>
+            <button onClick={() => shiftWindow(cadence === "weekly" ? 7 : 31)} style={{ background: "#F7F6F3", border: "1px solid #E5E2DC", borderRadius: 8, padding: "6px 10px", cursor: "pointer", fontFamily: FF }}>›</button>
+          </div>
+        </div>
+
+        <div style={{ flex: 1, overflowY: "auto", padding: "8px 0" }}>
+          {isLoading ? (
+            <div style={{ textAlign: "center", color: "#9E9B94", padding: 40 }}>Loading…</div>
+          ) : clients.length === 0 ? (
+            <div style={{ textAlign: "center", padding: 48 }}>
+              <AlertCircle size={36} style={{ color: "#C4C0BB", marginBottom: 12 }} />
+              <p style={{ fontSize: 14, fontWeight: 600, color: "#6B7280", margin: "0 0 4px" }}>No visits to invoice this {cadence === "weekly" ? "week" : "month"}</p>
+              <p style={{ fontSize: 12, color: "#9E9B94", margin: 0 }}>Only consolidated-billing clients with pending visits appear here.</p>
+            </div>
+          ) : (
+            clients.map((c: any) => {
+              const isOpen = expanded.has(c.client_id);
+              const incl = (c.visits || []).filter((v: any) => !excluded.has(v.invoice_id));
+              const inclTotal = incl.reduce((s: number, v: any) => s + (v.total || 0), 0);
+              return (
+                <div key={c.client_id} style={{ borderBottom: "1px solid #F0EDE8", padding: "14px 24px" }}>
+                  <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+                    <button onClick={() => setExpanded(p => { const n = new Set(p); n.has(c.client_id) ? n.delete(c.client_id) : n.add(c.client_id); return n; })}
+                      style={{ background: "none", border: "none", cursor: "pointer", padding: 0, display: "flex" }}>
+                      {isOpen ? <ChevronUp size={16} color="#9E9B94" /> : <ChevronDown size={16} color="#9E9B94" />}
+                    </button>
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      <p style={{ margin: 0, fontSize: 14, fontWeight: 700, color: "#1A1917", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{c.client_name || `Client #${c.client_id}`}</p>
+                      <p style={{ margin: "2px 0 0", fontSize: 12, color: "#9E9B94" }}>{incl.length} visit{incl.length !== 1 ? "s" : ""}{excluded.size ? ` · ${(c.visits || []).length - incl.length} excluded` : ""}</p>
+                    </div>
+                    <span style={{ fontSize: 15, fontWeight: 800, color: "#1A1917" }}>${inclTotal.toFixed(2)}</span>
+                    <button onClick={() => consolidate(c.client_id)} disabled={busyClient === c.client_id || incl.length === 0}
+                      style={{ backgroundColor: incl.length === 0 ? "#C4C0BB" : "var(--brand)", color: "#FFFFFF", border: "none", borderRadius: 8, padding: "8px 14px", fontSize: 13, fontWeight: 700, cursor: incl.length === 0 ? "default" : "pointer", fontFamily: FF, whiteSpace: "nowrap" }}>
+                      {busyClient === c.client_id ? "Working…" : "Generate invoice"}
+                    </button>
+                  </div>
+                  {isOpen && (
+                    <div style={{ marginTop: 10, marginLeft: 28, borderLeft: "2px solid #F0EDE8", paddingLeft: 14 }}>
+                      {(c.visits || []).map((v: any) => {
+                        const isExcl = excluded.has(v.invoice_id);
+                        return (
+                          <div key={v.invoice_id} style={{ display: "flex", alignItems: "center", gap: 10, padding: "6px 0", opacity: isExcl ? 0.45 : 1 }}>
+                            <button onClick={() => setExcluded(p => { const n = new Set(p); n.has(v.invoice_id) ? n.delete(v.invoice_id) : n.add(v.invoice_id); return n; })}
+                              title={isExcl ? "Include this visit" : "Exclude this visit"}
+                              style={{ background: "none", border: "none", cursor: "pointer", padding: 0, color: isExcl ? "#C4C0BB" : "var(--brand)", display: "flex" }}>
+                              {isExcl ? <Square size={15} /> : <CheckSquare size={15} />}
+                            </button>
+                            <span style={{ flex: 1, fontSize: 12, color: "#6B7280" }}>{v.service_label || v.service_date}</span>
+                            <span style={{ fontSize: 13, fontWeight: 600, color: "#1A1917", textDecoration: isExcl ? "line-through" : "none" }}>${(v.total || 0).toFixed(2)}</span>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  )}
+                </div>
+              );
+            })
+          )}
+        </div>
+
+        <div style={{ padding: "14px 24px", borderTop: "1px solid #EEECE7", flexShrink: 0, backgroundColor: "#FAFAF9" }}>
+          <p style={{ margin: 0, fontSize: 11, color: "#9E9B94" }}>One invoice per client, one line per visit (service date), due on receipt. Pushes a single document to QuickBooks.</p>
+        </div>
+      </div>
+    </>
+  );
+}
+
 function BatchInvoiceDrawer({ onClose, onDone }: { onClose: () => void; onDone: () => void }) {
   const { toast } = useToast();
   const qc = useQueryClient();
@@ -468,6 +612,7 @@ export default function InvoicesPage() {
   const [dateFrom, setDateFrom] = useState("");
   const [dateTo, setDateTo] = useState("");
   const [showBatch, setShowBatch] = useState(false);
+  const [showWeekly, setShowWeekly] = useState(false);
   const [showCloseDay, setShowCloseDay] = useState(false);
   const [showNewInvoice, setShowNewInvoice] = useState(false);
   useEffect(() => {
@@ -747,6 +892,10 @@ export default function InvoicesPage() {
                       style={{ display: "flex", alignItems: "center", gap: 6, padding: "8px 13px", backgroundColor: "#F7F6F3", color: "var(--brand)", border: "1px solid var(--brand)", borderRadius: 8, fontSize: 13, fontWeight: 600, cursor: "pointer", fontFamily: FF }}>
                       <Layers size={14} strokeWidth={2} /> {isMobile ? "Batch" : "Batch Invoice"}
                     </button>
+                    <button onClick={() => setShowWeekly(true)}
+                      style={{ display: "flex", alignItems: "center", gap: 6, padding: "8px 13px", backgroundColor: "#F7F6F3", color: "var(--brand)", border: "1px solid var(--brand)", borderRadius: 8, fontSize: 13, fontWeight: 600, cursor: "pointer", fontFamily: FF }}>
+                      <Calendar size={14} strokeWidth={2} /> {isMobile ? "Weekly" : "Weekly Invoicing"}
+                    </button>
                   </>
                 )}
                 <button
@@ -899,6 +1048,7 @@ export default function InvoicesPage() {
       </DashboardLayout>
 
       {showBatch && <BatchInvoiceDrawer onClose={() => setShowBatch(false)} onDone={() => refetch()} />}
+      {showWeekly && <WeeklyInvoicingDrawer onClose={() => setShowWeekly(false)} onDone={() => refetch()} />}
       {showCloseDay && <CloseDayModal onClose={() => setShowCloseDay(false)} onOpenBatchInvoice={() => setShowBatch(true)} />}
       {showNewInvoice && <NewInvoiceModal onClose={() => setShowNewInvoice(false)} onDone={() => refetch()} />}
     </>


### PR DESCRIPTION
Gives the office + owner full control over every automated message customers receive, and a complete sent/received audit trail on each customer.

## What's new
**Control panel** (Company → Customer Messages)
- Every message grouped Before / During / After the visit: booking confirmation, 3-day + next-day reminders, on-my-way, thank-you, review request.
- Per-channel **on/off** (pause), inline **copy editor** with live sample preview, fully editable email bodies.
- **Edit the cadence** — change how many days before/after and what hour each offset message sends.
- **Add a message** — create a custom automated message (e.g. "2 days after the visit") with its own timing, channel(s), and copy. Delete custom ones; built-ins pause only.

**Per-customer audit trail** (customer profile → Messages tab)
- Every text + email sent to AND received from that customer, newest first, with status.

## The load-bearing rewiring
The 3-day/next-day reminders and on-my-way were **hardcoded** — editing/pausing them did nothing. They now render from the editable templates, so controls actually take effect. Built-in copy remains only as a fallback if a row is missing; a paused message is honored.

## Engine + safety
- New `customer_message_schedules` (timing) + `job_message_sends` (per-job/message/channel ledger). The ledger is a **hard idempotency guard** — a message fires at most once per job per channel.
- One hourly `runScheduledJobMessages()` replaces the fixed 72h/24h triggers; each tenant's messages carry their own send hour. 1-day catch-up grace (offset≥2) so a missed window self-recovers.
- Boot migration backfills the ledger from the legacy `reminder_*_sent` flags. **Dry-run against prod confirmed 0 double-sends** (8 + 9 already-reminded co1 jobs correctly skipped) and correct send windows.
- All existing gates unchanged (COMMS_ENABLED, company/account comms, opt-out/STOP, branch from-number). Office role has full access (office-admin parity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)