### PR TITLE
feat(agreements): seed commercial agreement + send it from a won estimate

### DIFF
--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -5163,6 +5163,7 @@ export async function runPhesDataMigration(): Promise<void> {
   // follow-up sequence — INACTIVE by default so the drip is inert until the
   // office turns it on. Idempotent (skips if estimate_followup already exists).
   await runEstimateSequenceSeed();
+  await runAgreementTemplateSeed();
 }
 
 // ── Estimate Follow-Up Sequence Seed (PHES, INACTIVE by default) ────────────
@@ -5228,6 +5229,49 @@ async function runEstimateSequenceSeed(): Promise<void> {
     console.log(`[estimate-sequence-seed] estimate_followup seeded INACTIVE for PHES (${ESTIMATE_SEQUENCE_STEPS.length} steps).`);
   } catch (err) {
     console.error("[estimate-sequence-seed] Seed error (non-fatal):", err);
+  }
+}
+
+// ── Commercial Cleaning Service Agreement template (PHES) ───────────────────
+// A ready-to-send, e-signable agreement (form_templates + requires_sign). Generic
+// terms that incorporate the per-client estimate by reference, so no merge fields
+// are needed. Idempotent: skips if a template of this name already exists.
+const COMMERCIAL_AGREEMENT_BODY = `COMMERCIAL CLEANING SERVICE AGREEMENT
+
+1. PARTIES
+This Commercial Cleaning Service Agreement ("Agreement") is entered into between Phes LLC, an Illinois company (the "Service Provider"), and the Client identified in the estimate provided to the Client (the "Client").
+
+2. SERVICES
+The Service Provider will perform the commercial cleaning services, at the frequency and pricing, set out in the estimate provided to the Client, which is incorporated into this Agreement by reference. The Service Provider will furnish all cleaning supplies and equipment necessary to perform these services unless otherwise agreed in writing.
+
+3. PAYMENT TERMS
+Pricing and billing follow the estimate provided to the Client. Unless otherwise stated, payment is due upon each visit and the card on file will be charged for each completed service. Work is strictly limited to the services listed in the estimate; additional tasks require prior written approval and will be billed separately.
+
+4. SCHEDULING & ACCESS
+Service dates and times are determined by the Service Provider and may be adjusted for holidays, weather, building access, or operational needs, with reasonable notice to the Client. The Service Provider will provide forty-eight (48) hours notice of the scheduled time. If the Service Provider is ready and able to perform on-site but access is denied, the Client will be charged 100% of the service cost. The Service Provider will provide a prorated credit for any scheduled service it fails to provide.
+
+5. TERM & TERMINATION
+This Agreement continues until terminated. Either party may terminate with thirty (30) days written notice. The Client remains responsible for all amounts due for services provided or scheduled during the term and any notice period.
+
+6. LIABILITY & GOVERNING LAW
+The Service Provider will maintain general liability insurance for the duration of this Agreement. This Agreement is governed by the laws of the State of Illinois, and any disputes will be resolved in Cook County, Illinois.
+
+7. ENTIRE AGREEMENT
+This Agreement constitutes the entire understanding between the parties. Any amendments must be in writing and signed by both parties. By signing, the Client acknowledges they have read and agree to this Agreement, and the individual signing represents they have authority to bind the Client.`;
+
+async function runAgreementTemplateSeed(): Promise<void> {
+  const PHES = 1;
+  const NAME = "Commercial Cleaning Service Agreement";
+  try {
+    const ex = await db.execute(sql`SELECT id FROM form_templates WHERE company_id = ${PHES} AND name = ${NAME} LIMIT 1`);
+    if ((ex as any).rows.length) { console.log("[agreement-template-seed] already present — skipping."); return; }
+    await db.execute(sql`
+      INSERT INTO form_templates (company_id, name, type, category, terms_body, requires_sign, is_active)
+      VALUES (${PHES}, ${NAME}, 'agreement', 'commercial', ${COMMERCIAL_AGREEMENT_BODY}, true, true)
+    `);
+    console.log("[agreement-template-seed] Commercial Cleaning Service Agreement seeded for PHES.");
+  } catch (err) {
+    console.error("[agreement-template-seed] Seed error (non-fatal):", err);
   }
 }
 

--- a/artifacts/api-server/src/routes/estimates.ts
+++ b/artifacts/api-server/src/routes/estimates.ts
@@ -986,6 +986,42 @@ router.post("/:id/ensure-client", requireAuth, async (req, res) => {
   }
 });
 
+// Send the e-signable commercial service agreement for a won estimate. Creates a
+// form_submission for the company's agreement template + the estimate's contact,
+// records the 'sent' audit event, and returns the tokenized signing link.
+router.post("/:id/send-agreement", requireAuth, async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    const id = parseInt(req.params.id, 10);
+    const e = await db.execute(sql`SELECT contact_email, contact_name, client_id FROM estimates WHERE id = ${id} AND company_id = ${companyId} LIMIT 1`);
+    const est: any = (e as any).rows[0];
+    if (!est) return res.status(404).json({ error: "Not Found" });
+    if (!est.contact_email) return res.json({ sent: false, reason: "no_email" });
+    const tpl = await db.execute(sql`
+      SELECT id FROM form_templates
+      WHERE company_id = ${companyId} AND requires_sign = true AND is_active = true
+        AND (category = 'commercial' OR name ILIKE '%agreement%')
+      ORDER BY (name ILIKE '%commercial%') DESC, id ASC LIMIT 1
+    `);
+    const templateId = (tpl as any).rows[0]?.id;
+    if (!templateId) return res.json({ sent: false, reason: "no_template" });
+    const token = randomUUID();
+    const expires = new Date(); expires.setDate(expires.getDate() + 30);
+    const ins = await db.execute(sql`
+      INSERT INTO form_submissions (company_id, form_id, client_id, responses, status, sign_token, sent_at, sent_to, expires_at, submitted_by)
+      VALUES (${companyId}, ${templateId}, ${est.client_id ?? null}, '{}'::jsonb, 'pending', ${token}, now(), ${est.contact_email}, ${expires}, ${req.auth!.userId})
+      RETURNING id
+    `);
+    const submissionId = (ins as any).rows[0].id;
+    await db.execute(sql`INSERT INTO agreement_events (company_id, agreement_id, event_type, actor_email, meta)
+      VALUES (${companyId}, ${submissionId}, 'sent', ${est.contact_email}, ${JSON.stringify({ by_user: req.auth!.userId, estimate_id: id })}::jsonb)`);
+    return res.json({ sent: true, signing_url: `${appBaseUrl()}/sign/${token}`, sent_to: est.contact_email });
+  } catch (err) {
+    console.error("Estimate send-agreement error:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
 // ─── Create estimate ─────────────────────────────────────────────────────────
 router.post("/", requireAuth, async (req, res) => {
   try {

--- a/artifacts/api-server/src/routes/form-templates.ts
+++ b/artifacts/api-server/src/routes/form-templates.ts
@@ -429,6 +429,10 @@ router.post("/:id/send", requireAuth, async (req, res) => {
       })
       .returning();
 
+    // [agreement-esign] Record the 'sent' audit event for the Certificate of Completion.
+    await db.execute(sql`INSERT INTO agreement_events (company_id, agreement_id, event_type, actor_email, meta)
+      VALUES (${req.auth!.companyId}, ${submission.id}, 'sent', ${clientEmail ?? null}, ${JSON.stringify({ by_user: req.auth!.userId })}::jsonb)`).catch(() => {});
+
     const signingUrl = `${req.headers.origin || ''}/sign/${signToken}`;
     console.log(`[AGREEMENT SENT] To: ${clientEmail} | Name: ${clientName} | URL: ${signingUrl}`);
 

--- a/artifacts/api-server/src/tests/agreement-send-from-estimate.test.ts
+++ b/artifacts/api-server/src/tests/agreement-send-from-estimate.test.ts
@@ -1,0 +1,32 @@
+/** Send the commercial service agreement from a won estimate + seed the template. */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+const here = dirname(fileURLToPath(import.meta.url));
+const read = (rel: string) => readFileSync(resolve(here, rel), "utf8");
+
+describe("send agreement from estimate", () => {
+  const route = read("../routes/estimates.ts");
+  const mig = read("../phes-data-migration.ts");
+  const form = read("../routes/form-templates.ts");
+  const ui = read("../../../qleno/src/pages/estimate-builder.tsx");
+  it("estimate endpoint creates submission + 'sent' event for the agreement template", () => {
+    assert.match(route, /router\.post\("\/:id\/send-agreement"/);
+    assert.match(route, /INSERT INTO form_submissions \(company_id, form_id, client_id, responses, status, sign_token/);
+    assert.match(route, /VALUES \(\$\{companyId\}, \$\{submissionId\}, 'sent'/);
+    assert.match(route, /signing_url: `\$\{appBaseUrl\(\)\}\/sign\/\$\{token\}`/);
+  });
+  it("migration seeds the Commercial Cleaning Service Agreement template", () => {
+    assert.match(mig, /runAgreementTemplateSeed/);
+    assert.match(mig, /COMMERCIAL CLEANING SERVICE AGREEMENT/);
+    assert.match(mig, /INSERT INTO form_templates \(company_id, name, type, category, terms_body, requires_sign, is_active\)/);
+  });
+  it("builder send-from-estimate is wired + form-templates records 'sent'", () => {
+    assert.match(ui, /async function sendAgreement/);
+    assert.match(ui, /\/api\/estimates\/\$\{savedId\}\/send-agreement/);
+    assert.match(ui, /Send agreement/);
+    assert.match(form, /'sent', \$\{clientEmail \?\? null\}/);
+  });
+});

--- a/artifacts/qleno/src/pages/estimate-builder.tsx
+++ b/artifacts/qleno/src/pages/estimate-builder.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useRoute } from "wouter";
 import { getAuthHeaders } from "@/lib/auth";
 import { DashboardLayout } from "@/components/layout/dashboard-layout";
-import { Plus, Trash2, ArrowLeft, Save, Send, LayoutTemplate, GripVertical, Check, FileText, Mail, Eye, Clock, MousePointerClick, MessageSquare, X, CreditCard } from "lucide-react";
+import { Plus, Trash2, ArrowLeft, Save, Send, LayoutTemplate, GripVertical, Check, FileText, Mail, Eye, Clock, MousePointerClick, MessageSquare, X, CreditCard, FileSignature } from "lucide-react";
 import { toast } from "sonner";
 import { CalendarPopover } from "@/components/calendar-popover";
 import { useAddressAutocomplete } from "@/hooks/use-address-autocomplete";
@@ -393,6 +393,25 @@ export default function EstimateBuilderPage() {
     finally { setCardBusy(false); }
   }
 
+  // [agreement-esign] Send the e-signable commercial service agreement.
+  const [agrBusy, setAgrBusy] = useState(false);
+  const [agrLink, setAgrLink] = useState<{ url: string; to: string } | null>(null);
+  const AGR_REASON: Record<string, string> = {
+    no_email: "Add a contact email first, then send the agreement.",
+    no_template: "No agreement template found. Create one in Settings → Agreements.",
+  };
+  async function sendAgreement() {
+    const savedId = await save();
+    if (!savedId) return;
+    setAgrBusy(true);
+    try {
+      const r = await apiFetch(`/api/estimates/${savedId}/send-agreement`, { method: "POST" });
+      if (r.sent) { setAgrLink({ url: r.signing_url, to: r.sent_to }); }
+      else toast.error(AGR_REASON[r.reason] || "Couldn't create the agreement.");
+    } catch { toast.error("Couldn't create the agreement."); }
+    finally { setAgrBusy(false); }
+  }
+
   const [pdfBusy, setPdfBusy] = useState(false);
   async function downloadPdf() {
     // Always persist current edits first — the PDF is rendered server-side from
@@ -714,6 +733,7 @@ export default function EstimateBuilderPage() {
           <button onClick={downloadPdf} disabled={pdfBusy} style={ghostBtn}><FileText size={15} /> {pdfBusy ? "Preparing…" : "PDF preview"}</button>
           <button onClick={openSms} style={ghostBtn}><MessageSquare size={15} /> Text to client</button>
           <button onClick={sendCardOnFile} disabled={cardBusy} style={ghostBtn}><CreditCard size={15} /> {cardBusy ? "Sending…" : "Card on file"}</button>
+          <button onClick={sendAgreement} disabled={agrBusy} style={ghostBtn}><FileSignature size={15} /> {agrBusy ? "Preparing…" : "Send agreement"}</button>
           <button onClick={save} disabled={saving} style={ghostBtn}><Save size={15} /> {saving ? "Saving…" : "Save"}</button>
           <button onClick={markSent} style={primaryBtn}><Send size={15} /> {publicToken ? "Resend to client" : "Send to client"}</button>
         </div>
@@ -741,6 +761,26 @@ export default function EstimateBuilderPage() {
               <button onClick={sendSms} disabled={smsSending || !smsTo.trim()} style={{ ...primaryBtn, opacity: smsTo.trim() ? 1 : 0.5 }}>
                 <MessageSquare size={15} /> {smsSending ? "Sending…" : "Send text"}
               </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* [agreement-esign] Signing link after creating the agreement */}
+      {agrLink && (
+        <div style={{ position: "fixed", inset: 0, background: "rgba(10,14,26,0.45)", display: "flex", alignItems: "center", justifyContent: "center", padding: 18, zIndex: 60 }} onClick={() => setAgrLink(null)}>
+          <div onClick={e => e.stopPropagation()} style={{ background: "#fff", borderRadius: 16, padding: 22, width: "100%", maxWidth: 460, fontFamily: FF }}>
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 6 }}>
+              <span style={{ fontSize: 16, fontWeight: 800, color: INK }}>Agreement ready to sign</span>
+              <button onClick={() => setAgrLink(null)} style={{ background: "none", border: "none", cursor: "pointer", color: "#9CA3AF" }}><X size={16} /></button>
+            </div>
+            <p style={{ fontSize: 13, color: MUTE, margin: "0 0 14px", lineHeight: 1.5 }}>Send this secure signing link to {agrLink.to}. They consent and e-sign; you get a Certificate of Completion with the full audit trail.</p>
+            <div style={{ display: "flex", gap: 6, marginBottom: 14 }}>
+              <input readOnly value={agrLink.url} style={{ ...inp, flex: 1, fontSize: 12 }} onFocus={e => e.currentTarget.select()} />
+              <button onClick={() => { navigator.clipboard?.writeText(agrLink.url); toast.success("Link copied"); }} style={ghostBtn}>Copy</button>
+            </div>
+            <div style={{ display: "flex", gap: 10, justifyContent: "flex-end" }}>
+              <a href={agrLink.url} target="_blank" rel="noreferrer" style={{ ...primaryBtn, textDecoration: "none" }}><FileSignature size={15} /> Open signing page</a>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Closes the loop on the DocuSign-grade agreement.

- Seeds the **Commercial Cleaning Service Agreement** e-signable template for PHES (generic terms incorporating the client's estimate by reference). Idempotent.
- `POST /api/estimates/:id/send-agreement` — creates a tokenized form_submission for the estimate's contact, records the **'sent'** audit event, returns the `/sign/:token` link.
- Builder: a **Send agreement** button → signing link modal (copy/open). Client views (audited) → consents → signs → Certificate of Completion.
- form-templates send also records 'sent' for a complete certificate.

send-agreement guard 3/3 · esbuild OK · zero net-new type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)