### PR TITLE
feat(documents): view sent invoices and quotes as branded PDFs

### DIFF
--- a/artifacts/api-server/src/lib/invoice-pdf.ts
+++ b/artifacts/api-server/src/lib/invoice-pdf.ts
@@ -1,0 +1,151 @@
+// [invoice-pdf] Renders an invoice as a branded PDF so the office can view /
+// download exactly what the client was billed. Built with pdfkit (Railway has
+// no Chromium, so HTML->PDF is avoided), mirroring estimate-pdf.ts. Returns a
+// Buffer. Style matches the estimate PDF for a consistent customer-facing look.
+import PDFDocument from "pdfkit";
+
+const NAVY = "#0A0E1A";
+const MINT = "#00C9A0";
+const INK = "#1A1917";
+const MUTE = "#6B6860";
+const BORDER = "#E5E2DC";
+
+export interface InvoicePdfItem {
+  description: string | null;
+  quantity: string | number;
+  unit_price: string | number;
+  total: string | number;
+}
+
+export interface InvoicePdfData {
+  companyName: string;
+  logo?: Buffer | null;
+  invoiceNumber: string | null;
+  status: string;
+  billToName: string | null;
+  billToAddress: string | null;
+  billToEmail: string | null;
+  billToPhone: string | null;
+  serviceDate: string | null;
+  issuedDate: string | null;
+  dueDate: string | null;
+  items: InvoicePdfItem[];
+  subtotal: string | number;
+  tips: string | number;
+  total: string | number;
+  paid: boolean;
+}
+
+const money = (n: any) => `$${Number(n || 0).toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+const fmtDate = (d: string | null) => {
+  if (!d) return null;
+  const [y, m, day] = String(d).slice(0, 10).split("-").map(Number);
+  if (!y || !m || !day) return null;
+  return new Date(y, m - 1, day).toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric" });
+};
+
+export function renderInvoicePdf(data: InvoicePdfData): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const doc = new PDFDocument({ margin: 50, size: "LETTER" });
+    const chunks: Buffer[] = [];
+    doc.on("data", (c) => chunks.push(c as Buffer));
+    doc.on("end", () => resolve(Buffer.concat(chunks)));
+    doc.on("error", reject);
+
+    const left = 50;
+    const right = doc.page.width - 50;
+    const width = right - left;
+
+    // Header band — logo chip left, INVOICE / number / status right.
+    doc.rect(0, 0, doc.page.width, 84).fill(NAVY);
+    let drewLogo = false;
+    if (data.logo) {
+      try {
+        doc.roundedRect(left, 22, 156, 40, 6).fill("#FFFFFF");
+        doc.image(data.logo, left + 10, 27, { fit: [136, 30] });
+        drewLogo = true;
+      } catch { drewLogo = false; }
+    }
+    if (!drewLogo) {
+      doc.fillColor("#FFFFFF").fontSize(20).font("Helvetica-Bold").text(data.companyName || "Invoice", left, 32);
+    }
+    doc.fillColor("#FFFFFF").fontSize(20).font("Helvetica-Bold").text("INVOICE", right - 200, 24, { width: 200, align: "right" });
+    const statusLabel = data.paid ? "PAID" : (data.status || "").toUpperCase();
+    doc.fillColor(MINT).fontSize(10).font("Helvetica-Bold")
+      .text(`${data.invoiceNumber ? `#${data.invoiceNumber}` : ""}${statusLabel ? `   ${statusLabel}` : ""}`, right - 200, 52, { width: 200, align: "right" });
+
+    let y = 104;
+
+    // Bill-to + dates row
+    doc.fillColor(MUTE).fontSize(9).font("Helvetica-Bold").text("BILL TO", left, y);
+    const datesX = right - 220;
+    doc.fillColor(MUTE).fontSize(9).font("Helvetica-Bold").text("DETAILS", datesX, y, { width: 220, align: "right" });
+    y += 14;
+    const billStartY = y;
+    if (data.billToName) { doc.fillColor(INK).fontSize(11).font("Helvetica-Bold").text(data.billToName, left, y, { width: width - 230 }); y = doc.y + 1; }
+    if (data.billToAddress) { doc.fillColor("#374151").fontSize(10).font("Helvetica").text(data.billToAddress, left, y, { width: width - 230 }); y = doc.y + 1; }
+    if (data.billToEmail) { doc.fillColor(MUTE).fontSize(9.5).font("Helvetica").text(data.billToEmail, left, y, { width: width - 230 }); y = doc.y + 1; }
+    if (data.billToPhone) { doc.fillColor(MUTE).fontSize(9.5).font("Helvetica").text(data.billToPhone, left, y, { width: width - 230 }); y = doc.y + 1; }
+    // Dates column (right-aligned)
+    let dy = billStartY;
+    const dateRow = (label: string, val: string | null) => {
+      if (!val) return;
+      doc.fillColor(MUTE).fontSize(9.5).font("Helvetica").text(`${label}  `, datesX, dy, { width: 130, align: "right" });
+      doc.fillColor(INK).fontSize(9.5).font("Helvetica-Bold").text(val, datesX + 130, dy, { width: 90, align: "right" });
+      dy += 15;
+    };
+    dateRow("Issued", fmtDate(data.issuedDate));
+    dateRow("Service date", fmtDate(data.serviceDate));
+    dateRow("Due", fmtDate(data.dueDate) || "Upon receipt");
+    y = Math.max(y, dy) + 12;
+
+    doc.moveTo(left, y).lineTo(right, y).strokeColor(BORDER).stroke();
+    y += 16;
+
+    // Line items table
+    doc.fillColor(MUTE).fontSize(9).font("Helvetica-Bold").text("DESCRIPTION", left, y);
+    doc.text("AMOUNT", right - 90, y, { width: 90, align: "right" });
+    y += 16;
+    doc.moveTo(left, y).lineTo(right, y).strokeColor("#F0EEE9").stroke();
+    y += 10;
+    const items = Array.isArray(data.items) ? data.items : [];
+    for (const it of items) {
+      const qty = Number(it.quantity);
+      const sub = qty && qty !== 1 ? `${qty} × ${money(it.unit_price)}` : null;
+      const startY = y;
+      doc.fillColor(INK).fontSize(10.5).font("Helvetica-Bold").text(it.description || "Service", left, y, { width: width - 100 });
+      y = doc.y;
+      if (sub) { doc.fillColor(MUTE).fontSize(9).font("Helvetica").text(sub, left, y, { width: width - 100 }); y = doc.y; }
+      doc.fillColor(INK).fontSize(10.5).font("Helvetica-Bold").text(money(it.total), right - 90, startY, { width: 90, align: "right" });
+      y += 8;
+      doc.moveTo(left, y).lineTo(right, y).strokeColor("#F0EEE9").stroke();
+      y += 8;
+    }
+
+    // Totals
+    y += 6;
+    const labelX = right - 220, valX = right - 110;
+    doc.fillColor(MUTE).fontSize(10).font("Helvetica").text("Subtotal", labelX, y, { width: 110 });
+    doc.fillColor(INK).text(money(data.subtotal || data.total), valX, y, { width: 110, align: "right" });
+    y += 16;
+    if (Number(data.tips) > 0) {
+      doc.fillColor(MUTE).fontSize(10).font("Helvetica").text("Tip", labelX, y, { width: 110 });
+      doc.fillColor(INK).text(money(data.tips), valX, y, { width: 110, align: "right" });
+      y += 16;
+    }
+    doc.moveTo(labelX, y).lineTo(right, y).strokeColor(INK).lineWidth(1.2).stroke();
+    y += 8;
+    doc.fillColor(INK).fontSize(13).font("Helvetica-Bold").text("Total", labelX, y, { width: 110 });
+    doc.fillColor(NAVY).fontSize(16).font("Helvetica-Bold").text(money(data.total), valX - 60, y - 2, { width: 170, align: "right" });
+    y += 34;
+
+    // Paid stamp / pay note
+    if (data.paid) {
+      doc.fillColor("#047857").fontSize(11).font("Helvetica-Bold").text("Paid in full — thank you!", left, y);
+    } else {
+      doc.fillColor(MUTE).fontSize(9.5).font("Helvetica").text(`Please remit ${money(data.total)} by ${fmtDate(data.dueDate) || "the due date"}. Thank you for your business.`, left, y, { width });
+    }
+
+    doc.end();
+  });
+}

--- a/artifacts/api-server/src/routes/clients.ts
+++ b/artifacts/api-server/src/routes/clients.ts
@@ -613,24 +613,40 @@ router.get("/:id/messages", requireAuth, requireRole("owner", "admin", "office")
 
     const result = await db.execute(sql`
       SELECT * FROM (
-        SELECT sent_at AS at, channel::text AS channel, 'outbound'::text AS direction,
-               trigger::text AS type, recipient::text AS recipient, status::text AS status,
-               NULL::text AS subject, NULL::text AS body, 'automated'::text AS source
-          FROM notification_log
-         WHERE company_id = ${companyId}
-           AND (( ${email} <> '' AND recipient = ${email}) OR ( ${phone} <> '' AND recipient = ${phone}))
+        SELECT nl.sent_at AS at, nl.channel::text AS channel, 'outbound'::text AS direction,
+               nl.trigger::text AS type, nl.recipient::text AS recipient, nl.status::text AS status,
+               NULL::text AS subject, NULL::text AS body, 'automated'::text AS source,
+               CASE WHEN nl.trigger = 'invoice_sent' THEN 'invoice' END::text AS doc_type,
+               CASE WHEN nl.trigger = 'invoice_sent'
+                    THEN (SELECT i.id FROM invoices i
+                           WHERE i.company_id = nl.company_id AND i.client_id = ${clientId}
+                             AND i.invoice_number = (nl.metadata->>'invoice_number') LIMIT 1)
+               END AS doc_id
+          FROM notification_log nl
+         WHERE nl.company_id = ${companyId}
+           AND (( ${email} <> '' AND nl.recipient = ${email}) OR ( ${phone} <> '' AND nl.recipient = ${phone}))
         UNION ALL
         SELECT created_at AS at, 'sms'::text AS channel, direction::text AS direction,
                'sms'::text AS type, COALESCE(to_number, from_number)::text AS recipient,
-               status::text AS status, NULL::text AS subject, body::text AS body, 'two_way'::text AS source
+               status::text AS status, NULL::text AS subject, body::text AS body, 'two_way'::text AS source,
+               NULL::text AS doc_type, NULL::int AS doc_id
           FROM sms_messages
          WHERE company_id = ${companyId} AND client_id = ${clientId}
         UNION ALL
         SELECT logged_at AS at, channel::text AS channel, direction::text AS direction,
                COALESCE(source, 'message')::text AS type, recipient::text AS recipient,
-               delivery_status::text AS status, subject::text AS subject, body::text AS body, 'logged'::text AS source
+               delivery_status::text AS status, subject::text AS subject, body::text AS body, 'logged'::text AS source,
+               NULL::text AS doc_type, NULL::int AS doc_id
           FROM communication_log
          WHERE company_id = ${companyId} AND customer_id = ${clientId}
+        UNION ALL
+        SELECT sent_at AS at, channel::text AS channel, 'outbound'::text AS direction,
+               COALESCE(sequence_name, 'message')::text AS type,
+               COALESCE(recipient_email, recipient_phone)::text AS recipient,
+               status::text AS status, subject::text AS subject, body::text AS body, 'cadence'::text AS source,
+               NULL::text AS doc_type, NULL::int AS doc_id
+          FROM message_log
+         WHERE company_id = ${companyId} AND client_id = ${clientId}
       ) t
       ORDER BY at DESC NULLS LAST
       LIMIT 200`);

--- a/artifacts/api-server/src/routes/invoices.ts
+++ b/artifacts/api-server/src/routes/invoices.ts
@@ -438,6 +438,90 @@ router.get("/:id", requireAuth, async (req, res) => {
   }
 });
 
+// ── Invoice PDF ──────────────────────────────────────────────────────────────
+// Branded, downloadable PDF of the invoice — same look as the estimate PDF.
+// Inline disposition so it opens in a browser tab.
+router.get("/:id/pdf", requireAuth, async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    const invoiceId = parseInt(req.params.id);
+    const [inv] = await db
+      .select({
+        invoice_number: invoicesTable.invoice_number,
+        status: invoicesTable.status,
+        line_items: invoicesTable.line_items,
+        subtotal: invoicesTable.subtotal,
+        tips: invoicesTable.tips,
+        total: invoicesTable.total,
+        due_date: invoicesTable.due_date,
+        created_at: invoicesTable.created_at,
+        paid_at: invoicesTable.paid_at,
+        first_name: clientsTable.first_name,
+        last_name: clientsTable.last_name,
+        email: clientsTable.email,
+        phone: clientsTable.phone,
+        address: clientsTable.address,
+        city: clientsTable.city,
+        state: clientsTable.state,
+        zip: clientsTable.zip,
+        account_name: sql<string | null>`(SELECT a.account_name FROM accounts a WHERE a.id = ${invoicesTable.account_id})`,
+        service_date: sql<string | null>`(SELECT j.scheduled_date FROM jobs j WHERE j.id = ${invoicesTable.job_id})`,
+      })
+      .from(invoicesTable)
+      .leftJoin(clientsTable, eq(invoicesTable.client_id, clientsTable.id))
+      .where(and(eq(invoicesTable.id, invoiceId), eq(invoicesTable.company_id, companyId)))
+      .limit(1);
+    if (!inv) return res.status(404).json({ error: "Not Found", message: "Invoice not found" });
+
+    const co = await db.execute(sql`SELECT name, logo_url FROM companies WHERE id = ${companyId} LIMIT 1`);
+    const company: any = (co as any).rows[0] ?? {};
+    let logo: Buffer | null = null;
+    if (company.logo_url) {
+      try {
+        const abs = /^https?:\/\//i.test(company.logo_url) ? company.logo_url : `${appBaseUrl()}${company.logo_url}`;
+        const r = await fetch(abs);
+        if (r.ok && /image\/(png|jpe?g)/i.test(r.headers.get("content-type") || "")) logo = Buffer.from(await r.arrayBuffer());
+      } catch { logo = null; }
+    }
+
+    const rawItems = Array.isArray(inv.line_items) ? inv.line_items : [];
+    const items = rawItems.map((it: any) => ({
+      description: it.description ?? it.name ?? "Service",
+      quantity: it.quantity ?? 1,
+      unit_price: it.unit_price ?? it.unit_rate ?? it.total ?? 0,
+      total: it.total ?? it.amount ?? 0,
+    }));
+    const billName = [inv.first_name, inv.last_name].filter(Boolean).join(" ") || inv.account_name || "Customer";
+    const billAddr = [inv.address, [inv.city, inv.state].filter(Boolean).join(", "), inv.zip].filter(Boolean).join(", ");
+
+    const { renderInvoicePdf } = await import("../lib/invoice-pdf.js");
+    const pdf = await renderInvoicePdf({
+      companyName: company.name || "Invoice",
+      logo,
+      invoiceNumber: inv.invoice_number || generateInvoiceNumber(invoiceId),
+      status: inv.status || "sent",
+      billToName: billName,
+      billToAddress: billAddr || null,
+      billToEmail: inv.email || null,
+      billToPhone: inv.phone || null,
+      serviceDate: inv.service_date ? String(inv.service_date) : null,
+      issuedDate: inv.created_at ? String(inv.created_at) : null,
+      dueDate: inv.due_date ? String(inv.due_date) : null,
+      items,
+      subtotal: inv.subtotal ?? inv.total ?? 0,
+      tips: inv.tips ?? 0,
+      total: inv.total ?? 0,
+      paid: !!inv.paid_at,
+    });
+    res.setHeader("Content-Type", "application/pdf");
+    res.setHeader("Content-Disposition", `inline; filename="${inv.invoice_number || `invoice-${invoiceId}`}.pdf"`);
+    return res.end(pdf);
+  } catch (err) {
+    console.error("Invoice PDF error:", err);
+    return res.status(500).json({ error: "Internal Server Error", message: "Failed to render invoice PDF" });
+  }
+});
+
 router.put("/:id", requireAuth, requireRole("owner", "admin", "office"), async (req, res) => {
   try {
     const invoiceId = parseInt(req.params.id);

--- a/artifacts/api-server/src/routes/quotes.ts
+++ b/artifacts/api-server/src/routes/quotes.ts
@@ -289,6 +289,80 @@ router.patch("/:id", requireAuth, requireRole("owner", "admin", "office"), async
   }
 });
 
+// ── Quote PDF ────────────────────────────────────────────────────────────────
+// Branded, downloadable PDF of the quote — reuses the estimate PDF renderer so
+// quotes and estimates look identical to the customer. Inline disposition.
+router.get("/:id/pdf", requireAuth, async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    const id = parseInt(req.params.id);
+    const [q] = await db
+      .select({
+        client_id: quotesTable.client_id,
+        lead_name: quotesTable.lead_name,
+        address: quotesTable.address,
+        service_type: quotesTable.service_type,
+        frequency: quotesTable.frequency,
+        base_price: quotesTable.base_price,
+        total_price: quotesTable.total_price,
+        discount_amount: quotesTable.discount_amount,
+        status: quotesTable.status,
+        notes: quotesTable.notes,
+        created_at: quotesTable.created_at,
+        client_first: clientsTable.first_name,
+        client_last: clientsTable.last_name,
+      })
+      .from(quotesTable)
+      .leftJoin(clientsTable, eq(quotesTable.client_id, clientsTable.id))
+      .where(and(eq(quotesTable.id, id), eq(quotesTable.company_id, companyId)))
+      .limit(1);
+    if (!q) return res.status(404).json({ error: "Not Found" });
+
+    const co = await db.execute(sql`SELECT name, logo_url FROM companies WHERE id = ${companyId} LIMIT 1`);
+    const company: any = (co as any).rows[0] ?? {};
+    let logo: Buffer | null = null;
+    if (company.logo_url && /^https?:\/\//i.test(company.logo_url)) {
+      try {
+        const r = await fetch(company.logo_url);
+        if (r.ok && /image\/(png|jpe?g)/i.test(r.headers.get("content-type") || "")) logo = Buffer.from(await r.arrayBuffer());
+      } catch { logo = null; }
+    }
+
+    const total = Number(q.total_price ?? q.base_price ?? 0);
+    const discount = Number(q.discount_amount ?? 0);
+    const contactName = [q.client_first, q.client_last].filter(Boolean).join(" ") || q.lead_name || null;
+    const svcLabel = (q.service_type || "Cleaning Service").replace(/_/g, " ").replace(/\b\w/g, (m) => m.toUpperCase());
+
+    const { renderEstimatePdf } = await import("../lib/estimate-pdf.js");
+    const pdf = await renderEstimatePdf({
+      companyName: company.name || "Quote",
+      logo,
+      estimateNumber: `Q-${id}`,
+      status: q.status || "draft",
+      title: svcLabel,
+      introNote: null,
+      contactName,
+      propertyName: null,
+      serviceAddress: q.address || null,
+      billingMode: "flat",
+      flatPriceUnit: q.frequency && q.frequency !== "one_time" ? "visit" : "total",
+      scopeNote: q.notes || null,
+      items: [{ name: svcLabel, pricing_type: "flat", frequency: q.frequency || null, quantity: 1, unit_rate: total, amount: total }],
+      subtotal: total + discount,
+      discount,
+      total,
+      terms: null,
+      validUntil: null,
+    });
+    res.setHeader("Content-Type", "application/pdf");
+    res.setHeader("Content-Disposition", `inline; filename="quote-${id}.pdf"`);
+    return res.end(pdf);
+  } catch (err) {
+    console.error("Quote PDF error:", err);
+    return res.status(500).json({ error: "Internal Server Error", message: "Failed to render quote PDF" });
+  }
+});
+
 router.post("/:id/send", requireAuth, requireRole("owner", "admin", "office"), async (req, res) => {
   try {
     const id = parseInt(req.params.id);

--- a/artifacts/qleno/src/pages/customer-profile-tabs2.tsx
+++ b/artifacts/qleno/src/pages/customer-profile-tabs2.tsx
@@ -20,6 +20,18 @@ async function apiFetch(path: string, opts: RequestInit = {}) {
   return r.json();
 }
 
+// Open an auth-gated PDF (invoice/quote) in a new tab — window.open can't carry
+// the Bearer header, so fetch with auth → blob URL → open.
+async function openAuthedPdf(path: string) {
+  try {
+    const r = await fetch(`${API}${path}`, { headers: getAuthHeaders() });
+    if (!r.ok) { alert("Could not open the PDF."); return; }
+    const url = URL.createObjectURL(await r.blob());
+    window.open(url, "_blank");
+    setTimeout(() => URL.revokeObjectURL(url), 60000);
+  } catch { alert("Could not open the PDF."); }
+}
+
 async function apiFetchJSON(path: string, opts: RequestInit = {}) {
   return apiFetch(path, { ...opts, headers: { "Content-Type": "application/json", ...opts.headers } });
 }
@@ -193,6 +205,9 @@ export function QuotesTab({ clientId, client }: { clientId: number; client: any 
                   <td style={{ padding: "12px 14px", fontSize: "12px", color: "#6B7280" }}>{q.sent_at ? fmtDate(q.sent_at) : "—"}</td>
                   <td style={{ padding: "12px 14px" }}>
                     <div style={{ display: "flex", gap: "6px", flexWrap: "wrap" }}>
+                      <button onClick={() => openAuthedPdf(`/api/quotes/${q.id}/pdf`)} style={{ backgroundColor: "#F3F4F6", color: "#374151", border: "none", borderRadius: "4px", padding: "4px 8px", fontSize: "11px", fontWeight: 600, cursor: "pointer" }}>
+                        PDF
+                      </button>
                       {q.status === "draft" && (
                         <button onClick={() => sendMut.mutate(q.id)} disabled={sendMut.isPending} style={{ backgroundColor: "#EFF6FF", color: "#1D4ED8", border: "none", borderRadius: "4px", padding: "4px 8px", fontSize: "11px", fontWeight: 600, cursor: "pointer", display: "flex", alignItems: "center", gap: "4px" }}>
                           <Send size={10} /> Send

--- a/artifacts/qleno/src/pages/customer-profile.tsx
+++ b/artifacts/qleno/src/pages/customer-profile.tsx
@@ -1378,8 +1378,9 @@ function BillingTab({ invoices }: { invoices: any[] }) {
                     {inv.status}
                   </span>
                 </td>
-                <td style={{ padding: "12px 16px" }}>
+                <td style={{ padding: "12px 16px", whiteSpace: "nowrap" }}>
                   <button onClick={() => navigate(`/invoices/${inv.id}`)} style={{ fontSize: "12px", color: "var(--brand)", background: "none", border: "none", cursor: "pointer", fontWeight: 600 }}>View</button>
+                  <button onClick={() => openAuthedPdf(`/api/invoices/${inv.id}/pdf`)} style={{ fontSize: "12px", color: "var(--brand)", background: "none", border: "none", cursor: "pointer", fontWeight: 600, marginLeft: 12 }}>PDF</button>
                 </td>
               </tr>
             ))}
@@ -5484,6 +5485,18 @@ function ActivityTab({ clientId }: { clientId: number }) {
   );
 }
 
+// Open an auth-gated PDF (invoice/quote) in a new tab. window.open can't send
+// the Bearer header, so fetch with auth → blob URL → open.
+async function openAuthedPdf(path: string) {
+  try {
+    const r = await fetch(`${API}${path}`, { headers: getAuthHeaders() });
+    if (!r.ok) { alert("Could not open the PDF."); return; }
+    const url = URL.createObjectURL(await r.blob());
+    window.open(url, "_blank");
+    setTimeout(() => URL.revokeObjectURL(url), 60000);
+  } catch { alert("Could not open the PDF."); }
+}
+
 // Per-customer message timeline — every automated + manual text/email we've
 // sent this customer, newest first (GET /api/clients/:id/messages).
 function CustomerMessagesTab({ clientId }: { clientId: number }) {
@@ -5526,6 +5539,12 @@ function CustomerMessagesTab({ clientId }: { clientId: number }) {
               </p>
             )}
             <span style={{ fontSize: 11, fontWeight: 600, color: statusColor(m.status) }}>{m.status || ""}</span>
+            {m.doc_type && m.doc_id && (
+              <button onClick={() => openAuthedPdf(`/api/${m.doc_type === "quote" ? "quotes" : "invoices"}/${m.doc_id}/pdf`)}
+                style={{ marginLeft: 10, fontSize: 11, fontWeight: 600, color: "var(--brand)", background: "none", border: "none", cursor: "pointer", padding: 0 }}>
+                View PDF
+              </button>
+            )}
           </div>
         </div>
       ))}


### PR DESCRIPTION
Lets the office pull up any invoice or quote sent to a customer as a branded PDF.

## What's new
- **Invoice PDF (new — none existed)**: `lib/invoice-pdf.ts` renders a branded invoice (logo, bill-to, line items, subtotal/tip/total, due date, paid stamp), styled to match the existing quote/estimate PDF. Served inline at `GET /api/invoices/:id/pdf`.
- **Quote PDF**: `GET /api/quotes/:id/pdf` renders a quote by reusing the estimate renderer (flat mode) so quotes and estimates look identical to the customer.
- **Customer profile**: a 'PDF' button on each invoice (Billing) and each quote (Quotes). Opens via an auth-aware fetch→blob (a plain `window.open` can't carry the Bearer token).
- **Messages timeline**: now also unions `message_log` (the quote/estimate cadence sends) so the audit trail is truly complete, and attaches a 'View PDF' link to invoice-sent rows (resolves the invoice by number from the log metadata).

## Notes
- PDFs use pdfkit (Railway has no Chromium), matching the existing estimate PDF approach.
- Read-only/additive — no changes to send logic, gates, or existing endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)