### PR TITLE
feat(comms): Communication Log panel shows full history + inbox click-to-profile

### DIFF
--- a/artifacts/qleno/src/pages/customer-profile-tabs2.tsx
+++ b/artifacts/qleno/src/pages/customer-profile-tabs2.tsx
@@ -850,9 +850,35 @@ export function CommLog2({ clientId }: { clientId: number }) {
   const [perPage, setPerPage] = useState(10);
 
   const qk = ["comm-log", clientId, filter];
+  // [comms-unify 2026-06-26] This panel now reads the SAME complete history as
+  // the Messages tab (/api/clients/:id/messages) — every text + email sent to
+  // AND received from the customer, matched by phone so duplicate-profile texts
+  // still show. The old /api/comms source only held manual logs, which is why
+  // the box looked empty even when conversations existed. Manual "+ Log
+  // Communication" entries still post to /api/comms (communication_log) and come
+  // back through this union, so nothing is lost. Filter is applied client-side.
   const { data: logs = [], isLoading, refetch } = useQuery<any[]>({
     queryKey: qk,
-    queryFn: () => apiFetch(`/api/comms?customer_id=${clientId}${filter ? `&filter=${filter}` : ""}&limit=200`),
+    queryFn: async () => {
+      const d = await apiFetch(`/api/clients/${clientId}/messages`);
+      const rows = (d.data || []).map((m: any, i: number) => ({
+        id: `${m.source || "msg"}-${m.at}-${i}`,
+        channel: m.channel,
+        direction: m.direction,
+        source: m.source || "staff",
+        body: m.body,
+        subject: m.subject,
+        recipient: m.recipient,
+        logged_at: m.at,
+        delivery_status: m.status,
+        sent_by: null,
+      }));
+      if (filter && filter !== "all") {
+        const f = filter.toLowerCase();
+        return rows.filter((r: any) => (r.channel || "").toLowerCase() === f);
+      }
+      return rows;
+    },
     staleTime: 30000,
   });
 

--- a/artifacts/qleno/src/pages/messages.tsx
+++ b/artifacts/qleno/src/pages/messages.tsx
@@ -212,8 +212,18 @@ export default function MessagesPage() {
                 <>
                   <div style={{ padding: "12px 14px", borderBottom: `1px solid ${BORDER}`, display: "flex", alignItems: "center", gap: 10 }}>
                     {isMobile && <button onClick={() => setActive(null)} style={{ border: "none", background: "transparent", cursor: "pointer", padding: 0 }}><ChevronLeft size={20} color={INK} /></button>}
-                    <div>
-                      <div style={{ fontSize: 15, fontWeight: 700, color: INK }}>{active.name || fmtPhone(active.contact_phone)}</div>
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      {active.client_id ? (
+                        <button
+                          onClick={() => window.open(`${import.meta.env.BASE_URL.replace(/\/$/, "")}/customers/${active.client_id}`, "_blank")}
+                          title="Open client profile in a new tab"
+                          style={{ fontSize: 15, fontWeight: 700, color: INK, background: "none", border: "none", padding: 0, cursor: "pointer", fontFamily: "inherit", textAlign: "left" }}>
+                          {active.name || fmtPhone(active.contact_phone)}
+                          <span style={{ fontSize: 11, color: "var(--brand, #5B9BD5)", marginLeft: 8, fontWeight: 600 }}>Open profile ↗</span>
+                        </button>
+                      ) : (
+                        <div style={{ fontSize: 15, fontWeight: 700, color: INK }}>{active.name || fmtPhone(active.contact_phone)}</div>
+                      )}
                       <div style={{ fontSize: 12, color: MUTE }}>{fmtPhone(active.contact_phone)}{active.client_id ? " · Client" : active.lead_id ? " · Lead" : ""}</div>
                     </div>
                   </div>


### PR DESCRIPTION
Two follow-ups to the customer-comms work:
- The Client-tab 'Communication Log' box now reads the same complete history as the Messages tab (matched by phone), so it's no longer empty/misleading. Manual log entries still work and appear in the union.
- In the two-way texting inbox, clicking the conversation name opens that client's profile in a new tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)