### PR TITLE
feat: Add Property autocomplete, account job service toggle, team photo notes

### DIFF
--- a/artifacts/api-server/src/index.ts
+++ b/artifacts/api-server/src/index.ts
@@ -266,6 +266,16 @@ async function runStartupMigrations() {
   } catch (err: any) {
     console.error("[startup] runCommsOptOutMigration — non-fatal:", err?.message ?? err);
   }
+  // [team-photo-notes] team_photo_notes table (pictures + notes attached to a
+  // job or made sticky to a customer/property).
+  try {
+    await withBootTimeout("runTeamPhotoNotesMigration", SCHEMA_TIMEOUT_MS, async () => {
+      const { runTeamPhotoNotesMigration } = await import("./lib/team-photo-notes-migrate.js");
+      await runTeamPhotoNotesMigration();
+    });
+  } catch (err: any) {
+    console.error("[startup] runTeamPhotoNotesMigration — non-fatal:", err?.message ?? err);
+  }
   // [customer-messages 2026-06-26] customer_message_schedules + job_message_sends
   // tables + ledger backfill from the legacy reminder_*_sent flags (so the new
   // engine never re-sends an already-reminded job).

--- a/artifacts/api-server/src/lib/team-photo-notes-migrate.ts
+++ b/artifacts/api-server/src/lib/team-photo-notes-migrate.ts
@@ -1,0 +1,32 @@
+// [team-photo-notes] Idempotent boot migration. Creates the team_photo_notes
+// table via raw SQL so the feature works on a fresh deploy WITHOUT a separate
+// drizzle-kit push. Safe to call on every cold start. Mirrors runGuidesMigration.
+import { db } from "@workspace/db";
+import { sql } from "drizzle-orm";
+
+export async function runTeamPhotoNotesMigration(): Promise<void> {
+  try {
+    await db.execute(sql`
+      CREATE TABLE IF NOT EXISTS team_photo_notes (
+        id serial PRIMARY KEY,
+        company_id integer NOT NULL,
+        job_id integer,
+        client_id integer,
+        account_id integer,
+        account_property_id integer,
+        is_sticky boolean NOT NULL DEFAULT false,
+        image_url text,
+        note text,
+        uploaded_by integer,
+        created_at timestamp NOT NULL DEFAULT now()
+      )
+    `);
+    // The job panel reads job-specific notes by job_id; the customer/account
+    // pages and the sticky-match query read by client_id / account scope.
+    await db.execute(sql`CREATE INDEX IF NOT EXISTS team_photo_notes_job_idx ON team_photo_notes (company_id, job_id)`);
+    await db.execute(sql`CREATE INDEX IF NOT EXISTS team_photo_notes_sticky_idx ON team_photo_notes (company_id, is_sticky, client_id, account_id, account_property_id)`);
+    console.log("[team-photo-notes] migration ok — table ready");
+  } catch (err) {
+    console.error("[team-photo-notes] migration error (non-fatal):", err);
+  }
+}

--- a/artifacts/api-server/src/routes/index.ts
+++ b/artifacts/api-server/src/routes/index.ts
@@ -32,6 +32,7 @@ import estimatesRouter from "./estimates.js";
 import trackRouter from "./track.js";
 import paymentsRouter from "./payments.js";
 import attachmentsRouter from "./attachments.js";
+import teamPhotoNotesRouter from "./team-photo-notes.js";
 import { quoteAttachmentsRouter, jobAttachmentsRouter } from "./quote-attachments.js";
 import propertyGroupsRouter from "./property-groups.js";
 import agreementTemplatesRouter from "./agreement-templates.js";
@@ -142,6 +143,7 @@ router.use("/estimates", estimatesRouter);
 router.use("/track", trackRouter);
 router.use("/payments", paymentsRouter);
 router.use("/attachments", attachmentsRouter);
+router.use("/team-photo-notes", teamPhotoNotesRouter);
 // [translate-job-notes 2026-05-27] Office-only translation endpoint —
 // Claude API. POST /api/translate {text, target} → {translated}.
 router.use("/translate", translateRouter);

--- a/artifacts/api-server/src/routes/team-photo-notes.ts
+++ b/artifacts/api-server/src/routes/team-photo-notes.ts
@@ -1,0 +1,158 @@
+// [team-photo-notes] Pictures + notes the team attaches to a job, or makes
+// sticky to a customer/property so they re-surface on every job there.
+// Office + techs both add (requireAuth). Mirrors attachments.ts for upload.
+import { Router } from "express";
+import { db } from "@workspace/db";
+import { teamPhotoNotesTable, jobsTable } from "@workspace/db/schema";
+import { eq, and, or, desc, isNull } from "drizzle-orm";
+import { requireAuth } from "../lib/auth.js";
+import multer from "multer";
+import path from "path";
+import fs from "fs";
+
+const upload = multer({
+  storage: multer.diskStorage({
+    destination: (_req, _file, cb) => {
+      const dir = "/tmp/uploads";
+      fs.mkdirSync(dir, { recursive: true });
+      cb(null, dir);
+    },
+    filename: (_req, file, cb) => {
+      const ext = path.extname(file.originalname);
+      cb(null, `${Date.now()}-${Math.random().toString(36).slice(2)}${ext}`);
+    },
+  }),
+  limits: { fileSize: 10 * 1024 * 1024 },
+});
+
+const router = Router();
+const toInt = (v: any) => (v === undefined || v === null || v === "" ? null : parseInt(String(v)));
+
+// List notes. Three query modes (company-scoped throughout):
+//   ?job_id=    → that job's own notes PLUS sticky notes matching the job's
+//                 customer scope (client / account / property).
+//   ?client_id= → sticky notes pinned to that client.
+//   ?account_id= (&account_property_id=) → sticky notes pinned to that account
+//                 (or that specific property).
+router.get("/", requireAuth, async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    const jobId = toInt(req.query.job_id);
+    const clientId = toInt(req.query.client_id);
+    const accountId = toInt(req.query.account_id);
+    const propertyId = toInt(req.query.account_property_id);
+
+    if (jobId) {
+      const [job] = await db.select({
+        client_id: jobsTable.client_id,
+        account_id: jobsTable.account_id,
+        account_property_id: jobsTable.account_property_id,
+      }).from(jobsTable).where(and(eq(jobsTable.id, jobId), eq(jobsTable.company_id, companyId)));
+      if (!job) return res.status(404).json({ error: "Job not found" });
+
+      // Sticky matches: same client, same property, or whole-account (no
+      // property pin) on this job's account.
+      const stickyMatches = [];
+      if (job.client_id != null) stickyMatches.push(eq(teamPhotoNotesTable.client_id, job.client_id));
+      if (job.account_property_id != null) stickyMatches.push(eq(teamPhotoNotesTable.account_property_id, job.account_property_id));
+      if (job.account_id != null) {
+        stickyMatches.push(and(
+          eq(teamPhotoNotesTable.account_id, job.account_id),
+          isNull(teamPhotoNotesTable.account_property_id),
+        ));
+      }
+      const stickyClause = stickyMatches.length
+        ? and(eq(teamPhotoNotesTable.is_sticky, true), or(...stickyMatches))
+        : undefined;
+
+      const rows = await db.select().from(teamPhotoNotesTable).where(and(
+        eq(teamPhotoNotesTable.company_id, companyId),
+        stickyClause
+          ? or(eq(teamPhotoNotesTable.job_id, jobId), stickyClause)
+          : eq(teamPhotoNotesTable.job_id, jobId),
+      )).orderBy(desc(teamPhotoNotesTable.is_sticky), desc(teamPhotoNotesTable.created_at));
+      return res.json(rows);
+    }
+
+    let scope;
+    if (clientId) scope = eq(teamPhotoNotesTable.client_id, clientId);
+    else if (propertyId) scope = eq(teamPhotoNotesTable.account_property_id, propertyId);
+    else if (accountId) scope = eq(teamPhotoNotesTable.account_id, accountId);
+    else return res.status(400).json({ error: "job_id, client_id, or account_id required" });
+
+    const rows = await db.select().from(teamPhotoNotesTable).where(and(
+      eq(teamPhotoNotesTable.company_id, companyId),
+      eq(teamPhotoNotesTable.is_sticky, true),
+      scope,
+    )).orderBy(desc(teamPhotoNotesTable.created_at));
+    res.json(rows);
+  } catch (e: any) {
+    console.error("List team photo notes error:", e);
+    res.status(500).json({ error: "Internal Server Error", message: e.message });
+  }
+});
+
+// Create a note. Accepts a multipart "file" (the picture) and/or a text note.
+// is_sticky=true pins it to the supplied customer scope; otherwise it's tied to
+// job_id. When sticky from a job context, the client pre-resolves the customer
+// scope (client_id / account_id / account_property_id) and passes it through.
+router.post("/", requireAuth, upload.single("file"), async (req, res) => {
+  try {
+    const { note } = req.body;
+    const isSticky = req.body.is_sticky === true || req.body.is_sticky === "true";
+    const jobId = toInt(req.body.job_id);
+    const clientId = toInt(req.body.client_id);
+    const accountId = toInt(req.body.account_id);
+    const propertyId = toInt(req.body.account_property_id);
+
+    if (isSticky && clientId == null && accountId == null && propertyId == null) {
+      return res.status(400).json({ error: "A sticky note needs a customer scope (client or account/property)" });
+    }
+    if (!isSticky && jobId == null) {
+      return res.status(400).json({ error: "A job-specific note needs job_id" });
+    }
+    if (!req.file && !(note && String(note).trim())) {
+      return res.status(400).json({ error: "Add a picture or a note" });
+    }
+
+    let imageUrl: string | null = null;
+    if (req.file) {
+      const uploadsDir = process.env.UPLOADS_DIR ?? path.join(process.cwd(), "uploads");
+      fs.mkdirSync(uploadsDir, { recursive: true });
+      fs.renameSync(req.file.path, path.join(uploadsDir, req.file.filename));
+      imageUrl = `/api/uploads/${req.file.filename}`;
+    }
+
+    const [row] = await db.insert(teamPhotoNotesTable).values({
+      company_id: req.auth!.companyId,
+      job_id: jobId,
+      client_id: clientId,
+      account_id: accountId,
+      account_property_id: propertyId,
+      is_sticky: isSticky,
+      image_url: imageUrl,
+      note: note ? String(note) : null,
+      uploaded_by: req.auth!.userId,
+    }).returning();
+    res.status(201).json(row);
+  } catch (e: any) {
+    console.error("Create team photo note error:", e);
+    res.status(500).json({ error: "Internal Server Error", message: e.message });
+  }
+});
+
+router.delete("/:id", requireAuth, async (req, res) => {
+  try {
+    const id = parseInt(req.params.id);
+    await db.delete(teamPhotoNotesTable).where(and(
+      eq(teamPhotoNotesTable.id, id),
+      eq(teamPhotoNotesTable.company_id, req.auth!.companyId),
+    ));
+    res.json({ success: true });
+  } catch (e: any) {
+    console.error("Delete team photo note error:", e);
+    res.status(500).json({ error: "Internal Server Error", message: e.message });
+  }
+});
+
+export default router;

--- a/artifacts/qleno/src/components/edit-job-modal.tsx
+++ b/artifacts/qleno/src/components/edit-job-modal.tsx
@@ -18,6 +18,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { X, AlertTriangle, Loader2 } from "lucide-react";
 import { CalendarPopover } from "@/components/calendar-popover";
+import { TeamPhotoNotes } from "@/components/team-photo-notes";
 import { useAuthStore } from "@/lib/auth";
 import { useToast } from "@/hooks/use-toast";
 
@@ -2319,6 +2320,16 @@ export default function EditJobModal({
               placeholder="Notes the cleaner sees on this job…"
               rows={4}
               style={{ ...INPUT, height: "auto", padding: "10px 12px", lineHeight: 1.5, resize: "vertical" }} />
+          </div>
+
+          {/* [team-photo-notes] Pictures + notes for the team. Attach to this
+              job, or tick sticky to pin to the customer for every visit. */}
+          <div style={SECTION}>
+            <TeamPhotoNotes
+              jobId={job.id}
+              jobClientId={job.client_id ?? null}
+              jobAccountId={job.account_id ?? null}
+            />
           </div>
 
           <div style={{ height: 16 }} />

--- a/artifacts/qleno/src/components/job-wizard.tsx
+++ b/artifacts/qleno/src/components/job-wizard.tsx
@@ -258,7 +258,17 @@ export function JobWizard({ open, onClose, onCreated, preselectedClient, presetD
   const [quoteError, setQuoteError] = useState("");
 
   // Step 2 — Commercial Service + Rate
-  const [commercialServiceType, setCommercialServiceType] = useState("standard_clean");
+  // No default slug: 'standard_clean' isn't in the commercial grid, so
+  // pre-selecting it fired a spurious "No rate configured for Standard Clean"
+  // before the operator picked anything. Start empty → forces an explicit
+  // pick (Next stays disabled until then) and kills the phantom warning.
+  const [commercialServiceType, setCommercialServiceType] = useState("");
+  // Account jobs aren't only buildings — some accounts are individuals (e.g.
+  // Meg) who need residential services (Standard, Deep Clean, Move In/Out).
+  // This toggle flips the account Service-step grid between the account's
+  // commercial types and the residential set. Commission/billing routing is
+  // unchanged (still keyed on account_id) — this only controls the picker.
+  const [acctServiceParent, setAcctServiceParent] = useState<"commercial" | "residential">("commercial");
   const [rateLookup, setRateLookup] = useState<any>(null);
   const [rateLookupLoading, setRateLookupLoading] = useState(false);
   const [rateLookupDone, setRateLookupDone] = useState(false);
@@ -366,7 +376,7 @@ export function JobWizard({ open, onClose, onCreated, preselectedClient, presetD
       setServiceType("standard_clean"); setScheduledDate(todayStr()); setScheduledTime("09:00");
       setDuration(120); setPrice(120); setPriceOverridden(false); setFrequency("on_demand"); setNotes("");
       setShowQuote(false); setQuoteSending(false); setQuoteSent(false); setQuoteError("");
-      setCommercialServiceType("standard_clean"); setRateLookup(null); setRateLookupLoading(false);
+      setCommercialServiceType(""); setAcctServiceParent("commercial"); setRateLookup(null); setRateLookupLoading(false);
       setRateLookupDone(false); setRateOverride(false); setOverrideRate(""); setEstimatedHours("");
       setManualBillingMethod("hourly"); setManualRate("");
       setCommercialScheduledDate(todayStr()); setCommercialScheduledTime("09:00");
@@ -648,12 +658,15 @@ export function JobWizard({ open, onClose, onCreated, preselectedClient, presetD
   // Pricing settings page get pre-fill behavior for free.
   useEffect(() => {
     if (clientType !== "commercial") return;
-    const apiRow = apiServiceTypes.find(s => s.parent_slug === "commercial" && s.slug === commercialServiceType);
+    // Honor the account Service-Category toggle so a residential type's
+    // default allowed-hours pre-fills too; plain commercial clients stay pinned.
+    const gridParent = selectedAccount ? acctServiceParent : "commercial";
+    const apiRow = apiServiceTypes.find(s => s.parent_slug === gridParent && s.slug === commercialServiceType);
     const apiHours = apiRow?.default_allowed_hours ? parseFloat(apiRow.default_allowed_hours) : null;
     if (apiHours && Number.isFinite(apiHours) && !estimatedHours) {
       setEstimatedHours(String(apiHours));
     }
-  }, [commercialServiceType, apiServiceTypes, clientType]);
+  }, [commercialServiceType, apiServiceTypes, clientType, selectedAccount, acctServiceParent]);
 
   // ── Add-ons math + payload ────────────────────────────────────────────
   // The service base a %-priced add-on applies to. Residential = the entered
@@ -1605,22 +1618,54 @@ export function JobWizard({ open, onClose, onCreated, preselectedClient, presetD
                 );
               })()}
 
+              {/* Account jobs aren't only buildings — individual accounts
+                  (e.g. Meg) need residential services. This toggle flips the
+                  grid between the account's commercial types and the
+                  residential set. Only the account path gets it; a plain
+                  commercial client stays commercial-only. */}
+              {selectedAccount && (
+                <div>
+                  <p style={{ fontSize: 12, fontWeight: 700, color: "#6B7280", margin: "0 0 8px", textTransform: "uppercase", letterSpacing: "0.06em" }}>Service Category</p>
+                  <div style={{ display: "flex", gap: 8 }}>
+                    {(["commercial", "residential"] as const).map(p => (
+                      <button key={p} type="button"
+                        onClick={() => { setAcctServiceParent(p); setCommercialServiceType(""); setRateLookup(null); setRateLookupDone(false); setRateOverride(false); }}
+                        style={{
+                          flex: 1, padding: "9px 12px", borderRadius: 8, cursor: "pointer", textAlign: "center",
+                          border: `1.5px solid ${acctServiceParent === p ? "var(--brand, #00C9A0)" : "#E5E2DC"}`,
+                          background: acctServiceParent === p ? "rgba(0,201,160,0.08)" : "#FFFFFF",
+                          color: acctServiceParent === p ? "var(--brand, #00C9A0)" : "#1A1917",
+                          fontSize: 13, fontWeight: 700, fontFamily: "inherit",
+                        }}>
+                        {p === "commercial" ? "Commercial" : "Residential"}
+                      </button>
+                    ))}
+                  </div>
+                  <p style={{ fontSize: 11, color: "#9E9B94", marginTop: 4 }}>
+                    Switch to Residential for individual accounts (move in/out, deep clean, standard).
+                  </p>
+                </div>
+              )}
+
               <div>
                 <p style={{ fontSize: 12, fontWeight: 700, color: "#6B7280", margin: "0 0 10px", textTransform: "uppercase", letterSpacing: "0.06em" }}>Service Type</p>
-                {/* [commercial-workflow PR #3] Commercial children
-                    fetched from /api/service-types?parent=commercial.
-                    Tenant-managed (admins add new types in
-                    /settings/pricing) so no fallback to a hardcoded
-                    list — empty state surfaces a config gap. */}
+                {/* [commercial-workflow PR #3] Children fetched from
+                    /api/service-types (both parents). Tenant-managed
+                    (admins add new types in /settings/pricing) so no
+                    fallback to a hardcoded list — empty state surfaces a
+                    config gap. On the account path the Service Category
+                    toggle picks the parent; a plain commercial client is
+                    pinned to commercial. */}
                 {(() => {
+                  const gridParent = selectedAccount ? acctServiceParent : "commercial";
                   const children = apiServiceTypes
-                    .filter(s => s.parent_slug === "commercial" && s.is_active)
+                    .filter(s => s.parent_slug === gridParent && s.is_active)
                     .sort((a, b) => a.display_order - b.display_order);
                   if (serviceTypesLoading && children.length === 0) {
                     return <p style={{ fontSize: 12, color: "#9E9B94" }}>Loading service types…</p>;
                   }
                   if (children.length === 0) {
-                    return <p style={{ fontSize: 12, color: "#991B1B" }}>No active commercial service types configured.</p>;
+                    return <p style={{ fontSize: 12, color: "#991B1B" }}>No active {gridParent} service types configured.</p>;
                   }
                   return (
                     <div style={{ display: "grid", gridTemplateColumns: "repeat(4, 1fr)", gap: 8 }}>

--- a/artifacts/qleno/src/components/team-photo-notes.tsx
+++ b/artifacts/qleno/src/components/team-photo-notes.tsx
@@ -1,0 +1,202 @@
+import { useEffect, useRef, useState } from "react";
+import { Camera, Pin, Trash2, Loader2, ImagePlus } from "lucide-react";
+import { getAuthHeaders } from "@/lib/auth";
+
+const API = import.meta.env.BASE_URL.replace(/\/$/, "");
+
+// [team-photo-notes] Pictures + notes the team shares. Two scopes:
+//   • Job context (jobId): adds attach to THIS job by default; an operator can
+//     tick "Show on every visit" to make it sticky to the job's customer, in
+//     which case the job's customer scope (passed via job* props) is pinned.
+//   • Customer context (clientId / accountId / accountPropertyId): every note
+//     added here is sticky to that customer/property.
+// Sticky notes render pinned at the top with a Pin badge on the job panel.
+export type TeamPhotoNotesProps = {
+  jobId?: number | null;
+  clientId?: number | null;
+  accountId?: number | null;
+  accountPropertyId?: number | null;
+  // For a job context: the job's customer scope, so "Show on every visit" can pin.
+  jobClientId?: number | null;
+  jobAccountId?: number | null;
+  jobAccountPropertyId?: number | null;
+  title?: string;
+};
+
+type Note = {
+  id: number;
+  job_id: number | null;
+  client_id: number | null;
+  account_id: number | null;
+  account_property_id: number | null;
+  is_sticky: boolean;
+  image_url: string | null;
+  note: string | null;
+  created_at: string;
+};
+
+const MINT = "#00C9A0";
+const INK = "#1A1917";
+const MUTE = "#6B7280";
+const BORDER = "#E5E2DC";
+
+export function TeamPhotoNotes(props: TeamPhotoNotesProps) {
+  const { jobId, clientId, accountId, accountPropertyId } = props;
+  const isJobContext = jobId != null;
+  // In a job context, a sticky toggle is only meaningful if the job actually has
+  // a customer to pin to.
+  const jobHasCustomer =
+    props.jobClientId != null || props.jobAccountId != null || props.jobAccountPropertyId != null;
+
+  const [notes, setNotes] = useState<Note[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [file, setFile] = useState<File | null>(null);
+  const [text, setText] = useState("");
+  const [sticky, setSticky] = useState(!isJobContext); // customer context = always sticky
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  function query(): string {
+    if (jobId != null) return `job_id=${jobId}`;
+    if (clientId != null) return `client_id=${clientId}`;
+    if (accountPropertyId != null) return `account_property_id=${accountPropertyId}`;
+    if (accountId != null) return `account_id=${accountId}`;
+    return "";
+  }
+
+  async function load() {
+    const q = query();
+    if (!q) return;
+    setLoading(true);
+    try {
+      const r = await fetch(`${API}/api/team-photo-notes?${q}`, { headers: getAuthHeaders() });
+      setNotes(r.ok ? await r.json() : []);
+    } catch { setNotes([]); }
+    finally { setLoading(false); }
+  }
+
+  useEffect(() => { load(); /* eslint-disable-next-line */ }, [jobId, clientId, accountId, accountPropertyId]);
+
+  async function add() {
+    if (!file && !text.trim()) { setError("Add a picture or a note."); return; }
+    setSaving(true); setError("");
+    try {
+      const form = new FormData();
+      if (file) form.append("file", file);
+      if (text.trim()) form.append("note", text.trim());
+
+      const makeSticky = isJobContext ? sticky && jobHasCustomer : true;
+      form.append("is_sticky", makeSticky ? "true" : "false");
+
+      if (isJobContext) {
+        form.append("job_id", String(jobId));
+        if (makeSticky) {
+          // Pin to the most specific customer scope the job carries.
+          if (props.jobClientId != null) form.append("client_id", String(props.jobClientId));
+          if (props.jobAccountPropertyId != null) form.append("account_property_id", String(props.jobAccountPropertyId));
+          else if (props.jobAccountId != null) form.append("account_id", String(props.jobAccountId));
+        }
+      } else {
+        if (clientId != null) form.append("client_id", String(clientId));
+        if (accountPropertyId != null) form.append("account_property_id", String(accountPropertyId));
+        else if (accountId != null) form.append("account_id", String(accountId));
+      }
+
+      const r = await fetch(`${API}/api/team-photo-notes`, {
+        method: "POST",
+        headers: getAuthHeaders() as Record<string, string>,
+        body: form,
+      });
+      if (!r.ok) { const b = await r.json().catch(() => ({})); throw new Error(b.error || "Failed to save"); }
+      setFile(null); setText(""); if (fileRef.current) fileRef.current.value = "";
+      if (isJobContext) setSticky(false);
+      await load();
+    } catch (e: any) { setError(e.message || "Failed to save"); }
+    finally { setSaving(false); }
+  }
+
+  async function remove(id: number) {
+    try {
+      await fetch(`${API}/api/team-photo-notes/${id}`, { method: "DELETE", headers: getAuthHeaders() });
+      setNotes((n) => n.filter((x) => x.id !== id));
+    } catch { /* leave it; reload will reconcile */ }
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <Camera size={16} color={MINT} />
+        <span style={{ fontSize: 13, fontWeight: 700, color: INK }}>
+          {props.title ?? "Team Photos & Notes"}
+        </span>
+      </div>
+
+      {/* Add form */}
+      <div style={{ border: `1px solid ${BORDER}`, borderRadius: 10, padding: 12, background: "#FFFFFF", display: "flex", flexDirection: "column", gap: 8 }}>
+        <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+          <button type="button" onClick={() => fileRef.current?.click()}
+            style={{ display: "inline-flex", alignItems: "center", gap: 6, border: `1px solid ${BORDER}`, borderRadius: 8, padding: "7px 12px", background: "#F7F6F3", cursor: "pointer", fontSize: 12, fontWeight: 600, color: INK, fontFamily: "inherit" }}>
+            <ImagePlus size={15} color={MUTE} /> {file ? "Change photo" : "Add photo"}
+          </button>
+          {file && <span style={{ fontSize: 12, color: MUTE, maxWidth: 180, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{file.name}</span>}
+          <input ref={fileRef} type="file" accept="image/*" capture="environment" style={{ display: "none" }}
+            onChange={(e) => setFile(e.target.files?.[0] ?? null)} />
+        </div>
+        <textarea value={text} onChange={(e) => setText(e.target.value)} rows={2}
+          placeholder="Note for the team — e.g. gate code 2247, park on the south side, dog is friendly"
+          style={{ width: "100%", border: `1px solid ${BORDER}`, borderRadius: 8, padding: "8px 10px", fontSize: 13, fontFamily: "inherit", resize: "vertical", outline: "none", boxSizing: "border-box", color: INK }} />
+
+        {isJobContext && jobHasCustomer && (
+          <label style={{ display: "inline-flex", alignItems: "center", gap: 8, fontSize: 12, color: INK, cursor: "pointer" }}>
+            <input type="checkbox" checked={sticky} onChange={(e) => setSticky(e.target.checked)} style={{ accentColor: MINT }} />
+            <Pin size={13} color={sticky ? MINT : MUTE} />
+            Show on every visit for this customer (sticky)
+          </label>
+        )}
+
+        {error && <p style={{ fontSize: 12, color: "#DC2626", margin: 0 }}>{error}</p>}
+
+        <div>
+          <button type="button" onClick={add} disabled={saving}
+            style={{ display: "inline-flex", alignItems: "center", gap: 6, border: "none", borderRadius: 8, padding: "8px 16px", background: MINT, color: "#fff", cursor: saving ? "default" : "pointer", fontSize: 13, fontWeight: 700, fontFamily: "inherit", opacity: saving ? 0.7 : 1 }}>
+            {saving ? <Loader2 size={14} className="animate-spin" /> : null}
+            {saving ? "Saving..." : "Add"}
+          </button>
+        </div>
+      </div>
+
+      {/* List */}
+      {loading && notes.length === 0 ? (
+        <p style={{ fontSize: 12, color: MUTE }}>Loading…</p>
+      ) : notes.length === 0 ? (
+        <p style={{ fontSize: 12, color: MUTE }}>No photos or notes yet.</p>
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+          {notes.map((n) => (
+            <div key={n.id} style={{ display: "flex", gap: 10, border: `1px solid ${n.is_sticky ? "#99E6D5" : BORDER}`, background: n.is_sticky ? "#F0FDFB" : "#FFFFFF", borderRadius: 10, padding: 10 }}>
+              {n.image_url && (
+                <a href={`${API}${n.image_url}`} target="_blank" rel="noreferrer" style={{ flexShrink: 0 }}>
+                  <img src={`${API}${n.image_url}`} alt="" style={{ width: 56, height: 56, objectFit: "cover", borderRadius: 8, border: `1px solid ${BORDER}` }} />
+                </a>
+              )}
+              <div style={{ flex: 1, minWidth: 0 }}>
+                {n.is_sticky && (
+                  <span style={{ display: "inline-flex", alignItems: "center", gap: 4, fontSize: 10, fontWeight: 700, color: "#0F766E", background: "#CCFBEF", borderRadius: 999, padding: "2px 7px", marginBottom: 4 }}>
+                    <Pin size={10} /> Sticky
+                  </span>
+                )}
+                {n.note && <p style={{ fontSize: 13, color: INK, margin: 0, whiteSpace: "pre-wrap", wordBreak: "break-word" }}>{n.note}</p>}
+                <p style={{ fontSize: 11, color: MUTE, margin: "4px 0 0" }}>{new Date(n.created_at).toLocaleDateString()}</p>
+              </div>
+              <button type="button" onClick={() => remove(n.id)} title="Delete"
+                style={{ flexShrink: 0, border: "none", background: "transparent", cursor: "pointer", color: MUTE, padding: 4 }}>
+                <Trash2 size={15} />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/artifacts/qleno/src/pages/account-detail.tsx
+++ b/artifacts/qleno/src/pages/account-detail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useParams, Link } from "wouter";
 import {
   Building2, ChevronLeft, ChevronDown, Plus, Pencil, Trash2, DollarSign,
@@ -17,6 +17,8 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "
 import { Switch } from "@/components/ui/switch";
 import { useToast } from "@/hooks/use-toast";
 import { getAuthHeaders } from "@/lib/auth";
+import { useAddressAutocomplete } from "@/hooks/use-address-autocomplete";
+import { TeamPhotoNotes } from "@/components/team-photo-notes";
 import { AccountJobsCalendar } from "@/components/account-jobs-calendar";
 
 const API = import.meta.env.BASE_URL.replace(/\/$/, "");
@@ -137,6 +139,19 @@ export default function AccountDetailPage() {
   const [showProperty, setShowProperty] = useState(false);
   const [editProp, setEditProp] = useState<any>(null);
   const [propForm, setPropForm] = useState({ property_name: "", address: "", city: "", state: "IL", zip: "", unit_count: "", property_type: "apartment_building", default_service_type: "", access_notes: "", notes: "" });
+  // Google Places autocomplete on the Add/Edit Property street field — the
+  // same help every other address form gets. Picking a suggestion fills
+  // street + city + state + zip in one shot so the office isn't hand-typing.
+  const propAddrRef = useRef<HTMLInputElement>(null);
+  useAddressAutocomplete(propAddrRef, showProperty, (p) => {
+    setPropForm((f) => ({
+      ...f,
+      address: p.street || f.address,
+      city: p.city || f.city,
+      state: p.state || f.state,
+      zip: p.zip || f.zip,
+    }));
+  });
   const [propSaving, setPropSaving] = useState(false);
 
   // Contact
@@ -624,6 +639,15 @@ export default function AccountDetailPage() {
                 <p className="text-sm text-gray-700 whitespace-pre-wrap">{account.notes}</p>
               </div>
             )}
+          </div>
+        )}
+
+        {/* [team-photo-notes] Sticky pictures + notes for the whole account —
+            surface on every job for this account so the team always has the
+            context (gate codes, parking, contacts). */}
+        {tab === "overview" && (
+          <div className="bg-white border border-gray-100 rounded-xl p-4">
+            <TeamPhotoNotes accountId={Number(id)} title="Team Photos & Notes (shown on every job for this account)" />
           </div>
         )}
 
@@ -1145,7 +1169,7 @@ export default function AccountDetailPage() {
               </div>
               <div className="space-y-1.5 col-span-2">
                 <Label>Street Address *</Label>
-                <Input placeholder="4801 W 95th St" value={propForm.address} onChange={(e) => setPropForm({ ...propForm, address: e.target.value })} />
+                <Input ref={propAddrRef} placeholder="4801 W 95th St" value={propForm.address} onChange={(e) => setPropForm({ ...propForm, address: e.target.value })} />
               </div>
               <div className="space-y-1.5">
                 <Label>City</Label>

--- a/artifacts/qleno/src/pages/customer-profile.tsx
+++ b/artifacts/qleno/src/pages/customer-profile.tsx
@@ -15,6 +15,7 @@ import {
 } from "lucide-react";
 import { QuotesTab, PaymentsTab, QuickBooksTab, AttachmentsTab, CommLog2 } from "./customer-profile-tabs2";
 import { JobWizard } from "@/components/job-wizard";
+import { TeamPhotoNotes } from "@/components/team-photo-notes";
 // [job-card-redesign 2026-06-25] The SAME editable dispatch card, opened from the
 // client calendar (Maribel: "edit everything there, not just void/cancel"). Lazy
 // so jobs.tsx stays out of the profile's main chunk — loaded when a card opens.
@@ -4577,7 +4578,16 @@ function InspectionsSection() {
 
 // ─── Attachments Section ──────────────────────────────────────────────────────
 function AttachmentsSection({ clientId }: { clientId: number }) {
-  return <AttachmentsTab clientId={clientId} />;
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 24 }}>
+      <AttachmentsTab clientId={clientId} />
+      {/* [team-photo-notes] Sticky pictures + notes pinned to this client —
+          surface on every job so the team always has the context. */}
+      <div style={{ borderTop: "1px solid #E5E2DC", paddingTop: 20 }}>
+        <TeamPhotoNotes clientId={clientId} title="Team Photos & Notes (shown on every job for this customer)" />
+      </div>
+    </div>
+  );
 }
 
 // ─── Home Images Section ──────────────────────────────────────────────────────

--- a/artifacts/qleno/src/pages/my-jobs.tsx
+++ b/artifacts/qleno/src/pages/my-jobs.tsx
@@ -3,6 +3,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAuthStore, getTokenRole } from "@/lib/auth";
 import { InlinePriceEdit } from "@/components/inline-price-edit";
 import { EarningsPanel } from "@/components/earnings-panel";
+import { TeamPhotoNotes } from "@/components/team-photo-notes";
 import { useToast } from "@/hooks/use-toast";
 import { Check, Eye, Navigation, Phone, GraduationCap, DollarSign, Users, MapPin, Sun, Cloud, CloudSun, CloudRain, CloudSnow, CloudDrizzle, CloudLightning, Plane, Bell, KeyRound, LogOut, Camera } from "lucide-react";
 import { Link, useLocation } from "wouter";
@@ -1049,6 +1050,16 @@ export function JobCard({ job, empPos, onRefresh, isPreviewMode, actingForUserId
 
       <PhotoGrid jobId={job.id} type="before" photos={photosBefore} onUploaded={loadPhotos} />
       <PhotoGrid jobId={job.id} type="after" photos={photosAfter} onUploaded={loadPhotos} />
+
+      {/* [team-photo-notes] Pictures + notes for the team. Tech can attach to
+          this job, or tick sticky to pin to the customer for every visit. */}
+      <div style={{ marginTop: 12 }}>
+        <TeamPhotoNotes
+          jobId={job.id}
+          jobAccountId={job.account_id ?? null}
+          jobAccountPropertyId={job.account_property_id ?? null}
+        />
+      </div>
 
       {isClockedIn && photoGate && (
         <div style={{ backgroundColor: "#FEF3C7", borderLeft: "3px solid #F59E0B", borderRadius: "0 6px 6px 0", padding: "10px 12px", marginTop: 12 }}>

--- a/lib/db/src/schema/index.ts
+++ b/lib/db/src/schema/index.ts
@@ -15,6 +15,7 @@ export * from "./lead_report_settings";
 export * from "./clients";
 export * from "./jobs";
 export * from "./job_photos";
+export * from "./team_photo_notes";
 export * from "./timeclock";
 export * from "./invoices";
 export * from "./scorecards";

--- a/lib/db/src/schema/team_photo_notes.ts
+++ b/lib/db/src/schema/team_photo_notes.ts
@@ -1,0 +1,36 @@
+import { pgTable, serial, text, integer, boolean, timestamp } from "drizzle-orm/pg-core";
+import { createInsertSchema } from "drizzle-zod";
+import { z } from "zod/v4";
+import { companiesTable } from "./companies";
+import { jobsTable } from "./jobs";
+import { clientsTable } from "./clients";
+import { usersTable } from "./users";
+
+// [team-photo-notes] Pictures + notes the team attaches so everyone sees the
+// same field context (gate codes, where to park, pet/alarm warnings, supply
+// closet). Two scopes, set by `is_sticky`:
+//   • job-specific  → job_id set, is_sticky=false. One-off for that visit.
+//   • sticky        → is_sticky=true + a customer scope so it re-surfaces on
+//                     EVERY job for that customer: client_id (residential) OR
+//                     account_property_id (a specific building) OR account_id
+//                     (whole commercial account). job_id may still record where
+//                     the note was first added.
+// account_id / account_property_id are loose integers (no FK) to match how the
+// dispatch layer treats account linkage; company_id scopes every read.
+export const teamPhotoNotesTable = pgTable("team_photo_notes", {
+  id: serial("id").primaryKey(),
+  company_id: integer("company_id").references(() => companiesTable.id).notNull(),
+  job_id: integer("job_id").references(() => jobsTable.id),
+  client_id: integer("client_id").references(() => clientsTable.id),
+  account_id: integer("account_id"),
+  account_property_id: integer("account_property_id"),
+  is_sticky: boolean("is_sticky").notNull().default(false),
+  image_url: text("image_url"),
+  note: text("note"),
+  uploaded_by: integer("uploaded_by").references(() => usersTable.id),
+  created_at: timestamp("created_at").notNull().defaultNow(),
+});
+
+export const insertTeamPhotoNoteSchema = createInsertSchema(teamPhotoNotesTable).omit({ id: true, created_at: true });
+export type InsertTeamPhotoNote = z.infer<typeof insertTeamPhotoNoteSchema>;
+export type TeamPhotoNote = typeof teamPhotoNotesTable.$inferSelect;


### PR DESCRIPTION
## Summary

- **Add Property autocomplete**: wired `useAddressAutocomplete` to the Street Address input in the Add Property modal (`account-detail.tsx`) so Google Places fills city/state/zip automatically — no more hand-typed addresses.

- **Account job service type toggle**: added a Residential/Commercial toggle in the Create New Job wizard for account jobs. Defaults to Commercial; office can switch to Residential to book Standard Clean, Deep Clean, Move In/Out for individual accounts (e.g. Meg). Fixed the spurious "No rate configured for Standard Clean" warning by changing the default `commercialServiceType` from `"standard_clean"` to `""`. Commission routing is unchanged — `account_id` presence still gates all commercial commission logic regardless of service type selected.

- **Team Photos & Notes**: full-stack sticky note system for job/customer context:
  - New `team_photo_notes` DB table with boot migration (idempotent)
  - `GET/POST/DELETE /api/team-photo-notes` — multipart file upload, company-scoped
  - `TeamPhotoNotes` React component with job and customer context modes, sticky toggle (Pin badge), mobile camera capture (`capture="environment"`)
  - Mounted in: **edit-job-modal** (office web), **my-jobs** (tech field app), **account-detail** (account overview tab), **customer-profile** (client attachments tab)

## Test plan

- [ ] Add Property modal: type a street address → Google Places dropdown appears → selecting fills city/state/zip
- [ ] New Job wizard for an account: Service step shows Residential/Commercial toggle; switching to Residential shows Standard Clean / Deep Clean / Move In/Out grid; no "No rate configured" warning on open
- [ ] New Job wizard for an account: book a residential service type → commission panel shows commercial hourly rate (not 35% pool)
- [ ] Edit-job-modal: Team Photos & Notes section appears below Cleaner Notes; can add a photo + note; sticky checkbox visible when job has a customer
- [ ] My-jobs (tech view): Team Photos & Notes section appears on job card; sticky notes from the customer surface with Pin badge
- [ ] Account detail overview: Team Photos & Notes section shows; notes added here have `is_sticky=true` and surface on future jobs for this account
- [ ] Customer profile: Team Photos & Notes section in Attachments tab; sticky notes surface on the client's job cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WPHYUzeR8WqE3Fau1A7Fsa

---
_Generated by [Claude Code](https://claude.ai/code/session_01WPHYUzeR8WqE3Fau1A7Fsa)_