### PR TITLE
feat(estimates): office can mark an estimate won / lost

### DIFF
--- a/artifacts/api-server/src/routes/estimates.ts
+++ b/artifacts/api-server/src/routes/estimates.ts
@@ -894,6 +894,33 @@ router.post("/:id/sms", requireAuth, async (req, res) => {
   }
 });
 
+// Office marks the outcome (e.g. the client said "proceed" on the phone). Mirrors
+// the client-side accept/decline: sets status + timestamp and stops the drip.
+router.post("/:id/mark-outcome", requireAuth, async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    const id = parseInt(req.params.id, 10);
+    const outcome = String(req.body?.outcome) === "declined" ? "declined" : String(req.body?.outcome) === "accepted" ? "accepted" : null;
+    if (!outcome) return res.status(400).json({ error: "Bad Request", message: "outcome must be accepted or declined" });
+    const e = await db.execute(sql`SELECT id, contact_name FROM estimates WHERE id = ${id} AND company_id = ${companyId} LIMIT 1`);
+    const est = (e as any).rows[0];
+    if (!est) return res.status(404).json({ error: "Not Found" });
+    const name = str(req.body?.name, 200) || est.contact_name || "Office";
+    if (outcome === "accepted") {
+      await db.execute(sql`UPDATE estimates SET status = 'accepted', accepted_at = now(), accepted_name = ${name}, updated_at = now() WHERE id = ${id} AND company_id = ${companyId}`);
+    } else {
+      await db.execute(sql`UPDATE estimates SET status = 'declined', declined_at = now(), updated_at = now() WHERE id = ${id} AND company_id = ${companyId}`);
+    }
+    stopEnrollmentsForEstimate(id, outcome).catch(() => {});
+    recordEngagementEvent({ companyId, estimateId: id, eventType: outcome, channel: "office", recipient: null,
+      meta: { by_user: req.auth!.userId, name } }).catch(() => {});
+    return res.json({ ok: true, status: outcome });
+  } catch (err) {
+    console.error("Estimate mark-outcome error:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
 // ─── Create estimate ─────────────────────────────────────────────────────────
 router.post("/", requireAuth, async (req, res) => {
   try {

--- a/artifacts/api-server/src/tests/estimate-mark-outcome.test.ts
+++ b/artifacts/api-server/src/tests/estimate-mark-outcome.test.ts
@@ -1,0 +1,26 @@
+/** Office can mark an estimate won/lost (client said "proceed" off-app). */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+const here = dirname(fileURLToPath(import.meta.url));
+const read = (rel: string) => readFileSync(resolve(here, rel), "utf8");
+
+describe("office mark-outcome", () => {
+  const route = read("../routes/estimates.ts");
+  const ui = read("../../../qleno/src/pages/estimate-builder.tsx");
+  it("route sets status + timestamp + stops the drip", () => {
+    assert.match(route, /router\.post\("\/:id\/mark-outcome"/);
+    assert.match(route, /UPDATE estimates SET status = 'accepted', accepted_at = now\(\)/);
+    assert.match(route, /UPDATE estimates SET status = 'declined', declined_at = now\(\)/);
+    assert.match(route, /stopEnrollmentsForEstimate\(id, outcome\)/);
+    assert.match(route, /eventType: outcome, channel: "office"/);
+  });
+  it("builder has the Mark won / lost controls", () => {
+    assert.match(ui, /const markOutcome = async \(outcome: "accepted" \| "declined"\)/);
+    assert.match(ui, /\/api\/estimates\/\$\{estimateId\}\/mark-outcome/);
+    assert.match(ui, /Mark as won/);
+    assert.match(ui, /Mark as lost/);
+  });
+});

--- a/artifacts/qleno/src/pages/estimate-builder.tsx
+++ b/artifacts/qleno/src/pages/estimate-builder.tsx
@@ -788,12 +788,25 @@ function EstimateTracking({ estimateId, version }: { estimateId: number; version
     catch { toast.error("Couldn't stop follow-ups"); }
     finally { setStopping(false); }
   };
+  // Office marks the outcome when the client says "proceed" (or passes) off-app.
+  const markOutcome = async (outcome: "accepted" | "declined") => {
+    const verb = outcome === "accepted" ? "won" : "lost";
+    if (!confirm(`Mark this estimate as ${verb}? This stops the follow-ups.`)) return;
+    try { await apiFetch(`/api/estimates/${estimateId}/mark-outcome`, { method: "POST", body: { outcome } }); await load(); toast.success(`Marked as ${verb}`); }
+    catch { toast.error("Couldn't update the status"); }
+  };
 
   return (
     <div style={{ background: "#fff", border: `1px solid ${BORDER}`, borderRadius: 14, overflow: "hidden", marginBottom: 16 }}>
       <div style={{ display: "flex", alignItems: "center", gap: 9, padding: "13px 16px", borderBottom: `1px solid #EEECE7` }}>
         <span style={{ fontSize: 14, fontWeight: 700, color: INK }}>Sent &amp; tracking</span>
         <span style={{ fontSize: 10, fontWeight: 700, letterSpacing: "0.05em", color: pill.fg, background: pill.bg, padding: "2px 9px", borderRadius: 20 }}>{status}</span>
+        {!accepted && (
+          <div style={{ display: "flex", gap: 6, marginLeft: "auto" }}>
+            <button onClick={() => markOutcome("accepted")} style={{ fontSize: 12, fontWeight: 700, color: "#fff", background: "#0F6E56", border: "none", borderRadius: 8, padding: "6px 12px", cursor: "pointer", fontFamily: FF }}>Mark as won</button>
+            <button onClick={() => markOutcome("declined")} style={{ fontSize: 12, fontWeight: 600, color: "#6B7280", background: "#fff", border: `1px solid ${BORDER}`, borderRadius: 8, padding: "6px 12px", cursor: "pointer", fontFamily: FF }}>Mark as lost</button>
+          </div>
+        )}
       </div>
 
       <div style={{ padding: "14px 16px", borderBottom: `1px solid #EEECE7` }}>


### PR DESCRIPTION
Only the client could accept/decline before. When a client says 'proceed' on the phone, the office now has **Mark as won / Mark as lost** on the Sent & tracking panel.

- **API:** `POST /:id/mark-outcome` mirrors the client accept/decline — status + timestamp, stops the drip, records the outcome (channel 'office').
- **UI:** buttons in the panel header (hidden once accepted/declined); confirm then refresh.

mark-outcome guard 2/2 · esbuild OK · zero net-new type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)