### PR TITLE
feat(estimates): text the estimate by SMS, with an on-screen preview

### DIFF
--- a/artifacts/api-server/src/routes/estimates.ts
+++ b/artifacts/api-server/src/routes/estimates.ts
@@ -822,6 +822,76 @@ router.get("/:id/pdf", requireAuth, async (req, res) => {
   }
 });
 
+// ─── Text the estimate (SMS) + preview ───────────────────────────────────────
+// Loads the estimate, ensures a public link exists, and builds the SMS body.
+// Shared by the preview (GET) and the send (POST) so they never drift.
+async function loadEstimateForSms(companyId: number, id: number) {
+  const e = await db.execute(sql`
+    SELECT e.id, e.status, e.public_token, e.branch_id, e.contact_name, e.contact_phone, c.name AS company_name
+    FROM estimates e JOIN companies c ON c.id = e.company_id
+    WHERE e.id = ${id} AND e.company_id = ${companyId} LIMIT 1
+  `);
+  const est = (e as any).rows[0];
+  if (!est) return null;
+  // Ensure a resolvable link (generate token + flip draft→sent so the hosted
+  // page renders) without touching the drip — that still starts via /send.
+  let token = est.public_token as string | null;
+  if (!token || est.status === "draft") {
+    token = token || randomUUID();
+    await db.execute(sql`
+      UPDATE estimates SET public_token = ${token}, status = CASE WHEN status = 'draft' THEN 'sent' ELSE status END,
+        sent_at = COALESCE(sent_at, now()), updated_at = now()
+      WHERE id = ${id} AND company_id = ${companyId}
+    `);
+  }
+  const first = (est.contact_name || "").split(" ")[0] || "there";
+  const link = `${appBaseUrl()}/estimate/${token}`;
+  const body = `Hi ${first}, here is your cleaning estimate from ${est.company_name || "us"}: ${link}`;
+  return { est, body };
+}
+const smsPhone = (p: string | null | undefined): string | null => {
+  const d = String(p || "").replace(/\D/g, "");
+  if (d.length === 10) return `+1${d}`;
+  if (d.length === 11 && d.startsWith("1")) return `+${d}`;
+  return d ? `+${d}` : null;
+};
+
+router.get("/:id/sms-preview", requireAuth, async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    const id = parseInt(req.params.id, 10);
+    const r = await loadEstimateForSms(companyId, id);
+    if (!r) return res.status(404).json({ error: "Not Found" });
+    return res.json({ to: r.est.contact_phone || null, to_e164: smsPhone(r.est.contact_phone), body: r.body });
+  } catch (err) {
+    console.error("Estimate SMS preview error:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
+router.post("/:id/sms", requireAuth, async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    const id = parseInt(req.params.id, 10);
+    const r = await loadEstimateForSms(companyId, id);
+    if (!r) return res.status(404).json({ error: "Not Found" });
+    const to = smsPhone(r.est.contact_phone);
+    if (!to) return res.json({ sent: false, reason: "no_phone" });
+
+    const { resolveSender, sendSmsVia } = await import("../lib/comms-sender.js");
+    const sender = await resolveSender(companyId, r.est.branch_id);
+    if (sender.reason) return res.json({ sent: false, reason: sender.reason, to });
+    await sendSmsVia(sender, to, r.body);
+    // Record the manual SMS touch so it shows in the tracking timeline.
+    recordEngagementEvent({ companyId, estimateId: id, eventType: "sent", channel: "sms", recipient: to,
+      meta: { manual: true } }).catch(() => {});
+    return res.json({ sent: true, to });
+  } catch (err) {
+    console.error("Estimate SMS send error:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
 // ─── Create estimate ─────────────────────────────────────────────────────────
 router.post("/", requireAuth, async (req, res) => {
   try {

--- a/artifacts/api-server/src/tests/estimate-sms.test.ts
+++ b/artifacts/api-server/src/tests/estimate-sms.test.ts
@@ -1,0 +1,28 @@
+/** Text-the-estimate: gated SMS send + preview, with a builder preview modal. */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+const here = dirname(fileURLToPath(import.meta.url));
+const read = (rel: string) => readFileSync(resolve(here, rel), "utf8");
+
+describe("text the estimate (SMS)", () => {
+  const route = read("../routes/estimates.ts");
+  const ui = read("../../../qleno/src/pages/estimate-builder.tsx");
+  it("preview + send routes share one body builder and use the gated sender", () => {
+    assert.match(route, /router\.get\("\/:id\/sms-preview"/);
+    assert.match(route, /router\.post\("\/:id\/sms"/);
+    assert.match(route, /async function loadEstimateForSms/);
+    assert.match(route, /const sender = await resolveSender\(companyId, r\.est\.branch_id\)/);
+    assert.match(route, /if \(sender\.reason\) return res\.json\(\{ sent: false, reason: sender\.reason/);
+    assert.match(route, /await sendSmsVia\(sender, to, r\.body\)/);
+  });
+  it("builder has the Text-to-client button + preview modal", () => {
+    assert.match(ui, /async function openSms/);
+    assert.match(ui, /\/api\/estimates\/\$\{savedId\}\/sms-preview/);
+    assert.match(ui, /\/api\/estimates\/\$\{id\}\/sms/);
+    assert.match(ui, /Text to client/);
+    assert.match(ui, /Text the estimate/);
+  });
+});

--- a/artifacts/qleno/src/pages/estimate-builder.tsx
+++ b/artifacts/qleno/src/pages/estimate-builder.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useRoute } from "wouter";
 import { getAuthHeaders } from "@/lib/auth";
 import { DashboardLayout } from "@/components/layout/dashboard-layout";
-import { Plus, Trash2, ArrowLeft, Save, Send, LayoutTemplate, GripVertical, Check, FileText, Mail, Eye, Clock, MousePointerClick } from "lucide-react";
+import { Plus, Trash2, ArrowLeft, Save, Send, LayoutTemplate, GripVertical, Check, FileText, Mail, Eye, Clock, MousePointerClick, MessageSquare, X } from "lucide-react";
 import { toast } from "sonner";
 import { CalendarPopover } from "@/components/calendar-popover";
 import { useAddressAutocomplete } from "@/hooks/use-address-autocomplete";
@@ -334,6 +334,38 @@ export default function EstimateBuilderPage() {
   // [estimate-pdf] Save (if needed) then fetch the branded PDF with auth and open
   // it in a new tab — a preview of exactly what the client receives. Falls back
   // to a download if a popup is blocked.
+  // [estimate-sms] Text-the-estimate preview modal.
+  const [smsOpen, setSmsOpen] = useState(false);
+  const [smsData, setSmsData] = useState<{ to: string | null; to_e164: string | null; body: string } | null>(null);
+  const [smsSending, setSmsSending] = useState(false);
+  async function openSms() {
+    const savedId = await save();
+    if (!savedId) return;
+    try {
+      const r = await apiFetch(`/api/estimates/${savedId}/sms-preview`);
+      setSmsData(r); setSmsOpen(true);
+    } catch { toast.error("Couldn't build the SMS preview"); }
+  }
+  const SMS_REASON: Record<string, string> = {
+    no_phone: "No phone number on this estimate — add one under “Who it's for.”",
+    comms_disabled: "Texting is turned off (global comms).",
+    company_comms_disabled: "Texting is turned off for this company.",
+    branch_comms_disabled: "Texting is turned off for this branch.",
+    twilio_disabled: "SMS isn't enabled yet (Twilio go-live).",
+    twilio_unconfigured: "SMS isn't configured (Twilio credentials).",
+    no_from_number: "No SMS sending number is configured.",
+  };
+  async function sendSms() {
+    if (!id) return;
+    setSmsSending(true);
+    try {
+      const r = await apiFetch(`/api/estimates/${id}/sms`, { method: "POST" });
+      if (r.sent) { toast.success(`Texted to ${r.to}`); setSmsOpen(false); setTrackVersion(v => v + 1); }
+      else toast.error(SMS_REASON[r.reason] || "Couldn't send the text.");
+    } catch { toast.error("Couldn't send the text."); }
+    finally { setSmsSending(false); }
+  }
+
   const [pdfBusy, setPdfBusy] = useState(false);
   async function downloadPdf() {
     // Always persist current edits first — the PDF is rendered server-side from
@@ -648,10 +680,37 @@ export default function EstimateBuilderPage() {
             {autoStatus === "saving" ? "Saving…" : autoStatus === "saved" ? "All changes saved" : autoStatus === "error" ? "Save failed — retry" : ""}
           </span>
           <button onClick={downloadPdf} disabled={pdfBusy} style={ghostBtn}><FileText size={15} /> {pdfBusy ? "Preparing…" : "PDF preview"}</button>
+          <button onClick={openSms} style={ghostBtn}><MessageSquare size={15} /> Text to client</button>
           <button onClick={save} disabled={saving} style={ghostBtn}><Save size={15} /> {saving ? "Saving…" : "Save"}</button>
           <button onClick={markSent} style={primaryBtn}><Send size={15} /> {publicToken ? "Resend to client" : "Send to client"}</button>
         </div>
       </div>
+
+      {/* [estimate-sms] Text-the-estimate preview modal */}
+      {smsOpen && smsData && (
+        <div style={{ position: "fixed", inset: 0, background: "rgba(10,14,26,0.45)", display: "flex", alignItems: "center", justifyContent: "center", padding: 18, zIndex: 60 }} onClick={() => setSmsOpen(false)}>
+          <div onClick={e => e.stopPropagation()} style={{ background: "#fff", borderRadius: 16, padding: 22, width: "100%", maxWidth: 420, fontFamily: FF }}>
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 14 }}>
+              <span style={{ fontSize: 16, fontWeight: 800, color: INK }}>Text the estimate</span>
+              <button onClick={() => setSmsOpen(false)} style={{ background: "none", border: "none", cursor: "pointer", color: "#9CA3AF" }}><X size={16} /></button>
+            </div>
+            <div style={{ fontSize: 11, fontWeight: 700, color: MUTE, textTransform: "uppercase", letterSpacing: "0.04em", marginBottom: 5 }}>To</div>
+            <div style={{ ...inp, marginBottom: 14, color: smsData.to ? INK : "#B91C1C" }}>{smsData.to || "No phone number on this estimate"}</div>
+            <div style={{ fontSize: 11, fontWeight: 700, color: MUTE, textTransform: "uppercase", letterSpacing: "0.04em", marginBottom: 5 }}>Message preview</div>
+            {/* Phone-bubble preview */}
+            <div style={{ background: "#F0F0F2", borderRadius: 12, padding: 12, marginBottom: 4 }}>
+              <div style={{ background: "#00C9A0", color: "#063", borderRadius: 16, borderBottomRightRadius: 4, padding: "9px 13px", fontSize: 13.5, lineHeight: 1.45, marginLeft: "auto", maxWidth: "92%", width: "fit-content", whiteSpace: "pre-wrap" }}>{smsData.body}</div>
+            </div>
+            <div style={{ fontSize: 11, color: "#9CA3AF", marginBottom: 16 }}>Sent from your Phes number · standard messaging rates apply</div>
+            <div style={{ display: "flex", gap: 10, justifyContent: "flex-end" }}>
+              <button onClick={() => setSmsOpen(false)} style={ghostBtn}>Cancel</button>
+              <button onClick={sendSms} disabled={smsSending || !smsData.to} style={{ ...primaryBtn, opacity: smsData.to ? 1 : 0.5 }}>
+                <MessageSquare size={15} /> {smsSending ? "Sending…" : "Send text"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </DashboardLayout>
   );
 }


### PR DESCRIPTION
Adds **Text to client** — sends the estimate link by SMS via the tenant's Twilio number, after an iMessage-style preview.

- **API:** `GET /:id/sms-preview` + `POST /:id/sms` share one body builder. Send uses `resolveSender`'s full gate ladder (never invents a number); blocked sends return `{sent:false, reason}`. Records a 'sent' SMS touch.
- **UI:** preview modal (recipient + message bubble) with friendly reasons when texting is off/unconfigured.

Second of three (metrics ✓ → SMS ✓ → per-recipient tracking). estimate-sms guard 2/2 · esbuild OK · zero net-new type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)