### PR TITLE
fix: messages timestamps, manual read marking, sender name

### DIFF
--- a/artifacts/api-server/src/lib/sms-store.ts
+++ b/artifacts/api-server/src/lib/sms-store.ts
@@ -113,17 +113,20 @@ export async function recordOutboundSms(args: {
 }
 
 // Read a contact's SMS thread (chronological) by client_id, lead_id, or phone.
+// Returns sent_by_name so the UI can show which team member sent each outbound message.
 export async function getThread(companyId: number, key: { clientId?: number | null; leadId?: number | null; phone?: string | null }) {
   let where;
-  if (key.clientId != null) where = sql`client_id = ${key.clientId}`;
-  else if (key.leadId != null) where = sql`lead_id = ${key.leadId}`;
-  else where = sql`contact_phone = ${phone10(key.phone)}`;
+  if (key.clientId != null) where = sql`m.client_id = ${key.clientId}`;
+  else if (key.leadId != null) where = sql`m.lead_id = ${key.leadId}`;
+  else where = sql`m.contact_phone = ${phone10(key.phone)}`;
   const r = await db.execute(sql`
-    SELECT id, direction, body, from_number, to_number, status, read_at, created_at,
-           contact_phone, client_id, lead_id, media_urls
-      FROM sms_messages
-     WHERE company_id = ${companyId} AND ${where}
-     ORDER BY created_at ASC`);
+    SELECT m.id, m.direction, m.body, m.from_number, m.to_number, m.status, m.read_at, m.created_at,
+           m.contact_phone, m.client_id, m.lead_id, m.media_urls, m.sent_by,
+           NULLIF(trim(u.first_name || ' ' || coalesce(u.last_name, '')), '') AS sent_by_name
+      FROM sms_messages m
+      LEFT JOIN users u ON u.id = m.sent_by
+     WHERE m.company_id = ${companyId} AND ${where}
+     ORDER BY m.created_at ASC`);
   return r.rows;
 }
 

--- a/artifacts/api-server/src/routes/sms.ts
+++ b/artifacts/api-server/src/routes/sms.ts
@@ -57,7 +57,8 @@ router.get("/conversations", requireAuth, requireRole("owner", "admin", "office"
   }
 });
 
-// ── GET /api/sms/thread?phone=|client_id=|lead_id= — full thread, marks read ───
+// ── GET /api/sms/thread?phone=|client_id=|lead_id= — full thread ───────────────
+// Does NOT mark messages read — staff must do that manually via POST /mark-read.
 router.get("/thread", requireAuth, requireRole("owner", "admin", "office"), async (req, res) => {
   try {
     const companyId = req.auth!.companyId;
@@ -65,12 +66,24 @@ router.get("/thread", requireAuth, requireRole("owner", "admin", "office"), asyn
     const clientId = req.query.client_id ? parseInt(String(req.query.client_id)) : null;
     const leadId = req.query.lead_id ? parseInt(String(req.query.lead_id)) : null;
     const messages = await getThread(companyId, { clientId, leadId, phone });
-    // Mark inbound read for the thread's contact phone.
     const cp = phone10(phone || (messages[0] as any)?.contact_phone || "");
-    if (cp) await markThreadRead(companyId, cp);
     return res.json({ contact_phone: cp, messages });
   } catch (err) {
     console.error("GET /sms/thread:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
+// ── POST /api/sms/mark-read — manually mark a thread's inbound messages read ──
+router.post("/mark-read", requireAuth, requireRole("owner", "admin", "office"), async (req, res) => {
+  try {
+    const companyId = req.auth!.companyId;
+    const phone = String(req.body?.phone ?? "");
+    if (!phone) return res.status(400).json({ error: "phone required" });
+    await markThreadRead(companyId, phone);
+    return res.json({ ok: true });
+  } catch (err) {
+    console.error("POST /sms/mark-read:", err);
     return res.status(500).json({ error: "Internal Server Error" });
   }
 });

--- a/artifacts/qleno/src/pages/messages.tsx
+++ b/artifacts/qleno/src/pages/messages.tsx
@@ -19,7 +19,7 @@ interface Convo {
 interface Msg {
   id: number; direction: string; body: string; from_number: string | null;
   to_number: string | null; status: string; read_at: string | null; created_at: string;
-  media_urls?: string[] | null;
+  media_urls?: string[] | null; sent_by_name?: string | null;
 }
 interface ScheduledMsg {
   id: number; message: string; media_urls?: string[] | null;
@@ -33,7 +33,11 @@ function fmtPhone(p: string) {
 }
 function fmtTime(s: string) {
   if (!s) return "";
-  const d = new Date(s);
+  // Normalize to UTC: replace space separator and append Z if no timezone marker
+  const iso = s.includes("T") ? s : s.replace(" ", "T");
+  const withTZ = /Z$|[+-]\d{2}:\d{2}$/.test(iso) ? iso : iso + "Z";
+  const d = new Date(withTZ);
+  if (isNaN(d.getTime())) return s;
   const today = new Date();
   const sameDay = d.toDateString() === today.toDateString();
   return sameDay
@@ -124,6 +128,16 @@ export default function MessagesPage() {
     try {
       const r = await fetch(`${API}/api/sms/thread?phone=${encodeURIComponent(c.contact_phone)}`, { headers: getAuthHeaders() });
       if (r.ok) { const d = await r.json(); setThread(d.messages || []); }
+    } catch { /* silent */ }
+  }, []);
+
+  const markRead = useCallback(async (c: Convo) => {
+    try {
+      await fetch(`${API}/api/sms/mark-read`, {
+        method: "POST",
+        headers: { ...getAuthHeaders(), "Content-Type": "application/json" },
+        body: JSON.stringify({ phone: c.contact_phone }),
+      });
       setConvos(cs => cs.map(x => x.contact_phone === c.contact_phone ? { ...x, unread: 0 } : x));
     } catch { /* silent */ }
   }, []);
@@ -418,6 +432,12 @@ export default function MessagesPage() {
                       )}
                       <div style={{ fontSize: 12, color: MUTE }}>{fmtPhone(active.contact_phone)}{active.client_id ? " · Client" : active.lead_id ? " · Lead" : ""}</div>
                     </div>
+                    {active.unread > 0 && (
+                      <button onClick={() => markRead(active)}
+                        style={{ padding: "6px 12px", background: "#F1F0EC", border: `1px solid ${BORDER}`, borderRadius: 8, fontSize: 12, fontWeight: 700, color: INK, cursor: "pointer", fontFamily: FF, flexShrink: 0 }}>
+                        Mark as read
+                      </button>
+                    )}
                   </div>
 
                   {/* Thread messages */}
@@ -448,7 +468,10 @@ export default function MessagesPage() {
                       const inbound = m.direction === "inbound";
                       const mediaKeys = Array.isArray(m.media_urls) ? m.media_urls : [];
                       return (
-                        <div key={m.id} style={{ display: "flex", justifyContent: inbound ? "flex-start" : "flex-end" }}>
+                        <div key={m.id} style={{ display: "flex", flexDirection: "column", alignItems: inbound ? "flex-start" : "flex-end" }}>
+                          {!inbound && m.sent_by_name && (
+                            <div style={{ fontSize: 10, color: MUTE, fontWeight: 600, marginBottom: 2, paddingRight: 4 }}>{m.sent_by_name}</div>
+                          )}
                           <div style={{ maxWidth: "75%", padding: "9px 12px", borderRadius: 12, background: inbound ? "#F1F0EC" : BRAND, color: inbound ? INK : "#04241d",
                             borderBottomLeftRadius: inbound ? 3 : 12, borderBottomRightRadius: inbound ? 12 : 3 }}>
                             {m.body && (


### PR DESCRIPTION
Fixes 3 of 4 reported issues in the Messages page.

- Timestamps normalized to UTC
- Manual read marking (button in thread header)
- Sender name shown on outbound bubbles
- Multimedia requires R2 + COMMS_ENABLED=true on Railway