### PR TITLE
feat(estimates): facility type + win-rate-by-industry breakdown

### DIFF
--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -403,6 +403,8 @@ async function runBookingSchemaGuard(): Promise<void> {
     // [estimate-recipient-tracking 2026-06-26] Which recipient a tracked link /
     // open-pixel belongs to, so opens/clicks attribute to a person. Additive.
     { label: "tracked_links.recipient", stmt: `ALTER TABLE tracked_links ADD COLUMN IF NOT EXISTS recipient TEXT` },
+    // [estimate-industry 2026-06-26] Facility type for win-rate-by-industry. Additive.
+    { label: "estimates.facility_type", stmt: `ALTER TABLE estimates ADD COLUMN IF NOT EXISTS facility_type TEXT` },
     // [engagement-tracking-phase4 2026-06-25] Unified engagement timeline +
     // native click-redirect / open-pixel tokens. Additive + idempotent.
     { label: "CREATE engagement_events", stmt: `

--- a/artifacts/api-server/src/routes/estimates.ts
+++ b/artifacts/api-server/src/routes/estimates.ts
@@ -402,6 +402,32 @@ router.get("/engagement/pipeline", requireAuth, async (req, res) => {
   }
 });
 
+// GET /api/estimates/engagement/by-industry — win rate + value by facility type.
+router.get("/engagement/by-industry", requireAuth, async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    const rows = await db.execute(sql`
+      SELECT COALESCE(NULLIF(facility_type, ''), 'unspecified') AS facility_type,
+        COUNT(*)::int AS sent,
+        COUNT(*) FILTER (WHERE status = 'accepted')::int AS won,
+        COALESCE(SUM(total) FILTER (WHERE status = 'accepted'), 0)::numeric AS won_value,
+        COALESCE(SUM(total) FILTER (WHERE status IN ('sent','viewed')), 0)::numeric AS open_value
+      FROM estimates
+      WHERE company_id = ${companyId} AND status <> 'draft'
+      GROUP BY 1
+      ORDER BY won DESC, sent DESC
+    `);
+    const data = (rows as any).rows.map((r: any) => ({
+      ...r,
+      win_rate: Number(r.sent) > 0 ? Math.round((Number(r.won) / Number(r.sent)) * 100) : 0,
+    }));
+    return res.json({ data });
+  } catch (err) {
+    console.error("Engagement by-industry error:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
 // GET /api/estimates/engagement/summary?month=YYYY-MM — month rollup.
 router.get("/engagement/summary", requireAuth, async (req, res) => {
   try {
@@ -984,12 +1010,12 @@ router.post("/", requireAuth, async (req, res) => {
       INSERT INTO estimates
         (company_id, branch_id, account_id, account_property_id, client_id,
          contact_name, contact_email, cc_emails, contact_phone, property_name, service_address,
-         title, intro_note, terms, internal_notes, status, billing_mode, flat_price, flat_price_unit, scope_note,
+         title, intro_note, terms, internal_notes, status, billing_mode, flat_price, flat_price_unit, scope_note, facility_type,
          subtotal, discount_amount, total, valid_until, created_by, updated_at)
       VALUES
         (${companyId}, ${intOrNull(b.branch_id)}, ${intOrNull(b.account_id)}, ${intOrNull(b.account_property_id)}, ${intOrNull(b.client_id)},
          ${str(b.contact_name, 200)}, ${str(b.contact_email, 200)}, ${normalizeEmails(b.cc_emails, str(b.contact_email, 200))}, ${str(b.contact_phone, 40)}, ${str(b.property_name, 300)}, ${str(b.service_address, 400)},
-         ${str(b.title, 300)}, ${str(b.intro_note)}, ${str(b.terms)}, ${str(b.internal_notes)}, 'draft', ${billingMode}, ${flatPrice}, ${priceUnitOf(b.flat_price_unit)}, ${str(b.scope_note)},
+         ${str(b.title, 300)}, ${str(b.intro_note)}, ${str(b.terms)}, ${str(b.internal_notes)}, 'draft', ${billingMode}, ${flatPrice}, ${priceUnitOf(b.flat_price_unit)}, ${str(b.scope_note)}, ${str(b.facility_type, 40)},
          ${subtotal}, ${discount}, ${total}, ${b.valid_until ? new Date(b.valid_until) : null}, ${req.auth!.userId}, now())
       RETURNING id
     `);
@@ -1024,6 +1050,7 @@ router.patch("/:id", requireAuth, async (req, res) => {
         flat_price = ${flatPrice},
         flat_price_unit = ${priceUnitOf(b.flat_price_unit)},
         scope_note = ${str(b.scope_note)},
+        facility_type = ${str(b.facility_type, 40)},
         account_property_id = ${intOrNull(b.account_property_id)},
         client_id = ${intOrNull(b.client_id)},
         contact_name = ${str(b.contact_name, 200)},

--- a/artifacts/api-server/src/tests/estimate-industry.test.ts
+++ b/artifacts/api-server/src/tests/estimate-industry.test.ts
@@ -1,0 +1,31 @@
+/** Win-rate-by-industry: facility_type on estimates + the breakdown endpoint/UI. */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+const here = dirname(fileURLToPath(import.meta.url));
+const read = (rel: string) => readFileSync(resolve(here, rel), "utf8");
+
+describe("estimate industry breakdown", () => {
+  const route = read("../routes/estimates.ts");
+  const mig = read("../phes-data-migration.ts");
+  const builder = read("../../../qleno/src/pages/estimate-builder.tsx");
+  const eng = read("../../../qleno/src/pages/estimate-engagement.tsx");
+  it("facility_type column + persisted on create/update", () => {
+    assert.match(mig, /estimates\.facility_type/);
+    assert.match(route, /scope_note, facility_type,/);           // INSERT
+    assert.match(route, /facility_type = \$\{str\(b\.facility_type, 40\)\}/); // PATCH
+  });
+  it("by-industry endpoint groups + computes win rate", () => {
+    assert.match(route, /router\.get\("\/engagement\/by-industry"/);
+    assert.match(route, /GROUP BY 1/);
+    assert.match(route, /win_rate: Number\(r\.sent\) > 0 \? Math\.round\(\(Number\(r\.won\) \/ Number\(r\.sent\)\) \* 100\) : 0/);
+  });
+  it("builder has facility type; engagement renders the breakdown", () => {
+    assert.match(builder, /const FACILITY_TYPES/);
+    assert.match(builder, /facility_type: facilityType \|\| null/);
+    assert.match(eng, /Where we win — by industry/);
+    assert.match(eng, /engagement\/by-industry/);
+  });
+});

--- a/artifacts/qleno/src/pages/estimate-builder.tsx
+++ b/artifacts/qleno/src/pages/estimate-builder.tsx
@@ -41,6 +41,13 @@ const PRICE_UNITS = [
 ];
 const unitSuffix = (u: string) => (u && u !== "total" ? ` / ${u}` : "");
 
+// [estimate-industry] Facility types drive the win-rate-by-industry report.
+const FACILITY_TYPES: [string, string][] = [
+  ["", "—"], ["medical", "Medical"], ["corporate_office", "Corporate office"],
+  ["industrial", "Industrial / warehouse"], ["retail", "Retail"], ["education", "Education"],
+  ["common_area", "Common area / HOA"], ["religious", "Religious / nonprofit"], ["other", "Other"],
+];
+
 type PricingType = "flat" | "hourly" | "one_time";
 interface Item {
   name: string;
@@ -120,6 +127,7 @@ export default function EstimateBuilderPage() {
   // scope paragraph (alternative to itemizing the checklist).
   const [flatPriceUnit, setFlatPriceUnit] = useState("visit");
   const [scopeNote, setScopeNote] = useState("");
+  const [facilityType, setFacilityType] = useState("");
 
   // [estimate-templates-phase2] One-click template picker (new estimates only).
   const [templates, setTemplates] = useState<any[]>([]);
@@ -159,6 +167,7 @@ export default function EstimateBuilderPage() {
           setFlatPrice(e.flat_price != null && Number(e.flat_price) > 0 ? String(e.flat_price) : "");
           setFlatPriceUnit(e.flat_price_unit || "visit");
           setScopeNote(e.scope_note || "");
+          setFacilityType(e.facility_type || "");
           setValidUntil(e.valid_until ? String(e.valid_until).slice(0, 10) : "");
           setItems((e.items || []).length ? e.items.map(mapRow) : [blankItem()]);
         } else {
@@ -207,6 +216,7 @@ export default function EstimateBuilderPage() {
     flat_price: billingMode === "flat" ? (Number(flatPrice) || 0) : 0,
     flat_price_unit: flatPriceUnit,
     scope_note: billingMode === "flat" ? (scopeNote.trim() || null) : null,
+    facility_type: facilityType || null,
     valid_until: validUntil || null,
     // Flat mode persists scope only (name + shared frequency, no price); itemized
     // keeps the full priced line. Empty scope rows are dropped either way.
@@ -536,6 +546,11 @@ export default function EstimateBuilderPage() {
             <Field label="Property / building"><input style={inp} value={propertyName} onChange={e => setPropertyName(e.target.value)} placeholder="e.g. 5721 W 103rd St Condos" /></Field>
             <Field label="Email"><input style={inp} value={contactEmail} onChange={e => setContactEmail(e.target.value)} placeholder="name@email.com" /></Field>
             <Field label="Phone"><input style={inp} value={contactPhone} onChange={e => setContactPhone(e.target.value)} placeholder="(773) 555-0123" /></Field>
+            <Field label="Facility type">
+              <select style={inp} value={facilityType} onChange={e => setFacilityType(e.target.value)}>
+                {FACILITY_TYPES.map(([v, l]) => <option key={v} value={v}>{l}</option>)}
+              </select>
+            </Field>
           </Grid>
           {/* [multi-recipient-estimates] Additional recipients (CC). Every emailed
               touch goes to the primary Email + all of these. */}

--- a/artifacts/qleno/src/pages/estimate-engagement.tsx
+++ b/artifacts/qleno/src/pages/estimate-engagement.tsx
@@ -143,7 +143,16 @@ export default function EstimateEngagementPage() {
 
   const { data: summary } = useQuery({ queryKey: ["engagement-summary"], queryFn: () => apiFetch("/api/estimates/engagement/summary") });
   const { data: pipeline, isLoading } = useQuery({ queryKey: ["engagement-pipeline"], queryFn: () => apiFetch("/api/estimates/engagement/pipeline") });
+  const { data: industry } = useQuery({ queryKey: ["engagement-by-industry"], queryFn: () => apiFetch("/api/estimates/engagement/by-industry") });
   const rows: any[] = pipeline?.data || [];
+  const industryRows: any[] = industry?.data || [];
+  const FACILITY_LABEL: Record<string, string> = {
+    medical: "Medical", corporate_office: "Corporate office", industrial: "Industrial / warehouse",
+    retail: "Retail", education: "Education", common_area: "Common area / HOA", religious: "Religious / nonprofit",
+    other: "Other", unspecified: "Unspecified",
+  };
+  const fmt$ = (n: any) => `$${Math.round(Number(n || 0)).toLocaleString("en-US")}`;
+  const bestIndustry = industryRows.filter(r => r.sent >= 1).slice().sort((a, b) => b.win_rate - a.win_rate)[0];
 
   return (
     <DashboardLayout>
@@ -161,6 +170,28 @@ export default function EstimateEngagementPage() {
           <StatCard label="Won" value={String(summary?.won ?? 0)} sub={`${summary?.lost ?? 0} lost`} />
           <StatCard label="Avg touches / win" value={String(summary?.avg_touches_to_win ?? 0)} sub="to close" />
         </div>
+
+        {/* Win rate by industry */}
+        {industryRows.length > 0 && (
+          <div style={{ background: "#fff", border: `1px solid ${BORDER}`, borderRadius: 12, padding: "16px 18px", marginBottom: 24 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", marginBottom: 14 }}>
+              <span style={{ fontSize: 13, fontWeight: 800, color: INK }}>Where we win — by industry</span>
+              {bestIndustry && <span style={{ fontSize: 12, color: MUTE }}>Best close rate: <b style={{ color: "#0F6E56" }}>{FACILITY_LABEL[bestIndustry.facility_type] || bestIndustry.facility_type} ({bestIndustry.win_rate}%)</b></span>}
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 11 }}>
+              {industryRows.map((r) => (
+                <div key={r.facility_type} style={{ display: "flex", alignItems: "center", gap: 10 }}>
+                  <span style={{ width: 150, fontSize: 12.5, color: INK, flexShrink: 0, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{FACILITY_LABEL[r.facility_type] || r.facility_type}</span>
+                  <div style={{ flex: 1, background: "#F1EFE8", borderRadius: 6, height: 22 }}>
+                    <div style={{ width: `${Math.max(2, r.win_rate)}%`, height: 22, borderRadius: 6, background: "#00C9A0" }} />
+                  </div>
+                  <span style={{ width: 150, textAlign: "right", fontSize: 12, color: MUTE, flexShrink: 0 }}><b style={{ color: INK }}>{r.win_rate}%</b> · {r.won}/{r.sent} · {fmt$(r.won_value)} won</span>
+                </div>
+              ))}
+            </div>
+            <div style={{ fontSize: 11, color: "#9CA3AF", marginTop: 12, borderTop: `1px solid #EEECE7`, paddingTop: 10 }}>Set a facility type on each estimate (under "Who it's for") to sharpen this breakdown.</div>
+          </div>
+        )}
 
         {/* Pipeline */}
         <h2 style={{ fontSize: 13, fontWeight: 800, color: INK, textTransform: "uppercase", letterSpacing: "0.05em", margin: "0 0 10px" }}>Pipeline</h2>

--- a/lib/db/src/schema/estimates.ts
+++ b/lib/db/src/schema/estimates.ts
@@ -50,6 +50,8 @@ export const estimatesTable = pgTable("estimates", {
   // paragraph for when the office would rather describe the work than itemize it.
   flat_price_unit: text("flat_price_unit").notNull().default("visit"),
   scope_note: text("scope_note"),
+  // [estimate-industry 2026-06-26] Facility type for win-rate-by-industry reporting.
+  facility_type: text("facility_type"),
   subtotal: numeric("subtotal", { precision: 12, scale: 2 }).notNull().default("0"),
   discount_amount: numeric("discount_amount", { precision: 12, scale: 2 }).notNull().default("0"),
   total: numeric("total", { precision: 12, scale: 2 }).notNull().default("0"),


### PR DESCRIPTION
Answers 'where do we win best.'

- `estimates.facility_type` (additive) + a **Facility type** dropdown in the builder; persisted on create/update.
- `GET /api/estimates/engagement/by-industry` — sent / won / **win_rate** / won $ / open $ per facility type.
- Engagement page: a **'Where we win — by industry'** bar chart with a best-close-rate callout.

Phase 1 of two (industry ✓ → DocuSign-grade agreement next). industry guard 3/3 · esbuild OK · zero net-new type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)