### PR TITLE
feat(agreements): DocuSign-grade audit trail on the live sign flow

### DIFF
--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -424,6 +424,10 @@ async function runBookingSchemaGuard(): Promise<void> {
         created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
       )` },
     { label: "idx agreement_events", stmt: `CREATE INDEX IF NOT EXISTS idx_agreement_events_agreement ON agreement_events(agreement_id, created_at)` },
+    // [agreement-esign] Audit columns on the live form_submissions sign flow.
+    { label: "form_submissions.viewed_at", stmt: `ALTER TABLE form_submissions ADD COLUMN IF NOT EXISTS viewed_at TIMESTAMPTZ` },
+    { label: "form_submissions.user_agent", stmt: `ALTER TABLE form_submissions ADD COLUMN IF NOT EXISTS user_agent TEXT` },
+    { label: "form_submissions.consent_at", stmt: `ALTER TABLE form_submissions ADD COLUMN IF NOT EXISTS consent_at TIMESTAMPTZ` },
     // [engagement-tracking-phase4 2026-06-25] Unified engagement timeline +
     // native click-redirect / open-pixel tokens. Additive + idempotent.
     { label: "CREATE engagement_events", stmt: `

--- a/artifacts/api-server/src/routes/sign.ts
+++ b/artifacts/api-server/src/routes/sign.ts
@@ -3,9 +3,13 @@ import { db } from "@workspace/db";
 import { formSubmissionsTable, formTemplatesTable, clientsTable } from "@workspace/db/schema";
 import { eq, and, sql } from "drizzle-orm";
 import { generateAgreementPdf } from "../lib/generate-agreement-pdf.js";
+import { renderAgreementCertificate } from "../lib/agreement-certificate.js";
 import { createHash } from "crypto";
 
 const router = Router();
+
+const reqIp = (req: any) => (req.headers["x-forwarded-for"] as string)?.split(",")[0]?.trim() || req.socket?.remoteAddress || req.ip || "";
+const reqUa = (req: any) => (req.headers["user-agent"] as string) || "";
 
 router.get("/:token", async (req, res) => {
   try {
@@ -58,6 +62,15 @@ router.get("/:token", async (req, res) => {
       return res.status(410).json({ error: "This agreement link has expired" });
     }
 
+    // [agreement-esign] Record the first 'viewed' event for the audit trail.
+    try {
+      const upd: any = await db.execute(sql`UPDATE form_submissions SET viewed_at = now() WHERE sign_token = ${token} AND viewed_at IS NULL AND status <> 'signed'`);
+      if ((upd?.rowCount ?? 0) > 0) {
+        await db.execute(sql`INSERT INTO agreement_events (company_id, agreement_id, event_type, actor_email, ip_address, user_agent)
+          VALUES (${submission.company_id}, ${submission.id}, 'viewed', ${submission.sent_to ?? null}, ${reqIp(req)}, ${reqUa(req)})`);
+      }
+    } catch (e) { console.error("viewed-event (non-fatal):", e); }
+
     return res.json({ ...submission, already_signed: false });
   } catch (err) {
     console.error("Get sign token error:", err);
@@ -68,7 +81,7 @@ router.get("/:token", async (req, res) => {
 router.post("/:token", async (req, res) => {
   try {
     const { token } = req.params;
-    const { responses, signature_name, ip_address } = req.body;
+    const { responses, signature_name, ip_address, agreed } = req.body;
 
     const [submission] = await db
       .select({
@@ -78,6 +91,7 @@ router.post("/:token", async (req, res) => {
         company_id: formSubmissionsTable.company_id,
         status: formSubmissionsTable.status,
         expires_at: formSubmissionsTable.expires_at,
+        sent_to: formSubmissionsTable.sent_to,
         form_name: formTemplatesTable.name,
         terms_body: formTemplatesTable.terms_body,
         company_name: sql<string>`(select name from companies where id = ${formSubmissionsTable.company_id})`,
@@ -99,7 +113,14 @@ router.post("/:token", async (req, res) => {
       return res.status(410).json({ error: "Agreement link has expired" });
     }
 
+    // [agreement-esign] ESIGN/UETA: the signer must affirm consent + sign.
+    if (!signature_name || !agreed) {
+      return res.status(400).json({ error: "Signature and consent are required" });
+    }
+
     const signedAt = new Date();
+    const ua = reqUa(req);
+    const ip = ip_address && ip_address !== "client" ? ip_address : reqIp(req);
     const contentToHash = JSON.stringify({ responses, signature_name, signed_at: signedAt.toISOString(), token });
     const contentHash = createHash("sha256").update(contentToHash).digest("hex");
 
@@ -113,7 +134,7 @@ router.post("/:token", async (req, res) => {
         responses: responses || {},
         signatureName: signature_name,
         signedAt: signedAt.toLocaleString("en-US", { timeZone: "America/Chicago" }),
-        ipAddress: ip_address || req.ip || "unknown",
+        ipAddress: ip,
         contentHash,
       });
     } catch (pdfErr) {
@@ -128,14 +149,20 @@ router.post("/:token", async (req, res) => {
         submitted_at: signedAt,
         signature_name,
         signature_at: signedAt,
-        ip_address: ip_address || req.ip || "unknown",
+        ip_address: ip,
         content_hash: contentHash,
         pdf_url: pdfUrl,
       })
       .where(eq(formSubmissionsTable.sign_token, token))
       .returning();
 
-    console.log(`[AGREEMENT SIGNED] submission_id=${submission.id} name="${signature_name}" ip=${ip_address} hash=${contentHash.slice(0, 16)}...`);
+    // [agreement-esign] Capture consent + device and seal the audit trail.
+    await db.execute(sql`UPDATE form_submissions SET consent_at = now(), user_agent = ${ua} WHERE sign_token = ${token}`);
+    await db.execute(sql`INSERT INTO agreement_events (company_id, agreement_id, event_type, actor_email, ip_address, user_agent)
+      VALUES (${submission.company_id}, ${submission.id}, 'signed', ${submission.sent_to ?? null}, ${ip}, ${ua})`);
+    await db.execute(sql`INSERT INTO agreement_events (company_id, agreement_id, event_type) VALUES (${submission.company_id}, ${submission.id}, 'sealed')`);
+
+    console.log(`[AGREEMENT SIGNED] submission_id=${submission.id} name="${signature_name}" ip=${ip} hash=${contentHash.slice(0, 16)}...`);
 
     return res.json({
       success: true,
@@ -146,6 +173,46 @@ router.post("/:token", async (req, res) => {
     });
   } catch (err) {
     console.error("Sign agreement error:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
+// [agreement-esign] Certificate of Completion (audit trail) — public by token so
+// the signer can keep their copy too.
+router.get("/:token/certificate.pdf", async (req, res) => {
+  try {
+    const { token } = req.params;
+    const rows = await db.execute(sql`
+      SELECT fs.id, fs.company_id, fs.content_hash, fs.signature_name, fs.signature_at, fs.consent_at, fs.sent_to, fs.status,
+             ft.name AS form_name, c.name AS company_name
+      FROM form_submissions fs
+      LEFT JOIN form_templates ft ON ft.id = fs.form_id
+      LEFT JOIN companies c ON c.id = fs.company_id
+      WHERE fs.sign_token = ${token} LIMIT 1
+    `);
+    const s: any = (rows as any).rows[0];
+    if (!s) return res.status(404).json({ error: "Not Found" });
+    const evs = await db.execute(sql`
+      SELECT event_type, created_at, ip_address, user_agent, actor_email
+      FROM agreement_events WHERE agreement_id = ${s.id} AND company_id = ${s.company_id} ORDER BY created_at ASC, id ASC
+    `);
+    const pdf = await renderAgreementCertificate({
+      companyName: s.company_name || "Qleno",
+      agreementTitle: s.form_name || "Service Agreement",
+      envelopeId: `QL-${String(token).slice(0, 8).toUpperCase()}`,
+      signerName: s.signature_name, signerEmail: s.sent_to,
+      status: s.status === "signed" ? "completed" : s.status,
+      contentHash: s.content_hash || "—",
+      consent: !!s.consent_at,
+      events: ((evs as any).rows || []).map((e: any) => ({
+        type: e.event_type, at: e.created_at, ip: e.ip_address, userAgent: e.user_agent, email: e.actor_email,
+      })),
+    });
+    res.setHeader("Content-Type", "application/pdf");
+    res.setHeader("Content-Disposition", `inline; filename="certificate-of-completion.pdf"`);
+    return res.end(pdf);
+  } catch (err) {
+    console.error("Certificate error:", err);
     return res.status(500).json({ error: "Internal Server Error" });
   }
 });

--- a/artifacts/api-server/src/tests/sign-audit.test.ts
+++ b/artifacts/api-server/src/tests/sign-audit.test.ts
@@ -1,0 +1,31 @@
+/** Live sign flow (form_submissions) gains the DocuSign-grade audit trail. */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+const here = dirname(fileURLToPath(import.meta.url));
+const read = (rel: string) => readFileSync(resolve(here, rel), "utf8");
+
+describe("live sign audit trail", () => {
+  const sign = read("../routes/sign.ts");
+  const ui = read("../../../qleno/src/pages/sign.tsx");
+  const mig = read("../phes-data-migration.ts");
+  it("records viewed, requires consent, records signed/sealed, serves certificate", () => {
+    assert.match(sign, /SET viewed_at = now\(\) WHERE sign_token = \$\{token\} AND viewed_at IS NULL/);
+    assert.match(sign, /'viewed'/);
+    assert.match(sign, /Signature and consent are required/);
+    assert.match(sign, /'signed'/);
+    assert.match(sign, /'sealed'/);
+    assert.match(sign, /router\.get\("\/:token\/certificate\.pdf"/);
+  });
+  it("frontend sends consent + offers the certificate", () => {
+    assert.match(ui, /ip_address: "client", agreed/);
+    assert.match(ui, /\/api\/sign\/\$\{token\}\/certificate\.pdf/);
+    assert.match(ui, /Certificate of Completion/);
+  });
+  it("migration adds form_submissions audit columns", () => {
+    assert.match(mig, /form_submissions\.viewed_at/);
+    assert.match(mig, /form_submissions\.consent_at/);
+  });
+});

--- a/artifacts/qleno/src/pages/sign.tsx
+++ b/artifacts/qleno/src/pages/sign.tsx
@@ -70,7 +70,7 @@ export default function SignPage() {
     try {
       const result = await publicFetch(`/api/sign/${token}`, {
         method: "POST",
-        body: JSON.stringify({ responses, signature_name: signatureName, ip_address: "client" }),
+        body: JSON.stringify({ responses, signature_name: signatureName, ip_address: "client", agreed }),
       });
       setSuccess(result);
     } catch (err: any) {
@@ -119,11 +119,16 @@ export default function SignPage() {
             ? "This agreement has already been signed."
             : `Thank you, ${success?.signature_name || signatureName}. Your signed agreement has been recorded.`}
         </div>
-        {(success?.pdf_url || data?.pdf_url) && (
-          <a href={success?.pdf_url || data?.pdf_url} target="_blank" rel="noreferrer" style={{ display: "inline-flex", alignItems: "center", gap: 6, background: brand, color: "#fff", padding: "10px 24px", borderRadius: 8, textDecoration: "none", fontWeight: 600, fontSize: 14 }}>
-            <FileText size={16} /> Download Signed Copy
+        <div style={{ display: "flex", gap: 10, justifyContent: "center", flexWrap: "wrap" }}>
+          {(success?.pdf_url || data?.pdf_url) && (
+            <a href={success?.pdf_url || data?.pdf_url} target="_blank" rel="noreferrer" style={{ display: "inline-flex", alignItems: "center", gap: 6, background: brand, color: "#fff", padding: "10px 24px", borderRadius: 8, textDecoration: "none", fontWeight: 600, fontSize: 14 }}>
+              <FileText size={16} /> Download Signed Copy
+            </a>
+          )}
+          <a href={`${API}/api/sign/${token}/certificate.pdf`} target="_blank" rel="noreferrer" style={{ display: "inline-flex", alignItems: "center", gap: 6, background: "#fff", color: "#1A1917", border: "1px solid #E5E2DC", padding: "10px 24px", borderRadius: 8, textDecoration: "none", fontWeight: 600, fontSize: 14 }}>
+            <Shield size={16} /> Certificate of Completion
           </a>
-        )}
+        </div>
         <div style={{ marginTop: 20, display: "flex", alignItems: "center", justifyContent: "center", gap: 6, fontSize: 12, color: "#9E9B94" }}>
           <Shield size={13} /> Secured by Qleno eSign
         </div>


### PR DESCRIPTION
Brings the audit trail to the **live** agreement path (form_submissions + `/sign/:token`, which the agreement-builder actually uses).

- form_submissions audit columns (viewed_at, user_agent, consent_at).
- `GET /sign/:token` records the first **'viewed'** event (IP + device).
- `POST /sign/:token` **requires consent** (ESIGN/UETA), captures user-agent, records **'signed' + 'sealed'** (shared agreement_events table).
- `GET /sign/:token/certificate.pdf` → Certificate of Completion (public).
- Sign page sends consent + offers the certificate download.

sign-audit guard 3/3 · esbuild OK · zero net-new type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)