### PR TITLE
feat(estimates): review/edit agreement before sending + track it + toolbar cleanup

### DIFF
--- a/artifacts/api-server/src/phes-data-migration.ts
+++ b/artifacts/api-server/src/phes-data-migration.ts
@@ -428,6 +428,10 @@ async function runBookingSchemaGuard(): Promise<void> {
     { label: "form_submissions.viewed_at", stmt: `ALTER TABLE form_submissions ADD COLUMN IF NOT EXISTS viewed_at TIMESTAMPTZ` },
     { label: "form_submissions.user_agent", stmt: `ALTER TABLE form_submissions ADD COLUMN IF NOT EXISTS user_agent TEXT` },
     { label: "form_submissions.consent_at", stmt: `ALTER TABLE form_submissions ADD COLUMN IF NOT EXISTS consent_at TIMESTAMPTZ` },
+    // [agreement-review] Per-send editable agreement text + link to the estimate.
+    { label: "form_submissions.terms_body_override", stmt: `ALTER TABLE form_submissions ADD COLUMN IF NOT EXISTS terms_body_override TEXT` },
+    { label: "form_submissions.estimate_id", stmt: `ALTER TABLE form_submissions ADD COLUMN IF NOT EXISTS estimate_id INTEGER` },
+    { label: "idx form_submissions estimate", stmt: `CREATE INDEX IF NOT EXISTS idx_form_submissions_estimate ON form_submissions(estimate_id)` },
     // [engagement-tracking-phase4 2026-06-25] Unified engagement timeline +
     // native click-redirect / open-pixel tokens. Additive + idempotent.
     { label: "CREATE engagement_events", stmt: `

--- a/artifacts/api-server/src/routes/estimates.ts
+++ b/artifacts/api-server/src/routes/estimates.ts
@@ -1007,9 +1007,10 @@ router.post("/:id/send-agreement", requireAuth, async (req, res) => {
     if (!templateId) return res.json({ sent: false, reason: "no_template" });
     const token = randomUUID();
     const expires = new Date(); expires.setDate(expires.getDate() + 30);
+    const bodyOverride = str(req.body?.terms_body, 20000) || null;
     const ins = await db.execute(sql`
-      INSERT INTO form_submissions (company_id, form_id, client_id, responses, status, sign_token, sent_at, sent_to, expires_at, submitted_by)
-      VALUES (${companyId}, ${templateId}, ${est.client_id ?? null}, '{}'::jsonb, 'pending', ${token}, now(), ${est.contact_email}, ${expires}, ${req.auth!.userId})
+      INSERT INTO form_submissions (company_id, form_id, client_id, estimate_id, responses, status, sign_token, sent_at, sent_to, expires_at, submitted_by, terms_body_override)
+      VALUES (${companyId}, ${templateId}, ${est.client_id ?? null}, ${id}, '{}'::jsonb, 'pending', ${token}, now(), ${est.contact_email}, ${expires}, ${req.auth!.userId}, ${bodyOverride})
       RETURNING id
     `);
     const submissionId = (ins as any).rows[0].id;
@@ -1018,6 +1019,48 @@ router.post("/:id/send-agreement", requireAuth, async (req, res) => {
     return res.json({ sent: true, signing_url: `${appBaseUrl()}/sign/${token}`, sent_to: est.contact_email });
   } catch (err) {
     console.error("Estimate send-agreement error:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
+// Draft for the Send-agreement review modal: the template body (or a prior edit)
+// + recipient so the office sees exactly what will be sent and can edit it.
+router.get("/:id/agreement-draft", requireAuth, async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    const id = parseInt(req.params.id, 10);
+    const e = await db.execute(sql`SELECT contact_email, contact_name FROM estimates WHERE id = ${id} AND company_id = ${companyId} LIMIT 1`);
+    const est: any = (e as any).rows[0];
+    if (!est) return res.status(404).json({ error: "Not Found" });
+    const tpl = await db.execute(sql`
+      SELECT id, name, terms_body FROM form_templates
+      WHERE company_id = ${companyId} AND requires_sign = true AND is_active = true
+        AND (category = 'commercial' OR name ILIKE '%agreement%')
+      ORDER BY (name ILIKE '%commercial%') DESC, id ASC LIMIT 1
+    `);
+    const t: any = (tpl as any).rows[0];
+    if (!t) return res.json({ has_template: false });
+    return res.json({ has_template: true, template_id: t.id, title: t.name, body: t.terms_body || "", to: est.contact_email, to_name: est.contact_name });
+  } catch (err) {
+    console.error("Estimate agreement-draft error:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
+// Track the e-sign agreements sent for this estimate (status + audit + links).
+router.get("/:id/agreements", requireAuth, async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    const id = parseInt(req.params.id, 10);
+    const rows = await db.execute(sql`
+      SELECT id, sign_token, status, sent_to, sent_at, viewed_at, signature_at, signature_name, pdf_url
+      FROM form_submissions
+      WHERE estimate_id = ${id} AND company_id = ${companyId}
+      ORDER BY id DESC
+    `);
+    return res.json({ data: (rows as any).rows });
+  } catch (err) {
+    console.error("Estimate agreements list error:", err);
     return res.status(500).json({ error: "Internal Server Error" });
   }
 });

--- a/artifacts/api-server/src/routes/sign.ts
+++ b/artifacts/api-server/src/routes/sign.ts
@@ -29,6 +29,7 @@ router.get("/:token", async (req, res) => {
         form_category: formTemplatesTable.category,
         form_schema: formTemplatesTable.schema,
         terms_body: formTemplatesTable.terms_body,
+        terms_body_override: formSubmissionsTable.terms_body_override,
         requires_sign: formTemplatesTable.requires_sign,
         company_id: formSubmissionsTable.company_id,
         company_name: sql<string>`(select name from companies where id = ${formSubmissionsTable.company_id})`,
@@ -50,8 +51,11 @@ router.get("/:token", async (req, res) => {
       return res.status(404).json({ error: "Agreement not found" });
     }
 
+    // Per-send edited text wins over the template body.
+    const effectiveTerms = (submission as any).terms_body_override || submission.terms_body;
+
     if (submission.status === "signed") {
-      return res.json({ ...submission, already_signed: true });
+      return res.json({ ...submission, terms_body: effectiveTerms, already_signed: true });
     }
 
     if (submission.expires_at && new Date() > new Date(submission.expires_at)) {
@@ -71,7 +75,7 @@ router.get("/:token", async (req, res) => {
       }
     } catch (e) { console.error("viewed-event (non-fatal):", e); }
 
-    return res.json({ ...submission, already_signed: false });
+    return res.json({ ...submission, terms_body: effectiveTerms, already_signed: false });
   } catch (err) {
     console.error("Get sign token error:", err);
     return res.status(500).json({ error: "Internal Server Error" });
@@ -94,6 +98,7 @@ router.post("/:token", async (req, res) => {
         sent_to: formSubmissionsTable.sent_to,
         form_name: formTemplatesTable.name,
         terms_body: formTemplatesTable.terms_body,
+        terms_body_override: formSubmissionsTable.terms_body_override,
         company_name: sql<string>`(select name from companies where id = ${formSubmissionsTable.company_id})`,
       })
       .from(formSubmissionsTable)
@@ -130,7 +135,7 @@ router.post("/:token", async (req, res) => {
         submissionId: submission.id,
         formName: submission.form_name || "Service Agreement",
         companyName: submission.company_name || "Qleno",
-        termsBody: submission.terms_body || "",
+        termsBody: (submission as any).terms_body_override || submission.terms_body || "",
         responses: responses || {},
         signatureName: signature_name,
         signedAt: signedAt.toLocaleString("en-US", { timeZone: "America/Chicago" }),

--- a/artifacts/api-server/src/tests/agreement-review-track.test.ts
+++ b/artifacts/api-server/src/tests/agreement-review-track.test.ts
@@ -1,0 +1,33 @@
+/** Review/edit agreement before send + per-estimate tracking. */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+const here = dirname(fileURLToPath(import.meta.url));
+const read = (rel: string) => readFileSync(resolve(here, rel), "utf8");
+
+describe("agreement review + track", () => {
+  const route = read("../routes/estimates.ts");
+  const sign = read("../routes/sign.ts");
+  const mig = read("../phes-data-migration.ts");
+  const ui = read("../../../qleno/src/pages/estimate-builder.tsx");
+  it("draft + list endpoints; send stores edited body + estimate link", () => {
+    assert.match(route, /router\.get\("\/:id\/agreement-draft"/);
+    assert.match(route, /router\.get\("\/:id\/agreements"/);
+    assert.match(route, /INSERT INTO form_submissions \(company_id, form_id, client_id, estimate_id, responses, status, sign_token, sent_at, sent_to, expires_at, submitted_by, terms_body_override\)/);
+  });
+  it("sign flow uses the per-send edited body", () => {
+    assert.match(sign, /terms_body_override: formSubmissionsTable\.terms_body_override/);
+    assert.match(sign, /\(submission as any\)\.terms_body_override \|\| submission\.terms_body/);
+    assert.match(mig, /form_submissions\.terms_body_override/);
+    assert.match(mig, /form_submissions\.estimate_id/);
+  });
+  it("builder: review modal, send, tracker, More menu", () => {
+    assert.match(ui, /async function openAgreement/);
+    assert.match(ui, /async function submitAgreement/);
+    assert.match(ui, /AGREEMENT TEXT — EDITABLE/);
+    assert.match(ui, /function AgreementTracking/);
+    assert.match(ui, /setMoreOpen/);
+  });
+});

--- a/artifacts/qleno/src/pages/estimate-builder.tsx
+++ b/artifacts/qleno/src/pages/estimate-builder.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useRoute } from "wouter";
 import { getAuthHeaders } from "@/lib/auth";
 import { DashboardLayout } from "@/components/layout/dashboard-layout";
-import { Plus, Trash2, ArrowLeft, Save, Send, LayoutTemplate, GripVertical, Check, FileText, Mail, Eye, Clock, MousePointerClick, MessageSquare, X, CreditCard, FileSignature } from "lucide-react";
+import { Plus, Trash2, ArrowLeft, Save, Send, LayoutTemplate, GripVertical, Check, FileText, Mail, Eye, Clock, MousePointerClick, MessageSquare, X, CreditCard, FileSignature, MoreHorizontal, Copy, ShieldCheck, RefreshCw } from "lucide-react";
 import { toast } from "sonner";
 import { CalendarPopover } from "@/components/calendar-popover";
 import { useAddressAutocomplete } from "@/hooks/use-address-autocomplete";
@@ -393,25 +393,39 @@ export default function EstimateBuilderPage() {
     finally { setCardBusy(false); }
   }
 
-  // [agreement-esign] Send the e-signable commercial service agreement.
+  // [agreement-esign] Review → edit → send the e-signable agreement.
   const [agrBusy, setAgrBusy] = useState(false);
   const [agrLink, setAgrLink] = useState<{ url: string; to: string } | null>(null);
+  const [agrModal, setAgrModal] = useState<null | { title: string; to: string; to_name: string }>(null);
+  const [agrBody, setAgrBody] = useState("");
+  const [agrVersion, setAgrVersion] = useState(0);
   const AGR_REASON: Record<string, string> = {
     no_email: "Add a contact email first, then send the agreement.",
     no_template: "No agreement template found. Create one in Settings → Agreements.",
   };
-  async function sendAgreement() {
+  async function openAgreement() {
     const savedId = await save();
     if (!savedId) return;
     setAgrBusy(true);
     try {
-      const r = await apiFetch(`/api/estimates/${savedId}/send-agreement`, { method: "POST" });
-      if (r.sent) { setAgrLink({ url: r.signing_url, to: r.sent_to }); }
-      else toast.error(AGR_REASON[r.reason] || "Couldn't create the agreement.");
-    } catch { toast.error("Couldn't create the agreement."); }
+      const d = await apiFetch(`/api/estimates/${savedId}/agreement-draft`);
+      if (!d.has_template) { toast.error(AGR_REASON.no_template); return; }
+      setAgrModal({ title: d.title, to: d.to, to_name: d.to_name }); setAgrBody(d.body || "");
+    } catch { toast.error("Couldn't load the agreement"); }
+    finally { setAgrBusy(false); }
+  }
+  async function submitAgreement() {
+    if (!id) return;
+    setAgrBusy(true);
+    try {
+      const r = await apiFetch(`/api/estimates/${id}/send-agreement`, { method: "POST", body: { terms_body: agrBody } });
+      if (r.sent) { setAgrModal(null); setAgrLink({ url: r.signing_url, to: r.sent_to }); setAgrVersion(v => v + 1); }
+      else toast.error(AGR_REASON[r.reason] || "Couldn't send the agreement.");
+    } catch { toast.error("Couldn't send the agreement."); }
     finally { setAgrBusy(false); }
   }
 
+  const [moreOpen, setMoreOpen] = useState(false);
   const [pdfBusy, setPdfBusy] = useState(false);
   async function downloadPdf() {
     // Always persist current edits first — the PDF is rendered server-side from
@@ -507,6 +521,7 @@ export default function EstimateBuilderPage() {
           </div>
         )}
         {id && status !== "draft" && <EstimateTracking estimateId={id} version={trackVersion} />}
+        {id && <AgreementTracking estimateId={id} version={agrVersion} />}
 
         <div style={{ display: "flex", alignItems: "baseline", justifyContent: "space-between", flexWrap: "wrap", gap: 8, marginBottom: 18 }}>
           <h1 style={{ fontSize: 23, fontWeight: 800, color: INK, margin: 0 }}>{isNew && !id ? "New Estimate" : (estimateNumber || "Estimate")}</h1>
@@ -724,16 +739,32 @@ export default function EstimateBuilderPage() {
 
       {/* Sticky action bar */}
       <div style={{ position: "fixed", bottom: 0, left: 0, right: 0, background: "#fff", borderTop: `1px solid ${BORDER}`, padding: "12px 16px", display: "flex", justifyContent: "center", gap: 10, zIndex: 20 }}>
-        <div style={{ display: "flex", gap: 10, width: "100%", maxWidth: 860 }}>
-          <button onClick={saveAsTemplate} style={ghostBtn}><LayoutTemplate size={15} /> Save as template</button>
-          <div style={{ flex: 1 }} />
-          <span style={{ alignSelf: "center", fontSize: 12, fontWeight: 600, marginRight: 4, whiteSpace: "nowrap", color: autoStatus === "error" ? "#B91C1C" : MUTE }}>
+        <div style={{ display: "flex", gap: 10, width: "100%", maxWidth: 860, alignItems: "center" }}>
+          <span style={{ fontSize: 12, fontWeight: 600, whiteSpace: "nowrap", color: autoStatus === "error" ? "#B91C1C" : MUTE }}>
             {autoStatus === "saving" ? "Saving…" : autoStatus === "saved" ? "All changes saved" : autoStatus === "error" ? "Save failed — retry" : ""}
           </span>
-          <button onClick={downloadPdf} disabled={pdfBusy} style={ghostBtn}><FileText size={15} /> {pdfBusy ? "Preparing…" : "PDF preview"}</button>
-          <button onClick={openSms} style={ghostBtn}><MessageSquare size={15} /> Text to client</button>
-          <button onClick={sendCardOnFile} disabled={cardBusy} style={ghostBtn}><CreditCard size={15} /> {cardBusy ? "Sending…" : "Card on file"}</button>
-          <button onClick={sendAgreement} disabled={agrBusy} style={ghostBtn}><FileSignature size={15} /> {agrBusy ? "Preparing…" : "Send agreement"}</button>
+          <div style={{ flex: 1 }} />
+          {/* More menu — secondary actions */}
+          <div style={{ position: "relative" }}>
+            <button onClick={() => setMoreOpen(o => !o)} style={ghostBtn}><MoreHorizontal size={15} /> More</button>
+            {moreOpen && (
+              <>
+                <div onClick={() => setMoreOpen(false)} style={{ position: "fixed", inset: 0, zIndex: 25 }} />
+                <div style={{ position: "absolute", right: 0, bottom: 48, background: "#fff", border: `1px solid ${BORDER}`, borderRadius: 12, boxShadow: "0 8px 28px rgba(10,14,26,0.14)", padding: 6, width: 216, zIndex: 26 }}>
+                  {[
+                    { icon: FileText, label: pdfBusy ? "Preparing…" : "PDF preview", fn: downloadPdf },
+                    { icon: MessageSquare, label: "Text to client", fn: openSms },
+                    { icon: CreditCard, label: cardBusy ? "Sending…" : "Card on file", fn: sendCardOnFile },
+                    { icon: FileSignature, label: agrBusy ? "Preparing…" : "Send agreement", fn: openAgreement },
+                  ].map(({ icon: Icon, label, fn }) => (
+                    <button key={label} onClick={() => { setMoreOpen(false); fn(); }} style={menuItem}><Icon size={15} style={{ color: MUTE }} /> {label}</button>
+                  ))}
+                  <div style={{ height: 1, background: "#EEECE7", margin: "4px 8px" }} />
+                  <button onClick={() => { setMoreOpen(false); saveAsTemplate(); }} style={menuItem}><LayoutTemplate size={15} style={{ color: MUTE }} /> Save as template</button>
+                </div>
+              </>
+            )}
+          </div>
           <button onClick={save} disabled={saving} style={ghostBtn}><Save size={15} /> {saving ? "Saving…" : "Save"}</button>
           <button onClick={markSent} style={primaryBtn}><Send size={15} /> {publicToken ? "Resend to client" : "Send to client"}</button>
         </div>
@@ -760,6 +791,33 @@ export default function EstimateBuilderPage() {
               <button onClick={() => setSmsOpen(false)} style={ghostBtn}>Cancel</button>
               <button onClick={sendSms} disabled={smsSending || !smsTo.trim()} style={{ ...primaryBtn, opacity: smsTo.trim() ? 1 : 0.5 }}>
                 <MessageSquare size={15} /> {smsSending ? "Sending…" : "Send text"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* [agreement-esign] Review & edit the agreement before sending */}
+      {agrModal && (
+        <div style={{ position: "fixed", inset: 0, background: "rgba(10,14,26,0.45)", display: "flex", alignItems: "center", justifyContent: "center", padding: 18, zIndex: 60 }} onClick={() => setAgrModal(null)}>
+          <div onClick={e => e.stopPropagation()} style={{ background: "#fff", borderRadius: 16, padding: 0, width: "100%", maxWidth: 580, maxHeight: "88vh", display: "flex", flexDirection: "column", fontFamily: FF }}>
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", padding: "15px 18px", borderBottom: `1px solid #EEECE7` }}>
+              <span style={{ fontSize: 16, fontWeight: 800, color: INK }}>Send agreement</span>
+              <button onClick={() => setAgrModal(null)} style={{ background: "none", border: "none", cursor: "pointer", color: "#9CA3AF" }}><X size={16} /></button>
+            </div>
+            <div style={{ padding: 18, overflowY: "auto" }}>
+              <div style={{ display: "flex", gap: 20, marginBottom: 14, flexWrap: "wrap" }}>
+                <div><div style={{ fontSize: 10, fontWeight: 700, letterSpacing: "0.05em", color: "#9CA3AF" }}>TO</div><div style={{ fontSize: 13, color: agrModal.to ? INK : "#B91C1C" }}>{agrModal.to_name ? `${agrModal.to_name} · ` : ""}{agrModal.to || "No contact email"}</div></div>
+                <div><div style={{ fontSize: 10, fontWeight: 700, letterSpacing: "0.05em", color: "#9CA3AF" }}>TEMPLATE</div><div style={{ fontSize: 13, color: INK }}>{agrModal.title} <span onClick={() => navigate("/company/agreements")} style={{ color: "#185FA5", cursor: "pointer" }}>· Edit template ↗</span></div></div>
+              </div>
+              <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: "0.05em", color: "#9CA3AF", marginBottom: 5 }}>AGREEMENT TEXT — EDITABLE</div>
+              <textarea value={agrBody} onChange={e => setAgrBody(e.target.value)} style={{ ...inp, minHeight: 260, resize: "vertical", lineHeight: 1.55, fontSize: 13, whiteSpace: "pre-wrap" }} />
+              <div style={{ fontSize: 11, color: "#9CA3AF", marginTop: 7 }}>Edits apply to this agreement only — the client e-signs this exact text.</div>
+            </div>
+            <div style={{ display: "flex", justifyContent: "flex-end", gap: 10, padding: "14px 18px", borderTop: `1px solid #EEECE7` }}>
+              <button onClick={() => setAgrModal(null)} style={ghostBtn}>Cancel</button>
+              <button onClick={submitAgreement} disabled={agrBusy || !agrModal.to || !agrBody.trim()} style={{ ...primaryBtn, opacity: (agrModal.to && agrBody.trim()) ? 1 : 0.5 }}>
+                <FileSignature size={15} /> {agrBusy ? "Sending…" : "Send for signature"}
               </button>
             </div>
           </div>
@@ -831,6 +889,58 @@ const STATUS_PILL: Record<string, { bg: string; fg: string }> = {
   ACCEPTED: { bg: "#EAF3DE", fg: "#3B6D11" }, DECLINED: { bg: "#FCEBEB", fg: "#A32D2D" },
   EXPIRED: { bg: "#FAEEDA", fg: "#854F0B" },
 };
+
+// [agreement-esign] Live Sent → Viewed → Signed tracker for e-sign agreements.
+function AgreementTracking({ estimateId, version }: { estimateId: number; version: number }) {
+  const [rows, setRows] = useState<any[]>([]);
+  useEffect(() => {
+    fetch(`${API}/api/estimates/${estimateId}/agreements`, { headers: { ...(getAuthHeaders() as Record<string, string>) } })
+      .then(r => (r.ok ? r.json() : { data: [] })).then(d => setRows(d.data || [])).catch(() => {});
+  }, [estimateId, version]);
+  if (!rows.length) return null;
+  const origin = typeof window !== "undefined" ? window.location.origin : "";
+  const ts = (v: any) => (v ? new Date(v).toLocaleString("en-US", { month: "short", day: "numeric", hour: "numeric", minute: "2-digit" }) : "—");
+  const Step = ({ done, label, when, icon }: any) => (
+    <div style={{ flex: 1, textAlign: "center" }}>
+      <div style={{ width: 26, height: 26, borderRadius: "50%", margin: "0 auto", background: done ? "#0F6E56" : "#F1EFE8", color: done ? "#fff" : "#9CA3AF", display: "flex", alignItems: "center", justifyContent: "center" }}>{icon}</div>
+      <div style={{ fontSize: 11, marginTop: 4, color: done ? INK : "#9CA3AF" }}>{label}</div>
+      <div style={{ fontSize: 10, color: "#9CA3AF" }}>{when}</div>
+    </div>
+  );
+  return (
+    <div style={{ background: "#fff", border: `1px solid ${BORDER}`, borderRadius: 14, padding: 16, marginBottom: 16 }}>
+      <div style={{ fontSize: 14, fontWeight: 800, color: INK, marginBottom: 12 }}>Service agreement</div>
+      {rows.map((a: any) => {
+        const signed = a.status === "signed" || !!a.signature_at;
+        const viewed = !!a.viewed_at;
+        const pill = signed ? { t: "SIGNED", bg: "#E1F5EE", fg: "#0F6E56" } : viewed ? { t: "VIEWED · NOT SIGNED", bg: "#FAEEDA", fg: "#854F0B" } : { t: "SENT", bg: "#E6F1FB", fg: "#185FA5" };
+        const link = `${origin}/sign/${a.sign_token}`;
+        const cert = `${API}/api/sign/${a.sign_token}/certificate.pdf`;
+        return (
+          <div key={a.id} style={{ borderTop: `1px solid #F4F2EE`, paddingTop: 12, marginTop: 12 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 12 }}>
+              <span style={{ fontSize: 12.5, color: MUTE }}>{a.sent_to || "—"}</span>
+              <span style={{ fontSize: 10, fontWeight: 700, letterSpacing: "0.05em", color: pill.fg, background: pill.bg, padding: "3px 9px", borderRadius: 20 }}>{pill.t}</span>
+            </div>
+            <div style={{ display: "flex", alignItems: "flex-start", marginBottom: 14 }}>
+              <Step done label="Sent" when={ts(a.sent_at)} icon={<Check size={13} />} />
+              <div style={{ height: 2, flex: "0 0 32px", marginTop: 12, background: viewed ? "#0F6E56" : "#E5E2DC" }} />
+              <Step done={viewed} label="Viewed" when={viewed ? ts(a.viewed_at) : "—"} icon={<Eye size={13} />} />
+              <div style={{ height: 2, flex: "0 0 32px", marginTop: 12, background: signed ? "#0F6E56" : "#E5E2DC" }} />
+              <Step done={signed} label="Signed" when={signed ? ts(a.signature_at) : "—"} icon={<FileSignature size={13} />} />
+            </div>
+            <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+              <button onClick={() => { navigator.clipboard?.writeText(link); toast.success("Signing link copied"); }} style={trackBtn}><Copy size={13} /> Copy link</button>
+              <a href={cert} target="_blank" rel="noreferrer" style={{ ...trackBtn, textDecoration: "none" }}><ShieldCheck size={13} /> Certificate</a>
+              {signed && a.pdf_url && <a href={a.pdf_url} target="_blank" rel="noreferrer" style={{ ...trackBtn, textDecoration: "none" }}><FileText size={13} /> Signed PDF</a>}
+              {!signed && <a href={link} target="_blank" rel="noreferrer" style={{ ...trackBtn, textDecoration: "none" }}><RefreshCw size={13} /> Open signing page</a>}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
 
 function EstimateTracking({ estimateId, version }: { estimateId: number; version: number }) {
   const [data, setData] = useState<any>(null);
@@ -948,3 +1058,5 @@ const iconBtn: React.CSSProperties = { width: 34, height: 34, display: "inline-f
 const addBtn: React.CSSProperties = { display: "inline-flex", alignItems: "center", gap: 5, background: "#fff", border: `1px solid ${BORDER}`, borderRadius: 9, padding: "7px 12px", fontSize: 13, fontWeight: 700, color: INK, cursor: "pointer", fontFamily: FF };
 const ghostBtn: React.CSSProperties = { display: "inline-flex", alignItems: "center", gap: 6, background: "#fff", border: `1px solid ${BORDER}`, borderRadius: 10, padding: "10px 16px", fontSize: 14, fontWeight: 700, color: INK, cursor: "pointer", fontFamily: FF };
 const primaryBtn: React.CSSProperties = { display: "inline-flex", alignItems: "center", gap: 6, background: INK, color: "#fff", border: "none", borderRadius: 10, padding: "10px 18px", fontSize: 14, fontWeight: 700, cursor: "pointer", fontFamily: FF };
+const menuItem: React.CSSProperties = { display: "flex", alignItems: "center", gap: 10, width: "100%", textAlign: "left", background: "none", border: "none", padding: "9px 11px", borderRadius: 8, fontSize: 13, fontWeight: 600, color: INK, cursor: "pointer", fontFamily: FF };
+const trackBtn: React.CSSProperties = { display: "inline-flex", alignItems: "center", gap: 6, background: "#fff", border: `1px solid ${BORDER}`, borderRadius: 8, padding: "7px 12px", fontSize: 12, fontWeight: 600, color: INK, cursor: "pointer", fontFamily: FF };

--- a/lib/db/src/schema/form_submissions.ts
+++ b/lib/db/src/schema/form_submissions.ts
@@ -26,6 +26,12 @@ export const formSubmissionsTable = pgTable("form_submissions", {
   sent_at: timestamp("sent_at"),
   sent_to: text("sent_to"),
   expires_at: timestamp("expires_at"),
+  // [agreement-esign] Audit + per-send edits.
+  viewed_at: timestamp("viewed_at"),
+  user_agent: text("user_agent"),
+  consent_at: timestamp("consent_at"),
+  terms_body_override: text("terms_body_override"),
+  estimate_id: integer("estimate_id"),
   created_at: timestamp("created_at").notNull().defaultNow(),
 });
 


### PR DESCRIPTION
Fixes the blind 'Send agreement'.

- **Review modal:** see the agreement text (from the template), **editable per-send** (stored as `terms_body_override`; sign page + PDF + hash use the edited text), with recipient + 'Edit template' link.
- **Tracking:** a 'Service agreement' card on the estimate with a live **Sent → Viewed → Signed** tracker, copy-link, Certificate of Completion, signed PDF, open-signing-page. (`GET /:id/agreements`, `/:id/agreement-draft`; submissions carry `estimate_id`.)
- **Toolbar:** collapsed 7 buttons into **Save + Send to client** with the rest under **More**.

review-track guard 3/3 · esbuild OK · zero net-new type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)