### PR TITLE
feat(estimates): send a Stripe card-on-file link from a won estimate

### DIFF
--- a/artifacts/api-server/src/routes/estimates.ts
+++ b/artifacts/api-server/src/routes/estimates.ts
@@ -921,6 +921,45 @@ router.post("/:id/mark-outcome", requireAuth, async (req, res) => {
   }
 });
 
+// Ensure a client record exists for an estimate's contact (so the existing
+// Stripe save-card payment-link flow can target it). Links it back onto the
+// estimate. Returns the client id + contact channels for sending the link.
+router.post("/:id/ensure-client", requireAuth, async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    const id = parseInt(req.params.id, 10);
+    const e = await db.execute(sql`
+      SELECT id, client_id, contact_name, contact_email, contact_phone, property_name
+      FROM estimates WHERE id = ${id} AND company_id = ${companyId} LIMIT 1
+    `);
+    const est = (e as any).rows[0];
+    if (!est) return res.status(404).json({ error: "Not Found" });
+    if (est.client_id) return res.json({ client_id: est.client_id, email: est.contact_email, phone: est.contact_phone });
+
+    let clientId: number | null = null;
+    if (est.contact_email) {
+      const f = await db.execute(sql`SELECT id FROM clients WHERE company_id = ${companyId} AND lower(email) = lower(${est.contact_email}) LIMIT 1`);
+      clientId = (f as any).rows[0]?.id ?? null;
+    }
+    if (!clientId) {
+      const parts = String(est.contact_name || "").trim().split(/\s+/).filter(Boolean);
+      const first = parts[0] || "Client";
+      const last = parts.slice(1).join(" ") || est.property_name || "Contact";
+      const ins = await db.execute(sql`
+        INSERT INTO clients (company_id, first_name, last_name, email, phone, client_type, payment_method)
+        VALUES (${companyId}, ${first}, ${last}, ${str(est.contact_email, 200)}, ${str(est.contact_phone, 40)}, 'commercial', 'card_on_file')
+        RETURNING id
+      `);
+      clientId = (ins as any).rows[0].id;
+    }
+    await db.execute(sql`UPDATE estimates SET client_id = ${clientId}, updated_at = now() WHERE id = ${id} AND company_id = ${companyId}`);
+    return res.json({ client_id: clientId, email: est.contact_email, phone: est.contact_phone });
+  } catch (err) {
+    console.error("Estimate ensure-client error:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
 // ─── Create estimate ─────────────────────────────────────────────────────────
 router.post("/", requireAuth, async (req, res) => {
   try {

--- a/artifacts/api-server/src/tests/estimate-card-on-file.test.ts
+++ b/artifacts/api-server/src/tests/estimate-card-on-file.test.ts
@@ -1,0 +1,24 @@
+/** Send a Stripe card-on-file link from a won estimate (reuses save_card flow). */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+const here = dirname(fileURLToPath(import.meta.url));
+const read = (rel: string) => readFileSync(resolve(here, rel), "utf8");
+
+describe("estimate card-on-file link", () => {
+  const route = read("../routes/estimates.ts");
+  const ui = read("../../../qleno/src/pages/estimate-builder.tsx");
+  it("ensure-client links/creates a client from the estimate contact", () => {
+    assert.match(route, /router\.post\("\/:id\/ensure-client"/);
+    assert.match(route, /INSERT INTO clients \(company_id, first_name, last_name, email, phone, client_type, payment_method\)/);
+    assert.match(route, /UPDATE estimates SET client_id = \$\{clientId\}/);
+  });
+  it("builder sends the save_card link via payment-links", () => {
+    assert.match(ui, /async function sendCardOnFile/);
+    assert.match(ui, /\/api\/estimates\/\$\{savedId\}\/ensure-client/);
+    assert.match(ui, /purpose: "save_card"/);
+    assert.match(ui, /Card on file/);
+  });
+});

--- a/artifacts/qleno/src/pages/estimate-builder.tsx
+++ b/artifacts/qleno/src/pages/estimate-builder.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useRoute } from "wouter";
 import { getAuthHeaders } from "@/lib/auth";
 import { DashboardLayout } from "@/components/layout/dashboard-layout";
-import { Plus, Trash2, ArrowLeft, Save, Send, LayoutTemplate, GripVertical, Check, FileText, Mail, Eye, Clock, MousePointerClick, MessageSquare, X } from "lucide-react";
+import { Plus, Trash2, ArrowLeft, Save, Send, LayoutTemplate, GripVertical, Check, FileText, Mail, Eye, Clock, MousePointerClick, MessageSquare, X, CreditCard } from "lucide-react";
 import { toast } from "sonner";
 import { CalendarPopover } from "@/components/calendar-popover";
 import { useAddressAutocomplete } from "@/hooks/use-address-autocomplete";
@@ -367,6 +367,22 @@ export default function EstimateBuilderPage() {
     finally { setSmsSending(false); }
   }
 
+  // [estimate-card-on-file] Send the client a Stripe save-card link (reuses the
+  // payment-links save_card flow): ensure a client record, then send the link.
+  const [cardBusy, setCardBusy] = useState(false);
+  async function sendCardOnFile() {
+    const savedId = await save();
+    if (!savedId) return;
+    setCardBusy(true);
+    try {
+      const c = await apiFetch(`/api/estimates/${savedId}/ensure-client`, { method: "POST" });
+      if (!c.email && !c.phone) { toast.error("Add an email or phone first, then send the card link."); return; }
+      await apiFetch(`/api/payment-links`, { method: "POST", body: { client_id: c.client_id, purpose: "save_card", send_email: !!c.email, send_sms: !c.email && !!c.phone } });
+      toast.success(`Card-on-file link sent to ${c.email || c.phone}`);
+    } catch { toast.error("Couldn't send the card-on-file link"); }
+    finally { setCardBusy(false); }
+  }
+
   const [pdfBusy, setPdfBusy] = useState(false);
   async function downloadPdf() {
     // Always persist current edits first — the PDF is rendered server-side from
@@ -682,6 +698,7 @@ export default function EstimateBuilderPage() {
           </span>
           <button onClick={downloadPdf} disabled={pdfBusy} style={ghostBtn}><FileText size={15} /> {pdfBusy ? "Preparing…" : "PDF preview"}</button>
           <button onClick={openSms} style={ghostBtn}><MessageSquare size={15} /> Text to client</button>
+          <button onClick={sendCardOnFile} disabled={cardBusy} style={ghostBtn}><CreditCard size={15} /> {cardBusy ? "Sending…" : "Card on file"}</button>
           <button onClick={save} disabled={saving} style={ghostBtn}><Save size={15} /> {saving ? "Saving…" : "Save"}</button>
           <button onClick={markSent} style={primaryBtn}><Send size={15} /> {publicToken ? "Resend to client" : "Send to client"}</button>
         </div>


### PR DESCRIPTION
Surfaces the existing save-card payment-link flow on the estimate. **Card on file** ensures a client record for the contact (create/link if needed) and sends the Stripe save-card link (hosted `/pay/:token` SetupIntent + webhook stores the card). Email if present, else SMS.

- **API:** `POST /:id/ensure-client` — find-or-create a client from the estimate contact, link it back.
- **UI:** 'Card on file' toolbar action.

First of two (card-on-file ✓ → official W-9 next, needs company EIN/tax info in settings). card-on-file guard 2/2 · esbuild OK · zero net-new type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)