### PR TITLE
fix(address): Google Places autocomplete on every address field

### DIFF
--- a/artifacts/qleno/src/pages/account-detail.tsx
+++ b/artifacts/qleno/src/pages/account-detail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useParams, Link } from "wouter";
 import {
   Building2, ChevronLeft, ChevronDown, Plus, Pencil, Trash2, DollarSign,
@@ -18,6 +18,7 @@ import { Switch } from "@/components/ui/switch";
 import { useToast } from "@/hooks/use-toast";
 import { getAuthHeaders } from "@/lib/auth";
 import { AccountJobsCalendar } from "@/components/account-jobs-calendar";
+import { useAddressAutocomplete } from "@/hooks/use-address-autocomplete";
 
 const API = import.meta.env.BASE_URL.replace(/\/$/, "");
 
@@ -137,6 +138,19 @@ export default function AccountDetailPage() {
   const [showProperty, setShowProperty] = useState(false);
   const [editProp, setEditProp] = useState<any>(null);
   const [propForm, setPropForm] = useState({ property_name: "", address: "", city: "", state: "IL", zip: "", unit_count: "", property_type: "apartment_building", default_service_type: "", access_notes: "", notes: "" });
+  const propAddrRef = useRef<HTMLInputElement>(null);
+  // Google Places autocomplete on the property's Street Address. Fills
+  // street/city/state/zip from the selected suggestion; only overwrites a
+  // field when Google returns a value so a manual entry isn't blanked.
+  useAddressAutocomplete(propAddrRef, showProperty, (p) =>
+    setPropForm((f) => ({
+      ...f,
+      address: p.street || f.address,
+      city: p.city || f.city,
+      state: p.state || f.state,
+      zip: p.zip || f.zip,
+    })),
+  );
   const [propSaving, setPropSaving] = useState(false);
 
   // Contact
@@ -1145,7 +1159,7 @@ export default function AccountDetailPage() {
               </div>
               <div className="space-y-1.5 col-span-2">
                 <Label>Street Address *</Label>
-                <Input placeholder="4801 W 95th St" value={propForm.address} onChange={(e) => setPropForm({ ...propForm, address: e.target.value })} />
+                <Input ref={propAddrRef} placeholder="4801 W 95th St" value={propForm.address} onChange={(e) => setPropForm({ ...propForm, address: e.target.value })} />
               </div>
               <div className="space-y-1.5">
                 <Label>City</Label>

--- a/artifacts/qleno/src/pages/add-client.tsx
+++ b/artifacts/qleno/src/pages/add-client.tsx
@@ -1,7 +1,8 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useLocation } from "wouter";
 import { DashboardLayout } from "@/components/layout/dashboard-layout";
 import { getAuthHeaders } from "@/lib/auth";
+import { useAddressAutocomplete } from "@/hooks/use-address-autocomplete";
 import { toast } from "sonner";
 import { ArrowLeft, Loader2 } from "lucide-react";
 
@@ -33,6 +34,15 @@ export default function AddClientPage() {
   const [form, setForm] = useState<Form>(EMPTY);
   const [saving, setSaving] = useState(false);
   const set = <K extends keyof Form>(key: K, value: Form[K]) => setForm(prev => ({ ...prev, [key]: value }));
+  const addrRef = useRef<HTMLInputElement>(null);
+  // Google Places autocomplete on the street address — fills city/state/zip too.
+  useAddressAutocomplete(addrRef, true, (p) => setForm(prev => ({
+    ...prev,
+    address: p.street || prev.address,
+    city: p.city || prev.city,
+    state: p.state || prev.state,
+    zip: p.zip || prev.zip,
+  })));
   const canSave = form.first_name.trim().length > 0 && form.last_name.trim().length > 0 && !saving;
 
   const handleSave = async () => {
@@ -102,7 +112,11 @@ export default function AddClientPage() {
             {field("phone", "Phone", { type: "tel" })}
           </div>
           {field("company_name", "Company name", { placeholder: "Optional — for commercial clients" })}
-          {field("address", "Street address")}
+          <div>
+            <label style={label}>Street address</label>
+            <input ref={addrRef} style={input} type="text" placeholder="Start typing — Google will complete it"
+              value={form.address} onChange={e => set("address", e.target.value)} />
+          </div>
           <div style={{ display: "grid", gridTemplateColumns: "2fr 1fr 1fr", gap: "16px" }}>
             {field("city", "City")}
             {field("state", "State")}

--- a/artifacts/qleno/src/pages/add-employee.tsx
+++ b/artifacts/qleno/src/pages/add-employee.tsx
@@ -1,7 +1,8 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useLocation } from "wouter";
 import { DashboardLayout } from "@/components/layout/dashboard-layout";
 import { getAuthHeaders } from "@/lib/auth";
+import { useAddressAutocomplete } from "@/hooks/use-address-autocomplete";
 import { toast } from "sonner";
 import { ArrowLeft, Loader2 } from "lucide-react";
 
@@ -33,6 +34,15 @@ export default function AddEmployeePage() {
   const [form, setForm] = useState<Form>(EMPTY);
   const [saving, setSaving] = useState(false);
   const set = <K extends keyof Form>(k: K, v: Form[K]) => setForm(p => ({ ...p, [k]: v }));
+  const addrRef = useRef<HTMLInputElement>(null);
+  // Google Places autocomplete on the street address — fills city/state/zip too.
+  useAddressAutocomplete(addrRef, true, (p) => setForm(prev => ({
+    ...prev,
+    address: p.street || prev.address,
+    city: p.city || prev.city,
+    state: p.state || prev.state,
+    zip: p.zip || prev.zip,
+  })));
   const canSave = form.first_name.trim() && form.email.trim() && !saving;
 
   async function handleSave() {
@@ -109,7 +119,11 @@ export default function AddEmployeePage() {
               </select>
             </div>
           </div>
-          {field("address", "Street address")}
+          <div>
+            <label style={label}>Street address</label>
+            <input ref={addrRef} style={input} type="text" placeholder="Start typing — Google will complete it"
+              value={form.address} onChange={e => set("address", e.target.value)} />
+          </div>
           <div style={{ display: "grid", gridTemplateColumns: "2fr 1fr 1fr", gap: "16px" }}>
             {field("city", "City")}
             {field("state", "State")}

--- a/artifacts/qleno/src/pages/employee-profile.tsx
+++ b/artifacts/qleno/src/pages/employee-profile.tsx
@@ -1,5 +1,6 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef, forwardRef } from "react";
 import { useIsMobile } from "@/hooks/use-mobile";
+import { useAddressAutocomplete } from "@/hooks/use-address-autocomplete";
 import { useParams, useLocation } from "wouter";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { DashboardLayout } from "@/components/layout/dashboard-layout";
@@ -219,21 +220,24 @@ function Field({ label, children }: { label: string; children: React.ReactNode }
   );
 }
 
-function Input({ value, onChange, type='text', readOnly }: { value: string; onChange?: (v: string) => void; type?: string; readOnly?: boolean }) {
-  return (
-    <input
-      type={type}
-      value={value || ''}
-      readOnly={readOnly}
-      onChange={e => onChange?.(e.target.value)}
-      style={{
-        height:36, padding:'0 12px', border:'1px solid #E5E2DC', borderRadius:8,
-        fontSize:13, color:'#1A1917', background: readOnly ? '#F7F6F3' : '#FFFFFF',
-        outline:'none', width:'100%',
-      }}
-    />
-  );
-}
+const Input = forwardRef<HTMLInputElement, { value: string; onChange?: (v: string) => void; type?: string; readOnly?: boolean }>(
+  function Input({ value, onChange, type='text', readOnly }, ref) {
+    return (
+      <input
+        ref={ref}
+        type={type}
+        value={value || ''}
+        readOnly={readOnly}
+        onChange={e => onChange?.(e.target.value)}
+        style={{
+          height:36, padding:'0 12px', border:'1px solid #E5E2DC', borderRadius:8,
+          fontSize:13, color:'#1A1917', background: readOnly ? '#F7F6F3' : '#FFFFFF',
+          outline:'none', width:'100%',
+        }}
+      />
+    );
+  }
+);
 
 function Select({ value, onChange, options }: { value: string; onChange: (v: string) => void; options: { value: string; label: string }[] }) {
   return (
@@ -782,6 +786,15 @@ export default function EmployeeProfilePage() {
 
   const [form, setForm] = useState<Record<string, any>>({});
   useEffect(() => { if (user) setForm(user); }, [user]);
+  const addrRef = useRef<HTMLInputElement>(null);
+  // Google Places autocomplete on the employee's street address.
+  useAddressAutocomplete(addrRef, true, (p) => setForm(f => ({
+    ...f,
+    address: p.street || f.address,
+    city: p.city || f.city,
+    state: p.state || f.state,
+    zip: p.zip || f.zip,
+  })));
 
   const setField = (k: string, v: any) => setForm(p => ({ ...p, [k]: v }));
 
@@ -1178,7 +1191,7 @@ export default function EmployeeProfilePage() {
 
               <SectionCard title="Address">
                 <div style={{ display:'grid', gridTemplateColumns:'2fr 1fr 1fr 1fr', gap:16 }}>
-                  <Field label="Street"><Input value={form.address||''} onChange={v=>setField('address',v)}/></Field>
+                  <Field label="Street"><Input ref={addrRef} value={form.address||''} onChange={v=>setField('address',v)}/></Field>
                   <Field label="City"><Input value={form.city||''} onChange={v=>setField('city',v)}/></Field>
                   <Field label="State"><Input value={form.state||''} onChange={v=>setField('state',v)}/></Field>
                   <Field label="Zip"><Input value={form.zip||''} onChange={v=>setField('zip',v)}/></Field>

--- a/artifacts/qleno/src/pages/leads.tsx
+++ b/artifacts/qleno/src/pages/leads.tsx
@@ -3,6 +3,7 @@ import { getAuthHeaders } from "@/lib/auth";
 import { formatAddress } from "@/lib/format-address";
 import { DashboardLayout } from "@/components/layout/dashboard-layout";
 import { useIsMobile } from "@/hooks/use-mobile";
+import { useAddressAutocomplete } from "@/hooks/use-address-autocomplete";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { CalendarPopover } from "@/components/calendar-popover";
@@ -149,6 +150,15 @@ function AddLeadDrawer({ onClose, onSaved }: { onClose: () => void; onSaved: () 
   });
 
   const set = (k: string, v: string) => setForm(f => ({ ...f, [k]: v }));
+  const addrRef = useRef<HTMLInputElement>(null);
+  // Google Places autocomplete on the street address — fills city/state/zip too.
+  useAddressAutocomplete(addrRef, true, (p) => setForm(f => ({
+    ...f,
+    address: p.street || f.address,
+    city: p.city || f.city,
+    state: p.state || f.state,
+    zip: p.zip || f.zip,
+  })));
 
   async function handleSave() {
     if (!form.first_name.trim()) {
@@ -206,7 +216,7 @@ function AddLeadDrawer({ onClose, onSaved }: { onClose: () => void; onSaved: () 
           </div>
           <div>
             <label style={lbl}>Address</label>
-            <Input value={form.address} onChange={e => set("address", e.target.value)} placeholder="Street address" />
+            <Input ref={addrRef} value={form.address} onChange={e => set("address", e.target.value)} placeholder="Start typing — Google will complete it" />
           </div>
           <div style={{ display: "grid", gridTemplateColumns: "1fr auto 80px", gap: 8 }}>
             <div>

--- a/artifacts/qleno/src/pages/training.tsx
+++ b/artifacts/qleno/src/pages/training.tsx
@@ -30,6 +30,7 @@ import * as React from "react";
 import { useEffect, useMemo, useRef, useState, useCallback } from "react";
 import { useLocation } from "wouter";
 import { useAuthStore } from "@/lib/auth";
+import { useAddressAutocomplete } from "@/hooks/use-address-autocomplete";
 import {
   getCurriculum,
   type Curriculum,
@@ -6484,6 +6485,16 @@ function OnboardingIntakeView({
     setForm((prev) => ({ ...prev, [key]: value }));
   }
 
+  const homeAddrRef = useRef<HTMLInputElement>(null);
+  // Google Places autocomplete on the home street address — fills city/state/zip.
+  useAddressAutocomplete(homeAddrRef, true, (p) => setForm((prev) => ({
+    ...prev,
+    home_address_street: p.street || prev.home_address_street,
+    home_address_city: p.city || prev.home_address_city,
+    home_address_state: p.state || prev.home_address_state,
+    home_address_zip: p.zip || prev.home_address_zip,
+  })));
+
   const required = (label: string) => (
     <span>
       {label}
@@ -6569,6 +6580,7 @@ function OnboardingIntakeView({
           value={form.home_address_street}
           onChange={(v) => set("home_address_street", v)}
           placeholder={locale === "es" ? "Calle y número" : "Street address"}
+          inputRef={homeAddrRef}
         />
         <Field
           label={
@@ -6985,12 +6997,14 @@ function Field({
   onChange,
   type = "text",
   placeholder,
+  inputRef,
 }: {
   label: React.ReactNode;
   value: string;
   onChange: (v: string) => void;
   type?: "text" | "email" | "tel" | "date";
   placeholder?: string;
+  inputRef?: React.RefObject<HTMLInputElement | null>;
 }) {
   return (
     <label style={{ display: "flex", flexDirection: "column", gap: 4 }}>
@@ -6999,6 +7013,7 @@ function Field({
         <CalendarPopover value={value} onChange={onChange} block />
       ) : (
         <input
+          ref={inputRef}
           type={type}
           value={value}
           onChange={(e) => onChange(e.target.value)}


### PR DESCRIPTION
## Problem
Address autocomplete (Google Places — type a few characters, pick the standardized address, city/state/zip auto-fill) was wired into only **1 of 11** address-input surfaces. Six had **no autocomplete at all**, forcing the office to type and standardize addresses by hand.

Reported by the team: the commercial **"Add Property"** modal had a plain Street Address input with no Google autocomplete.

## Fix
There was already a shared `useAddressAutocomplete` hook — it just wasn't used in most places. Wired it into the six missing surfaces, each filling street/city/state/zip from the selected suggestion (only overwriting a field when Google returns a value, so a manual entry is never blanked):

| Surface | File |
|---|---|
| **Add/Edit Property** (commercial accounts) — the reported bug | account-detail.tsx |
| New client form | add-client.tsx |
| New team member form | add-employee.tsx |
| Employee profile address (local `Input` → `forwardRef`) | employee-profile.tsx |
| Add Lead drawer | leads.tsx |
| Onboarding home address (`Field` gains optional `inputRef`) | training.tsx |

The other 4 surfaces (quote-builder, job-wizard, customer-profile, book) already had it.

## Verification
Drove the **Add Property** modal live against the production API: the Street Address input now mounts with Google's `pac-target-input` class and a constructed `.pac-container` (autocomplete attached via the real Maps key) — where before it was a plain input. Production build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)