### PR TITLE
feat(estimates): drip editor as a vertical sequence flow (replaces master-detail)

### DIFF
--- a/artifacts/qleno/src/pages/estimates-followup-editor.tsx
+++ b/artifacts/qleno/src/pages/estimates-followup-editor.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { getAuthHeaders } from "@/lib/auth";
-import { Mail, MessageSquare, Plus, Trash2, ChevronUp, ChevronDown } from "lucide-react";
+import { Mail, MessageSquare, Plus, Trash2, ChevronUp, ChevronDown, Send, Flag, Clock } from "lucide-react";
 import { toast } from "sonner";
 
 const FF = "'Plus Jakarta Sans', sans-serif";
@@ -82,6 +82,7 @@ export function FollowUpEditor() {
     let h = 0; return steps.map((s, i) => { h += i === 0 ? 0 : s.delay_hours; return Math.floor(h / 24); });
   }, [steps]);
   const totalDays = days.length ? days[days.length - 1] : 0;
+  const waitLabel = (h: number) => (h % 24 === 0 ? `Wait ${h / 24} day${h / 24 === 1 ? "" : "s"}` : `Wait ${h} hour${h === 1 ? "" : "s"}`);
 
   const activePreset = useMemo(() => {
     for (const [name, f] of Object.entries(PRESETS)) {
@@ -165,104 +166,126 @@ export function FollowUpEditor() {
       </div>
       <p style={{ fontSize: 12, color: MUTE, margin: "0 0 16px" }}>Sent automatically after an estimate goes out · stops on accept or decline · all in Qleno{!active && " · currently paused"}</p>
 
-      <div style={{ display: "flex", gap: 14, alignItems: "flex-start", flexWrap: "wrap" }}>
-        {/* Left: touch list */}
-        <div style={{ width: 210, flexShrink: 0, border: `1px solid ${BORDER}`, borderRadius: 12, overflow: "hidden", background: "#fff" }}>
-          <div style={{ padding: "8px 11px", borderBottom: `1px solid #EEECE7`, fontSize: 10, fontWeight: 700, letterSpacing: "0.05em", color: "#9CA3AF" }}>
-            {steps.length} TOUCHES · {totalDays} DAYS
-          </div>
-          {steps.map((s, i) => {
-            const Icon = s.channel === "sms" ? MessageSquare : Mail;
-            const isSel = i === sel;
-            return (
-              <button key={i} onClick={() => setSel(i)} style={{
-                display: "flex", alignItems: "center", gap: 9, width: "100%", textAlign: "left", padding: "9px 11px",
-                borderBottom: `1px solid #F4F2EE`, border: "none", cursor: "pointer", fontFamily: FF,
-                background: isSel ? "#F0FBF7" : "#fff", boxShadow: isSel ? `inset 3px 0 0 ${MINT}` : "none",
-              }}>
-                <Icon size={15} style={{ color: s.channel === "sms" ? TEAL : BLUE, flexShrink: 0 }} />
-                <span style={{ lineHeight: 1.2 }}>
-                  <span style={{ display: "block", fontSize: 12, fontWeight: 700, color: INK }}>Touch {i + 1}</span>
-                  <span style={{ display: "block", fontSize: 10, color: "#9CA3AF" }}>Day {days[i]} · {s.channel === "sms" ? "SMS" : "Email"}</span>
-                </span>
-              </button>
-            );
-          })}
-          <button onClick={addTouch} style={{ display: "flex", alignItems: "center", gap: 6, width: "100%", padding: "10px 11px", border: "none", background: "#fff", cursor: "pointer", fontFamily: FF, fontSize: 12, fontWeight: 700, color: INK }}>
-            <Plus size={14} /> Add touch
-          </button>
+      <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: "0.05em", color: "#9CA3AF", marginBottom: 12 }}>{steps.length} TOUCHES · {totalDays} DAYS</div>
+
+      {/* Vertical sequence flow: trigger → touch → wait → touch → … → stop */}
+      <div>
+        <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+          <span style={dot(MINT, "#fff")}><Send size={14} /></span>
+          <span style={{ fontSize: 13, fontWeight: 700, color: INK }}>Estimate sent</span>
+          <span style={{ fontSize: 11, color: "#9CA3AF" }}>trigger</span>
         </div>
+        <div style={connector}><span style={{ fontSize: 11, color: "#9CA3AF" }}>Sends immediately</span></div>
 
-        {/* Right: detail editor */}
-        {cur && (
-          <div style={{ flex: 1, minWidth: 280, border: `1px solid ${BORDER}`, borderRadius: 12, padding: 16, background: "#fff" }}>
-            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 15 }}>
-              <span style={{ fontSize: 14, fontWeight: 800, color: INK }}>Touch {sel + 1}</span>
-              <div style={{ display: "flex", gap: 4 }}>
-                <button onClick={() => move(-1)} disabled={sel === 0} title="Move up" style={miniBtn}><ChevronUp size={15} /></button>
-                <button onClick={() => move(1)} disabled={sel === steps.length - 1} title="Move down" style={miniBtn}><ChevronDown size={15} /></button>
-                <button onClick={() => removeTouch(sel)} title="Delete touch" style={{ ...miniBtn, color: "#B91C1C" }}><Trash2 size={15} /></button>
-              </div>
-            </div>
-
-            <span style={lbl}>CHANNEL</span>
-            <div style={{ display: "inline-flex", border: `1px solid ${BORDER}`, borderRadius: 8, overflow: "hidden", marginBottom: 15 }}>
-              {(["email", "sms"] as const).map(ch => (
-                <button key={ch} onClick={() => patch({ channel: ch })} style={{
-                  fontFamily: FF, fontSize: 12.5, fontWeight: 700, padding: "7px 16px", border: "none", cursor: "pointer",
-                  background: cur.channel === ch ? INK : "#fff", color: cur.channel === ch ? "#fff" : MUTE,
-                }}>{ch === "sms" ? "SMS" : "Email"}</button>
-              ))}
-            </div>
-
-            <span style={lbl}>TIMING</span>
-            <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 6, flexWrap: "wrap" }}>
-              {sel === 0 ? (
-                <span style={{ fontSize: 13, color: INK }}>Sends immediately when the estimate is sent</span>
+        {steps.map((s, i) => {
+          const isOpen = i === sel;
+          const Icon = s.channel === "sms" ? MessageSquare : Mail;
+          const snippet = s.channel === "email" ? (s.subject || "(no subject)") : (s.message_template || "").replace(/\n/g, " ").slice(0, 70);
+          return (
+            <div key={i}>
+              {i > 0 && (
+                <div style={connector}>
+                  <span style={{ fontSize: 11, color: "#6B7280", background: "#F1EFE8", padding: "2px 9px", borderRadius: 20, display: "inline-flex", alignItems: "center", gap: 5 }}>
+                    <Clock size={12} /> {waitLabel(s.delay_hours)}
+                  </span>
+                </div>
+              )}
+              {!isOpen ? (
+                <button onClick={() => setSel(i)} style={{ display: "flex", alignItems: "center", gap: 11, width: "100%", textAlign: "left", border: `1px solid ${BORDER}`, borderRadius: 11, padding: "11px 13px", background: "#fff", cursor: "pointer", fontFamily: FF }}>
+                  <Icon size={18} style={{ color: s.channel === "sms" ? TEAL : BLUE, flexShrink: 0 }} />
+                  <span style={{ flex: 1, minWidth: 0 }}>
+                    <span style={{ display: "block", fontSize: 13, fontWeight: 700, color: INK }}>Touch {i + 1} · {s.channel === "sms" ? "SMS" : "Email"}</span>
+                    <span style={{ display: "block", fontSize: 11.5, color: "#6B7280", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{snippet}</span>
+                  </span>
+                  <span style={{ fontSize: 11, color: TEAL, background: TEAL_BG, padding: "2px 8px", borderRadius: 20, flexShrink: 0 }}>Day {days[i]}</span>
+                  <ChevronDown size={16} style={{ color: "#C9C6BF", flexShrink: 0 }} />
+                </button>
               ) : (
-                <>
-                  <span style={{ fontSize: 13, color: MUTE }}>Wait</span>
-                  <input type="number" min={1} value={cur.delay_hours % 24 === 0 ? cur.delay_hours / 24 : cur.delay_hours}
-                    onChange={e => { const n = Math.max(1, Number(e.target.value) || 1); patch({ delay_hours: cur.delay_hours % 24 === 0 ? n * 24 : n }); }}
-                    style={{ ...inp, width: 60, textAlign: "center" }} />
-                  <select value={cur.delay_hours % 24 === 0 ? "days" : "hours"}
-                    onChange={e => { const v = cur.delay_hours % 24 === 0 ? cur.delay_hours / 24 : cur.delay_hours; patch({ delay_hours: e.target.value === "days" ? v * 24 : v }); }}
-                    style={{ ...inp, width: "auto" }}>
-                    <option value="hours">hours</option>
-                    <option value="days">days</option>
-                  </select>
-                  <span style={{ fontSize: 13, color: MUTE }}>after the previous touch</span>
-                </>
+                <div style={{ border: `2px solid ${MINT}`, borderRadius: 11, padding: 14, background: "#fff" }}>
+                  <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 13 }}>
+                    <button onClick={() => setSel(-1)} style={{ display: "inline-flex", alignItems: "center", gap: 9, background: "none", border: "none", cursor: "pointer", fontFamily: FF, padding: 0 }}>
+                      <Icon size={18} style={{ color: s.channel === "sms" ? TEAL : BLUE }} />
+                      <span style={{ fontSize: 13, fontWeight: 800, color: INK }}>Touch {i + 1} · {s.channel === "sms" ? "SMS" : "Email"} · Day {days[i]}</span>
+                      <ChevronUp size={15} style={{ color: "#C9C6BF" }} />
+                    </button>
+                    <div style={{ display: "flex", gap: 4 }}>
+                      <button onClick={() => move(-1)} disabled={i === 0} title="Move up" style={miniBtn}><ChevronUp size={15} /></button>
+                      <button onClick={() => move(1)} disabled={i === steps.length - 1} title="Move down" style={miniBtn}><ChevronDown size={15} /></button>
+                      <button onClick={() => removeTouch(i)} title="Delete touch" style={{ ...miniBtn, color: "#B91C1C" }}><Trash2 size={15} /></button>
+                    </div>
+                  </div>
+
+                  <span style={lbl}>CHANNEL</span>
+                  <div style={{ display: "inline-flex", border: `1px solid ${BORDER}`, borderRadius: 8, overflow: "hidden", marginBottom: 14 }}>
+                    {(["email", "sms"] as const).map(ch => (
+                      <button key={ch} onClick={() => patch({ channel: ch })} style={{ fontFamily: FF, fontSize: 12.5, fontWeight: 700, padding: "7px 16px", border: "none", cursor: "pointer", background: s.channel === ch ? INK : "#fff", color: s.channel === ch ? "#fff" : MUTE }}>{ch === "sms" ? "SMS" : "Email"}</button>
+                    ))}
+                  </div>
+
+                  <span style={lbl}>TIMING</span>
+                  <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 6, flexWrap: "wrap" }}>
+                    {i === 0 ? (
+                      <span style={{ fontSize: 13, color: INK }}>Sends immediately when the estimate is sent</span>
+                    ) : (
+                      <>
+                        <span style={{ fontSize: 13, color: MUTE }}>Wait</span>
+                        <input type="number" min={1} value={s.delay_hours % 24 === 0 ? s.delay_hours / 24 : s.delay_hours}
+                          onChange={e => { const n = Math.max(1, Number(e.target.value) || 1); patch({ delay_hours: s.delay_hours % 24 === 0 ? n * 24 : n }); }}
+                          style={{ ...inp, width: 60, textAlign: "center" }} />
+                        <select value={s.delay_hours % 24 === 0 ? "days" : "hours"}
+                          onChange={e => { const v = s.delay_hours % 24 === 0 ? s.delay_hours / 24 : s.delay_hours; patch({ delay_hours: e.target.value === "days" ? v * 24 : v }); }}
+                          style={{ ...inp, width: "auto" }}>
+                          <option value="hours">hours</option>
+                          <option value="days">days</option>
+                        </select>
+                        <span style={{ fontSize: 13, color: MUTE }}>after the previous touch</span>
+                      </>
+                    )}
+                  </div>
+                  <span style={{ fontSize: 11, color: TEAL, background: TEAL_BG, display: "inline-block", padding: "2px 9px", borderRadius: 20, marginBottom: 14 }}>Sends on Day {days[i]}</span>
+
+                  {s.channel === "email" && (
+                    <div style={{ marginBottom: 12 }}>
+                      <span style={lbl}>SUBJECT</span>
+                      <input style={inp} value={s.subject || ""} onChange={e => patch({ subject: e.target.value })} placeholder="Your cleaning estimate for {{property}}" />
+                    </div>
+                  )}
+
+                  <span style={lbl}>MESSAGE</span>
+                  <textarea ref={msgRef} style={{ ...inp, minHeight: 120, resize: "vertical", lineHeight: 1.5 }} value={s.message_template} onChange={e => patch({ message_template: e.target.value })} placeholder="Write the message…" />
+                  <div style={{ display: "flex", flexWrap: "wrap", gap: 6, margin: "9px 0 14px" }}>
+                    <span style={{ fontSize: 11, color: MUTE, alignSelf: "center", marginRight: 2 }}>Insert:</span>
+                    {VARS.map(v => (
+                      <button key={v} onClick={() => insertVar(v)} style={{ fontFamily: "monospace", fontSize: 11, background: "#F1EFE8", border: "none", padding: "3px 7px", borderRadius: 5, cursor: "pointer", color: "#444441" }}>{`{{${v}}}`}</button>
+                    ))}
+                  </div>
+
+                  <div style={{ background: "#F8F7F4", borderRadius: 9, padding: "11px 13px" }}>
+                    <span style={lbl}>PREVIEW</span>
+                    {s.channel === "email" && s.subject && <div style={{ fontSize: 12.5, fontWeight: 700, color: INK, marginBottom: 4 }}>{fillVars(s.subject)}</div>}
+                    <div style={{ fontSize: 12.5, color: "#374151", lineHeight: 1.55, whiteSpace: "pre-wrap" }}>{fillVars(s.message_template) || "…"}</div>
+                  </div>
+                </div>
               )}
             </div>
-            <span style={{ fontSize: 11, color: TEAL, background: TEAL_BG, display: "inline-block", padding: "2px 9px", borderRadius: 20, marginBottom: 15 }}>Sends on Day {days[sel]}</span>
+          );
+        })}
 
-            {cur.channel === "email" && (
-              <div style={{ marginBottom: 12 }}>
-                <span style={lbl}>SUBJECT</span>
-                <input style={inp} value={cur.subject || ""} onChange={e => patch({ subject: e.target.value })} placeholder="Your cleaning estimate for {{property}}" />
-              </div>
-            )}
-
-            <span style={lbl}>MESSAGE</span>
-            <textarea ref={msgRef} style={{ ...inp, minHeight: 120, resize: "vertical", lineHeight: 1.5 }} value={cur.message_template} onChange={e => patch({ message_template: e.target.value })} placeholder="Write the message…" />
-            <div style={{ display: "flex", flexWrap: "wrap", gap: 6, margin: "9px 0 14px" }}>
-              <span style={{ fontSize: 11, color: MUTE, alignSelf: "center", marginRight: 2 }}>Insert:</span>
-              {VARS.map(v => (
-                <button key={v} onClick={() => insertVar(v)} style={{ fontFamily: "monospace", fontSize: 11, background: "#F1EFE8", border: "none", padding: "3px 7px", borderRadius: 5, cursor: "pointer", color: "#444441" }}>{`{{${v}}}`}</button>
-              ))}
-            </div>
-
-            <div style={{ background: "#F8F7F4", borderRadius: 9, padding: "11px 13px" }}>
-              <span style={lbl}>PREVIEW</span>
-              {cur.channel === "email" && cur.subject && <div style={{ fontSize: 12.5, fontWeight: 700, color: INK, marginBottom: 4 }}>{fillVars(cur.subject)}</div>}
-              <div style={{ fontSize: 12.5, color: "#374151", lineHeight: 1.55, whiteSpace: "pre-wrap" }}>{fillVars(cur.message_template) || "—"}</div>
-            </div>
-          </div>
-        )}
+        <div style={{ ...connector, paddingBottom: 4 }} />
+        <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+          <span style={dot("#F1EFE8", "#5F5E5A")}><Flag size={14} /></span>
+          <span style={{ fontSize: 12.5, color: "#6B7280" }}>Stops automatically when the client accepts or declines</span>
+        </div>
       </div>
+
+      <button onClick={addTouch} style={{ marginTop: 14, display: "inline-flex", alignItems: "center", justifyContent: "center", gap: 6, width: "100%", padding: "10px 14px", border: `1px dashed #C9C6BF`, background: "#fff", borderRadius: 9, cursor: "pointer", fontFamily: FF, fontSize: 13, fontWeight: 700, color: INK }}>
+        <Plus size={15} /> Add touch
+      </button>
     </div>
   );
 }
+
+const dot = (bg: string, fg: string): React.CSSProperties => ({ width: 30, height: 30, borderRadius: "50%", background: bg, color: fg, display: "inline-flex", alignItems: "center", justifyContent: "center", flexShrink: 0 });
+const connector: React.CSSProperties = { marginLeft: 15, borderLeft: `2px solid ${BORDER}`, padding: "7px 0 7px 21px" };
 
 const miniBtn: React.CSSProperties = { width: 30, height: 30, display: "inline-flex", alignItems: "center", justifyContent: "center", background: "#fff", border: `1px solid ${BORDER}`, borderRadius: 7, color: MUTE, cursor: "pointer" };


### PR DESCRIPTION
Per feedback that you couldn't see 'what's next', the editor is now a top-to-bottom **flow**: trigger → touch → labeled wait → touch → … → stop.

- Each touch collapses to one line (channel · subject · Day); click to expand the full editor in place (accordion).
- The **wait between touches is labeled on each connector** so cadence is visible at a glance.
- Reorder/add/delete, cadence preset, Active toggle all carry over.

Frontend-only; backend unchanged. drip-editor guard 3/3 · esbuild OK · zero net-new type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)