### PR TITLE
feat(estimates): real pipeline metrics + recurring tag on the dashboard

### DIFF
--- a/artifacts/api-server/src/routes/estimates.ts
+++ b/artifacts/api-server/src/routes/estimates.ts
@@ -155,11 +155,24 @@ router.get("/stats", requireAuth, async (req, res) => {
         COUNT(*) FILTER (WHERE status = 'draft')::int AS draft,
         COUNT(*) FILTER (WHERE status IN ('sent','viewed'))::int AS outstanding,
         COUNT(*) FILTER (WHERE status = 'accepted')::int AS accepted,
+        COUNT(*) FILTER (WHERE status <> 'draft')::int AS sent,
+        -- Recurring pipeline (flat, priced per month) still open
+        COALESCE(SUM(flat_price) FILTER (WHERE billing_mode = 'flat' AND flat_price_unit = 'month'
+          AND status IN ('sent','viewed')), 0)::numeric AS mrr_pipeline,
+        -- Recurring won, annualized
+        COALESCE(SUM(flat_price * 12) FILTER (WHERE billing_mode = 'flat' AND flat_price_unit = 'month'
+          AND status = 'accepted'), 0)::numeric AS arr_won,
+        -- Open non-recurring (one-time / add-ons / itemized)
+        COALESCE(SUM(total) FILTER (WHERE status IN ('sent','viewed')
+          AND NOT (billing_mode = 'flat' AND flat_price_unit = 'month')), 0)::numeric AS specialty_pipeline,
         COALESCE(SUM(total) FILTER (WHERE status = 'accepted'
           AND accepted_at >= date_trunc('month', now())), 0)::numeric AS accepted_value_month
       FROM estimates WHERE company_id = ${companyId}
     `);
-    return res.json((rows as any).rows[0] ?? {});
+    const r: any = (rows as any).rows[0] ?? {};
+    const sent = Number(r.sent) || 0, accepted = Number(r.accepted) || 0;
+    r.close_rate = sent > 0 ? Math.round((accepted / sent) * 100) : 0;
+    return res.json(r);
   } catch (err) {
     console.error("Estimate stats error:", err);
     return res.status(500).json({ error: "Internal Server Error" });
@@ -726,6 +739,7 @@ router.get("/", requireAuth, async (req, res) => {
     const search = str(req.query?.search, 120);
     const rows = await db.execute(sql`
       SELECT e.id, e.estimate_number, e.status, e.title, e.total, e.subtotal,
+             e.billing_mode, e.flat_price_unit,
              e.contact_name, e.property_name, e.service_address,
              e.sent_at, e.viewed_at, e.accepted_at, e.valid_until, e.created_at,
              a.account_name,

--- a/artifacts/api-server/src/tests/estimate-dashboard-metrics.test.ts
+++ b/artifacts/api-server/src/tests/estimate-dashboard-metrics.test.ts
@@ -1,0 +1,30 @@
+/** Dashboard metrics: real close rate / MRR / ARR / specialty pipeline + row billing tag. */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+const here = dirname(fileURLToPath(import.meta.url));
+const read = (rel: string) => readFileSync(resolve(here, rel), "utf8");
+
+describe("estimate dashboard metrics", () => {
+  const route = read("../routes/estimates.ts");
+  const page = read("../../../qleno/src/pages/estimates.tsx");
+  it("stats endpoint computes the pipeline metrics + close rate", () => {
+    assert.match(route, /AS mrr_pipeline/);
+    assert.match(route, /AS arr_won/);
+    assert.match(route, /AS specialty_pipeline/);
+    assert.match(route, /COUNT\(\*\) FILTER \(WHERE status <> 'draft'\)::int AS sent/);
+    assert.match(route, /r\.close_rate = sent > 0 \? Math\.round\(\(accepted \/ sent\) \* 100\) : 0/);
+  });
+  it("list returns billing fields for the row tag", () => {
+    assert.match(route, /e\.billing_mode, e\.flat_price_unit,/);
+  });
+  it("dashboard shows the real metric cards + recurring tag", () => {
+    assert.match(page, /label: "Pipeline MRR"/);
+    assert.match(page, /label: "Close rate"/);
+    assert.match(page, /label: "Closed ARR"/);
+    assert.match(page, /label: "Specialty pipeline"/);
+    assert.match(page, /e\.billing_mode === "flat" && e\.flat_price_unit === "month"/);
+  });
+});

--- a/artifacts/qleno/src/pages/estimates.tsx
+++ b/artifacts/qleno/src/pages/estimates.tsx
@@ -75,10 +75,10 @@ export default function EstimatesPage() {
   });
 
   const statCards = [
-    { label: "Outstanding", value: stats.outstanding ?? 0, sub: "sent / viewed" },
-    { label: "Accepted", value: stats.accepted ?? 0, sub: "all time" },
-    { label: "Won this month", value: money(stats.accepted_value_month), sub: "accepted value" },
-    { label: "Drafts", value: stats.draft ?? 0, sub: "not yet sent" },
+    { label: "Pipeline MRR", value: money(stats.mrr_pipeline), sub: `${stats.outstanding ?? 0} active bid${(stats.outstanding ?? 0) === 1 ? "" : "s"}`, accent: true },
+    { label: "Close rate", value: `${stats.close_rate ?? 0}%`, sub: `${stats.accepted ?? 0} won of ${stats.sent ?? 0} sent` },
+    { label: "Closed ARR", value: money(stats.arr_won), sub: "recurring won", accent: true },
+    { label: "Specialty pipeline", value: money(stats.specialty_pipeline), sub: "one-time / add-ons" },
   ];
 
   return (
@@ -106,7 +106,7 @@ export default function EstimatesPage() {
           {statCards.map(c => (
             <div key={c.label} style={{ background: "#fff", border: `1px solid ${BORDER}`, borderRadius: 12, padding: "14px 16px" }}>
               <p style={{ fontSize: 11, fontWeight: 700, color: MUTE, textTransform: "uppercase", letterSpacing: "0.05em", margin: "0 0 6px" }}>{c.label}</p>
-              <p style={{ fontSize: 24, fontWeight: 800, color: INK, margin: 0, lineHeight: 1 }}>{c.value}</p>
+              <p style={{ fontSize: 24, fontWeight: 800, color: (c as any).accent ? "#0F6E56" : INK, margin: 0, lineHeight: 1 }}>{c.value}</p>
               <p style={{ fontSize: 11, color: MUTE, margin: "5px 0 0" }}>{c.sub}</p>
             </div>
           ))}
@@ -150,6 +150,11 @@ export default function EstimatesPage() {
                         <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
                           <span style={{ fontSize: 14, fontWeight: 700, color: INK, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{recipient}</span>
                           <StatusChip status={e.status} />
+                          {e.billing_mode === "flat" && e.flat_price_unit === "month" ? (
+                            <span style={{ fontSize: 10, fontWeight: 700, color: "#0F6E56", background: "#E1F5EE", padding: "1px 7px", borderRadius: 20, whiteSpace: "nowrap" }}>Recurring</span>
+                          ) : (
+                            <span style={{ fontSize: 10, fontWeight: 700, color: "#5F5E5A", background: "#F1EFE8", padding: "1px 7px", borderRadius: 20, whiteSpace: "nowrap" }}>One-time</span>
+                          )}
                         </div>
                         <p style={{ fontSize: 12, color: MUTE, margin: "3px 0 0", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
                           {e.estimate_number || "—"}{e.title ? ` · ${e.title}` : ""}{e.service_address ? ` · ${e.service_address}` : ""}


### PR DESCRIPTION
Replaces placeholder stat cards with live metrics.

- `/stats` returns sent, **close_rate** (accepted ÷ sent), **mrr_pipeline** (open flat monthly), **arr_won** (accepted recurring × 12), **specialty_pipeline** (open non-recurring).
- Cards: Pipeline MRR (+ active bids), Close rate (won of sent), Closed ARR, Specialty pipeline.
- Each row shows a **Recurring / One-time** tag.

First of three (metrics+layout → SMS+preview → per-recipient tracking). dashboard-metrics guard 3/3 · esbuild OK · zero net-new type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)