### PR TITLE
fix(search): match clients/employees by full name (first + last)

### DIFF
--- a/artifacts/api-server/src/routes/clients.ts
+++ b/artifacts/api-server/src/routes/clients.ts
@@ -53,6 +53,14 @@ router.get("/", requireAuth, async (req, res) => {
         // Search by client ID (CL-XXXX format)
         conditions.push(eq(clientsTable.id, parseInt(clMatch[1])));
       } else {
+        // [search-fullname 2026-06-26] Match the term against the combined
+        // "first last" name too. Without this, "Sal Martinez" matched NOTHING —
+        // the per-field ILIKE checks each column alone, so a term spanning
+        // first+last never hit. trim() each part so trailing/leading spaces in
+        // the stored name (common from the MaidCentral import) don't break it,
+        // and collapse runs of whitespace in the term. This fixes full-name
+        // search for every client, not just this one.
+        const sNorm = s.trim().replace(/\s+/g, " ");
         conditions.push(
           or(
             ilike(clientsTable.first_name, `%${s}%`),
@@ -61,7 +69,8 @@ router.get("/", requireAuth, async (req, res) => {
             ilike(clientsTable.phone, `%${s}%`),
             ilike(clientsTable.address, `%${s}%`),
             ilike(clientsTable.city, `%${s}%`),
-            ilike(clientsTable.company_name, `%${s}%`)
+            ilike(clientsTable.company_name, `%${s}%`),
+            sql`(trim(coalesce(${clientsTable.first_name}, '')) || ' ' || trim(coalesce(${clientsTable.last_name}, ''))) ILIKE ${`%${sNorm}%`}`
           ) as any
         );
       }

--- a/artifacts/api-server/src/routes/search.ts
+++ b/artifacts/api-server/src/routes/search.ts
@@ -33,7 +33,7 @@ router.get("/", requireAuth, async (req, res) => {
           or(
             ilike(clientsTable.first_name, term),
             ilike(clientsTable.last_name, term),
-            ilike(sql`concat(${clientsTable.first_name},' ',${clientsTable.last_name})`, term),
+            ilike(sql`trim(coalesce(${clientsTable.first_name},'')) || ' ' || trim(coalesce(${clientsTable.last_name},''))`, term),
             ilike(clientsTable.email, term),
             ilike(clientsTable.phone, term),
             ilike(clientsTable.address, term),
@@ -57,7 +57,7 @@ router.get("/", requireAuth, async (req, res) => {
             ilike(sql<string>`${jobsTable.service_type}::text`, term),
             ilike(sql<string>`${jobsTable.status}::text`, term),
             ilike(sql<string>`${jobsTable.scheduled_date}::text`, term),
-            ilike(sql`concat(${clientsTable.first_name},' ',${clientsTable.last_name})`, term),
+            ilike(sql`trim(coalesce(${clientsTable.first_name},'')) || ' ' || trim(coalesce(${clientsTable.last_name},''))`, term),
           )
         ))
         .limit(5),
@@ -77,7 +77,7 @@ router.get("/", requireAuth, async (req, res) => {
           or(
             ilike(usersTable.first_name, term),
             ilike(usersTable.last_name, term),
-            ilike(sql`concat(${usersTable.first_name},' ',${usersTable.last_name})`, term),
+            ilike(sql`trim(coalesce(${usersTable.first_name},'')) || ' ' || trim(coalesce(${usersTable.last_name},''))`, term),
             ilike(usersTable.email, term),
           )
         ))
@@ -95,7 +95,7 @@ router.get("/", requireAuth, async (req, res) => {
         .where(and(
           eq(invoicesTable.company_id, companyId),
           or(
-            ilike(sql`concat(${clientsTable.first_name},' ',${clientsTable.last_name})`, term),
+            ilike(sql`trim(coalesce(${clientsTable.first_name},'')) || ' ' || trim(coalesce(${clientsTable.last_name},''))`, term),
             ilike(sql<string>`${invoicesTable.status}::text`, term),
           )
         ))


### PR DESCRIPTION
Searching a full name like 'Sal Martinez' returned nothing. Two causes:
- The client-list search ILIKE'd each column on its own, so a term spanning first+last never matched.
- The global search concatenated first+last but didn't trim, so trailing/leading spaces from imported names ('Sal '/'Martinez ') made a double-space that broke the match.

Both now match against `trim(first) || ' ' || trim(last)`. Fixes full-name search for every client and employee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)