### PR TITLE
feat(estimates): attribute opens/clicks to the recipient (who opened it)

### DIFF
--- a/artifacts/api-server/src/lib/engagement.ts
+++ b/artifacts/api-server/src/lib/engagement.ts
@@ -51,13 +51,13 @@ function genToken(len = 18): string {
 // when hit, records a 'clicked' event tied to the estimate + enrollment then
 // 302s to target_url. Falls back to target_url on any DB failure.
 export async function createTrackedLink(args: {
-  companyId: number; targetUrl: string; estimateId?: number | null; enrollmentId?: number | null;
+  companyId: number; targetUrl: string; estimateId?: number | null; enrollmentId?: number | null; recipient?: string | null;
 }): Promise<string> {
   try {
     const token = genToken();
     await db.execute(sql`
-      INSERT INTO tracked_links (token, company_id, estimate_id, enrollment_id, kind, target_url)
-      VALUES (${token}, ${args.companyId}, ${args.estimateId ?? null}, ${args.enrollmentId ?? null}, 'click', ${args.targetUrl})
+      INSERT INTO tracked_links (token, company_id, estimate_id, enrollment_id, kind, target_url, recipient)
+      VALUES (${token}, ${args.companyId}, ${args.estimateId ?? null}, ${args.enrollmentId ?? null}, 'click', ${args.targetUrl}, ${args.recipient ?? null})
     `);
     return `${appBaseUrl()}/api/track/c/${token}`;
   } catch (err) {
@@ -69,13 +69,13 @@ export async function createTrackedLink(args: {
 // Mint an open-pixel URL (/api/track/o/<token>.png). Returns "" on failure so
 // callers can simply skip the pixel.
 export async function createOpenPixel(args: {
-  companyId: number; estimateId?: number | null; enrollmentId?: number | null;
+  companyId: number; estimateId?: number | null; enrollmentId?: number | null; recipient?: string | null;
 }): Promise<string> {
   try {
     const token = genToken();
     await db.execute(sql`
-      INSERT INTO tracked_links (token, company_id, estimate_id, enrollment_id, kind, target_url)
-      VALUES (${token}, ${args.companyId}, ${args.estimateId ?? null}, ${args.enrollmentId ?? null}, 'open', NULL)
+      INSERT INTO tracked_links (token, company_id, estimate_id, enrollment_id, kind, target_url, recipient)
+      VALUES (${token}, ${args.companyId}, ${args.estimateId ?? null}, ${args.enrollmentId ?? null}, 'open', NULL, ${args.recipient ?? null})
     `);
     return `${appBaseUrl()}/api/track/o/${token}.png`;
   } catch (err) {

--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -392,6 +392,9 @@ async function runBookingSchemaGuard(): Promise<void> {
     // free-text scope paragraph. Additive + idempotent.
     { label: "estimates.flat_price_unit", stmt: `ALTER TABLE estimates ADD COLUMN IF NOT EXISTS flat_price_unit TEXT NOT NULL DEFAULT 'visit'` },
     { label: "estimates.scope_note", stmt: `ALTER TABLE estimates ADD COLUMN IF NOT EXISTS scope_note TEXT` },
+    // [estimate-recipient-tracking 2026-06-26] Which recipient a tracked link /
+    // open-pixel belongs to, so opens/clicks attribute to a person. Additive.
+    { label: "tracked_links.recipient", stmt: `ALTER TABLE tracked_links ADD COLUMN IF NOT EXISTS recipient TEXT` },
     // [engagement-tracking-phase4 2026-06-25] Unified engagement timeline +
     // native click-redirect / open-pixel tokens. Additive + idempotent.
     { label: "CREATE engagement_events", stmt: `

--- a/artifacts/api-server/src/routes/track.ts
+++ b/artifacts/api-server/src/routes/track.ts
@@ -34,7 +34,7 @@ router.get("/c/:token", async (req, res) => {
   let target = `${appBaseUrl()}/`;
   try {
     const rows = await db.execute(sql`
-      SELECT company_id, estimate_id, enrollment_id, target_url
+      SELECT company_id, estimate_id, enrollment_id, target_url, recipient
       FROM tracked_links WHERE token = ${token} AND kind = 'click' LIMIT 1
     `);
     const link = (rows as any).rows[0];
@@ -46,6 +46,7 @@ router.get("/c/:token", async (req, res) => {
         enrollmentId: link.enrollment_id,
         eventType: "clicked",
         channel: "email",
+        recipient: link.recipient ?? null,
         meta: { token, target_url: link.target_url, ua: req.get("user-agent") || null },
       });
     }
@@ -61,7 +62,7 @@ router.get("/o/:token", async (req, res) => {
   const token = String(req.params.token || "").trim().replace(/\.png$/i, "");
   try {
     const rows = await db.execute(sql`
-      SELECT company_id, estimate_id, enrollment_id
+      SELECT company_id, estimate_id, enrollment_id, recipient
       FROM tracked_links WHERE token = ${token} AND kind = 'open' LIMIT 1
     `);
     const link = (rows as any).rows[0];
@@ -72,6 +73,7 @@ router.get("/o/:token", async (req, res) => {
         enrollmentId: link.enrollment_id,
         eventType: "opened",
         channel: "email",
+        recipient: link.recipient ?? null,
         meta: { token, ua: req.get("user-agent") || null },
       });
     }

--- a/artifacts/api-server/src/services/followUpService.ts
+++ b/artifacts/api-server/src/services/followUpService.ts
@@ -192,7 +192,7 @@ async function buildQuoteMergeVars(companyId: number, quoteId: number): Promise<
 // {{first_name}} {{company_name}} {{company_phone}} {{property}} {{monthly}} {{estimate_link}}.
 async function buildEstimateMergeVars(companyId: number, estimateId: number, enrollmentId?: number): Promise<Record<string, string>> {
   const r = await db.execute(sql`
-    SELECT e.id, e.total, e.property_name, e.service_address, e.public_token, e.contact_name,
+    SELECT e.id, e.total, e.property_name, e.service_address, e.public_token, e.contact_name, e.contact_email,
            c.name AS company_name, c.phone AS company_phone, c.email AS company_email
     FROM estimates e JOIN companies c ON c.id = e.company_id
     WHERE e.id = ${estimateId} AND e.company_id = ${companyId} LIMIT 1
@@ -206,7 +206,7 @@ async function buildEstimateMergeVars(companyId: number, estimateId: number, enr
   let link: string;
   if (enrollmentId) {
     const { createTrackedLink } = await import("../lib/engagement.js");
-    link = await createTrackedLink({ companyId, targetUrl: fullLink, estimateId, enrollmentId });
+    link = await createTrackedLink({ companyId, targetUrl: fullLink, estimateId, enrollmentId, recipient: e.contact_email ?? null });
   } else {
     link = e.public_token ? ((await shortenUrl(fullLink, companyId)) || fullLink) : fullLink;
   }
@@ -693,7 +693,7 @@ async function processEnrollment(enr: any): Promise<TouchResult | null> {
   if (enr.estimate_id && step.channel === "email") {
     try {
       const { createOpenPixel } = await import("../lib/engagement.js");
-      const pixel = await createOpenPixel({ companyId: enr.company_id, estimateId: enr.estimate_id, enrollmentId: enr.id });
+      const pixel = await createOpenPixel({ companyId: enr.company_id, estimateId: enr.estimate_id, enrollmentId: enr.id, recipient: recipientEmail });
       if (pixel) body += `\n<img src="${pixel}" width="1" height="1" alt="" style="display:none" />`;
     } catch { /* pixel optional */ }
   }

--- a/artifacts/api-server/src/tests/estimate-recipient-tracking.test.ts
+++ b/artifacts/api-server/src/tests/estimate-recipient-tracking.test.ts
@@ -1,0 +1,35 @@
+/** Per-recipient open/click attribution: tracked_links carry a recipient, the
+ *  track route records it, and the drip mints recipient-tagged pixel + link. */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+const here = dirname(fileURLToPath(import.meta.url));
+const read = (rel: string) => readFileSync(resolve(here, rel), "utf8");
+
+describe("per-recipient open/click tracking", () => {
+  const mig = read("../phes-data-migration.ts");
+  const eng = read("../lib/engagement.ts");
+  const track = read("../routes/track.ts");
+  const svc = read("../services/followUpService.ts");
+  const ui = read("../../../qleno/src/pages/estimate-builder.tsx");
+
+  it("tracked_links gains a recipient column", () => {
+    assert.match(mig, /ALTER TABLE tracked_links ADD COLUMN IF NOT EXISTS recipient TEXT/);
+    assert.match(eng, /INSERT INTO tracked_links \(token, company_id, estimate_id, enrollment_id, kind, target_url, recipient\)/);
+  });
+  it("track route reads + records the recipient on open + click", () => {
+    assert.match(track, /SELECT company_id, estimate_id, enrollment_id, target_url, recipient/);
+    assert.match(track, /SELECT company_id, estimate_id, enrollment_id, recipient/);
+    assert.match(track, /recipient: link\.recipient \?\? null/);
+  });
+  it("drip mints recipient-tagged pixel + link", () => {
+    assert.match(svc, /createOpenPixel\(\{ companyId: enr\.company_id, estimateId: enr\.estimate_id, enrollmentId: enr\.id, recipient: recipientEmail \}\)/);
+    assert.match(svc, /recipient: e\.contact_email \?\? null/);
+  });
+  it("tracking panel shows who opened / clicked", () => {
+    assert.match(ui, /Email opened\$\{r \? ` by \$\{r\}` : ""\}/);
+    assert.match(ui, /Link clicked\$\{r \? ` by \$\{r\}` : ""\}/);
+  });
+});

--- a/artifacts/qleno/src/pages/estimate-builder.tsx
+++ b/artifacts/qleno/src/pages/estimate-builder.tsx
@@ -769,11 +769,11 @@ function EstimateTracking({ estimateId, version }: { estimateId: number; version
   const status = String(estimate.status || "").toUpperCase();
   const pill = STATUS_PILL[status] || { bg: "#F1EFE8", fg: "#5F5E5A" };
   const ICONS: Record<string, any> = { sent: Mail, viewed: Eye, opened: Mail, clicked: MousePointerClick };
-  const LABELS: Record<string, (r: string | null) => string> = {
-    sent: (r) => `Email sent${r ? ` to ${r}` : ""}`,
+  const LABELS: Record<string, (r: string | null, ch?: string | null) => string> = {
+    sent: (r, ch) => `${ch === "sms" ? "Text" : "Email"} sent${r ? ` to ${r}` : ""}`,
     viewed: () => "Client opened the estimate",
-    opened: () => "Email opened",
-    clicked: () => "Link clicked",
+    opened: (r) => `Email opened${r ? ` by ${r}` : ""}`,
+    clicked: (r) => `Link clicked${r ? ` by ${r}` : ""}`,
   };
   const step = Number(enrollment?.current_step || 0);
   const total = Number(enrollment?.total_steps || 0);
@@ -798,8 +798,8 @@ function EstimateTracking({ estimateId, version }: { estimateId: number; version
         <div style={{ display: "flex", flexDirection: "column", gap: 11 }}>
           {timeline.length === 0 && <span style={{ fontSize: 13, color: MUTE }}>No activity yet.</span>}
           {timeline.map((t: any, i: number) => {
-            const Icon = ICONS[t.event_type] || Clock;
-            const label = (LABELS[t.event_type] || ((): string => t.event_type))(t.recipient);
+            const Icon = t.event_type === "sent" && t.channel === "sms" ? MessageSquare : (ICONS[t.event_type] || Clock);
+            const label = (LABELS[t.event_type] || ((): string => t.event_type))(t.recipient, t.channel);
             return (
               <div key={i} style={{ display: "flex", gap: 11, alignItems: "flex-start" }}>
                 <Icon size={16} style={{ color: MINT, marginTop: 1, flexShrink: 0 }} />


### PR DESCRIPTION
Opens/clicks were anonymous because the pixel/link carried no recipient.

- `tracked_links.recipient` column (additive); pixel + link creators store it.
- Drip mints recipient-tagged pixel/link (contact_email); `/api/track` records it on opened/clicked events.
- Panel reads **"Email opened by <addr>"** / **"Link clicked by <addr>"**; manual SMS shows as "Text sent to <phone>".

Attributes to the **primary contact (To)**. CC recipients share one email/pixel, so a CC open still attributes to the To — true per-CC attribution needs separate per-recipient sends (a follow-up if you want it).

Third of three (metrics ✓ → SMS ✓ → tracking ✓). recipient-tracking guard 4/4 · esbuild OK · zero net-new type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)